### PR TITLE
Wazuh running SCA checks while Macbook disk is still encrypted

### DIFF
--- a/ruleset/sca/darwin/21/cis_apple_macOS_12.0.yml
+++ b/ruleset/sca/darwin/21/cis_apple_macOS_12.0.yml
@@ -20,11 +20,10 @@ policy:
 requirements:
   title: "Check macOS version."
   description: "Requirements for running the SCA scan against macOS 12.x (Monterey)."
-  condition: any
+  condition: all
   rules:
     - 'c:sw_vers -> r:^ProductVersion:\t*\s*12\p'
-    - 'c:system_profiler SPSoftwareDataType -> r:System Version:\.*12\p'
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\t*\s*12\p'
+    - 'c:bash -c "ioreg -rd1 -c IOPMrootDomain | grep -q ''\"IOPMUserIsActive\" = Yes'' && echo awake || echo asleep" -> r:^awake$'
 
 checks:
   ############################################################

--- a/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
+++ b/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
@@ -19,11 +19,10 @@ policy:
 requirements:
   title: "Check MacOS 13 Ventura platform."
   description: "Requirements for running the policy against MacOS 13 Ventura."
-  condition: any
+  condition: all
   rules:
     - 'c:sw_vers -> r:^ProductVersion:\t*\s*13\p'
-    - 'c:system_profiler SPSoftwareDataType -> r:System Version:.*13\p'
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*13\p'
+    - 'c:bash -c "ioreg -rd1 -c IOPMrootDomain | grep -q ''\"IOPMUserIsActive\" = Yes'' && echo awake || echo asleep" -> r:^awake$'
 
 checks:
   ##########################################################################

--- a/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
+++ b/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
@@ -19,11 +19,10 @@ policy:
 requirements:
   title: "Check MacOS 14 Sonoma platform."
   description: "Requirements for running the policy against MacOS 14 Sonoma."
-  condition: any
+  condition: all
   rules:
     - 'c:sw_vers -> r:^ProductVersion:\t*\s*14\p'
-    - 'c:system_profiler SPSoftwareDataType -> r:System Version:.*14\p'
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*14\p'
+    - 'c:bash -c "ioreg -rd1 -c IOPMrootDomain | grep -q ''\"IOPMUserIsActive\" = Yes'' && echo awake || echo asleep" -> r:^awake$'
 
 checks:
   # 1.1 Ensure All Apple-provided Software Is Current. (Automated) - Not Implemented

--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -19,11 +19,10 @@ policy:
 requirements:
   title: "Check MacOS 15 Sequoia platform."
   description: "Requirements for running the policy against MacOS 15 Sequoia."
-  condition: any
+  condition: all
   rules:
     - 'c:sw_vers -> r:^ProductVersion:\t*\s*15\p'
-    - 'c:system_profiler SPSoftwareDataType -> r:System Version:.*15\p'
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*15\p'
+    - 'c:bash -c "ioreg -rd1 -c IOPMrootDomain | grep -q ''\"IOPMUserIsActive\" = Yes'' && echo awake || echo asleep" -> r:^awake$'
 
 checks:
   ##########################################################################


### PR DESCRIPTION
A community user reported the below:

> Wazuh manager 4.12.0, Agents: 4.12.0, Component SCA, Manager on Debian 12, Agents on MacOs 15.5

> We have Wazuh running as minimal as possible, making only a custom SCA file run every day to check if the macbooks are compliant to our security standards. And it works wonders, except we have FileVault enabled on our macbooks, and SCA sometimes runs when the macbook is in sleep / hibernation, and some random checks fail (different every time). if the user logs in > and restarts the wazuh agent, the SCA runs on start, and gets a score of 100. 
> How can we suppress wazuh SCA running when the disk is encrypted?

This PR aims to fix the issue for **macOS 12 (Monterey) → 15 (Sequoia):**