### PR TITLE
Enhancement/30846 add reason field to sca scan messages

### DIFF
--- a/src/unit_tests/wrappers/wazuh/shared/indexed_queue_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/indexed_queue_op_wrappers.c
@@ -10,6 +10,7 @@
 #include "indexed_queue_op_wrappers.h"
 #include <stddef.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/src/wazuh_modules/sca/sca_impl/include/isca_policy.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/isca_policy.hpp
@@ -14,12 +14,12 @@ public:
     /// @brief Runs the policy check
     /// @param scanInterval Scan interval in milliseconds
     /// @param scanOnStart Scan on start
-    /// @param reportCheckResult Function to report check result
+    /// @param reportCheckResult Function to report check result (policyId, checkId, result, reason)
     /// @param wait Function to wait for the next scan
     virtual void
     Run(std::time_t scanInterval,
         bool scanOnStart,
-        std::function<void(const std::string&, const std::string&, const std::string&)> reportCheckResult,
+        std::function<void(const std::string&, const std::string&, const std::string&, const std::string&)> reportCheckResult,
         std::function<void(std::chrono::milliseconds)> wait) = 0;
 
     /// @brief Stops the policy check

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
@@ -24,37 +24,41 @@ CheckConditionEvaluator::CheckConditionEvaluator(ConditionType type)
 {
 }
 
-void CheckConditionEvaluator::AddResult(RuleResult result)
+void CheckConditionEvaluator::AddResult(const RuleEvaluationResult& result)
 {
     if (m_result.has_value())
     {
         return;
     }
 
-    if (result == RuleResult::Invalid)
+    if (result.result == RuleResult::Invalid)
     {
         m_hasInvalid = true;
+        if (!result.reason.empty() && m_invalidReason.empty())
+        {
+            m_invalidReason = result.reason;
+        }
     }
 
     ++m_totalRules;
-    m_passedRules += (RuleResult::Found == result) ? 1 : 0;
+    m_passedRules += (RuleResult::Found == result.result) ? 1 : 0;
 
     switch (m_type)
     {
         case ConditionType::All:
-            if (RuleResult::NotFound == result)
+            if (RuleResult::NotFound == result.result)
             {
                 m_result = false;
             }
             break;
         case ConditionType::Any:
-            if (RuleResult::Found == result)
+            if (RuleResult::Found == result.result)
             {
                 m_result = true;
             }
             break;
         case ConditionType::None:
-            if (RuleResult::Found == result)
+            if (RuleResult::Found == result.result)
             {
                 m_result = false;
             }
@@ -81,4 +85,9 @@ sca::CheckResult CheckConditionEvaluator::Result() const
         case ConditionType::None: return sca::CheckResult::Passed;
         default: throw std::runtime_error("Invalid condition type");
     }
+}
+
+std::string CheckConditionEvaluator::GetInvalidReason() const
+{
+    return m_invalidReason;
 }

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
@@ -20,9 +20,10 @@ public:
 
     explicit CheckConditionEvaluator(ConditionType type);
 
-    void AddResult(RuleResult result);
+    void AddResult(const RuleEvaluationResult& result);
 
     sca::CheckResult Result() const;
+    std::string GetInvalidReason() const;
 
 private:
     ConditionType m_type;
@@ -30,4 +31,5 @@ private:
     int m_passedRules {0};
     std::optional<bool> m_result;
     bool m_hasInvalid = false;
+    std::string m_invalidReason;
 };

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -59,7 +59,8 @@ void SCAEventHandler::ReportPoliciesDelta(
 
 void SCAEventHandler::ReportCheckResult(const std::string& policyId,
                                         const std::string& checkId,
-                                        const std::string& checkResult) const
+                                        const std::string& checkResult,
+                                        const std::string& reason) const
 {
     if (!m_dBSync)
     {
@@ -70,6 +71,12 @@ void SCAEventHandler::ReportCheckResult(const std::string& policyId,
     auto policyData = GetPolicyById(policyId);
     auto checkData = GetPolicyCheckById(checkId);
     checkData["result"] = checkResult;
+    
+    // Set reason field if provided and check result indicates an invalid check
+    if (!reason.empty() && checkResult == "Not applicable")
+    {
+        checkData["reason"] = reason;
+    }
 
     try
     {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp
@@ -45,8 +45,9 @@ public:
     /// @param policyId The ID of the policy associated with the check.
     /// @param checkId The ID of the check.
     /// @param checkResult Indicates the result of the check execution.
+    /// @param reason Optional reason for invalid checks.
     void
-    ReportCheckResult(const std::string& policyId, const std::string& checkId, const std::string& checkResult) const;
+    ReportCheckResult(const std::string& policyId, const std::string& checkId, const std::string& checkResult, const std::string& reason = "") const;
 
 protected:
     /// @brief Processes modified items and returns a list of events.

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -85,7 +85,7 @@ void SecurityConfigurationAssessment::Run()
                 policy->Run(
                     m_scanInterval,
                     m_scanOnStart,
-                    [this](const std::string& policyId, const std::string& checkId, const std::string& result)
+                    [this](const std::string& policyId, const std::string& checkId, const std::string& result, const std::string& reason)
                     {
                         const SCAEventHandler eventHandler(
                             m_agentUUID,
@@ -93,7 +93,7 @@ void SecurityConfigurationAssessment::Run()
                             m_pushStatelessMessage,
                             m_pushStatefulMessage
                         );
-                        eventHandler.ReportCheckResult(policyId, checkId, result);
+                        eventHandler.ReportCheckResult(policyId, checkId, result, reason);
                     },
                     nullptr
                 );

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy.hpp
@@ -31,7 +31,7 @@ public:
     void
     Run(std::time_t scanInterval,
         bool scanOnStart,
-        std::function<void(const std::string&, const std::string&, const std::string&)> reportCheckResult,
+        std::function<void(const std::string&, const std::string&, const std::string&, const std::string&)> reportCheckResult,
         std::function<void(std::chrono::milliseconds)> wait) override;
 
     /// @copydoc ISCAPolicy::Stop
@@ -39,8 +39,8 @@ public:
 
 private:
     /// @brief Runs the policy checks
-    /// @param reportCheckResult Function to report check result
-    void Scan(const std::function<void(const std::string&, const std::string&, const std::string&)>& reportCheckResult);
+    /// @param reportCheckResult Function to report check result (policyId, checkId, result, reason)
+    void Scan(const std::function<void(const std::string&, const std::string&, const std::string&, const std::string&)>& reportCheckResult);
 
     std::string m_id;
     Check m_requirements;

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -17,6 +17,18 @@ enum class RuleResult
     NotFound
 };
 
+struct RuleEvaluationResult
+{
+    RuleEvaluationResult(RuleResult r, const std::string& reasonValue = "")
+    : result(r)
+    , reason(reasonValue)
+    {
+    }
+
+    RuleResult result;
+    std::string reason;
+};
+
 struct PolicyEvaluationContext
 {
     std::string rule = {};
@@ -36,6 +48,8 @@ public:
     virtual RuleResult Evaluate() = 0;
 
     virtual const PolicyEvaluationContext& GetContext() const = 0;
+
+    virtual std::string GetInvalidReason() const = 0;
 };
 
 class RuleEvaluator : public IRuleEvaluator
@@ -45,9 +59,12 @@ public:
 
     const PolicyEvaluationContext& GetContext() const override;
 
+    std::string GetInvalidReason() const override { return m_lastInvalidReason; }
+
 protected:
     std::unique_ptr<IFileSystemWrapper> m_fileSystemWrapper = nullptr;
     PolicyEvaluationContext m_ctx = {};
+    std::string m_lastInvalidReason;
 };
 
 class FileRuleEvaluator : public RuleEvaluator

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -159,12 +159,14 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
         if (!m_isValidKey(m_ctx.rule))
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Key '{}' does not exist" + m_ctx.rule);
+            m_lastInvalidReason = "Registry key '" + m_ctx.rule + "' does not exist";
             return RuleResult::Invalid;
         }
     }
     catch (const std::exception& e)
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, std::string("RegistryRuleEvaluator::Evaluate: Exception: {}") + e.what());
+        m_lastInvalidReason = "Exception accessing registry key '" + m_ctx.rule + "': " + e.what();
         return RuleResult::Invalid;
     }
 
@@ -180,6 +182,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
         if (!obtainedValue.has_value())
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Value '{}' does not exist" + valueName);
+            m_lastInvalidReason = "Registry value '" + valueName + "' does not exist in key '" + m_ctx.rule + "'";
             return RuleResult::Invalid;
         }
 
@@ -242,6 +245,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyExistence()
     catch (const std::exception& e)
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, std::string("RegistryRuleEvaluator::Evaluate: Exception: ") + e.what());
+        m_lastInvalidReason = "Exception checking registry key existence '" + m_ctx.rule + "': " + e.what();
         return RuleResult::Invalid;
     }
 

--- a/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
@@ -14,18 +14,18 @@ TEST(CheckConditionEvaluatorTest, AllConditionBehavior)
     // No rules added yet: should be NotApplicable.
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
-    evaluator.AddResult(RuleResult::Found);
-    evaluator.AddResult(RuleResult::Found);
-    evaluator.AddResult(RuleResult::Found);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
-    evaluator.AddResult(RuleResult::NotFound);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 }
 
@@ -36,14 +36,14 @@ TEST(CheckConditionEvaluatorTest, AnyConditionBehavior)
     // No rules added yet: should be NotApplicable.
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
-    evaluator.AddResult(RuleResult::NotFound);
-    evaluator.AddResult(RuleResult::NotFound);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 
-    evaluator.AddResult(RuleResult::Found);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 }
 
@@ -54,17 +54,17 @@ TEST(CheckConditionEvaluatorTest, NoneConditionBehavior)
     // No rules added yet: should be NotApplicable.
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
-    evaluator.AddResult(RuleResult::NotFound);
-    evaluator.AddResult(RuleResult::NotFound);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
-    evaluator.AddResult(RuleResult::Found); // At least one passed -> should now be false.
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found)); // At least one passed -> should now be false.
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 }
 
@@ -72,18 +72,18 @@ TEST(CheckConditionEvaluatorTest, AddResultStopsAfterResultDetermined)
 {
     auto evaluator = CheckConditionEvaluator::FromString("any");
 
-    evaluator.AddResult(RuleResult::Found); // Should determine result = true immediately
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found)); // Should determine result = true immediately
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
-    evaluator.AddResult(RuleResult::NotFound); // Should have no effect
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound)); // Should have no effect
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
     auto evaluator2 = CheckConditionEvaluator::FromString("all");
 
-    evaluator2.AddResult(RuleResult::NotFound); // Should determine result = false immediately
+    evaluator2.AddResult(RuleEvaluationResult(RuleResult::NotFound)); // Should determine result = false immediately
     EXPECT_EQ(evaluator2.Result(), sca::CheckResult::Failed);
 
-    evaluator2.AddResult(RuleResult::Found); // Should have no effect
+    evaluator2.AddResult(RuleEvaluationResult(RuleResult::Found)); // Should have no effect
     EXPECT_EQ(evaluator2.Result(), sca::CheckResult::Failed);
 }
 
@@ -91,9 +91,9 @@ TEST(CheckConditionEvaluatorTest, AllConditionWithInvalidMakesResultNotApplicabl
 {
     auto evaluator = CheckConditionEvaluator::FromString("all");
 
-    evaluator.AddResult(RuleResult::Found);
-    evaluator.AddResult(RuleResult::Found);
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
 
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 }
@@ -102,8 +102,8 @@ TEST(CheckConditionEvaluatorTest, NoneConditionWithInvalidMakesResultNotApplicab
 {
     auto evaluator = CheckConditionEvaluator::FromString("none");
 
-    evaluator.AddResult(RuleResult::NotFound);
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
 
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 }
@@ -112,15 +112,15 @@ TEST(CheckConditionEvaluatorTest, AnyConditionWithInvalidCanBeTrueAsLongAsOnePas
 {
     auto evaluator = CheckConditionEvaluator::FromString("any");
 
-    evaluator.AddResult(RuleResult::NotFound);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotFound));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Failed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotApplicable);
 
-    evaluator.AddResult(RuleResult::Found);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 
-    evaluator.AddResult(RuleResult::Invalid);
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 }

--- a/src/wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
@@ -91,3 +91,19 @@ TEST_F(ProcessRuleEvaluatorTest, ProcessListRetrievalFailsReturnsInvalid)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
 }
+
+TEST_F(ProcessRuleEvaluatorTest, GetProcessesFailureHasReasonString)
+{
+    m_ctx.rule = "test_process";
+
+    m_processesMock = []() -> std::vector<std::string>
+    {
+        throw std::runtime_error("Failed to read /proc");
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("test_process"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Failed to get process list"));
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/registry_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/registry_rule_evaluator_test.cpp
@@ -244,3 +244,78 @@ TEST_F(RegistryRuleEvaluatorTest, PatternArrowRegexValueNotFoundReturnsNotFound)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
 }
+
+TEST_F(RegistryRuleEvaluatorTest, KeyDoesNotExistHasReasonString)
+{
+    m_ctx.rule = "HKLM\\NonExistentKey";
+    m_ctx.pattern = std::string("r:foo");
+
+    m_isValidKeyMock = [](const std::string&) -> bool
+    {
+        return false;
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\NonExistentKey"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("does not exist"));
+}
+
+TEST_F(RegistryRuleEvaluatorTest, KeyAccessExceptionHasReasonString)
+{
+    m_ctx.rule = "HKLM\\SomeKey";
+    m_ctx.pattern = std::string("r:foo");
+
+    m_isValidKeyMock = [](const std::string&) -> bool
+    {
+        throw std::runtime_error("Access denied to registry");
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Exception accessing registry"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Access denied to registry"));
+}
+
+TEST_F(RegistryRuleEvaluatorTest, ValueDoesNotExistHasReasonString)
+{
+    m_ctx.rule = "HKLM\\SomeKey";
+    m_ctx.pattern = std::string("NonExistentValue -> SomeContent");
+
+    m_isValidKeyMock = [](const std::string&) -> bool
+    {
+        return true;
+    };
+
+    m_getValueMock = [](const std::string&, const std::string&) -> std::optional<std::string>
+    {
+        return std::nullopt;
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("NonExistentValue"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("does not exist"));
+}
+
+TEST_F(RegistryRuleEvaluatorTest, KeyExistenceCheckExceptionHasReasonString)
+{
+    m_ctx.rule = "HKLM\\SomeKey";
+
+    m_isValidKeyMock = [](const std::string&) -> bool
+    {
+        throw std::runtime_error("Registry access error");
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
+    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Exception checking registry key existence"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Registry access error"));
+}


### PR DESCRIPTION
## Description

This PR adds a _reason_ field to the check results reports when a result turns out to be invalid.