### PR TITLE
Add the documentation for persistence of FIM differences

### DIFF
--- a/architecture/FIM/db/sequence_diagram.puml
+++ b/architecture/FIM/db/sequence_diagram.puml
@@ -3,18 +3,17 @@
 ' This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 @startuml sequence_diagram_db_fim
-database "<agent-id>.db" as agent.db
+database "Indexer" as indexer
 actor "wazuh-manager" as manager
 actor "wazuh-agent" as fim
 participant os as os
 participant dbsync
+participant "agent_sync_protocol" as asp
 database fim.db as fdb
 
 activate fim
 
-fim -> dbsync ++: reset DB
-dbsync -> fdb -- : reset
-
+note over asp: Agent Sync Protocol\nhandles persistence of\ndifferences for later\nsynchronization
 
 loop scan (each ""frequency"" seconds)
     group for each [directory]
@@ -23,12 +22,26 @@ loop scan (each ""frequency"" seconds)
         fim -> dbsync++ : update DB with new file data
         dbsync -> fdb : save data DB
         dbsync <-- fdb
-        fim <-- dbsync
+        fim <-- dbsync --: comparison result
+
+        alt if differences detected
+            fim -> asp ++: asp_persist_diff(id, operation, index, data)
+            note right: Persist file/registry differences\nfor synchronization
+            asp --> fim --: persisted
+        end
+
         manager <- fim ++: send fim event
-        manager --> fim
+        manager --> fim --
      end group
-        dbsync--
 end loop
-        agent.db <- manager++: update db
-        agent.db --> manager --
+
+group periodic synchronization
+    fim -> asp ++: asp_sync_module(handle, MODE_DELTA, timeout, retries, max_eps)
+    asp -> manager ++: sync_process
+    asp <-- manager --: result sync_process
+    asp --> fim --: sync complete
+end
+
+indexer <- manager++: Upsert/Delete
+indexer --> manager --
 @enduml

--- a/docs/ref/modules/fim/README.md
+++ b/docs/ref/modules/fim/README.md
@@ -1,0 +1,7 @@
+# Introduction
+
+The **FIM (File Integrity Monitoring)** module has been enhanced with a reliable synchronization mechanism that ensures file and registry changes are persisted and synchronized with the manager even during network interruptions or agent restarts.
+
+The module implements a **dual event system** that provides both real-time alerts and reliable state synchronization. It leverages the **Agent Sync Protocol** to persist differences in a local SQLite database and synchronizes them periodically with the manager through a session-based protocol.
+
+FIM persistence supports **stateful synchronization** for complete file/registry metadata including checksums, while maintaining **stateless real-time alerts** for immediate threat detection.

--- a/docs/ref/modules/fim/api-reference.md
+++ b/docs/ref/modules/fim/api-reference.md
@@ -1,0 +1,234 @@
+# API Reference
+
+The FIM module integrates with the Agent Sync Protocol through the C interface exposed by the `agent_sync_protocol` module.
+
+---
+
+## Agent Sync Protocol C Interface
+
+FIM uses the sync protocol C interface defined in `agent_sync_protocol_c_interface.h` provided by the `agent_sync_protocol` module.
+
+### Core Functions
+
+#### `asp_create()`
+
+Creates and initializes an Agent Sync Protocol handle for FIM.
+
+**Signature:**
+```c
+AgentSyncProtocolHandle* asp_create(const char* module,
+                                   const char* db_path,
+                                   const MQ_Functions* mq_funcs,
+                                   asp_logger_t logger);
+```
+
+**Parameters:**
+- `module`: Module name (`"fim"`)
+- `db_path`: Path to sync protocol database (`FIM_SYNC_PROTOCOL_DB_PATH`)
+- `mq_funcs`: Message queue function pointers
+- `logger`: Logging callback function
+
+**Usage Example:**
+```c
+// FIM initializes sync protocol handle during startup
+MQ_Functions mq_funcs = {
+    .start = fim_startmq,
+    .send_binary = fim_send_binary_msg
+};
+
+AgentSyncProtocolHandle* sync_handle = asp_create("fim",
+                                                  FIM_SYNC_PROTOCOL_DB_PATH,
+                                                  &mq_funcs,
+                                                  loggingFunction);
+```
+
+#### `asp_persist_diff()`
+
+Persists a file or registry difference for later synchronization.
+
+**Signature:**
+```c
+void asp_persist_diff(AgentSyncProtocolHandle* handle,
+                      const char* id,
+                      Operation_t operation,
+                      const char* index,
+                      const char* data);
+```
+
+**Parameters:**
+- `handle`: Sync protocol handle from `asp_create()`
+- `id`: Unique identifier (SHA1 hash of file path)
+- `operation`: Operation type (`OPERATION_CREATE`, `OPERATION_UPDATE`, `OPERATION_DELETE`)
+- `index`: Sync index name
+- `data`: JSON string containing file/registry data
+
+**Usage Example:**
+```c
+void persist_syscheck_msg(const char *id, Operation_t operation,
+                         const char *index, const cJSON* msg) {
+    if (syscheck.enable_synchronization) {
+        char* json_msg = cJSON_PrintUnformatted(msg);
+        asp_persist_diff(syscheck.sync_handle, id, operation, index, json_msg);
+        os_free(json_msg);
+    }
+}
+
+// Example calls for different operations:
+persist_syscheck_msg(file_hash, OPERATION_CREATE, FIM_FILES_SYNC_INDEX, file_json);
+persist_syscheck_msg(file_hash, OPERATION_UPDATE, FIM_FILES_SYNC_INDEX, file_json);
+persist_syscheck_msg(file_hash, OPERATION_DELETE, FIM_FILES_SYNC_INDEX, file_json);
+```
+
+#### `asp_sync_module()`
+
+Triggers synchronization of all pending differences.
+
+**Signature:**
+```c
+bool asp_sync_module(AgentSyncProtocolHandle* handle,
+                     Mode_t mode,
+                     unsigned int sync_timeout,
+                     unsigned int sync_retries,
+                     size_t max_eps);
+```
+
+**Parameters:**
+- `handle`: Sync protocol handle
+- `mode`: Sync mode (`MODE_DELTA` for FIM)
+- `sync_timeout`: Response timeout in seconds
+- `sync_retries`: Maximum retry attempts
+- `max_eps`: Maximum events per second (0 = unlimited)
+
+**Usage Example:**
+```c
+// FIM integrity thread triggers periodic synchronization
+bool sync_success = asp_sync_module(syscheck.sync_handle,
+                                   MODE_DELTA,                    // sync mode
+                                   syscheck.sync_response_timeout, // timeout
+                                   FIM_SYNC_RETRIES,              // retries
+                                   syscheck.sync_max_eps);        // max events/sec
+```
+
+#### `asp_parse_response_buffer()`
+
+Processes FlatBuffer responses from the manager.
+
+**Signature:**
+```c
+bool asp_parse_response_buffer(AgentSyncProtocolHandle* handle,
+                               const uint8_t* data,
+                               size_t length);
+```
+
+**Parameters:**
+- `handle`: Sync protocol handle
+- `data`: Pointer to FlatBuffer-encoded message
+- `length`: Size of message in bytes
+
+**Usage Example:**
+```c
+// Process FlatBuffer responses from manager
+bool success = asp_parse_response_buffer(syscheck.sync_handle,
+                                        response_data,
+                                        response_length);
+```
+
+#### `asp_destroy()`
+
+Destroys and cleans up an Agent Sync Protocol handle.
+
+**Signature:**
+```c
+void asp_destroy(AgentSyncProtocolHandle* handle);
+```
+
+**Parameters:**
+- `handle`: Sync protocol handle to destroy
+
+---
+
+## Operation Types
+
+FIM uses the following operation types defined in `agent_sync_protocol_c_interface_types.h`:
+
+```c
+typedef enum {
+    OPERATION_CREATE = 0,    // New file/registry entry
+    OPERATION_UPDATE = 1,    // Modified file/registry entry
+    OPERATION_DELETE = 2,    // Deleted file/registry entry
+    OPERATION_NO_OP = 3     // No operation (internal use)
+} Operation_t;
+```
+
+---
+
+## Sync Indexes
+
+FIM uses different indexes for different data types:
+
+| Data Type | Index Name | Constant |
+|-----------|------------|----------|
+| Files | `"wazuh-states-fim-files"` | `FIM_FILES_SYNC_INDEX` |
+| Registry Keys | `"wazuh-states-fim-registry-keys"` | `FIM_REGISTRY_KEYS_SYNC_INDEX` |
+| Registry Values | `"wazuh-states-fim-registry-values"` | `FIM_REGISTRY_VALUES_SYNC_INDEX` |
+
+---
+
+## FIM Database Integration
+
+FIM integrates with DBSync through the FIMDB wrapper class for local database operations:
+
+### Database Initialization
+
+```c
+// FIM initializes database through DB interface (C wrapper)
+void DB::init(const int storage,
+              std::function<void(modules_log_level_t, const std::string&)> callbackLogWrapper,
+              const int fileLimit,
+              const int valueLimit) {
+    auto dbsyncHandler = std::make_shared<DBSync>(...);
+    FIMDB::instance().init(callbackLogWrapper, dbsyncHandler, fileLimit, valueLimit);
+}
+```
+
+### Database Transaction Operations
+
+FIM uses database transactions for state comparison, not direct database calls:
+
+```c
+// Start database transaction for file operations
+TXN_HANDLE db_transaction_handle = fim_db_transaction_start(FIMDB_FILE_TXN_TABLE,
+                                                            transaction_callback,
+                                                            &txn_ctx);
+
+// Transaction callback processes database comparison results
+STATIC void transaction_callback(ReturnTypeCallback resultType,
+                                const cJSON* result_json,
+                                void* user_data) {
+    // Database comparison result processed here
+    // Events generated based on comparison
+    persist_syscheck_msg(file_path_sha1, sync_operation,
+                        FIM_FILES_SYNC_INDEX, stateful_event);
+}
+```
+
+---
+
+## Syscom Integration
+
+FIM handles manager responses through the syscom interface:
+
+```c
+// Process sync protocol messages from manager
+if (strncmp(command, FIM_SYNC_HEADER, strlen(FIM_SYNC_HEADER)) == 0) {
+    if (syscheck.enable_synchronization) {
+        const uint8_t *data = (const uint8_t *)(command + header_len);
+        size_t data_len = command_len - header_len;
+
+        bool ret = asp_parse_response_buffer(syscheck.sync_handle, data, data_len);
+        if (!ret) {
+            // Handle parsing error
+        }
+    }
+}
+```

--- a/docs/ref/modules/fim/architecture.md
+++ b/docs/ref/modules/fim/architecture.md
@@ -1,0 +1,208 @@
+# Architecture
+
+The **FIM module** implements a **dual event architecture** designed to provide both immediate alerting and reliable state synchronization for file integrity monitoring. It combines real-time stateless events with persistent stateful events using the Agent Sync Protocol for guaranteed delivery.
+
+---
+
+## Main Components
+
+### **FIM Database Integration (FIMDB + DBSync)**
+
+The local database component responsible for storing and comparing file/registry states.
+Responsibilities:
+
+* FIMDB acts as a wrapper around DBSync for FIM-specific operations
+* DBSync manages the actual SQLite database operations and synchronization
+* Provides transaction-based state comparison through callback mechanisms
+* Compares current file/registry state with stored state via database transactions
+* Triggers transaction callbacks when changes are detected
+* Supports atomic database transactions for consistency
+
+### **Agent Sync Protocol Integration**
+
+FIM integrates with the sync protocol through C interface functions.
+Responsibilities:
+
+* Creates and manages sync protocol handle via `asp_create()`
+* Persists differences using `asp_persist_diff()` when changes detected
+* Triggers periodic synchronization via `asp_sync_module()`
+* Handles manager responses through `asp_parse_response_buffer()`
+* Manages persistent queue for reliable message delivery
+
+### **Transaction Callbacks**
+
+Handle database comparison results and generate appropriate events.
+Responsibilities:
+
+* Process database transaction results from FIMDB
+* Determine change type (add, modify, delete) based on stored state
+* Generate both stateless and stateful events for each change
+* Handle file path hashing for unique identification
+* Coordinate event generation and persistence
+* Called for all changes detected through database transactions
+
+### **Realtime Monitoring Threads**
+
+Dedicated threads that monitor filesystem changes in real-time and trigger event processing.
+Responsibilities:
+
+* **`fim_run_realtime()`** - Platform-specific realtime monitoring thread:
+  - **Linux/Unix**: Uses inotify to watch filesystem events (`INOTIFY_ENABLED`)
+  - **Windows**: Uses ReadDirectoryChangesW API (`WIN32`)
+  - **Other platforms**: Falls back to polling-based monitoring
+* Monitors configured directories for changes (create, modify, delete, move)
+* Triggers `fim_checker()` which leads to database transactions and `transaction_callback()`
+* Runs continuously in background thread launched at FIM startup
+
+---
+
+## Event Flow Architecture
+
+### Complete FIM Event Flow
+
+```
+File/Registry Change Detected
+         │
+         ▼
+ fim_checker() / registry checking
+         │
+         ▼
+ fim_db_transaction_start() ──► FIMDB Database Operation
+         │                           │
+         ▼                           ▼
+ transaction_callback()      Compare with stored state
+         │
+         ├─► Generate Stateless Event ─────► send_syscheck_msg() ─────► Manager (immediate)
+         │
+         └─► Generate Stateful Event ──────► persist_syscheck_msg()
+                                                      │
+                                                      └─► asp_persist_diff()
+                                                                │
+                                                                ▼
+                                                        Persistent Database
+                                                                │
+                                                                ▼
+                                            Periodic Sync Thread (fim_run_integrity)
+                                                                │
+                                                                └─► asp_sync_module()
+                                                                         │
+                                                                         ▼
+                                                                     Manager
+```
+
+---
+
+## Dual Event System
+
+### Stateless Events (Real-time Alerts)
+
+Generated immediately when changes are detected and sent directly to the manager:
+
+```c
+if (notify_scan != 0 && txn_context->event->report_event) {
+    send_syscheck_msg(stateless_event);  // Immediate send to manager
+}
+```
+
+**Characteristics:**
+- Sent immediately when changes detected
+- Contain essential alert information
+- No persistence or retry mechanism
+- Lost if network is down or agent restarts
+
+### Stateful Events (Synchronization State)
+
+Generated with complete data including checksums and persisted for synchronization:
+
+```c
+persist_syscheck_msg(file_path_sha1, sync_operation, FIM_FILES_SYNC_INDEX, stateful_event);
+```
+
+**Characteristics:**
+- Include complete checksums and metadata
+- Persisted to sync protocol database
+- Survive agent restarts and network failures
+- Synchronized periodically with manager
+
+---
+
+## Database Transaction Flow
+
+### Transaction Process
+
+FIM uses database transactions to ensure consistency between change detection and event generation:
+
+```c
+TXN_HANDLE db_transaction_handle = fim_db_transaction_start(FIMDB_FILE_TXN_TABLE,
+                                                            transaction_callback,
+                                                            &txn_ctx);
+```
+
+### Transaction Callback Processing
+
+The `transaction_callback()` function handles the database response:
+
+1. **Receives database comparison result** from FIMDB
+2. **Determines change type** (add, modify, delete) based on database state
+3. **Generates both event types**:
+   - Stateless event for immediate alerts
+   - Stateful event for synchronization
+4. **Persists stateful event** to sync protocol
+
+#### **Central Event Processing Hub**
+
+**Most FIM events flow through `transaction_callback()`**, including:
+- File modifications detected by realtime monitoring
+- New file creation events
+- File attribute changes (permissions, ownership, etc.)
+- Registry key and value changes (Windows)
+- Scheduled scan results comparing current vs. stored state
+
+#### **File Deletion Exception**
+
+**File deletions are handled differently** and may bypass `transaction_callback()` in some scenarios:
+
+- **Standard deletions**: Use `fim_db_transaction_deleted_rows()` which calls `transaction_callback()`
+- **Bulk cleanup**: At scan completion, `fim_db_transaction_deleted_rows()` processes all files that weren't found during the scan
+- **Special case**: Some deletion events may be processed through alternative paths depending on detection method
+
+**Implementation**:
+```c
+// At end of file scan - handles files deleted since last scan
+fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
+```
+
+---
+
+## Synchronization Architecture
+
+### Periodic Synchronization Thread
+
+FIM runs a dedicated thread for inventory synchronization:
+
+```c
+// Function: fim_run_integrity()
+void * fim_run_integrity(__attribute__((unused)) void * args) {
+    while (FOREVER()) {
+        mdebug1("Running inventory synchronization.");
+
+        // Trigger synchronization of all pending FIM changes
+        asp_sync_module(syscheck.sync_handle, MODE_DELTA,
+                       syscheck.sync_response_timeout, FIM_SYNC_RETRIES,
+                       syscheck.sync_max_eps);
+
+        sleep(syscheck.sync_interval);
+    }
+}
+```
+
+### Manager Response Handling
+
+FIM processes manager responses through the syscom interface:
+
+```c
+// Handle FIM sync messages from manager
+bool ret = asp_parse_response_buffer(syscheck.sync_handle, data, data_len);
+```
+
+---

--- a/docs/ref/modules/fim/configuration.md
+++ b/docs/ref/modules/fim/configuration.md
@@ -1,0 +1,233 @@
+# Configuration
+
+The **FIM** module's persistence functionality can be configured through the `<synchronization>` section within the `<syscheck>` block in `ossec.conf`. The module works with default settings but allows fine-tuning of synchronization behavior for different environments.
+
+---
+
+## Synchronization Configuration
+
+### Basic Configuration
+
+```xml
+<syscheck>
+    <max_eps>50</max_eps>                        <!-- Stateless/real-time FIM event rate limit -->
+    <notify_first_scan>no</notify_first_scan>    <!-- First scan notification -->
+
+    <synchronization>
+        <enabled>yes</enabled>                    <!-- Enable/disable persistence -->
+        <interval>300</interval>                  <!-- Sync interval in seconds -->
+        <response_timeout>30</response_timeout>   <!-- Response timeout in seconds -->
+        <max_eps>10</max_eps>                    <!-- Max sync events per second (0 = unlimited) -->
+    </synchronization>
+</syscheck>
+```
+
+### Synchronization Configuration Parameters
+
+| Parameter | Type | Default | Range | Description |
+|-----------|------|---------|--------|-------------|
+| `enabled` | Boolean | `yes` | `yes`/`no` | Enable or disable FIM synchronization persistence |
+| `interval` | Integer | `300` | `1` - `∞` | How often to trigger synchronization with the manager (seconds) |
+| `response_timeout` | Integer | `30` | `1` - `∞` | Timeout for waiting manager responses during sync (seconds) |
+| `max_eps` | Integer | `10` | `0` - `1000000` | Maximum events per second for **sync messages** (0 = unlimited) |
+
+### General Syscheck Parameters
+
+| Parameter | Type | Default | Range | Description |
+|-----------|------|---------|--------|-------------|
+| `max_eps` | Integer | `50` | `0` - `1000000` | Maximum events per second for **stateless/real-time FIM events** (0 = unlimited) |
+| `notify_first_scan` | Boolean | `no` | `yes`/`no` | Generate events during initial scan |
+
+---
+
+## Configuration Details
+
+### Enable/Disable Persistence
+
+The `enabled` parameter controls whether FIM uses persistence or falls back to legacy behavior:
+
+```xml
+<synchronization>
+    <enabled>yes</enabled>
+</synchronization>
+```
+
+**Implementation:**
+```c
+unsigned int enable_synchronization:1;  /* Enable database synchronization */
+```
+
+When disabled, FIM only generates stateless events without persistence.
+
+### Synchronization Interval
+
+Controls how frequently the agent attempts to synchronize pending events:
+
+```xml
+<synchronization>
+    <interval>300</interval>  <!-- 5 minutes -->
+</synchronization>
+```
+
+**Implementation:**
+```c
+uint32_t sync_interval;  /* Synchronization interval */
+```
+
+**Considerations:**
+- Lower values provide faster synchronization but increase manager load
+- Higher values reduce network traffic but delay event delivery
+
+### Response Timeout
+
+Defines how long to wait for manager acknowledgments during synchronization:
+
+```xml
+<synchronization>
+    <response_timeout>30</response_timeout>
+</synchronization>
+```
+
+**Implementation:**
+```c
+uint32_t sync_response_timeout;  /* Minimum interval for the synchronization process */
+```
+
+**Considerations:**
+- Should be adjusted based on network latency
+- Too low may cause unnecessary retries
+- Too high may delay error detection
+
+### Rate Limiting (max_eps)
+
+Controls the maximum rate of synchronization message transmission:
+
+```xml
+<synchronization>
+    <max_eps>100</max_eps>  <!-- 100 events per second -->
+</synchronization>
+```
+
+**Implementation:**
+```c
+long sync_max_eps;  /* Maximum events per second for synchronization messages. */
+```
+
+**Special Values:**
+- `0`: No rate limiting (unlimited)
+- `1-1000000`: Events per second limit
+
+---
+
+## Hard-coded Constants
+
+Some synchronization parameters are defined as constants and cannot be changed via configuration:
+
+```c
+#define FIM_SYNC_PROTOCOL_DB_PATH   "queue/fim/db/fim_sync.db"  // Database path
+#define FIM_SYNC_RETRIES 3                                      // Retry attempts
+```
+
+### Retry Logic
+
+The sync protocol automatically retries failed operations up to `FIM_SYNC_RETRIES` (3) times before giving up.
+
+---
+
+## Database Paths
+
+### Fixed Paths
+
+The following database paths are hard-coded and cannot be changed:
+
+- **FIM Database**: `queue/fim/db/fim.db`
+- **Sync Protocol Database**: `queue/fim/db/fim_sync.db` (`FIM_SYNC_PROTOCOL_DB_PATH`)
+
+These paths are relative to the Wazuh installation directory.
+
+---
+
+## General Syscheck Configuration
+
+FIM configuration options at the main syscheck level:
+
+### max_eps
+
+Controls the maximum rate of FIM event generation (separate from sync rate limiting):
+
+```xml
+<syscheck>
+    <max_eps>100</max_eps>  <!-- Maximum FIM events per second -->
+</syscheck>
+```
+
+**Implementation:**
+```c
+int max_eps;  /* Maximum events per second. */
+```
+
+**Configuration Details:**
+- **Range:** `0` - `1000000`
+- **Default:** `50`
+- **Purpose:** Rate limiting for stateless/real-time FIM event generation
+- **Event Types:** Applies to immediate FIM events sent to the manager in real-time
+- **Note:** This is different from `synchronization->max_eps` which only limits synchronization messages for stateful events
+
+### notify_first_scan
+
+Controls whether to generate events during the initial file system scan:
+
+```xml
+<syscheck>
+    <notify_first_scan>yes</notify_first_scan>  <!-- Generate events on first scan -->
+</syscheck>
+```
+
+**Implementation:**
+```c
+unsigned int notify_first_scan;  /* Notify the first scan */
+```
+
+**Configuration Details:**
+- **Values:** `yes`/`no`
+- **Default:** `no`
+- **Purpose:** When enabled, FIM generates events for all files found during the initial scan
+- **Use Case:** Useful for getting immediate visibility into the file system state
+
+---
+
+## Configuration Examples
+
+### Basic Configuration with General Options
+
+```xml
+<syscheck>
+    <max_eps>100</max_eps>                     <!-- Stateless/real-time FIM event rate limit -->
+    <notify_first_scan>yes</notify_first_scan> <!-- Generate events on first scan -->
+
+    <synchronization>
+        <enabled>yes</enabled>
+        <interval>300</interval>
+        <response_timeout>30</response_timeout>
+        <max_eps>10</max_eps>                  <!-- Sync-specific rate limit -->
+    </synchronization>
+</syscheck>
+```
+
+### High-Performance Environment
+
+For environments with high file change rates:
+
+```xml
+<syscheck>
+    <max_eps>1000</max_eps>                    <!-- High stateless/real-time event rate -->
+    <notify_first_scan>no</notify_first_scan>  <!-- Skip first scan events -->
+
+    <synchronization>
+        <enabled>yes</enabled>
+        <interval>60</interval>                <!-- More frequent sync -->
+        <response_timeout>15</response_timeout><!-- Shorter timeout -->
+        <max_eps>500</max_eps>                 <!-- High sync rate limit -->
+    </synchronization>
+</syscheck>
+```

--- a/docs/ref/modules/fim/database-schema.md
+++ b/docs/ref/modules/fim/database-schema.md
@@ -1,0 +1,237 @@
+# Database Schema
+
+The FIM module uses multiple database schemas to store and manage file integrity monitoring data. The architecture includes both local FIMDB databases for state comparison and sync protocol databases for reliable message persistence.
+
+---
+
+## FIM Local Databases (FIMDB + DBSync)
+
+FIM uses FIMDB as a wrapper around DBSync to maintain local SQLite databases for storing current file and registry states for comparison during monitoring. The actual database operations are handled by DBSync, while FIMDB provides FIM-specific functionality.
+
+### File Entries Table
+
+Stores metadata for monitored files:
+
+```sql
+CREATE TABLE IF NOT EXISTS file_entry (
+    path TEXT NOT NULL,
+    checksum TEXT NOT NULL,
+    device INTEGER,
+    inode INTEGER,
+    size INTEGER,
+    permissions TEXT,
+    attributes TEXT,
+    uid TEXT,
+    gid TEXT,
+    owner TEXT,
+    group_ TEXT,
+    hash_md5 TEXT,
+    hash_sha1 TEXT,
+    hash_sha256 TEXT,
+    mtime INTEGER,
+    PRIMARY KEY(path)
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS path_index ON file_entry (path);
+CREATE INDEX IF NOT EXISTS inode_index ON file_entry (device, inode);
+```
+
+#### Field Descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | TEXT | Full file path (primary key) |
+| `checksum` | TEXT | File checksum for change detection |
+| `device` | INTEGER | Device ID where file resides |
+| `inode` | INTEGER | File system inode number |
+| `size` | INTEGER | File size in bytes |
+| `permissions` | TEXT | File permissions (e.g., "755") |
+| `attributes` | TEXT | File attributes (platform-specific) |
+| `uid` | TEXT | User ID of file owner |
+| `gid` | TEXT | Group ID of file owner |
+| `owner` | TEXT | Username of file owner |
+| `group_` | TEXT | Group name of file owner |
+| `hash_md5` | TEXT | MD5 hash of file contents |
+| `hash_sha1` | TEXT | SHA1 hash of file contents |
+| `hash_sha256` | TEXT | SHA256 hash of file contents |
+| `mtime` | INTEGER | Last modification time (Unix timestamp) |
+
+---
+
+### Registry Key Table (Windows Only)
+
+Stores metadata for monitored registry keys:
+
+```sql
+CREATE TABLE IF NOT EXISTS registry_key (
+    path TEXT NOT NULL,
+    permissions TEXT,
+    uid TEXT,
+    gid TEXT,
+    owner TEXT,
+    group_ TEXT,
+    mtime INTEGER,
+    architecture TEXT CHECK (architecture IN ('[x32]', '[x64]')),
+    checksum TEXT NOT NULL,
+    PRIMARY KEY (architecture, path)
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS path_index ON registry_key (path);
+```
+
+#### Field Descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | TEXT | Registry key path |
+| `permissions` | TEXT | Registry key permissions |
+| `uid` | TEXT | User ID with access |
+| `gid` | TEXT | Group ID with access |
+| `owner` | TEXT | Owner of registry key |
+| `group_` | TEXT | Group with access |
+| `mtime` | INTEGER | Last modification time |
+| `architecture` | TEXT | Architecture (`[x32]` or `[x64]`) |
+| `checksum` | TEXT | Registry key checksum |
+
+**Primary Key:** `(architecture, path)` - Allows same path in different architectures
+
+---
+
+### Registry Data Table (Windows Only)
+
+Stores individual registry values:
+
+```sql
+CREATE TABLE IF NOT EXISTS registry_data (
+    path TEXT,
+    architecture TEXT CHECK (architecture IN ('[x32]', '[x64]')),
+    value TEXT NOT NULL,
+    type INTEGER,
+    size INTEGER,
+    hash_md5 TEXT,
+    hash_sha1 TEXT,
+    hash_sha256 TEXT,
+    checksum TEXT NOT NULL,
+    PRIMARY KEY(path, architecture, value),
+    FOREIGN KEY (path) REFERENCES registry_key(path),
+    FOREIGN KEY (architecture) REFERENCES registry_key(architecture)
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS key_name_index ON registry_data (path, value);
+```
+
+#### Field Descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | TEXT | Registry key path (foreign key) |
+| `architecture` | TEXT | Architecture (`[x32]` or `[x64]`) |
+| `value` | TEXT | Registry value name |
+| `type` | INTEGER | Registry value type (REG_SZ, REG_DWORD, etc.) |
+| `size` | INTEGER | Size of registry value data |
+| `hash_md5` | TEXT | MD5 hash of value data |
+| `hash_sha1` | TEXT | SHA1 hash of value data |
+| `hash_sha256` | TEXT | SHA256 hash of value data |
+| `checksum` | TEXT | Value checksum for change detection |
+
+**Primary Key:** `(path, architecture, value)` - Unique per registry value
+**Foreign Keys:** References `registry_key` table
+
+---
+
+## Sync Protocol Database
+
+The sync protocol maintains its own persistence layer in a separate SQLite database for reliable message delivery.
+
+### Persistent Queue Table
+
+```sql
+CREATE TABLE IF NOT EXISTS persistent_queue (
+    id TEXT PRIMARY KEY NOT NULL,
+    idx TEXT NOT NULL,
+    data TEXT NOT NULL,
+    operation INTEGER NOT NULL,
+    sync_status INTEGER NOT NULL DEFAULT 0,
+    create_status INTEGER NOT NULL DEFAULT 0,
+    operation_syncing INTEGER NOT NULL DEFAULT 3
+);
+```
+
+#### Field Descriptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | TEXT | - | Unique identifier for FIM entry (SHA1 hash of file path) |
+| `idx` | TEXT | - | Index identifier for grouping related entries |
+| `data` | TEXT | - | JSON serialized FIM data |
+| `operation` | INTEGER | - | Type of operation (0=CREATE, 1=UPDATE, 2=DELETE) |
+| `sync_status` | INTEGER | 0 | Current sync state (0=PENDING, 1=SYNCING, 2=SYNCING_UPDATED) |
+| `create_status` | INTEGER | 0 | Creation tracking (0=EXISTING, 1=NEW, 2=NEW_DELETED) |
+| `operation_syncing` | INTEGER | 3 | Original operation being synchronized |
+
+#### Sync Status Values
+
+```c
+enum class SyncStatus : int {
+    PENDING = 0,        // Message waiting to be synchronized
+    SYNCING = 1,        // Message currently being synchronized
+    SYNCING_UPDATED = 2 // Message being synchronized with updated contents
+};
+```
+
+#### Create Status Values
+
+```c
+enum class CreateStatus : int {
+    EXISTING = 0,     // Message existed prior to current session
+    NEW = 1,          // Message newly created during current session
+    NEW_DELETED = 2   // Message created then deleted before sync
+};
+```
+
+---
+
+## Database Operations Flow
+
+### State Comparison Process
+
+1. **File System Scan**: FIM detects file/registry changes
+2. **Database Transaction**: Start transaction with FIMDB
+3. **State Comparison**: Compare current state with stored state
+4. **Change Detection**: Determine operation type (create/update/delete)
+5. **Event Generation**: Generate stateless and stateful events
+6. **Persistence**: Store stateful event in sync protocol database
+
+### Database Maintenance
+
+#### Index Optimization
+
+Both databases use indexes to optimize common queries:
+
+**FIMDB Indexes:**
+- `path_index`: Fast file path lookups
+- `inode_index`: Detect file moves/renames
+- `key_name_index`: Registry value lookups
+
+**Sync Protocol:** Uses primary key for fast ID-based operations
+
+---
+
+## Database File Locations
+
+### Fixed Paths
+
+Database files are stored in fixed locations relative to Wazuh installation:
+
+- **FIM Database**: `queue/fim/db/fim.db`
+- **Sync Protocol Database**: `queue/fim/db/fim_sync.db`
+
+### Database Configuration
+
+**SQLite Pragmas** used for optimization:
+
+```sql
+-- Sync protocol database optimizations
+PRAGMA synchronous = NORMAL;    -- Balanced durability/performance
+PRAGMA journal_mode = WAL;      -- Write-Ahead Logging for concurrency
+```


### PR DESCRIPTION
## Description

This PR adds documentation describing how FIM differences are persisted by module and sequence for use in the sync protocol.

## Proposed Changes

Adds an explanation about integration with the Agent Sync protocol.
Adds DB schemas
Adds reference for configuration options.

### Results and Evidence

<img width="1122" height="107" alt="image" src="https://github.com/user-attachments/assets/b013cfbd-9060-42d4-9671-365180798a1f" />

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
