### PR TITLE
New option to toggle Global Queries component activation. 

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -442,7 +442,7 @@ vulnerability-detection.disable_scan_manager=1
 # Global queries - Enable or disable processing of incoming events.
 # 0. Enabled
 # 1. Disabled
-global-queries.enabled=1
+global-queries.disabled=0
 
 # Debug options.
 # Debug 0 -> no debug

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -439,6 +439,11 @@ vulnerability-detection.remediation_lru_size=2048
 # 1. Disabled
 vulnerability-detection.disable_scan_manager=1
 
+# Global queries - Enable or disable processing of incoming events.
+# 0. Enabled
+# 1. Disabled
+global-queries.enabled=1
+
 # Debug options.
 # Debug 0 -> no debug
 # Debug 1 -> first level of debug

--- a/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.cpp
+++ b/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.cpp
@@ -298,7 +298,7 @@ void InventoryHarvesterFacade::start(
 
         auto& policyManagerInstance = PolicyHarvesterManager::instance();
         policyManagerInstance.initialize(configuration);
-        if (!policyManagerInstance.isGlobalQueriesEnabled())
+        if (policyManagerInstance.isGlobalQueriesDisabled())
         {
             logInfo(LOGGER_DEFAULT_TAG, "Global queries are disabled. Exiting Inventory Harvester module.");
             return;

--- a/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.cpp
+++ b/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.cpp
@@ -296,7 +296,13 @@ void InventoryHarvesterFacade::start(
         // Initialize logging
         Log::assignLogFunction(logFunction);
 
-        PolicyHarvesterManager::instance().initialize(configuration);
+        auto& policyManagerInstance = PolicyHarvesterManager::instance();
+        policyManagerInstance.initialize(configuration);
+        if (!policyManagerInstance.isGlobalQueriesEnabled())
+        {
+            logInfo(LOGGER_DEFAULT_TAG, "Global queries are disabled. Exiting Inventory Harvester module.");
+            return;
+        }
 
         // Initialize all event dispatchers.
         m_eventFimInventoryDispatcher = std::make_shared<EventDispatcher>(FIM_EVENTS_QUEUE_PATH, EVENTS_BULK_SIZE);

--- a/src/wazuh_modules/inventory_harvester/src/policyHarvesterManager.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/policyHarvesterManager.hpp
@@ -20,7 +20,7 @@
 
 constexpr auto UNKNOWN_VALUE {" "};
 constexpr auto STATES_INDEX_NAME_PREFIX {"wazuh-states-"};
-constexpr auto GLOBAL_QUERIES_ENABLED {1};
+constexpr auto GLOBAL_QUERIES_DISABLED {1};
 
 enum class InventoryType : std::uint8_t
 {
@@ -128,9 +128,9 @@ private:
             newPolicy["clusterEnabled"] = false;
         }
 
-        if (!newPolicy.contains("enabled"))
+        if (!newPolicy.contains("disabled"))
         {
-            newPolicy["enabled"] = true;
+            newPolicy["disabled"] = false;
         }
 
         return newPolicy;
@@ -252,9 +252,9 @@ public:
      *
      * @return true if enabled or false if not.
      */
-    bool isGlobalQueriesEnabled() const
+    bool isGlobalQueriesDisabled() const
     {
-        return m_configuration.at("enabled").get<int32_t>() == GLOBAL_QUERIES_ENABLED;
+        return m_configuration.at("disabled").get<int32_t>() == GLOBAL_QUERIES_DISABLED;
     }
 
     /**

--- a/src/wazuh_modules/inventory_harvester/src/policyHarvesterManager.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/policyHarvesterManager.hpp
@@ -20,6 +20,7 @@
 
 constexpr auto UNKNOWN_VALUE {" "};
 constexpr auto STATES_INDEX_NAME_PREFIX {"wazuh-states-"};
+constexpr auto GLOBAL_QUERIES_ENABLED {1};
 
 enum class InventoryType : std::uint8_t
 {
@@ -125,6 +126,11 @@ private:
         if (!newPolicy.contains("clusterEnabled"))
         {
             newPolicy["clusterEnabled"] = false;
+        }
+
+        if (!newPolicy.contains("enabled"))
+        {
+            newPolicy["enabled"] = true;
         }
 
         return newPolicy;
@@ -239,6 +245,16 @@ public:
     bool isIndexerEnabled() const
     {
         return Utils::parseStrToBool(m_configuration.at("indexer").at("enabled"));
+    }
+
+    /**
+     * @brief Get Global Queries status.
+     *
+     * @return true if enabled or false if not.
+     */
+    bool isGlobalQueriesEnabled() const
+    {
+        return m_configuration.at("enabled").get<int32_t>() == GLOBAL_QUERIES_ENABLED;
     }
 
     /**

--- a/src/wazuh_modules/inventory_harvester/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/policyManager_test.cpp
@@ -26,25 +26,25 @@ protected:
 TEST_F(PolicyHarvesterManagerTest, ModuleEnabled)
 {
     nlohmann::json configJson = nlohmann::json::parse(R"({
-        "enabled": true,
+        "disabled": false,
         "clusterName": "clusterName",
         "clusterEnabled": false
     })");
 
     m_policyHarvesterManager->initialize(configJson);
-    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesEnabled(), true);
+    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesDisabled(), false);
 }
 
 TEST_F(PolicyHarvesterManagerTest, ModuleDisabled)
 {
     nlohmann::json configJson = nlohmann::json::parse(R"({
-        "enabled": false,
+        "disabled": true,
         "clusterName": "clusterName",
         "clusterEnabled": false
     })");
 
     m_policyHarvesterManager->initialize(configJson);
-    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesEnabled(), false);
+    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesDisabled(), true);
 }
 
 TEST_F(PolicyHarvesterManagerTest, EnabledOptionNotFound)
@@ -55,5 +55,5 @@ TEST_F(PolicyHarvesterManagerTest, EnabledOptionNotFound)
     })");
 
     m_policyHarvesterManager->initialize(configJson);
-    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesEnabled(), true);
+    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesDisabled(), false);
 }

--- a/src/wazuh_modules/inventory_harvester/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/policyManager_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * Wazuh inventory harvester
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 3, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "policyHarvesterManager.hpp"
+#include "gtest/gtest.h"
+
+class PolicyHarvesterManagerTest : public ::testing::Test
+{
+protected:
+    PolicyHarvesterManagerTest() = default;
+    // LCOV_EXCL_START
+    ~PolicyHarvesterManagerTest() override = default;
+    // LCOV_EXCL_STOP
+
+    std::unique_ptr<PolicyHarvesterManager> m_policyHarvesterManager = std::make_unique<PolicyHarvesterManager>();
+};
+
+TEST_F(PolicyHarvesterManagerTest, ModuleEnabled)
+{
+    nlohmann::json configJson = nlohmann::json::parse(R"({
+        "enabled": true,
+        "clusterName": "clusterName",
+        "clusterEnabled": false
+    })");
+
+    m_policyHarvesterManager->initialize(configJson);
+    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesEnabled(), true);
+}
+
+TEST_F(PolicyHarvesterManagerTest, ModuleDisabled)
+{
+    nlohmann::json configJson = nlohmann::json::parse(R"({
+        "enabled": false,
+        "clusterName": "clusterName",
+        "clusterEnabled": false
+    })");
+
+    m_policyHarvesterManager->initialize(configJson);
+    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesEnabled(), false);
+}
+
+TEST_F(PolicyHarvesterManagerTest, EnabledOptionNotFound)
+{
+    nlohmann::json configJson = nlohmann::json::parse(R"({
+        "clusterName": "clusterName",
+        "clusterEnabled": false
+    })");
+
+    m_policyHarvesterManager->initialize(configJson);
+    EXPECT_EQ(m_policyHarvesterManager->isGlobalQueriesEnabled(), true);
+}

--- a/src/wazuh_modules/wm_harvester.c
+++ b/src/wazuh_modules/wm_harvester.c
@@ -104,6 +104,11 @@ void* wm_inventory_harvester_main(__attribute__((unused))wm_inventory_harvester_
                 cJSON_AddStringToObject(config_json, "clusterNodeName", "undefined");
             }
 
+            // Add enabled option
+            cJSON_AddNumberToObject(config_json,
+                                    "enabled",
+                                    getDefine_Int("global-queries", "enabled", 0, 1));
+
             wm_inventory_harvester_log_config(config_json);
             inventory_harvester_start_ptr(mtLoggingFunctionsWrapper, config_json);
             cJSON_Delete(config_json);

--- a/src/wazuh_modules/wm_harvester.c
+++ b/src/wazuh_modules/wm_harvester.c
@@ -104,10 +104,10 @@ void* wm_inventory_harvester_main(__attribute__((unused))wm_inventory_harvester_
                 cJSON_AddStringToObject(config_json, "clusterNodeName", "undefined");
             }
 
-            // Add enabled option
+            // Add disabled option
             cJSON_AddNumberToObject(config_json,
-                                    "enabled",
-                                    getDefine_Int("global-queries", "enabled", 0, 1));
+                                    "disabled",
+                                    getDefine_Int("global-queries", "disabled", 0, 1));
 
             wm_inventory_harvester_log_config(config_json);
             inventory_harvester_start_ptr(mtLoggingFunctionsWrapper, config_json);


### PR DESCRIPTION
## Description

Closes # 31708

## Proposed Changes

Added option to disable Inventory Harvester processing, no cleanup is performed during reactivation. 

### Manual tests with their corresponding evidence

https://github.com/wazuh/wazuh/issues/31708#issuecomment-3249559714

### Configuration Changes

New internal option 

```console
global-queries.disabled=0
```

