### PR TITLE
Update the expected libsysinfo.so file in Linux AMD64 RPM package

### DIFF
--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -91,7 +91,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhshared.so,root,wazuh,750,file,-rwxr-x---,156152,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,10539864,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
-/var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,1980344,0.1
+/var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2179736,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,466648,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526048,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,44600,0.1


### PR DESCRIPTION
## Description

This PR updates the expected file size for `/var/ossec/lib/libsysinfo.so` in the Linux RPM AMD64 package generation check. The size mismatch was reported after merging changes from version 4.14.0 to 4.14.1, causing the package validation to fail with an unexpected file size.

## Proposed Changes

- Update expected size for `/var/ossec/lib/libsysinfo.so` from previous value to 2179736 bytes in the Linux RPM AMD64 package check configuration (like in 5.0.0)

### Results and Evidence

Let the check of this PR serve as evidence of the fix.

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues