### PR TITLE
Revert auto-replicas setting for Global Queries indices

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hotfixes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hotfixes.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-interfaces.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-interfaces.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-networks.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-networks.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-protocols.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-protocols.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [


### PR DESCRIPTION
### Description
This PR removes the index setting to automatically create replicas whenever possible from the Global Queries indices.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1100
