### PR TITLE
wazuh-remoted - Improve control message processing

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10452,7 +10452,7 @@ paths:
                         email_to: recipient@example.wazuh.com
                         email_maxperhour: 12
                         email_log_source: alerts.log
-                        agents_disconnection_time: "10m"
+                        agents_disconnection_time: "15m"
                         agents_disconnection_alert_time: 0
                         update_check: yes
                         white_list:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7634,7 +7634,7 @@ paths:
                 data:
                   client:
                     config-profile: "ubuntu, ubuntu20, ubuntu20.04"
-                    notify_time: 10
+                    notify_time: 20
                     time-reconnect: 60
                     force_reconnect_interval: 0
                     ip_update_interval: 0

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -241,6 +241,10 @@ remoted.tcp_keepintvl=10
 # Maximum number of keepalive probes TCP should send before dropping the connection [1..50]
 remoted.tcp_keepcnt=3
 
+# TODO: CHECK THE DEFAULT VALUE
+# Save control messages queue size, in messages [1024..1048576]
+remoted.control_msg_queue_size=131072
+
 # Timeout to execute remote requests [1..3600]
 execd.request_timeout=60
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -241,9 +241,8 @@ remoted.tcp_keepintvl=10
 # Maximum number of keepalive probes TCP should send before dropping the connection [1..50]
 remoted.tcp_keepcnt=3
 
-# TODO: CHECK THE DEFAULT VALUE
 # Save control messages queue size, in messages [1024..1048576]
-remoted.control_msg_queue_size=131072
+remoted.control_msg_queue_size=16384
 
 # Timeout to execute remote requests [1..3600]
 execd.request_timeout=60

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -16,7 +16,7 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_time>15m</agents_disconnection_time>
     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -16,7 +16,7 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_time>15m</agents_disconnection_time>
     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>
 

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -16,7 +16,7 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_time>15m</agents_disconnection_time>
     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   </global>
 

--- a/etc/templates/config/generic/global.template
+++ b/etc/templates/config/generic/global.template
@@ -9,7 +9,7 @@
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>
-    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_time>15m</agents_disconnection_time>
     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
     <update_check>yes</update_check>
   </global>

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -92,7 +92,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #endif
 
 /* Notify the manager */
-#define NOTIFY_TIME     10      // ... every 10 seconds
+#define NOTIFY_TIME     20      // ... every 20 seconds
 #define RECONNECT_TIME  60      // Time to reconnect
 
 /* User Configuration */

--- a/src/headers/indexed_queue_op.h
+++ b/src/headers/indexed_queue_op.h
@@ -1,0 +1,249 @@
+/**
+ * @file indexed_queue_op.h
+ * @brief Indexed Queue (abstract data type)
+ * @date 2025-08-08
+ *
+ * @copyright Copyright (C) 2015 Wazuh, Inc.
+ */
+
+/*
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+/**
+ * Library that creates a queue where items are pushed and popped following
+ * the FIFO (First In, First Out) principle, while also providing O(log n)
+ * access by key through a red-black tree index.
+ *
+ * Features:
+ * - FIFO queue operations (push, pop, peek)
+ * - O(log n) key-based operations (get, update, delete)
+ * - Optional size limitation
+ * - Thread-safe with mutex and condition variables
+ * - Upsert operation (insert or update)
+ */
+
+#ifndef INDEXED_QUEUE_OP_H
+#define INDEXED_QUEUE_OP_H
+
+#include <pthread.h>
+#include "queue_linked_op.h"
+#include "rbtree_op.h"
+
+/**
+ * @brief Indexed queue node entry
+ *
+ * Links a queue node with its key for indexing
+ */
+typedef struct w_indexed_queue_entry {
+    char *key;                           ///< Node key for indexing
+    void *data;                         ///< Pointer to the actual data
+    w_linked_queue_node_t *queue_node;  ///< Reference to the queue node
+} w_indexed_queue_entry_t;
+
+/**
+ * @brief Indexed queue main structure
+ *
+ * Combines a FIFO queue with a red-black tree index for fast key-based access
+ */
+typedef struct w_indexed_queue {
+    w_linked_queue_t *queue;            ///< Underlying FIFO queue
+    rb_tree *index;                     ///< Red-black tree for key-based access
+    pthread_mutex_t mutex;              ///< Mutex for mutual exclusion
+    pthread_cond_t available;           ///< Condition variable when queue is empty
+    pthread_cond_t available_not_full;  ///< Condition variable when queue is full
+    size_t max_size;                    ///< Maximum size (0 = unlimited)
+    size_t current_size;                ///< Current number of elements
+    void (*dispose)(void *);            ///< Function to dispose data elements
+} w_indexed_queue_t;
+
+/**
+ * @brief Initialize a new indexed queue structure
+ *
+ * @param max_size Maximum size of the queue (0 for unlimited)
+ * @return Initialized queue structure or NULL on error
+ */
+w_indexed_queue_t *indexed_queue_init(size_t max_size);
+
+/**
+ * @brief Free an indexed queue and all its elements
+ *
+ * @param queue The indexed queue to free
+ */
+void indexed_queue_free(w_indexed_queue_t *queue);
+
+/**
+ * @brief Set function to dispose data elements
+ *
+ * @param queue The indexed queue
+ * @param dispose Function to call when disposing elements
+ */
+void indexed_queue_set_dispose(w_indexed_queue_t *queue, void (*dispose)(void *));
+
+/**
+ * @brief Check if the queue is empty
+ *
+ * @param queue The indexed queue
+ * @return 1 if empty, 0 otherwise
+ */
+int indexed_queue_empty(const w_indexed_queue_t *queue);
+
+/**
+ * @brief Check if the queue is full
+ *
+ * @param queue The indexed queue
+ * @return 1 if full, 0 otherwise
+ */
+int indexed_queue_full(const w_indexed_queue_t *queue);
+
+/**
+ * @brief Get current size of the queue
+ *
+ * @param queue The indexed queue
+ * @return Current number of elements
+ */
+size_t indexed_queue_size(const w_indexed_queue_t *queue);
+
+/**
+ * @brief Insert element at the end of the queue (FIFO push)
+ *
+ * @param queue The indexed queue
+ * @param key Unique key for the element
+ * @param data Data to insert
+ * @return 0 on success, -1 on error (key exists or queue full)
+ */
+int indexed_queue_push(w_indexed_queue_t *queue, const char *key, void *data);
+
+/**
+ * @brief Thread-safe insert with blocking when full
+ *
+ * @param queue The indexed queue
+ * @param key Unique key for the element
+ * @param data Data to insert
+ * @return 0 on success, -1 on error (key exists)
+ */
+int indexed_queue_push_ex(w_indexed_queue_t *queue, const char *key, void *data);
+
+/**
+ * @brief Insert or update element (upsert operation)
+ *
+ * If key exists, updates the value. If not, inserts as new element.
+ *
+ * @param queue The indexed queue
+ * @param key Key for the element
+ * @param data Data to insert or update
+ * @return 0 on success, -1 on error
+ */
+int indexed_queue_upsert(w_indexed_queue_t *queue, const char *key, void *data);
+
+/**
+ * @brief Thread-safe upsert operation
+ *
+ * @param queue The indexed queue
+ * @param key Key for the element
+ * @param data Data to insert or update
+ * @return 0 on success, -1 on error
+ */
+int indexed_queue_upsert_ex(w_indexed_queue_t *queue, const char *key, void *data);
+
+/**
+ * @brief Get element by key (without removing)
+ *
+ * @param queue The indexed queue
+ * @param key Key to search for
+ * @return Pointer to data if found, NULL otherwise
+ */
+void *indexed_queue_get(const w_indexed_queue_t *queue, const char *key);
+
+/**
+ * @brief Thread-safe get element by key
+ *
+ * @param queue The indexed queue
+ * @param key Key to search for
+ * @return Pointer to data if found, NULL otherwise
+ */
+void *indexed_queue_get_ex(w_indexed_queue_t *queue, const char *key);
+
+/**
+ * @brief Peek at the next element (FIFO head) without removing
+ *
+ * @param queue The indexed queue
+ * @return Pointer to data of next element, NULL if empty
+ */
+void *indexed_queue_peek(const w_indexed_queue_t *queue);
+
+/**
+ * @brief Thread-safe peek operation
+ *
+ * @param queue The indexed queue
+ * @return Pointer to data of next element, NULL if empty
+ */
+void *indexed_queue_peek_ex(w_indexed_queue_t *queue);
+
+/**
+ * @brief Remove and return next element (FIFO pop)
+ *
+ * @param queue The indexed queue
+ * @return Pointer to data of popped element, NULL if empty
+ */
+void *indexed_queue_pop(w_indexed_queue_t *queue);
+
+/**
+ * @brief Thread-safe pop with blocking when empty
+ *
+ * @param queue The indexed queue
+ * @return Pointer to data of popped element
+ */
+void *indexed_queue_pop_ex(w_indexed_queue_t *queue);
+
+/**
+ * @brief Thread-safe pop with timeout
+ *
+ * @param queue The indexed queue
+ * @param abstime Timeout specification
+ * @return Pointer to data of popped element, NULL on timeout
+ */
+void *indexed_queue_pop_ex_timedwait(w_indexed_queue_t *queue, const struct timespec *abstime);
+
+/**
+ * @brief Delete element by key
+ *
+ * @param queue The indexed queue
+ * @param key Key of element to delete
+ * @return 1 if element found and deleted, 0 otherwise
+ */
+int indexed_queue_delete(w_indexed_queue_t *queue, const char *key);
+
+/**
+ * @brief Thread-safe delete element by key
+ *
+ * @param queue The indexed queue
+ * @param key Key of element to delete
+ * @return 1 if element found and deleted, 0 otherwise
+ */
+int indexed_queue_delete_ex(w_indexed_queue_t *queue, const char *key);
+
+/**
+ * @brief Update element by key (key must exist)
+ *
+ * @param queue The indexed queue
+ * @param key Key of element to update
+ * @param data New data value
+ * @return Pointer to old data on success, NULL if key not found
+ */
+void *indexed_queue_update(w_indexed_queue_t *queue, const char *key, void *data);
+
+/**
+ * @brief Thread-safe update element by key
+ *
+ * @param queue The indexed queue
+ * @param key Key of element to update
+ * @param data New data value
+ * @return Pointer to old data on success, NULL if key not found
+ */
+void *indexed_queue_update_ex(w_indexed_queue_t *queue, const char *key, void *data);
+
+#endif // INDEXED_QUEUE_OP_H

--- a/src/headers/indexed_queue_op.h
+++ b/src/headers/indexed_queue_op.h
@@ -59,6 +59,7 @@ typedef struct w_indexed_queue {
     size_t max_size;                    ///< Maximum size (0 = unlimited)
     _Atomic size_t current_size;        ///< Current number of elements
     void (*dispose)(void *);            ///< Function to dispose data elements
+    char *(*get_key)(void *);           ///< Function to get key from data element
 } w_indexed_queue_t;
 
 /**
@@ -83,6 +84,14 @@ void indexed_queue_free(w_indexed_queue_t *queue);
  * @param dispose Function to call when disposing elements
  */
 void indexed_queue_set_dispose(w_indexed_queue_t *queue, void (*dispose)(void *));
+
+/**
+ * @brief Set function to get key from data element
+ *
+ * @param queue The indexed queue
+ * @param get_key Function to call to get key from data element
+ */
+void indexed_queue_set_get_key(w_indexed_queue_t *queue, char *(*get_key)(void *));
 
 /**
  * @brief Check if the queue is empty

--- a/src/headers/indexed_queue_op.h
+++ b/src/headers/indexed_queue_op.h
@@ -29,6 +29,7 @@
 #ifndef INDEXED_QUEUE_OP_H
 #define INDEXED_QUEUE_OP_H
 
+#include <stdatomic.h>
 #include <pthread.h>
 #include "queue_linked_op.h"
 #include "rbtree_op.h"
@@ -56,7 +57,7 @@ typedef struct w_indexed_queue {
     pthread_cond_t available;           ///< Condition variable when queue is empty
     pthread_cond_t available_not_full;  ///< Condition variable when queue is full
     size_t max_size;                    ///< Maximum size (0 = unlimited)
-    size_t current_size;                ///< Current number of elements
+    _Atomic size_t current_size;        ///< Current number of elements
     void (*dispose)(void *);            ///< Function to dispose data elements
 } w_indexed_queue_t;
 

--- a/src/headers/indexed_queue_op.h
+++ b/src/headers/indexed_queue_op.h
@@ -145,7 +145,7 @@ int indexed_queue_upsert(w_indexed_queue_t *queue, const char *key, void *data);
  * @param queue The indexed queue
  * @param key Key for the element
  * @param data Data to insert or update
- * @return 0 on success, -1 on error
+ * @return 1 if updated, 0 if inserted, -1 on error
  */
 int indexed_queue_upsert_ex(w_indexed_queue_t *queue, const char *key, void *data);
 

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -51,7 +51,7 @@ typedef struct _keyentry {
     char *raw_key;
     char *encryption_key;
     char *name;
-    _Atomic (bool) is_startup;
+    _Atomic (bool) post_startup;
 
     ino_t inode;
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -382,7 +382,7 @@ WriteAgent()
         fi
       fi
     fi
-    echo "    <notify_time>10</notify_time>" >> $NEWCONFIG
+    echo "    <notify_time>20</notify_time>" >> $NEWCONFIG
     echo "    <time-reconnect>60</time-reconnect>" >> $NEWCONFIG
     echo "    <auto_restart>yes</auto_restart>" >> $NEWCONFIG
     echo "    <crypto_method>aes</crypto_method>" >> $NEWCONFIG

--- a/src/monitord/monitord.c
+++ b/src/monitord/monitord.c
@@ -186,7 +186,7 @@ int MonitordConfig(const char *cfg, monitor_config *mond, int no_agents, short d
     mond->emailidsname = NULL;
 
     /* Setting default agent's global configuration */
-    mond->global.agents_disconnection_time = 600;
+    mond->global.agents_disconnection_time = 900;
     mond->global.agents_disconnection_alert_time = 0;
 
     modules |= CREPORTS;

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -96,7 +96,7 @@ int OS_AddKey(keystore *keys, const char *id, const char *name, const char *ip, 
     os_strdup(name, keys->keyentries[keys->keysize]->name);
 
     /* Initialize the variables */
-    keys->keyentries[keys->keysize]->is_startup = false;
+    keys->keyentries[keys->keysize]->post_startup = false;
     keys->keyentries[keys->keysize]->rcvd = 0;
     keys->keyentries[keys->keysize]->local = 0;
     keys->keyentries[keys->keysize]->keyid = keys->keysize;
@@ -657,7 +657,7 @@ keyentry * OS_DupKeyEntry(const keyentry * key) {
 
     os_calloc(1, sizeof(keyentry), copy);
 
-    copy->is_startup = key->is_startup;
+    copy->post_startup = key->post_startup;
     copy->rcvd = key->rcvd;
     copy->local = key->local;
     copy->keyid = key->keyid;

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -47,7 +47,7 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     send_timeout_to_retry = getDefine_Int("remoted", "send_timeout_to_retry", 1, 60);
 
     /* Setting default values for global parameters */
-    cfg->global.agents_disconnection_time = 600;
+    cfg->global.agents_disconnection_time = 900;
     cfg->global.agents_disconnection_alert_time = 0;
 
     if (ReadConfig(modules, cfgfile, cfg, NULL) < 0 ||

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -248,9 +248,8 @@ void free_file_time(void *data) {
 /* Pre process control message and return whether it should be queued for wdb processing
  * Returns: 1 if message should be queued, 0 if not, -1 on error
  */
-int pre_preprocess_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown)
+int validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown)
 {
-    char *msg = NULL;
     char *end = NULL;
     char msg_ack[OS_FLSIZE + 1] = "";
 
@@ -329,7 +328,6 @@ int pre_preprocess_control_msg(const keyentry * key, char *r_msg, size_t msg_len
         }
     } else {
         /* Clean msg and shared files (remove random string) */
-        msg = clean;
 
         if ((clean = strchr(clean, '\n'))) {
             /* Forward to random string (pass shared files) */
@@ -358,7 +356,7 @@ int pre_preprocess_control_msg(const keyentry * key, char *r_msg, size_t msg_len
  * wait_for_msgs (other thread) is going to deal with it
  * (only if message changed)
  */
-void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown)
+void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown)
 {
     char *msg = NULL;
     char *end = NULL;
@@ -372,7 +370,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
     int result = 0;
 
     // Process only database-related operations here
-    // All validation and ACK sending was done in pre_preprocess_control_msg
+    // All validation and ACK sending was done in validate_control_msg
     // Parameters is_startup and is_shutdown come from validation results
 
     if (is_startup) {

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -356,7 +356,7 @@ int validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, c
  * wait_for_msgs (other thread) is going to deal with it
  * (only if message changed)
  */
-void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown)
+void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *post_startup, int is_startup, int is_shutdown)
 {
     char *msg = NULL;
     char *end = NULL;
@@ -418,9 +418,9 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *sta
     if (data = OSHash_Get(pending_data, key->id), data && data->changed && data->message && msg && strcmp(data->message, msg) == 0) {
         w_mutex_unlock(&lastmsg_mutex);
 
-        char *sync_status = logr.worker_node ? (*startup_msg ? "syncreq" : "syncreq_keepalive") : "synced";
+        char *sync_status = logr.worker_node ? (*post_startup ? "syncreq" : "syncreq_keepalive") : "synced";
 
-        *startup_msg = false;
+        *post_startup = false;
 
         agent_id = atoi(key->id);
 
@@ -444,7 +444,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *sta
         if (is_startup) {
             w_mutex_unlock(&lastmsg_mutex);
 
-            *startup_msg = true;
+            *post_startup = true;
 
             agent_id = atoi(key->id);
 
@@ -560,9 +560,9 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *sta
 
             agent_data->id = atoi(key->id);
             os_strdup(AGENT_CS_ACTIVE, agent_data->connection_status);
-            os_strdup(logr.worker_node ? (*startup_msg ? "syncreq" : "syncreq_keepalive") : "synced", agent_data->sync_status);
+            os_strdup(logr.worker_node ? (*post_startup ? "syncreq" : "syncreq_keepalive") : "synced", agent_data->sync_status);
 
-            *startup_msg = false;
+            *post_startup = false;
 
             w_mutex_lock(&lastmsg_mutex);
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -390,7 +390,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *sta
                         return;
                     }
                 } else {
-                    merror("Error getting version from agent '%s'", key->id);
+                    mwarn("Unable to get version from agent '%s' on startup message", key->id);
                     send_wrong_version_response(key->id, HC_RETRIEVE_VERSION, ERR_VERSION_RECV, NULL, wdb_sock);
                     cJSON_Delete(agent_info);
                     return;

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -325,6 +325,31 @@ int validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, c
             rem_inc_recv_ctrl_shutdown(key->id);
             void *deleted = OSHash_Delete_ex(agent_data_hash, key->id);
             os_free(deleted);
+
+            /* Generate alert for shutdown */
+            char srcmsg[OS_SIZE_256];
+            char msg[OS_SIZE_1024];
+
+            memset(srcmsg, '\0', OS_SIZE_256);
+            memset(msg, '\0', OS_SIZE_1024);
+
+            snprintf(srcmsg, OS_SIZE_256, "[%s] (%s) %s", key->id, key->name, key->ip->ip);
+            snprintf(msg, OS_SIZE_1024, AG_STOP_MSG, key->name, key->ip->ip);
+
+            /* Send stopped message */
+            if (SendMSG(logr.m_queue, msg, srcmsg, SECURE_MQ) < 0) {
+                merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+
+                // Try to reconnect infinitely
+                logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
+
+                minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
+
+                if (SendMSG(logr.m_queue, msg, srcmsg, SECURE_MQ) < 0) {
+                    // Something went wrong sending a message after an immediate reconnection...
+                    merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+                }
+            }
         }
     } else {
         /* Clean msg and shared files (remove random string) */
@@ -462,31 +487,6 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *pos
 
             if (OS_SUCCESS != result) {
                 mwarn("Unable to set connection status as disconnected for agent: %s", key->id);
-            } else {
-                /* Generate alert */
-                char srcmsg[OS_SIZE_256];
-                char msg[OS_SIZE_1024];
-
-                memset(srcmsg, '\0', OS_SIZE_256);
-                memset(msg, '\0', OS_SIZE_1024);
-
-                snprintf(srcmsg, OS_SIZE_256, "[%s] (%s) %s", key->id, key->name, key->ip->ip);
-                snprintf(msg, OS_SIZE_1024, AG_STOP_MSG, key->name, key->ip->ip);
-
-                /* Send stopped message */
-                if (SendMSG(logr.m_queue, msg, srcmsg, SECURE_MQ) < 0) {
-                    merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-
-                    // Try to reconnect infinitely
-                    logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
-
-                    minfo("Successfully reconnected to '%s'", DEFAULTQUEUE);
-
-                    if (SendMSG(logr.m_queue, msg, srcmsg, SECURE_MQ) < 0) {
-                        // Something went wrong sending a message after an immediate reconnection...
-                        merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-                    }
-                }
             }
         } else {
             /* Update message */

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -97,10 +97,10 @@ void *wait_for_msgs(void *none);
 void *update_shared_files(void *none);
 
 /* Save control messages */
-void save_controlmsg(const keyentry * key, char *msg, size_t msg_length, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown);
+void save_controlmsg(const keyentry * key, char *msg, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown);
 
 /* Pre process control message and return whether it should be queued for wdb processing */
-int pre_preprocess_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown);
+int validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown);
 
 /* Assign a group to an agent without group */
 cJSON *assign_group_to_agent(const char *agent_id, const char *md5);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -97,7 +97,10 @@ void *wait_for_msgs(void *none);
 void *update_shared_files(void *none);
 
 /* Save control messages */
-void save_controlmsg(const keyentry * key, char *msg, size_t msg_length, int *wdb_sock, bool *startup_msg);
+void save_controlmsg(const keyentry * key, char *msg, size_t msg_length, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown);
+
+/* Pre process control message and return whether it should be queued for wdb processing */
+int pre_preprocess_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown);
 
 /* Assign a group to an agent without group */
 cJSON *assign_group_to_agent(const char *agent_id, const char *md5);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -98,7 +98,7 @@ void *wait_for_msgs(void *none);
 void *update_shared_files(void *none);
 
 /* Save control messages */
-void save_controlmsg(const keyentry * key, char *msg, int *wdb_sock, bool *startup_msg, int is_startup, int is_shutdown);
+void save_controlmsg(const keyentry * key, char *msg, int *wdb_sock, bool *post_startup, int is_startup, int is_shutdown);
 
 /* Pre process control message and return whether it should be queued for wdb processing */
 int validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -20,6 +20,7 @@
 #include "../config/global-config.h"
 #include "../os_crypto/md5/md5_op.h"
 #include "sec.h"
+#include "indexed_queue_op.h"
 
 #define FD_LIST_INIT_VALUE 1024
 #define REMOTED_MSG_HEADER "1:" ARGV0 ":"
@@ -192,6 +193,7 @@ size_t rem_getCounter(int fd);
 
 extern keystore keys;
 extern remoted logr;
+extern w_indexed_queue_t *control_msg_queue;
 extern char* node_name;
 extern int timeout;
 extern int pass_empty_keyfile;

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -75,7 +75,7 @@ static void * rem_handler_main(void * args);
 void * rem_keyupdate_main(__attribute__((unused)) void * args);
 
 /* Handle each message received */
-STATIC void HandleSecureMessage(const message_t *message, w_linked_queue_t * control_msg_queue);
+STATIC void HandleSecureMessage(const message_t *message, w_queue_t * control_msg_queue);
 
 // Close and remove socket from keystore
 int _close_sock(keystore * keys, int sock);
@@ -128,6 +128,25 @@ typedef struct {
 } w_ctrl_msg_data_t;
 
 /**
+ * @brief Free control message data
+ *
+ * @param ptr_ctrl_msg_data Pointer to the control message data to be freed
+ * @warning The ctrl_msg_data pointer will be invalid after this function call.
+ */
+static void w_free_ctrl_msg_data(w_ctrl_msg_data_t * ctrl_msg_data) {
+
+    if (ctrl_msg_data == NULL) {
+        return;
+    }
+
+    if (ctrl_msg_data->key) {
+        OS_FreeKey(ctrl_msg_data->key);
+    }
+    os_free(ctrl_msg_data->message);
+    os_free(ctrl_msg_data);
+}
+
+/**
  * @brief Thread function to save control messages
  *
  * This function is executed by the control message thread pool. It waits for messages to be pushed into the queue and processes them.
@@ -144,7 +163,9 @@ void HandleSecure()
     const int protocol = logr.proto[logr.position];
     int n_events = 0;
 
-    w_linked_queue_t * control_msg_queue = linked_queue_init(); ///< Pointer to the control message queue
+
+    size_t ctrl_msg_queue_size = (size_t) getDefine_Int("remoted", "control_msg_queue_size", 4096, 0x1 << 20); // 1MB
+    w_queue_t * control_msg_queue = queue_init(ctrl_msg_queue_size);
 
     struct sockaddr_storage peer_info;
     memset(&peer_info, 0, sizeof(struct sockaddr_storage));
@@ -437,7 +458,7 @@ STATIC void handle_outgoing_data_to_tcp_socket(int sock_client)
 // Message handler thread
 void * rem_handler_main(void * args) {
     message_t * message;
-    w_linked_queue_t * control_msg_queue = (w_linked_queue_t *) args;
+    w_queue_t * control_msg_queue = (w_queue_t *) args;
     mdebug1("Message handler thread started.");
 
     while (1) {
@@ -512,7 +533,7 @@ STATIC void * close_fp_main(void * args) {
     return NULL;
 }
 
-STATIC void HandleSecureMessage(const message_t *message, w_linked_queue_t * control_msg_queue) {
+STATIC void HandleSecureMessage(const message_t *message, w_queue_t * control_msg_queue) {
     int agentid;
     const int protocol = (message->sock == USING_UDP_NO_CLIENT_SOCKET) ? REMOTED_NET_PROTOCOL_UDP : REMOTED_NET_PROTOCOL_TCP;
     char cleartext_msg[OS_MAXSTR + 1];
@@ -811,10 +832,14 @@ STATIC void HandleSecureMessage(const message_t *message, w_linked_queue_t * con
                 os_calloc(msg_length, sizeof(char), ctrl_msg_data->message);
                 memcpy(ctrl_msg_data->message, tmp_msg, ctrl_msg_data->length);
 
-                linked_queue_push_ex(control_msg_queue, ctrl_msg_data);
+                if (queue_push_ex(control_msg_queue, ctrl_msg_data) == 0) {
+                    rem_inc_ctrl_msg_queue_usage();
+                    mdebug2("Control message pushed to queue.");
+                } else {
+                    mwarn("Control message queue is full. Discarding control message for agent ID '%s'.", ctrl_msg_data->key->id);
+                    w_free_ctrl_msg_data(ctrl_msg_data);
+                }
 
-                rem_inc_ctrl_msg_queue_usage();
-                mdebug2("Control message pushed to queue.");
             }
 
         } else {
@@ -1057,12 +1082,12 @@ void *current_timestamp(__attribute__((unused)) void *none)
 void * save_control_thread(void * control_msg_queue)
 {
     assert(control_msg_queue != NULL);
-    w_linked_queue_t * queue = (w_linked_queue_t *)control_msg_queue;
+    w_queue_t * queue = (w_queue_t *)control_msg_queue;
     w_ctrl_msg_data_t * ctrl_msg_data = NULL;
     int wdb_sock = -1;
 
     while (FOREVER()) {
-        if ((ctrl_msg_data = (w_ctrl_msg_data_t *)linked_queue_pop_ex(queue))) {
+        if ((ctrl_msg_data = (w_ctrl_msg_data_t *)queue_pop_ex(queue))) {
 
             rem_dec_ctrl_msg_queue_usage();
 
@@ -1078,10 +1103,7 @@ void * save_control_thread(void * control_msg_queue)
                 key_unlock();
             }
 
-            // Free the key entry
-            OS_FreeKey(ctrl_msg_data->key);
-            os_free(ctrl_msg_data->message);
-            os_free(ctrl_msg_data);
+            w_free_ctrl_msg_data(ctrl_msg_data);
         }
     }
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -822,7 +822,7 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
 
             // Update keystore startup status immediately after validation
             if (is_startup) {
-                keys.keyentries[agentid]->is_startup = true;
+                keys.keyentries[agentid]->post_startup = true;
             }
 
             key_unlock();
@@ -1136,20 +1136,20 @@ void * save_control_thread(void * control_msg_queue)
         if ((ctrl_msg_data = (w_ctrl_msg_data_t *)indexed_queue_pop_ex(queue))) {
             rem_inc_ctrl_queue_processed();
 
-            bool is_startup = ctrl_msg_data->key->is_startup;
+            bool post_startup = ctrl_msg_data->key->post_startup;
 
             // Process the control message with the validation results
             save_controlmsg(ctrl_msg_data->key, ctrl_msg_data->message,
-                          &wdb_sock, &is_startup, ctrl_msg_data->is_startup, ctrl_msg_data->is_shutdown);
+                          &wdb_sock, &post_startup, ctrl_msg_data->is_startup, ctrl_msg_data->is_shutdown);
 
             // Update startup flag after processing the first keepalive post-startup
-            if (ctrl_msg_data->key->is_startup != is_startup) {
+            if (ctrl_msg_data->key->post_startup != post_startup) {
                 key_lock_read();
 
                 // Use efficient tree lookup to find the key index
                 int key_index = OS_IsAllowedID(&keys, ctrl_msg_data->key->id);
                 if (key_index >= 0 && key_index < (int)keys.keysize) {
-                    keys.keyentries[key_index]->is_startup = is_startup;
+                    keys.keyentries[key_index]->post_startup = post_startup;
                 }
 
                 key_unlock();

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -848,11 +848,14 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
                 // Create key based on agent_id for indexing
                 char agent_key[32];
                 snprintf(agent_key, sizeof(agent_key), "%d", agentid);
-                
+
                 // Use upsert to allow updating existing control messages for the same agent
-                if (indexed_queue_upsert_ex(control_msg_queue, agent_key, ctrl_msg_data) == 0) {
+                int res = indexed_queue_upsert_ex(control_msg_queue, agent_key, ctrl_msg_data);
+                if (res == 1) {
+                    mdebug2("Control message updated in queue for agent ID '%s'.", agent_key);
+                } else if (res == 0) {
+                    mdebug2("Control message pushed in queue for agent ID '%s'.", agent_key);
                     rem_inc_ctrl_msg_queue_usage();
-                    mdebug2("Control message pushed/updated in queue for agent ID '%s'.", agent_key);
                 } else {
                     mwarn("Failed to insert control message for agent ID '%s'.", agent_key);
                     w_free_ctrl_msg_data(ctrl_msg_data);

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -206,11 +206,17 @@ int rem_write_state() {
         "\n"
         "# Control messages queue usage\n"
         "ctrl_msg_queue_usage='%zu'\n"
+        "\n"
+        "# Control messages queue breakdown\n"
+        "ctrl_msg_queue_inserted='%u'\n"
+        "ctrl_msg_queue_replaced='%u'\n"
+        "ctrl_msg_queue_processed='%u'\n"
         "\n",
         __local_name, refresh_time, rem_get_qsize(), rem_get_tsize(), state_cpy.tcp_sessions,
         state_cpy.recv_breakdown.evt_count, state_cpy.recv_breakdown.ctrl_count, state_cpy.recv_breakdown.discarded_count,
         state_cpy.sent_bytes, state_cpy.recv_bytes, state_cpy.recv_breakdown.dequeued_count,
-        control_msg_queue ? indexed_queue_size(control_msg_queue) : 0);
+        control_msg_queue ? indexed_queue_size(control_msg_queue) : 0,
+        state_cpy.ctrl_queue_breakdown.inserted_count, state_cpy.ctrl_queue_breakdown.replaced_count, state_cpy.ctrl_queue_breakdown.processed_count);
 
     fclose(fp);
 
@@ -537,6 +543,24 @@ void rem_inc_keys_reload() {
     w_mutex_unlock(&state_mutex);
 }
 
+void rem_inc_ctrl_queue_inserted() {
+    w_mutex_lock(&state_mutex);
+    remoted_state.ctrl_queue_breakdown.inserted_count++;
+    w_mutex_unlock(&state_mutex);
+}
+
+void rem_inc_ctrl_queue_replaced() {
+    w_mutex_lock(&state_mutex);
+    remoted_state.ctrl_queue_breakdown.replaced_count++;
+    w_mutex_unlock(&state_mutex);
+}
+
+void rem_inc_ctrl_queue_processed() {
+    w_mutex_lock(&state_mutex);
+    remoted_state.ctrl_queue_breakdown.processed_count++;
+    w_mutex_unlock(&state_mutex);
+}
+
 cJSON* rem_create_state_json() {
     remoted_state_t state_cpy;
 
@@ -607,6 +631,13 @@ cJSON* rem_create_state_json() {
     cJSON_AddNumberToObject(_metrics, "tcp_sessions", state_cpy.tcp_sessions);
 
     cJSON_AddNumberToObject(_metrics, "control_messages_queue_usage", control_msg_queue ? indexed_queue_size(control_msg_queue) : 0);
+
+    cJSON *_ctrl_queue_breakdown = cJSON_CreateObject();
+    cJSON_AddItemToObject(_metrics, "control_messages_queue_breakdown", _ctrl_queue_breakdown);
+
+    cJSON_AddNumberToObject(_ctrl_queue_breakdown, "inserted", state_cpy.ctrl_queue_breakdown.inserted_count);
+    cJSON_AddNumberToObject(_ctrl_queue_breakdown, "replaced", state_cpy.ctrl_queue_breakdown.replaced_count);
+    cJSON_AddNumberToObject(_ctrl_queue_breakdown, "processed", state_cpy.ctrl_queue_breakdown.processed_count);
 
     return rem_state_json;
 }

--- a/src/remoted/state.h
+++ b/src/remoted/state.h
@@ -50,7 +50,6 @@ typedef struct _remoted_state_t {
     uint64_t sent_bytes;
     uint32_t tcp_sessions;
     uint32_t keys_reload_count;
-    uint32_t ctrl_msg_queue_usage;
     recv_msgs_t recv_breakdown;
     sent_msgs_t sent_breakdown;
 } remoted_state_t;
@@ -85,15 +84,6 @@ void rem_inc_tcp();
  */
 void rem_dec_tcp();
 
-/**
- * @brief Increment control message queue usage
- */
-void rem_inc_ctrl_msg_queue_usage();
-
-/**
- * @brief Decrement control message queue usage
- */
-void rem_dec_ctrl_msg_queue_usage();
 
 /**
  * @brief Increment bytes received

--- a/src/remoted/state.h
+++ b/src/remoted/state.h
@@ -35,6 +35,12 @@ typedef struct _recv_msgs_t {
     ctrl_msgs_t ctrl_breakdown;
 } recv_msgs_t;
 
+typedef struct _ctrl_queue_breakdown_t {
+    uint32_t inserted_count;     // New messages inserted into queue
+    uint32_t replaced_count;     // Messages replaced/updated in queue  
+    uint32_t processed_count;    // Messages processed from queue
+} ctrl_queue_breakdown_t;
+
 typedef struct _sent_msgs_t {
     uint64_t ack_count;
     uint64_t shared_count;
@@ -52,6 +58,7 @@ typedef struct _remoted_state_t {
     uint32_t keys_reload_count;
     recv_msgs_t recv_breakdown;
     sent_msgs_t sent_breakdown;
+    ctrl_queue_breakdown_t ctrl_queue_breakdown;
 } remoted_state_t;
 
 typedef struct _remoted_agent_state_t {
@@ -193,6 +200,21 @@ void rem_inc_send_discarded(const char *agent_id);
  * @brief Increment keys reload counter
  */
 void rem_inc_keys_reload();
+
+/**
+ * @brief Increment control message queue inserted counter
+ */
+void rem_inc_ctrl_queue_inserted();
+
+/**
+ * @brief Increment control message queue replaced counter
+ */
+void rem_inc_ctrl_queue_replaced();
+
+/**
+ * @brief Increment control message queue processed counter
+ */
+void rem_inc_ctrl_queue_processed();
 
 /**
  * @brief Create a JSON object with all the remoted state information

--- a/src/shared/indexed_queue_op.c
+++ b/src/shared/indexed_queue_op.c
@@ -1,0 +1,465 @@
+/**
+ * @file indexed_queue_op.c
+ * @brief Indexed Queue implementation
+ * @date 2025-08-08
+ *
+ * @copyright Copyright (C) 2015 Wazuh, Inc.
+ */
+
+/*
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include "indexed_queue_op.h"
+#include "shared.h"
+
+static void indexed_queue_entry_free(void *entry_ptr) {
+    w_indexed_queue_entry_t *entry = (w_indexed_queue_entry_t *)entry_ptr;
+    if (entry) {
+        free(entry->key);
+        free(entry);
+    }
+}
+
+w_indexed_queue_t *indexed_queue_init(size_t max_size) {
+    w_indexed_queue_t *queue = calloc(1, sizeof(w_indexed_queue_t));
+    if (!queue) {
+        return NULL;
+    }
+
+    queue->queue = linked_queue_init();
+    if (!queue->queue) {
+        free(queue);
+        return NULL;
+    }
+
+    queue->index = rbtree_init();
+    if (!queue->index) {
+        linked_queue_free(queue->queue);
+        free(queue);
+        return NULL;
+    }
+
+    rbtree_set_dispose(queue->index, indexed_queue_entry_free);
+
+    if (pthread_mutex_init(&queue->mutex, NULL) != 0) {
+        rbtree_destroy(queue->index);
+        linked_queue_free(queue->queue);
+        free(queue);
+        return NULL;
+    }
+
+    if (pthread_cond_init(&queue->available, NULL) != 0) {
+        pthread_mutex_destroy(&queue->mutex);
+        rbtree_destroy(queue->index);
+        linked_queue_free(queue->queue);
+        free(queue);
+        return NULL;
+    }
+
+    if (pthread_cond_init(&queue->available_not_full, NULL) != 0) {
+        pthread_cond_destroy(&queue->available);
+        pthread_mutex_destroy(&queue->mutex);
+        rbtree_destroy(queue->index);
+        linked_queue_free(queue->queue);
+        free(queue);
+        return NULL;
+    }
+
+    queue->max_size = max_size;
+    queue->current_size = 0;
+    queue->dispose = NULL;
+
+    return queue;
+}
+
+void indexed_queue_free(w_indexed_queue_t *queue) {
+    if (!queue) {
+        return;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+
+    // Free all remaining data if dispose function is set
+    if (queue->dispose) {
+        void *data;
+        while ((data = linked_queue_pop(queue->queue)) != NULL) {
+            queue->dispose(data);
+        }
+    } else {
+        // Just empty the queue
+        while (linked_queue_pop(queue->queue) != NULL) {
+            // Do nothing, just remove elements
+        }
+    }
+
+    pthread_mutex_unlock(&queue->mutex);
+
+    rbtree_destroy(queue->index);
+    linked_queue_free(queue->queue);
+    pthread_cond_destroy(&queue->available_not_full);
+    pthread_cond_destroy(&queue->available);
+    pthread_mutex_destroy(&queue->mutex);
+    free(queue);
+}
+
+void indexed_queue_set_dispose(w_indexed_queue_t *queue, void (*dispose)(void *)) {
+    if (queue) {
+        pthread_mutex_lock(&queue->mutex);
+        queue->dispose = dispose;
+        pthread_mutex_unlock(&queue->mutex);
+    }
+}
+
+int indexed_queue_empty(const w_indexed_queue_t *queue) {
+    return queue ? (queue->current_size == 0) : 1;
+}
+
+int indexed_queue_full(const w_indexed_queue_t *queue) {
+    if (!queue || queue->max_size == 0) {
+        return 0; // Unlimited size
+    }
+    return queue->current_size >= queue->max_size;
+}
+
+size_t indexed_queue_size(const w_indexed_queue_t *queue) {
+    return queue ? queue->current_size : 0;
+}
+
+int indexed_queue_push(w_indexed_queue_t *queue, const char *key, void *data) {
+    if (!queue || !key || !data) {
+        return -1;
+    }
+
+    // Check if queue is full
+    if (indexed_queue_full(queue)) {
+        return -1;
+    }
+
+    // Check if key already exists
+    if (rbtree_get(queue->index, key) != NULL) {
+        return -1; // Key already exists
+    }
+
+    // Create entry
+    w_indexed_queue_entry_t *entry = malloc(sizeof(w_indexed_queue_entry_t));
+    if (!entry) {
+        return -1;
+    }
+
+    entry->key = strdup(key);
+    if (!entry->key) {
+        free(entry);
+        return -1;
+    }
+    entry->data = data;
+
+    // Add to queue
+    entry->queue_node = linked_queue_push(queue->queue, data);
+    if (!entry->queue_node) {
+        free(entry->key);
+        free(entry);
+        return -1;
+    }
+
+    // Add to index
+    if (!rbtree_insert(queue->index, key, entry)) {
+        // This shouldn't happen since we checked above, but cleanup anyway
+        linked_queue_pop(queue->queue); // Remove from queue
+        free(entry->key);
+        free(entry);
+        return -1;
+    }
+
+    atomic_fetch_add(&queue->current_size, 1);
+    return 0;
+}
+
+int indexed_queue_push_ex(w_indexed_queue_t *queue, const char *key, void *data) {
+    if (!queue || !key || !data) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+
+    // Wait if queue is full
+    while (indexed_queue_full(queue)) {
+        pthread_cond_wait(&queue->available_not_full, &queue->mutex);
+    }
+
+    int result = indexed_queue_push(queue, key, data);
+    if (result == 0) {
+        pthread_cond_signal(&queue->available);
+    }
+
+    pthread_mutex_unlock(&queue->mutex);
+    return result;
+}
+
+int indexed_queue_upsert(w_indexed_queue_t *queue, const char *key, void *data) {
+    if (!queue || !key || !data) {
+        return -1;
+    }
+
+    w_indexed_queue_entry_t *entry = rbtree_get(queue->index, key);
+    if (entry) {
+        // Update existing entry
+        if (queue->dispose) {
+            queue->dispose(entry->data);
+        }
+        entry->data = data;
+        // Update the queue node data too
+        entry->queue_node->data = data;
+        return 0;
+    } else {
+        // Insert new entry
+        return indexed_queue_push(queue, key, data);
+    }
+}
+
+int indexed_queue_upsert_ex(w_indexed_queue_t *queue, const char *key, void *data) {
+    if (!queue || !key || !data) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+
+    w_indexed_queue_entry_t *entry = rbtree_get(queue->index, key);
+    if (entry) {
+        // Update existing entry
+        if (queue->dispose) {
+            queue->dispose(entry->data);
+        }
+        entry->data = data;
+        entry->queue_node->data = data;
+        pthread_mutex_unlock(&queue->mutex);
+        return 0;
+    } else {
+        // Wait if queue is full for new insertions
+        while (indexed_queue_full(queue)) {
+            pthread_cond_wait(&queue->available_not_full, &queue->mutex);
+        }
+
+        int result = indexed_queue_push(queue, key, data);
+        if (result == 0) {
+            pthread_cond_signal(&queue->available);
+        }
+
+        pthread_mutex_unlock(&queue->mutex);
+        return result;
+    }
+}
+
+void *indexed_queue_get(const w_indexed_queue_t *queue, const char *key) {
+    if (!queue || !key) {
+        return NULL;
+    }
+
+    w_indexed_queue_entry_t *entry = rbtree_get(queue->index, key);
+    return entry ? entry->data : NULL;
+}
+
+void *indexed_queue_get_ex(w_indexed_queue_t *queue, const char *key) {
+    if (!queue || !key) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+    void *data = indexed_queue_get(queue, key);
+    pthread_mutex_unlock(&queue->mutex);
+    return data;
+}
+
+void *indexed_queue_peek(const w_indexed_queue_t *queue) {
+    if (!queue || indexed_queue_empty(queue)) {
+        return NULL;
+    }
+
+    // Peek at the first element in the queue
+    if (queue->queue->first) {
+        return queue->queue->first->data;
+    }
+    return NULL;
+}
+
+void *indexed_queue_peek_ex(w_indexed_queue_t *queue) {
+    if (!queue) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+    void *data = indexed_queue_peek(queue);
+    pthread_mutex_unlock(&queue->mutex);
+    return data;
+}
+
+void *indexed_queue_pop(w_indexed_queue_t *queue) {
+    if (!queue || indexed_queue_empty(queue)) {
+        return NULL;
+    }
+
+    // Pop from queue
+    void *data = linked_queue_pop(queue->queue);
+    if (!data) {
+        return NULL;
+    }
+
+    // Find and remove from index
+    // We need to find which key corresponds to this data
+    // This is inefficient, but necessary for this design
+    char **keys = rbtree_keys(queue->index);
+    if (keys) {
+        for (int i = 0; keys[i]; i++) {
+            w_indexed_queue_entry_t *entry = rbtree_get(queue->index, keys[i]);
+            if (entry && entry->data == data) {
+                rbtree_delete(queue->index, keys[i]);
+                break;
+            }
+        }
+        // Free keys array
+        for (int i = 0; keys[i]; i++) {
+            free(keys[i]);
+        }
+        free(keys);
+    }
+
+    atomic_fetch_sub(&queue->current_size, 1);
+    return data;
+}
+
+void *indexed_queue_pop_ex(w_indexed_queue_t *queue) {
+    if (!queue) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+
+    while (indexed_queue_empty(queue)) {
+        pthread_cond_wait(&queue->available, &queue->mutex);
+    }
+
+    void *data = indexed_queue_pop(queue);
+    pthread_cond_signal(&queue->available_not_full);
+
+    pthread_mutex_unlock(&queue->mutex);
+    return data;
+}
+
+void *indexed_queue_pop_ex_timedwait(w_indexed_queue_t *queue, const struct timespec *abstime) {
+    if (!queue) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+
+    while (indexed_queue_empty(queue)) {
+        int result = pthread_cond_timedwait(&queue->available, &queue->mutex, abstime);
+        if (result == ETIMEDOUT) {
+            pthread_mutex_unlock(&queue->mutex);
+            return NULL;
+        }
+        if (result != 0) {
+            pthread_mutex_unlock(&queue->mutex);
+            return NULL;
+        }
+    }
+
+    void *data = indexed_queue_pop(queue);
+    pthread_cond_signal(&queue->available_not_full);
+
+    pthread_mutex_unlock(&queue->mutex);
+    return data;
+}
+
+int indexed_queue_delete(w_indexed_queue_t *queue, const char *key) {
+    if (!queue || !key) {
+        return 0;
+    }
+
+    w_indexed_queue_entry_t *entry = rbtree_get(queue->index, key);
+    if (!entry) {
+        return 0; // Key not found
+    }
+
+    // Remove from queue by unlinking the node
+    // We need to manually unlink since we have the node reference
+    w_linked_queue_node_t *node = entry->queue_node;
+    if (node->prev) {
+        node->prev->next = node->next;
+    } else {
+        // This was the first node
+        queue->queue->first = node->next;
+    }
+
+    if (node->next) {
+        node->next->prev = node->prev;
+    } else {
+        // This was the last node
+        queue->queue->last = node->prev;
+    }
+
+    queue->queue->elements--;
+
+    // Dispose data if function is set
+    if (queue->dispose) {
+        queue->dispose(entry->data);
+    }
+
+    // Free the queue node
+    free(node);
+
+    // Remove from index (this will also free the entry)
+    rbtree_delete(queue->index, key);
+
+    atomic_fetch_sub(&queue->current_size, 1);
+    return 1;
+}
+
+int indexed_queue_delete_ex(w_indexed_queue_t *queue, const char *key) {
+    if (!queue || !key) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+    int result = indexed_queue_delete(queue, key);
+    if (result) {
+        pthread_cond_signal(&queue->available_not_full);
+    }
+    pthread_mutex_unlock(&queue->mutex);
+    return result;
+}
+
+void *indexed_queue_update(w_indexed_queue_t *queue, const char *key, void *data) {
+    if (!queue || !key || !data) {
+        return NULL;
+    }
+
+    w_indexed_queue_entry_t *entry = rbtree_get(queue->index, key);
+    if (!entry) {
+        return NULL; // Key not found
+    }
+
+    void *old_data = entry->data;
+    entry->data = data;
+    entry->queue_node->data = data;
+
+    return old_data;
+}
+
+void *indexed_queue_update_ex(w_indexed_queue_t *queue, const char *key, void *data) {
+    if (!queue || !key || !data) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&queue->mutex);
+    void *old_data = indexed_queue_update(queue, key, data);
+    pthread_mutex_unlock(&queue->mutex);
+    return old_data;
+}

--- a/src/shared/indexed_queue_op.c
+++ b/src/shared/indexed_queue_op.c
@@ -240,7 +240,7 @@ int indexed_queue_upsert_ex(w_indexed_queue_t *queue, const char *key, void *dat
         entry->data = data;
         entry->queue_node->data = data;
         pthread_mutex_unlock(&queue->mutex);
-        return 0;
+        return 1;
     } else {
         // Wait if queue is full for new insertions
         while (indexed_queue_full(queue)) {

--- a/src/unit_tests/monitord/test_monitord.c
+++ b/src/unit_tests/monitord/test_monitord.c
@@ -475,7 +475,7 @@ void test_MonitordConfig_success(void **state) {
     result = MonitordConfig(cfg, &mond, no_agents, day_wait);
 
     assert_int_equal(result, OS_SUCCESS);
-    assert_int_equal(mond.global.agents_disconnection_time, 600);
+    assert_int_equal(mond.global.agents_disconnection_time, 900);
     assert_int_equal(mond.global.agents_disconnection_alert_time, 0);
 
     assert_null(mond.agents);

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -80,7 +80,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
                             -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,remove \
-                            -Wl,--wrap,FOREVER -Wl,--wrap,linked_queue_push_ex  -Wl,--wrap,linked_queue_pop_ex \
+                            -Wl,--wrap,FOREVER -Wl,--wrap,queue_push_ex  -Wl,--wrap,queue_pop_ex \
                             -Wl,--wrap,save_controlmsg")
 
 list(APPEND remoted_names "test_netbuffer")

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -69,7 +69,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,rem_getCounter -Wl,--wrap,rem_inc_recv_ctrl \
                             -Wl,--wrap,rem_inc_recv_unknown -Wl,--wrap,rem_inc_tcp \
                             -Wl,--wrap,rem_msgpush -Wl,--wrap,rem_setCounter -Wl,--wrap,remove \
-                            -Wl,--wrap,save_controlmsg -Wl,--wrap,sleep -Wl,--wrap,stat -Wl,--wrap,time \
+                            -Wl,--wrap,save_controlmsg -Wl,--wrap,validate_control_msg -Wl,--wrap,sleep -Wl,--wrap,stat -Wl,--wrap,time \
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock \
                             -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_evt \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -80,7 +80,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
                             -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fread \
                             -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,remove \
-                            -Wl,--wrap,FOREVER -Wl,--wrap,queue_push_ex  -Wl,--wrap,queue_pop_ex \
+                            -Wl,--wrap,FOREVER -Wl,--wrap,indexed_queue_pop_ex  -Wl,--wrap,indexed_queue_pop_ex \
                             -Wl,--wrap,save_controlmsg")
 
 list(APPEND remoted_names "test_netbuffer")

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -4843,7 +4843,7 @@ void test_save_controlmsg_agent_invalid_version(void** state)
 
     bool is_startup = true;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
     strcpy(r_msg, "agent startup {\"version\":\"v4.6.0\"}");
     snprintf(s_msg,
              OS_FLSIZE,
@@ -4876,7 +4876,7 @@ void test_save_controlmsg_agent_invalid_version(void** state)
 
     expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
 }
@@ -4889,7 +4889,7 @@ void test_save_controlmsg_get_agent_version_fail(void** state)
 
     bool is_startup = true;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
     strcpy(r_msg, "agent startup {\"test\":\"fail\"}");
     snprintf(s_msg, OS_FLSIZE, "%s%s%s%s%s", CONTROL_HEADER, HC_ERROR, "{\"message\":\"", HC_RETRIEVE_VERSION, "\"}");
 
@@ -4912,7 +4912,7 @@ void test_save_controlmsg_get_agent_version_fail(void** state)
     expect_string(__wrap__mwarn, formatted_msg, "Unable to set status code for agent: '001'");
     expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
 }
@@ -4926,7 +4926,7 @@ void test_save_controlmsg_could_not_add_pending_data(void** state)
 
     bool is_startup = false;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
@@ -4948,7 +4948,7 @@ void test_save_controlmsg_could_not_add_pending_data(void** state)
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
 }
@@ -4961,7 +4961,7 @@ void test_save_controlmsg_unable_to_save_last_keepalive(void** state)
 
     bool is_startup = false;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
@@ -4992,7 +4992,7 @@ void test_save_controlmsg_unable_to_save_last_keepalive(void** state)
                   formatted_msg,
                   "Unable to save last keepalive and set connection status as active for agent: 001");
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(data.message);
@@ -5006,7 +5006,7 @@ void test_save_controlmsg_update_msg_error_parsing(void** state)
 
     bool is_startup = false;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
@@ -5064,7 +5064,7 @@ void test_save_controlmsg_update_msg_error_parsing(void** state)
 
     expect_string(__wrap__merror, formatted_msg, "Error parsing message for agent '001'");
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     os_free(agent_data);
     free_keyentry(&key);
@@ -5081,7 +5081,7 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void** state)
 
     bool is_startup = false;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
@@ -5156,7 +5156,7 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void** state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Unable to update information in global.db for agent: 001");
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     os_free(group->name);
     os_free(group);
@@ -5180,7 +5180,7 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 
     bool is_startup = false;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
@@ -5230,7 +5230,7 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Unable to update information in global.db for agent: 001");
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     os_free(agent_data->manager_host);
     os_free(agent_data);
@@ -5250,7 +5250,7 @@ void test_save_controlmsg_startup(void **state)
 
     bool is_startup = true;
     bool is_shutdown = false;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
@@ -5284,7 +5284,7 @@ void test_save_controlmsg_startup(void **state)
     expect_string(__wrap__mwarn, formatted_msg, "Unable to save last keepalive and set connection status as pending for agent: 001");
 
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(message);
@@ -5299,7 +5299,7 @@ void test_save_controlmsg_shutdown(void **state)
 
     bool is_startup = false;
     bool is_shutdown = true;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
@@ -5354,7 +5354,7 @@ void test_save_controlmsg_shutdown(void **state)
     // expect_string(__wrap_OSHash_Delete_ex, key, "001");
     // expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(message);
@@ -5368,7 +5368,7 @@ void test_save_controlmsg_shutdown_wdb_fail(void **state)
 
     bool is_startup = false;
     bool is_shutdown = true;
-    bool startup_msg; // Output parameter for save_controlmsg
+    bool post_startup; // Output parameter for save_controlmsg
 
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
@@ -5402,7 +5402,7 @@ void test_save_controlmsg_shutdown_wdb_fail(void **state)
     // expect_string(__wrap_OSHash_Delete_ex, key, "001");
     // expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
 
-    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(message);

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -4604,7 +4604,7 @@ void test_validate_control_msg_hc_request_success(void** state)
 void test_validate_control_msg_hc_request_error(void** state)
 {
     keyentry key;
-    char* r_msg = strdup("req only_id");
+    char* r_msg = strdup("req ");
     size_t msg_length = strlen(r_msg);
     char* cleaned_msg = NULL;
     int is_startup = 0, is_shutdown = 0;
@@ -4612,7 +4612,7 @@ void test_validate_control_msg_hc_request_error(void** state)
     keyentry_init(&key, "agent1", "001", "192.168.1.1", "test_key");
 
     expect_string(__wrap__merror, formatted_msg, "Request control format error.");
-    expect_string(__wrap__mdebug2, formatted_msg, "r_msg = \"req only_id\"");
+    expect_string(__wrap__mdebug2, formatted_msg, "r_msg = \"req \"");
 
     int result = validate_control_msg(&key, r_msg, msg_length, &cleaned_msg, &is_startup, &is_shutdown);
 
@@ -4749,81 +4749,116 @@ void test_validate_control_msg_invalid_msg(void** state)
     free_keyentry(&key);
 }
 
+void test_validate_control_msg_invalid_msg_2(void** state)
+{
+    keyentry key;
+    char* r_msg = "Invalid message";
+    size_t msg_length = strlen(r_msg);
+    char* cleaned_msg = NULL;
+    int is_startup = 0, is_shutdown = 0;
+
+    keyentry_init(&key, "agent1", "001", "192.168.1.1", "test_key");
+
+    expect_string(__wrap__mwarn, formatted_msg, "Invalid message from agent: 'agent1' (001)");
+
+    int result = validate_control_msg(&key, r_msg, msg_length, &cleaned_msg, &is_startup, &is_shutdown);
+
+    assert_int_equal(result, -1); // Error
+    assert_int_equal(is_startup, 0);
+    assert_int_equal(is_shutdown, 0);
+    assert_non_null(cleaned_msg);
+
+    os_free(cleaned_msg);
+    free_keyentry(&key);
+}
+
+void test_validate_control_msg_invalid_agent_version(void** state)
+{
+    keyentry key;
+    char* r_msg = strdup("agent startup {\"version\":\"v4.6.0\"}");
+    size_t msg_length = strlen(r_msg);
+    char* cleaned_msg = NULL;
+    int is_startup = 99, is_shutdown = 99;
+
+    keyentry_init(&key, "agent1", "001", "192.168.1.1", "test_key");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Agent agent1 sent HC_STARTUP from ''");
+
+    expect_string(__wrap_compare_wazuh_versions, version1, __ossec_version);
+    expect_string(__wrap_compare_wazuh_versions, version2, "v4.6.0");
+    expect_value(__wrap_compare_wazuh_versions, compare_patch, false);
+    will_return(__wrap_compare_wazuh_versions, -1);
+
+    expect_string(__wrap_rem_inc_recv_ctrl_startup, agent_id, "001");
+
+    int result = validate_control_msg(&key, r_msg, msg_length, &cleaned_msg, &is_startup, &is_shutdown);
+
+    assert_int_equal(result, 1); // We need to queue this message, for saving later
+    assert_int_equal(is_startup, 1);
+    assert_non_null(cleaned_msg);
+
+    assert_string_equal(cleaned_msg, "agent startup {\"version\":\"v4.6.0\"}");
+
+    os_free(cleaned_msg);
+    free_keyentry(&key);
+    free(r_msg);
+}
+
+void test_validate_control_msg_get_agent_version_fail(void** state)
+{
+    keyentry key;
+    char* r_msg = strdup("agent startup {\"test\":\"fail\"}");
+    size_t msg_length = strlen(r_msg);
+    char* cleaned_msg = NULL;
+    int is_startup = 99, is_shutdown = 99;
+
+    keyentry_init(&key, "agent1", "001", "192.168.1.1", "test_key");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Agent agent1 sent HC_STARTUP from ''");
+    expect_string(__wrap_rem_inc_recv_ctrl_startup, agent_id, "001");
+
+    int result = validate_control_msg(&key, r_msg, msg_length, &cleaned_msg, &is_startup, &is_shutdown);
+
+    // We store the message for later processing, if the version cannot be retrieved
+    // but we need to queue it for wazuh-db processing
+    assert_int_equal(result, 1);
+    assert_int_equal(is_startup, 1);
+    assert_int_equal(is_shutdown, 0);
+    assert_non_null(cleaned_msg);
+
+    assert_string_equal(cleaned_msg, "agent startup {\"test\":\"fail\"}");
+
+    os_free(cleaned_msg);
+    free_keyentry(&key);
+    free(r_msg);
+}
+
 /* Test save_controlmsg function */
-/*
-void test_save_controlmsg_request_error(void **state)
+
+void test_save_controlmsg_agent_invalid_version(void** state)
 {
-    keyentry * key =  NULL;
-    char *r_msg = "req ";
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap__merror, formatted_msg, "Request control format error.");
-    expect_string(__wrap__mdebug2, formatted_msg, "r_msg = \"req \"");
-
-    save_controlmsg(key, r_msg, msg_length, wdb_sock, NULL, 0, 0);
-}
-
-void test_save_controlmsg_request_success(void **state)
-{
-    char r_msg[OS_SIZE_128] = {0};
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    strcpy(r_msg, "req payload is here");
-
-    keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    expect_string(__wrap_req_save, counter, "payload");
-    expect_string(__wrap_req_save, buffer, "is here");
-    expect_value(__wrap_req_save, length, OS_SIZE_128 - strlen(HC_REQUEST) - strlen("payload "));
-    will_return(__wrap_req_save, 0);
-
-    expect_string(__wrap_rem_inc_recv_ctrl_request, agent_id, "001");
-
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
-
-    free_keyentry(&key);
-}
-
-void test_save_controlmsg_invalid_msg(void **state)
-{
-    char r_msg[OS_SIZE_128] = {0};
-    strcpy(r_msg, "Invalid message");
-
-    keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap__mwarn, formatted_msg, "Invalid message from agent: 'NEW_AGENT' (001)");
-
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
-
-    free_keyentry(&key);
-}
-
-void test_save_controlmsg_agent_invalid_version(void **state)
-{
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     char s_msg[OS_FLSIZE + 1] = {0};
+
+    bool is_startup = true;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
     strcpy(r_msg, "agent startup {\"version\":\"v4.6.0\"}");
-    snprintf(s_msg, OS_FLSIZE, "%s%s%s%s%s", CONTROL_HEADER, HC_ERROR, "{\"message\":\"", HC_INVALID_VERSION_RESPONSE, "\"}");
+    snprintf(s_msg,
+             OS_FLSIZE,
+             "%s%s%s%s%s",
+             CONTROL_HEADER,
+             HC_ERROR,
+             "{\"message\":\"",
+             HC_INVALID_VERSION_RESPONSE,
+             "\"}");
 
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
     memset(&key.peer_info, 0, sizeof(struct sockaddr_storage));
 
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Agent NEW_AGENT sent HC_STARTUP from ''");
-
-    expect_string(__wrap_compare_wazuh_versions, version1, "v4.5.0");
+    expect_string(__wrap_compare_wazuh_versions, version1, __ossec_version);
     expect_string(__wrap_compare_wazuh_versions, version2, "v4.6.0");
     expect_value(__wrap_compare_wazuh_versions, compare_patch, false);
     will_return(__wrap_compare_wazuh_versions, -1);
@@ -4841,29 +4876,32 @@ void test_save_controlmsg_agent_invalid_version(void **state)
 
     expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     free_keyentry(&key);
 }
 
-void test_save_controlmsg_get_agent_version_fail(void **state)
+void test_save_controlmsg_get_agent_version_fail(void** state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     char s_msg[OS_FLSIZE + 1] = {0};
+
+    bool is_startup = true;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
     strcpy(r_msg, "agent startup {\"test\":\"fail\"}");
     snprintf(s_msg, OS_FLSIZE, "%s%s%s%s%s", CONTROL_HEADER, HC_ERROR, "{\"message\":\"", HC_RETRIEVE_VERSION, "\"}");
 
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
+
     memset(&key.peer_info, 0, sizeof(struct sockaddr_storage));
 
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
+    expect_string(__wrap__mwarn, formatted_msg, "Unable to get version from agent '001' on startup message");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Agent NEW_AGENT sent HC_STARTUP from ''");
-    expect_string(__wrap__merror, formatted_msg, "Error getting version from agent '001'");
-
+    expect_string(__wrap_send_msg, agent_id, "001");
+    expect_string(__wrap_send_msg, msg, s_msg);
     expect_string(__wrap__mdebug2, formatted_msg, "Unable to connect agent: '001': 'Couldn't retrieve version'");
 
     expect_value(__wrap_wdb_update_agent_status_code, id, 1);
@@ -4872,35 +4910,26 @@ void test_save_controlmsg_get_agent_version_fail(void **state)
     will_return(__wrap_wdb_update_agent_status_code, OS_INVALID);
 
     expect_string(__wrap__mwarn, formatted_msg, "Unable to set status code for agent: '001'");
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, s_msg);
-
     expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     free_keyentry(&key);
 }
 
-void test_save_controlmsg_could_not_add_pending_data(void **state)
+void test_save_controlmsg_could_not_add_pending_data(void** state)
 {
+
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "Invalid message \n with enter");
 
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_keepalive, agent_id, "001");
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -4919,36 +4948,31 @@ void test_save_controlmsg_could_not_add_pending_data(void **state)
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     free_keyentry(&key);
 }
 
-void test_save_controlmsg_unable_to_save_last_keepalive(void **state)
+void test_save_controlmsg_unable_to_save_last_keepalive(void** state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "Invalid message \n with enter");
 
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_keepalive, agent_id, "001");
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
+    memset(&key.peer_info, 0, sizeof(struct sockaddr_storage));
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
     pending_data = OSHash_Create();
 
     pending_data_t data;
-    char * message = strdup("Invalid message \n");
+    char* message = strdup("Invalid message \n");
     data.changed = true;
     data.message = message;
 
@@ -4964,39 +4988,36 @@ void test_save_controlmsg_unable_to_save_last_keepalive(void **state)
     expect_string(__wrap_wdb_update_agent_keepalive, sync_status, "synced");
     will_return(__wrap_wdb_update_agent_keepalive, OS_INVALID);
 
-    expect_string(__wrap__mwarn, formatted_msg, "Unable to save last keepalive and set connection status as active for agent: 001");
+    expect_string(__wrap__mwarn,
+                  formatted_msg,
+                  "Unable to save last keepalive and set connection status as active for agent: 001");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
+
     free_keyentry(&key);
     os_free(data.message);
 }
 
-void test_save_controlmsg_update_msg_error_parsing(void **state)
+void test_save_controlmsg_update_msg_error_parsing(void** state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "valid message \n with enter");
 
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_keepalive, agent_id, "001");
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
     pending_data = OSHash_Create();
 
-    pending_data_t *data;
+    pending_data_t* data;
     os_calloc(1, sizeof(struct pending_data_t), data);
-    char * message = strdup("different message");
+    char* message = strdup("different message");
     data->changed = true;
     data->message = message;
 
@@ -5008,8 +5029,8 @@ void test_save_controlmsg_update_msg_error_parsing(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "save_controlmsg(): inserting 'valid message \n'");
 
-    groups = (OSHash *)10;
-    multi_groups = (OSHash *)10;
+    groups = (OSHash*)10;
+    multi_groups = (OSHash*)10;
 
     char* group = NULL;
     w_strdup("test_group", group);
@@ -5033,7 +5054,7 @@ void test_save_controlmsg_update_msg_error_parsing(void **state)
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    agent_info_data *agent_data;
+    agent_info_data* agent_data;
     os_calloc(1, sizeof(agent_info_data), agent_data);
     agent_data->id = 1;
 
@@ -5043,42 +5064,35 @@ void test_save_controlmsg_update_msg_error_parsing(void **state)
 
     expect_string(__wrap__merror, formatted_msg, "Error parsing message for agent '001'");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     os_free(agent_data);
-
     free_keyentry(&key);
     os_free(data->message);
     os_free(data->group);
     os_free(data);
 }
 
-void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
+void test_save_controlmsg_update_msg_unable_to_update_information(void** state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "valid message \n with enter");
 
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_keepalive, agent_id, "001");
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
     pending_data = OSHash_Create();
 
-    pending_data_t *data;
+    pending_data_t* data;
     os_calloc(1, sizeof(struct pending_data_t), data);
-    char * message = strdup("different message");
+    char* message = strdup("different message");
     data->changed = false;
     data->message = message;
 
@@ -5090,10 +5104,10 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 
     expect_string(__wrap__mdebug2, formatted_msg, "save_controlmsg(): inserting 'valid message \n'");
 
-    groups = (OSHash *)10;
-    multi_groups = (OSHash *)10;
+    groups = (OSHash*)10;
+    multi_groups = (OSHash*)10;
 
-    group_t *group = NULL;
+    group_t* group = NULL;
     os_calloc(1, sizeof(group_t), group);
     group->name = strdup("test_group");
     memset(&group->merged_sum, 0, sizeof(os_md5));
@@ -5115,7 +5129,7 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
     expect_function_call(__wrap_pthread_mutex_unlock);
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    agent_info_data *agent_data;
+    agent_info_data* agent_data;
     os_calloc(1, sizeof(agent_info_data), agent_data);
     agent_data->id = 1;
     os_strdup("managerHost", agent_data->manager_host);
@@ -5142,8 +5156,7 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Unable to update information in global.db for agent: 001");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     os_free(group->name);
     os_free(group);
@@ -5161,21 +5174,16 @@ void test_save_controlmsg_update_msg_unable_to_update_information(void **state)
 
 void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "valid message \n with enter");
 
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_keepalive, agent_id, "001");
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -5222,8 +5230,7 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "Unable to update information in global.db for agent: 001");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 0);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     os_free(agent_data->manager_host);
     os_free(agent_data);
@@ -5234,24 +5241,19 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
     os_free(data);
 }
 
+
 void test_save_controlmsg_startup(void **state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, "agent startup {\"version\":\"v4.5.0\"}");
+
+    bool is_startup = true;
+    bool is_shutdown = false;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
-    keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
-    key.peer_info.ss_family = 0;
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_string(__wrap_send_msg, agent_id, "001");
-    expect_string(__wrap_send_msg, msg, "#!-agent ack ");
-
-    expect_string(__wrap_rem_inc_send_ack, agent_id, "001");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_startup, agent_id, "001");
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Agent NEW_AGENT sent HC_STARTUP from ''");
+    keyentry_init(&key, "NEW_AGENT", "001", "192.168.1.1", "test_key");
 
     expect_string(__wrap_compare_wazuh_versions, version1, "v4.5.0");
     expect_string(__wrap_compare_wazuh_versions, version2, "v4.5.0");
@@ -5281,32 +5283,29 @@ void test_save_controlmsg_startup(void **state)
 
     expect_string(__wrap__mwarn, formatted_msg, "Unable to save last keepalive and set connection status as pending for agent: 001");
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 1, 0);
+
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(message);
+
 }
 
 void test_save_controlmsg_shutdown(void **state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, HC_SHUTDOWN);
+
+    bool is_startup = false;
+    bool is_shutdown = true;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
     memset(&key.peer_info, 0, sizeof(struct sockaddr_storage));
     key.peer_info.ss_family = AF_INET;
 
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_any(__wrap_get_ipv4_string, address);
-    expect_any(__wrap_get_ipv4_string, address_size);
-    will_return(__wrap_get_ipv4_string, OS_INVALID);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Agent NEW_AGENT sent HC_SHUTDOWN from ''");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_shutdown, agent_id, "001");
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -5351,12 +5350,11 @@ void test_save_controlmsg_shutdown(void **state)
     will_return(__wrap_strerror, "fail");
     expect_string(__wrap__merror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'fail'");
 
-    will_return(__wrap_OSHash_Delete_ex, NULL);
-    expect_string(__wrap_OSHash_Delete_ex, key, "001");
-    expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
+    // will_return(__wrap_OSHash_Delete_ex, NULL);
+    // expect_string(__wrap_OSHash_Delete_ex, key, "001");
+    // expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 1);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(message);
@@ -5364,22 +5362,18 @@ void test_save_controlmsg_shutdown(void **state)
 
 void test_save_controlmsg_shutdown_wdb_fail(void **state)
 {
+    int wdb_sock = -1;
     char r_msg[OS_SIZE_128] = {0};
     strcpy(r_msg, HC_SHUTDOWN);
+
+    bool is_startup = false;
+    bool is_shutdown = true;
+    bool startup_msg; // Output parameter for save_controlmsg
+
     keyentry key;
     keyentry_init(&key, "NEW_AGENT", "001", "10.2.2.5", NULL);
     memset(&key.peer_info, 0, sizeof(struct sockaddr_storage));
     key.peer_info.ss_family = AF_INET6;
-    size_t msg_length = sizeof(r_msg);
-    int *wdb_sock = NULL;
-
-    expect_any(__wrap_get_ipv6_string, address);
-    expect_any(__wrap_get_ipv6_string, address_size);
-    will_return(__wrap_get_ipv6_string, OS_INVALID);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Agent NEW_AGENT sent HC_SHUTDOWN from ''");
-
-    expect_string(__wrap_rem_inc_recv_ctrl_shutdown, agent_id, "001");
 
     expect_function_call(__wrap_OSHash_Create);
     will_return(__wrap_OSHash_Create, 1);
@@ -5404,17 +5398,16 @@ void test_save_controlmsg_shutdown_wdb_fail(void **state)
 
     expect_string(__wrap__mwarn, formatted_msg, "Unable to set connection status as disconnected for agent: 001");
 
-    will_return(__wrap_OSHash_Delete_ex, NULL);
-    expect_string(__wrap_OSHash_Delete_ex, key, "001");
-    expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
+    // will_return(__wrap_OSHash_Delete_ex, NULL);
+    // expect_string(__wrap_OSHash_Delete_ex, key, "001");
+    // expect_value(__wrap_OSHash_Delete_ex, self, agent_data_hash);
 
-    bool startup_msg = key.is_startup;
-    save_controlmsg(&key, r_msg, msg_length, wdb_sock, &startup_msg, 0, 1);
+    save_controlmsg(&key, r_msg, &wdb_sock, &startup_msg, is_startup, is_shutdown);
 
     free_keyentry(&key);
     os_free(message);
 }
-*/
+
 
 int main(void)
 {
@@ -5542,20 +5535,20 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_validate_control_msg_startup_success, setup_globals, teardown_globals),
         cmocka_unit_test(test_validate_control_msg_keepalive_success),
         cmocka_unit_test(test_validate_control_msg_invalid_msg),
+        cmocka_unit_test(test_validate_control_msg_invalid_msg_2),
+        cmocka_unit_test_setup_teardown(test_validate_control_msg_invalid_agent_version, setup_globals, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_validate_control_msg_get_agent_version_fail, setup_globals, teardown_globals),
         // Tests save_controlmsg
-        // cmocka_unit_test(test_save_controlmsg_request_error),
-        // cmocka_unit_test(test_save_controlmsg_request_success),
-        // cmocka_unit_test(test_save_controlmsg_invalid_msg),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_agent_invalid_version, setup_globals_no_test_mode, teardown_globals),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_get_agent_version_fail, setup_test_mode, teardown_test_mode),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_could_not_add_pending_data, setup_test_mode, teardown_test_mode),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_unable_to_save_last_keepalive, setup_test_mode, teardown_test_mode),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_update_msg_error_parsing, setup_test_mode, teardown_test_mode),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_update_msg_unable_to_update_information, setup_test_mode, teardown_test_mode),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_update_msg_lookfor_agent_group_fail, setup_test_mode, teardown_test_mode),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_startup, setup_globals, teardown_globals),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_shutdown, setup_globals, teardown_globals),
-        // cmocka_unit_test_setup_teardown(test_save_controlmsg_shutdown_wdb_fail, setup_globals, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_agent_invalid_version, setup_globals_no_test_mode, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_get_agent_version_fail, setup_test_mode, teardown_test_mode),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_could_not_add_pending_data, setup_test_mode, teardown_test_mode),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_unable_to_save_last_keepalive, setup_test_mode, teardown_test_mode),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_update_msg_error_parsing, setup_test_mode, teardown_test_mode),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_update_msg_unable_to_update_information, setup_test_mode, teardown_test_mode),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_update_msg_lookfor_agent_group_fail, setup_test_mode, teardown_test_mode),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_startup, setup_globals, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_shutdown, setup_globals, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_shutdown_wdb_fail, setup_globals, teardown_globals),
     };
     return cmocka_run_group_tests(tests, test_setup_group, test_teardown_group);
 }

--- a/src/unit_tests/remoted/test_save_ctrlmsg_thread.c
+++ b/src/unit_tests/remoted/test_save_ctrlmsg_thread.c
@@ -47,9 +47,9 @@ void test_save_control_message_ok(void **state)
     os_calloc(sizeof(w_ctrl_msg_data_t), 1, ctrl_msg_data);
     os_calloc(sizeof(keyentry), 1, ctrl_msg_data->key);
 
-    ctrl_msg_data->length = strlen("test message") + 1;
-    os_calloc(ctrl_msg_data->length, sizeof(char), ctrl_msg_data->message);
-    memcpy(ctrl_msg_data->message, "test message", ctrl_msg_data->length);
+    size_t len = strlen("test message") + 1;
+    os_calloc(len, sizeof(char), ctrl_msg_data->message);
+    memcpy(ctrl_msg_data->message, "test message", len);
 
     queue_push(queue, ctrl_msg_data);
 

--- a/src/unit_tests/remoted/test_save_ctrlmsg_thread.c
+++ b/src/unit_tests/remoted/test_save_ctrlmsg_thread.c
@@ -18,7 +18,7 @@
 #include "../../remoted/remoted.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/libc/stdio_wrappers.h"
-#include "../wrappers/wazuh/shared/queue_linked_op_wrappers.h"
+#include "../wrappers/wazuh/shared/queue_op_wrappers.h"
 
 #include "../wrappers/wazuh/remoted/queue_wrappers.h"
 #include "../wrappers/wazuh/remoted/manager_wrappers.h"
@@ -29,8 +29,8 @@ void * save_control_thread(void * control_msg_queue);
 void test_save_control_message_empty(void **state)
 {
     will_return(__wrap_FOREVER, 1);
-    will_return(__wrap_linked_queue_pop_ex, (w_linked_queue_t *) -1);
-    expect_value(__wrap_linked_queue_pop_ex, queue, 0x1);
+    will_return(__wrap_queue_pop_ex, (w_queue_t *) -1);
+    expect_value(__wrap_queue_pop_ex, queue, 0x1);
 
 
     will_return(__wrap_FOREVER, 0);
@@ -41,7 +41,7 @@ void test_save_control_message_empty(void **state)
 
 void test_save_control_message_ok(void **state)
 {
-    w_linked_queue_t * queue = linked_queue_init();
+    w_queue_t * queue = queue_init(10);
 
     w_ctrl_msg_data_t * ctrl_msg_data;
     os_calloc(sizeof(w_ctrl_msg_data_t), 1, ctrl_msg_data);
@@ -51,11 +51,11 @@ void test_save_control_message_ok(void **state)
     os_calloc(ctrl_msg_data->length, sizeof(char), ctrl_msg_data->message);
     memcpy(ctrl_msg_data->message, "test message", ctrl_msg_data->length);
 
-    linked_queue_push(queue, ctrl_msg_data);
+    queue_push(queue, ctrl_msg_data);
 
     will_return(__wrap_FOREVER, 1);
-    will_return(__wrap_linked_queue_pop_ex, (void *) ctrl_msg_data);
-    expect_value(__wrap_linked_queue_pop_ex, queue, queue);
+    will_return(__wrap_queue_pop_ex, (void *) ctrl_msg_data);
+    expect_value(__wrap_queue_pop_ex, queue, queue);
 
     expect_value(__wrap_save_controlmsg, key, ctrl_msg_data->key);
     expect_value(__wrap_save_controlmsg, r_msg, ctrl_msg_data->message);
@@ -64,7 +64,7 @@ void test_save_control_message_ok(void **state)
     will_return(__wrap_FOREVER, 0);
 
     assert_null(save_control_thread((void *) queue));
-    linked_queue_free(queue);
+    queue_free(queue);
 }
 
 

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -54,7 +54,7 @@ void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family);
 
 /* Forward declarations */
 void * close_fp_main(void * args);
-void HandleSecureMessage(const message_t *message, w_linked_queue_t * control_msg_queue);
+void HandleSecureMessage(const message_t *message, w_queue_t * control_msg_queue);
 
 /* Setup/teardown */
 
@@ -458,7 +458,7 @@ void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family)
     char buffer[OS_MAXSTR + 1] = "!1234!";
     message_t message = {.buffer = buffer, .size = 6, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -500,7 +500,7 @@ void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_invalid_family_address_af_unspec(void** state)
@@ -533,7 +533,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-agent shutdown ";
     message_t message = {.buffer = buffer, .size = 18, .sock = 1, .counter = 10};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -589,7 +589,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    w_ctrl_msg_data_t * node = linked_queue_pop(control_msg_queue);
+    w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent shutdown ");
     assert_int_equal(node->length, strlen("agent shutdown "));
@@ -604,7 +604,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
@@ -612,7 +612,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-agent startup ";
     message_t message = {.buffer = buffer, .size = 17, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -675,7 +675,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    w_ctrl_msg_data_t * node = linked_queue_pop(control_msg_queue);
+    w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent startup ");
     assert_int_equal(node->length, strlen("agent startup "));
@@ -690,7 +690,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void** state)
@@ -698,7 +698,7 @@ void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-agent startup ";
     message_t message = {.buffer = buffer, .size = 17, .sock = 1, .counter = 5};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -741,7 +741,7 @@ void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_invalid_message(void** state)
@@ -749,7 +749,7 @@ void test_HandleSecureMessage_invalid_message(void** state)
     char buffer[OS_MAXSTR + 1] = "!1234!";
     message_t message = {.buffer = buffer, .size = 6, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -809,7 +809,7 @@ void test_HandleSecureMessage_invalid_message(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_different_sock(void** state)
@@ -817,7 +817,7 @@ void test_HandleSecureMessage_different_sock(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     logr.connection_overtake_time = 60;
 
@@ -879,7 +879,7 @@ void test_HandleSecureMessage_different_sock(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_different_sock_2(void** state)
@@ -887,7 +887,7 @@ void test_HandleSecureMessage_different_sock_2(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     logr.connection_overtake_time = 60;
 
@@ -948,7 +948,7 @@ void test_HandleSecureMessage_different_sock_2(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock(void** state)
@@ -956,7 +956,7 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1043,7 +1043,7 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_2(void** state)
@@ -1051,7 +1051,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!AAA";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1138,7 +1138,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_disabled(void** state)
@@ -1146,7 +1146,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1212,7 +1212,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_disabled_2(void** state)
@@ -1220,7 +1220,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled_2(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!AAA";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1287,7 +1287,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled_2(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_recv_fail(void** state)
@@ -1295,7 +1295,7 @@ void test_HandleSecureMessage_close_idle_sock_recv_fail(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 0, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1388,7 +1388,7 @@ void test_HandleSecureMessage_close_idle_sock_recv_fail(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
@@ -1396,7 +1396,7 @@ void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1498,7 +1498,7 @@ void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
@@ -1506,7 +1506,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-12!";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1601,7 +1601,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    w_ctrl_msg_data_t * node = linked_queue_pop(control_msg_queue);
+    w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "12!");
     assert_int_equal(node->key->keyid, 1);
@@ -1616,7 +1616,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_same_sock(void** state)
@@ -1624,7 +1624,7 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1688,7 +1688,7 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_same_sock_2(void** state)
@@ -1696,7 +1696,7 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!AAA";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1};
     struct sockaddr_in peer_info;
-    w_linked_queue_t * control_msg_queue = linked_queue_init();
+    w_queue_t * control_msg_queue = queue_init(10);
 
     current_ts = 61;
 
@@ -1761,7 +1761,7 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    linked_queue_free(control_msg_queue);
+    queue_free(control_msg_queue);
 }
 
 void test_handle_new_tcp_connection_success(void** state)

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -543,6 +543,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     os_calloc(1, sizeof(keyentry), key);
 
     key->id = strdup("009");
+    key->name = strdup("test_agent");
     key->sock = 1;
     key->keyid = 1;
 
@@ -583,6 +584,12 @@ void test_HandleSecureMessage_shutdown_message(void** state)
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
 
+    // Should be added to the queue
+    expect_value(__wrap_validate_control_msg, key, key);
+    expect_string(__wrap_validate_control_msg, r_msg, "agent shutdown ");
+    expect_value(__wrap_validate_control_msg, msg_length, 15);
+    will_return(__wrap_validate_control_msg, 1);
+
     // OS_FreeKey
     expect_value(__wrap_OS_FreeKey, key, key);
 
@@ -592,7 +599,6 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent shutdown ");
-    assert_int_equal(node->length, strlen("agent shutdown "));
     assert_int_equal(node->key->keyid, 1);
     assert_int_equal(node->key->sock, 1);
     assert_string_equal(node->key->id, "009");
@@ -602,10 +608,185 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     os_free(node);
 
     os_free(key->id);
+    os_free(key->name);
     os_free(key);
     os_free(keyentries);
     queue_free(control_msg_queue);
 }
+
+void test_HandleSecureMessage_HC_req_message(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "#!-req payload";
+    message_t message = {.buffer = buffer, .size = 14, .sock = 1, .counter = 11};
+    struct sockaddr_in peer_info;
+    w_queue_t * control_msg_queue = queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(1, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    key->id = strdup("009");
+    key->name = strdup("test_agent");
+    key->sock = 1;
+    key->keyid = 1;
+
+    keys.keyentries[0] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = 0x0100007F;
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 0);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, "#!-req payload");
+    expect_value(__wrap_ReadSecMSG, id, 0);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, "#!-req payload");
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_value(__wrap_rem_getCounter, fd, 1);
+    will_return(__wrap_rem_getCounter, 10);
+
+    // OS_DupKeyEntry
+    expect_value(__wrap_OS_DupKeyEntry, key, key);
+    will_return(__wrap_OS_DupKeyEntry, key);
+
+    // OS_AddSocket
+    expect_value(__wrap_OS_AddSocket, keys, &keys);
+    expect_value(__wrap_OS_AddSocket, i, 0);
+    expect_value(__wrap_OS_AddSocket, sock, message.sock);
+    will_return(__wrap_OS_AddSocket, OS_ADDSOCKET_KEY_ADDED);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "TCP socket 1 added to keystore.");
+
+    expect_function_call(__wrap_key_unlock);
+
+    expect_value(__wrap_rem_getCounter, fd, 1);
+    will_return(__wrap_rem_getCounter, 10);
+
+    expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
+
+    // Should be added to the queue
+    expect_value(__wrap_validate_control_msg, key, key);
+    expect_string(__wrap_validate_control_msg, r_msg, "req payload");
+    expect_value(__wrap_validate_control_msg, msg_length, 11);
+    will_return(__wrap_validate_control_msg, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Control message processed directly, not queued.");
+
+
+    // OS_FreeKey
+    expect_value(__wrap_OS_FreeKey, key, key);
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Expect the control message to be added to the queue
+    assert_true(queue_empty(control_msg_queue));
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key);
+    os_free(keyentries);
+    queue_free(control_msg_queue);
+}
+
+
+void test_HandleSecureMessage_invalid_HC_req_message(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "#!-req witouthCounter";
+    message_t message = {.buffer = buffer, .size = 21, .sock = 1, .counter = 11};
+    struct sockaddr_in peer_info;
+    w_queue_t * control_msg_queue = queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(1, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    key->id = strdup("009");
+    key->name = strdup("test_agent");
+    key->sock = 1;
+    key->keyid = 1;
+
+    keys.keyentries[0] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = 0x0100007F;
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 0);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, "#!-req witouthCounter");
+    expect_value(__wrap_ReadSecMSG, id, 0);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, "#!-req witouthCounter");
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_value(__wrap_rem_getCounter, fd, 1);
+    will_return(__wrap_rem_getCounter, 10);
+
+    // OS_DupKeyEntry
+    expect_value(__wrap_OS_DupKeyEntry, key, key);
+    will_return(__wrap_OS_DupKeyEntry, key);
+
+    // OS_AddSocket
+    expect_value(__wrap_OS_AddSocket, keys, &keys);
+    expect_value(__wrap_OS_AddSocket, i, 0);
+    expect_value(__wrap_OS_AddSocket, sock, message.sock);
+    will_return(__wrap_OS_AddSocket, OS_ADDSOCKET_KEY_ADDED);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "TCP socket 1 added to keystore.");
+
+    expect_function_call(__wrap_key_unlock);
+
+    expect_value(__wrap_rem_getCounter, fd, 1);
+    will_return(__wrap_rem_getCounter, 10);
+
+    expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
+
+    // Should be added to the queue
+    expect_value(__wrap_validate_control_msg, key, key);
+    expect_string(__wrap_validate_control_msg, r_msg, "req witouthCounter");
+    expect_value(__wrap_validate_control_msg, msg_length, 18);
+    will_return(__wrap_validate_control_msg, -1);
+
+    expect_string(__wrap__mwarn, formatted_msg, "Error validating control message from agent ID '009'.");
+
+
+    // OS_FreeKey
+    expect_value(__wrap_OS_FreeKey, key, key);
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Expect the control message to be added to the queue
+    assert_true(queue_empty(control_msg_queue));
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key);
+    os_free(keyentries);
+    queue_free(control_msg_queue);
+}
+
 
 void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
 {
@@ -669,6 +850,12 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
 
+    // Should be added to the queue
+    expect_value(__wrap_validate_control_msg, key, key);
+    expect_string(__wrap_validate_control_msg, r_msg, "agent startup ");
+    expect_value(__wrap_validate_control_msg, msg_length, 14);
+    will_return(__wrap_validate_control_msg, 1);
+
     // OS_FreeKey
     expect_value(__wrap_OS_FreeKey, key, key);
 
@@ -678,7 +865,6 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent startup ");
-    assert_int_equal(node->length, strlen("agent startup "));
     assert_int_equal(node->key->keyid, 1);
     assert_int_equal(node->key->sock, 1);
     assert_string_equal(node->key->id, "009");
@@ -1504,7 +1690,7 @@ void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
 void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
 {
     char buffer[OS_MAXSTR + 1] = "#!-12!";
-    message_t message = {.buffer = buffer, .size = 7, .sock = 1, .counter = 11};
+    message_t message = {.buffer = buffer, .size = 6, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
     w_queue_t * control_msg_queue = queue_init(10);
 
@@ -1595,6 +1781,11 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, "001");
 
+    // Should be added to the control message queue
+    expect_value(__wrap_validate_control_msg, key, key);
+    expect_string(__wrap_validate_control_msg, r_msg, "12!");
+    expect_value(__wrap_validate_control_msg, msg_length, 3);
+    will_return(__wrap_validate_control_msg, 1);
     // OS_FreeKey
     expect_value(__wrap_OS_FreeKey, key, key);
 
@@ -2110,6 +2301,8 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_invalid_family_address_not_found),
         cmocka_unit_test(test_HandleSecureMessage_invalid_message),
         cmocka_unit_test(test_HandleSecureMessage_shutdown_message),
+        cmocka_unit_test(test_HandleSecureMessage_HC_req_message),
+        cmocka_unit_test(test_HandleSecureMessage_invalid_HC_req_message),
         cmocka_unit_test(test_HandleSecureMessage_NewMessage_NoShutdownMessage),
         cmocka_unit_test(test_HandleSecureMessage_OldMessage_NoShutdownMessage),
         cmocka_unit_test(test_HandleSecureMessage_different_sock),

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -580,7 +580,6 @@ void test_HandleSecureMessage_shutdown_message(void** state)
 
     expect_function_call(__wrap_key_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed in queue for agent ID '0'.");
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
 
@@ -846,7 +845,6 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
 
     expect_function_call(__wrap_key_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed in queue for agent ID '0'.");
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
 
@@ -1777,7 +1775,6 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [4]");
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed in queue for agent ID '1'.");
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, "001");
 

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -54,7 +54,7 @@ void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family);
 
 /* Forward declarations */
 void * close_fp_main(void * args);
-void HandleSecureMessage(const message_t *message, w_queue_t * control_msg_queue);
+void HandleSecureMessage(const message_t *message, w_indexed_queue_t * control_msg_queue);
 
 /* Setup/teardown */
 

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -458,7 +458,7 @@ void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family)
     char buffer[OS_MAXSTR + 1] = "!1234!";
     message_t message = {.buffer = buffer, .size = 6, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -500,7 +500,7 @@ void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_invalid_family_address_af_unspec(void** state)
@@ -533,7 +533,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-agent shutdown ";
     message_t message = {.buffer = buffer, .size = 18, .sock = 1, .counter = 10};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -580,7 +580,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
 
     expect_function_call(__wrap_key_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed to queue.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed in queue for agent ID '0'.");
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
 
@@ -596,7 +596,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
+    w_ctrl_msg_data_t * node = indexed_queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent shutdown ");
     assert_int_equal(node->key->keyid, 1);
@@ -611,7 +611,7 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_HC_req_message(void** state)
@@ -619,7 +619,7 @@ void test_HandleSecureMessage_HC_req_message(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-req payload";
     message_t message = {.buffer = buffer, .size = 14, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -691,13 +691,13 @@ void test_HandleSecureMessage_HC_req_message(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    assert_true(queue_empty(control_msg_queue));
+    assert_true(indexed_queue_empty(control_msg_queue));
 
     os_free(key->id);
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 
@@ -706,7 +706,7 @@ void test_HandleSecureMessage_invalid_HC_req_message(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-req witouthCounter";
     message_t message = {.buffer = buffer, .size = 21, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -778,13 +778,13 @@ void test_HandleSecureMessage_invalid_HC_req_message(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    assert_true(queue_empty(control_msg_queue));
+    assert_true(indexed_queue_empty(control_msg_queue));
 
     os_free(key->id);
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 
@@ -793,7 +793,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-agent startup ";
     message_t message = {.buffer = buffer, .size = 17, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -846,7 +846,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
 
     expect_function_call(__wrap_key_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed to queue.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed in queue for agent ID '0'.");
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
 
@@ -862,7 +862,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
+    w_ctrl_msg_data_t * node = indexed_queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent startup ");
     assert_int_equal(node->key->keyid, 1);
@@ -876,7 +876,7 @@ void test_HandleSecureMessage_NewMessage_NoShutdownMessage(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void** state)
@@ -884,7 +884,7 @@ void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-agent startup ";
     message_t message = {.buffer = buffer, .size = 17, .sock = 1, .counter = 5};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -927,7 +927,7 @@ void test_HandleSecureMessage_OldMessage_NoShutdownMessage(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_invalid_message(void** state)
@@ -935,7 +935,7 @@ void test_HandleSecureMessage_invalid_message(void** state)
     char buffer[OS_MAXSTR + 1] = "!1234!";
     message_t message = {.buffer = buffer, .size = 6, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     keyentry** keyentries;
     os_calloc(1, sizeof(keyentry*), keyentries);
@@ -995,7 +995,7 @@ void test_HandleSecureMessage_invalid_message(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_different_sock(void** state)
@@ -1003,7 +1003,7 @@ void test_HandleSecureMessage_different_sock(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     logr.connection_overtake_time = 60;
 
@@ -1065,7 +1065,7 @@ void test_HandleSecureMessage_different_sock(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_different_sock_2(void** state)
@@ -1073,7 +1073,7 @@ void test_HandleSecureMessage_different_sock_2(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     logr.connection_overtake_time = 60;
 
@@ -1134,7 +1134,7 @@ void test_HandleSecureMessage_different_sock_2(void** state)
     os_free(key->id);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock(void** state)
@@ -1142,7 +1142,7 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1229,7 +1229,7 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_2(void** state)
@@ -1237,7 +1237,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!AAA";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1324,7 +1324,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_disabled(void** state)
@@ -1332,7 +1332,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1398,7 +1398,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_disabled_2(void** state)
@@ -1406,7 +1406,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled_2(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!AAA";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1473,7 +1473,7 @@ void test_HandleSecureMessage_close_idle_sock_disabled_2(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_recv_fail(void** state)
@@ -1481,7 +1481,7 @@ void test_HandleSecureMessage_close_idle_sock_recv_fail(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 0, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1574,7 +1574,7 @@ void test_HandleSecureMessage_close_idle_sock_recv_fail(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
@@ -1582,7 +1582,7 @@ void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1684,7 +1684,7 @@ void test_HandleSecureMessage_close_idle_sock_decrypt_fail(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
@@ -1692,7 +1692,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
     char buffer[OS_MAXSTR + 1] = "#!-12!";
     message_t message = {.buffer = buffer, .size = 6, .sock = 1, .counter = 11};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1777,7 +1777,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
 
     expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [4]");
 
-    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed to queue.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Control message pushed in queue for agent ID '1'.");
 
     expect_string(__wrap_rem_inc_recv_ctrl, agent_id, "001");
 
@@ -1792,7 +1792,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
     HandleSecureMessage(&message, control_msg_queue);
 
     // Expect the control message to be added to the queue
-    w_ctrl_msg_data_t * node = queue_pop(control_msg_queue);
+    w_ctrl_msg_data_t * node = indexed_queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "12!");
     assert_int_equal(node->key->keyid, 1);
@@ -1807,7 +1807,7 @@ void test_HandleSecureMessage_close_idle_sock_control_msg_succes(void** state)
     os_free(key->ip);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_same_sock(void** state)
@@ -1815,7 +1815,7 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     char buffer[OS_MAXSTR + 1] = "12!";
     message_t message = {.buffer = buffer, .size = 4, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1879,7 +1879,7 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_HandleSecureMessage_close_same_sock_2(void** state)
@@ -1887,7 +1887,7 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     char buffer[OS_MAXSTR + 1] = "!12!AAA";
     message_t message = {.buffer = buffer, .size = 7, .sock = 1};
     struct sockaddr_in peer_info;
-    w_queue_t * control_msg_queue = queue_init(10);
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
 
     current_ts = 61;
 
@@ -1952,7 +1952,7 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     os_free(key->name);
     os_free(key);
     os_free(keyentries);
-    queue_free(control_msg_queue);
+    indexed_queue_free(control_msg_queue);
 }
 
 void test_handle_new_tcp_connection_success(void** state)

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -117,6 +117,17 @@ else()
 list(APPEND shared_tests_flags "${QUEUE_LINKED_OP_BASE_FLAGS}")
 endif()
 
+list(APPEND shared_tests_names "test_indexed_queue_op")
+set(INDEXED_QUEUE_OP_FLAGS "-Wl,--wrap=pthread_mutex_lock,--wrap=pthread_mutex_unlock,--wrap=pthread_cond_wait \
+                            -Wl,--wrap=pthread_cond_signal,--wrap=pthread_cond_timedwait")
+if(${TARGET} STREQUAL "winagent")
+list(APPEND shared_tests_flags "${INDEXED_QUEUE_OP_FLAGS} -Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
+                                -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                                -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown")
+else()
+list(APPEND shared_tests_flags "${INDEXED_QUEUE_OP_FLAGS}")
+endif()
+
 list(APPEND shared_tests_names "test_agent_op")
 if(${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_flags "-Wl,--wrap,wdb_get_agent_info -Wl,--wrap,_mdebug1 -Wl,--wrap,getpid \

--- a/src/unit_tests/shared/test_indexed_queue_op.c
+++ b/src/unit_tests/shared/test_indexed_queue_op.c
@@ -1,0 +1,415 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "shared.h"
+#include "indexed_queue_op.h"
+
+static w_indexed_queue_t *queue_ptr = NULL;
+
+/****************SETUP/TEARDOWN******************/
+
+int setup_indexed_queue(void **state) {
+    w_indexed_queue_t *queue = indexed_queue_init(5); // Limited size for testing
+    *state = queue;
+    queue_ptr = queue;
+    return 0;
+}
+
+int setup_indexed_queue_unlimited(void **state) {
+    w_indexed_queue_t *queue = indexed_queue_init(0); // Unlimited size
+    *state = queue;
+    queue_ptr = queue;
+    return 0;
+}
+
+int teardown_indexed_queue(void **state) {
+    w_indexed_queue_t *queue = *state;
+    if (queue) {
+        // Clean up any remaining data first
+        void *data;
+        while ((data = indexed_queue_pop(queue)) != NULL) {
+            free(data);
+        }
+        // Use the proper destructor
+        indexed_queue_free(queue);
+    }
+    queue_ptr = NULL;
+    return 0;
+}
+
+void test_data_dispose(void *data) {
+    free(data);
+}
+
+/****************SIMPLE PTHREAD WRAPPERS******************/
+// No-op wrappers to avoid mock complexities
+
+int __wrap_pthread_mutex_lock(pthread_mutex_t *mutex) {
+    (void)mutex; // Avoid unused parameter warning
+    return 0; // Success
+}
+
+int __wrap_pthread_mutex_unlock(pthread_mutex_t *mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int __wrap_pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
+    (void)cond;
+    (void)mutex;
+    return 0;
+}
+
+int __wrap_pthread_cond_signal(pthread_cond_t *cond) {
+    (void)cond;
+    return 0;
+}
+
+int __wrap_pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime) {
+    (void)cond;
+    (void)mutex;
+    (void)abstime;
+    return 0;
+}
+
+/****************TESTS******************/
+
+void test_indexed_queue_init(void **state) {
+    (void) state;
+
+    w_indexed_queue_t *queue = indexed_queue_init(10);
+    assert_non_null(queue);
+    assert_int_equal(indexed_queue_size(queue), 0);
+    assert_int_equal(indexed_queue_empty(queue), 1);
+    assert_int_equal(indexed_queue_full(queue), 0);
+
+    indexed_queue_free(queue);
+}
+
+void test_indexed_queue_init_unlimited(void **state) {
+    (void) state;
+
+    w_indexed_queue_t *queue = indexed_queue_init(0);
+    assert_non_null(queue);
+    assert_int_equal(indexed_queue_size(queue), 0);
+    assert_int_equal(indexed_queue_empty(queue), 1);
+    assert_int_equal(indexed_queue_full(queue), 0); // Never full when unlimited
+
+    indexed_queue_free(queue);
+}
+
+void test_indexed_queue_push(void **state) {
+    w_indexed_queue_t *queue = *state;
+    int *data = malloc(sizeof(int));
+    *data = 42;
+
+    int result = indexed_queue_push(queue, "key1", data);
+    assert_int_equal(result, 0);
+    assert_int_equal(indexed_queue_size(queue), 1);
+    assert_int_equal(indexed_queue_empty(queue), 0);
+
+    // Test duplicate key
+    int *data2 = malloc(sizeof(int));
+    *data2 = 43;
+    result = indexed_queue_push(queue, "key1", data2);
+    assert_int_equal(result, -1); // Should fail
+    assert_int_equal(indexed_queue_size(queue), 1); // Size unchanged
+
+    free(data2);
+}
+
+void test_indexed_queue_push_full(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Fill queue to capacity (5 elements)
+    for (int i = 0; i < 5; i++) {
+        int *data = malloc(sizeof(int));
+        *data = i;
+        char key[10];
+        snprintf(key, sizeof(key), "key%d", i);
+        assert_int_equal(indexed_queue_push(queue, key, data), 0);
+    }
+
+    assert_int_equal(indexed_queue_full(queue), 1);
+
+    // Try to push one more - should fail
+    int *data = malloc(sizeof(int));
+    *data = 99;
+    int result = indexed_queue_push(queue, "key99", data);
+    assert_int_equal(result, -1);
+
+    free(data);
+}
+
+void test_indexed_queue_get(void **state) {
+    w_indexed_queue_t *queue = *state;
+    int *data = malloc(sizeof(int));
+    *data = 42;
+
+    indexed_queue_push(queue, "test_key", data);
+
+    int *retrieved = (int *)indexed_queue_get(queue, "test_key");
+    assert_non_null(retrieved);
+    assert_int_equal(*retrieved, 42);
+
+    // Test non-existent key
+    void *not_found = indexed_queue_get(queue, "non_existent");
+    assert_null(not_found);
+}
+
+void test_indexed_queue_upsert(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Insert new element
+    int *data1 = malloc(sizeof(int));
+    *data1 = 42;
+    int result = indexed_queue_upsert(queue, "key1", data1);
+    assert_int_equal(result, 0);
+    assert_int_equal(indexed_queue_size(queue), 1);
+
+    // Update existing element - upsert will handle the old data cleanup
+    // but since we don't have dispose function set, we need to handle manually
+    indexed_queue_set_dispose(queue, test_data_dispose);
+
+    int *data2 = malloc(sizeof(int));
+    *data2 = 99;
+    result = indexed_queue_upsert(queue, "key1", data2);
+    assert_int_equal(result, 0);
+    assert_int_equal(indexed_queue_size(queue), 1); // Size should remain the same
+
+    // Verify updated value
+    int *retrieved = (int *)indexed_queue_get(queue, "key1");
+    assert_non_null(retrieved);
+    assert_int_equal(*retrieved, 99);
+
+    // Reset dispose to NULL to avoid issues in teardown
+    indexed_queue_set_dispose(queue, NULL);
+}
+
+void test_indexed_queue_pop(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Add some elements
+    for (int i = 0; i < 3; i++) {
+        int *data = malloc(sizeof(int));
+        *data = i;
+        char key[10];
+        snprintf(key, sizeof(key), "key%d", i);
+        indexed_queue_push(queue, key, data);
+    }
+
+    // Pop should return in FIFO order
+    int *popped = (int *)indexed_queue_pop(queue);
+    assert_non_null(popped);
+    assert_int_equal(*popped, 0); // First element
+    assert_int_equal(indexed_queue_size(queue), 2);
+
+    // Verify element was removed from index too
+    void *not_found = indexed_queue_get(queue, "key0");
+    assert_null(not_found);
+
+    free(popped);
+}
+
+void test_indexed_queue_peek(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Empty queue peek
+    void *peeked = indexed_queue_peek(queue);
+    assert_null(peeked);
+
+    // Add element and peek
+    int *data = malloc(sizeof(int));
+    *data = 42;
+    indexed_queue_push(queue, "peek_key", data);
+
+    peeked = indexed_queue_peek(queue);
+    assert_non_null(peeked);
+    assert_int_equal(*(int *)peeked, 42);
+
+    // Verify element is still in queue
+    assert_int_equal(indexed_queue_size(queue), 1);
+    void *still_there = indexed_queue_get(queue, "peek_key");
+    assert_non_null(still_there);
+}
+
+void test_indexed_queue_delete(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Set dispose function to handle cleanup automatically
+    indexed_queue_set_dispose(queue, test_data_dispose);
+
+    // Add some elements
+    for (int i = 0; i < 3; i++) {
+        int *data = malloc(sizeof(int));
+        *data = i;
+        char key[10];
+        snprintf(key, sizeof(key), "key%d", i);
+        indexed_queue_push(queue, key, data);
+    }
+
+    // Delete middle element
+    int result = indexed_queue_delete(queue, "key1");
+    assert_int_equal(result, 1);
+    assert_int_equal(indexed_queue_size(queue), 2);
+
+    // Verify element was removed
+    void *not_found = indexed_queue_get(queue, "key1");
+    assert_null(not_found);
+
+    // Delete non-existent element
+    result = indexed_queue_delete(queue, "non_existent");
+    assert_int_equal(result, 0);
+    assert_int_equal(indexed_queue_size(queue), 2); // Size unchanged
+
+    // Reset dispose to NULL to avoid issues in teardown
+    indexed_queue_set_dispose(queue, NULL);
+}
+
+void test_indexed_queue_update(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Add element
+    int *data1 = malloc(sizeof(int));
+    *data1 = 42;
+    indexed_queue_push(queue, "update_key", data1);
+
+    // Update element
+    int *data2 = malloc(sizeof(int));
+    *data2 = 99;
+    void *old_data = indexed_queue_update(queue, "update_key", data2);
+    assert_non_null(old_data);
+    assert_int_equal(*(int *)old_data, 42);
+
+    // Verify new value
+    int *retrieved = (int *)indexed_queue_get(queue, "update_key");
+    assert_non_null(retrieved);
+    assert_int_equal(*retrieved, 99);
+
+    // Update non-existent key
+    int *data3 = malloc(sizeof(int));
+    *data3 = 123;
+    old_data = indexed_queue_update(queue, "non_existent", data3);
+    assert_null(old_data);
+
+    free(data1);
+    free(data3);
+}
+
+void test_indexed_queue_fifo_order(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Add elements
+    for (int i = 0; i < 3; i++) {
+        int *data = malloc(sizeof(int));
+        *data = i;
+        char key[10];
+        snprintf(key, sizeof(key), "key%d", i);
+        indexed_queue_push(queue, key, data);
+    }
+
+    // Pop all elements and verify FIFO order
+    for (int i = 0; i < 3; i++) {
+        int *popped = (int *)indexed_queue_pop(queue);
+        assert_non_null(popped);
+        assert_int_equal(*popped, i);
+        free(popped);
+    }
+
+    // Queue should be empty now
+    assert_int_equal(indexed_queue_empty(queue), 1);
+    void *empty_pop = indexed_queue_pop(queue);
+    assert_null(empty_pop);
+}
+
+void test_indexed_queue_mixed_operations(void **state) {
+    w_indexed_queue_t *queue = *state;
+
+    // Set dispose function to handle memory cleanup automatically
+    indexed_queue_set_dispose(queue, test_data_dispose);
+
+    // Insert some elements
+    for (int i = 0; i < 3; i++) {
+        int *data = malloc(sizeof(int));
+        *data = i;
+        char key[10];
+        snprintf(key, sizeof(key), "key%d", i);
+        indexed_queue_push(queue, key, data);
+    }
+
+    // Get by key
+    int *retrieved = (int *)indexed_queue_get(queue, "key1");
+    assert_non_null(retrieved);
+    assert_int_equal(*retrieved, 1);
+
+    // Delete middle element (dispose will free the data automatically)
+    indexed_queue_delete(queue, "key1");
+
+    // Pop should skip deleted element
+    int *popped1 = (int *)indexed_queue_pop(queue);
+    assert_non_null(popped1);
+    assert_int_equal(*popped1, 0); // First element (key0)
+    free(popped1); // Manual free since pop doesn't call dispose
+
+    int *popped2 = (int *)indexed_queue_pop(queue);
+    assert_non_null(popped2);
+    assert_int_equal(*popped2, 2); // Third element (key2), key1 was deleted
+    free(popped2); // Manual free since pop doesn't call dispose
+
+    // Reset dispose to NULL to avoid issues in teardown
+    indexed_queue_set_dispose(queue, NULL);
+}
+
+void test_indexed_queue_null_parameters(void **state) {
+    (void) state;
+
+    // Test with NULL queue
+    assert_int_equal(indexed_queue_push(NULL, "key", NULL), -1);
+    assert_null(indexed_queue_get(NULL, "key"));
+    assert_int_equal(indexed_queue_delete(NULL, "key"), 0);
+
+    w_indexed_queue_t *queue = indexed_queue_init(5);
+
+    // Test with NULL key/data
+    assert_int_equal(indexed_queue_push(queue, NULL, NULL), -1);
+    assert_int_equal(indexed_queue_push(queue, "key", NULL), -1);
+    assert_null(indexed_queue_get(queue, NULL));
+
+    indexed_queue_free(queue);
+}
+
+/****************MAIN******************/
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_indexed_queue_init),
+        cmocka_unit_test(test_indexed_queue_init_unlimited),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_push, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_push_full, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_get, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_upsert, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_pop, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_peek, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_delete, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_update, setup_indexed_queue, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_fifo_order, setup_indexed_queue_unlimited, teardown_indexed_queue),
+        cmocka_unit_test_setup_teardown(test_indexed_queue_mixed_operations, setup_indexed_queue_unlimited, teardown_indexed_queue),
+        cmocka_unit_test(test_indexed_queue_null_parameters),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.c
@@ -28,3 +28,11 @@ void __wrap_save_controlmsg(const keyentry * key, char *r_msg, __attribute__((un
 
     return;
 }
+
+int __wrap_validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length,  __attribute__((unused)) char **cleaned_msg,  __attribute__((unused)) int *is_startup,  __attribute__((unused)) int *is_shutdown) {
+    check_expected(key);
+    check_expected(r_msg);
+    check_expected(msg_length);
+
+    return mock_type(int);
+}

--- a/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/manager_wrappers.h
@@ -19,4 +19,7 @@ cJSON *__wrap_assign_group_to_agent(const char *agent_id, const char *md5);
 
 void __wrap_save_controlmsg(const keyentry * key, char *r_msg, __attribute__((unused)) size_t msg_length, int *wdb_sock);
 
+int __wrap_validate_control_msg(const keyentry * key, char *r_msg, size_t msg_length, char **cleaned_msg, int *is_startup, int *is_shutdown);
+
+
 #endif /* REM_MANAGER_WRAPPERS_H */

--- a/src/unit_tests/wrappers/wazuh/shared/indexed_queue_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/indexed_queue_op_wrappers.c
@@ -1,0 +1,67 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "indexed_queue_op_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+w_indexed_queue_t *__wrap_indexed_queue_init(size_t max_size) {
+    check_expected(max_size);
+    return mock_type(w_indexed_queue_t *);
+}
+
+void __wrap_indexed_queue_free(w_indexed_queue_t *queue) {
+    check_expected_ptr(queue);
+}
+
+int __wrap_indexed_queue_push_ex(w_indexed_queue_t *queue, const char *key, void *data) {
+    check_expected_ptr(queue);
+    check_expected_ptr(key);
+    check_expected_ptr(data);
+    return mock_type(int);
+}
+
+int __wrap_indexed_queue_upsert_ex(w_indexed_queue_t *queue, const char *key, void *data) {
+    check_expected_ptr(queue);
+    check_expected_ptr(key);
+    check_expected_ptr(data);
+    return mock_type(int);
+}
+
+void *__wrap_indexed_queue_get_ex(w_indexed_queue_t *queue, const char *key) {
+    check_expected_ptr(queue);
+    check_expected_ptr(key);
+    return mock_type(void *);
+}
+
+void *__wrap_indexed_queue_pop_ex(w_indexed_queue_t *queue) {
+    check_expected_ptr(queue);
+    return mock_type(void *);
+}
+
+void *__wrap_indexed_queue_pop_ex_timedwait(w_indexed_queue_t *queue, const struct timespec *abstime) {
+    check_expected_ptr(queue);
+    check_expected_ptr(abstime);
+    return mock_type(void *);
+}
+
+int __wrap_indexed_queue_delete_ex(w_indexed_queue_t *queue, const char *key) {
+    check_expected_ptr(queue);
+    check_expected_ptr(key);
+    return mock_type(int);
+}
+
+void *__wrap_indexed_queue_update_ex(w_indexed_queue_t *queue, const char *key, void *data) {
+    check_expected_ptr(queue);
+    check_expected_ptr(key);
+    check_expected_ptr(data);
+    return mock_type(void *);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/indexed_queue_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/indexed_queue_op_wrappers.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef INDEXED_QUEUE_OP_WRAPPERS_H
+#define INDEXED_QUEUE_OP_WRAPPERS_H
+
+#include "../../../../headers/indexed_queue_op.h"
+
+w_indexed_queue_t *__wrap_indexed_queue_init(size_t max_size);
+
+void __wrap_indexed_queue_free(w_indexed_queue_t *queue);
+
+int __wrap_indexed_queue_push_ex(w_indexed_queue_t *queue, const char *key, void *data);
+
+int __wrap_indexed_queue_upsert_ex(w_indexed_queue_t *queue, const char *key, void *data);
+
+void *__wrap_indexed_queue_get_ex(w_indexed_queue_t *queue, const char *key);
+
+void *__wrap_indexed_queue_pop_ex(w_indexed_queue_t *queue);
+
+void *__wrap_indexed_queue_pop_ex_timedwait(w_indexed_queue_t *queue, const struct timespec *abstime);
+
+int __wrap_indexed_queue_delete_ex(w_indexed_queue_t *queue, const char *key);
+
+void *__wrap_indexed_queue_update_ex(w_indexed_queue_t *queue, const char *key, void *data);
+
+#endif

--- a/src/unit_tests/wrappers/wazuh/shared/queue_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/queue_op_wrappers.h
@@ -11,7 +11,7 @@
 #ifndef QUEUE_OP_WRAPPERS_H
 #define QUEUE_OP_WRAPPERS_H
 
-#include "headers/queue_op.h"
+#include "../../../../headers/queue_op.h"
 
 int __wrap_queue_push_ex(w_queue_t * queue, void * data);
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -13,7 +13,7 @@
       <protocol>tcp</protocol>
     </server>
     <crypto_method>aes</crypto_method>
-    <notify_time>10</notify_time>
+    <notify_time>20</notify_time>
     <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
   </client>

--- a/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_request_agent_info.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_request_agent_info.yaml
@@ -23,7 +23,7 @@
   metadata:
     protocol: 'TCP'
     command_request: 'agent getconfig client'
-    expected_answer: '{"client":{"config-profile":"centos8","notify_time":10,"time-reconnect":60}}'
+    expected_answer: '{"client":{"config-profile":"centos8","notify_time":20,"time-reconnect":60}}'
 
 - name: test request agent info
   description: test request agent info
@@ -32,7 +32,7 @@
   metadata:
     protocol: 'UDP'
     command_request: 'agent getconfig client'
-    expected_answer: '{"client":{"config-profile":"centos8","notify_time":10,"time-reconnect":60}}'
+    expected_answer: '{"client":{"config-profile":"centos8","notify_time":20,"time-reconnect":60}}'
 
 - name: test request agent info
   description: test request agent info


### PR DESCRIPTION
## Description

This PR addresses the memory exhaustion vulnerability in wazuh-remoted introduced in v4.13.0-RC3 (#28933) by implementing a bounded, indexed queue for control messages. The new implementation prevents unbounded memory growth while optimizing database operations through intelligent message deduplication.

## Proposed Changes

### Core Implementation

- **Indexed Queue Structure**: New `indexed_queue` data structure combining linked queue with RB tree for O(log n) lookups and deduplication
- **Bounded Queue**: Control message queue limited to 16K elements by default (configurable via `remoted.ctrl_msg_queue_size`)
- **Smart Message Replacement**: Queue maintains single control message per agent with intelligent state transitions:
  - Startup message replaced by keepalive: Avoids unnecessary Pending state
  - Keepalive replaced by shutdown: Skips timestamp update, directly marks as Disconnected
  - Shutdown replaced by startup/keepalive: Skips Disconnected state, updates keepalive timestamp directly
- **Backpressure Mechanism**: Queue saturation triggers backpressure instead of dropping messages

### Performance Optimizations

- Queue growth limited by connected agents count, not message volume
- Reduced wazuh-db update operations through message deduplication
- Preserved cluster sync optimization from #29398:
  - `post_startup` flag set on startup message receipt (pre-queue)
  - First keepalive after startup triggers full sync, then flag cleared
  - Subsequent keepalives only update timestamp

### Bug Fixes

- Fixed race condition from PR #29426 in `post_startup` flag handling during client.keys reload

### Monitoring

New statistics counters added:
- `ctrl_msg_queue_inserted`: Total messages inserted
- `ctrl_msg_queue_replaced`: Messages that replaced older ones
- `ctrl_msg_queue_processed`: Messages dispatched

### Evidences

#### First keepalive handling after startup

```
DEBUG: Agent bd6401193142 sent HC_STARTUP from '172.21.176.1'
DEBUG: SAVING (1): syncreq
DEBUG: SAVING (1): syncreq_keepalive
```

#### Agent startup and shutdown alerts on restart

```
** Alert 1755086226.2523785: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2025 Aug 13 13:57:06 (402295d993ef) any->wazuh-remoted
Rule: 506 (level 3) -> 'Wazuh agent stopped.'
ossec: Agent stopped: '402295d993ef->any'.

** Alert 1755086228.2524122: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2025 Aug 13 13:57:08 (402295d993ef) any->wazuh-agent
Rule: 503 (level 3) -> 'Wazuh agent started.'
ossec: Agent started: '402295d993ef->any'.
```

#### Remoted statistics showing message replacements

```
# Control messages queue usage
ctrl_msg_queue_usage='0'

# Control messages queue breakdown
ctrl_msg_queue_inserted='5587'
ctrl_msg_queue_replaced='13'
ctrl_msg_queue_processed='5587'
```

<details><summary>JSON stats</summary>

```json
{
  "uptime": "2025-08-13T10:54:40+00:00",
  "timestamp": "2025-08-13T10:57:53+00:00",
  "name": "wazuh-remoted",
  "metrics": {
    "bytes": {
      "received": 5330920,
      "sent": 1664300
    },
    "keys_reload_count": 0,
    "messages": {
      "received_breakdown": {
        "control": 18700,
        "control_breakdown": {
          "keepalive": 18600,
          "request": 0,
          "shutdown": 0,
          "startup": 100
        },
        "dequeued_after": 0,
        "discarded": 0,
        "event": 0,
        "ping": 0,
        "unknown": 0
      },
      "sent_breakdown": {
        "ack": 18700,
        "ar": 0,
        "discarded": 0,
        "request": 0,
        "sca": 0,
        "shared": 0
      }
    },
    "queues": {
      "received": {
        "size": 131072,
        "usage": 0
      }
    },
    "tcp_sessions": 100,
    "control_messages_queue_usage": 0,
    "control_messages_queue_breakdown": {
      "inserted": 18687,
      "replaced": 13,
      "processed": 18687
    }
  }
}
```

</details>

#### Performance charts

|CPU|Memory|Queue usage|
|---|---|---|
|<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/eba41da7-96ad-4aa1-9e8b-fc24e4879cfe" />|<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/06539efa-238c-44bf-82a9-97ee6f7a5033" />|<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/6d9941b7-4563-42df-9c64-5498d6f426fb" />|

### Artifacts Affected

- `src/remoted/`: Core remoted daemon changes
- `src/shared/`: Indexed queue implementation
- `src/unit_tests/remoted/`: Updated unit tests
- `src/unit_tests/monitord/`: Fixed unit tests

### Configuration Changes

#### New Parameters
- `remoted.ctrl_msg_queue_size`: Control message queue size limit (default: 16384)

#### Modified Defaults
- `agents_disconnection_time`: Changed from 10 minutes to 15 minutes
- `notify_time`: Changed from 10 seconds to 20 seconds

### Tests Introduced

- [x] Unit tests for `indexed_queue` data structure
- [x] Updated remoted unit tests for new queue behavior
- [x] Manual testing with AddressSanitizer and ThreadSanitizer

<details><summary>ASAN log</summary>

```bash

=================================================================
==25751==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 74 byte(s) in 1 object(s) allocated from:
    #0 0x7f63e0ea89a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x56068eee5728 in Read_Global config/global-config.c:210
    #2 0x56068eed8596 in read_main_elements config/config.c:85
    #3 0x56068eedacda in ReadConfig config/config.c:372
    #4 0x56068eeac8d2 in RemotedConfig remoted/config.c:54
    #5 0x56068eeaeca0 in main remoted/main.c:133
    #6 0x7f63dfb9bd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

SUMMARY: AddressSanitizer: 74 byte(s) leaked in 1 allocation(s).

```

</details>

<details><summary>TSAN log</summary>

```bash
==================
WARNING: ThreadSanitizer: data race (pid=38238)
  Write of size 8 at 0x7b0c00000a18 by main thread:
    #0 <null> <null> (libtsan.so.0+0x37ab8)
    #1 <null> <null> (libwazuhext.so+0x34a5c3)
    #2 <null> <null> (libtsan.so.0+0x2d883)
    #3 wnotify_wait shared/notify_op.c:54 (wazuh-remoted+0x10999f)
    #4 HandleSecure remoted/secure.c:317 (wazuh-remoted+0x22976)
    #5 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #6 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Previous read of size 1 at 0x7b0c00000a18 by thread T2 (mutexes: write M36, read M76):
    #0 <null> <null> (libtsan.so.0+0x672c1)
    #1 <null> <null> (libwazuhext.so+0x387448)
    #2 c_group remoted/manager.c:828 (wazuh-remoted+0x15cff)
    #3 process_groups remoted/manager.c:973 (wazuh-remoted+0x167f8)
    #4 c_files remoted/manager.c:908 (wazuh-remoted+0x1627e)
    #5 update_shared_files remoted/manager.c:1800 (wazuh-remoted+0x1ad1a)
    #6 <null> <null> (libtsan.so.0+0x2e5ff)

  Mutex M36 (0x55d12e78c3c0) created at:
    #0 <null> <null> (libtsan.so.0+0x53908)
    #1 c_files remoted/manager.c:905 (wazuh-remoted+0x16231)
    #2 manager_init remoted/manager.c:1834 (wazuh-remoted+0x1af75)
    #3 HandleSecure remoted/secure.c:189 (wazuh-remoted+0x21fcd)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #5 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Mutex M76 (0x7b1000000b00) created at:
    #0 <null> <null> (libtsan.so.0+0x3866b)
    #1 <null> <null> (libwazuhext.so+0x35d309)
    #2 c_group remoted/manager.c:801 (wazuh-remoted+0x15a3d)
    #3 process_groups remoted/manager.c:966 (wazuh-remoted+0x16734)
    #4 c_files remoted/manager.c:908 (wazuh-remoted+0x1627e)
    #5 manager_init remoted/manager.c:1834 (wazuh-remoted+0x1af75)
    #6 HandleSecure remoted/secure.c:189 (wazuh-remoted+0x21fcd)
    #7 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #8 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Thread T2 (tid=38250, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x10af2d)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x10aff6)
    #3 HandleSecure remoted/secure.c:201 (wazuh-remoted+0x22049)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #5 main remoted/main.c:220 (wazuh-remoted+0x11e27)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x37ab8) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=38238)
  Write of size 1 at 0x7b1000000b00 by main thread:
    #0 <null> <null> (libtsan.so.0+0x354c8)
    #1 <null> <null> (libwazuhext.so+0x35d3ad)
    #2 <null> <null> (libtsan.so.0+0x2d883)
    #3 wnotify_wait shared/notify_op.c:54 (wazuh-remoted+0x10999f)
    #4 HandleSecure remoted/secure.c:317 (wazuh-remoted+0x22976)
    #5 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #6 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Previous atomic read of size 1 at 0x7b1000000b00 by thread T2 (mutexes: write M36):
    #0 <null> <null> (libtsan.so.0+0x3cab8)
    #1 <null> <null> (libwazuhext.so+0x35d348)
    #2 c_group remoted/manager.c:828 (wazuh-remoted+0x15cff)
    #3 process_groups remoted/manager.c:973 (wazuh-remoted+0x167f8)
    #4 c_files remoted/manager.c:908 (wazuh-remoted+0x1627e)
    #5 update_shared_files remoted/manager.c:1800 (wazuh-remoted+0x1ad1a)
    #6 <null> <null> (libtsan.so.0+0x2e5ff)

  Location is heap block of size 56 at 0x7b1000000b00 allocated by main thread:
    #0 <null> <null> (libtsan.so.0+0x31c57)
    #1 <null> <null> (libwazuhext.so+0x34fb89)
    #2 c_group remoted/manager.c:801 (wazuh-remoted+0x15a3d)
    #3 process_groups remoted/manager.c:966 (wazuh-remoted+0x16734)
    #4 c_files remoted/manager.c:908 (wazuh-remoted+0x1627e)
    #5 manager_init remoted/manager.c:1834 (wazuh-remoted+0x1af75)
    #6 HandleSecure remoted/secure.c:189 (wazuh-remoted+0x21fcd)
    #7 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #8 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Mutex M36 (0x55d12e78c3c0) created at:
    #0 <null> <null> (libtsan.so.0+0x53908)
    #1 c_files remoted/manager.c:905 (wazuh-remoted+0x16231)
    #2 manager_init remoted/manager.c:1834 (wazuh-remoted+0x1af75)
    #3 HandleSecure remoted/secure.c:189 (wazuh-remoted+0x21fcd)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #5 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Thread T2 (tid=38250, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x10af2d)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x10aff6)
    #3 HandleSecure remoted/secure.c:201 (wazuh-remoted+0x22049)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #5 main remoted/main.c:220 (wazuh-remoted+0x11e27)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x354c8) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=38238)
  Write of size 1 at 0x7b1000000540 by main thread:
    #0 <null> <null> (libtsan.so.0+0x354c8)
    #1 <null> <null> (libwazuhext.so+0x35d3ad)
    #2 <null> <null> (libtsan.so.0+0x2d883)
    #3 wnotify_wait shared/notify_op.c:54 (wazuh-remoted+0x10999f)
    #4 HandleSecure remoted/secure.c:317 (wazuh-remoted+0x22976)
    #5 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #6 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Previous atomic read of size 1 at 0x7b1000000540 by thread T2 (mutexes: write M36, read M13364632555095360):
    #0 <null> <null> (libtsan.so.0+0x33ea6)
    #1 <null> <null> (libwazuhext.so+0x35d388)
    #2 c_group remoted/manager.c:828 (wazuh-remoted+0x15cff)
    #3 process_groups remoted/manager.c:973 (wazuh-remoted+0x167f8)
    #4 c_files remoted/manager.c:908 (wazuh-remoted+0x1627e)
    #5 update_shared_files remoted/manager.c:1800 (wazuh-remoted+0x1ad1a)
    #6 <null> <null> (libtsan.so.0+0x2e5ff)

  Location is heap block of size 56 at 0x7b1000000540 allocated by main thread:
    #0 <null> <null> (libtsan.so.0+0x31c57)
    #1 <null> <null> (libwazuhext.so+0x34fb89)
    #2 <null> <null> (libwazuhext.so+0x35d3d8)
    #3 <null> <null> (libwazuhext.so+0x35d3d8)
    #4 c_group remoted/manager.c:801 (wazuh-remoted+0x15a3d)
    #5 process_groups remoted/manager.c:966 (wazuh-remoted+0x16734)
    #6 c_files remoted/manager.c:908 (wazuh-remoted+0x1627e)
    #7 manager_init remoted/manager.c:1834 (wazuh-remoted+0x1af75)
    #8 HandleSecure remoted/secure.c:189 (wazuh-remoted+0x21fcd)
    #9 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #10 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Mutex M36 (0x55d12e78c3c0) created at:
    #0 <null> <null> (libtsan.so.0+0x53908)
    #1 c_files remoted/manager.c:905 (wazuh-remoted+0x16231)
    #2 manager_init remoted/manager.c:1834 (wazuh-remoted+0x1af75)
    #3 HandleSecure remoted/secure.c:189 (wazuh-remoted+0x21fcd)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #5 main remoted/main.c:220 (wazuh-remoted+0x11e27)

  Mutex M13364632555095360 is already destroyed.

  Thread T2 (tid=38250, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-remoted+0x10af2d)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-remoted+0x10aff6)
    #3 HandleSecure remoted/secure.c:201 (wazuh-remoted+0x22049)
    #4 HandleRemote remoted/remoted.c:138 (wazuh-remoted+0x1fe8d)
    #5 main remoted/main.c:220 (wazuh-remoted+0x11e27)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x354c8) 
==================
ThreadSanitizer: reported 3 warnings
```

</details>

## Review Checklist
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
## Documentation Updates Required

- [ ] Add `remoted.ctrl_msg_queue_size` to internal options documentation
- [ ] Update default value for `agents_disconnection_time` in documentation
- [ ] Update default value for `notify_time` in documentation
- [ ] Add new queue statistics fields to monitoring documentation
-->