### PR TITLE
Refactor add support for Amazon Inspector v2

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -104,7 +104,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10880,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -104,7 +104,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10880,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/rpm5_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_amd64.csv
@@ -169,7 +169,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10880,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/rpm5_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_i386.csv
@@ -169,7 +169,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10880,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -172,7 +172,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10880,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -172,7 +172,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10880,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/wodles/aws/services/inspector.py
+++ b/wodles/aws/services/inspector.py
@@ -210,7 +210,7 @@ class AWSInspector(aws_service.AWSService):
         response = client.list_findings(
             maxResults=100,
             filterCriteria={
-                'firstObservedAt': [{
+                'updatedAt': [{
                     'startInclusive': date_scan.isoformat(),
                     'endInclusive': date_current.isoformat()
                 }]
@@ -223,7 +223,7 @@ class AWSInspector(aws_service.AWSService):
                 maxResults=100,
                 nextToken=response['nextToken'],
                 filterCriteria={
-                    'firstObservedAt': [{
+                    'updatedAt': [{
                         'startInclusive': date_scan.isoformat(),
                         'endInclusive': date_current.isoformat()
                     }]

--- a/wodles/aws/services/inspector.py
+++ b/wodles/aws/services/inspector.py
@@ -95,39 +95,6 @@ class AWSInspector(aws_service.AWSService):
                 self.send_msg(self.format_message(elem))
                 self.sent_events += 1
 
-    def send_describe_findings_v2(self, client, finding_arns: list):
-        """
-        Collect and send to analysisd the requested findings from Inspector v2.
-
-        Parameters
-        ----------
-        finding_arns : list[str]
-            The ARNs of the findings that should be requested to AWS and sent to analysisd.
-        """
-        if not finding_arns:
-            return
-        # Split into chunks of 10 (Inspector v2 API limit)
-        chunk_size = 10
-        aws_tools.debug(f"+++ [InspectorV2] Processing {len(finding_arns)} events", 3)
-        for i in range(0, len(finding_arns), chunk_size):
-            chunk = finding_arns[i:i + chunk_size]
-
-            try:
-                response = client.batch_get_finding_details(findingArns=chunk)
-                findings = response.get('findingDetails', [])
-
-                for finding in findings:
-                    if self.event_should_be_skipped(finding):
-                        aws_tools.debug(f'+++ [InspectorV2] The "{self.discard_regex.pattern}" regex found a match in the '
-                                        f'"{self.discard_field}" field. The event will be skipped.', 2)
-                        continue
-                    formatted = self.format_message(finding)
-                    self.send_msg(formatted)
-                    self.sent_events += 1
-
-            except Exception as e:
-                aws_tools.debug(f"+++ Error processing findings: {str(e)}", 1)
-
     def get_alerts(self):
         self.init_db(self.sql_create_table.format(table_name=self.db_table_name))
         try:
@@ -219,6 +186,27 @@ class AWSInspector(aws_service.AWSService):
             iam_role_duration=self.iam_role_duration
         )
 
+        def process_page(resp):
+            """
+            Process a single page of Inspector v2 findings.
+
+            Parameters
+            ----------
+            resp : dict
+                AWS Inspector2 list_findings response containing a 'findings' list.
+            """
+            findings = resp.get('findings', [])
+            aws_tools.debug(f"+++ [InspectorV2] Processing {len(findings)} events", 3)
+            for finding in findings:
+                if self.event_should_be_skipped(finding):
+                    aws_tools.debug(
+                        f'+++ [InspectorV2] The "{self.discard_regex.pattern}" regex found a match in the '
+                        f'"{self.discard_field}" field. The event will be skipped.', 2
+                    )
+                    continue
+                self.send_msg(self.format_message(finding))
+                self.sent_events += 1
+
         response = client.list_findings(
             maxResults=100,
             filterCriteria={
@@ -228,9 +216,7 @@ class AWSInspector(aws_service.AWSService):
                 }]
             }
         )
-
-        finding_arns = [f['findingArn'] for f in response.get('findings', [])]
-        self.send_describe_findings_v2(client, finding_arns)
+        process_page(response)
 
         while 'nextToken' in response:
             response = client.list_findings(
@@ -243,8 +229,7 @@ class AWSInspector(aws_service.AWSService):
                     }]
                 }
             )
-            finding_arns = [f['findingArn'] for f in response.get('findings', [])]
-            self.send_describe_findings_v2(client, finding_arns)
+            process_page(response)
 
     @staticmethod
     def check_region(region: str) -> None:

--- a/wodles/aws/tests/test_inspector.py
+++ b/wodles/aws/tests/test_inspector.py
@@ -20,14 +20,21 @@ TEST_SERVICES_SCHEMA = 'schema_services_test.sql'
 
 def mock_get_client(*args, **kwargs):
     if kwargs.get('region') in inspector.INSPECTOR_V2_REGIONS:
+        # Inspector v2: list_findings devuelve 'findings' (no usamos batch_get_finding_details)
         mock_client = MagicMock()
-        mock_client.list_findings.return_value = {'findingArns': ['arn1', 'arn2']}
-        mock_client.batch_get_finding_details.return_value = {
-            'findingDetails': [
-                {'arn': 'arn1', 'schemaVersion': 123, 'service': 'inspector2_service'},
-                {'arn': 'arn2', 'schemaVersion': 123, 'service': 'inspector2_service'}
-            ]
-        }
+        mock_client.list_findings.side_effect = [
+            {
+                'findings': [
+                    {'arn': 'arn1', 'schemaVersion': 123, 'service': 'inspector2'}
+                ],
+                'nextToken': 'tok1'
+            },
+            {
+                'findings': [
+                    {'arn': 'arn2', 'schemaVersion': 123, 'service': 'inspector2'}
+                ]
+            }
+        ]
         return mock_client
     else:
         mock_client = MagicMock()
@@ -85,8 +92,9 @@ def test_aws_inspector_send_describe_findings(mock_sts_client):
 @patch('inspector.AWSInspector.send_describe_findings')
 @patch('inspector.aws_tools.debug')
 @patch('wazuh_integration.WazuhIntegration.get_sts_client')
+@patch('wazuh_integration.WazuhIntegration.send_msg')
 @patch.object(inspector.AWSInspector, 'get_client', mock_get_client)
-def test_aws_inspector_get_alerts(mock_sts_client, mock_debug, mock_send_describe_findings, mock_init_db, mock_close_db,
+def test_aws_inspector_get_alerts(mock_send_msg, mock_sts_client, mock_debug, mock_send_describe_findings, mock_init_db, mock_close_db,
                                   only_logs_after, reparse, custom_database):
     """Test 'get_alerts' method sends the collected events and updates the DB accordingly."""
     utils.database_execute_script(custom_database, TEST_SERVICES_SCHEMA)
@@ -121,36 +129,34 @@ def test_aws_inspector_get_alerts(mock_sts_client, mock_debug, mock_send_describ
 @pytest.mark.parametrize('region', inspector.INSPECTOR_V2_REGIONS)
 @patch('wazuh_integration.WazuhAWSDatabase.init_db')
 @patch('wazuh_integration.WazuhAWSDatabase.close_db')
-@patch('inspector.AWSInspector.send_describe_findings')
 @patch('inspector.aws_tools.debug')
 @patch('wazuh_integration.WazuhIntegration.get_sts_client')
+@patch('wazuh_integration.WazuhIntegration.send_msg')
 @patch.object(inspector.AWSInspector, 'get_client', mock_get_client)
-def test_aws_inspector_v2_get_alerts(mock_sts_client, mock_debug, mock_send_describe_findings, mock_init_db, mock_close_db,
+def test_aws_inspector_v2_get_alerts(mock_send_msg, mock_sts_client, mock_debug, mock_init_db, mock_close_db,
                                      region, custom_database):
     """Test 'get_alerts' for Inspector v2 to ensure proper handling."""
     utils.database_execute_script(custom_database, TEST_SERVICES_SCHEMA)
 
     instance = utils.get_mocked_service(class_=inspector.AWSInspector, region=region)
-
     instance.account_id = utils.TEST_ACCOUNT_ID
 
     instance.db_connector = custom_database
     instance.db_cursor = instance.db_connector.cursor()
 
     instance.client = MagicMock()
-    mock_list_findings = instance.client.list_findings
-    mock_list_findings.side_effect = [{'findingArns': ['arn1'], 'nextToken': None},
-                                      {'findingArns': ['arn2']}]
+    instance.client.list_findings.return_value = {'findingArns': []}
+    instance.client.describe_findings.return_value = {'findings': []}
 
     instance.get_alerts()
 
-    last_scan_date = utils.database_execute_query(custom_database,
-                                                  instance.sql_find_last_scan.format(table_name=instance.db_table_name),
-                                                  {
-                                                      'service_name': instance.service_name,
-                                                      'aws_account_id': instance.account_id,
-                                                      'aws_region': instance.region}
-                                                  )
-
-    assert datetime.strptime(last_scan_date.split(' ')[0], "%Y-%m-%d").strftime("%Y%m%d") == datetime.utcnow().strftime(
-        "%Y%m%d")
+    last_scan_date = utils.database_execute_query(
+        custom_database,
+        instance.sql_find_last_scan.format(table_name=instance.db_table_name),
+        {
+            'service_name': instance.service_name,
+            'aws_account_id': instance.account_id,
+            'aws_region': instance.region
+        }
+    )
+    assert datetime.strptime(last_scan_date.split(' ')[0], "%Y-%m-%d").strftime("%Y%m%d") == datetime.utcnow().strftime("%Y%m%d")

--- a/wodles/aws/tests/test_inspector.py
+++ b/wodles/aws/tests/test_inspector.py
@@ -20,7 +20,6 @@ TEST_SERVICES_SCHEMA = 'schema_services_test.sql'
 
 def mock_get_client(*args, **kwargs):
     if kwargs.get('region') in inspector.INSPECTOR_V2_REGIONS:
-        # Inspector v2: list_findings devuelve 'findings' (no usamos batch_get_finding_details)
         mock_client = MagicMock()
         mock_client.list_findings.side_effect = [
             {


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR closes https://github.com/wazuh/wazuh/issues/21532. The changes introduced in https://github.com/wazuh/wazuh/pull/31163
 have been refactored. The method of retrieving these `v2` events has been modified, now using `list_findings`


<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<details>

<summary>unit_tests</summary>

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/test_inspector.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 37 items                                                                                                                                                                                                

wodles/aws/tests/test_inspector.py .....................................                                                                                                                                    [100%]

=============================================================================================== 37 passed in 0.55s ================================================================================================
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 738 items                                                                                                                                                                                               

wodles/aws/tests/test_aws_bucket.py ....................................................................................................................................................................... [ 22%]
..........................................................................                                                                                                                                  [ 32%]
wodles/aws/tests/test_aws_s3.py ......................                                                                                                                                                      [ 35%]
wodles/aws/tests/test_aws_service.py ....                                                                                                                                                                   [ 36%]
wodles/aws/tests/test_cloudtrail.py ..                                                                                                                                                                      [ 36%]
wodles/aws/tests/test_cloudwatchlogs.py .....................................................                                                                                                               [ 43%]
wodles/aws/tests/test_config.py .................................................................................                                                                                           [ 54%]
wodles/aws/tests/test_guardduty.py .................                                                                                                                                                        [ 56%]
wodles/aws/tests/test_inspector.py .....................................                                                                                                                                    [ 61%]
wodles/aws/tests/test_load_balancers.py ............                                                                                                                                                        [ 63%]
wodles/aws/tests/test_s3_log_handler.py .........................                                                                                                                                           [ 66%]
wodles/aws/tests/test_server_access.py .................................                                                                                                                                    [ 71%]
wodles/aws/tests/test_sqs_message_processor.py ........                                                                                                                                                     [ 72%]
wodles/aws/tests/test_sqs_queue.py .......                                                                                                                                                                  [ 73%]
wodles/aws/tests/test_tools.py ..................................                                                                                                                                           [ 78%]
wodles/aws/tests/test_umbrella.py ......                                                                                                                                                                    [ 78%]
wodles/aws/tests/test_vpcflow.py ...........................                                                                                                                                                [ 82%]
wodles/aws/tests/test_waf.py .......                                                                                                                                                                        [ 83%]
wodles/aws/tests/test_wazuh_integration.py ..........................................................................................................................                                       [100%]

=============================================================================================== 738 passed in 3.62s ===============================================================================================

```

</details>

<details>

<summary>Output</summary>

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr inspector -d 3 -s 2022-JAN-26 -r us-east-1 --reparse
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: +++ No 'region' found in profile 'default'
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: +++ Listing findings from 2022-01-26 00:00:00
DEBUG: +++ [InspectorV1] Processing 6 events
DEBUG: {"integration": "aws", "aws": {"arn": "arn:aws:inspector:us-east-1:xxx:target/xxx/template/xxx/run/xxx/finding/xxx", "schemaVersion": 1, "serviceAttributes": {"schemaVersion": 1, "assessmentRunArn": "arn:aws:inspector:us-east-1:xxx:target/xxx/template/xxx/run/xxx", "rulesPackageArn": "arn:aws:inspector:us-east-1:xxx:rulespackage/xxx"}, "assetType": "ec2-instance", "assetAttributes": {"schemaVersion": 1, "agentId": "i-xxx", "amiId": "ami-xxx", "hostname": "xxxx.compute-1.amazonaws.com", "ipv4Addresses": [], "tags": [{"key": "inspector", "value": "true"}, {"key": "team", "value": "xxxxx"}, {"key": "Name", "value": "xxx"}], "networkInterfaces": [{"networkInterfaceId": "eni-xxx", "subnetId": "subnet-xxx", "vpcId": "vpc-xxx", "privateDnsName": "ip-xxx.ec2.internal", "privateIpAddress": "xxx", "privateIpAddresses": [{"privateDnsName": "ip-xxx.ec2.internal", "privateIpAddress": "xxx"}], "publicDnsName": "xxxx.compute-1.amazonaws.com", "publicIp": "xxx", "ipv6Addresses": [], "securityGroups": [{"groupName": "default", "groupId": "sg-xxx"}, {"groupName": "SiteOX + SSH", "groupId": "sg-xxx"}]}]}, "id": "4.1.16 Ensure system administrator actions (sudolog) are collected", "title": "Instance i-xxx is not compliant with rule 4.1.16 ...", "description": "Description ...", "recommendation": "Add the following lines to the /etc/audit/rules.d/audit.rules file: -w /var/log/sudo.log -p wa -k actions", "severity": "High", "numericSeverity": 9.0, "confidence": 10, "indicatorOfCompromise": false, "attributes": [{"key": "CIS_BENCHMARK_PROFILE", "value": "Level 2"}, {"key": "BENCHMARK_RULE_ID", "value": "4.1.16 Ensure system administrator actions sudolog are collected"}, {"key": "CIS_WEIGHT", "value": "SCORED"}, {"key": "BENCHMARK_ID", "value": "1.0.0 CIS Amazon Linux 2 Benchmark"}, {"key": "INSTANCE_ID", "value": "i-xxx"}], "userAttributes": [], "createdAt": "2022-01-26T12:24:43Z", "updatedAt": "2022-01-26T12:24:43Z", "source": "inspector"}}
DEBUG: {"integration": "aws", "aws": {"arn": "arn:aws:inspector:us-east-1:xxx:target/xxx/template/xxx/run/xxx/finding/xxx", "schemaVersion": 1, "serviceAttributes": {"schemaVersion": 1, "assessmentRunArn": "arn:aws:inspector:us-east-1:xxx:target/xxx/template/xxx/run/xxx", "rulesPackageArn": "arn:aws:inspector:us-east-1:xxx:rulespackage/xxx"}, "assetType": "ec2-instance", "assetAttributes": {"schemaVersion": 1, "agentId": "i-xxx", "amiId": "ami-xxx", "hostname": "xxxxxx.compute-1.amazonaws.com", "ipv4Addresses": [], "tags": [{"key": "issue", "value": "xxx"}, {"key": "aws:ec2launchtemplate:id", "value": "lt-xxx"}, {"key": "Name", "value": "xxx"}, {"key": "inspector", "value": "true"}, {"key": "team", "value": "xxxxxx"}, {"key": "inspector-integration-test", "value": "xxx"}, {"key": "termination_date", "value": "xxx"}, {"key": "aws:ec2launchtemplate:version", "value": "7"}], "networkInterfaces": [{"networkInterfaceId": "eni-xxx", "subnetId": "subnet-xxx", "vpcId": "vpc-xxx", "privateDnsName": "ip-xxx.ec2.internal", "privateIpAddress": "xxx", "privateIpAddresses": [{"privateDnsName": "ip-xxx.ec2.internal", "privateIpAddress": "xxx"}], "publicDnsName": "xxx-xxx.compute-1.amazonaws.com", "publicIp": "xxx", "ipv6Addresses": [], "securityGroups": [{"groupName": "TestInstancesSG", "groupId": "sg-xxx"}, {"groupName": "SiteOX + SSH", "groupId": "sg-xxx"}]}]}, "id": "Recognized port reachable from internet", "title": "On instance i-xxx, TCP port 22 ...", "description": "On this instance, TCP port 22 ...", "recommendation": "You can edit the Security Group sg-xxx to remove access from the internet on port 22", "severity": "Medium", "numericSeverity": 6.0, "confidence": 10, "indicatorOfCompromise": false, "attributes": [{"key": "ENI", "value": "eni-xxx"}, {"key": "RULE_TYPE", "value": "RecognizedPortNoAgent"}, {"key": "PORT", "value": "22"}, {"key": "PORT_GROUP_NAME", "value": "SSH"}, {"key": "PROTOCOL", "value": "TCP"}, {"key": "IGW", "value": "igw-xxx"}, {"key": "VPC", "value": "vpc-xxx"}, {"key": "SECURITY_GROUP", "value": "sg-xxx"}, {"key": "REACHABILITY_TYPE", "value": "Internet"}, {"key": "ACL", "value": "acl-xxx"}, {"key": "INSTANCE_ID", "value": "i-xxx"}], "userAttributes": [], "createdAt": "2024-04-05T14:41:52Z", "updatedAt": "2024-04-05T14:41:52Z", "source": "inspector"}}
...
DEBUG: {"integration": "aws", "aws": {"awsAccountId": "xxx", "description": "In the Linux kernel, the following vulnerability has been resolved: vsock: prevent null-ptr-deref ...", "epss": {"score": 0.00039}, "exploitAvailable": "NO", "findingArn": "arn:aws:inspector2:us-east-1:xxx:finding/xxx", "firstObservedAt": "2025-02-12 20:02:50.802000+00:00", "fixAvailable": "YES", "inspectorScore": 5.5, "inspectorScoreDetails": {"adjustedCvss": {"adjustments": [], "cvssSource": "NVD", "score": 5.5, "scoreSource": "NVD", "scoringVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}}, "lastObservedAt": "2025-07-14 18:10:18.703000+00:00", "packageVulnerabilityDetails": {"cvss": [{"baseScore": 5.5, "scoringVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", "source": "NVD", "version": "3.1"}], "referenceUrls": ["https://security-tracker.debian.org/tracker/CVE-2025-21666"], "relatedVulnerabilities": [], "source": "DEBIAN_CVE", "sourceUrl": "https://security-tracker.debian.org/tracker/CVE-2025-21666", "vendorSeverity": "not yet assigned", "vulnerabilityId": "CVE-2025-21666", "vulnerablePackages": [{"arch": "AMD64", "epoch": 0, "fixedInVersion": "0:5.10.234-1", "name": "linux", "packageManager": "OS", "release": "3", "remediation": "apt-get update && apt-get upgrade", "sourceLayerHash": "sha256:xxx", "version": "5.10.178"}]}, "remediation": {"recommendation": {"text": "None Provided"}}, "resources": [{"details": {"awsEcrContainerImage": {"architecture": "amd64", "imageHash": "sha256:xxx", "imageTags": ["python3.10"], "platform": "DEBIAN_11", "pushedAt": "2023-05-11 18:43:18+00:00", "registry": "xxx", "repositoryName": "xxx"}}, "id": "arn:aws:ecr:us-east-1:xxx:repository/xxx/sha256:xxx", "partition": "aws", "region": "us-east-1", "tags": {}, "type": "AWS_ECR_CONTAINER_IMAGE"}], "severity": "MEDIUM", "status": "ACTIVE", "title": "CVE-2025-21666 - linux", "type": "PACKAGE_VULNERABILITY", "updatedAt": "2025-07-14T18:10:18Z", "source": "inspector2"}}
DEBUG: {"integration": "aws", "aws": {"awsAccountId": "xxx", "description": "In the Linux kernel, the following vulnerability has been resolved: s390/dasd: protect device queue against concurrent access ...", "epss": {"score": 0.0002}, "exploitAvailable": "NO", "findingArn": "arn:aws:inspector2:us-east-1:xxx:finding/xxx", "firstObservedAt": "2024-05-26 10:17:02.677000+00:00", "fixAvailable": "YES", "lastObservedAt": "2025-08-12 03:31:11.330000+00:00", "packageVulnerabilityDetails": {"cvss": [], "referenceUrls": ["https://security-tracker.debian.org/tracker/CVE-2023-52774"], "relatedVulnerabilities": [], "source": "DEBIAN_CVE", "sourceUrl": "https://security-tracker.debian.org/tracker/CVE-2023-52774", "vendorSeverity": "not yet assigned", "vulnerabilityId": "CVE-2023-52774", "vulnerablePackages": [{"arch": "AMD64", "epoch": 0, "fixedInVersion": "0:5.10.205-1", "name": "linux", "packageManager": "OS", "release": "3", "remediation": "apt-get update && apt-get upgrade", "sourceLayerHash": "sha256:xxx", "version": "5.10.178"}]}, "remediation": {"recommendation": {"text": "None Provided"}}, "resources": [{"details": {"awsEcrContainerImage": {"architecture": "amd64", "imageHash": "sha256:xxx", "imageTags": ["python3.10"], "platform": "DEBIAN_11", "pushedAt": "2023-05-11 18:43:18+00:00", "registry": "xxx", "repositoryName": "xxx"}}, "id": "arn:aws:ecr:us-east-1:xxx:repository/xxx/sha256:xxx", "partition": "aws", "region": "us-east-1", "tags": {}, "type": "AWS_ECR_CONTAINER_IMAGE"}], "severity": "UNTRIAGED", "status": "ACTIVE", "title": "CVE-2023-52774 - linux", "type": "PACKAGE_VULNERABILITY", "updatedAt": "2025-08-12T03:31:11Z", "source": "inspector2"}}
```

</details>

<details>

<summary>/var/ossec/logs/alerts/alerts.log</summary>

<details>

<summary>inspector</summary>

```console
Rule: 80496 (level 10) -> 'AWS inspector - network assessment [2022-01-26T12:24:44Z]: 
{"integration": "aws", "aws": {"arn": "arn:aws:inspector:us-east-1:xxx:target/xxx/template/xxx/run/xxx/finding/xxx", "schemaVersion": 1, "serviceAttributes": {"schemaVersion": 1, "assessmentRunArn": "arn:aws:inspector:us-east-1:xxx:target/xxx/template/xxx/run/xxx", "rulesPackageArn": "arn:aws:inspector:us-east-1:xxx:rulespackage/xxx"}, "assetType": "ec2-instance", "assetAttributes": {"schemaVersion": 1, "agentId": "i-xxx", "amiId": "ami-xxx", "hostname": "ec2-xxx.compute-1.amazonaws.com", "ipv4Addresses": [], "tags": [{"key": "inspector", "value": "true"}, {"key": "team", "value": "xxxxx"}, {"key": "Name", "value": "xxx"}], "networkInterfaces": [{"networkInterfaceId": "eni-xxx", "subnetId": "subnet-xxx", "vpcId": "vpc-xxx", "privateDnsName": "ip-xxx.ec2.internal", "privateIpAddress": "xxx", "privateIpAddresses": [{"privateDnsName": "ip-xxx.ec2.internal", "privateIpAddress": "xxx"}], "publicDnsName": "ec2-xxx.compute-1.amazonaws.com", "publicIp": "xxx", "ipv6Addresses": [], "securityGroups": [{"groupName": "xxxxx", "groupId": "sg-xxx"}, {"groupName": "xxxx", "groupId": "sg-xxx"}]}]}, "id": "5.2.10 Ensure SSH root login is disabled", "title": "Instance i-xxx is not compliant with rule 5.2.10 Ensure SSH root login is disabled, 1.0.0 CIS Amazon Linux 2 Benchmark. Applicable profiles: Level 1, Level 2.", "description": "Description ...", "recommendation": "Edit the /etc/ssh/sshd_config file to set the parameter as follows:\nPermitRootLogin no", "severity": "High", "numericSeverity": 9.0, "confidence": 10, "indicatorOfCompromise": false, "attributes": [{"key": "CIS_BENCHMARK_PROFILE", "value": "Level 1, Level 2"}, {"key": "BENCHMARK_RULE_ID", "value": "5.2.10 Ensure SSH root login is disabled"}, {"key": "CIS_WEIGHT", "value": "SCORED"}, {"key": "BENCHMARK_ID", "value": "1.0.0 CIS Amazon Linux 2 Benchmark"}, {"key": "INSTANCE_ID", "value": "i-xxx"}], "userAttributes": [], "createdAt": "2022-01-26T12:24:44Z", "updatedAt": "2022-01-26T12:24:44Z", "source": "inspector"}}
```


</details>

<details>

<summary>inspector2</summary>

```console
Rule: 80496 (level 10) -> 'AWS inspector - network assessment []: CVE-2024-27008 - linux [HIGH].'
{"integration": "aws", "aws": {"awsAccountId": "xxx", "description": "In the Linux kernel, the following vulnerability has been resolved: drm: nv04: Fix out of bounds access ...", "epss": {"score": 0.00012}, "exploitAvailable": "NO", "findingArn": "arn:aws:inspector2:us-east-1:xxx:finding/xxx", "firstObservedAt": "2024-05-06 18:41:09.885000+00:00", "fixAvailable": "YES", "inspectorScore": 7.8, "inspectorScoreDetails": {"adjustedCvss": {"adjustments": [], "cvssSource": "NVD", "score": 7.8, "scoreSource": "NVD", "scoringVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", "version": "3.1"}}, "lastObservedAt": "2025-08-01 12:03:58.560000+00:00", "packageVulnerabilityDetails": {"cvss": [{"baseScore": 7.8, "scoringVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", "source": "NVD", "version": "3.1"}], "referenceUrls": ["https://security-tracker.debian.org/tracker/CVE-2024-27008"], "relatedVulnerabilities": [], "source": "DEBIAN_CVE", "sourceUrl": "https://security-tracker.debian.org/tracker/CVE-2024-27008", "vendorSeverity": "not yet assigned", "vulnerabilityId": "CVE-2024-27008", "vulnerablePackages": [{"arch": "AMD64", "epoch": 0, "fixedInVersion": "0:5.10.216-1", "name": "linux", "packageManager": "OS", "release": "3", "remediation": "apt-get update && apt-get upgrade", "sourceLayerHash": "sha256:xxx", "version": "5.10.178"}]}, "remediation": {"recommendation": {"text": "None Provided"}}, "resources": [{"details": {"awsEcrContainerImage": {"architecture": "amd64", "imageHash": "sha256:xxx", "imageTags": ["python3.10"], "platform": "DEBIAN_11", "pushedAt": "2023-05-11 18:43:18+00:00", "registry": "xxx", "repositoryName": "xxx"}}, "id": "arn:aws:ecr:us-east-1:xxx:repository/xxx/sha256:xxx", "partition": "aws", "region": "us-east-1", "tags": {}, "type": "AWS_ECR_CONTAINER_IMAGE"}], "severity": "HIGH", "status": "ACTIVE", "title": "CVE-2024-27008 - linux", "type": "PACKAGE_VULNERABILITY", "updatedAt": "2025-08-01T12:03:58Z", "source": "inspector2"}}
```


</details>

</details>



<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
