### PR TITLE
Add state modified at to stateful messages

### DIFF
--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -210,6 +210,15 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
         }
     }
 
+    // Add state modified_at field for stateful event only
+    cJSON* state = cJSON_CreateObject();
+    if (state != NULL) {
+        char modified_at_time[32];
+        get_iso8601_utc_time(modified_at_time, sizeof(modified_at_time));
+        cJSON_AddStringToObject(state, "modified_at", modified_at_time);
+        cJSON_AddItemToObject(stateful_event, "state", state);
+    }
+
     char file_path_sha1[FILE_PATH_SHA1_BUFFER_SIZE] = {0};
     OS_SHA1_Str(path, -1, file_path_sha1);
 

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -273,6 +273,15 @@ STATIC void registry_key_transaction_callback(ReturnTypeCallback resultType,
         }
     }
 
+    // Add state modified_at field for stateful event only
+    cJSON* state = cJSON_CreateObject();
+    if (state != NULL) {
+        char modified_at_time[32];
+        get_iso8601_utc_time(modified_at_time, sizeof(modified_at_time));
+        cJSON_AddStringToObject(state, "modified_at", modified_at_time);
+        cJSON_AddItemToObject(stateful_event, "state", state);
+    }
+
     char id_source_string[OS_MAXSTR] = {0};
     snprintf(id_source_string, OS_MAXSTR - 1, "%d:%s", arch, path);
 
@@ -471,6 +480,15 @@ STATIC void registry_value_transaction_callback(ReturnTypeCallback resultType,
             mdebug1("Couldn't find checksum for '%s", path);
             goto end; // LCOV_EXCL_LINE
         }
+    }
+
+    // Add state modified_at field for stateful event only
+    cJSON* state = cJSON_CreateObject();
+    if (state != NULL) {
+        char modified_at_time[32];
+        get_iso8601_utc_time(modified_at_time, sizeof(modified_at_time));
+        cJSON_AddStringToObject(state, "modified_at", modified_at_time);
+        cJSON_AddItemToObject(stateful_event, "state", state);
     }
 
     char id_source_string[OS_MAXSTR] = {0};

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -193,10 +193,15 @@ void Syscollector::processEvent(ReturnTypeCallback result, const nlohmann::json&
         m_persistDiffFunction(calculateHashId(data, table), OPERATION_STATES_MAP.at(result), indexIt->second, statefulToSend);
     }
 
-    // Remove checksum from newData to avoid sending it in the diff
+    // Remove checksum and state from newData to avoid sending them in the diff
     if (newData.contains("checksum"))
     {
         newData.erase("checksum");
+    }
+
+    if (newData.contains("state"))
+    {
+        newData.erase("state");
     }
 
     if (m_notify)
@@ -399,6 +404,11 @@ nlohmann::json Syscollector::ecsData(const nlohmann::json& data, const std::stri
     if (createFields)
     {
         setJsonField(ret, data, "/checksum/hash/sha1", "checksum", std::nullopt, true);
+
+        // Add state modified_at field for stateful events only
+        nlohmann::json state;
+        state["modified_at"] = Utils::getCurrentISO8601();
+        ret["state"] = state;
     }
 
     return ret;

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -184,7 +184,14 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -434,7 +441,14 @@ TEST_F(SyscollectorImpTest, noHardware)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -587,7 +601,14 @@ TEST_F(SyscollectorImpTest, noOs)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -739,7 +760,14 @@ TEST_F(SyscollectorImpTest, noNetwork)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -865,7 +893,14 @@ TEST_F(SyscollectorImpTest, noPackages)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1017,7 +1052,14 @@ TEST_F(SyscollectorImpTest, noPorts)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1170,7 +1212,14 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1332,7 +1381,14 @@ TEST_F(SyscollectorImpTest, noProcesses)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1485,7 +1541,14 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1639,7 +1702,14 @@ TEST_F(SyscollectorImpTest, noUsers)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1792,7 +1862,14 @@ TEST_F(SyscollectorImpTest, noGroups)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -1989,7 +2066,14 @@ TEST_F(SyscollectorImpTest, portAllEnable)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -2161,7 +2245,14 @@ TEST_F(SyscollectorImpTest, portAllDisable)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -2261,7 +2352,14 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 
@@ -2349,7 +2447,14 @@ TEST_F(SyscollectorImpTest, sanitizeJsonValues)
     {
         [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data)
         {
-            wrapperPersist.callbackMock(id, operation, index, data);
+            auto persist = nlohmann::json::parse(data);
+
+            if (persist.contains("state"))
+            {
+                persist.erase("state");
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, persist.dump());
         }
     };
 


### PR DESCRIPTION
## Description

This PR introduces the `state.modified_at` field to stateful events so that there is a record of when each record was last modified.

## Proposed Changes

- Added `state.modified_at` to FIM stateful events.
- Added `state.modified_at` to Inventory stateful events.

### Results and Evidence

FIM:

```json
{
    "file": {
        "size": 42,
        "permissions": [
            "rwxrwxrwx"
        ],
        "uid": "0",
        "owner": "root",
        "gid": "0",
        "group": "root",
        "inode": "3276943",
        "device": 64512,
        "mtime": 1756584175,
        "hash": {
            "md5": "d41d8cd98f00b204e9800998ecf8427e",
            "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
        },
        "path": "/etc/systemd/system/snapd.mounts.target.wants/snap-core22-2115.mount"
    },
    "checksum": {
        "hash": {
            "sha1": "82332d2bfde6d7a8408ae677a6aee354109dc44d"
        }
    },
    "state": {
        "modified_at": "2025-08-30T20:03:00.007Z"
    }
}
```

Inventory:

```json
{
    "checksum": {
        "hash": {
            "sha1": "68459d3ff67c520a547725cd0d6b2ff413cfa883"
        }
    },
    "process": {
        "args": [
            "180"
        ],
        "args_count": 1,
        "command_line": "sleep",
        "name": "sleep",
        "parent": {
            "pid": 1255
        },
        "pid": "18999",
        "start": 1756740742,
        "state": "S",
        "stime": 0,
        "utime": 0
    },
    "state": {
        "modified_at": "2025-09-01T15:32:47.568Z"
    }
}
```

### Artifacts Affected

Agent

### Configuration Changes

N/A

### Tests Introduced

Fixed related tests after changes introduced.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues