### PR TITLE
wazuh-engine - Improve logic for indexed event test

### DIFF
--- a/src/engine/tools/api-communication/src/api_communication/client.py
+++ b/src/engine/tools/api-communication/src/api_communication/client.py
@@ -13,7 +13,7 @@ from api_communication.proto.engine_pb2 import GenericStatus_Response
 from api_communication.proto.engine_pb2 import ReturnStatus
 
 
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 30
 
 class APIClient:
     """Client to communicate with the Engine API socket


### PR DESCRIPTION
## Description

Closes #31335 

Often, when the ruleset is large and the host where it runs is slow, the indexerconnector queue that sends events to OpenSearch takes a long time to advance, causing the retrieval of elements in the tests to compare validation to fail due to timeout. This PR improves the concept of timeout and test failure.

## Proposed Changes

It is proposed to change the way the test is executed. When the test retrieves opensearch events, it has a timeout and number of retries to retrieve them. This PR proposes that if more documents are obtained between two consecutive retries, then it should not count as a failed retry. In other words, retries only count when no new documents are retrieved between iterations, thus improving the use case when indexing is being performed but is slow.

### Results and Evidence

Run in `Engine Health Test` workflow:

- run id:  `16967896470` / Branch: `enhancement/2683-add-websphere-decoder`
- run id:  `16968159607` / Branch: `decoders_development` 

> [!NOTE] 
> It is expected that the `Rules Health Test` stage will fail due to the branch having bad spects

### Manual tests with their corresponding evidence

### Artifacts Affected

- `engine-health-test`: New logic of checking events
- `api-communiaction`: Increase the api timeout

### Configuration Changes

Increment the default tiemout of the API from 10 seg to 30 seg.

### Tests Introduced

NONE

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
