### PR TITLE
Avoid a debug log in eBPF that generates spam 

### DIFF
--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.h
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.h
@@ -27,7 +27,7 @@ extern "C" {
  * @param loggingFn Pointer to loggingFunction.
  * @param abspathFn Pointer to abspath.
  */
-void fimebpf_initialize(directory_t *(*fim_conf)(const char *),
+void fimebpf_initialize(directory_t *(*fim_conf)(const char *, bool),
                         char *(*getUser)(int),
                         char *(*getGroup)(int),
                         void (*fimWhodataEvent)(whodata_evt *),

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
@@ -27,7 +27,7 @@ public:
     }
 
     // Function pointer types for required C functions
-    using fim_configuration_directory_t = directory_t*(*)(const char*);
+    using fim_configuration_directory_t = directory_t*(*)(const char*, bool);
     using get_user_t = char* (*)(int);
     using get_group_t = char* (*)(int);
     using fim_whodata_event_t = void (*)(whodata_evt*);

--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -63,7 +63,7 @@ int handle_event(void* ctx, void* data, size_t data_sz) {
         return 0;
     }
 
-    directory_t* config = confFn(e->filename);
+    directory_t* config = confFn(e->filename, false);
     if (config && (config->options & WHODATA_ACTIVE)) {
         auto event = std::make_unique<dynamic_file_event>(dynamic_file_event{
             .filename    = std::string(e->filename),
@@ -324,7 +324,7 @@ void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<dynamic_file_event>>& loc
 extern "C" {
 #endif
 
-void fimebpf_initialize(directory_t *(*fim_conf)(const char *),
+void fimebpf_initialize(directory_t *(*fim_conf)(const char *, bool),
                         char *(*getUser)(int),
                         char *(*getGroup)(int),
                         void (*fimWhodataEvent)(whodata_evt *),

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -68,8 +68,8 @@ fimebpf::fim_whodata_event_t MockFimebpf::mock_fim_whodata_event = nullptr;
 fimebpf::loggingFunction_t MockFimebpf::mock_loggingFunction = nullptr;
 fimebpf::abspath_t MockFimebpf::mock_abspath = nullptr;
 
-directory_t* mock_fim_conf_failure([[maybe_unused]] const char* config_path) { return nullptr; }
-directory_t* mock_fim_conf_success([[maybe_unused]] const char* config_path) {
+directory_t* mock_fim_conf_failure([[maybe_unused]] const char* config_path, [[maybe_unused]] bool notify_not_found) { return nullptr; }
+directory_t* mock_fim_conf_success([[maybe_unused]] const char* config_path, [[maybe_unused]] bool notify_not_found) {
     static directory_t mockDirectory;
     mockDirectory.options = WHODATA_ACTIVE;
     return &mockDirectory;

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -74,7 +74,7 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
     }
 
     if (txn_context->config == NULL) {
-        txn_context->config = fim_configuration_directory(path);
+        txn_context->config = fim_configuration_directory(path, true);
         if (txn_context->config == NULL) {
             goto end;
         }
@@ -239,7 +239,7 @@ void fim_db_remove_validated_path(void * data, void * ctx)
     char *path = (char *)data;
     struct callback_ctx *ctx_data = (struct callback_ctx *)ctx;
 
-    directory_t *validated_configuration = fim_configuration_directory(path);
+    directory_t *validated_configuration = fim_configuration_directory(path, true);
 
     if (validated_configuration == ctx_data->config)
     {
@@ -247,7 +247,7 @@ void fim_db_remove_validated_path(void * data, void * ctx)
     }
 }
 
-directory_t *fim_configuration_directory(const char *key) {
+directory_t *fim_configuration_directory(const char *key, bool notify_not_found) {
     char full_path[OS_SIZE_4096 + 1] = {'\0'};
     char full_entry[OS_SIZE_4096 + 1] = {'\0'};
     directory_t *dir_it = NULL;
@@ -287,7 +287,7 @@ directory_t *fim_configuration_directory(const char *key) {
         os_free(real_path);
     }
 
-    if (dir == NULL) {
+    if (dir == NULL && notify_not_found) {
         mdebug2(FIM_CONFIGURATION_NOTFOUND, "file", key);
     }
 
@@ -601,7 +601,7 @@ void fim_checker(const char *path,
     }
 #endif
 
-    configuration = fim_configuration_directory(path);
+    configuration = fim_configuration_directory(path, true);
     if (configuration == NULL) {
         return;
     }
@@ -812,7 +812,7 @@ void fim_file(const char *path,
 void fim_process_missing_entry(char * pathname, fim_event_mode mode, whodata_evt * w_evt) {
     directory_t *configuration = NULL;
 
-    configuration = fim_configuration_directory(pathname);
+    configuration = fim_configuration_directory(pathname, true);
     if (NULL == configuration) {
         return;
     }

--- a/src/syscheckd/src/file/file.h
+++ b/src/syscheckd/src/file/file.h
@@ -27,9 +27,10 @@ typedef struct callback_ctx
  * @brief Search the position of the path in directories array
  *
  * @param key Path to seek in the directories array
+ * @param notify_not_found If true, a debug message is logged when the path is not found
  * @return Returns a pointer to the configuration associated with the provided path, NULL if the path is not found
  */
-directory_t* fim_configuration_directory(const char* key);
+directory_t* fim_configuration_directory(const char* key, bool notify_not_found);
 
 /**
  * @brief Evaluates the depth of the directory or file to check if it exceeds the configured max_depth value

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -705,7 +705,7 @@ static void *symlink_checker_thread(__attribute__((unused)) void * data) {
                     snprintf(path, PATH_MAX, "%s", dir_it->symbolic_links);
                     fim_link_check_delete(dir_it);
 
-                    directory_t *config = fim_configuration_directory(path);
+                    directory_t *config = fim_configuration_directory(path, true);
 
                     if (config != NULL) {
                         fim_link_silent_scan(path, config);

--- a/src/syscheckd/src/run_realtime.c
+++ b/src/syscheckd/src/run_realtime.c
@@ -173,7 +173,7 @@ void fim_realtime_delete_watches(const directory_t *configuration) {
         if (data == NULL) {
             continue;
         }
-        watch_conf = fim_configuration_directory(data);
+        watch_conf = fim_configuration_directory(data, true);
 
         if (configuration == watch_conf) {
             W_Vector_insert(watch_to_delete, hash_node->key);
@@ -299,7 +299,7 @@ int realtime_update_watch(const char *wd, const char *dir) {
         return -1;
     }
 
-    configuration = fim_configuration_directory(dir);
+    configuration = fim_configuration_directory(dir, true);
 
     if (configuration == NULL) {
         inotify_rm_watch(syscheck.realtime->fd, atoi(wd));
@@ -509,8 +509,8 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
             }
             str_lowercase(final_path);
 
-            directory_t *index = fim_configuration_directory(wdchar);
-            directory_t *file_index = fim_configuration_directory(final_path);
+            directory_t *index = fim_configuration_directory(wdchar, true);
+            directory_t *file_index = fim_configuration_directory(final_path, true);
 
             if (index == file_index) {
                 /* Check the change */

--- a/src/syscheckd/src/whodata/win_whodata.c
+++ b/src/syscheckd/src/whodata/win_whodata.c
@@ -789,7 +789,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
                 }
 
                 w_rwlock_rdlock(&syscheck.directories_lock);
-                configuration = fim_configuration_directory(w_evt->path);
+                configuration = fim_configuration_directory(w_evt->path, true);
                 if (configuration == NULL) {
                     if (!(mask & (FILE_APPEND_DATA | FILE_WRITE_DATA))) {
                         // Discard the file or directory if its monitoring has not been activated
@@ -900,7 +900,7 @@ unsigned long WINAPI whodata_callback(EVT_SUBSCRIBE_NOTIFY_ACTION action, __attr
 
                 // Check if is a valid directory
                 w_rwlock_rdlock(&syscheck.directories_lock);
-                if (fim_configuration_directory(w_evt->path) == NULL) {
+                if (fim_configuration_directory(w_evt->path, false) == NULL) {
                     mdebug2(FIM_WHODATA_DIRECTORY_DISCARDED, w_evt->path);
                     w_evt->scan_directory = 2;
                     w_rwlock_unlock(&syscheck.directories_lock);

--- a/src/unit_tests/syscheckd/whodata/test_win_whodata.c
+++ b/src/unit_tests/syscheckd/whodata/test_win_whodata.c
@@ -5510,8 +5510,6 @@ void test_whodata_callback_4663_non_monitored_directory(void **state) {
     will_return(__wrap_OSHash_Get, w_evt);
 
     expect_string(__wrap__mdebug2, formatted_msg,
-        "(6319): No configuration found for (file):'c:\\a\\path'");
-    expect_string(__wrap__mdebug2, formatted_msg,
         "(6243): The 'c:\\a\\path' directory has been discarded because it is not being monitored in whodata mode.");
 
     result = whodata_callback(action, NULL, event);

--- a/src/unit_tests/wrappers/linux/ebpf_wrappers.h
+++ b/src/unit_tests/wrappers/linux/ebpf_wrappers.h
@@ -23,13 +23,13 @@ int __wrap_ebpf_whodata_healthcheck(void);
 
 // Declare the wrap version of fimebpf_initialize
 void __wrap_fimebpf_initialize(const char* config_dir,
-                                FunctionPtr get_user,
-                                FunctionPtr get_group,
-                                FunctionPtr whodata_event,
-                                FunctionPtr free_whodata_event,
-                                FunctionPtr loggingFunction,
-                                FunctionPtr abspath,
-                                FunctionPtr is_shutdown,
-                                syscheck_config syscheck);
+                               FunctionPtr get_user,
+                               FunctionPtr get_group,
+                               FunctionPtr whodata_event,
+                               FunctionPtr free_whodata_event,
+                               FunctionPtr loggingFunction,
+                               FunctionPtr abspath,
+                               FunctionPtr is_shutdown,
+                               syscheck_config syscheck);
 
 #endif // WRAP_EBPF_FUNCTIONS_H


### PR DESCRIPTION
Closes #31583

# Description

In this PR, we are including a new parameter in the fim_configuration_directory function to select whether or not we need the debug message, since in the case of eBPF, that message can generate infinite spam because ossec.log itself infinitely triggers an eBPF modification event.


## Solution
The `fim_configuration_directory` function is responsible for analyzing whether or not a certain path is included in the syscheck configuration. If it is, it returns a pointer to the configuration structure for that path, but if not, it returns NULL. In addition, when it does not find a path, it generates a debug message warning that it has attempted to analyze a path that is NOT configured. When this function was designed, it was not expected that any path that was NOT configured would be analyzed, since in the places where this function was called, the appropriate filter or instructions were already in place in the code. For example, for realtime or whodata, this function was only reached for configured paths, since events were only generated through the rules of each mode. 

In short, reaching this function with an unconfigured path indicated that some previous problem must have occurred. Therefore, the debug message helped us detect any anomalies in the code.
However, after the inclusion of the whodata eBPF provider, we have used this same function at a point where it itself is the filter that detects whether or not a path is configured, so the debug message is unnecessary and only generates spam.

To solve this, we have included a parameter to the function to decide whether to print the log message or not, depending on the context:
- `directory_t* fim_configuration_directory(const char* key, bool notify_not_found);`

