### PR TITLE
Fix FIM ITs on Windows

### DIFF
--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -25,10 +25,8 @@ from wazuh_testing.modules.fim.utils import create_registry, delete_registry
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.tools.simulators.authd_simulator import AuthdSimulator
 from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
-from wazuh_testing.utils import file
+from wazuh_testing.utils import file, services
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.utils.services import get_service
-
 
 @pytest.fixture()
 def file_to_monitor(test_metadata: dict) -> Any:
@@ -228,6 +226,11 @@ def clean_fim_sync_db():
     before each test.
     Works on both Linux and Windows agents.
     """
+
+    # Stop wazuh-service and ensure all daemons are stopped
+    services.control_service('stop')
+    services.wait_expected_daemon_status(running_condition=False, timeout=180)
+
     for filename in FIM_SYNC_DB_FILES:
         file_path = os.path.join(FIM_SYNC_DB_DIR, filename)
         try:


### PR DESCRIPTION
## Description

This PR fixes the execution of FIM ITs that are failing on Windows.

## Proposed Changes

Increased the timeouts for stopping the service

### Results and Evidence

### Manual tests with their corresponding evidence

The error could not be reproduced in a local environment.

All tests passed in GHA:
https://github.com/wazuh/wazuh/actions/runs/17109615836/job/48529108599?pr=31457

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
