### PR TITLE
Fix API endpoints IT related to ruleset reload

### DIFF
--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -706,8 +706,23 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         nodes_list: 'worker1,worker2'
-    response:
-      <<: *permission_denied
+    response: 
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - name: worker2
+              msg: !anystr
+          failed_items:
+            - error:
+                code: 4000
+                message: !anystr
+                remediation: !anystr
+              id:
+                - worker1
+          total_affected_items: 1
+          total_failed_items: 1
 
 ---
 test_name: PUT /cluster/{node_id}/configuration


### PR DESCRIPTION
## Description

# Closes 31627

This PR aims to fix the API endpoint IT related to ruleset reload that were failing at https://github.com/wazuh/wazuh/issues/31552

## Proposed Changes

Change the expected response at `PUT /cluster/analysisd/reload` test, part of `api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml` due to the partially allowed reload privilages on the requested cluster nodes

### Results and Evidence

https://jenkins-production.qa.wazuh.info/job/4.13.0/job/Test_integration_endpoints/18/

### Manual tests with their corresponding evidence

```
root@wazuh-dev:~/repos/wazuh/api/test/integration# pytest --nobuild -vvv test_rbac_white_cluster_endpoints.tavern.yaml --html=report.html
=================================================================== test session starts ===================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.15.0-152-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'cov': '4.1.0', 'trio': '0.8.0', 'tornasync': '0.6.0', 'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '2.0.4', 'anyio': '3.7.1'}}
rootdir: /root/repos/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, cov-4.1.0, trio-0.8.0, tornasync-0.6.0, testinfra-5.0.0, html-3.1.1, metadata-2.0.4, anyio-3.7.1
asyncio: mode=auto
collected 20 items                                                                                                                                        

test_rbac_white_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                         [  5%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                      [ 10%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                          [ 15%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                       [ 20%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                            [ 25%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/nodes/{node_id} PASSED                                                                  [ 30%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                           [ 35%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                          [ 40%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                         [ 45%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                              [ 50%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                                                                   [ 55%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                                                                   [ 60%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED                                                           [ 65%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats PASSED                                                          [ 70%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats PASSED                                                                  [ 75%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                                                                 [ 80%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                       [ 85%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                          [ 90%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/analysisd/reload PASSED                                                                 [ 95%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                          [100%]

==================================================================== warnings summary =====================================================================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642
  /usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_white_cluster_endpoints.tavern.yaml: 20 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------- generated html file: file:///root/repos/wazuh/api/test/integration/report.html --------------------------------------
====================================================== 20 passed, 21 warnings in 2489.45s (0:41:29) =======================================================
```

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

N/A
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

N/A

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

N/A

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
