### PR TITLE
Fix engine PID detection in wazuh-control (locale-agnostic)

### DIFF
--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -242,21 +242,20 @@ testconfig()
 
 get_wazuh_engine_pid()
 {
-    local max_wait=10
-    local interval=0.1
-    local elapsed=0
+    local max_ticks=100
+    local ticks=0
     local pidfile
 
     ${DIR}/bin/wazuh-engine
 
-    while awk "BEGIN { exit !($elapsed < $max_wait) }"; do
+    while [ $ticks -lt $max_ticks ]; do
         pidfile=$(ls ${DIR}/var/run/wazuh-engine-*.pid 2>/dev/null | head -n1)
         if [ -n "$pidfile" ]; then
             echo "${pidfile##*-}" | sed 's/\.pid$//'
             return 0
         fi
-        sleep $interval
-        elapsed=$(awk "BEGIN { print $elapsed + $interval }")
+        ticks=$((ticks + 1))
+        sleep 0.1
     done
 
     return 1  # timeout


### PR DESCRIPTION
## Description

This PR fixes a startup failure in the manager init script installed as `/var/ossec/bin/wazuh-control` when the system locale uses a comma decimal separator (e.g., `LC_NUMERIC=es_ES.UTF-8`). The original `get_wazuh_engine_pid()` loop relied on `awk` floating‑point arithmetic, which is locale‑dependent. Under comma locales, `awk` raised `syntax error at or near ,`, making the script report that `wazuh-engine` failed to start even though the process was running.

Closes #31482.

## Proposed Changes

- Replace the `awk`‑based floating‑point loop in `get_wazuh_engine_pid()` with an **integer tick counter** (`max_ticks`/`ticks`)

### Results and Evidence

**Before (under `es_ES.UTF-8`):**
```
awk: line 1: syntax error at or near ,
Failed to obtain PID for wazuh-engine
wazuh-engine did not start correctly.
```

**After (locale‑agnostic integer ticks):**
```
Started wazuh-engine...
Completed.
```

**Repro/validation commands:**
```
/var/ossec/bin/wazuh-control stop || true
sh -x /var/ossec/bin/wazuh-control start

LC_ALL=C /var/ossec/bin/wazuh-control restart
LC_ALL=es_ES.UTF-8 /var/ossec/bin/wazuh-control restart

/var/ossec/bin/wazuh-control status
/var/ossec/bin/wazuh-control stop
```

### Manual tests with their corresponding evidence

**What the validator checks**
- Installs the proper package for the family (RPM on RHEL/Rocky/CentOS; DEB on Debian/Ubuntu).
- Ensures **Spanish locale** is present (`es_ES.UTF-8` or `es_ES.utf8`) and tests **both** `C` and Spanish.
- Starts Wazuh, then asserts **core daemons** are running:
  `wazuh-modulesd, wazuh-monitord, wazuh-logcollector, wazuh-remoted, wazuh-syscheckd, wazuh-engine, wazuh-execd, wazuh-db, wazuh-authd, wazuh-apid`.
  (Cluster and forwarder are **not required**.)
- Prints status, tails errors on failure, and shuts everything down cleanly.

**Artifacts layout for tests:**
```
artifacts_root/
├─ pkgs/
│  ├─ wazuh-manager_5.0.0-0_amd64_587d331.deb
│  └─ wazuh-manager_5.0.0-0_x86_64_587d331.rpm
└─ validate_wazuh_locales.sh
```

The script `validate_wazuh_locales.sh` installs the appropriate package, ensures locales are available, starts Wazuh under **two locales** (`C` and `es_ES`), asserts core services are running, prints status, then stops.

```bash
#!/usr/bin/env bash
set -euo pipefail

# Directory inside the container where packages are mounted
PKG_DIR="${PKG_DIR:-/pkg}"

log() { printf "\n==> %s\n" "$*"; }
have() { command -v "$1" >/dev/null 2>&1; }

pkg_install_rhel() {
  # Use dnf, else microdnf, else yum
  if have dnf; then dnf -y "$@"
  elif have microdnf; then microdnf -y "$@"
  else yum -y "$@"
  fi
}

ensure_locales_debian() {
  log "Installing locales & basics (Debian/Ubuntu)"
  apt-get update -y
  DEBIAN_FRONTEND=noninteractive apt-get install -y locales lsb-release ca-certificates curl procps
  # Ensure es_ES.UTF-8 is generated
  if ! locale -a 2>/dev/null | grep -qi '^es_ES\.utf8$'; then
    echo "es_ES.UTF-8 UTF-8" >> /etc/locale.gen
    locale-gen
  fi
}

ensure_locales_rhel() {
  log "Installing langpacks & basics (RHEL/Rocky/CentOS Stream)"
  pkg_install_rhel install glibc-langpack-en glibc-langpack-es ca-certificates procps-ng which || true
}

install_wazuh_deb() {
  local deb
  deb="$(ls -1 ${PKG_DIR}/wazuh-manager_*_amd64_*.deb 2>/dev/null | head -n1 || true)"
  [ -n "${deb}" ] || { echo "No .deb package found in ${PKG_DIR}"; exit 2; }
  log "Installing ${deb}"
  dpkg -i "${deb}" || apt-get -y -f install
}

install_wazuh_rpm() {
  local rpm
  rpm="$(ls -1 ${PKG_DIR}/wazuh-manager_*_x86_64_*.rpm 2>/dev/null | head -n1 || true)"
  [ -n "${rpm}" ] || { echo "No .rpm package found in ${PKG_DIR}"; exit 2; }
  log "Installing ${rpm}"
  pkg_install_rhel install "${rpm}" || pkg_install_rhel install --allowerasing "${rpm}"
}

require_manager() {
  if [ -x /var/ossec/bin/wazuh-control ]; then
    log "Wazuh Manager already installed"
    return
  fi

  if [ -f /etc/redhat-release ]; then
    ensure_locales_rhel
    install_wazuh_rpm
  else
    ensure_locales_debian
    install_wazuh_deb
  fi
}

check_core_running() {
  # Check only core daemons. We DO NOT require clusterd or forwarder.
  local required=(wazuh-modulesd wazuh-monitord wazuh-logcollector wazuh-remoted wazuh-syscheckd wazuh-engine wazuh-execd wazuh-db wazuh-authd wazuh-apid)
  local s ok=1
  s="$(/var/ossec/bin/wazuh-control status || true)"
  for svc in "${required[@]}"; do
    if ! echo "${s}" | grep -qE "^${svc} is running"; then
      ok=0
      echo "  - ${svc}: NOT running"
    fi
  done
  if [ "${ok}" -eq 1 ]; then
    echo "${s}"
    return 0
  fi
  echo "${s}"
  echo
  echo "Last lines of /var/ossec/logs/ossec.log:"
  tail -n 200 /var/ossec/logs/ossec.log || true
  return 1
}

run_for_locale() {
  local L="$1"
  export LC_ALL="$L"
  log "=== Locale=${LC_ALL} ==="
  locale -a 2>/dev/null | grep -Ei "^${L//./\\.}$" || echo "(locale $L not present)"

  /var/ossec/bin/wazuh-control stop || true
  /var/ossec/bin/wazuh-control start || {
    echo "Start failed with LC_ALL=${LC_ALL}"
    tail -n 200 /var/ossec/logs/ossec.log || true
    return 1
  }

  check_core_running
  local rc=$?
  /var/ossec/bin/wazuh-control stop || true
  return ${rc}
}

main() {
  require_manager

  # Normalize Spanish locale name on RHEL-family (often es_ES.utf8)
  local ES_LOCALE="es_ES.UTF-8"
  if locale -a 2>/dev/null | grep -qi '^es_ES\.utf8$'; then
    ES_LOCALE="es_ES.utf8"
  fi

  run_for_locale "C"
  run_for_locale "${ES_LOCALE}"

  log "Validation OK for locales: C and ${ES_LOCALE}"
}

main "$@"
```

### Negative Test **pre-fix package**:  `wazuh-manager_5.0.0-0_amd64_48ee3f3.deb` (build without the fix)
**Package:** `wazuh-manager_5.0.0-0_amd64_48ee3f3.deb` (build without the fix)
**Expectation:** OK under `LC_ALL=C`, **fails** under Spanish locale (`es_ES.*`).

Ubuntu 22.04:
```bash
docker run --rm -t -v "$PWD/pkgs":/pkg -v "$PWD/validate_wazuh_locales.sh":/validate.sh \
  ubuntu:22.04 bash -lc 'bash /validate.sh'
```

**Run log — Locale=C (passes):**
```
==> Installing /pkg/wazuh-manager_5.0.0-0_amd64_48ee3f3.deb
Selecting previously unselected package wazuh-manager.
(Reading database ... 6382 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_5.0.0-0_amd64_48ee3f3.deb ...
Unpacking wazuh-manager (5.0.0-0) ...
Setting up wazuh-manager (5.0.0-0) ...

==> === Locale=C ===
C
wazuh-clusterd not running...
wazuh-modulesd not running...
wazuh-monitord not running...
wazuh-logcollector not running...
wazuh-remoted not running...
wazuh-syscheckd not running...
wazuh-engine not running...
wazuh-execd not running...
wazuh-db not running...
wazuh-authd not running...
wazuh-apid not running...
wazuh-forwarder not running...
Wazuh v5.0.0 Stopped
2025/08/26 12:04:46 wazuh-modulesd:router: INFO: Loaded router module.
2025/08/26 12:04:46 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/08/26 12:04:46 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
Starting Wazuh v5.0.0...
Started wazuh-forwarder...
Started wazuh-apid...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-engine...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2025/08/26 12:05:05 wazuh-modulesd:router: INFO: Loaded router module.
2025/08/26 12:05:05 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/08/26 12:05:05 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
Started wazuh-modulesd...
Completed.
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-engine is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...
wazuh-forwarder is running...
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-engine...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
Killing wazuh-apid...
Killing wazuh-forwarder...
Wazuh v5.0.0 Stopped
```

**Run log — Locale=es_ES.utf8 (fails, reproduces original bug):**
```
es_ES.utf8
wazuh-clusterd not running...
wazuh-modulesd not running...
wazuh-monitord not running...
wazuh-logcollector not running...
wazuh-remoted not running...
wazuh-syscheckd not running...
wazuh-engine not running...
wazuh-execd not running...
wazuh-db not running...
wazuh-authd not running...
wazuh-apid not running...
wazuh-forwarder not running...
Wazuh v5.0.0 Stopped
2025/08/26 12:05:13 wazuh-modulesd:router: INFO: Loaded router module.
2025/08/26 12:05:13 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/08/26 12:05:13 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
Starting Wazuh v5.0.0...
Started wazuh-forwarder...
Started wazuh-apid...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
awk: line 1: syntax error at or near ,
Failed to obtain PID for wazuh-engine
wazuh-engine did not start correctly.
Start failed with LC_ALL=es_ES.utf8
```

The pre-fix package works under `C` but **fails under Spanish locales** due to the `awk` parsing issue; the fixed package removes this failure as seen below.

### Positive Tests

- Rocky Linux 9 (RPM):
```bash
docker run --rm -t -v "$PWD/pkgs":/pkg -v "$PWD/validate_wazuh_locales.sh":/validate.sh \
  rockylinux:9 bash -lc 'bash /validate.sh'
```
```text
==> === Locale=C ===
Started wazuh-engine...
Completed.
... (all core daemons show "is running")

==> === Locale=es_ES.utf8 ===
Started wazuh-engine...
Completed.
... (all core daemons show "is running")
```

- CentOS Stream 9:
```bash
docker run --rm -t -v "$PWD/pkgs":/pkg -v "$PWD/validate_wazuh_locales.sh":/validate.sh \
  quay.io/centos/centos:stream9 bash -lc 'bash /validate.sh'
```
```text
==> === Locale=C ===
Started wazuh-engine...
Completed.

==> === Locale=es_ES.utf8 ===
Started wazuh-engine...
Completed.
```

- Debian 12:
```bash
docker run --rm -t -v "$PWD/pkgs":/pkg -v "$PWD/validate_wazuh_locales.sh":/validate.sh \
  debian:12 bash -lc 'bash /validate.sh'
```
```text
==> === Locale=C ===
Started wazuh-engine...
Completed.

==> === Locale=es_ES.utf8 ===
Started wazuh-engine...
Completed.
```

- Ubuntu 22.04:
```bash
docker run --rm -t -v "$PWD/pkgs":/pkg -v "$PWD/validate_wazuh_locales.sh":/validate.sh \
  ubuntu:22.04 bash -lc 'bash /validate.sh'
```
```text
==> === Locale=C ===
Started wazuh-engine...
Completed.

==> === Locale=es_ES.utf8 ===
Started wazuh-engine...
Completed.
```

## Conclusion
- The locale‑agnostic change **eliminates the `awk` error** under Spanish locale on all tested distributions with both **RPM** and **DEB** packages.
- Core daemons consistently report **"is running"** under both `LC_ALL=C` and `LC_ALL=es_ES.*`.

**Distributions covered:** Rocky Linux 9, CentOS Stream 9, Debian 12, Ubuntu 22.04

| Distro | Package | Locale C | Locale es_ES | Outcome | Representative log line |
|---|---|---|---|---|---|
| Rocky Linux 9 | RPM | ✅ | ✅ (`es_ES.utf8`) | **PASS** | `Started wazuh-engine...` → `Completed.` |
| CentOS Stream 9 | RPM | ✅ | ✅ (`es_ES.utf8`) | **PASS** | `Started wazuh-engine...` → `Completed.` |
| Debian 12 | DEB | ✅ | ✅ (`es_ES.utf8`) | **PASS** | `Started wazuh-engine...` → `Completed.` |
| Ubuntu 22.04 | DEB | ✅ | ✅ (`es_ES.utf8`) | **PASS** | `Started wazuh-engine...` → `Completed.` |

The workflow **“Build wazuh legacy unit tests”** is expected to fail for now; it is being tracked and resolved in: https://github.com/wazuh/wazuh/issues/30922

### Artifacts Affected

- Manager init script installed as `/var/ossec/bin/wazuh-control`.

### Configuration Changes

- **N/A**

### Tests Introduced

- **N/A** 
- 
## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
