### PR TITLE
Fix literal parser dangling std::string_view capture, and add regression test in 6.0.0

### DIFF
--- a/src/engine/source/hlp/src/parsers/literal.cpp
+++ b/src/engine/source/hlp/src/parsers/literal.cpp
@@ -12,7 +12,7 @@ namespace
 using namespace hlp;
 using namespace hlp::parser;
 
-Mapper getMapper(std::string_view parsed, const std::string& targetField)
+Mapper getMapper(const std::string& parsed, const std::string& targetField)
 {
     return [parsed, targetField](json::Json& event)
     {
@@ -20,9 +20,9 @@ Mapper getMapper(std::string_view parsed, const std::string& targetField)
     };
 }
 
-SemParser getSemParser(std::string_view parsed, const Mapper& mapper)
+SemParser getSemParser(const Mapper& mapper)
 {
-    return [parsed, mapper](std::string_view)
+    return [mapper](std::string_view)
     {
         return mapper;
     };
@@ -47,7 +47,7 @@ Parser getLiteralParser(const Params& params)
     const auto& literal = params.options[0];
     const auto synP = getSynParser(literal);
     const auto mapper = params.targetField.empty() ? noMapper() : getMapper(literal, params.targetField);
-    const auto semP = getSemParser(literal, mapper);
+    const auto semP = getSemParser(mapper);
 
     return [name = params.name, synP, semP](std::string_view txt)
     {

--- a/src/engine/source/hlp/test/src/unit/hlp_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/hlp_test.cpp
@@ -105,3 +105,15 @@ TEST_P(HlpParseTest, NoMappingParse)
     auto parser = builder(params);
     parseTest(success, input, expected, index, parser);
 }
+
+// Build from a short-lived params copy to catch use-after-free
+TEST_P(HlpParseTest, MapperLifetime)
+{
+    auto [success, input, expected, index, builder, params] = GetParam();
+    auto parser = [&]
+    {
+        auto params_tmp = params;
+        return builder(params_tmp);
+    }();
+    parseTest(success, input, expected, index, parser);
+}


### PR DESCRIPTION
## Description

Fix a heap-use-after-free in the HLP **literal** parser that caused nondeterministic values to be written when a literal was captured into a target field.

**Root cause**: the literal parser captured a `std::string_view` to `Params.options[0]` and stored it inside a mapper lambda. The `Params` object is temporary at build time and goes out of scope before the mapper executes, leaving the view dangling. Using that view later (e.g., `event.setString(parsed, targetField)`) led to UAF and memory corruption.

Closes #31456.

(cherry picked from commit a0797749b486b8f2fac6dae16bd0fb3714feb42a)

## Proposed Changes

- **Fix**: Copy the literal into the mapper by value (use `const std::string&` in the mapper capture path; the mapper holds an owning copy) to guarantee lifetime.
- **New unit test**: Add a parameterized test that builds the parser with a short-lived `Params`, then exercises the returned mapper after `Params` is destroyed, ensuring correct behavior and stable mapping.
- **Refactor**: Remove unused `parsed` parameter from `getSemParser` and its lambda; new signature `SemParser getSemParser(const Mapper& mapper)`.

### Results and Evidence
**Summary:** The fix was verified with AddressSanitizer (ASan) catching the same heap-use-after-free in two independent ways, and confirming it disappears after the change.

#### 1) Unit test with ASan (parameterized parser test)
**Test name:** `HlpParseTest.MapperLifetime`

**Command:**
```bash
./hlp_utest --gtest_filter="*MapperLifetime*"
```

**Before (without fix):**
ASan reports UAF when applying the mapper captured from a parser built with short‑lived params. The backtrace reaches the lambda in `literal.cpp:19`.
```text
==108266==ERROR: AddressSanitizer: heap-use-after-free
#3 json::Json::setString(...)
#4 (anonymous namespace)::getMapper(...): operator()  <-- literal.cpp:19
...
freed by thread T0 here:
... hlp::Params::~Params() ...  <-- params destroyed before mapper use
```

**After (with fix):**
All tests (including the new lifetime test) pass under ASan.
```text
[==========] 412 tests from 25 test suites ran.
[  PASSED  ] 412 tests.
```

#### 2) Manual end-to-end run via `engine-test`
Objective: capture a fixed literal into `tmp.host.name` and propagate to `host.name`.

**Decoder used in test**:
```yaml
name: decoder/literal-bug/0

definitions:
  DATE1: <event.start/%b %d %Y %T>
  SYSLOG_PRIORITY: <?tmp.syslog.priority/between/</\>>

normalize:
  - parse|event.original:
      - '$SYSLOG_PRIORITY$DATE1 <process.name>: <tmp.host.name/literal/aabb>: <_message>'
      - '<process.name>: <tmp.host.name/literal/aabb>: <_message>'

    map:
      - host.name: $tmp.host.name
      - wazuh.decoders: array_append(literal-sanity)

  - check:
      - tmp.syslog.priority: exists()
    map:
      - log.syslog.priority: parse_long($tmp.syslog.priority)

  - check:
      - event.severity: not_exists()
    map:
      - event.severity: 7
```

**Command:**
```bash
engine-test -c /workspaces/wazuh-5.x/engine-test.json run test -n wazuh -dd
# Paste an event, e.g.:
<14>Aug 14 2019 13:56:30 platformSettingEdit.cgi: aabb: rest of line...
```

**Before (without fix):**
The engine crashes under ASan while decoding, and `engine-test` shows connection errors. ASan pinpoints `literal.cpp:19` in the mapper lambda (same root cause as the unit test).
```text
HTTP error: Server disconnected without sending a response
...
==34170==ERROR: AddressSanitizer: heap-use-after-free
#3 json::Json::setString(...)
#4 getMapper(...): operator()  <-- literal.cpp:19
```

**After (with fix):**
The engine responds correctly; traces show successful mapping and stable value in `host.name`, in this case `aabb` 
```text
traces:
[🟢] decoder/literal-bug/0 -> success
  ↳ [/event/original: <?tmp.syslog.priority/between/</\>><event.start/%b %d %Y %T> <process.name>: <tmp.host.name/literal/aabb>: <_message>] -> Success
  ↳ host.name: map($tmp.host.name) -> Success
  ↳ wazuh.decoders: array_append("literal-sanity") -> Success
  ↳ tmp.syslog.priority: exists -> Success
  ↳ log.syslog.priority: parse_long($tmp.syslog.priority) -> Success
  ↳ event.severity: not_exists -> Success
  ↳ event.severity: map(7) -> Success

output:
  '@timestamp': '2025-08-22T15:13:02Z'
  agent:
    id: '000'
    manager_name: fe4d49e55ea8
    name: fe4d49e55ea8
  event:
    original: '<14>Aug 14 2019 13:56:30 platformSettingEdit.cgi: aabb: rest of line...'
    severity: 7
    start: '2019-08-14T13:56:30.000Z'
  host:
    name: aabb
  log:
    syslog:
      priority: 14
  process:
    name: platformSettingEdit.cgi
  tmp:
    host:
      name: aabb
    syslog:
      priority: '14'
  wazuh:
    decoders:
    - literal-sanity
    location: /tmp/json
    queue: 49
```

### Manual tests with their corresponding evidence

<!-- Depending on the affected components by this PR, select the checks and mark them. -->

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
  - [x] Test run in parallel
  - [x] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine

### Artifacts Affected

- Executables: `wazuh-engine` (Linux) — runtime stability improvement (no functional change).

### Configuration Changes

- N/A

### Tests Introduced

- **Suite**: `HlpParseLiteralTest`
- **Case**: `MapperLifetime` (parameterized)
  - **Scope**: Ensures the mapper uses a safe copy of the literal and remains valid after the `Params` used to build the parser has been destroyed.
  - **Expected**: Exact consumption of literal length and deterministic mapping into `/TargetField`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
