### PR TITLE
feat(#25587): add CephFS type to skip_nfs flag

### DIFF
--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -27,6 +27,7 @@
 #define SYSFS       0x62656572
 #define OVERLAYFS   0x794c7630
 #define BTRFS       0x9123683E
+#define CEPHFS      0x00C36400
 #define CIFS        0xFF534D42
 #define V9FS        0x01021997
 #define ST_NODEV    4
@@ -43,6 +44,7 @@
 const struct file_system_type network_file_systems[] = {
 #ifdef __linux__
     {.name="NFS",  .f_type=NFS, .flag=1},
+    {.name="CEPHFS", .f_type=CEPHFS, .flag=1},
     {.name="CIFS", .f_type=CIFS, .flag=1},
 #endif
     /*  The last entry must be name=NULL */
@@ -67,7 +69,7 @@ short IsNFS(const char *dir_name)
 #if defined(Linux)
     struct statfs stfs;
 
-    /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */
+    /* ignore NFS (0x6969) or CEPHFS (0x00C36400) or CIFS (0xFF534D42) mounts */
     if ( ! statfs(dir_name, &stfs) )
     {
         int i;
@@ -150,6 +152,8 @@ bool HasFilesystem(__attribute__((unused))const char * path, __attribute__((unus
 #endif
     case SYSFS:
         return set.sys;
+    case CEPHFS:
+        return set.nfs;
     case CIFS:
         return set.nfs;
     }


### PR DESCRIPTION
[ceph-csi](https://github.com/ceph/ceph-csi) for Kubernetes mounts CephFS filesystems under /var/lib/kubelet/plugins/kubernetes.io/csi/cephfs.csi.ceph.com/*/globalmount
 
Wazuh rootcheck scans include /var/lib by default
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html?utm_source=chatgpt.com#readall
 
As a result, Wazuh on Kubernetes hosts will recurse into those network filesystems, which is typically not desired, as they may be mounted by multiple hosts at the same time, as well as potentially causing performance issues.
 
I suggest that skip_nfs include CephFS (but not necessarily Ceph RBD) in addition to CIFS and NFS.

I can confirm that this patch (backported to 4.x) worked as intended for the Linux systems that I'm administrator for. This was confirmed by manually triggering a rootcheck via
`/var/ossec/bin/agent_control -r`
and observing the scanned paths on the monitored hosts with
`strace -f -e trace=lstat -p $(pidof wazuh-syscheckd)`
 
Closes https://github.com/wazuh/wazuh/issues/25587