### PR TITLE
Windows Server 2016 SCA bug fix

### DIFF
--- a/ruleset/sca/windows/cis_win2016.yml
+++ b/ruleset/sca/windows/cis_win2016.yml
@@ -710,9 +710,9 @@ checks:
       - cis: ["2.3.9.2"]
     condition: all
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters'
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> RequireSecuritySignature'
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> RequireSecuritySignature -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> RequireSecuritySignature'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> RequireSecuritySignature -> 1'
 
   # 2.3.9.3 (L1) Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'. (Automated)
   - id: 16031


### PR DESCRIPTION
A user has reported the [issue ](https://github.com/wazuh/wazuh/issues/31118) below and this PR aims to correct the detected bug


Hello,

in cis_win2016.yml there are copy & paste issues i assume. 

Please fix it to check for the proper registry keys in below, thanks.

The policies for SMB signing are located in Computer Configuration > Windows Settings > Security Settings > Local Policies > Security Options.

Microsoft network **client**: Digitally sign communications (always)
Registry key: HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\**LanManWorkstation**\Parameters
Registry value: RequireSecuritySignature
Data Type: REG_DWORD
Data: 0 (disable), 1 (enable)

Microsoft network **server**: Digitally sign communications (always)
Registry key: HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\**LanManServer**\Parameters
Registry value: RequireSecuritySignature
Data Type: REG_DWORD Data: 0 (disable), 1 (enable)

Cheers much.