### PR TITLE
fix: prevent null hotfixes in windows agent

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -983,9 +983,12 @@ nlohmann::json SysInfo::getHotfixes() const
 
     for (auto& hotfix : hotfixes)
     {
-        nlohmann::json hotfixValue;
-        hotfixValue["hotfix"] = std::move(hotfix);
-        ret.push_back(std::move(hotfixValue));
+        if (!hotfix.empty())
+        {
+            nlohmann::json hotfixValue;
+            hotfixValue["hotfix"] = std::move(hotfix);
+            ret.push_back(std::move(hotfixValue));
+        }
     }
 
     return ret;


### PR DESCRIPTION
## Description
|Related issue|
|--------------|
|Closes #30507| 

The Windows agent could send a hotfix with an empty string as its value to the manager, which would cause the manager to register a null hotfix and potentially crash in Wazuh versions earlier than 4.13.0.

## Proposed Changes

Additional logic was added to check if a hotfix is empty before adding it to the database.

### Results and Evidence

Before the fix, the agent would log a hotfix with a "" value, which would then be sent to the manager.

<img width="1316" height="443" alt="image" src="https://github.com/user-attachments/assets/29f29aa8-9a91-4668-a14d-34f603880996" />

Since this is Wazuh 4.14.1, the manager does not crash and filters the value, but some log errors are generated.

<img width="1462" height="48" alt="image" src="https://github.com/user-attachments/assets/2f973ea3-d316-46d4-a828-688a16206e3b" />

After the fix, the agent no longer logs the "" value, allowing only valid hotfixes to be processed:

<img width="1313" height="417" alt="image" src="https://github.com/user-attachments/assets/aacca3a5-4cb6-4648-bd09-3d619ff77cd7" />



