### PR TITLE
Fix: update windows package name

### DIFF
--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -136,12 +136,10 @@ function ExtractDebugSymbols(){
   #compress every pdb file in current folder
 	$pdbFiles = Get-ChildItem -Filter ".\*.pdb"
 
-  $ZIP_NAME = "$($MSI_NAME.Replace('.msi', '-debug-symbols.zip'))"
+    $ZIP_NAME = $MSI_NAME -replace 'wazuh-agent', 'wazuh-agent-debug-symbols' -replace '\.msi$', '.zip'
 
 	Write-Host "Compressing debug symbols to $ZIP_NAME"
 	Compress-Archive -Path $pdbFiles -Force -DestinationPath "$ZIP_NAME"
-
-  dir "*debug-symbols.zip"
 
 	Remove-Item -Path "*.pdb"
 }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR addresses and resolves issue #433, which reported an error with the naming of the debug symbols ZIP file.

The previous logic for generating the ZIP file name, `$($MSI_NAME.Replace('.msi', '-debug-symbols.zip'))`, did not correctly handle all cases, particularly with the `.msi` extension. This led to a malformed filename for the debug symbols package.

The updated logic, `$MSI_NAME -replace 'wazuh-agent', 'wazuh-agent-debug-symbols' -replace '\.msi$', '.zip'`, uses PowerShell's -replace operator to provide a more robust and reliable method for generating the correct filename. This ensures that the ZIP file for debug symbols is consistently and accurately named, regardless of the full filename of the MSI.

This change guarantees the proper packaging and distribution of the debug symbols, fixing the reported problem and preventing similar issues in the future.

# Test
- :green_circle:  Workflow: https://github.com/wazuh/wazuh-agent-packages/actions/runs/17048892963/job/48331532137


Besides this, I got the following output during the unzip step and when we created the package.

```
Write-Progress : Win32 internal error "Access is denied" 0x5 occurred while reading the console output buffer. Contact 
Microsoft Customer Support Services.
At 
C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1:1132 
char:9
+         Write-Progress -Activity $cmdletName -Status $status -Percent ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ReadError: (:) [Write-Progress], HostException
    + FullyQualifiedErrorId : ReadConsoleOutput,Microsoft.PowerShell.Commands.WriteProgressCommand
```
**Note**: When we run a PowerShell command over SSH, it's considered a non-interactive session. The Write-Progress cmdlet is designed to display a progress bar in an interactive console window, which doesn't exist in a remote, headless session. The "Access is denied" error occurs because the script is trying to write to a console buffer that it can't access. The strange thing is that I [reviewed other workflows](https://github.com/wazuh/wazuh-agent-packages/actions/runs/15858225252/job/44710240542#:~:text=Run%20sshpass%20%2Dp,Create%20MSI%20package) and it doesn't happen there. According to the AI, this could be because of Windows policies.

closes #433