### PR TITLE
Kernel version include in the release field for windows

### DIFF
--- a/src/data_provider/src/osinfo/sysOsInfoInterface.h
+++ b/src/data_provider/src/osinfo/sysOsInfoInterface.h
@@ -50,7 +50,7 @@ class SysOsInfo
             output["hostname"] = osInfoProvider->nodeName();
             output["os_distribution_release"] = osInfoProvider->release();
             output["os_full"] = osInfoProvider->displayVersion();
-            output["release"]  = osInfoProvider->version();
+            output["os_kernel_release"]  = osInfoProvider->version();
             output["architecture"] = osInfoProvider->machine();
             output["os_platform"] = "windows";
         }

--- a/src/data_provider/src/osinfo/sysOsInfoInterface.h
+++ b/src/data_provider/src/osinfo/sysOsInfoInterface.h
@@ -50,6 +50,7 @@ class SysOsInfo
             output["hostname"] = osInfoProvider->nodeName();
             output["os_distribution_release"] = osInfoProvider->release();
             output["os_full"] = osInfoProvider->displayVersion();
+            output["release"]  = osInfoProvider->version();
             output["architecture"] = osInfoProvider->machine();
             output["os_platform"] = "windows";
         }

--- a/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
@@ -62,4 +62,5 @@ TEST_F(SysOsInfoTest, setOsInfoSchema)
     EXPECT_EQ("1903", output.at("os_distribution_release"));
     EXPECT_EQ("19H1", output.at("os_full"));
     EXPECT_EQ("10.0.18362", output.at("os_version"));
+    EXPECT_EQ("10.0.18362", output.at("os_kernel_release"));
 }

--- a/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
@@ -44,7 +44,7 @@ TEST_F(SysOsInfoTest, setOsInfoSchema)
         pOsInfoProvider
     };
     EXPECT_CALL(*pOsInfoProvider, name()).WillOnce(Return("Microsoft Windows 10 Home"));
-    EXPECT_CALL(*pOsInfoProvider, version()).WillOnce(Return("10.0.18362"));
+    EXPECT_CALL(*pOsInfoProvider, version()).Times(2).WillRepeatedly(Return("10.0.18362"));
     EXPECT_CALL(*pOsInfoProvider, majorVersion()).WillOnce(Return("10"));
     EXPECT_CALL(*pOsInfoProvider, minorVersion()).WillOnce(Return("0"));
     EXPECT_CALL(*pOsInfoProvider, build()).WillOnce(Return("18362"));


### PR DESCRIPTION
Closes #30785 

<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Wazuh agent already  collects and sends the OS  version . In the case of Windows OS, the version accurately represents the kernel version. This pull request fills the field `os_kernel_relaease`, with the value obtained from the version field `os_version`, in the file `sysOsInfoInterface.h`

```
 output["os_version"] = osInfoProvider->version();
 output["os_kernel_release"]  = osInfoProvider->version(); //Updated field for Windows OS
```

In this sense also the test file: `sysOsInfo_test`, was changed, as the function `osInfoProvider->version()`  now is called twice:

`EXPECT_CALL(*pOsInfoProvider, version()).Times(2).WillRepeatedly(Return("10.0.18362"));`

**Relevant fields:**

| Column         | Type | Description                      |
|----------------|------|----------------------------------|
| `os_kernel_release`         | text | Operating system kernel version     |
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

- Add `os_kernel_release` field for Windows Os
- Add unit tests to validate the value in `os_kernel_release` must be the same as `os_version`

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

Using a Windows machine and sqlite3 to test, the field os_kernel_release now is successfully displayed:
 
<img width="1563" height="240" alt="image" src="https://github.com/user-attachments/assets/a3af070f-a2c2-46bf-8823-bc39cf1ceee0" />

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->
### Artifacts Affected
  - syscollector module (Windows platform)
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

- NA

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

Changes on the test file:` sysOsInfo_test.cpp`. Added lines:

`EXPECT_CALL(*pOsInfoProvider, version()).Times(2).WillRepeatedly(Return("10.0.18362"));`

`EXPECT_EQ("10.0.18362", output.at("os_kernel_release"));`

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues


<!--
Include any additional information relevant to the review process.
-->
