### PR TITLE
Backport: fix Solaris 11 SSL certs error

### DIFF
--- a/packages/solaris/solaris11/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris11/generate_wazuh_packages.sh
@@ -93,6 +93,9 @@ build_environment() {
     cd ..
     rm -rf *cmake-*
     ln -sf /usr/local/bin/cmake /usr/bin/cmake
+
+    export CURL_CA_BUNDLE="/etc/certs/ca-bundle.crt"
+    echo "export CURL_CA_BUNDLE=/etc/certs/ca-bundle.crt" >> /etc/profile
 }
 
 compute_version_revision() {
@@ -129,6 +132,7 @@ compile() {
     export PATH=/usr/local/gcc-5.5.0/bin:/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin
     export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0
     export LD_LIBRARY_PATH=/usr/local/gcc-5.5.0/lib
+    export CURL_CA_BUNDLE="/etc/certs/ca-bundle.crt"
 
     cd ${current_path}
     VERSION=`cat $SOURCE/src/VERSION`


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/31257|

## Description

This PR fixes the SSL certificate problem on both _Solaris 11 i386_ and _Solaris 11 SPARC_, both of which had the same error.
The solution has been to download and pass the `curl` certificate bundle to the machine, to be used by default via the `CURL_CA_BUNDLE` environment variable.

## Tests
