### PR TITLE
Add ruleset reload endpoint

### DIFF
--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -796,6 +796,42 @@ async def put_restart(pretty: bool = False, wait_for_complete: bool = False,
     return json_response(data, pretty=pretty)
 
 
+async def put_reload_analysisd(pretty: bool = False, wait_for_complete: bool = False,
+                               nodes_list: str = '*') -> ConnexionResponse:
+    """Restart the analysisd process on all nodes in the cluster, or a list of them.
+
+    Parameters
+    ----------
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+    nodes_list : str
+        List of node IDs.
+
+    Returns
+    -------
+    ConnexionResponse
+        API response.
+    """
+    f_kwargs = {'node_list': nodes_list}
+
+    nodes = raise_if_exc(await get_system_nodes())
+    dapi = DistributedAPI(f=manager.reload_ruleset,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='distributed_master',
+                          is_async=False,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          broadcasting=nodes_list == '*',
+                          rbac_permissions=request.context['token_info']['rbac_policies'],
+                          nodes=nodes
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return json_response(data, pretty=pretty)
+
+
 async def get_conf_validation(pretty: bool = False, wait_for_complete: bool = False,
                               nodes_list: str = '*') -> ConnexionResponse:
     """Check whether the Wazuh configuration in a list of cluster nodes is correct or not.

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -798,7 +798,7 @@ async def put_restart(pretty: bool = False, wait_for_complete: bool = False,
 
 async def put_reload_analysisd(pretty: bool = False, wait_for_complete: bool = False,
                                nodes_list: str = '*') -> ConnexionResponse:
-    """Restart the analysisd process on all nodes in the cluster, or a list of them.
+    """Reloads the analysisd process on all nodes in the cluster, or a list of them.
 
     Parameters
     ----------

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -823,7 +823,6 @@ async def put_reload_analysisd(pretty: bool = False, wait_for_complete: bool = F
                           is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
-                          local_client_arg='lc',
                           broadcasting=nodes_list == '*',
                           rbac_permissions=request.context['token_info']['rbac_policies'],
                           nodes=nodes

--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -820,9 +820,10 @@ async def put_reload_analysisd(pretty: bool = False, wait_for_complete: bool = F
     dapi = DistributedAPI(f=manager.reload_ruleset,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
+                          local_client_arg='lc',
                           broadcasting=nodes_list == '*',
                           rbac_permissions=request.context['token_info']['rbac_policies'],
                           nodes=nodes

--- a/api/api/controllers/test/test_cluster_controller.py
+++ b/api/api/controllers/test/test_cluster_controller.py
@@ -599,6 +599,35 @@ async def test_put_restart(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_re
 @patch('api.controllers.cluster_controller.remove_nones_to_dict')
 @patch('api.controllers.cluster_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.cluster_controller.raise_if_exc', return_value=CustomAffectedItems())
+async def test_put_reload_analysisd(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+    """Verify 'put_reload_analysisd' endpoint is working as expected."""
+    with patch('api.controllers.cluster_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:
+        from api.controllers.cluster_controller import put_reload_analysisd
+        result = await put_reload_analysisd()
+        f_kwargs = {'node_list': '*'}
+        mock_dapi.assert_called_once_with(f=manager.reload_ruleset,
+                                          f_kwargs=mock_remove.return_value,
+                                          request_type='distributed_master',
+                                          is_async=True,
+                                          wait_for_complete=False,
+                                          logger=ANY,
+                                          broadcasting=True,
+                                          rbac_permissions=mock_request.context['token_info']['rbac_policies'],
+                                          nodes=mock_exc.return_value
+                                          )
+        mock_exc.assert_has_calls([call(mock_snodes.return_value),
+                                   call(mock_dfunc.return_value)])
+        assert mock_exc.call_count == 2
+        mock_remove.assert_called_once_with(f_kwargs)
+        assert isinstance(result, ConnexionResponse)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mock_request", ["cluster_controller"], indirect=True)
+@patch('api.controllers.cluster_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
+@patch('api.controllers.cluster_controller.remove_nones_to_dict')
+@patch('api.controllers.cluster_controller.DistributedAPI.__init__', return_value=None)
+@patch('api.controllers.cluster_controller.raise_if_exc', return_value=CustomAffectedItems())
 async def test_get_conf_validation(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_conf_validation' endpoint is working as expected."""
     with patch('api.controllers.cluster_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11518,8 +11518,8 @@ paths:
     put:
       tags:
         - Cluster
-      summary: "Restart the analysis process for the nodes"
-      description: "Restart the analysisd process on all nodes in the cluster, or on a specified list of nodes"
+      summary: "Reloads the analysis process for the nodes"
+      description: "Reloads the analysisd process on all nodes in the cluster, or on a specified list of nodes"
       operationId: api.controllers.manager_controller.put_reload_analysisd
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11514,6 +11514,54 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /cluster/analysisd/reload:
+    put:
+      tags:
+        - Cluster
+      summary: "Restart the analysis process for the nodes"
+      description: "Restart the analysisd process on all nodes in the cluster, or on a specified list of nodes"
+      operationId: api.controllers.manager_controller.put_reload_analysisd
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/cluster:read'
+        - $ref: '#/x-rbac-catalog/actions/cluster:restart'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/nodes_list'
+      responses:
+        '200':
+          description: "List of affected nodes"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AllItemsResponseNodeIDs'
+                example:
+                  data:
+                    affected_items:
+                      - 'master-node'
+                      - 'worker1'
+                      - 'worker2'
+                    total_affected_items: 3
+                    total_failed_items: 0
+                    failed_items: [ ]
+                  message: "Restart request sent to all specified nodes"
+                  error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /cluster/configuration/validation:
     get:
       tags:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -11520,7 +11520,7 @@ paths:
         - Cluster
       summary: "Reloads the analysis process for the nodes"
       description: "Reloads the analysisd process on all nodes in the cluster, or on a specified list of nodes"
-      operationId: api.controllers.manager_controller.put_reload_analysisd
+      operationId: api.controllers.cluster_controller.put_reload_analysisd
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
         - $ref: '#/x-rbac-catalog/actions/cluster:restart'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -132,6 +132,14 @@ x-rbac-catalog:
         actions: ['agent:modify_group']
         resources: ['agent:id:004', 'agent:group:us-east']
         effect: "allow"
+    'analysisd:reload':
+      description: "Reloads Wazuh's ruleset"
+      resources:
+        - $ref: '#/x-rbac-catalog/resources/node:id'
+      example:
+        actions: [ 'analysisd:reload' ]
+        resources: [ 'node:id:worker1' ]
+        effect: "allow"
     'group:modify_assignments':
       description: "Change the agents assigned to the group"
       resources:
@@ -11523,7 +11531,7 @@ paths:
       operationId: api.controllers.cluster_controller.put_reload_analysisd
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
-        - $ref: '#/x-rbac-catalog/actions/cluster:restart'
+        - $ref: '#/x-rbac-catalog/actions/analysisd:reload'
       parameters:
         - $ref: '#/components/parameters/pretty'
         - $ref: '#/components/parameters/wait_for_complete'

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -133,7 +133,7 @@ x-rbac-catalog:
         resources: ['agent:id:004', 'agent:group:us-east']
         effect: "allow"
     'analysisd:reload':
-      description: "Reloads Wazuh's ruleset"
+      description: "Reload the ruleset"
       resources:
         - $ref: '#/x-rbac-catalog/resources/node:id'
       example:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -2387,3 +2387,52 @@ stages:
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
+
+---
+test_name: PUT /cluster/analysisd/reload
+
+marks:
+  - cluster
+
+stages:
+
+  - name: Reload analysisd on worker1 and worker2
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        nodes_list: 'worker1,worker2'
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - 'worker1'
+            - 'worker2'
+          failed_items: []
+          total_affected_items: 2
+          total_failed_items: 0
+
+  - name: Reload analysisd on all nodes
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      method: PUT
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - 'master-node'
+            - 'worker1'
+            - 'worker2'
+          failed_items: []
+          total_affected_items: 3
+          total_failed_items: 0

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -6,7 +6,6 @@ from os import remove
 from os.path import join, split, exists, isfile, dirname as path_dirname
 
 from wazuh.core import common
-from wazuh.core.analysis import send_reload_ruleset_msg
 from wazuh.core.cdb_list import iterate_lists, get_list_from_file, REQUIRED_FIELDS, SORT_FIELDS, delete_list, \
     get_filenames_paths, validate_cdb_list, LIST_FIELDS
 from wazuh.core.exception import WazuhError
@@ -151,10 +150,6 @@ def upload_list_file(filename: str = None, content: str = None, overwrite: bool 
 
         upload_file(content, to_relative_path(full_path), check_xml_formula_values=False)
 
-        # After uploading the file, reload rulesets
-        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
-        socket_response.update_affected_items(results=result, error_code=1811)
-
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         # Remove back up file if no exceptions were raised.
@@ -188,10 +183,6 @@ def delete_list_file(filename: list) -> AffectedItemsWazuhResult:
 
     try:
         delete_list(to_relative_path(full_path))
-
-        # After deleting the file, reload rulesets
-        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
-        socket_response.update_affected_items(results=result, error_code=1811)
 
         result.affected_items.append(to_relative_path(full_path))
     except WazuhError as e:

--- a/framework/wazuh/core/analysis.py
+++ b/framework/wazuh/core/analysis.py
@@ -106,28 +106,6 @@ class RulesetReloadResponse:
         """
         return self.success
 
-    def update_affected_items(self, results: AffectedItemsWazuhResult, error_code: int):
-        """
-        Update the results object with warnings or raise an error if the reload failed.
-
-        Parameters
-        ----------
-        results : AffectedItemsWazuhResult
-            Object to update with warning messages.
-        error_code : int
-            Error code to use if raising a WazuhError.
-
-        Raises
-        ------
-        WazuhError
-            If the reload operation was not successful.
-        """
-        if self.is_ok():
-            if self.has_warnings():
-                results.all_msg = ','.join(self.warnings)
-        else:
-            raise WazuhError(error_code, extra_message=','.join(self.errors))
-
 def send_reload_ruleset_msg(origin: dict[str, str]) -> RulesetReloadResponse:
     """Send the reload ruleset command to Analysisd socket.
 

--- a/framework/wazuh/core/analysis.py
+++ b/framework/wazuh/core/analysis.py
@@ -3,8 +3,6 @@ from json import dumps, loads
 from typing import List
 
 from wazuh.core import common
-from wazuh.core.exception import WazuhError
-from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.wazuh_socket import create_wazuh_socket_message, WazuhSocket
 
 RELOAD_RULESET_COMMAND = "reload-ruleset"

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -223,6 +223,18 @@ async def get_node_ruleset_integrity(lc: local_client.LocalClient) -> dict:
     return result
 
 async def set_reload_ruleset_flag(lc: local_client.LocalClient) -> dict:
+    """Set the reload ruleset flag on the specified cluster node.
+
+    Parameters
+    ----------
+    lc : LocalClient
+        LocalClient instance.
+
+    Returns
+    -------
+    dict
+        Dictionary with results.
+    """
     response = await lc.execute(command=b"sendrreload", data=b"")
     result = json.loads(response, object_hook=as_wazuh_object)
 

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -223,7 +223,7 @@ async def get_node_ruleset_integrity(lc: local_client.LocalClient) -> dict:
     return result
 
 async def set_reload_ruleset_flag(lc: local_client.LocalClient) -> dict:
-    response = await lc.execute(command=b"ruleset_reload", data=b"")
+    response = await lc.execute(command=b"sendrreload", data=b"")
     result = json.loads(response, object_hook=as_wazuh_object)
 
     if isinstance(result, Exception):

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -221,3 +221,12 @@ async def get_node_ruleset_integrity(lc: local_client.LocalClient) -> dict:
         raise result
 
     return result
+
+async def set_reload_ruleset_flag(lc: local_client.LocalClient) -> dict:
+    response = await lc.execute(command=b"ruleset_reload", data=b"")
+    result = json.loads(response, object_hook=as_wazuh_object)
+
+    if isinstance(result, Exception):
+        raise result
+
+    return result

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -407,6 +407,11 @@ class LocalServerHandlerWorker(LocalServerHandler):
             return super().process_request(command, data)
 
     async def set_reload_ruleset_flag(self):
+        """Set the reload ruleset flag asynchronously for the worker node.
+
+        This method acquires the reload_ruleset_flag lock and sets the flag,
+        indicating that the ruleset should be reloaded.
+        """
         async with self.server.node.client.reload_ruleset_flag:
             self.server.node.client.reload_ruleset_flag.set()
 

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -402,7 +402,7 @@ class LocalServerHandlerWorker(LocalServerHandler):
             if self.server.node.client is None:
                 raise WazuhClusterError(3023)
             asyncio.create_task(self.log_exceptions(self.set_reload_ruleset_flag()))
-            return b'ok', b'Reload ruleset flag set'
+            return b'ok', json.dumps({'msg': 'Reload ruleset flag set successfully'}).encode()
         else:
             return super().process_request(command, data)
 

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -402,7 +402,7 @@ class LocalServerHandlerWorker(LocalServerHandler):
             if self.server.node.client is None:
                 raise WazuhClusterError(3023)
             asyncio.create_task(self.log_exceptions(self.set_reload_ruleset_flag()))
-            return b'ok', json.dumps({'msg': 'Reload ruleset flag set successfully'}).encode()
+            return b'ok', json.dumps({'success': True}).encode()
         else:
             return super().process_request(command, data)
 

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -398,7 +398,7 @@ class LocalServerHandlerWorker(LocalServerHandler):
             asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data)))
             return b'ok', b'Added request to sendsync requests queue'
-        elif command == b'ruleset_reload':
+        elif command == b'sendrreload':
             if self.server.node.client is None:
                 raise WazuhClusterError(3023)
             asyncio.create_task(self.log_exceptions(self.set_reload_ruleset_flag()))

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -176,3 +176,24 @@ async def test_get_node_ruleset_integrity():
 
         with pytest.raises(json.JSONDecodeError):
             await control.get_health(lc=local_client)
+
+
+@pytest.mark.asyncio
+async def test_set_reload_ruleset_flag():
+    """Verify that set_reload_ruleset_flag function uses the expected command and handles responses."""
+    local_client = LocalClient()
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client) as execute_mock:
+        with patch('json.loads'):
+            await control.set_reload_ruleset_flag(lc=local_client)
+        execute_mock.assert_called_once_with(command=b'sendrreload', data=b'')
+
+        with patch('json.loads', return_value=KeyError(1)):
+            with pytest.raises(KeyError):
+                await control.set_reload_ruleset_flag(lc=local_client)
+
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=[WazuhClusterError(3020), 'error']):
+        with pytest.raises(WazuhClusterError):
+            await control.set_reload_ruleset_flag(lc=local_client)
+
+        with pytest.raises(json.JSONDecodeError):
+            await control.set_reload_ruleset_flag(lc=local_client)

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1087,9 +1087,8 @@ async def test_worker_handler_process_files_from_master_ko(send_request_mock,
 @patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
 @patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
 @patch('wazuh.core.analysis.is_ruleset_file', return_value=True)
-@patch('wazuh.core.analysis.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0}))
 async def test_worker_handler_update_master_files_in_worker_reload(
-    mock_reload, mock_is_ruleset, wazuh_gid_mock, wazuh_uid_mock, path_join_mock,
+    mock_is_ruleset, wazuh_gid_mock, wazuh_uid_mock, path_join_mock,
     mkdir_with_mode_mock, safe_move_mock, path_exists_mock, open_mock, event_loop
 ):
     """Test that updating a ruleset file triggers a reload and logs success."""
@@ -1104,8 +1103,6 @@ async def test_worker_handler_update_master_files_in_worker_reload(
                     "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, zip_path="/zip/path",
                 cluster_items=cluster_items)
 
-            mock_reload.assert_called_once()
-
 
 @pytest.mark.asyncio
 @patch("builtins.open")
@@ -1115,9 +1112,7 @@ async def test_worker_handler_update_master_files_in_worker_reload(
 @patch("os.path.join", return_value="queue/testing/")
 @patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
 @patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
-@patch('wazuh.core.analysis.is_ruleset_file', return_value=False)
-@patch('wazuh.core.analysis.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0}))
-async def test_worker_handler_update_master_files_in_worker_ok(mock_reload, mock_is_ruleset, wazuh_gid_mock, wazuh_uid_mock, path_join_mock,
+async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, wazuh_uid_mock, path_join_mock,
                                                                mkdir_with_mode_mock, safe_move_mock, path_exists_mock,
                                                                open_mock, event_loop):
     """Check if the method is properly receiving and updating files."""

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -312,7 +312,7 @@ async def test_worker_handler_process_request_ok(logger_mock, event_loop):
     # Test the first condition
     with patch("wazuh.core.cluster.worker.WorkerHandler.sync_integrity_ok_from_master",
                return_value=b"ok") as ok_mock:
-        assert worker_handler.process_request(command=b"syn_m_c_ok", data=b"data") == b"ok"
+        assert worker_handler.process_request(command=b"syn_m_c_ok", data=b"data") ==  (b'ok', b'Thanks')
         ok_mock.assert_called_once()
         logger_mock.assert_called_with("Command received: 'b'syn_m_c_ok''")
     # Test the second condition

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -15,7 +15,7 @@ from time import perf_counter
 from typing import Tuple, Dict, Callable, List
 from typing import Union
 
-from wazuh.core import cluster as metadata, common, exception, utils, analysis
+from wazuh.core import cluster as metadata, common, exception, utils
 from wazuh.core.cluster import client, cluster, common as c_common
 from wazuh.core.cluster.utils import log_subprocess_execution
 from wazuh.core.cluster.dapi import dapi
@@ -753,7 +753,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                           ownership=(common.wazuh_uid(), common.wazuh_gid())
                           )
 
-        reload_ruleset_files = []
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
         result_logs = {'debug2': defaultdict(list), 'error': defaultdict(list), 'generic_errors': []}
 
@@ -763,10 +762,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 for filename, data in files.items():
                     try:
                         result_logs['debug2'][filename].append(f"Processing file {filename}")
-                        if analysis.is_ruleset_file(filename):
-                            result_logs['debug2'][filename].append("This file update will trigger a hot-reload in analysisd")
-                            reload_ruleset_files.append({'type': filetype, 'file': filename})
-
                         overwrite_or_create_files(filename, data)
                     except Exception as e:
                         errors[filetype] += 1
@@ -778,10 +773,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 for file_to_remove in files:
                     try:
                         result_logs['debug2'][file_to_remove].append(f"Remove file: '{file_to_remove}'")
-                        if analysis.is_ruleset_file(file_to_remove):
-                            result_logs['debug2'][file_to_remove].append("This file update will trigger a hot-reload in analysisd")
-                            reload_ruleset_files.append({'type': filetype, 'file': file_to_remove})
-
                         file_path = os.path.join(common.WAZUH_PATH, file_to_remove)
                         try:
                             os.remove(file_path)
@@ -811,40 +802,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 errors['extra'] += 1
                 result_logs["debug2"][directory].append(f"Error removing directory '{directory}': {e}")
                 continue
-
-        # If analysisd must be reloaded
-        if len(reload_ruleset_files) > 0:
-            try:
-                response = analysis.send_reload_ruleset_msg(origin={'module': 'cluster'})
-                if response.is_ok():
-                    if response.has_warnings():
-                        for warning in response.warnings:
-                            matched = [file_info for file_info in reload_ruleset_files if file_info['file'] in warning]
-                            if matched:
-                                for match in matched:
-                                    result_logs['debug2'][match['file']].append(warning)
-                            else:
-                                result_logs['debug2']['warnings'].append(warning)
-
-                else:
-                    for error in response.errors:
-                        matched = [file_info for file_info in reload_ruleset_files if file_info['file'] in error]
-                        if matched:
-                            for match in matched:
-                                result_logs['error'][match['type']].append(f"Error reloading {match['type']} "
-                                                                      f"file '{match['file']}': {error}")
-                                errors[match['type']] += 1
-                        else:
-                            result_logs['generic_errors'].append(f"Error reloading ruleset {error}")
-
-                            # Add an error to all filetypes if we can't specify the file
-                            unique_types = []
-                            for file_info in reload_ruleset_files:
-                                unique_types.append(file_info['type'])
-
-                            for file_type in set(unique_types):
-                                errors[file_type] += 1
-
 
             except Exception as e:
                 result_logs['generic_errors'].append(f"Error reloading ruleset {e}")

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -239,8 +239,8 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         self.logger.debug(f"Command received: '{command}'")
         if command == b'syn_m_c_ok':
-            asyncio.create_task(self.sync_integrity_ok_from_master())
-            return b'ok', b'Thanks'
+            asyncio.create_task(self.log_exceptions(self.sync_integrity_ok_from_master()))
+            return b'ok'
         elif command == b'syn_m_c':
             return self.setup_receive_files_from_master()
         elif command == b'syn_m_c_e':

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -239,7 +239,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         """
         self.logger.debug(f"Command received: '{command}'")
         if command == b'syn_m_c_ok':
-            self.sync_integrity_ok_from_master()
             asyncio.create_task(self.sync_integrity_ok_from_master())
             return b'ok', b'Thanks'
         elif command == b'syn_m_c':

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -401,19 +401,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         async with self.reload_ruleset_flag:
             if self.reload_ruleset_flag.is_set():
                 response = analysis.send_reload_ruleset_msg(origin={'module': 'cluster'})
-                if response.is_ok():
-                    if response.has_warnings():
-                        integrity_logger.warning(
-                            f"Ruleset reloaded with warnings after cluster integrity check: {', '.join(response.warnings)}"
-                        )
-                    else:
-                        integrity_logger.info(
-                            "Ruleset reload triggered by cluster integrity check: reload message sent successfully."
-                        )
-                else:
-                    integrity_logger.error(
-                        f"Ruleset reload failed after cluster integrity check: {', '.join(response.errors)}"
-                    )
+                analysis.log_ruleset_reload_response(self.logger, response)
 
                 # Clear the flag
                 self.reload_ruleset_flag.clear()
@@ -747,19 +735,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
             async with self.reload_ruleset_flag:
                 if self.reload_ruleset_flag.is_set():
                     response = analysis.send_reload_ruleset_msg(origin={'module': 'cluster'})
-                    if response.is_ok():
-                        if response.has_warnings():
-                            self.logger.warning(
-                                f"Ruleset reloaded with warnings after cluster integrity check: {', '.join(response.warnings)}"
-                            )
-                        else:
-                            self.logger.info(
-                                "Ruleset reload triggered by cluster integrity check: reload message sent successfully."
-                            )
-                    else:
-                        self.logger.error(
-                            f"Ruleset reload failed after cluster integrity check: {', '.join(response.errors)}"
-                        )
+                    analysis.log_ruleset_reload_response(self.logger, response)
 
                     # Clear the flag
                     self.reload_ruleset_flag.clear()

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -118,24 +118,49 @@ class ReceiveIntegrityTask(c_common.ReceiveFileTask):
 
 
 class AsyncReloadRulesetFlag:
+    """
+    Asynchronous flag with locking to control ruleset reload operations in worker nodes.
+
+    This class provides an async context manager for safely setting and clearing a boolean flag
+    used to indicate when the ruleset should be reloaded.
+    """
+
     def __init__(self):
+        """Initializes the asynchronous lock and the flag state."""
         self._lock = asyncio.Lock()
         self._flag = False
 
     async def __aenter__(self):
+        """Acquire the lock asynchronously when entering the context.
+
+        Returns
+        -------
+        AsyncReloadRulesetFlag
+            The instance itself.
+        """
         await self._lock.acquire()
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
+        """Release the lock when exiting the context."""
         self._lock.release()
 
     def set(self):
+        """Set the flag to True, indicating a reload is required."""
         self._flag = True
 
     def clear(self):
+        """Clear the flag, indicating no reload is required."""
         self._flag = False
 
     def is_set(self):
+        """Check if the flag is set.
+
+        Returns
+        -------
+        bool
+            True if the flag is set, False otherwise.
+        """
         return self._flag
 
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -418,6 +418,8 @@ class WazuhException(Exception):
         1913: {'message': 'Error getting manager status, directory /proc is not found or permissions to see its status '
                           'are not granted',
                'remediation': 'Please, ensure /proc exists and permissions are granted'},
+        1914: {'message': 'Failed to reload ruleset',
+               'remediation': 'Check the Wazuh logs for details and verify the ruleset files and permissions.'},
 
         # Database:
         2000: {'message': 'No such database file'},

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -179,7 +179,6 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the rules'
                },
-        1212: {'message': 'Error sending Rules file update to Wazuh-Analysisd'},
 
         # Stats: 1300 - 1399
         1307: {'message': 'Invalid parameters',
@@ -261,7 +260,6 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the decoders'
                },
-        1508: {'message': 'Error sending decoders files update to Wazuh-Analysisd'},
 
         # Syscheck/AR: 1600 - 1699
         1603: 'Invalid status. Valid statuses are: all, solved and outstanding',
@@ -388,7 +386,6 @@ class WazuhException(Exception):
                },
         1810: {'message': 'Upgrade module\'s reserved exception IDs (1810-1899). '
                           'The error message will be the output of upgrade module'},
-        1811: {'message': 'Error sending CDB list files update to Wazuh-Analysisd'},
 
         # Manager:
         1901: {'message': '\'execq\' socket has not been created'

--- a/framework/wazuh/core/tests/test_analysis.py
+++ b/framework/wazuh/core/tests/test_analysis.py
@@ -40,26 +40,3 @@ def test_ruleset_reload_response(response, expected_success, expected_warnings, 
     assert rrr.errors == expected_errors
     assert rrr.is_ok() == expected_success
     assert rrr.has_warnings() == (len(expected_warnings) > 0)
-
-@pytest.mark.parametrize(
-    "response,expected_all_msg,should_raise",
-    [
-        ({"error": 0, "message": "ok", "data": []}, "", False),
-        ({"error": 0, "message": "ok", "data": ["Warning 1", "Warning 2"]}, "Warning 1,Warning 2", False),
-        ({"error": 1, "message": "fail", "data": ["Error 1"]}, "Error 1", True),
-    ]
-)
-def test_ruleset_update_affected_items(response, expected_all_msg, should_raise):
-    """Test RulesetReloadResponse.check_affected_items updates results or raises WazuhError."""
-    rrr = RulesetReloadResponse(response)
-    results = AffectedItemsWazuhResult(all_msg="")
-    error_code = 1234
-
-    if should_raise:
-        with pytest.raises(WazuhError) as excinfo:
-            rrr.update_affected_items(results, error_code)
-        assert str(error_code) in str(excinfo.value)
-        assert expected_all_msg in str(excinfo.value)
-    else:
-        rrr.update_affected_items(results, error_code)
-        assert results.all_msg == expected_all_msg

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -11,7 +11,6 @@ import xmltodict
 
 import wazuh.core.configuration as configuration
 from wazuh.core import common
-from wazuh.core.analysis import send_reload_ruleset_msg
 from wazuh.core.decoder import load_decoders_from_file, check_status, REQUIRED_FIELDS, SORT_FIELDS, DECODER_FIELDS, \
     DECODER_FILES_FIELDS, DECODER_FILES_REQUIRED_FIELDS
 from wazuh.core.exception import WazuhInternalError, WazuhError
@@ -375,10 +374,6 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
 
             raise exc
 
-        # After uploading the file, reload rulesets
-        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
-        socket_response.update_affected_items(results=result, error_code=1508)
-
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         backup_file and exists(backup_file) and remove(backup_file)
@@ -427,10 +422,6 @@ def delete_decoder_file(filename: Union[str, list], relative_dirname: str = None
                 raise WazuhError(1907) from exc
         else:
             raise WazuhError(1906)
-
-        # After deleting the file, reload rulesets
-        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
-        socket_response.update_affected_items(results=result, error_code=1508)
 
     except WazuhError as exc:
         result.add_failed_item(id_=to_relative_path(full_path), error=exc)

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -207,6 +207,15 @@ def restart() -> AffectedItemsWazuhResult:
     return result
 
 
+@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
+                  resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
+@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:restart"],
+                  resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'],
+                  post_proc_kwargs={'default_result_kwargs': _restart_default_result_kwargs})
+def reload_ruleset() -> AffectedItemsWazuhResult:
+    pass
+
+
 _validation_default_result_kwargs = {
     'all_msg': f"Validation was successfully checked{' in all nodes' if node_id != 'manager' else ''}",
     'some_msg': 'Could not check validation in some nodes',

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -221,7 +221,7 @@ _restart_ruleset_default_result_kwargs = {
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:restart"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'],
                   post_proc_kwargs={'default_result_kwargs': _restart_ruleset_default_result_kwargs})
-async def reload_ruleset(lc: local_client.LocalClient) -> AffectedItemsWazuhResult:
+async def reload_ruleset() -> AffectedItemsWazuhResult:
     results = AffectedItemsWazuhResult(**_restart_ruleset_default_result_kwargs)
 
     try:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -223,6 +223,13 @@ _restart_ruleset_default_result_kwargs = {
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'],
                   post_proc_kwargs={'default_result_kwargs': _restart_ruleset_default_result_kwargs})
 async def reload_ruleset() -> AffectedItemsWazuhResult:
+    """Reload the ruleset on the current node.
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
+        Result of the reload operation, including affected and failed items.
+    """
     results = AffectedItemsWazuhResult(**_restart_ruleset_default_result_kwargs)
 
     try:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -219,7 +219,7 @@ _restart_ruleset_default_result_kwargs = {
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
-@expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:restart"],
+@expose_resources(actions=["analysisd:reload"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'],
                   post_proc_kwargs={'default_result_kwargs': _restart_ruleset_default_result_kwargs})
 async def reload_ruleset() -> AffectedItemsWazuhResult:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -250,10 +250,12 @@ async def reload_ruleset() -> AffectedItemsWazuhResult:
             lc = local_client.LocalClient()
             result = await set_reload_ruleset_flag(lc)
 
-            if isinstance(result, dict) and 'msg' in result:
-                result = result['msg']
-            if result == 'Reload ruleset flag set successfully':
-                result = 'Ruleset reload request sent successfully'
+            if isinstance(result, dict) and 'success' in result:
+                result = result['success']
+                if result:
+                    result = 'Ruleset reload request sent successfully'
+                else:
+                    result = 'Failed to send the ruleset reload request.'
 
             results.affected_items.append({'name': node_id, 'msg': result})
     except WazuhError as e:

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -250,7 +250,6 @@ async def reload_ruleset() -> AffectedItemsWazuhResult:
             lc = local_client.LocalClient()
             result = await set_reload_ruleset_flag(lc)
 
-            # Replace technical details
             if isinstance(result, dict) and 'msg' in result:
                 result = result['msg']
             if result == 'Reload ruleset flag set successfully':

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -301,6 +301,7 @@ default_policies:
           - cluster:read
           - cluster:restart
           - cluster:update_config
+          - analysisd:reload
         resources:
           - node:id:*
         effect: allow

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -11,7 +11,6 @@ import xmltodict
 
 import wazuh.core.configuration as configuration
 from wazuh.core import common
-from wazuh.core.analysis import send_reload_ruleset_msg
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError
@@ -501,10 +500,6 @@ def upload_rule_file(filename: str, content: str, relative_dirname: str = None,
 
             raise exc
 
-        # After uploading the file, reload rulesets
-        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
-        socket_response.update_affected_items(results=result, error_code=1212)
-
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         backup_file and exists(backup_file) and remove(backup_file)
@@ -553,9 +548,6 @@ def delete_rule_file(filename: Union[str, list], relative_dirname: str = None) -
         else:
             raise WazuhError(1906)
 
-        # After deleting the file, reload rulesets
-        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
-        socket_response.update_affected_items(results=result, error_code=1212)
     except WazuhError as exc:
         result.add_failed_item(id_=to_relative_path(full_path), error=exc)
     result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -214,7 +214,7 @@ get_rbac_actions:
           - PUT /agents/upgrade_custom
           - GET /agents/upgrade_result
       analysisd:reload:
-        description: Reloads Wazuh's ruleset
+        description: Reload the ruleset
         resources:
           - node:id
         example:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -296,6 +296,7 @@ get_rbac_actions:
           - GET /cluster/{node_id}/logs
           - GET /cluster/{node_id}/logs/summary
           - PUT /cluster/restart
+          - PUT /cluster/analysisd/reload
           - GET /cluster/configuration/validation
           - GET /cluster/{node_id}/configuration/{component}/{configuration}
       ciscat:read:
@@ -363,6 +364,7 @@ get_rbac_actions:
           effect: allow
         related_endpoints:
           - PUT /cluster/restart
+          - PUT /cluster/analysisd/reload
       lists:read:
         description: Read CDB lists files
         resources:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -213,6 +213,18 @@ get_rbac_actions:
           - PUT /agents/upgrade
           - PUT /agents/upgrade_custom
           - GET /agents/upgrade_result
+      analysisd:reload:
+        description: Reloads Wazuh's ruleset
+        resources:
+          - node:id
+        example:
+          actions:
+            - analysisd:reload
+          resources:
+            - node:id:worker1
+          effect: allow
+        related_endpoints:
+          - PUT /cluster/analysisd/reload
       group:delete:
         description: Delete agent groups
         resources:
@@ -364,7 +376,6 @@ get_rbac_actions:
           effect: allow
         related_endpoints:
           - PUT /cluster/restart
-          - PUT /cluster/analysisd/reload
       lists:read:
         description: Read CDB lists files
         resources:

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -6,7 +6,6 @@
 import os
 import sys
 from unittest.mock import patch, MagicMock
-from wazuh.core.analysis import RulesetReloadResponse
 from wazuh.core.exception import WazuhInternalError
 
 import pytest
@@ -328,8 +327,7 @@ def test_get_list_file(filename, raw, expected_result, total_failed_items):
 @patch('wazuh.cdb_list.delete_list_file')
 @patch('wazuh.cdb_list.remove')
 @patch('wazuh.cdb_list.exists', return_value=True)
-@patch('wazuh.cdb_list.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0}))
-def test_upload_list_file(mock_reload, mock_exists, mock_remove, mock_delete_list_file, mock_upload_file,
+def test_upload_list_file(mock_exists, mock_remove, mock_delete_list_file, mock_upload_file,
                           mock_delete_file_with_backup, mock_safe_move):
     """Check that functions inside upload_list_file are called with expected params"""
     filename = 'test_file'
@@ -341,7 +339,6 @@ def test_upload_list_file(mock_reload, mock_exists, mock_remove, mock_delete_lis
     mock_delete_file_with_backup.assert_called_once_with(os.path.join(common.USER_LISTS_PATH, filename + '.backup'),
                                                          os.path.join(common.USER_LISTS_PATH, filename),
                                                          mock_delete_list_file)
-    mock_reload.assert_called_once()
 
 @patch('wazuh.cdb_list.common.USER_LISTS_PATH', return_value='/test/path')
 @patch('wazuh.cdb_list.remove')
@@ -377,8 +374,7 @@ def test_upload_list_file_ko(mock_remove, mock_lists_path):
 
 
 @patch('wazuh.core.cdb_list.delete_wazuh_file')
-@patch('wazuh.cdb_list.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0}))
-def test_delete_list_file(mock_reload, mock_delete_file):
+def test_delete_list_file(mock_delete_file):
     """Check that expected result is returned when the file is deleted."""
     try:
         # Create directory for the test
@@ -397,7 +393,6 @@ def test_delete_list_file(mock_reload, mock_delete_file):
             pass
 
     mock_delete_file.assert_called_once_with(test_file)
-    mock_reload.assert_called_once()
 
 def test_delete_list_file_ko():
     """Check that expected error code is returned when the file can't be deleted."""

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -8,7 +8,6 @@ import sys
 import glob
 from unittest.mock import patch, MagicMock
 import pytest
-from wazuh.core.analysis import RulesetReloadResponse
 from wazuh.core.common import USER_DECODERS_PATH
 
 
@@ -281,9 +280,8 @@ def test_upload_file(mock_logtest, mock_safe_move, mock_remove, mock_upload_file
     with patch('wazuh.decoder.validate_upload_delete_dir', return_value=ret_validation):
         with patch('wazuh.decoder.exists', return_value=overwrite):
             with patch('wazuh.decoder.to_relative_path',
-                    side_effect=lambda x: os.path.relpath(x, wazuh.core.common.WAZUH_PATH)):
-                with patch('wazuh.decoder.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0})) as mock_reload:
-                    result = decoder.upload_decoder_file(filename=file, content=content,
+                       side_effect=lambda x: os.path.relpath(x, wazuh.core.common.WAZUH_PATH)):
+                result = decoder.upload_decoder_file(filename=file, content=content,
                                                             relative_dirname=relative_dirname,
                                                             overwrite=overwrite)
 
@@ -303,7 +301,6 @@ def test_upload_file(mock_logtest, mock_safe_move, mock_remove, mock_upload_file
                 'delete_decoder_file function not called with expected parameters'
                 mock_remove.assert_called_once()
                 mock_safe_move.assert_called_once()
-                mock_reload.assert_called_once()
 
 
 @patch('wazuh.decoder.delete_decoder_file', side_effect=WazuhError(1019))
@@ -377,11 +374,9 @@ def test_delete_decoder_file(filename, relative_dirname):
     with patch('wazuh.decoder.exists', return_value=True):
         # Assert returned type is AffectedItemsWazuhResult when everything is correct
         with patch('wazuh.decoder.remove'):
-            with patch('wazuh.decoder.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0})) as mock_reload:
-                assert(isinstance(decoder.delete_decoder_file(filename=filename,
-                                                              relative_dirname=relative_dirname),
-                                                              AffectedItemsWazuhResult))
-                mock_reload.assert_called_once()
+            assert(isinstance(decoder.delete_decoder_file(filename=filename,
+                                                          relative_dirname=relative_dirname),
+                              AffectedItemsWazuhResult))
 
 
 def test_delete_decoder_file_ko():

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -369,3 +369,63 @@ def test_update_ossec_conf_ko(move_mock, remove_mock, exists_mock, full_copy_moc
     assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
     assert result.render()['data']['failed_items'][0]['error']['code'] == 1125
     move_mock.assert_called_once()
+
+
+import asyncio
+
+
+@pytest.mark.asyncio
+@patch('wazuh.manager.node_type', 'master')
+@patch('wazuh.manager.send_reload_ruleset_msg')
+async def test_reload_ruleset_master_ok(mock_send_reload_ruleset_msg):
+    """Test reload_ruleset() works as expected for master node with successful reload."""
+    mock_response = MagicMock()
+    mock_response.is_ok.return_value = True
+    mock_response.has_warnings.return_value = False
+    mock_send_reload_ruleset_msg.return_value = mock_response
+
+    result = await reload_ruleset()
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.total_affected_items == 1
+    assert result.failed_items == {}
+
+
+@pytest.mark.asyncio
+@patch('wazuh.manager.node_type', 'master')
+@patch('wazuh.manager.send_reload_ruleset_msg')
+async def test_reload_ruleset_master_nok(mock_send_reload_ruleset_msg):
+    """Test reload_ruleset() for master node with error in reload."""
+    mock_response = MagicMock()
+    mock_response.is_ok.return_value = False
+    mock_response.errors = ['error1']
+    mock_send_reload_ruleset_msg.return_value = mock_response
+
+    result = await reload_ruleset()
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.total_failed_items == 1
+
+
+@pytest.mark.asyncio
+@patch('wazuh.manager.node_type', 'worker')
+@patch('wazuh.manager.local_client.LocalClient')
+@patch('wazuh.manager.set_reload_ruleset_flag')
+async def test_reload_ruleset_worker_ok(mock_set_reload_flag, mock_local_client):
+    """Test reload_ruleset() works as expected for worker node with successful reload."""
+    mock_set_reload_flag.return_value = 'Reload ruleset flag set successfully'
+    result = await reload_ruleset()
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.total_affected_items == 1
+    assert result.failed_items == {}
+
+
+@pytest.mark.asyncio
+@patch('wazuh.manager.node_type', 'worker')
+@patch('wazuh.manager.local_client.LocalClient')
+@patch('wazuh.manager.set_reload_ruleset_flag')
+async def test_reload_ruleset_worker_nok(mock_set_reload_flag, mock_local_client):
+    """Test reload_ruleset() for worker node with error in reload."""
+    mock_set_reload_flag.side_effect = WazuhError(1914)
+    result = await reload_ruleset()
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.total_failed_items == 1
+

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -7,7 +7,6 @@ import sys
 import glob
 from unittest.mock import patch, mock_open, MagicMock
 from wazuh.core.common import USER_RULES_PATH
-from wazuh.core.analysis import RulesetReloadResponse
 import pytest
 
 with patch('wazuh.core.common.wazuh_uid'):
@@ -352,9 +351,8 @@ def test_upload_file(mock_logtest, mock_safe_move, mock_remove, mock_xml, mock_f
         ret_validation = rule.validate_upload_delete_dir(relative_dirname=relative_dirname)
         with patch('wazuh.rule.validate_upload_delete_dir', return_value=ret_validation):
             with patch('wazuh.rule.exists', return_value=overwrite):
-                with patch('wazuh.rule.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0})) as mock_reload:
-                    result = rule.upload_rule_file(filename=file, relative_dirname=relative_dirname,
-                                                    content=content, overwrite=overwrite)
+                result = rule.upload_rule_file(filename=file, relative_dirname=relative_dirname,
+                                                content=content, overwrite=overwrite)
 
                 # Assert data match what was expected, type of the result and correct
                 # parameters in delete() method.
@@ -437,11 +435,9 @@ def test_delete_rule_file(file, relative_dirname):
     with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
         with patch('wazuh.rule.exists', return_value=True):
             with patch('wazuh.rule.remove'):
-                with patch('wazuh.rule.send_reload_ruleset_msg', return_value=RulesetReloadResponse({'error': 0})) as mock_reload:
-                    # Assert returned type is AffectedItemsWazuhResult when everything is correct
-                    assert(isinstance(rule.delete_rule_file(filename=file, relative_dirname=relative_dirname),
-                                    AffectedItemsWazuhResult))
-                    mock_reload.assert_called_once()
+                # Assert returned type is AffectedItemsWazuhResult when everything is correct
+                assert(isinstance(rule.delete_rule_file(filename=file, relative_dirname=relative_dirname),
+                                AffectedItemsWazuhResult))
 
 def test_delete_rule_file_ko():
     """Delete rule file invalid test cases"""


### PR DESCRIPTION
## Description

The PRs introduce a new endpoint to trigger a ruleset reload across the cluster, implementing logic to broadcast the reload command to all nodes and set the reload in the `Integrity sync` using a runtime flag.

Closes https://github.com/wazuh/wazuh/issues/31188

## Proposed Changes

- Added the `PUT /cluster/analysisd/reload`endpoint for ruleset reload.
- Added logic to broadcast the reload to all nodes.
- Created a new command to set the reload flag during integrity sync.
- Added reload logic based on the value of the flag.
- Added new RBAC's action.

### Results and Evidence

The tests can be found in https://github.com/wazuh/wazuh/pull/31310#issuecomment-3189182392

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.



## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
