### PR TITLE
Remove debug stdout message.

### DIFF
--- a/src/shared_modules/utils/reflectiveJson.hpp
+++ b/src/shared_modules/utils/reflectiveJson.hpp
@@ -545,8 +545,6 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                      const auto& data = obj.*(std::get<2>(field));
                      if constexpr (NOEMPTY)
                      {
-                         std::cout << "2NOEMPTY" << std::endl;
-                         std::cout << NOEMPTY << std::endl;
                          if (isEmpty(data))
                          {
                              return;


### PR DESCRIPTION
## Description

This PR removes unused debug stdout messages from the `reflectiveJson.hpp` file. The removed lines were debug statements that were printing "2NOEMPTY" and the value of `NOEMPTY` to stdout, which are no longer needed in production code.

The changes specifically:
- Remove `std::cout << "2NOEMPTY" << std::endl;` 
- Remove `std::cout << NOEMPTY << std::endl;`
