### PR TITLE
Revert auto-replicas setting for Inventory Enrichment tier 2 indices

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-browser-extensions.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-browser-extensions.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-services.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-services.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [


### PR DESCRIPTION
### Description
This PR removes the index setting to automatically create replicas whenever possible from the  Inventory Enrichment tier 2 indices.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1102
