### PR TITLE
Follow symlinks in logcollector globs

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1336,8 +1336,8 @@ int check_pattern_expand(int do_seek) {
                 }
 
                 struct stat statbuf;
-                if (lstat(g.gl_pathv[glob_offset], &statbuf) < 0) {
-                    merror("Error on lstat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
+                if (stat(g.gl_pathv[glob_offset], &statbuf) < 0) {
+                    merror("Error on stat '%s' due to [(%d)-(%s)]", g.gl_pathv[glob_offset], errno, strerror(errno));
                     glob_offset++;
                     continue;
                 }


### PR DESCRIPTION
## Description
Closes https://github.com/wazuh/wazuh/issues/29853

After the changes introduced in [this PR](https://github.com/wazuh/wazuh/pull/3788), the logcollector module now longer follows glob-expanded symlinks.

This is due to using `lstat` on them during glob-expansion to determine whether they are regular files or not. Since symlinks themselves aren't regular files, they get ignored.

## Proposed Changes
The proposed change is to replace `lstat` with `stat`. This last command resolves the symlink before checking if it's a regular file or not, which resolves the issue.

## Testing
To test the changes I created the following directory structure:
```
lc_symlink_test/
├── file1.txt
├── file2.txt
├── symlink1 -> file1.txt
├── symlink2 -> file2.txt
```

Added this configuration to `ossec.conf`:
```
  <localfile>
    <log_format>syslog</log_format>
    <location>/home/vagrant/lc_symlink_test/symlink*</location>    
  </localfile>              
```
And enabled logging on the logcollector modules inside `internal_options.conf`
```
logcollector.debug=2
```

By checking the logs we can see symlinks get correctly expanded:
```
INFO: (1957): New file that matches the '/home/vagrant/lc_symlink_test/symlink*' pattern: '/home/vagrant/lc_symlink_test/symlink1'.
INFO: (1957): New file that matches the '/home/vagrant/lc_symlink_test/symlink*' pattern: '/home/vagrant/lc_symlink_test/symlink2'.
```
And updates to their resolved paths get reported: `echo "update" >> /home/vagrant/lc_symlink_test/file1.txt `
```
DEBUG: Reading syslog message: 'update'
DEBUG: Read 1 lines from /home/vagrant/lc_symlink_test/symlink1
```


