### PR TITLE
Cluster by default configuration changes

### DIFF
--- a/docs/ref/modules/vulnerability-scanner/test-tools.md
+++ b/docs/ref/modules/vulnerability-scanner/test-tools.md
@@ -1,22 +1,22 @@
 # Test tools
 
-Below is a quick overview of the usage of the vulnerability scanner command line tools that serve the purpose of debugging and testing. 
+Below is a quick overview of the usage of the vulnerability scanner command line tools that serve the purpose of debugging and testing.
 
-These tools ease the task of mocking and replicating a real environment where we can validate that new changes do not affect in an undesired way the current capabilities of the module. 
+These tools ease the task of mocking and replicating a real environment where we can validate that new changes do not affect in an undesired way the current capabilities of the module.
 
-## Compilation 
+## Compilation
 
 Command line test tools are intended for development purposes and they are not delivered in the Wazuh manager packages. To use them, it is required to compile the project by sources.
 
 ```console
 cd wazuh/src
-make deps 
+make deps
 make -j$(nproc) TARGET=server
-``` 
+```
 
-## Vulnerability Scanner tool 
+## Vulnerability Scanner tool
 
-Location path 
+Location path
 
 ```console
 src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool
@@ -24,7 +24,7 @@ src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testto
 
 **Note**: execute the cli with **--help** to display the available options.
 
-### Database creation 
+### Database creation
 
 Command
 
@@ -41,17 +41,15 @@ Configuration file
     "index-status": "no",
     "cti-url": "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0"
   },
-  "clusterName": "cluster01",
-  "clusterEnabled": false
+  "clusterName": "cluster01"
 }
 ```
 
 - The **-d** flag performs a snapshot download from CTI and processes the content to create a local CVE database.
-- In a real Wazuh Manager installation, **clusterName** is the hostname for a single node deployment, or the cluster name for a cluster setup.
-- The outcome of this command is a RocksDB CVE database **queue** in the current directory. 
+- The outcome of this command is a RocksDB CVE database **queue** in the current directory.
 - The process will take some minutes until the snapshot file is processed.
 
-**Note:** It's possible to follow the process with the logs printed by the tool. Optionally, with the **-l* argument,* the logs can be dumped to a file. 
+**Note:** It's possible to follow the process with the logs printed by the tool. Optionally, with the **-l* argument,* the logs can be dumped to a file.
 
 ```console
 ...
@@ -79,7 +77,7 @@ wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:188 processMessage 
 wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:369 operator() : Feed update process completed.
 ```
 
-### Detection 
+### Detection
 
 For details about event format please refer to [Events](events.md)
 
@@ -89,7 +87,7 @@ Command
 src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool -c config.json -u -i os.json,package.json
 ```
 
-- The command will detect vulnerabilities and fill the indexer databases. 
+- The command will detect vulnerabilities and fill the indexer databases.
 
 **Note:** It is possible to connect an instance of the Wazuh-Indexer and index the result of the vulnerability scan by adding the **Indexer Connector** configuration (more details [Configuration](configuration.md)).
 
@@ -122,17 +120,16 @@ Expanded configuration options for indexing
     },
     "update_mappings_path": ""
   },
-  "clusterName": "cluster01",
-  "clusterEnabled": false
+  "clusterName": "cluster01"
 }
 ```
 
 **Note:** It is important to modify accordingly the following fields:
 
   - hosts
-  - certificate 
-  - key 
-  - certificate_authorities 
+  - certificate
+  - key
+  - certificate_authorities
   - username
   - password
 
@@ -422,7 +419,7 @@ indexer-connector:indexerConnector.cpp:606 operator() : Added document for inser
 
 ### Mocking Wazuh-DB information
 
-As previously mentioned, the scanner requires OS and hotfixes information for detection. That could be mocked using the options **-h** for hotfixes and **-b** for OS. 
+As previously mentioned, the scanner requires OS and hotfixes information for detection. That could be mocked using the options **-h** for hotfixes and **-b** for OS.
 
 Example mocked hotfix data
 
@@ -489,7 +486,7 @@ src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testto
 
 **Note:** More details about required fields [Events](events.md).
 
-## RocksDB tool 
+## RocksDB tool
 
 Location path
 
@@ -499,9 +496,9 @@ src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/rocks_db_que
 
 **Note**: execute the cli with **--help** to display the available options.
 
-### Inspect databases 
+### Inspect databases
 
-#### Indexer databases 
+#### Indexer databases
 
 Commands
 
@@ -513,7 +510,7 @@ rocksDBQuery/rocks_db_query_testtool -d queue/indexer/wazuh-states-vulnerabiliti
 Example output
 
 ```console
-001_f21aca719022f009d80bbf9224741d79029b31f2_CVE-2024-12243 ==> 
+001_f21aca719022f009d80bbf9224741d79029b31f2_CVE-2024-12243 ==>
 {
   "agent": {
     "id": "001",
@@ -570,7 +567,7 @@ Example output
 
 #### Inventory database
 
-Command 
+Command
 
 ```console
 rocksDBQuery/rocks_db_query_testtool -d queue/inventory
@@ -584,15 +581,15 @@ Example output
 
 ### Remove indexed vulnerability and clean databases
 
-It is possible to clean the indexed vulnerabilities and related data using the scanner tool with proper Wazuh-DB events. 
+It is possible to clean the indexed vulnerabilities and related data using the scanner tool with proper Wazuh-DB events.
 
-Usage 
+Usage
 
 ```console
 src/build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool -c config2.json -t index-template.json -u -i deleteAction.json
 ```
 
-Delete single agent 
+Delete single agent
 
 ```json
 {
@@ -644,7 +641,7 @@ Delete hotfix
 }
 ```
 
-#### Output examples 
+#### Output examples
 
 Clean all agents
 
@@ -695,8 +692,7 @@ Configuration file
     "index-status": "no",
     "cti-url": "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0"
   },
-  "clusterName": "cluster01",
-  "clusterEnabled": false
+  "clusterName": "cluster01"
 }
 ```
 

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -92,7 +92,13 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                 merror("Detected a not allowed node type '%s'. Valid types are 'master' and 'worker'.", node[i]->content);
                 return OS_INVALID;
             }
-            os_strdup(node[i]->content, Config->node_type);
+            os_free(Config->node_type);
+            if (strcmp(node[i]->content, "client") == 0) {
+                mwarn("Deprecated node type 'client'. Using 'worker' instead.");
+                os_strdup("worker", Config->node_type);
+            } else {
+                os_strdup(node[i]->content, Config->node_type);
+            }
         } else if (!strcmp(node[i]->element, key)) {
         } else if (!strcmp(node[i]->element, socket_timeout)) {
         } else if (!strcmp(node[i]->element, connection_timeout)) {
@@ -168,7 +174,7 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                     return OS_INVALID;
                 }
             }
-        OS_ClearNode(child);
+            OS_ClearNode(child);
         } else {
             merror(XML_INVELEM, node[i]->element);
             return OS_INVALID;

--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -113,7 +113,6 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
         } else if (!strcmp(node[i]->element, port)) {
         } else if (!strcmp(node[i]->element, bind_addr)) {
         } else if (!strcmp(node[i]->element, haproxy_helper)) {
-
             if (!(child = OS_GetElementsbyNode(xml, node[i]))) {
                 continue;
             }
@@ -127,7 +126,7 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                     }
                 } else if (!strcmp(child[j]->element, frequency)) {
                 } else if (!strcmp(child[j]->element, haproxy_address)) {
-                    if (!strlen(node[i]->content)) {
+                    if (!strlen(child[j]->content)) {
                         merror("HAProxy address is missing in the configuration");
                         OS_ClearNode(child);
                         return OS_INVALID;
@@ -140,13 +139,13 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, haproxy_user)) {
-                    if (!strlen(node[i]->content)) {
+                    if (!strlen(child[j]->content)) {
                         merror("HAProxy user is missing in the configuration");
                         OS_ClearNode(child);
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, haproxy_password)) {
-                    if (!strlen(node[i]->content)) {
+                    if (!strlen(child[j]->content)) {
                         merror("HAProxy password is missing in the configuration");
                         OS_ClearNode(child);
                         return OS_INVALID;
@@ -169,11 +168,12 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                     return OS_INVALID;
                 }
             }
+        OS_ClearNode(child);
         } else {
             merror(XML_INVELEM, node[i]->element);
             return OS_INVALID;
         }
     }
-        
+
     return 0;
 }

--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -35,6 +35,8 @@ list(APPEND config_flags "-Wl,--wrap,OS_GetHost -Wl,--wrap=Start_win32_Syscheck 
 if(${TARGET} STREQUAL "server")
     list(APPEND config_names "test_indexer")
     list(APPEND config_flags "${DEBUG_OP_WRAPPERS}")
+    list(APPEND config_names "test_cluster")
+    list(APPEND config_flags "${DEBUG_OP_WRAPPERS}")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/config/test_cluster.c
+++ b/src/unit_tests/config/test_cluster.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <memory.h>
+
+#include "../../config/config.h"
+#include "../../headers/shared.h"
+#include "../../config/global-config.h"
+
+typedef struct {
+    OS_XML xml;
+    XML_NODE nodes;
+    _Config config;
+} test_structure;
+
+static const XML_NODE string_to_xml_node(const char * string, OS_XML *_lxml){
+    XML_NODE nodes;
+    OS_ReadXMLString(string, _lxml);
+    nodes = OS_GetElementsbyNode(_lxml, NULL);
+    return nodes;
+}
+
+static int setup_test_read(void **state) {
+    test_structure *test;
+    os_calloc(1, sizeof(test_structure), test);
+    *state = test;
+    return 0;
+}
+
+static int teardown_test_read(void **state) {
+    test_structure *test = *state;
+    OS_ClearNode(test->nodes);
+    OS_ClearXML(&(test->xml));
+    os_free(test->config.cluster_name);
+    os_free(test->config.node_name);
+    os_free(test->config.node_type);
+    os_free(test);
+    return 0;
+}
+
+/* Cluster config tests */
+void test_read_deprecated_disabled_option(void **state) {
+    const char * configuration =
+        "<disabled>yes</disabled>"
+        "<name>wazuh</name>"
+        "<node_name>node01</node_name>"
+        "<node_type>master</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__mwarn, formatted_msg, "Detected a deprecated configuration for cluster. The 'disabled' option is not longer available.");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), 0);
+}
+
+void test_read_deprecated_interval_option(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>no</haproxy_disabled>"
+        "<haproxy_address>wazuh-proxy</haproxy_address>"
+        "<haproxy_user>haproxy</haproxy_user>"
+        "<haproxy_password>haproxy</haproxy_password>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>"
+    "<interval>2m</interval>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__mwarn, formatted_msg, "Detected a deprecated configuration for cluster. The 'interval' option is not longer available.");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests_config[] = {
+        // Cluster config tests
+        cmocka_unit_test_setup_teardown(test_read_deprecated_disabled_option, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_deprecated_interval_option, setup_test_read, teardown_test_read)
+    };
+    return cmocka_run_group_tests(tests_config, NULL, NULL);
+}

--- a/src/unit_tests/config/test_cluster.c
+++ b/src/unit_tests/config/test_cluster.c
@@ -49,6 +49,156 @@ static int teardown_test_read(void **state) {
 }
 
 /* Cluster config tests */
+void test_read_empty_cluster_name(void **state) {
+    const char * configuration =
+        "<name></name>"
+        "<node_name>node01</node_name>"
+        "<node_type>master</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Cluster name is empty in configuration");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_invalid_characters_in_cluster_name(void **state) {
+    const char * configuration =
+        "<name>wazuh 01</name>"
+        "<node_name>node01</node_name>"
+        "<node_type>master</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Detected a not allowed character in cluster name: \"wazuh 01\". Characters allowed: \"!\"#$%&'-.0123456789:<=>?ABCDEFGHIJKLMNOPQRESTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~\".");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_empty_node_name(void **state) {
+    const char * configuration =
+        "<name>wazuh</name>"
+        "<node_name></node_name>"
+        "<node_type>master</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Node name is empty in configuration");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_invalid_characters_in_node_name(void **state) {
+    const char * configuration =
+        "<name>wazuh</name>"
+        "<node_name>node 01</node_name>"
+        "<node_type>master</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Detected a not allowed character in node name: \"node 01\". Characters allowed: \"!\"#$%&'-.0123456789:<=>?ABCDEFGHIJKLMNOPQRESTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~\".");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_empty_node_type(void **state) {
+    const char * configuration =
+        "<name>wazuh</name>"
+        "<node_name>node01</node_name>"
+        "<node_type></node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Node type is empty in configuration");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_invalid_node_type(void **state) {
+    const char * configuration =
+        "<name>wazuh</name>"
+        "<node_name>node01</node_name>"
+        "<node_type>invalid</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Detected a not allowed node type 'invalid'. Valid types are 'master' and 'worker'.");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
 void test_read_deprecated_disabled_option(void **state) {
     const char * configuration =
         "<disabled>yes</disabled>"
@@ -101,11 +251,192 @@ void test_read_deprecated_interval_option(void **state) {
     assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), 0);
 }
 
+void test_read_valid_configuration(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>no</haproxy_disabled>"
+        "<haproxy_address>wazuh-proxy</haproxy_address>"
+        "<haproxy_user>haproxy</haproxy_user>"
+        "<haproxy_password>haproxy</haproxy_password>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_SUCCESS);
+}
+
+void test_read_valid_configuration_no_haproxy(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_SUCCESS);
+}
+
+void test_read_invalid_haproxy_disable_option(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>invalid</haproxy_disabled>"
+        "<haproxy_address>wazuh-proxy</haproxy_address>"
+        "<haproxy_user>haproxy</haproxy_user>"
+        "<haproxy_password>haproxy</haproxy_password>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Detected an invalid value for the disabled tag 'haproxy_disabled'. Valid values are 'yes' and 'no'.");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_invalid_haproxy_protocol_option(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>no</haproxy_disabled>"
+        "<haproxy_address>wazuh-proxy</haproxy_address>"
+        "<haproxy_user>haproxy</haproxy_user>"
+        "<haproxy_password>haproxy</haproxy_password>"
+        "<haproxy_protocol>invalid</haproxy_protocol>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "Detected an invalid value for the haproxy_protocol tag 'haproxy_protocol'. Valid values are 'http' and 'https'.");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_valid_configuration_haproxy_empty_address(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>no</haproxy_disabled>"
+        "<haproxy_address></haproxy_address>"
+        "<haproxy_user>haproxy</haproxy_user>"
+        "<haproxy_password>haproxy</haproxy_password>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "HAProxy address is missing in the configuration");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_valid_configuration_haproxy_empty_user(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>no</haproxy_disabled>"
+        "<haproxy_address>wazuh-proxy</haproxy_address>"
+        "<haproxy_user></haproxy_user>"
+        "<haproxy_password>haproxy</haproxy_password>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "HAProxy user is missing in the configuration");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
+void test_read_valid_configuration_haproxy_empty_password(void **state) {
+    const char * configuration =
+    "<name>wazuh</name>"
+    "<node_name>node01</node_name>"
+    "<node_type>master</node_type>"
+    "<key></key>"
+    "<port>1516</port>"
+    "<bind_addr>localhost</bind_addr>"
+    "<nodes>"
+        "<node>NODE_IP</node>"
+    "</nodes>"
+    "<haproxy_helper>"
+        "<haproxy_disabled>no</haproxy_disabled>"
+        "<haproxy_address>wazuh-proxy</haproxy_address>"
+        "<haproxy_user>haproxy</haproxy_user>"
+        "<haproxy_password></haproxy_password>"
+    "</haproxy_helper>"
+    "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__merror, formatted_msg, "HAProxy password is missing in the configuration");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
+}
+
 int main(void) {
     const struct CMUnitTest tests_config[] = {
         // Cluster config tests
         cmocka_unit_test_setup_teardown(test_read_deprecated_disabled_option, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_deprecated_interval_option, setup_test_read, teardown_test_read)
+        cmocka_unit_test_setup_teardown(test_read_deprecated_interval_option, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_valid_configuration, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_valid_configuration_no_haproxy, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_haproxy_disable_option, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_haproxy_protocol_option, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_valid_configuration_haproxy_empty_address, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_valid_configuration_haproxy_empty_user, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_valid_configuration_haproxy_empty_password, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_cluster_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_characters_in_cluster_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_node_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_characters_in_node_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_node_type, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_node_type, setup_test_read, teardown_test_read),
     };
     return cmocka_run_group_tests(tests_config, NULL, NULL);
 }

--- a/src/unit_tests/config/test_cluster.c
+++ b/src/unit_tests/config/test_cluster.c
@@ -199,6 +199,32 @@ void test_read_invalid_node_type(void **state) {
     assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_INVALID);
 }
 
+void test_read_deprecated_client_value(void **state) {
+    const char * configuration =
+        "<name>wazuh</name>"
+        "<node_name>node01</node_name>"
+        "<node_type>client</node_type>"
+        "<key></key>"
+        "<port>1516</port>"
+        "<bind_addr>localhost</bind_addr>"
+        "<nodes>"
+            "<node>NODE_IP</node>"
+        "</nodes>"
+        "<haproxy_helper>"
+            "<haproxy_disabled>no</haproxy_disabled>"
+            "<haproxy_address>wazuh-proxy</haproxy_address>"
+            "<haproxy_user>haproxy</haproxy_user>"
+            "<haproxy_password>haproxy</haproxy_password>"
+        "</haproxy_helper>"
+        "<hidden>no</hidden>";
+
+    test_structure *test_data = *state;
+    test_data->nodes = string_to_xml_node(configuration, &(test_data->xml));
+    expect_string(__wrap__mwarn, formatted_msg, "Deprecated node type 'client'. Using 'worker' instead.");
+    assert_int_equal(Read_Cluster(&test_data->xml, test_data->nodes, &test_data->config, NULL), OS_SUCCESS);
+    assert_string_equal(test_data->config.node_type, "worker");
+}
+
 void test_read_deprecated_disabled_option(void **state) {
     const char * configuration =
         "<disabled>yes</disabled>"
@@ -422,6 +448,13 @@ void test_read_valid_configuration_haproxy_empty_password(void **state) {
 int main(void) {
     const struct CMUnitTest tests_config[] = {
         // Cluster config tests
+        cmocka_unit_test_setup_teardown(test_read_empty_cluster_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_characters_in_cluster_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_node_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_characters_in_node_name, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_empty_node_type, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_invalid_node_type, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_read_deprecated_client_value, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_deprecated_disabled_option, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_deprecated_interval_option, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_valid_configuration, setup_test_read, teardown_test_read),
@@ -431,12 +464,6 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_valid_configuration_haproxy_empty_address, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_valid_configuration_haproxy_empty_user, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_valid_configuration_haproxy_empty_password, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_empty_cluster_name, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_invalid_characters_in_cluster_name, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_empty_node_name, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_invalid_characters_in_node_name, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_empty_node_type, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_invalid_node_type, setup_test_read, teardown_test_read),
     };
     return cmocka_run_group_tests(tests_config, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
@@ -35,6 +35,5 @@
             "offset": 0
         }
     },
-    "clusterName":"cluster01",
-    "clusterEnabled":false
+    "clusterName":"cluster01"
 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.json
@@ -20,6 +20,5 @@
     },
     "update_mappings_path": ""
   },
-  "clusterName": "cluster01",
-  "clusterEnabled": false
+  "clusterName": "cluster01"
 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.offline_content_generation.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.offline_content_generation.json
@@ -5,6 +5,5 @@
         "cti-url": "https://dummy-url.com",
         "offline-url":"file://./src/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json"
     },
-    "clusterName":"cluster01",
-    "clusterEnabled":false
+    "clusterName":"cluster01"
 }

--- a/src/wazuh_modules/wm_inventory_sync.c
+++ b/src/wazuh_modules/wm_inventory_sync.c
@@ -14,20 +14,20 @@
  #include "external/cJSON/cJSON.h"
  #include "sym_load.h"
  #include "inventory_sync/include/inventory_sync.h"
- 
+
  #ifndef HOST_NAME_MAX
  #define HOST_NAME_MAX 255
  #endif
- 
+
  static void* wm_inventory_sync_main(wm_inventory_sync_t* data);
  static void wm_inventory_sync_destroy(wm_inventory_sync_t* data);
  static void wm_inventory_sync_stop(wm_inventory_sync_t* data);
  cJSON* wm_inventory_sync_dump(wm_inventory_sync_t* data);
- 
+
  void* inventory_sync_module = NULL;
  inventory_sync_start_func inventory_sync_start_ptr = NULL;
  inventory_sync_stop_func inventory_sync_stop_ptr = NULL;
- 
+
  const wm_context WM_INVENTORY_SYNC_CONTEXT = {
      .name = "inventory_sync",
      .start = (wm_routine)wm_inventory_sync_main,
@@ -37,7 +37,7 @@
      .stop = (void (*)(void*))wm_inventory_sync_stop,
      .query = NULL,
  };
- 
+
  static void wm_inventory_sync_log_config(cJSON* config_json)
  {
      if (config_json)
@@ -50,7 +50,7 @@
          }
      }
  }
- 
+
  void* wm_inventory_sync_main(__attribute__((unused))wm_inventory_sync_t* data)
  {
      mtinfo(WM_INVENTORY_SYNC_LOGTAG, "Starting inventory_sync module.");
@@ -58,11 +58,11 @@
      {
         inventory_sync_start_ptr = so_get_function_sym(inventory_sync_module, "inventory_sync_start");
         inventory_sync_stop_ptr = so_get_function_sym(inventory_sync_module, "inventory_sync_stop");
- 
+
          if (inventory_sync_start_ptr)
          {
              cJSON* config_json = cJSON_CreateObject();
- 
+
              if (indexer_config == NULL)
              {
                  cJSON_AddItemToObject(config_json, "indexer", cJSON_CreateObject());
@@ -71,16 +71,16 @@
              {
                  cJSON_AddItemToObject(config_json, "indexer", cJSON_Duplicate(indexer_config, TRUE));
              }
- 
+
              // Add cluster name to inventory sync configurations. From 5.x.x onwards, the cluster is enabled by default.
              char* cluster_name = get_cluster_name();
              cJSON_AddStringToObject(config_json, "clusterName", cluster_name);
              os_free(cluster_name);
- 
+
              char* manager_node_name = get_node_name();
              cJSON_AddStringToObject(config_json, "clusterNodeName", manager_node_name);
              os_free(manager_node_name);
- 
+
              wm_inventory_sync_log_config(config_json);
              inventory_sync_start_ptr(mtLoggingFunctionsWrapper, config_json);
              cJSON_Delete(config_json);
@@ -96,15 +96,15 @@
          mtwarn(WM_INVENTORY_SYNC_LOGTAG, "Unable to load inventory_sync module.");
          return NULL;
      }
- 
+
      return NULL;
  }
- 
+
  void wm_inventory_sync_destroy(wm_inventory_sync_t* data)
  {
      free(data);
  }
- 
+
  void wm_inventory_sync_stop(__attribute__((unused)) wm_inventory_sync_t* data)
  {
      mtinfo(WM_INVENTORY_SYNC_LOGTAG, "Stopping inventory_sync module.");
@@ -117,21 +117,21 @@
          mtwarn(WM_INVENTORY_SYNC_LOGTAG, "Unable to stop inventory_sync module.");
      }
  }
- 
+
  wmodule* wm_inventory_sync_read()
  {
      wmodule* module;
- 
+
      os_calloc(1, sizeof(wmodule), module);
      module->context = &WM_INVENTORY_SYNC_CONTEXT;
      module->tag = strdup(module->context->name);
      mtinfo(WM_INVENTORY_SYNC_LOGTAG, "Loaded Inventory sync module.");
      return module;
  }
- 
+
  cJSON* wm_inventory_sync_dump(__attribute__((unused)) wm_inventory_sync_t* data)
  {
      cJSON* root = cJSON_CreateObject();
- 
+
      return root;
  }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes: #31690 

Since now cluster will be always enabled by default, some changes related to single node and cluster status were. 

## Proposed Changes

- Deprecated options UTs, updated docu
- Removed getHostname function calls for inventory sync and vulnerability scanner 
- Only cluster name and node name are called
- Fixed a leak and some wrong call to parent node in cluster config parsing

### Results and Evidence

```console
root@0d24cf5241bb:/wazuh# /var/ossec/bin/wazuh-control restart
2025/09/08 21:04:24 wazuh-db: ERROR: HAProxy address is missing in the configuration
2025/09/08 21:04:24 wazuh-db: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2025/09/08 21:04:24 wazuh-db: CRITICAL: Invalid configuration block for Wazuh-DB.

root@0d24cf5241bb:/wazuh# /var/ossec/bin/wazuh-control restart
2025/09/08 21:05:01 wazuh-db: ERROR: HAProxy user is missing in the configuration
2025/09/08 21:05:01 wazuh-db: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2025/09/08 21:05:01 wazuh-db: CRITICAL: Invalid configuration block for Wazuh-DB.

root@0d24cf5241bb:/wazuh# /var/ossec/bin/wazuh-control restart
2025/09/08 21:05:22 wazuh-db: ERROR: HAProxy password is missing in the configuration
2025/09/08 21:05:22 wazuh-db: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2025/09/08 21:05:22 wazuh-db: CRITICAL: Invalid configuration block for Wazuh-DB.


```


