### PR TITLE
Syscollector does not send primary key fields from table 'services'

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -856,7 +856,7 @@ nlohmann::json SysInfo::getServices() const
         nlohmann::json serviceItem{};
 
         // ECS mapping based on the provided table
-        serviceItem["service_id"]                            = svc.value("id",                UNKNOWN_VALUE);
+        serviceItem["service_id"]                            = (svc.contains("id") && !svc["id"].get<std::string>().empty()) ? svc["id"] : UNKNOWN_VALUE;
         serviceItem["service_name"]                          = UNKNOWN_VALUE;
         serviceItem["service_description"]                   = svc.value("description",       UNKNOWN_VALUE);
         serviceItem["service_type"]                          = UNKNOWN_VALUE;
@@ -877,7 +877,7 @@ nlohmann::json SysInfo::getServices() const
         serviceItem["process_group_name"]                    = UNKNOWN_VALUE;
         serviceItem["process_working_directory"]             = UNKNOWN_VALUE;
         serviceItem["process_root_directory"]                = UNKNOWN_VALUE;
-        serviceItem["file_path"]                             = svc.value("source_path",       UNKNOWN_VALUE);
+        serviceItem["file_path"]                             = (svc.contains("source_path") && !svc["source_path"].get<std::string>().empty()) ? svc["source_path"] : UNKNOWN_VALUE;
         serviceItem["service_address"]                       = UNKNOWN_VALUE;
         serviceItem["log_file_path"]                         = UNKNOWN_VALUE;
         serviceItem["error_log_file_path"]                   = UNKNOWN_VALUE;

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -710,7 +710,7 @@ nlohmann::json SysInfo::getServices() const
         };
 
         // ECS mapping based on the provided table
-        serviceItem["service_id"]           = svc.value("label",        UNKNOWN_VALUE);
+        serviceItem["service_id"]           = (svc.contains("label") && !svc["label"].get<std::string>().empty()) ? svc["label"] : UNKNOWN_VALUE;
         serviceItem["service_name"]         = svc.value("name",         UNKNOWN_VALUE);
         serviceItem["service_description"]  = UNKNOWN_VALUE;
         serviceItem["service_type"]         = svc.value("process_type", UNKNOWN_VALUE);
@@ -753,7 +753,7 @@ nlohmann::json SysInfo::getServices() const
         serviceItem["process_group_name"]                    = svc.value("groupname",           UNKNOWN_VALUE);
         serviceItem["process_working_directory"]             = svc.value("working_directory",   UNKNOWN_VALUE);
         serviceItem["process_root_directory"]                = svc.value("root_directory",      UNKNOWN_VALUE);
-        serviceItem["file_path"]                             = svc.value("path",                UNKNOWN_VALUE);
+        serviceItem["file_path"]                             = (svc.contains("path") && !svc["path"].get<std::string>().empty()) ? svc["path"] : UNKNOWN_VALUE;
         serviceItem["service_address"]                       = UNKNOWN_VALUE;
         serviceItem["log_file_path"]                         = svc.value("stdout_path",         UNKNOWN_VALUE);
         serviceItem["error_log_file_path"]                   = svc.value("stderr_path",         UNKNOWN_VALUE);

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -1182,7 +1182,7 @@ nlohmann::json SysInfo::getServices() const
     {
         nlohmann::json serviceItem{};
 
-        serviceItem["service_id"]                            = svc.value("name",         UNKNOWN_VALUE);
+        serviceItem["service_id"]                            = (svc.contains("name") && !svc["name"].get<std::string>().empty()) ? svc["name"] : UNKNOWN_VALUE;
         serviceItem["service_name"]                          = svc.value("display_name", UNKNOWN_VALUE);
         serviceItem["service_description"]                   = svc.value("description",  UNKNOWN_VALUE);
         serviceItem["service_type"]                          = svc.value("service_type", UNKNOWN_VALUE);


### PR DESCRIPTION
## Description

Closes #31596

Syscollector is not sending all the primary key fields of the table `services`. When these fields contain an empty string `""`, they are removed by syscollector before sending the event. This prevents the event from being processed by the manager.

```console
2025/08/27 11:32:59 wazuh-db[55983] wdb_parser.c:405 at wdb_parse(): DEBUG: Agent 001 query: syscollector_services save2 {"attributes":{"checksum":"1f6ece92d18730a916ada0c95282cdcc68d25f4f","error_log_file_path":" ","item_id":"009c32417b49618d8e53c444ef87ec2cce747177","log_file_path":" ","process_args":" ","process_executable":"/usr/lib/systemd/system/shutdown.target","process_group_name":" ","process_pid":0,"scan_time":"2025/08/27 14:32:59","service_address":" ","service_description":"System Shutdown","service_enabled":"static","service_exit_code":0,"service_frequency":0,"service_id":"shutdown.target","service_inetd_compatibility":0,"service_name":" ","service_object_path":"/org/freedesktop/systemd1/unit/shutdown_2etarget","service_restart":" ","service_start_type":" ","service_starts_on_mount":0,"service_starts_on_not_empty_directory":" ","service_starts_on_path_modified":" ","service_state":"inactive","service_sub_state":"dead","service_target_address":"/","service_target_ephemeral_id":0,"service_type":" ","service_win32_exit_code":0},"index":"009c32417b49618d8e53c444ef87ec2cce747177","timestamp":""}
2025/08/27 11:32:59 logger-helper[56206] systemInventoryOrchestrator.hpp:42 at run(): DEBUG: SystemInventoryOrchestrator::run for agent: '001', operation: '1', component: '6'
2025/08/27 11:32:59 wazuh-db[55983] wdb_parser.c:2097 at wdb_parse_syscollector(): DEBUG: DB(001) syscollector_services Syscollector query.
2025/08/27 11:32:59 logger-helper[56206] upsertElement.hpp:103 at handleRequest(): DEBUG: UpsertSystemElement::build: {"id":"001_f19629d858393054b7075ec6db3d778db7f18f30","operation":"INSERTED","data":{"network":{"dhcp":false,"gateway":"10.0.2.2","metric":100,"type":"ipv4"},"interface":{"name":"eth0"},"agent":{"id":"001","name":"centos9","version":"v4.14.0"},"wazuh":{"cluster":{"name":"jammy"},"schema":{"version":"1.0"}}}}
2025/08/27 11:32:59 wazuh-db[55983] wdb_parser.c:2116 at wdb_parse_syscollector(): DEBUG: DB(001) Cannot save Syscollector.
2025/08/27 11:32:59 logger-helper[56206] systemInventoryOrchestrator.hpp:75 at processEvent(): DEBUG: SystemInventoryOrchestrator::processEvent finished
2025/08/27 11:32:59 wazuh-analysisd[56030] dbsync.c:195 at dispatch_state(): ERROR: dbsync: Bad response from database: Cannot save Syscollector

```

As you can see in this example obtained from a CentOS 9 agent, it is not sending the `file_path` field, which is the primary key of the `dbsync_services` table:

```json
{
  "attributes": {
    "checksum": "1f6ece92d18730a916ada0c95282cdcc68d25f4f",
    "error_log_file_path": " ",
    "item_id": "009c32417b49618d8e53c444ef87ec2cce747177",
    "log_file_path": " ",
    "process_args": " ",
    "process_executable": "/usr/lib/systemd/system/shutdown.target",
    "process_group_name": " ",
    "process_pid": 0,
    "scan_time": "2025/08/27 14:32:59",
    "service_address": " ",
    "service_description": "System Shutdown",
    "service_enabled": "static",
    "service_exit_code": 0,
    "service_frequency": 0,
    "service_id": "shutdown.target",
    "service_inetd_compatibility": 0,
    "service_name": " ",
    "service_object_path": "/org/freedesktop/systemd1/unit/shutdown_2etarget",
    "service_restart": " ",
    "service_start_type": " ",
    "service_starts_on_mount": 0,
    "service_starts_on_not_empty_directory": " ",
    "service_starts_on_path_modified": " ",
    "service_state": "inactive",
    "service_sub_state": "dead",
    "service_target_address": "/",
    "service_target_ephemeral_id": 0,
    "service_type": " ",
    "service_win32_exit_code": 0
  },
  "index": "009c32417b49618d8e53c444ef87ec2cce747177",
  "timestamp": ""
}
```


## Proposed Changes

- Check the primary key field. If the collector does not provide the field or its value is an empty string, assign UNKNOWN_VALUE to the field.

### Results and Evidence

<details><summary>Before the fix</summary>

```json
{
    "data":
    {
        "checksum": "07aab4171aab1847a9158d2ca7c72f00936ed806",
        "error_log_file_path": " ",
        "item_id": "ac2a14c854385ea05454aa5c592758eda4d92831",
        "log_file_path": " ",
        "process_args": " ",
        "process_executable": "/lib/systemd/system/gpu-manager.service",
        "process_group_name": " ",
        "process_pid": 0,
        "process_root_directory": " ",
        "process_working_directory": " ",
        "scan_time": "2025/08/27 16:04:05",
        "service_address": " ",
        "service_description": "Detect the available GPUs and deal with any system changes",
        "service_enabled": "enabled",
        "service_exit_code": 0,
        "service_frequency": 0,
        "service_id": "gpu-manager.service",
        "service_inetd_compatibility": 0,
        "service_name": " ",
        "service_object_path": "/org/freedesktop/systemd1/unit/gpu_2dmanager_2eservice",
        "service_restart": " ",
        "service_start_type": " ",
        "service_starts_on_mount": 0,
        "service_starts_on_not_empty_directory": " ",
        "service_starts_on_path_modified": " ",
        "service_state": "inactive",
        "service_sub_state": "dead",
        "service_target_address": "/",
        "service_target_ephemeral_id": 0,
        "service_type": " ",
        "service_win32_exit_code": 0
    },
    "operation": "INSERTED",
    "type": "dbsync_services"
}
```

</details> 

<details><summary>After the fix</summary>

```json
{
    "data":
    {
        "checksum": "828aac52ad0392b638bd86c8ebe5671bd0a9018b",
        "error_log_file_path": " ",
        "file_path": " ",
        "item_id": "db16842fc4fc28b4f96afda64fcf6982ab6f6caa",
        "log_file_path": " ",
        "process_args": " ",
        "process_executable": "/lib/systemd/system/gpu-manager.service",
        "process_group_name": " ",
        "process_pid": 0,
        "process_root_directory": " ",
        "process_working_directory": " ",
        "scan_time": "2025/08/27 16:51:57",
        "service_address": " ",
        "service_description": "Detect the available GPUs and deal with any system changes",
        "service_enabled": "enabled",
        "service_exit_code": 0,
        "service_frequency": 0,
        "service_id": "gpu-manager.service",
        "service_inetd_compatibility": 0,
        "service_name": " ",
        "service_object_path": "/org/freedesktop/systemd1/unit/gpu_2dmanager_2eservice",
        "service_restart": " ",
        "service_start_type": " ",
        "service_starts_on_mount": 0,
        "service_starts_on_not_empty_directory": " ",
        "service_starts_on_path_modified": " ",
        "service_state": "inactive",
        "service_sub_state": "dead",
        "service_target_address": "/",
        "service_target_ephemeral_id": 0,
        "service_type": " ",
        "service_win32_exit_code": 0
    },
    "operation": "INSERTED",
    "type": "dbsync_services"
}
```

</details> 

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X

### Artifacts Affected

- Sysinfo services collector (Windows, Linux, macOS)
- Syscollector module (Windows, Linux, macOS)

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

