### PR TITLE
Modify rootkit error messages to warnings due to deprecation in version 5.0

### DIFF
--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -115,7 +115,7 @@ void run_rk_check()
         } else {
             fp = wfopen(rootcheck.rootkit_files, "r");
             if (!fp) {
-                mterror(ARGV0, "No rootcheck_files file: '%s'", rootcheck.rootkit_files);
+                mtwarn(ARGV0, "No rootcheck_files file: '%s'", rootcheck.rootkit_files);
             }
 
             else {
@@ -134,7 +134,7 @@ void run_rk_check()
         } else {
             fp = wfopen(rootcheck.rootkit_trojans, "r");
             if (!fp) {
-                mterror(ARGV0, "No rootcheck_trojans file: '%s'", rootcheck.rootkit_trojans);
+                mtwarn(ARGV0, "No rootcheck_trojans file: '%s'", rootcheck.rootkit_trojans);
             } else {
 #ifndef HPUX
                 check_rc_trojans(rootcheck.basedir, fp);
@@ -155,7 +155,7 @@ void run_rk_check()
         } else {
             fp = wfopen(rootcheck.winaudit, "r");
             if (!fp) {
-                mterror(ARGV0, "No winaudit file: '%s'", rootcheck.winaudit);
+                mtwarn(ARGV0, "No winaudit file: '%s'", rootcheck.winaudit);
             } else {
                 check_rc_winaudit(fp, plist);
                 fclose(fp);
@@ -170,7 +170,7 @@ void run_rk_check()
         } else {
             fp = wfopen(rootcheck.winmalware, "r");
             if (!fp) {
-                mterror(ARGV0, "No winmalware file: '%s'", rootcheck.winmalware);
+                mtwarn(ARGV0, "No winmalware file: '%s'", rootcheck.winmalware);
             } else {
                 check_rc_winmalware(fp, plist);
                 fclose(fp);
@@ -185,7 +185,7 @@ void run_rk_check()
         } else {
             fp = wfopen(rootcheck.winapps, "r");
             if (!fp) {
-                mterror(ARGV0, "No winapps file: '%s'", rootcheck.winapps);
+                mtwarn(ARGV0, "No winapps file: '%s'", rootcheck.winapps);
             } else {
                 check_rc_winapps(fp, plist);
                 fclose(fp);
@@ -210,7 +210,7 @@ void run_rk_check()
             while (rootcheck.unixaudit[i]) {
                 fp = wfopen(rootcheck.unixaudit[i], "r");
                 if (!fp) {
-                    mterror(ARGV0, "No unixaudit file: '%s'", rootcheck.unixaudit[i]);
+                    mtwarn(ARGV0, "No unixaudit file: '%s'", rootcheck.unixaudit[i]);
                 } else {
                     /* Run unix audit */
                     check_rc_unixaudit(fp, plist);


### PR DESCRIPTION
## Description

| Related issue |
|---|
| Closes #31635 |

## Proposed Changes

Due to the deprecation of some rootcheck functionalities in version 5.0.0, the error messages related to these functionalities have been replaced with warning messages on both Linux and Windows systems.

## Testing

### Linux agent (Ubuntu 24.04 lts)

Rootcheck messages on Linux are no longer errors but warnings, as intended:

```
2025/08/29 13:35:40 rootcheck: INFO: Starting rootcheck scan.
2025/08/29 13:35:40 rootcheck: WARNING: No rootcheck_files file: 'etc/shared/rootkit_files.txt'
2025/08/29 13:35:40 rootcheck: WARNING: No rootcheck_trojans file: 'etc/shared/rootkit_trojans.txt'
```

### Windows agent 

Similarly, Windows error messages related to deprecated files have been updated to warnings.

<img width="897" height="88" alt="Image" src="https://github.com/user-attachments/assets/d80e11f8-1fa5-478f-9e34-601312324be3" />
