### PR TITLE
Add QA branch versioned conditional in 5.0 workflows

### DIFF
--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run Agentd integration tests.
       - name: Run Agentd integration tests
         run: |

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -33,10 +33,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${QA_IT_FW_BRANCH}`" != "X" ]; then
               QA_BRANCH=${QA_IT_FW_BRANCH}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -90,17 +90,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run enrollment integration tests.
       - name: Run enrollment integration tests
         run: |

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
-          if(git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
+          if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run execd integration tests.
       - name: Run execd integration tests
         run: |

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run fim integration tests.
       - name: Run fim integration tests
         run: |

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run fim integration tests.
       - name: Run fim integration tests
         run: |

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run github integration tests.
       - name: Run github integration tests
         run: |

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run logcollector integration tests.
       - name: Run logcollector integration tests
         run: |

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run office365 integration tests.
       - name: Run office365 integration tests
         run: |

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run sca integration tests.
       - name: Run sca integration tests
         run: |

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -73,17 +73,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run syscollector integration tests.
       - name: Run syscollector integration tests
         run: |

--- a/.github/workflows/5_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_agentd-tier-0-1-lin.yml
@@ -73,10 +73,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_agentd-tier-0-1-win.yml
@@ -89,17 +89,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run Agentd integration tests.
       - name: Run Agentd integration tests
         run: |

--- a/.github/workflows/5_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_api-tier-0-1.yml
@@ -72,10 +72,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_enrollment-tier-0-1-lin.yml
@@ -74,10 +74,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_enrollment-tier-0-1-win.yml
@@ -90,17 +90,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run enrollment integration tests.
       - name: Run enrollment integration tests
         run: |

--- a/.github/workflows/5_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_execd-tier-0-1-lin.yml
@@ -72,10 +72,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_execd-tier-0-1-win.yml
@@ -88,17 +88,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
-          if(git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
+          if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run execd integration tests.
       - name: Run execd integration tests
         run: |

--- a/.github/workflows/5_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-lin.yml
@@ -72,10 +72,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-macos.yml
@@ -70,10 +70,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-win.yml
@@ -87,17 +87,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run fim integration tests.
       - name: Run fim integration tests
         run: |

--- a/.github/workflows/5_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/5_testintegration_fim-tier-2-win.yml
@@ -78,17 +78,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run fim integration tests.
       - name: Run fim integration tests
         run: |

--- a/.github/workflows/5_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_github-tier-0-1-lin.yml
@@ -72,10 +72,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_github-tier-0-1-win.yml
@@ -88,17 +88,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run github integration tests.
       - name: Run github integration tests
         run: |

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-lin.yml
@@ -72,10 +72,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-macos.yml
@@ -70,10 +70,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-win.yml
@@ -87,17 +87,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run logcollector integration tests.
       - name: Run logcollector integration tests
         run: |

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -82,10 +82,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_office365-tier-0-1-lin.yml
@@ -72,10 +72,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_office365-tier-0-1-win.yml
@@ -88,17 +88,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run office365 integration tests.
       - name: Run office365 integration tests
         run: |

--- a/.github/workflows/5_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_rbac-tier-0-1.yml
@@ -70,10 +70,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_sca-tier-0-1-lin.yml
@@ -76,10 +76,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_sca-tier-0-1-win.yml
@@ -89,17 +89,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run sca integration tests.
       - name: Run sca integration tests
         run: |

--- a/.github/workflows/5_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_syscollector-tier-0-1-lin.yml
@@ -75,10 +75,13 @@ jobs:
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi

--- a/.github/workflows/5_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_syscollector-tier-0-1-win.yml
@@ -87,17 +87,22 @@ jobs:
           .\wazuh-agent--.msi /q WAZUH_MANAGER="127.0.0.1"
       # Download and install integration tests framework.
       - name: Download and install qa-integration-framework
+        shell: pwsh
         run: |
+          # Read version from VERSION.json
+          $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
           if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
               $QA_BRANCH = $env:BRANCH_NAME
           } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
               $QA_BRANCH = $env:BRANCH_BASE
+          } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
+              $QA_BRANCH = $VERSION
           } else {
               $QA_BRANCH = "main"
           }
           git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
           pip install qa-integration-framework/
-          rm qa-integration-framework/ -r -force
+          Remove-Item qa-integration-framework -Recurse -Force
       # Run syscollector integration tests.
       - name: Run syscollector integration tests
         run: |

--- a/.github/workflows/5_testunit_python-coverage.yml
+++ b/.github/workflows/5_testunit_python-coverage.yml
@@ -31,10 +31,13 @@ jobs:
 
       - name: Download integration tests framework
         run: |
+          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
           if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
               QA_BRANCH=${BRANCH_NAME}
           elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
               QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
+              QA_BRANCH=${VERSION}
           else
               QA_BRANCH="main"
           fi


### PR DESCRIPTION
# Description

This PR is an extension for this other issue:
- https://github.com/wazuh/wazuh/issues/31576
- PR: https://github.com/wazuh/wazuh/pull/31657

Including the same change in the new 5.0 workflows.

## Testing

Check the Windows commands to extract VERSION, using echo to print the variable:
```
Run # Read version from VERSION.json
  # Read version from VERSION.json
  $VERSION = (Get-Content -Raw VERSION.json | ConvertFrom-Json).version
  echo $VERSION
  if (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_NAME) {
      $QA_BRANCH = $env:BRANCH_NAME
  } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $env:BRANCH_BASE) {
      $QA_BRANCH = $env:BRANCH_BASE
  } elseif (git ls-remote https://github.com/wazuh/qa-integration-framework.git $VERSION) {
      $QA_BRANCH = $VERSION
  } else {
      $QA_BRANCH = "main"
  }
  git clone -b $QA_BRANCH --single-branch https://github.com/wazuh/qa-integration-framework.git
  pip install qa-integration-framework/
  Remove-Item qa-integration-framework -Recurse -Force
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    BRANCH_NAME: enhancement/31576-add-qa-branch-versioned
    BRANCH_BASE: 
    pythonLocation: C:\hostedtoolcache\windows\Python\3.11.9\x64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.11.9\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.11.9\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.11.9\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.11.9\x64
5.0.0
Cloning into 'qa-integration-framework'...
Processing d:\a\wazuh\wazuh\qa-integration-framework
```