### PR TITLE
Add regex type support to new sca implementation

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/include/sca_utils.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_utils.hpp
@@ -74,4 +74,14 @@ namespace sca
     /// @param pattern The pattern to check.
     /// @return True if the pattern is a regex pattern or a numeric pattern, false otherwise.
     bool IsRegexOrNumericPattern(const std::string& pattern);
+
+    /// @brief Converts a string to RegexEngineType enum.
+    /// @param regexType The string representation of the regex type.
+    /// @return The corresponding RegexEngineType enum value.
+    RegexEngineType StringToRegexEngineType(const std::string& regexType);
+
+    /// @brief Converts a RegexEngineType enum to string.
+    /// @param engineType The RegexEngineType enum value.
+    /// @return The string representation of the regex type.
+    std::string RegexEngineTypeToString(RegexEngineType engineType);
 } // namespace sca

--- a/src/wazuh_modules/sca/sca_impl/src/sca_checksum.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_checksum.cpp
@@ -23,8 +23,8 @@ namespace sca
         const std::string regexType = checkData.value("regex_type", "");
 
         return calculateChecksum(
-            id, policyId, name, description, rationale, remediation, refs, condition, compliance, rules, regexType
-        );
+                   id, policyId, name, description, rationale, remediation, refs, condition, compliance, rules, regexType
+               );
     }
 
     std::string calculateChecksum(const std::string& id,

--- a/src/wazuh_modules/sca/sca_impl/src/sca_checksum.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_checksum.cpp
@@ -20,9 +20,11 @@ namespace sca
         const std::string condition = checkData.value("condition", "");
         const std::string compliance = checkData.value("compliance", "");
         const std::string rules = checkData.value("rules", "");
+        const std::string regexType = checkData.value("regex_type", "");
 
         return calculateChecksum(
-                   id, policyId, name, description, rationale, remediation, refs, condition, compliance, rules);
+            id, policyId, name, description, rationale, remediation, refs, condition, compliance, rules, regexType
+        );
     }
 
     std::string calculateChecksum(const std::string& id,
@@ -34,12 +36,13 @@ namespace sca
                                   const std::string& refs,
                                   const std::string& condition,
                                   const std::string& compliance,
-                                  const std::string& rules)
+                                  const std::string& rules,
+                                  const std::string& regexType)
     {
         // Calculate required buffer size
         const auto size = std::snprintf(nullptr,
                                         0,
-                                        "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
+                                        "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
                                         id.c_str(),
                                         policyId.c_str(),
                                         name.c_str(),
@@ -49,7 +52,8 @@ namespace sca
                                         refs.c_str(),
                                         condition.c_str(),
                                         compliance.c_str(),
-                                        rules.c_str());
+                                        rules.c_str(),
+                                        regexType.c_str());
 
         if (size < 0)
         {
@@ -60,7 +64,7 @@ namespace sca
         std::unique_ptr<char[]> checksumBuffer(new char[size + 1]);
         std::snprintf(checksumBuffer.get(),
                       size + 1,
-                      "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
+                      "%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
                       id.c_str(),
                       policyId.c_str(),
                       name.c_str(),
@@ -70,7 +74,8 @@ namespace sca
                       refs.c_str(),
                       condition.c_str(),
                       compliance.c_str(),
-                      rules.c_str());
+                      rules.c_str(),
+                      regexType.c_str());
 
         // Calculate SHA1 hash using Utils::HashData
         try

--- a/src/wazuh_modules/sca/sca_impl/src/sca_checksum.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_checksum.hpp
@@ -10,7 +10,7 @@ namespace sca
      *
      * This function calculates a checksum based on the check's core attributes.
      * The checksum is based on: id, policy_id, name, description, rationale,
-     * remediation, refs, condition, compliance, and rules.
+     * remediation, refs, condition, compliance, rules, and regex_type.
      *
      * @param checkData JSON object containing the check data
      * @return SHA1 checksum as a hex string, or empty string on error
@@ -31,6 +31,7 @@ namespace sca
      * @param condition Check condition
      * @param compliance Check compliance information
      * @param rules Check rules
+     * @param regexType Check regex type
      * @return SHA1 checksum as a hex string, or empty string on error
      * @throw std::runtime_error if checksum calculation fails
      */
@@ -43,6 +44,7 @@ namespace sca
                                   const std::string& refs,
                                   const std::string& condition,
                                   const std::string& compliance,
-                                  const std::string& rules);
+                                  const std::string& rules,
+                                  const std::string& regexType);
 
 } // namespace sca

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -40,8 +40,8 @@ constexpr auto CHECK_SQL_STATEMENT
     reason TEXT,
     condition TEXT,
     compliance TEXT,
-    rules TEXT);)"
-};
+    rules TEXT,
+    regex_type TEXT DEFAULT 'pcre2');)"};
 
 SecurityConfigurationAssessment::SecurityConfigurationAssessment(
     std::string dbPath,

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -41,7 +41,8 @@ constexpr auto CHECK_SQL_STATEMENT
     condition TEXT,
     compliance TEXT,
     rules TEXT,
-    regex_type TEXT DEFAULT 'pcre2');)"};
+    regex_type TEXT DEFAULT 'pcre2');)"
+};
 
 SecurityConfigurationAssessment::SecurityConfigurationAssessment(
     std::string dbPath,

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy.hpp
@@ -2,6 +2,7 @@
 
 #include <isca_policy.hpp>
 #include <sca_policy_check.hpp>
+#include <sca_utils.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -16,6 +17,7 @@ struct Check
     std::optional<std::string> id;
     std::string condition;
     std::vector<std::unique_ptr<IRuleEvaluator>> rules;
+    sca::RegexEngineType regexEngine = sca::RegexEngineType::PCRE2;
 };
 
 class SCAPolicy : public ISCAPolicy

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -423,7 +423,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
 
                 if (file.filename().string() == fileName)
                 {
-                    const auto result = TryFunc([&]{ return FindContentInFile(m_fileUtils, fileName, content.value(), m_ctx); });
+                    const auto result = TryFunc([&] { return FindContentInFile(m_fileUtils, fileName, content.value(), m_ctx); });
 
                     if (result.has_value())
                     {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -11,10 +11,6 @@
 
 #include "logging_helper.hpp"
 
-// extern "C" {
-// #include <wm_exec.h>
-// }
-
 #include <stack>
 #include <stdexcept>
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -2,6 +2,7 @@
 
 #include <ifile_io_utils.hpp>
 #include <ifilesystem_wrapper.hpp>
+#include <sca_utils.hpp>
 #include <sysInfoInterface.h>
 
 #include <functional>
@@ -36,6 +37,7 @@ struct PolicyEvaluationContext
     bool isNegated = false;
     int commandsTimeout = 30;
     bool commandsEnabled = true;
+    sca::RegexEngineType regexEngine = sca::RegexEngineType::PCRE2;
 };
 
 class IRuleEvaluator
@@ -185,12 +187,13 @@ class RegistryRuleEvaluator : public RuleEvaluator
 
 class RuleEvaluatorFactory
 {
-    public:
-        static std::unique_ptr<IRuleEvaluator>
-        CreateEvaluator(const std::string& input,
-                        const int commandsTimeout,
-                        const bool commandsEnabled,
-                        std::unique_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,
-                        std::unique_ptr<IFileIOUtils> fileUtils = nullptr,
-                        std::unique_ptr<ISysInfo> sysInfo = nullptr);
+public:
+    static std::unique_ptr<IRuleEvaluator>
+    CreateEvaluator(const std::string& input,
+                    const int commandsTimeout,
+                    const bool commandsEnabled,
+                    sca::RegexEngineType regexEngine = sca::RegexEngineType::PCRE2,
+                    std::unique_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,
+                    std::unique_ptr<IFileIOUtils> fileUtils = nullptr,
+                    std::unique_ptr<ISysInfo> sysInfo = nullptr);
 };

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -187,13 +187,13 @@ class RegistryRuleEvaluator : public RuleEvaluator
 
 class RuleEvaluatorFactory
 {
-public:
-    static std::unique_ptr<IRuleEvaluator>
-    CreateEvaluator(const std::string& input,
-                    const int commandsTimeout,
-                    const bool commandsEnabled,
-                    sca::RegexEngineType regexEngine = sca::RegexEngineType::PCRE2,
-                    std::unique_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,
-                    std::unique_ptr<IFileIOUtils> fileUtils = nullptr,
-                    std::unique_ptr<ISysInfo> sysInfo = nullptr);
+    public:
+        static std::unique_ptr<IRuleEvaluator>
+        CreateEvaluator(const std::string& input,
+                        const int commandsTimeout,
+                        const bool commandsEnabled,
+                        sca::RegexEngineType regexEngine = sca::RegexEngineType::PCRE2,
+                        std::unique_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr,
+                        std::unique_ptr<IFileIOUtils> fileUtils = nullptr,
+                        std::unique_ptr<ISysInfo> sysInfo = nullptr);
 };

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -163,14 +163,14 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
     {
         if (!m_isValidKey(m_ctx.rule))
         {
-            LoggingHelper::getInstance().log(LOG_DEBUG, "Key '{}' does not exist" + m_ctx.rule);
+            LoggingHelper::getInstance().log(LOG_DEBUG, "Key '" + m_ctx.rule + "' does not exist");
             m_lastInvalidReason = "Registry key '" + m_ctx.rule + "' does not exist";
             return RuleResult::Invalid;
         }
     }
     catch (const std::exception& e)
     {
-        LoggingHelper::getInstance().log(LOG_DEBUG, std::string("RegistryRuleEvaluator::Evaluate: Exception: {}") + e.what());
+        LoggingHelper::getInstance().log(LOG_DEBUG, std::string("RegistryRuleEvaluator::Evaluate: Exception: ") + e.what());
         m_lastInvalidReason = "Exception accessing registry key '" + m_ctx.rule + "': " + e.what();
         return RuleResult::Invalid;
     }
@@ -186,7 +186,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
         // Check that the value exists
         if (!obtainedValue.has_value())
         {
-            LoggingHelper::getInstance().log(LOG_DEBUG, "Value '{}' does not exist" + valueName);
+            LoggingHelper::getInstance().log(LOG_DEBUG, "Value '" + valueName + "' does not exist");
             m_lastInvalidReason = "Registry value '" + valueName + "' does not exist in key '" + m_ctx.rule + "'";
             return RuleResult::Invalid;
         }
@@ -203,7 +203,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
             if (CheckMatch(key, pattern, isRegex) == RuleResult::Found)
             {
                 result = RuleResult::Found;
-                LoggingHelper::getInstance().log(LOG_DEBUG, "Key '{}' exists" + pattern);
+                LoggingHelper::getInstance().log(LOG_DEBUG, "Key '" + pattern + "' exists");
                 break;
             }
         }
@@ -215,7 +215,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
                 if (CheckMatch(value, pattern, isRegex) == RuleResult::Found)
                 {
                     result = RuleResult::Found;
-                    LoggingHelper::getInstance().log(LOG_DEBUG, "Value '{}' exists" + pattern);
+                    LoggingHelper::getInstance().log(LOG_DEBUG, "Value '" + pattern + "' exists");
                     break;
                 }
             }
@@ -243,7 +243,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyExistence()
         }
         else
         {
-            LoggingHelper::getInstance().log(LOG_DEBUG, std::string("Key exists.  Rule {}") + (m_ctx.isNegated ? "failed" : "passed"));
+            LoggingHelper::getInstance().log(LOG_DEBUG, std::string("Key exists.  Rule ") + (m_ctx.isNegated ? "failed" : "passed"));
             result = RuleResult::Found;
         }
     }

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_parser.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_parser.cpp
@@ -257,9 +257,10 @@ std::unique_ptr<ISCAPolicy> PolicyParser::ParsePolicy(nlohmann::json& policiesAn
 
                 LoggingHelper::getInstance().log(LOG_DEBUG, "Check " + check.id.value_or("Invalid id") + " parsed.");
 
-                checks.push_back(std::move(check));
                 nlohmann::json checkJson = YamlNodeToJson(checkWithValidRules);
                 checkJson["policy_id"] = policyId;
+                checkJson["regex_type"] = sca::RegexEngineTypeToString(check.regexEngine);
+                checks.push_back(std::move(check));
                 policiesAndChecks["checks"].push_back(checkJson);
             }
             catch (const std::exception& e)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_parser.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_parser.cpp
@@ -184,7 +184,7 @@ std::unique_ptr<ISCAPolicy> PolicyParser::ParsePolicy(nlohmann::json& policiesAn
 
             for (const auto& rule : rules)
             {
-                std::unique_ptr<IRuleEvaluator> RuleEvaluator = RuleEvaluatorFactory::CreateEvaluator(rule.AsString(), m_commandsTimeout, m_commandsEnabled);
+                std::unique_ptr<IRuleEvaluator> RuleEvaluator = RuleEvaluatorFactory::CreateEvaluator(rule.AsString(), m_commandsTimeout, m_commandsEnabled, requirements.regexEngine);
 
                 if (RuleEvaluator != nullptr)
                 {
@@ -243,7 +243,7 @@ std::unique_ptr<ISCAPolicy> PolicyParser::ParsePolicy(nlohmann::json& policiesAn
                     {
                         const auto ruleStr = rule.AsString();
 
-                        if (auto ruleEvaluator = RuleEvaluatorFactory::CreateEvaluator(ruleStr, m_commandsTimeout, m_commandsEnabled))
+                        if (auto ruleEvaluator = RuleEvaluatorFactory::CreateEvaluator(ruleStr, m_commandsTimeout, m_commandsEnabled, check.regexEngine))
                         {
                             check.rules.push_back(std::move(ruleEvaluator));
                             checkWithValidRules["rules"].AppendToSequence(ruleStr);

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_parser.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_parser.cpp
@@ -173,6 +173,13 @@ std::unique_ptr<ISCAPolicy> PolicyParser::ParsePolicy(nlohmann::json& policiesAn
             requirements.condition = requirementsNode["condition"].AsString();
             ValidateConditionString(requirements.condition);
 
+            if (requirementsNode.HasKey("regex_type"))
+            {
+                const auto regexTypeStr = requirementsNode["regex_type"].AsString();
+                requirements.regexEngine = sca::StringToRegexEngineType(regexTypeStr);
+                LoggingHelper::getInstance().log(LOG_DEBUG, "Requirements regex_type set to: " + regexTypeStr);
+            }
+
             const auto rules = requirementsNode["rules"].AsSequence();
 
             for (const auto& rule : rules)
@@ -211,6 +218,13 @@ std::unique_ptr<ISCAPolicy> PolicyParser::ParsePolicy(nlohmann::json& policiesAn
                 check.id = checkNode["id"].AsString();
                 check.condition = checkNode["condition"].AsString();
                 ValidateConditionString(check.condition);
+
+                if (checkNode.HasKey("regex_type"))
+                {
+                    const auto regexTypeStr = checkNode["regex_type"].AsString();
+                    check.regexEngine = sca::StringToRegexEngineType(regexTypeStr);
+                    LoggingHelper::getInstance().log(LOG_DEBUG, "Check " + check.id.value_or("Unknown") + " regex_type set to: " + regexTypeStr);
+                }
 
                 // create new document with valid rules
                 auto newDoc = checkNode.Clone();

--- a/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
@@ -356,4 +356,25 @@ namespace sca
                (pattern.size() >= 3 && pattern.compare(0, 3, "!n:") == 0);
     }
 
+    RegexEngineType StringToRegexEngineType(const std::string& regexType)
+    {
+        if (regexType == "pcre2")
+        {
+            return RegexEngineType::PCRE2;
+        }
+        return RegexEngineType::Invalid;
+    }
+
+    std::string RegexEngineTypeToString(RegexEngineType engineType)
+    {
+        switch (engineType)
+        {
+            case RegexEngineType::PCRE2:
+                return "pcre2";
+            case RegexEngineType::Invalid:
+            default:
+                return "invalid";
+        }
+    }
+
 } // namespace sca

--- a/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_utils.cpp
@@ -362,6 +362,7 @@ namespace sca
         {
             return RegexEngineType::PCRE2;
         }
+
         return RegexEngineType::Invalid;
     }
 
@@ -371,6 +372,7 @@ namespace sca
         {
             case RegexEngineType::PCRE2:
                 return "pcre2";
+
             case RegexEngineType::Invalid:
             default:
                 return "invalid";

--- a/src/wazuh_modules/sca/sca_impl/tests/rule_creation_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/rule_creation_test.cpp
@@ -10,94 +10,94 @@ bool IsInstanceOf(const std::unique_ptr<IRuleEvaluator>& evaluator)
 
 TEST(RuleEvaluatorFactoryTest, FileRuleWithoutPattern)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/motd", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/motd", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, FileRuleWithPattern)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/passwd -> root", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/passwd -> root", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, NegatedFileRule)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not f:/etc/shadow", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not f:/etc/shadow", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, DirRule)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("d:/etc/audit", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("d:/etc/audit", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<DirRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, DirRuleWithPattern)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("d:/etc/audit -> something", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("d:/etc/audit -> something", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<DirRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, ProcessRule)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("p:sshd", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("p:sshd", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<ProcessRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, NegatedProcessRule)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not p:cron", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not p:cron", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<ProcessRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, CommandRule)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("c:whoami", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("c:whoami", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<CommandRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, CommandRuleWithPattern)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("c:ls -> root", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("c:ls -> root", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     EXPECT_TRUE(IsInstanceOf<CommandRuleEvaluator>(evaluator));
 }
 
 TEST(RuleEvaluatorFactoryTest, InvalidType)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("x:/invalid", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("x:/invalid", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     EXPECT_EQ(evaluator, nullptr);
 }
 
 TEST(RuleEvaluatorFactoryTest, MissingColon)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not invalid", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not invalid", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     EXPECT_EQ(evaluator, nullptr);
 }
 
 TEST(RuleEvaluatorFactoryTest, IncompleteRule)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator(":", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator(":", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     EXPECT_EQ(evaluator, nullptr);
 }
 
 TEST(RuleEvaluatorFactoryTest, EmptyInput)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     EXPECT_EQ(evaluator, nullptr);
 }
 
 TEST(RuleEvaluatorFactoryTest, FileRuleWithoutPattern_ParsesCorrectContext)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/motd", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/motd", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     ASSERT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator));
 
@@ -112,7 +112,7 @@ TEST(RuleEvaluatorFactoryTest, FileRuleWithoutPattern_ParsesCorrectContext)
 
 TEST(RuleEvaluatorFactoryTest, FileRuleWithPattern_ParsesCorrectContext)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/passwd -> root", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("f:/etc/passwd -> root", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     ASSERT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator));
 
@@ -128,7 +128,7 @@ TEST(RuleEvaluatorFactoryTest, FileRuleWithPattern_ParsesCorrectContext)
 
 TEST(RuleEvaluatorFactoryTest, NegatedFileRule_ParsesCorrectContext)
 {
-    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not f:/etc/shadow", 30, false, nullptr, nullptr, nullptr);
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator("not f:/etc/shadow", 30, false, sca::RegexEngineType::PCRE2, nullptr, nullptr);
     ASSERT_NE(evaluator, nullptr);
     ASSERT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator));
 

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_checksum_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_checksum_test.cpp
@@ -89,7 +89,8 @@ TEST_F(SCAChecksumTest, CalculateChecksumFromFields_ValidData_ReturnsNonEmptyStr
                                                   "https://example.com/ref1,https://example.com/ref2",
                                                   "all",
                                                   "PCI_DSS_3.2.1",
-                                                  "file:$SSH_CONFIG -> exists");
+                                                  "file:$SSH_CONFIG -> exists",
+                                                  "");
 
     EXPECT_FALSE(checksum.empty());
     EXPECT_EQ(checksum.length(), 40);
@@ -97,7 +98,7 @@ TEST_F(SCAChecksumTest, CalculateChecksumFromFields_ValidData_ReturnsNonEmptyStr
 
 TEST_F(SCAChecksumTest, CalculateChecksumFromFields_EmptyStrings_ReturnsNonEmptyString)
 {
-    std::string checksum = sca::calculateChecksum("", "", "", "", "", "", "", "", "", "");
+    std::string checksum = sca::calculateChecksum("", "", "", "", "", "", "", "", "", "", "");
 
     EXPECT_FALSE(checksum.empty());
     EXPECT_EQ(checksum.length(), 40);
@@ -124,7 +125,8 @@ TEST_F(SCAChecksumTest, ConsistentResults_JSONAndFieldsProduceSameChecksum)
                                                             sampleCheckData["refs"],
                                                             sampleCheckData["condition"],
                                                             sampleCheckData["compliance"],
-                                                            sampleCheckData["rules"]);
+                                                            sampleCheckData["rules"],
+                                                            sampleCheckData.value("regex_type", ""));
 
     EXPECT_EQ(checksumFromJSON, checksumFromFields);
 }
@@ -143,8 +145,8 @@ TEST_F(SCAChecksumTest, DifferentData_ProducesDifferentChecksums)
 TEST_F(SCAChecksumTest, SensitiveToFieldOrder_DifferentFieldOrderProducesDifferentChecksums)
 {
     // Test that changing field values affects the checksum
-    std::string checksum1 = sca::calculateChecksum("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
-    std::string checksum2 = sca::calculateChecksum("b", "a", "c", "d", "e", "f", "g", "h", "i", "j");
+    std::string checksum1 = sca::calculateChecksum("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "");
+    std::string checksum2 = sca::calculateChecksum("b", "a", "c", "d", "e", "f", "g", "h", "i", "j", "");
 
     EXPECT_NE(checksum1, checksum2);
 }
@@ -255,7 +257,8 @@ TEST_F(SCAChecksumIntegrationTest, ChecksumEquivalence_JSONAndFieldsMatch)
                                                        sampleCheck.value("refs", ""),
                                                        sampleCheck.value("condition", ""),
                                                        sampleCheck.value("compliance", ""),
-                                                       sampleCheck.value("rules", ""));
+                                                       sampleCheck.value("rules", ""),
+                                                       sampleCheck.value("regex_type", ""));
 
     EXPECT_EQ(jsonChecksum, fieldChecksum);
 }


### PR DESCRIPTION
## Description

This PR closes issue #30847 by parsing the "regex_type" from policy yaml files.

### Proposed changes

* Parse "regex_type" when loading yaml policy files.
* Use regex type in checksum calculations.
* Persist it in database.
* Send it on events.
* Currently only PCRE2 is supported.
* Minor fixes to some log messages in SCA check evaluators.
