### PR TITLE
Add handling of geo_point type

### DIFF
--- a/src/engine/tools/docker/README.md
+++ b/src/engine/tools/docker/README.md
@@ -44,13 +44,13 @@ engine-container               latest       b29a5190594a   2 minutes ago   17.2G
 In order to create the container, you can use the following command:
 
 ``` bash
-docker create -p 4022:22 --name engine-container engine-container:latest
+docker create -p 4022:22 -v /var/run/docker.sock:/var/run/docker.sock --name engine-container engine-container:latest
 ```
 
 Alternatively, you can use a specific version of the image
 ``` bash
 export VERSION=20250701-0
-docker create -p 4022:22 --name engine-container engine-container:$VERSION
+docker create -p 4022:22 -v /var/run/docker.sock:/var/run/docker.sock --name engine-container engine-container:$VERSION
 ```
 This command will create a container named `engine-container` and will map the port `4022` of the host to the port `22` of the container. A container is created in a stopped state.
 


### PR DESCRIPTION
## Description

This PR aims to adapt the validate schema test to teach it what a geo_point type is, since currently the test fails if fields of that style come in.

Closes #31050 

## Proposed Changes

- Interpret that if the field is a child and the parent is of the geopoint type, it must be accepted as valid
- teach how a custom field should be to be considered a geo_point

### Results and Evidence

```
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src/engine ‹bug/31050-geo-point-field-main●› 
╰─# engine-health-test static -r /workspaces/devContainer/intelligence-data/ruleset schema_validate                               130 ↵
Running schema tests.
Validating both integration and rules.
Success execution
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
