### PR TITLE
Handle symlinks updates and modifications on logcollector

### DIFF
--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -11,6 +11,7 @@
 #ifndef CLOGREADER_H
 #define CLOGREADER_H
 
+#define SYS_LOG      "syslog"
 #define EVENTLOG     "eventlog"
 #define EVENTCHANNEL "eventchannel"
 #define MACOS        "macos"
@@ -242,6 +243,8 @@ typedef struct _logreader {
     int exists;
     unsigned int age;
     char *age_str;
+    bool follow_symlink;
+    char *symlink;
 
     void *(*read)(struct _logreader *lf, int *rc, int drop_it);
 
@@ -254,6 +257,7 @@ typedef struct _logreader_glob {
     char *exclude_path;
     int num_files;
     logreader *gfiles;
+    bool follow_symlink;
 } logreader_glob;
 
 typedef struct _logreader_config {

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -56,6 +56,7 @@
 #define NICE_ERROR      "(1142): Cannot set process priority: %s (%d)."
 #define RMDIR_ERROR     "(1143): Unable to delete folder '%s' due to [(%d)-(%s)]."
 #define ATEXIT_ERROR    "(1144): Unable to set exit function"
+#define REALPATH_ERROR    "(1145): Unable to resolve path '%s' -> '%s' due to [(%d)-(%s)]."
 
 /* COMMON ERRORS */
 #define CONN_ERROR      "(1201): No remote connection configured."
@@ -255,6 +256,9 @@
 #define WPOPENV_ERROR   "(1974): An error ocurred while calling wpopenv(): %s (%d)."
 #define LF_LOG_REGEX    "(1975): Syntax error on regex %s: '%s'"
 #define LF_MATCH_REGEX  "(1976): Ignoring the log line '%s' due to %s config: '%s'"
+#define NO_LONGER_ANALYZING_FILE     "(1977): No longer analyzing file '%s'."
+#define SKIP_REGULAR_FILE            "(1978): File %s is not a regular file. Skipping it."
+#define READING_SYMLINK    "(1950): Analyzing symlink: '%s' -> '%s.'"
 
 /* Encryption/auth errors */
 #define INVALID_KEY     "(1401): Error reading authentication key: '%s'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -161,6 +161,7 @@
 #define LOGCOLLECTOR_JOURNAL_CONFG_EMPTY_FILTER_EXPR  "(8020): The expression for the journal filter cannot be empty."
 #define LOGCOLLECTOR_JOURNAL_CONFG_FILTER_EXP_FAIL    "(8021): Error compiling the PCRE2 expression '%s' for field '%s' in journal filter."
 #define LOGCOLLECTOR_JOURNAL_CONFG_DISABLE_FILTER    "(8022): The filters of the journald log will be disabled in the merge, because one of the configuration does not have filters."
+#define LOGCOLLECTOR_INV_OPTION_WINDOWS              "(8023): Ignoring option '%s' as it's not supported on Windows"
 
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
This implementation allows the logcollector to track symlinks and update their states when they change the file they point to, the symlink is broken, or the symlink is deleted.

Cancelled since we're simply going to resolve symlinks and not keep track of updates to them: https://github.com/wazuh/wazuh/issues/29853#issuecomment-3205063712

I'm leaving the changes in this PR in case this feature is required in the future.

