### PR TITLE
Correct release date from Aug 6 to Aug 27 in AIX package spec

### DIFF
--- a/packages/aix/SPECS/wazuh-agent-aix.spec
+++ b/packages/aix/SPECS/wazuh-agent-aix.spec
@@ -284,7 +284,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/*
 
 %changelog
-* Wed Aug 06 2025 support <info@wazuh.com> - 4.10.4
+* Wed Aug 27 2025 support <info@wazuh.com> - 4.10.4
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
 * Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html


### PR DESCRIPTION
## Description

This PR fixes an incorrect release date in the AIX package specification file. The date for
version 4.10.4 was incorrectly set to August 6, 2025 and has been corrected to August 27, 2025.

## Proposed Changes

- Updated the release date in the changelog section of /packages/aix/SPECS/wazuh-agent-aix.spec
- Changed "Wed Aug 06 2025" to "Wed Aug 27 2025" for version 4.10.4

### Results and Evidence

The changelog entry on line 287 now correctly shows:
* Wed Aug 27 2025 support <info@wazuh.com> - 4.10.4

Artifacts Affected

- /packages/aix/SPECS/wazuh-agent-aix.spec - AIX package specification file

### Configuration Changes

No configuration changes required.

### Documentation Updates

No additional documentation updates needed - this is a date correction in package metadata.

### Tests Introduced

No new tests required for this metadata correction.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (N/A - metadata correction)
- [ ] Configuration changes documented (N/A - no config changes)
- [ ] Developer documentation reflects the changes (N/A - metadata correction)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues