### PR TITLE
Remove unneeded SSL verification at wdb_http

### DIFF
--- a/framework/wazuh/core/wdb_http.py
+++ b/framework/wazuh/core/wdb_http.py
@@ -83,7 +83,7 @@ class WazuhDBHTTPClient:
         self.socket_path = f'{common.WDB_HTTP_SOCKET}.sock'
 
         try:
-            transport = AsyncHTTPTransport(uds=self.socket_path, retries=retries)
+            transport = AsyncHTTPTransport(uds=self.socket_path, retries=retries, verify=False)
             self._client = AsyncClient(transport=transport, timeout=Timeout(timeout))
 
         except (OSError, TimeoutException) as e:


### PR DESCRIPTION
## Description

Closes #31715 

This PR aims to reduce wazuh-clusterd read operations at workers by removing unnecessary SSL verification and related certificates loading procedure during the connection with `wazuh-db` socket and its HTTP endpoints.

## Proposed Changes

- Set `verify=False` at httpx `AsyncHTTPTransport` method to avoid certificate load

### Results and Evidence

```
root@wazuh-dev:~/repos/wazuh# strace -e read -p 382709 -y -tt
strace: Process 382709 attached
12:46:14.771058 read(17</var/ossec/queue/cluster/worker/worker-1756914374.763308-5a7059e9afb44959a7830231a0463bf2.zip>, "files_metadata.json|//@@//|x\1\315\232\373"..., 5238784) = 4175
12:46:14.771610 read(17</var/ossec/queue/cluster/worker/worker-1756914374.763308-5a7059e9afb44959a7830231a0463bf2.zip>, "", 5234688) = 0
12:46:14.774740 read(17</var/ossec/queue/cluster/worker/worker-1756914374.763308-5a7059e9afb44959a7830231a0463bf2.zip>, "", 5238784) = 0
12:46:23.816701 read(17</var/ossec/queue/cluster/worker/worker-1756914383.805801-311d6dbfa8024851b6313a6cfdf55840.zip>, "files_metadata.json|//@@//|x\1\315\232\373"..., 5238784) = 4175
12:46:23.817111 read(17</var/ossec/queue/cluster/worker/worker-1756914383.805801-311d6dbfa8024851b6313a6cfdf55840.zip>, "", 5234688) = 0
12:46:23.822177 read(17</var/ossec/queue/cluster/worker/worker-1756914383.805801-311d6dbfa8024851b6313a6cfdf55840.zip>, "", 5238784) = 0
12:46:32.855860 read(17</var/ossec/queue/cluster/worker/worker-1756914392.845743-57a3397096bd4887ac587b02824bbbc5.zip>, "files_metadata.json|//@@//|x\1\315\232\373"..., 5238784) = 4175
12:46:32.856531 read(17</var/ossec/queue/cluster/worker/worker-1756914392.845743-57a3397096bd4887ac587b02824bbbc5.zip>, "", 5234688) = 0
12:46:32.861529 read(17</var/ossec/queue/cluster/worker/worker-1756914392.845743-57a3397096bd4887ac587b02824bbbc5.zip>, "", 5238784) = 0
12:46:41.911462 read(17</var/ossec/queue/cluster/worker/worker-1756914401.900716-1f4941a8923d4effbbb01ae1720e80e9.zip>, "files_metadata.json|//@@//|x\1\315\232\373"..., 5238784) = 4175
12:46:41.911703 read(17</var/ossec/queue/cluster/worker/worker-1756914401.900716-1f4941a8923d4effbbb01ae1720e80e9.zip>, "", 5234688) = 0
12:46:41.915812 read(17</var/ossec/queue/cluster/worker/worker-1756914401.900716-1f4941a8923d4effbbb01ae1720e80e9.zip>, "", 5238784) = 0
12:46:50.977620 read(17</var/ossec/queue/cluster/worker/worker-1756914410.958936-2bd08ae01cae42e8afdd2650edb467c9.zip>, "files_metadata.json|//@@//|x\1\315\232\373"..., 5238784) = 4175
12:46:50.978221 read(17</var/ossec/queue/cluster/worker/worker-1756914410.958936-2bd08ae01cae42e8afdd2650edb467c9.zip>, "", 5234688) = 0
12:46:50.984724 read(17</var/ossec/queue/cluster/worker/worker-1756914410.958936-2bd08ae01cae42e8afdd2650edb467c9.zip>, "", 5238784) = 0
12:47:00.213112 read(17</var/ossec/queue/cluster/worker/worker-1756914420.198443-a4f31bd34265442298a4ebeb4c5a3f75.zip>, "files_metadata.json|//@@//|x\1\315\232\373"..., 5238784) = 4175
12:47:00.213370 read(17</var/ossec/queue/cluster/worker/worker-1756914420.198443-a4f31bd34265442298a4ebeb4c5a3f75.zip>, "", 5234688) = 0
12:47:00.216350 read(17</var/ossec/queue/cluster/worker/worker-1756914420.198443-a4f31bd34265442298a4ebeb4c5a3f75.zip>, "", 5238784) = 0
```

```
025/09/03 12:46:14 INFO: [Worker worker] [Integrity check] Starting.
2025/09/03 12:46:14 INFO: [Worker worker] [Integrity check] Finished in 0.030s. Sync not required.
2025/09/03 12:46:14 INFO: [Worker worker] [Agent-info sync] Starting.
2025/09/03 12:46:14 INFO: [Worker worker] [Agent-info sync] No synchronization required, skipping.
2025/09/03 12:46:16 INFO: [Worker worker] [Agent-groups recv] Starting.
2025/09/03 12:46:16 INFO: [Worker worker] [Agent-groups recv] Finished in 0.011s. Updated 1 chunks.
2025/09/03 12:46:23 INFO: [Worker worker] [Integrity check] Starting.
2025/09/03 12:46:23 INFO: [Worker worker] [Integrity check] Finished in 0.042s. Sync not required.
2025/09/03 12:46:24 INFO: [Worker worker] [Agent-info sync] Starting.
2025/09/03 12:46:24 INFO: [Worker worker] [Agent-info sync] No synchronization required, skipping.
2025/09/03 12:46:26 INFO: [Worker worker] [Agent-groups recv] Starting.
2025/09/03 12:46:26 INFO: [Worker worker] [Agent-groups recv] Finished in 0.006s. Updated 1 chunks.
2025/09/03 12:46:32 INFO: [Worker worker] [Integrity check] Starting.
2025/09/03 12:46:32 INFO: [Worker worker] [Integrity check] Finished in 0.037s. Sync not required.
2025/09/03 12:46:34 INFO: [Worker worker] [Agent-info sync] Starting.
2025/09/03 12:46:34 INFO: [Worker worker] [Agent-info sync] No synchronization required, skipping.
2025/09/03 12:46:36 INFO: [Worker worker] [Agent-groups recv] Starting.
2025/09/03 12:46:36 INFO: [Worker worker] [Agent-groups recv] Finished in 0.009s. Updated 1 chunks.
2025/09/03 12:46:41 INFO: [Worker worker] [Integrity check] Starting.
2025/09/03 12:46:41 INFO: [Worker worker] [Integrity check] Finished in 0.035s. Sync not required.
2025/09/03 12:46:44 INFO: [Worker worker] [Keep Alive] Successful response from master: keepalive
2025/09/03 12:46:44 INFO: [Worker worker] [Agent-info sync] Starting.
2025/09/03 12:46:44 INFO: [Worker worker] [Agent-info sync] No synchronization required, skipping.
2025/09/03 12:46:46 INFO: [Worker worker] [Agent-groups recv] Starting.
2025/09/03 12:46:46 INFO: [Worker worker] [Agent-groups recv] Finished in 0.009s. Updated 1 chunks.
2025/09/03 12:46:50 INFO: [Worker worker] [Integrity check] Starting.
2025/09/03 12:46:50 INFO: [Worker worker] [Integrity check] Finished in 0.063s. Sync not required.
2025/09/03 12:46:54 INFO: [Worker worker] [Agent-info sync] Starting.
2025/09/03 12:46:55 INFO: [Worker worker] [Agent-info sync] No synchronization required, skipping.
2025/09/03 12:46:56 INFO: [Worker worker] [Agent-groups recv] Starting.
2025/09/03 12:46:56 INFO: [Worker worker] [Agent-groups recv] Finished in 0.006s. Updated 1 chunks.
```

Several `[Agent-info sync] Starting.` happened without certs load and related read ops

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected
N/A
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

N/A

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

N/A
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
