### PR TITLE
Helper function: delete fields by value in 6.0.0

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -9311,6 +9311,44 @@ normalize:
 
 *The operation was successful*
 
+### Example 9
+
+No deletions when argument is null but target has no nulls
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value(null)
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": "keep",
+    "b": 1,
+    "c": false
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "a": "keep",
+    "b": 1,
+    "c": false
+  }
+}
+```
+
+*The operation was successful*
+
 
 
 ---

--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -82,6 +82,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [array_append_unique](#array_append_unique)
 - [array_append_unique_any](#array_append_unique_any)
 - [delete](#delete)
+- [delete_fields_with_value](#delete_fields_with_value)
 - [erase_custom_fields](#erase_custom_fields)
 - [get_key_in](#get_key_in)
 - [kvdb_decode_bitmask](#kvdb_decode_bitmask)
@@ -8958,6 +8959,353 @@ normalize:
 ```json
 {
   "target_field": ""
+}
+```
+
+*The operation was successful*
+
+
+
+---
+# delete_fields_with_value
+
+## Signature
+
+```
+
+field: delete_fields_with_value(any_object)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| any_object | number, string, object, boolean, array | value or reference | Any object |
+
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| object | Any object |
+
+
+## Description
+
+Deletes all immediate children of “field” whose value equals the provided argument.
+The argument may be any JSON value (string, number, boolean, null, array, object) or a reference ($ref).
+Equality is type-aware and structural (objects/arrays compared by value).
+
+
+## Keywords
+
+- `delete` 
+
+## Examples
+
+### Example 1
+
+Deletes children equal to the given string
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value('N/A')
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": "N/A",
+    "b": "ok",
+    "c": "N/A"
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "b": "ok"
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 2
+
+Deletes children equal to integer 1
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value(1)
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": 1,
+    "b": 2,
+    "c": 1
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "b": 2
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 3
+
+Deletes children equal to the given double
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value(1.0)
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": 1.0,
+    "b": 2.0,
+    "c": 1.0
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "b": 2.0
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 4
+
+Deletes children equal to the given boolean
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value(True)
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": true,
+    "b": false,
+    "c": true
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "b": false
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 5
+
+Deletes children equal to the given object
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value({'k': 1})
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": {
+      "k": 1
+    },
+    "b": {
+      "k": 2
+    },
+    "c": {
+      "k": 1
+    }
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "b": {
+      "k": 2
+    }
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 6
+
+Deletes children equal to the given array
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value([1, 2])
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": [
+      1,
+      2
+    ],
+    "b": [
+      3
+    ],
+    "c": [
+      1,
+      2
+    ]
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "b": [
+      3
+    ]
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 7
+
+No deletions when there are no matches
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value('Z')
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": {
+    "a": "foo",
+    "b": 2
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "target_field": {
+    "a": "foo",
+    "b": 2
+  }
+}
+```
+
+*The operation was successful*
+
+### Example 8
+
+No deletions when reference path is not found
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: delete_fields_with_value($any_object)
+```
+
+#### Input Event
+
+```json
+{
+  "any_object": "$target.missing",
+  "target_field": {
+    "a": "keep",
+    "b": 1
+  }
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "any_object": "$target.missing",
+  "target_field": {
+    "a": "keep",
+    "b": 1
+  }
 }
 ```
 

--- a/src/engine/source/base/include/base/json.hpp
+++ b/src/engine/source/base/include/base/json.hpp
@@ -421,6 +421,19 @@ public:
     std::optional<std::vector<std::string>> getFields() const;
 
     /**
+     * @brief Get a list of fields from a JSON object at the given pointer path.
+     *
+     * If the path points to an object, returns the immediate member names (non-recursive).
+     * Returns std::nullopt if the path does not exist or is not an object.
+     *
+     * @param path The JSON Pointer path. Empty string or "/" refers to the root.
+     * @return std::optional<std::vector<std::string>> The list of field names, or std::nullopt.
+     *
+     * @throws std::runtime_error If the pointer path is invalid.
+     */
+    std::optional<std::vector<std::string>> getFields(std::string_view path) const;
+
+    /**
      * @brief Get Json prettyfied string.
      *
      * @return std::string The Json prettyfied string.

--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -72,7 +72,7 @@ std::string Json::formatJsonPath(std::string_view dotPath, bool skipDot)
 
     // Some helpers may indicate that the field is root element
     // In this case the path will be defined as "."
-    if ("." == ptrPath)
+    if (!skipDot && "." == ptrPath)
     {
         ptrPath = "";
     }
@@ -113,7 +113,11 @@ std::string Json::formatJsonPath(std::string_view dotPath, bool skipDot)
         }
 
         // Add / at the beginning
-        if (ptrPath.front() != '/')
+        if (ptrPath.empty())
+        {
+            ptrPath = "/";
+        }
+        else if (ptrPath.front() != '/')
         {
             ptrPath.insert(0, "/");
         }

--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -477,6 +477,29 @@ std::optional<std::vector<std::string>> Json::getFields() const
     return retval;
 }
 
+std::optional<std::vector<std::string>> Json::getFields(std::string_view path) const
+{
+    const auto pp = rapidjson::Pointer(path.data());
+    if (!pp.IsValid())
+    {
+        throw std::runtime_error(fmt::format(INVALID_POINTER_TYPE_MSG, path));
+    }
+
+    const rapidjson::Value* val = pp.Get(m_document);
+    if (val == nullptr || !val->IsObject())
+    {
+        return std::nullopt;
+    }
+
+    std::vector<std::string> out;
+    out.reserve(val->MemberCount());
+    for (auto it = val->MemberBegin(); it != val->MemberEnd(); ++it)
+    {
+        out.emplace_back(it->name.GetString(), it->name.GetStringLength());
+    }
+    return out;
+}
+
 std::string Json::prettyStr() const
 {
     rapidjson::StringBuffer buffer;

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
@@ -181,6 +181,19 @@ TransformOp opBuilderHelperDeleteField(const Reference& targetField,
                                        const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
+ * @brief Deletes, at top level (non-recursive), the keys of the target object whose value
+ *        equals the provided argument.
+ *
+ * @param targetField target field of the helper
+ * @param opArgs Vector of operation arguments where the first argument is the value to match (literal or reference).
+ * @param buildCtx Shared pointer to the build context used for the transformation operation.
+ * @return base::Expression The lifter with the `delete_fields_with_value` transformation.
+ */
+TransformOp opBuilderHelperDeleteFieldsWithValue(const Reference& targetField,
+                                                 const std::vector<OpArg>& opArgs,
+                                                 const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
  * @brief Renames a field of the json event
  *
  * @param targetField target field of the helper

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -227,6 +227,8 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
     // Transform helpers: Event Field functions
     registry->template add<builders::OpBuilderEntry>(
         "delete", {schemf::runtimeValidation(), builders::opBuilderHelperDeleteField});
+    registry->template add<builders::OpBuilderEntry>(
+        "delete_fields_with_value", {schemf::runtimeValidation(), builders::opBuilderHelperDeleteFieldsWithValue});
     // TODO: this builders should check that the field is an array or an object
     registry->template add<builders::OpBuilderEntry>("merge",
                                                      {schemf::runtimeValidation(), builders::opBuilderHelperMerge});

--- a/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
@@ -511,7 +511,16 @@ INSTANTIATE_TEST_SUITE_P(
         HelperT(R"(test(1, {"key": "value", "key2": "value2"}))",
                 makeSuccess<HelperToken>(
                     {.name = "test", .args = {val(R"(1)"), val(R"({"key": "value", "key2": "value2"})")}}, 43)),
-        HelperT(R"(test([1]123))", makeSuccess<HelperToken>({.name = "test", .args = {val(R"("[1]123")")}}, 12))));
+        HelperT(R"(test([1]123))", makeSuccess<HelperToken>({.name = "test", .args = {val(R"("[1]123")")}}, 12)),
+        HelperT("helper(null)", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"(null)")}}, 12)),
+        HelperT("helper( null )", makeSuccess<HelperToken>({.name = "helper", .args = {val(R"(null)")}}, 14)),
+
+        HelperT("test(null)", makeSuccess<HelperToken>({.name = "test", .args = {val(R"(null)")}}, 10)),
+        HelperT("test(arg1, null)",
+                makeSuccess<HelperToken>({.name = "test", .args = {val(R"("arg1")"), val(R"(null)")}}, 16)),
+        HelperT("test(null,)", makeSuccess<HelperToken>({.name = "test", .args = {val(R"(null)"), val()}}, 11)),
+        HelperT("test(,null)", makeSuccess<HelperToken>({.name = "test", .args = {val(), val(R"(null)")}}, 11)),
+        HelperT("test(null, )", makeSuccess<HelperToken>({.name = "test", .args = {val(R"(null)"), val()}}, 12))));
 
 INSTANTIATE_TEST_SUITE_P(Builder,
                          IsDefaultHelperTest,

--- a/src/engine/source/builder/test/src/unit/builders/optransform/jsonTransform_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/optransform/jsonTransform_test.cpp
@@ -350,6 +350,41 @@ INSTANTIATE_TEST_SUITE_P(
                    {makeValue("true")},
                    SUCCESS(makeEvent(R"({"target":{"x":false}})"))),
 
+        // Deletes only the dotted key "a.b"
+        TransformT(R"({"target":{"a.b":10,"x":11}})",
+                   opBuilderHelperDeleteFieldsWithValue,
+                   "target",
+                   {makeValue("10")},
+                   SUCCESS(makeEvent(R"({"target":{"x":11}})"))),
+
+        // Deletes "a.b" but keeps nested a/b
+        TransformT(R"({"target":{"a":{"b":999},"a.b":10,"x":0}})",
+                   opBuilderHelperDeleteFieldsWithValue,
+                   "target",
+                   {makeValue("10")},
+                   SUCCESS(makeEvent(R"({"target":{"a":{"b":999},"x":0}})"))),
+
+        // Deletes the literal key "."
+        TransformT(R"({"target":{".":10,"x":11}})",
+                   opBuilderHelperDeleteFieldsWithValue,
+                   "target",
+                   {makeValue("10")},
+                   SUCCESS(makeEvent(R"({"target":{"x":11}})"))),
+
+        // Deletes the empty-string key ""
+        TransformT(R"({"target":{"":10,"x":11}})",
+                   opBuilderHelperDeleteFieldsWithValue,
+                   "target",
+                   {makeValue("10")},
+                   SUCCESS(makeEvent(R"({"target":{"x":11}})"))),
+
+        // Deletes dotted ".", and "" keys; keeps escaped names and others
+        TransformT(R"({"target":{"a.b":10,".":10,"":10,"a/b":10,"a~b":10,"keep":1}})",
+                   opBuilderHelperDeleteFieldsWithValue,
+                   "target",
+                   {makeValue("10")},
+                   SUCCESS(makeEvent(R"({"target":{"keep":1}})"))),
+
         /*** Rename Field ***/
         TransformT(R"({"ref": "value"})",
                    opBuilderHelperRenameField,

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/mark_down_generator.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/mark_down_generator.py
@@ -22,6 +22,17 @@ class MarkdownGenerator(IExporter):
                 f"field: {doc.name}({', '.join(str(v) for v in doc.arguments)}, [...])")
         self.content.append(f"```\n")
 
+    def _format_call_arg(self, v):
+        """
+        Format a single call argument for the helper invocation in Markdown.
+
+        :param v: Argument value to render (may be None, bool, number, str, list, dict).
+        :return: String representation suitable for use inside the helper call.
+        """
+        if v is None:
+            return "null"
+        return repr(v)
+
     def create_table(self, arguments: dict, headers: list):
         """
         Create a table in Markdown format.
@@ -150,19 +161,19 @@ class MarkdownGenerator(IExporter):
                             args_values.append(f"${key}")
                             event_data[key] = arg.get("value")
                         else:
-                            args_values.append(repr(arg.get("value")))
+                            args_values.append(self._format_call_arg(arg.get("value")))
                     else:
                         if arg_source == "reference":
                             args_values.append(f"${key}")
                             event_data[key] = arg
                         elif arg_source == "both":
                             if idx % 2 == 1:
-                                args_values.append(repr(arg))
+                                args_values.append(self._format_call_arg(arg))
                             else:
                                 args_values.append(f"${key}")
                                 event_data[key] = arg
                         else:
-                            args_values.append(repr(arg))
+                            args_values.append(self._format_call_arg(arg))
 
             if getattr(example, "target_field", None):
                 event_data["target_field"] = example.target_field

--- a/src/engine/test/helper_tests/helpers_description/transformation/delete_fields_with_value.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/delete_fields_with_value.yml
@@ -1,0 +1,146 @@
+name: delete_fields_with_value
+
+metadata:
+  description: |
+    Deletes all immediate children of “field” whose value equals the provided argument.
+    The argument may be any JSON value (string, number, boolean, null, array, object) or a reference ($ref).
+    Equality is type-aware and structural (objects/arrays compared by value).
+
+  keywords:
+    - delete
+
+helper_type: transformation
+
+# Single, required argument: any JSON value or a $ref(...)
+is_variadic: false
+
+# Arguments expected by the helper function
+arguments:
+  any_object:
+    type:
+      - number
+      - string
+      - object
+      - boolean
+      - array
+    source: both # Includes values or references (their names start with $)
+
+skipped:
+  - success_cases
+
+target_field:
+  type: object
+  generate: object
+
+test:
+  # string by value
+  - arguments:
+      any_object:
+        source: value
+        value: "N/A"
+    target_field:
+      a: "N/A"
+      b: "ok"
+      c: "N/A"
+    should_pass: true
+    expected:
+      b: "ok"
+    description: Deletes children equal to the given string
+
+  # integer by value
+  - arguments:
+      any_object:
+        source: value
+        value: 1
+    target_field:
+      a: 1
+      b: 2
+      c: 1
+    should_pass: true
+    expected:
+      b: 2
+    description: Deletes children equal to integer 1
+
+  # double by value
+  - arguments:
+      any_object:
+        source: value
+        value: 1.0
+    target_field:
+      a: 1.0
+      b: 2.0
+      c: 1.0
+    should_pass: true
+    expected:
+      b: 2.0
+    description: Deletes children equal to the given double
+
+  # boolean by value (true)
+  - arguments:
+      any_object:
+        source: value
+        value: true
+    target_field:
+      a: true
+      b: false
+      c: true
+    should_pass: true
+    expected:
+      b: false
+    description: Deletes children equal to the given boolean
+
+  # object by value (structural equality)
+  - arguments:
+      any_object:
+        source: value
+        value: { k: 1 }
+    target_field:
+      a: { k: 1 }
+      b: { k: 2 }
+      c: { k: 1 }
+    should_pass: true
+    expected:
+      b: { k: 2 }
+    description: Deletes children equal to the given object
+
+  # array by value (structural equality)
+  - arguments:
+      any_object:
+        source: value
+        value: [1, 2]
+    target_field:
+      a: [1, 2]
+      b: [3]
+      c: [1, 2]
+    should_pass: true
+    expected:
+      b: [3]
+    description: Deletes children equal to the given array
+
+  # no-op (no matches)
+  - arguments:
+      any_object:
+        source: value
+        value: "Z"
+    target_field:
+      a: "foo"
+      b: 2
+    should_pass: true
+    expected:
+      a: "foo"
+      b: 2
+    description: No deletions when there are no matches
+
+  # missing reference (no-op; operation should not fail)
+  - arguments:
+      any_object:
+        source: reference
+        value: $target.missing
+    target_field:
+      a: "keep"
+      b: 1
+    should_pass: true
+    expected:
+      a: "keep"
+      b: 1
+    description: No deletions when reference path is not found

--- a/src/engine/test/helper_tests/helpers_description/transformation/delete_fields_with_value.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/delete_fields_with_value.yml
@@ -144,3 +144,19 @@ test:
       a: "keep"
       b: 1
     description: No deletions when reference path is not found
+
+  # null by value (no matches)
+  - arguments:
+      any_object:
+        source: value
+        value: null
+    target_field:
+      a: "keep"
+      b: 1
+      c: false
+    should_pass: true
+    expected:
+      a: "keep"
+      b: 1
+      c: false
+    description: No deletions when argument is null but target has no nulls


### PR DESCRIPTION
## Description


This PR introduces the `delete_fields_with_value(value)` helper for the Wazuh engine. The helper accepts any JSON value (string, number, boolean, null, array, or object) or a reference and transforms `target_field` by removing all immediate child fields at that level whose values are equal to the provided argument. The PR includes the full surface required for adoption: implementation, documentation, examples, and integration/unit tests.

In addition to the core feature, the PR includes the following improvements:

- **Targeted field extraction:** a new `getFields` variant that accepts the path of the target object to extract fields from. This avoids copying the entire JSON subtree for the target path before collecting fields, reducing overhead.
- **Helper parser enhancement:** support passing `null` as an explicit argument. Previously, a single `null` argument was cleared during parsing, making it impossible to use an intentional `null`. The parser now preserves `null` correctly.
- **Documentation generator fix:** when producing Markdown from YAML with `engine-helper-test generate-doc`, render Python `None` as JSON `null` in helper call examples, ensuring consistent and correct documentation output.


## Proposed Changes

- **Features added**
  - Implemented `delete_fields_with_value(value)` helper:
    - Accepts any JSON value (string, number, boolean, null, array, or object) or a reference.
    - Removes immediate children of `target_field` whose values equal the provided argument (type-aware, including `null`).
    - Added examples and end-to-end tests to validate behavior with strings, numbers, booleans, arrays/objects, and `null`.
  - Introduced an optimized `getFields` variant that accepts the target path to enumerate fields in-place, avoiding copying the entire JSON subtree.
  - Generated and updated documentation for the new helper, including autogenerated Markdown examples from YAML specs.

- **Bugs fixed**
  - **Helper parser**: preserve an explicit `null` as a valid single argument and support zero-argument helpers without altering historical error indices. Added unit tests (e.g., `helper(null)`, spacing variants) to cover the new behavior.
  - **Docs generator**: map Python `None` to JSON `null` in helper call examples generated by `engine-helper-test generate-doc`, ensuring consistent and correct output.

### Results and Evidence

**Unit tests (helper behavior)**  
Representative coverage verifies that `delete_fields_with_value(value)`:
- Removes matching immediate children of `target_field` when the argument is provided **by value** or **by reference**.
- Works across all JSON types: **string**, **number** (int/double), **boolean**, **null**, **object**, and **array** (object/array equality by reference).
- Handles snapshot references that point to a child of the same target object.
- Produces **no-op** when no children match.
- Fails when `target_field` is **missing** or **not an object** (string, number, double, boolean, array, null).
- Respects allowed-fields checks (negative path covered).

Builder (transform builder):
```bash
./builder_utest --gtest_filter="*TransformBuilderTest.Builds/JsonTransform*"
```
```
[==========] 28 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 28 tests.
```

Operation (transform operation):
```bash
 ./builder_utest --gtest_filter="*TransformOperationTest.Operates/JsonTransform*"
```
```
[==========] 71 tests from 1 test suite ran. (51 ms total)
[  PASSED  ] 71 tests.
```


**Unit tests (helper parser)**
- Preserves an explicit `null` as a valid argument (e.g., `helper(null)`, spacing variants).
- Supports zero-argument helpers without altering historical error indices (e.g., legacy index 11 cases remain stable).

Parser (helpers):
```bash
./builder_utest --gtest_filter="*Builder/Parse*"
```
```
[==========] 347 tests from 10 test suites ran. (42 ms total)
[  PASSED  ] 347 tests.
```

**Integration (engine-helper-test)**:

```bash
engine-helper-test -e /tmp/environment run --input-file /tmp/helper_tests/delete_fields_with_value.yml --show-failure
```
```
- Total test cases executed: 659
- Successful test cases: 659
- Failed test cases: 0
```

Documentation build (mdBook):
```
[INFO] Book building has started
[INFO] Running the html backend
[INFO] Serving on: http://0.0.0.0:3000
[INFO] Watching for changes...
```

<img width="736" height="857" alt="image" src="https://github.com/user-attachments/assets/ff79b0cd-06ee-4a24-a1cb-0e7993295153" />

<img width="721" height="669" alt="image" src="https://github.com/user-attachments/assets/0ff0803a-c851-4fc3-823f-9db26e16a95a" />

**Documentation rendering fix (evidence):** helper call examples now render Python `None` as JSON `null`. For instance:
```
Before: delete_fields_with_value(None)
After:  delete_fields_with_value(null)
```

### Manual tests with their corresponding evidence

**Workflow: Engine Health Test** -> run: 17684963871

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux *(local build and execution of unit/integration tests succeeded)*
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [x] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.


### Artifacts Affected

- **Engine helper functionality** within the Wazuh v5.x engine (transformation helpers). No new executables introduced.
- **Documentation**: autogenerated reference content for `delete_fields_with_value` (mdBook pages updated).

### Configuration Changes

- N/A (no new configuration parameters or default changes).

### Tests Introduced

- **Unit tests** for `delete_fields_with_value` covering argument validation, value vs. reference inputs, and behavior across JSON types (string, number, boolean, null, object, array), plus negative paths (missing/non-object targets, allowed-fields checks).
- **Parser tests** to preserve explicit `null` arguments and maintain legacy error indices; spacing variants included.
- **Integration tests** via `engine-helper-test` with YAML specifications for end-to-end validation and documentation examples.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented *(N/A)*
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

