### PR TITLE
Add WPK upgrade test Dockerfiles

### DIFF
--- a/packages/wpk/test/README.md
+++ b/packages/wpk/test/README.md
@@ -1,0 +1,3 @@
+## Description
+
+This folder contains the Dockerfiles used to build the images used in the WPK smoke upgrade test.

--- a/packages/wpk/test/deb_upgrade/Dockerfile
+++ b/packages/wpk/test/deb_upgrade/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+RUN apt update && apt install -y \
+    curl \
+    lsb-release \
+    pip \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install cryptography

--- a/packages/wpk/test/rpm_upgrade/Dockerfile
+++ b/packages/wpk/test/rpm_upgrade/Dockerfile
@@ -1,0 +1,8 @@
+FROM redhat/ubi9:9.5
+
+RUN yum update -y && yum install -y \
+    pip \
+    procps \
+    && yum clean all
+
+RUN pip3 install cryptography


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/437|

## Description

Hi team,

this PR includes the Dockerfiles used to test the upgrade test with the WPK packages.

Both images are already built and uploaded to the ghcr storage and both images are valid for `amd64/x86_64` and `arm64/aarch64` 