### PR TITLE
Add collector for the ie extensions table

### DIFF
--- a/src/data_provider/src/extended_sources/browser_extensions/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/browser_extensions/CMakeLists.txt
@@ -44,11 +44,16 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     ${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/windows/
   )
 
+  list(APPEND SRC_FILES 
+    src/ie_explorer.cpp
+  )
+
   add_library(browser_extensions STATIC ${SRC_FILES})
   target_link_libraries(browser_extensions
     ${SRC_FOLDER}/external/openssl/libcrypto.a
     ws2_32
     crypt32
+    version
   )
 endif()
 

--- a/src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp
@@ -14,6 +14,7 @@
 #include <windows.h>
 #include "json.hpp"
 #include "ie_extensions_wrapper.hpp"
+#include <map>
 
 /**
  * @brief List of registry keys where Internet Explorer Browser Helper Objects (BHOs) are stored.
@@ -44,6 +45,13 @@ const std::vector<std::string> CLASS_EXECUTABLES_SUBKEYS =
     "LocalServer",      ///< 16-bit legacy local server
     "LocalServer32",    ///< 32-bit local server (common)
     "LocalServer64"     ///< 64-bit local server (rare)
+};
+
+const std::map<HKEY, std::string> HKEY_TO_STRING_MAP =
+{
+    {HKEY_CLASSES_ROOT, "HKEY_CLASSES_ROOT"},
+    {HKEY_LOCAL_MACHINE, "HKEY_LOCAL_MACHINE"},
+    {HKEY_USERS, "HKEY_USERS"},
 };
 
 /**

--- a/src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp
@@ -1,0 +1,200 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include <windows.h>
+#include "json.hpp"
+#include "ie_extensions_wrapper.hpp"
+
+/**
+ * @brief List of registry keys where Internet Explorer Browser Helper Objects (BHOs) are stored.
+ */
+const std::vector<std::string> CLSIDS_KEYS =
+{
+    "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects",
+    "SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects",
+    "SOFTWARE\\Microsoft\\Internet Explorer\\URLSearchHooks",
+};
+
+/**
+ * @brief Base registry key for CLSID executable definitions.
+ */
+const std::string EXECUTABLES_BASE_KEY = "SOFTWARE\\Classes\\CLSID";
+
+/**
+ * @brief Subkeys under each CLSID that may point to an executable or library.
+ */
+const std::vector<std::string> CLASS_EXECUTABLES_SUBKEYS =
+{
+    "InProcServer",     ///< 16-bit legacy server
+    "InProcServer32",   ///< 32-bit server (most common)
+    "InProcServer64",   ///< 64-bit server (rare)
+    "InProcHandler",    ///< 16-bit legacy handler
+    "InProcHandler32",  ///< 32-bit handler (common)
+    "InProcHandler64",  ///< 64-bit handler (rare)
+    "LocalServer",      ///< 16-bit legacy local server
+    "LocalServer32",    ///< 32-bit local server (common)
+    "LocalServer64"     ///< 64-bit local server (rare)
+};
+
+/**
+ * @brief Registry path separator string.
+ */
+const std::string SEPARATOR = "\\";
+
+/**
+ * @class IEExtensionsProvider
+ * @brief Provides functionality to enumerate Internet Explorer extensions
+ *        (such as Browser Helper Objects and URL search hooks) from the Windows Registry.
+ *
+ * This class interacts with the Windows Registry (through an abstraction layer provided by
+ * IIEExtensionsWrapper) to collect information about installed IE extensions, including their
+ * CLSIDs, associated executables, and version information.
+ */
+class IEExtensionsProvider
+{
+    public:
+        /**
+         * @brief Construct an IEExtensionsProvider with a custom registry wrapper.
+         * @param ieExtensionsWrapper Shared pointer to an implementation of IIEExtensionsWrapper.
+         */
+        explicit IEExtensionsProvider(std::shared_ptr<IIEExtensionsWrapper> ieExtensionsWrapper);
+
+        /**
+         * @brief Construct an IEExtensionsProvider with the default registry wrapper.
+         */
+        IEExtensionsProvider();
+
+        /**
+         * @brief Destructor.
+         */
+        ~IEExtensionsProvider() = default;
+
+        /**
+         * @brief Collect information about installed IE extensions.
+         * @return JSON object containing extension data (CLSIDs, executables, versions).
+         */
+        nlohmann::json collect();
+
+    private:
+        /**
+         * @brief Retrieve the string value stored in a registry key.
+         * @param hKey Handle to the registry key.
+         * @return String value read from the key, or empty string if not found.
+         */
+        std::string getValueFromHKey(HKEY hKey);
+
+        /**
+         * @brief Retrieve the default (unnamed) value from a registry key.
+         * @param hKey Handle to the registry key.
+         * @return Default value as string, or empty string if not found.
+         */
+        std::string getDefaultValueFromHKey(HKEY hKey);
+
+        /**
+         * @brief Open a registry key from a hive and subkey path.
+         * @param hive Root hive handle (e.g., HKEY_LOCAL_MACHINE).
+         * @param key Subkey path string.
+         * @return Handle to the opened registry key, or nullptr on failure.
+         */
+        HKEY getHKeyFromKeyString(HKEY hive, const std::string& key);
+
+        /**
+         * @brief Get the name of a subkey from a registry key handle.
+         * @param hKey Handle to the registry key.
+         * @return Subkey name as string.
+         */
+        std::string getSubKeyNameFromHKey(HKEY hKey);
+
+        /**
+         * @brief Convert a registry handle to a string representation.
+         * @param hKey Registry handle.
+         * @return String representation of the handle.
+         */
+        std::string HKeyToString(HKEY hKey);
+
+        /**
+         * @brief Collect registry paths from a set of CLSID keys.
+         * @param hive Root hive handle.
+         * @param clsidKeys List of CLSID subkeys to enumerate.
+         * @param regPaths Vector to append found registry paths.
+         */
+        void getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string> clsidKeys, std::vector<std::string>& regPaths);
+
+        /**
+         * @brief Enumerate subkeys under a given registry hive.
+         * @param hive Root hive handle.
+         * @return Vector of subkey names.
+         */
+        std::vector<std::string> listSubKeys(HKEY hive);
+
+        /**
+         * @brief Expand a registry key that may contain user-specific paths (e.g., SIDs).
+         * @param key Registry path string with possible user placeholders.
+         * @return Expanded list of registry paths.
+         */
+        std::vector<std::string> expandUserKey(const std::string key);
+
+        /**
+         * @brief Expand multiple registry keys containing user placeholders.
+         * @param keys Vector of registry paths.
+         * @return Vector of expanded registry paths.
+         */
+        std::vector<std::string> expandUserKeys(const std::vector<std::string>& keys);
+
+        /**
+         * @brief Collect all relevant registry paths for IE extensions.
+         * @return Vector of registry path strings.
+         */
+        std::vector<std::string> getRegistryPaths();
+
+        /**
+         * @brief Retrieve executable paths associated with a registry key.
+         * @param hive Root hive handle.
+         * @param registryPath Subkey path string.
+         * @param executables Vector to append found executable paths.
+         */
+        void getExecutablesFromKey(HKEY hive, const std::string& registryPath, std::vector<std::string>& executables);
+
+        /**
+         * @brief Extract the CLSID from a registry path.
+         * @param regPath Registry path string.
+         * @return CLSID string.
+         */
+        std::string extractClsid(const std::string& regPath);
+
+        /**
+         * @brief Get executable file paths from a given registry path.
+         * @param registryPath Registry path string.
+         * @return Vector of executable file paths.
+         */
+        std::vector<std::string> getExecutables(const std::string& registryPath);
+
+        /**
+         * @brief Retrieve the file version of an executable.
+         * @param filePath Path to the executable file.
+         * @return File version string.
+         */
+        std::string GetFileVersion(const std::string& filePath);
+
+        /**
+         * @brief Extract the executable name from a registry path.
+         * @param registryPath Registry path string.
+         * @return Executable file name.
+         */
+        std::string getExecutableName(const std::string& registryPath);
+
+        /**
+         * @brief Wrapper used for accessing the Windows Registry.
+         */
+        std::shared_ptr<IIEExtensionsWrapper> m_ieExtensionsWrapper;
+};

--- a/src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp
@@ -1,3 +1,12 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
 #include "ie_explorer.hpp"
 #include <iostream>
 #include <string>
@@ -143,19 +152,10 @@ std::string IEExtensionsProvider::getSubKeyNameFromHKey(HKEY hKey)
 
 std::string IEExtensionsProvider::HKeyToString(HKEY hKey)
 {
-    if (hKey == HKEY_CLASSES_ROOT) return "HKEY_CLASSES_ROOT";
-
-    if (hKey == HKEY_CURRENT_USER) return "HKEY_CURRENT_USER";
-
-    if (hKey == HKEY_LOCAL_MACHINE) return "HKEY_LOCAL_MACHINE";
-
-    if (hKey == HKEY_USERS) return "HKEY_USERS";
-
-    if (hKey == HKEY_CURRENT_CONFIG) return "HKEY_CURRENT_CONFIG";
-
-    if (hKey == HKEY_PERFORMANCE_DATA) return "HKEY_PERFORMANCE_DATA";
-
-    if (hKey == HKEY_DYN_DATA) return "HKEY_DYN_DATA"; // legacy, 9x
+    if (HKEY_TO_STRING_MAP.find(hKey) != HKEY_TO_STRING_MAP.end())
+    {
+        return HKEY_TO_STRING_MAP.at(hKey);
+    }
 
     return "UNKNOWN_HKEY";
 }
@@ -314,18 +314,24 @@ std::string IEExtensionsProvider::GetFileVersion(const std::string& filePath)
     DWORD size = m_ieExtensionsWrapper->GetFileVersionInfoSizeWWrapper(wFilePath.c_str(), &handle);
 
     if (size == 0)
+    {
         return "No version info";
+    }
 
     std::vector<BYTE> buffer(size);
 
     if (!m_ieExtensionsWrapper->GetFileVersionInfoWWrapper(wFilePath.c_str(), handle, size, buffer.data()))
+    {
         return "Failed to get version info";
+    }
 
     VS_FIXEDFILEINFO* fileInfo = nullptr;
     UINT len = 0;
 
     if (!m_ieExtensionsWrapper->VerQueryValueWWrapper(buffer.data(), L"\\", reinterpret_cast<LPVOID*>(&fileInfo), &len))
+    {
         return "Failed to query version value";
+    }
 
     if (fileInfo)
     {

--- a/src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp
@@ -1,0 +1,387 @@
+#include "ie_explorer.hpp"
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <vector>
+
+std::string IEExtensionsProvider::getValueFromHKey(HKEY hKey)
+{
+    // If no subKeys, then get the value name
+    const DWORD MAX_VALUE_NAME = 16384;  // MAX_VALUE_NAME + 1
+    const DWORD MAX_VALUE_DATA = 1048576; // 1MB for registry data
+
+    std::vector<char> valueName(MAX_VALUE_NAME);
+    DWORD valueNameSize;
+    DWORD valueType;
+    std::vector<BYTE> data(MAX_VALUE_DATA);
+    DWORD dataSize;
+
+    // Enumerate all values in the key
+    valueNameSize = static_cast<DWORD>(valueName.size());
+    dataSize = static_cast<DWORD>(data.size());
+
+    LONG valResult = m_ieExtensionsWrapper->RegEnumValueAWrapper(
+                         hKey,
+                         0,
+                         valueName.data(),
+                         &valueNameSize,
+                         nullptr,
+                         &valueType,
+                         data.data(),
+                         &dataSize
+                     );
+
+    if (valResult == ERROR_SUCCESS)
+    {
+        // Ensure null termination and validate size
+        if (valueNameSize < valueName.size())
+        {
+            valueName[valueNameSize] = '\0';
+        }
+
+        return std::string(valueName.data());
+    }
+    else if (valResult == ERROR_NO_MORE_ITEMS)
+    {
+        return "";
+    }
+    else
+    {
+        std::cerr << "Failed to enumerate values. Error: " << valResult << std::endl;
+        return "";
+    }
+}
+
+std::string IEExtensionsProvider::getDefaultValueFromHKey(HKEY hKey)
+{
+    const DWORD MAX_VALUE_DATA = 1048576; // 1MB for registry data
+    std::vector<BYTE> data(MAX_VALUE_DATA);
+    DWORD dataSize = static_cast<DWORD>(data.size());
+    DWORD valueType;
+
+    // Query the default value by passing empty string as value name
+    LONG result = m_ieExtensionsWrapper->RegQueryValueExAWrapper(
+                      hKey,
+                      "",          // Empty string for default value
+                      nullptr,     // Reserved
+                      &valueType,  // Type of data
+                      data.data(), // Data buffer
+                      &dataSize    // Size of data
+                  );
+
+    if (result == ERROR_SUCCESS && valueType == REG_SZ)
+    {
+        // Ensure data size is within bounds and null-terminated
+        if (dataSize > 0 && dataSize <= data.size())
+        {
+            // Ensure null termination
+            if (dataSize < data.size())
+            {
+                data[dataSize] = '\0';
+            }
+
+            return std::string(reinterpret_cast<char*>(data.data()));
+        }
+    }
+
+    return "";
+}
+
+HKEY IEExtensionsProvider::getHKeyFromKeyString(HKEY hive, const std::string& key)
+{
+    HKEY hKey;
+
+    if (m_ieExtensionsWrapper->RegOpenKeyExAWrapper(hive, key.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        return hKey;
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+std::string IEExtensionsProvider::getSubKeyNameFromHKey(HKEY hKey)
+{
+    const DWORD MAX_KEY_NAME = 256; // Windows registry limit
+    std::vector<char> keyName(MAX_KEY_NAME);
+    DWORD keyNameSize = static_cast<DWORD>(keyName.size());
+    FILETIME lastWriteTime;
+
+    keyNameSize = static_cast<DWORD>(keyName.size()); // Reset for each call
+    LONG result = m_ieExtensionsWrapper->RegEnumKeyExAWrapper(
+                      hKey,
+                      0,
+                      keyName.data(),
+                      &keyNameSize,
+                      nullptr,
+                      nullptr,
+                      nullptr,
+                      &lastWriteTime);
+
+    if (result == ERROR_SUCCESS)
+    {
+        // Ensure null termination and validate size
+        if (keyNameSize < keyName.size())
+        {
+            keyName[keyNameSize] = '\0';
+        }
+
+        return std::string(keyName.data());
+    }
+
+    if (result == ERROR_NO_MORE_ITEMS)
+    {
+        return "";
+    }
+    else
+    {
+        std::cerr << "Failed to enumerate subkeys. Error: " << result << std::endl;
+        return "";
+    }
+}
+
+std::string IEExtensionsProvider::HKeyToString(HKEY hKey)
+{
+    if (hKey == HKEY_CLASSES_ROOT) return "HKEY_CLASSES_ROOT";
+
+    if (hKey == HKEY_CURRENT_USER) return "HKEY_CURRENT_USER";
+
+    if (hKey == HKEY_LOCAL_MACHINE) return "HKEY_LOCAL_MACHINE";
+
+    if (hKey == HKEY_USERS) return "HKEY_USERS";
+
+    if (hKey == HKEY_CURRENT_CONFIG) return "HKEY_CURRENT_CONFIG";
+
+    if (hKey == HKEY_PERFORMANCE_DATA) return "HKEY_PERFORMANCE_DATA";
+
+    if (hKey == HKEY_DYN_DATA) return "HKEY_DYN_DATA"; // legacy, 9x
+
+    return "UNKNOWN_HKEY";
+}
+
+
+void IEExtensionsProvider::getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string> clsidKeys, std::vector<std::string>& regPaths)
+{
+    for (auto& subKey : clsidKeys)
+    {
+        HKEY hKey = getHKeyFromKeyString(hive, subKey);
+
+        // Open the registry key
+        if (hKey != nullptr)
+        {
+            std::string clsid;
+            std::string subKeyName = getSubKeyNameFromHKey(hKey);
+
+            if (subKeyName == "")
+            {
+                clsid = getValueFromHKey(hKey);
+            }
+            else
+            {
+                clsid = subKeyName;
+            }
+
+            std::string registryPath = HKeyToString(hive) + SEPARATOR + subKey + SEPARATOR + clsid;
+
+            if (std::find(regPaths.begin(), regPaths.end(), registryPath) == regPaths.end())
+            {
+                regPaths.push_back(registryPath);  // Insert only if not already present
+            }
+
+            // Close the key
+            m_ieExtensionsWrapper->RegCloseKeyWrapper(hKey);
+        }
+    }
+}
+
+std::vector<std::string> IEExtensionsProvider::listSubKeys(HKEY hive)
+{
+    std::vector<std::string> subKeys;
+
+    DWORD index = 0;
+    const DWORD MAX_KEY_NAME = 256; // Windows registry limit
+    std::vector<char> subKey(MAX_KEY_NAME);
+    DWORD subKeySize = static_cast<DWORD>(subKey.size());
+    FILETIME ft;
+
+    // Enumerate all SIDs under hive
+    while (m_ieExtensionsWrapper->RegEnumKeyExAWrapper(hive, index, subKey.data(), &subKeySize, nullptr, nullptr, nullptr, &ft) == ERROR_SUCCESS)
+    {
+        // Ensure null termination and validate size
+        if (subKeySize < subKey.size())
+        {
+            subKey[subKeySize] = '\0';
+        }
+
+        subKeys.emplace_back(std::string(subKey.data()));
+        index++;
+        subKeySize = static_cast<DWORD>(subKey.size()); // Reset buffer size for next item
+    }
+
+    return subKeys;
+}
+
+std::vector<std::string> IEExtensionsProvider::expandUserKey(const std::string key)
+{
+    std::vector<std::string> expandedKeys;
+
+    for (const auto& prefix : listSubKeys(HKEY_USERS))
+    {
+        expandedKeys.emplace_back(prefix + SEPARATOR + key);
+    }
+
+    return expandedKeys;
+}
+
+std::vector<std::string> IEExtensionsProvider::expandUserKeys(const std::vector<std::string>& keys)
+{
+    std::vector<std::string> expandedKeys;
+
+    for (const auto& key : keys)
+    {
+        std::vector<std::string> result = expandUserKey(key);
+        expandedKeys.insert(expandedKeys.end(), result.begin(), result.end());
+    }
+
+    return expandedKeys;
+}
+
+std::vector<std::string> IEExtensionsProvider::getRegistryPaths()
+{
+    std::vector<std::string> regPaths;
+    std::vector<std::string> expandedUserKeys = expandUserKeys(CLSIDS_KEYS);
+
+    getRegistryPathsFromKeys(HKEY_LOCAL_MACHINE, CLSIDS_KEYS, regPaths);
+    getRegistryPathsFromKeys(HKEY_USERS, expandedUserKeys, regPaths);
+
+    return regPaths;
+}
+
+void IEExtensionsProvider::getExecutablesFromKey(HKEY hive, const std::string& registryPath, std::vector<std::string>& executables)
+{
+    HKEY hKey = getHKeyFromKeyString(hive, registryPath);
+
+    if (hKey != nullptr)
+    {
+        std::string executable = getDefaultValueFromHKey(hKey);
+        m_ieExtensionsWrapper->RegCloseKeyWrapper(hKey);
+
+        if (executable != "")
+        {
+            executables.emplace_back(executable);
+        }
+    }
+}
+
+std::string IEExtensionsProvider::extractClsid(const std::string& regPath)
+{
+    size_t pos = regPath.find_last_of("\\");
+
+    if (pos == std::string::npos)
+    {
+        return regPath; // no backslash found, return whole string
+    }
+
+    return regPath.substr(pos + 1);
+}
+
+std::vector<std::string> IEExtensionsProvider::getExecutables(const std::string& registryPath)
+{
+    std::vector<std::string> executables;
+    std::vector<std::string> expandedUserKeys = expandUserKey(EXECUTABLES_BASE_KEY);
+    std::string clsid = extractClsid(registryPath);
+
+    for (const auto& subKey : CLASS_EXECUTABLES_SUBKEYS)
+    {
+        getExecutablesFromKey(HKEY_LOCAL_MACHINE, EXECUTABLES_BASE_KEY + SEPARATOR + clsid + SEPARATOR + subKey, executables);
+
+        for (const auto& userKey : expandedUserKeys)
+        {
+            getExecutablesFromKey(HKEY_USERS, userKey + SEPARATOR + clsid + SEPARATOR + subKey, executables);
+        }
+    }
+
+    return executables;
+}
+
+std::string IEExtensionsProvider::GetFileVersion(const std::string& filePath)
+{
+    // Convert std::string (UTF-8/ANSI) to std::wstring (UTF-16)
+    std::wstring wFilePath(filePath.begin(), filePath.end());
+
+    DWORD handle = 0;
+    DWORD size = m_ieExtensionsWrapper->GetFileVersionInfoSizeWWrapper(wFilePath.c_str(), &handle);
+
+    if (size == 0)
+        return "No version info";
+
+    std::vector<BYTE> buffer(size);
+
+    if (!m_ieExtensionsWrapper->GetFileVersionInfoWWrapper(wFilePath.c_str(), handle, size, buffer.data()))
+        return "Failed to get version info";
+
+    VS_FIXEDFILEINFO* fileInfo = nullptr;
+    UINT len = 0;
+
+    if (!m_ieExtensionsWrapper->VerQueryValueWWrapper(buffer.data(), L"\\", reinterpret_cast<LPVOID*>(&fileInfo), &len))
+        return "Failed to query version value";
+
+    if (fileInfo)
+    {
+        DWORD major = HIWORD(fileInfo->dwFileVersionMS);
+        DWORD minor = LOWORD(fileInfo->dwFileVersionMS);
+        DWORD build = HIWORD(fileInfo->dwFileVersionLS);
+        DWORD revision = LOWORD(fileInfo->dwFileVersionLS);
+
+        const size_t MAX_VERSION_STR = 64;
+        std::vector<char> verStr(MAX_VERSION_STR);
+        sprintf_s(verStr.data(), verStr.size(), "%u.%u.%u.%u", major, minor, build, revision);
+        return std::string(verStr.data());
+    }
+
+    return "Unknown version";
+}
+
+std::string IEExtensionsProvider::getExecutableName(const std::string& registryPath)
+{
+    std::string clsid = extractClsid(registryPath);
+    std::string keyPath = "CLSID" + SEPARATOR + clsid;
+    HKEY hKey = getHKeyFromKeyString(HKEY_CLASSES_ROOT, keyPath);
+    std::string execName = ""; // Default value
+
+    if (hKey != nullptr)
+    {
+        execName = getDefaultValueFromHKey(hKey);
+        m_ieExtensionsWrapper->RegCloseKeyWrapper(hKey);
+    }
+
+    return execName;
+}
+
+IEExtensionsProvider::IEExtensionsProvider(std::shared_ptr<IIEExtensionsWrapper> ieExtensionsWrapper) : m_ieExtensionsWrapper(std::move(ieExtensionsWrapper)) {}
+
+IEExtensionsProvider::IEExtensionsProvider() : m_ieExtensionsWrapper(std::make_shared<IEExtensionsWrapper>()) {}
+
+nlohmann::json IEExtensionsProvider::collect()
+{
+    nlohmann::json jExtensions = nlohmann::json::array();
+    std::vector<std::string> regPaths = getRegistryPaths();
+
+    for (const auto& registryPath : regPaths)
+    {
+        std::vector<std::string> executables = getExecutables(registryPath);
+
+        for (const auto& exec : executables)
+        {
+            nlohmann::json jExtension;
+            jExtension["name"] = getExecutableName(registryPath);
+            jExtension["path"] = exec;
+            jExtension["registry_path"] = registryPath;
+            jExtension["version"] = GetFileVersion(exec);
+            jExtensions.push_back(jExtension);
+        }
+    }
+
+    return jExtensions;
+}

--- a/src/data_provider/src/extended_sources/browser_extensions/tests/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/browser_extensions/tests/CMakeLists.txt
@@ -12,20 +12,21 @@ link_directories(${CMAKE_SOURCE_DIR}/../external/googletest/lib/)
 set(TEST_SRC "main.cpp")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  list(APPEND TEST_SRC
+  list(APPEND TEST_SRC 
     test_safari_darwin.cpp
     test_chrome_darwin.cpp
     test_firefox_darwin.cpp
   )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  list(APPEND TEST_SRC
+  list(APPEND TEST_SRC 
     test_chrome_linux.cpp
     test_firefox_linux.cpp
   )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  list(APPEND TEST_SRC
+  list(APPEND TEST_SRC 
     test_chrome_windows.cpp
     test_firefox_windows.cpp
+    test_ie_explorer_windows.cpp
   )
 endif()
 

--- a/src/data_provider/src/extended_sources/browser_extensions/tests/test_ie_explorer_windows.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/tests/test_ie_explorer_windows.cpp
@@ -1,0 +1,356 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "iie_extensions_wrapper.hpp"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "filesystemHelper.h"
+#include "ie_explorer.hpp"
+
+class MockIEExtensionsWrapper : public IIEExtensionsWrapper
+{
+    public:
+        MOCK_METHOD(LSTATUS, RegCloseKeyWrapper, (HKEY hKey), (override));
+
+        MOCK_METHOD(LSTATUS, RegEnumValueAWrapper,
+                    (HKEY hKey, DWORD dwIndex, LPSTR lpValueName, LPDWORD lpcchValueName,
+                     LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData),
+                    (override));
+
+        MOCK_METHOD(LSTATUS, RegQueryValueExAWrapper,
+                    (HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType,
+                     LPBYTE lpData, LPDWORD lpcbData),
+                    (override));
+
+        MOCK_METHOD(LSTATUS, RegOpenKeyExAWrapper,
+                    (HKEY hKey, LPCSTR lpSubKey, DWORD ulOptions, REGSAM samDesired,
+                     PHKEY phkResult),
+                    (override));
+
+        MOCK_METHOD(LSTATUS, RegEnumKeyExAWrapper,
+                    (HKEY hKey, DWORD dwIndex, LPSTR lpName, LPDWORD lpcchName,
+                     LPDWORD lpReserved, LPSTR lpClass, LPDWORD lpcchClass,
+                     PFILETIME lpftLastWriteTime),
+                    (override));
+
+        MOCK_METHOD(DWORD, GetFileVersionInfoSizeWWrapper,
+                    (LPCWSTR lptstrFilename, LPDWORD lpdwHandle),
+                    (override));
+
+        MOCK_METHOD(BOOL, GetFileVersionInfoWWrapper,
+                    (LPCWSTR lptstrFilename, DWORD dwHandle, DWORD dwLen, LPVOID lpData),
+                    (override));
+
+        MOCK_METHOD(BOOL, VerQueryValueWWrapper,
+                    (LPCVOID pBlock, LPCWSTR lpSubBlock, LPVOID* lplpBuffer, PUINT puLen),
+                    (override));
+};
+
+void setupWrapper(std::shared_ptr<MockIEExtensionsWrapper>& ieExtensionsWrapper)
+{
+    EXPECT_CALL(*ieExtensionsWrapper,
+                RegEnumKeyExAWrapper(::testing::_, ::testing::_, ::testing::_, ::testing::_,
+                                     ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .WillRepeatedly([](HKEY hKey, DWORD dwIndex, char* lpName, DWORD * lpcchName,
+                       LPDWORD, LPSTR, LPDWORD, PFILETIME)
+    {
+        if (hKey == HKEY_USERS)
+        {
+            const char* names[] =
+            {
+                "S-1-5-19",
+                "S-1-5-20",
+                "S-1-5-21-873499442-690455868-1617690636-1001"
+            };
+
+            if (dwIndex < 3)
+            {
+                size_t len = strlen(names[dwIndex]);
+                memcpy(lpName, names[dwIndex], len);
+                lpName[len] = '\0';
+                *lpcchName = static_cast<DWORD>(len);
+                return ERROR_SUCCESS;
+            }
+
+            return ERROR_NO_MORE_ITEMS;
+        }
+        else if (hKey == (HKEY)0x128)
+        {
+            const char* name = "{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}";
+
+            if (dwIndex == 0)
+            {
+                size_t len = strlen(name);
+                memcpy(lpName, name, len);
+                lpName[len] = '\0';
+                *lpcchName = static_cast<DWORD>(len);
+                return ERROR_SUCCESS;
+            }
+
+            return ERROR_NO_MORE_ITEMS;
+        }
+        else if (hKey == (HKEY)0x130)
+        {
+            const char* name = "";
+
+            if (dwIndex == 0)
+            {
+                size_t len = strlen(name);
+                memcpy(lpName, name, len);
+                lpName[len] = '\0';
+                *lpcchName = static_cast<DWORD>(len);
+                return ERROR_SUCCESS;
+            }
+
+            return ERROR_NO_MORE_ITEMS;
+        }
+
+        // Catch-all for any other hKey to suppress warnings
+        if (lpcchName && lpName)
+        {
+            lpName[0] = '\0';
+            *lpcchName = 0;
+        }
+
+        return ERROR_NO_MORE_ITEMS;
+    });
+
+
+    EXPECT_CALL(*ieExtensionsWrapper, RegOpenKeyExAWrapper(::testing::_, ::testing::_, 0, KEY_READ, ::testing::_))
+    .WillRepeatedly([](HKEY, LPCSTR lpSubKey, DWORD, REGSAM,
+                       PHKEY phkResult)
+    {
+
+        if (strcmp(lpSubKey, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x128);
+            return ERROR_SUCCESS;
+        }
+        else if (strcmp(lpSubKey, "SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x128);
+            return ERROR_SUCCESS;
+        }
+        else if (strcmp(lpSubKey, "S-1-5-21-873499442-690455868-1617690636-1001\\SOFTWARE\\Microsoft\\Internet Explorer\\URLSearchHooks") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x130);
+            return ERROR_SUCCESS;
+        }
+        else if (strcmp(lpSubKey, "SOFTWARE\\Classes\\CLSID\\{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}\\InProcServer32") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x132);
+            return ERROR_SUCCESS;
+        }
+        else if (strcmp(lpSubKey, "SOFTWARE\\Classes\\CLSID\\{CFBFAE00-17A6-11D0-99CB-00C04FD64497}\\InProcServer32") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x134);
+            return ERROR_SUCCESS;
+        }
+        else if (strcmp(lpSubKey, "CLSID\\{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x136);
+            return ERROR_SUCCESS;
+        }
+        else if (strcmp(lpSubKey, "CLSID\\{CFBFAE00-17A6-11D0-99CB-00C04FD64497}") == 0)
+        {
+            *phkResult = reinterpret_cast<HKEY>(0x138);
+            return ERROR_SUCCESS;
+        }
+
+        // Catch-all for any other keys
+        if (phkResult)
+        {
+            *phkResult = nullptr;
+        }
+
+        return ERROR_NO_MORE_ITEMS;
+    });
+
+    EXPECT_CALL(*ieExtensionsWrapper,
+                RegEnumValueAWrapper(::testing::_, 0, ::testing::_, ::testing::_,
+                                     ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .WillRepeatedly([](HKEY hKey, DWORD dwIndex, LPSTR lpValueName, LPDWORD lpcchValueName,
+                       LPDWORD, LPDWORD, LPBYTE, LPDWORD)
+    {
+        if (hKey == (HKEY)0x130 && dwIndex == 0)
+        {
+            const char* guid = "{CFBFAE00-17A6-11D0-99CB-00C04FD64497}";
+            size_t len = strlen(guid);
+
+            memcpy(lpValueName, guid, len);
+            lpValueName[len] = '\0';                // null terminate
+
+            if (lpcchValueName)
+            {
+                *lpcchValueName = static_cast<DWORD>(len);
+            }
+
+            return ERROR_SUCCESS;
+        }
+
+        return ERROR_NO_MORE_ITEMS;  // default if not matching
+    });
+
+    EXPECT_CALL(*ieExtensionsWrapper,
+                RegQueryValueExAWrapper(::testing::_, ::testing::StrEq(""), ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .WillRepeatedly([](HKEY hKey, LPCSTR lpValueName, LPDWORD,
+                       LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData)
+    {
+        if (strcmp(lpValueName, "") != 0)
+        {
+            return ERROR_FILE_NOT_FOUND;  // not querying default value
+        }
+
+        const char* value = nullptr;
+
+        if (hKey == (HKEY)0x132)
+        {
+            value = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\139.0.3405.111\\BHO\\ie_to_edge_bho.dll";
+        }
+        else if (hKey == (HKEY)0x134)
+        {
+            value = "C:\\Windows\\SysWOW64\\ieframe.dll";
+        }
+        else if (hKey == (HKEY)0x136)
+        {
+            value = "IEToEdge BHO";
+        }
+        else if (hKey == (HKEY)0x138)
+        {
+            value = "Microsoft Url Search Hook";
+        }
+        else
+        {
+            return ERROR_FILE_NOT_FOUND;  // no value for other keys
+        }
+
+        size_t len = strlen(value) + 1;  // include null terminator
+
+        if (lpType)
+        {
+            *lpType = REG_SZ;
+        }
+
+        if (lpcbData)
+        {
+            *lpcbData = static_cast<DWORD>(len);
+        }
+
+        if (lpData)
+        {
+            memcpy(lpData, value, len);
+        }
+
+        return ERROR_SUCCESS;
+    });
+
+    EXPECT_CALL(*ieExtensionsWrapper,
+                GetFileVersionInfoSizeWWrapper(::testing::_, ::testing::_))
+    .WillOnce([](LPCWSTR, LPDWORD lpdwHandle) -> DWORD
+    {
+        if (lpdwHandle) *lpdwHandle = 0;
+        return 2132;
+    })
+    .WillOnce([](LPCWSTR, LPDWORD lpdwHandle) -> DWORD
+    {
+        if (lpdwHandle) *lpdwHandle = 0;
+        return 2132;
+    })
+    .WillOnce([](LPCWSTR, LPDWORD lpdwHandle) -> DWORD
+    {
+        if (lpdwHandle) *lpdwHandle = 0;
+        return 1844;
+    });
+
+    EXPECT_CALL(*ieExtensionsWrapper,
+                GetFileVersionInfoWWrapper(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .WillOnce([](LPCWSTR, DWORD, DWORD dwLen, LPVOID lpData) -> BOOL
+    {
+        const char data[] =
+        "☺ FileDescription     IEToEdge BHO     > ☼ ☺ FileVersion     139.0.3405.119 "
+        "F‼ ☺ InternalName   ie_to_edge_bho_dll "
+        "É6 ☺ LegalCopyright   Copyright Microsoft Corporation. All rights reserved. "
+        "N‼ ☺ OriginalFilename   ie_to_edge_bho. "
+        "☺ ProductName     IEToEdge BHO     "
+        "B☼ ☺ ProductVersion   139.0.3405.119";
+        memcpy(lpData, data, std::min<DWORD>(dwLen, sizeof(data)));
+        return TRUE;
+    })
+    .WillOnce([](LPCWSTR, DWORD, DWORD dwLen, LPVOID lpData) -> BOOL
+    {
+        const char data[] =
+        "☺ FileDescription     IEToEdge BHO     > ☼ ☺ FileVersion     139.0.3405.119 "
+        "F‼ ☺ InternalName   ie_to_edge_bho_dll "
+        "É6 ☺ LegalCopyright   Copyright Microsoft Corporation. All rights reserved. "
+        "N‼ ☺ OriginalFilename   ie_to_edge_bho. "
+        "☺ ProductName     IEToEdge BHO     "
+        "B☼ ☺ ProductVersion   139.0.3405.119";
+        memcpy(lpData, data, std::min<DWORD>(dwLen, sizeof(data)));
+        return TRUE;
+    })
+    .WillOnce([](LPCWSTR, DWORD, DWORD dwLen, LPVOID lpData) -> BOOL
+    {
+        const char data[] =
+        "ÿ♥4   VS_VERSION_INFO     "
+        "☺ StringFileInfo "
+        "☺ 040904B0 "
+        "CompanyName     Microsoft Corporation "
+        "FileDescription     Internet Browser "
+        "FileVersion     11.00.26100.1742 (WinBuild.160101.0800) "
+        "InternalName   IEFRAME.DLL "
+        "LegalCopyright   Microsoft Corporation. All rights reserved. "
+        "OriginalFilename   IEFRAME.DLL.MUI "
+        "ProductName     Internet Explorer "
+        "ProductVersion   11.00.26100.1742";
+        memcpy(lpData, data, std::min<DWORD>(dwLen, sizeof(data)));
+        return TRUE;
+    });
+
+    EXPECT_CALL(*ieExtensionsWrapper,
+                VerQueryValueWWrapper(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+    .WillOnce([](const void*, LPCWSTR, LPVOID * lplpBuffer, PUINT puLen)
+    {
+        VS_FIXEDFILEINFO* fixedFileInfo = reinterpret_cast<VS_FIXEDFILEINFO*>(lplpBuffer);
+        fixedFileInfo->dwFileVersionMS = (139 << 16) | 0;
+        fixedFileInfo->dwFileVersionLS = (3405 << 16) | 119;
+        *puLen = sizeof(*fixedFileInfo);
+        return TRUE;
+    })
+    .WillOnce([](const void*, LPCWSTR, LPVOID * lplpBuffer, PUINT puLen)
+    {
+        VS_FIXEDFILEINFO* fixedFileInfo = reinterpret_cast<VS_FIXEDFILEINFO*>(lplpBuffer);
+        fixedFileInfo->dwFileVersionMS = (139 << 16) | 0;
+        fixedFileInfo->dwFileVersionLS = (3405 << 16) | 119;
+        *puLen = sizeof(*fixedFileInfo);
+        return TRUE;
+    })
+    .WillOnce([](const void*, LPCWSTR, LPVOID * lplpBuffer, PUINT puLen)
+    {
+        VS_FIXEDFILEINFO* fixedFileInfo = reinterpret_cast<VS_FIXEDFILEINFO*>(lplpBuffer);
+        fixedFileInfo->dwFileVersionMS = (11 << 16) | 0;
+        fixedFileInfo->dwFileVersionLS = (26100 << 16) | 1742;
+        *puLen = sizeof(*fixedFileInfo);
+        return TRUE;
+    });
+
+    // Mock registry key closing
+    EXPECT_CALL(*ieExtensionsWrapper, RegCloseKeyWrapper(::testing::_))
+    .WillRepeatedly(::testing::Return(ERROR_SUCCESS));
+}
+
+TEST(IEExplorerTests, NumberOfExtensions)
+{
+    auto ieExtensionsWrapper = std::make_shared<MockIEExtensionsWrapper>();
+
+    setupWrapper(ieExtensionsWrapper);
+
+    IEExtensionsProvider ieExtensionsProvider(ieExtensionsWrapper);
+    nlohmann::json extensionsJson = ieExtensionsProvider.collect();
+    ASSERT_EQ(extensionsJson.size(), static_cast<size_t>(3));
+}

--- a/src/data_provider/src/extended_sources/wrappers/windows/ie_extensions_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/ie_extensions_wrapper.hpp
@@ -1,0 +1,101 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "iie_extensions_wrapper.hpp"
+
+class IEExtensionsWrapper : public IIEExtensionsWrapper
+{
+    public:
+        LSTATUS RegCloseKeyWrapper(HKEY hKey)
+        {
+            return RegCloseKey(hKey);
+        }
+
+        LSTATUS RegEnumValueAWrapper(
+            HKEY    hKey,
+            DWORD   dwIndex,
+            LPSTR   lpValueName,
+            LPDWORD lpcchValueName,
+            LPDWORD lpReserved,
+            LPDWORD lpType,
+            LPBYTE  lpData,
+            LPDWORD lpcbData
+        ) override
+        {
+            return RegEnumValueA(hKey, dwIndex, lpValueName, lpcchValueName,
+                                 lpReserved, lpType, lpData, lpcbData);
+        }
+
+        LSTATUS RegQueryValueExAWrapper(
+            HKEY    hKey,
+            LPCSTR  lpValueName,
+            LPDWORD lpReserved,
+            LPDWORD lpType,
+            LPBYTE  lpData,
+            LPDWORD lpcbData
+        ) override
+        {
+            return RegQueryValueExA(hKey, lpValueName, lpReserved, lpType, lpData, lpcbData);
+        }
+
+        LSTATUS RegOpenKeyExAWrapper(
+            HKEY   hKey,
+            LPCSTR lpSubKey,
+            DWORD  ulOptions,
+            REGSAM samDesired,
+            PHKEY  phkResult
+        ) override
+        {
+            return RegOpenKeyExA(hKey, lpSubKey, ulOptions, samDesired, phkResult);
+        }
+
+        LSTATUS RegEnumKeyExAWrapper(
+            HKEY      hKey,
+            DWORD     dwIndex,
+            LPSTR     lpName,
+            LPDWORD   lpcchName,
+            LPDWORD   lpReserved,
+            LPSTR     lpClass,
+            LPDWORD   lpcchClass,
+            PFILETIME lpftLastWriteTime
+        ) override
+        {
+            return RegEnumKeyExA(hKey, dwIndex, lpName, lpcchName, lpReserved, lpClass, lpcchClass, lpftLastWriteTime);
+        }
+
+        DWORD GetFileVersionInfoSizeWWrapper(
+            LPCWSTR lptstrFilename,
+            LPDWORD lpdwHandle
+        ) override
+        {
+            return ::GetFileVersionInfoSizeW(lptstrFilename, lpdwHandle);
+        }
+
+        BOOL GetFileVersionInfoWWrapper(
+            LPCWSTR lptstrFilename,
+            DWORD   dwHandle,
+            DWORD   dwLen,
+            LPVOID  lpData
+        ) override
+        {
+            return ::GetFileVersionInfoW(lptstrFilename, dwHandle, dwLen, lpData);
+        }
+
+        BOOL VerQueryValueWWrapper(
+            LPCVOID pBlock,
+            LPCWSTR lpSubBlock,
+            LPVOID*  lplpBuffer,
+            PUINT   puLen
+        ) override
+        {
+            return ::VerQueryValueW(pBlock, lpSubBlock, lplpBuffer, puLen);
+        }
+};

--- a/src/data_provider/src/extended_sources/wrappers/windows/iie_extensions_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/iie_extensions_wrapper.hpp
@@ -1,0 +1,80 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <windows.h>
+#include <vector>
+
+class IIEExtensionsWrapper
+{
+    public:
+        /// Destructor
+        virtual ~IIEExtensionsWrapper() = default;
+
+        virtual LSTATUS RegCloseKeyWrapper(HKEY hKey) = 0;
+
+        virtual LSTATUS RegEnumValueAWrapper(
+            HKEY    hKey,           // Handle to an open registry key
+            DWORD   dwIndex,        // Index of the value to retrieve (0-based)
+            LPSTR   lpValueName,    // Buffer for value name
+            LPDWORD lpcchValueName, // Size of value name buffer (in/out)
+            LPDWORD lpReserved,     // Reserved, must be NULL
+            LPDWORD lpType,         // Pointer to variable that receives value type
+            LPBYTE  lpData,         // Buffer for value data (can be NULL)
+            LPDWORD lpcbData        // Size of data buffer (in/out, can be NULL)
+        ) = 0;
+
+        virtual LSTATUS RegQueryValueExAWrapper(
+            HKEY    hKey,           // Handle to an open registry key
+            LPCSTR  lpValueName,    // Name of the value to query
+            LPDWORD lpReserved,     // Reserved, must be NULL
+            LPDWORD lpType,         // Pointer to variable that receives value type
+            LPBYTE  lpData,         // Buffer for value data (can be NULL)
+            LPDWORD lpcbData        // Size of data buffer (in/out, can be NULL)
+        ) = 0;
+
+        virtual LSTATUS RegOpenKeyExAWrapper(
+            HKEY   hKey,            // Handle to an open registry key
+            LPCSTR lpSubKey,        // Name of the subkey to open
+            DWORD  ulOptions,       // Reserved, must be 0
+            REGSAM samDesired,      // Security access mask
+            PHKEY  phkResult        // Pointer to variable that receives handle
+        ) = 0;
+
+        virtual LSTATUS RegEnumKeyExAWrapper(
+            HKEY      hKey,               // Handle to an open registry key
+            DWORD     dwIndex,            // Index of the subkey to retrieve (0-based)
+            LPSTR     lpName,             // Buffer for subkey name
+            LPDWORD   lpcchName,          // Size of subkey name buffer (in/out)
+            LPDWORD   lpReserved,         // Reserved, must be NULL
+            LPSTR     lpClass,            // Buffer for class string (can be NULL)
+            LPDWORD   lpcchClass,         // Size of class buffer (in/out, can be NULL)
+            PFILETIME lpftLastWriteTime   // Pointer to last write time (can be NULL)
+        ) = 0;
+
+        virtual DWORD GetFileVersionInfoSizeWWrapper(
+            LPCWSTR lptstrFilename,   // Pointer to filename string
+            LPDWORD lpdwHandle        // Pointer to variable to receive zero (unused)
+        ) = 0;
+
+        virtual BOOL GetFileVersionInfoWWrapper(
+            LPCWSTR lptstrFilename,   // Pointer to filename string
+            DWORD   dwHandle,         // Ignored, should be zero
+            DWORD   dwLen,            // Length of buffer (from GetFileVersionInfoSizeW)
+            LPVOID  lpData            // Pointer to buffer to receive version info
+        ) = 0;
+
+        virtual BOOL VerQueryValueWWrapper(
+            LPCVOID pBlock,           // Address of buffer with version info
+            LPCWSTR lpSubBlock,       // Address of value to retrieve
+            LPVOID*  lplpBuffer,      // Address of buffer for version info pointer
+            PUINT   puLen             // Address of version info length
+        ) = 0;
+};


### PR DESCRIPTION
## Description

Closes #29739 

Implements a new Internet Explorer Extensions collector for the `Browser Extensions` inventory table within the `syscollector` module. This collector will use the `extended_sources` submodule to retrieve detailed metadata about installed Internet Explorer Extensions.

The information collected will be mapped to the inventory model and formatted in accordance with ECS-compatible schemas where applicable. This will improve system observability, troubleshooting, and compliance auditing capabilities.

**Relevant fields:**

| Column         | Type | Description                      |
|----------------|------|----------------------------------|
| `name`         | text | Extension display name           |
| `registry_path`| text | Extension identifier             |
| `version`      | text | Version of the executable        |
| `path`         | text | Path to the extension executable |

## Proposed Changes

- [x] Implement platform-specific extractors for Linux, Windows, and macOS  
- [x] Implement logic in `extended_sources` to retrieve Firefox Addons data  
- [x] Normalize field values and structure to align with inventory schema  
- [x] Add unit tests to validate extraction logic per platform  

### Results and Evidence

<details><summary>Source item example</summary>

```json
  {
    "name": "IEToEdge BHO",
    "path": "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\139.0.3405.111\\BHO\\ie_to_edge_bho_64.dll",
    "registry_path": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}",
    "version": "139.0.3405.111"
  }
```
</details> 

<details><summary>Browser Extensions collector item example</summary>

```json
{
        "name": "IEToEdge BHO",
        "path": "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\139.0.3405.111\\BHO\\ie_to_edge_bho.dll",
        "registry_path": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser Helper Objects\\{1FD49718-1D00-4B19-AF5F-070AF6D5D54C}",
        "version": "139.0.3405.111"
}
```
</details>
  
### Artifacts Affected

  - syscollector module (all platforms)
  - extended_sources submodule
  - Browser Extensions inventory table
  - Unit test suites for Windows

### Configuration Changes

  - NA

### Tests Introduced

  - Cross-platform unit tests for Internet Explorer extension detection

### Documentation Updates

  - NA

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->