### PR TITLE
Improve error handler on alse positive build agent

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -14,6 +14,7 @@
 # ./src/init/template-select.sh
 
 ## Templates
+# set -e
 . ./src/init/template-select.sh
 
 HEADER_TEMPLATE="./etc/templates/config/generic/header-comments.template"
@@ -240,7 +241,7 @@ GenerateAuthCert()
 WriteLogs()
 {
   LOCALFILES_TMP=`cat ${LOCALFILES_TEMPLATE}`
-  HAS_JOURNALD=`command -v journalctl`
+  HAS_JOURNALD=`command -v journalctl || true`
 
   # If has journald, add journald to the configuration file
   if [ "X$HAS_JOURNALD" != "X" ]; then
@@ -279,7 +280,7 @@ WriteLogs()
       fi
 
       # If journald is not available, change the log_format from '[!journald] ${log_type}' to '${log_type}'
-      NEGATE_JOURNALD=$(echo "$LOG_FORMAT" | grep "\[!journald\] ")
+      NEGATE_JOURNALD=$(echo "$LOG_FORMAT" | grep "\[!journald\] " || true)
       if [ "X$HAS_JOURNALD" = "X" ]; then
         if [ -n "$NEGATE_JOURNALD" ]; then
           LOG_FORMAT=$(echo "$LOG_FORMAT" | sed -e "s|\[!journald\] ||g")
@@ -748,7 +749,6 @@ WriteLocal()
 
 InstallCommon()
 {
-
     WAZUH_GROUP='wazuh'
     WAZUH_USER='wazuh'
     INSTALL="install"
@@ -967,6 +967,13 @@ InstallCommon()
             fi
         fi
     fi
+
+  rm wazuh-logcollector
+  rm syscheckd/build/bin/wazuh-syscheckd
+  rm wazuh-execd
+  rm manage_agents
+  rm wazuh-modulesd
+
 
   ${INSTALL} -m 0750 -o root -g 0 wazuh-logcollector ${INSTALLDIR}/bin
   ${INSTALL} -m 0750 -o root -g 0 syscheckd/build/bin/wazuh-syscheckd ${INSTALLDIR}/bin

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -14,7 +14,7 @@
 # ./src/init/template-select.sh
 
 ## Templates
-# set -e
+set -e
 . ./src/init/template-select.sh
 
 HEADER_TEMPLATE="./etc/templates/config/generic/header-comments.template"

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -968,13 +968,6 @@ InstallCommon()
         fi
     fi
 
-  rm wazuh-logcollector
-  rm syscheckd/build/bin/wazuh-syscheckd
-  rm wazuh-execd
-  rm manage_agents
-  rm wazuh-modulesd
-
-
   ${INSTALL} -m 0750 -o root -g 0 wazuh-logcollector ${INSTALLDIR}/bin
   ${INSTALL} -m 0750 -o root -g 0 syscheckd/build/bin/wazuh-syscheckd ${INSTALLDIR}/bin
   ${INSTALL} -m 0750 -o root -g 0 wazuh-execd ${INSTALLDIR}/bin


### PR DESCRIPTION
## Description
This PR addresses a bug (closes wazuh/wazuh-agent-packages#392) where the agent build process was incorrectly reporting a false positive status, specifically when a build was successful. This led to confusion and unnecessary intervention in the build pipeline.

### Results and Evidence

To confirm the issue and validate the fix, I created three separate commits.

1. Demonstrating the Error:

This commit was created to intentionally trigger the false positive error. The build appears successful at first, but it fails later due to missing files.

Commit: [74afea86dd7bf2c44dd8a5cbfc81a9d1df484d81](https://github.com/wazuh/wazuh/commit/74afea86dd7bf2c44dd8a5cbfc81a9d1df484d81)

The error is:

```bash
...
Done building agent

make[2]: Leaving directory `/build_wazuh/agent/wazuh-agent-4.14.1/src'
Wait for success...
success
install: cannot stat `wazuh-logcollector': No such file or directory
install: cannot stat `syscheckd/build/bin/wazuh-syscheckd': No such file or directory
install: cannot stat `wazuh-execd': No such file or directory
install: cannot stat `manage_agents': No such file or directory
install: cannot stat `wazuh-modulesd': No such file or directory
...
```
Workflow: https://github.com/wazuh/wazuh-agent-packages/actions/runs/16662061663/job/47161237012

2. Applying the Solution:

This commit applies the proposed solution and demonstrates that the build now fails as expected, correctly reporting the issue.

Commit with the solution: [d2f3adcff4006ea9dcbbe22e6392bc43ddb7ddc7](https://github.com/wazuh/wazuh/commit/d2f3adcff4006ea9dcbbe22e6392bc43ddb7ddc7)


```bash
make[2]: Leaving directory `/build_wazuh/agent/wazuh-agent-4.14.1/src'
Wait for success...
success
install: cannot stat `wazuh-logcollector': No such file or directory
install.sh failed! Aborting.
make[1]: *** [override_dh_install] Error 1
make[1]: Leaving directory `/build_wazuh/agent/wazuh-agent-4.14.1'
make: *** [binary] Error 2
dpkg-buildpackage: error: sudo debian/rules binary gave error exit status 2
debuild: fatal error at line 1357:
dpkg-buildpackage -rsudo -D -us -uc -b -nc failed
```

Workflow: https://github.com/wazuh/wazuh-agent-packages/actions/runs/16662304250/job/47161948245

3. Final Commit:
This final commit removes the temporary code used for testing, leaving the branch ready for review.

Commit: [a1606d41dc443678fd238286b3d418c79b4675de](https://github.com/wazuh/wazuh/commit/a1606d41dc443678fd238286b3d418c79b4675de)

:green_circle: [Build deb wazuh-agent on amd64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16662334722/job/47162038568#logs)




