### PR TITLE
Syscollector sends `users` delta events on each scan

### DIFF
--- a/src/data_provider/src/extended_sources/users/src/logged_in_users_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/src/logged_in_users_linux.cpp
@@ -79,7 +79,7 @@ nlohmann::json LoggedInUsersProvider::collect()
             }
             else
             {
-                row["host"] = nullptr;
+                row["host"] = "";
             }
         }
         else
@@ -93,7 +93,7 @@ nlohmann::json LoggedInUsersProvider::collect()
             }
             else
             {
-                row["host"] = nullptr;
+                row["host"] = "";
             }
         }
 

--- a/src/data_provider/src/extended_sources/users/src/logged_in_users_win.cpp
+++ b/src/data_provider/src/extended_sources/users/src/logged_in_users_win.cpp
@@ -123,6 +123,8 @@ nlohmann::json LoggedInUsersProvider::collect()
 
         auto wtsClient = reinterpret_cast<WTSCLIENTA*>(clientInfo);
 
+        r["host"] = "";
+
         if (wtsClient->ClientAddressFamily == AF_INET)
         {
             r["host"] = std::to_string(wtsClient->ClientAddress[0]) + "." +
@@ -179,6 +181,9 @@ nlohmann::json LoggedInUsersProvider::collect()
             m_twsApiWrapper->WTSFreeMemory(sessionInfo);
             sessionInfo = nullptr;
         }
+
+        r["sid"] = "";
+        r["registry_hive"] = "";
 
         if (sidBuf == nullptr)
         {

--- a/src/data_provider/src/extended_sources/users/src/shadow_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/src/shadow_linux.cpp
@@ -82,6 +82,10 @@ nlohmann::json ShadowProvider::collect()
                 // Possible improvement assigning each hash name: "6" should be "sha512"
                 entry["hash_alg"] = std::string(matches[1]);
             }
+            else
+            {
+                entry["hash_alg"] = "";
+            }
         }
         else
         {

--- a/src/data_provider/src/extended_sources/users/src/sudoers_unix.cpp
+++ b/src/data_provider/src/extended_sources/users/src/sudoers_unix.cpp
@@ -86,27 +86,19 @@ void SudoersProvider::genSudoersFile(const std::string& fileName,
         // of previous line and append it to appropriate column.
         if (isLongLine)
         {
-            isLongLine = (line.back() == '\\');
+            isLongLine = (!line.empty() && line.back() == '\\');
             auto& lastLine = results.back();
 
-            if (lastLine["rule_details"].empty())
+            // Remove trailing backslash from the line before appending
+            std::string lineToAppend = line;
+
+            if (!lineToAppend.empty() && lineToAppend.back() == '\\')
             {
-                if (lastLine["header"].empty())
-                {
-                    std::string tmp = lastLine["header"];
-                    lastLine["header"] = tmp;
-                }
-            }
-            else
-            {
-                if (lastLine["rule_details"].empty())
-                {
-                    std::string tmp = lastLine["rule_details"];
-                    lastLine["rule_details"] = tmp;
-                }
+                lineToAppend.pop_back();
+                Utils::trimSpaces(lineToAppend);
             }
 
-            lastLine["rule_details"] = lastLine["rule_details"].get<std::string>() + line;
+            lastLine["rule_details"] = lastLine["rule_details"].get<std::string>() + " " + lineToAppend;
             continue;
         }
 
@@ -121,7 +113,7 @@ void SudoersProvider::genSudoersFile(const std::string& fileName,
         auto isIncludeDir = (header == "#includedir" || header == "@includedir");
 
         // skip comments.
-        if (line.at(0) == '#' && !isInclude && !isIncludeDir)
+        if (!line.empty() && line.at(0) == '#' && !isInclude && !isIncludeDir)
         {
             continue;
         }
@@ -138,9 +130,16 @@ void SudoersProvider::genSudoersFile(const std::string& fileName,
         }
 
         // Check if a blackslash is the last character on this line.
-        if (!isInclude && !isIncludeDir && line.back() == '\\')
+        if (!isInclude && !isIncludeDir && !line.empty() && line.back() == '\\')
         {
             isLongLine = true;
+
+            // Remove trailing backslash from rule_details for consistency
+            if (!ruleDetails.empty() && ruleDetails.back() == '\\')
+            {
+                ruleDetails.pop_back();
+                Utils::trimSpaces(ruleDetails);
+            }
         }
 
         nlohmann::json entry;
@@ -152,7 +151,7 @@ void SudoersProvider::genSudoersFile(const std::string& fileName,
         if (isIncludeDir)
         {
             // support both relative and full paths
-            if (ruleDetails.at(0) != '/')
+            if (!ruleDetails.empty() && ruleDetails.at(0) != '/')
             {
                 ruleDetails = Utils::resolvePath(fileName, ruleDetails);
             }
@@ -173,7 +172,7 @@ void SudoersProvider::genSudoersFile(const std::string& fileName,
                 // contain a '.' or end with '~' are ignored.
                 if (incBasename.empty() ||
                         incBasename.find('.') != std::string::npos ||
-                        incBasename.back() == '~')
+                        (!incBasename.empty() && incBasename.back() == '~'))
                 {
                     continue;
                 }
@@ -185,7 +184,7 @@ void SudoersProvider::genSudoersFile(const std::string& fileName,
         if (isInclude)
         {
             // Relative or full paths
-            if (ruleDetails.at(0) != '/')
+            if (!ruleDetails.empty() && ruleDetails.at(0) != '/')
             {
                 ruleDetails = Utils::resolvePath(fileName, ruleDetails);
             }

--- a/src/data_provider/src/extended_sources/users/src/users_darwin.cpp
+++ b/src/data_provider/src/extended_sources/users/src/users_darwin.cpp
@@ -115,7 +115,17 @@ nlohmann::json UsersProvider::collectUsers(const std::set<uid_t>& uids)
         }
         else
         {
+            // User exists in OpenDirectory but not in local passwd database
+            // Initialize all fields with default values to ensure consistent JSON structure
             user["username"] = username;
+            user["uid"] = static_cast<uid_t>(-1);  // Special value indicating user not found locally
+            user["gid"] = static_cast<gid_t>(-1);
+            user["uid_signed"] = -1;
+            user["gid_signed"] = -1;
+            user["description"] = "";
+            user["directory"] = "";
+            user["shell"] = "";
+            user["uuid"] = "";
         }
 
         user["is_hidden"] = static_cast<int>(isHidden);

--- a/src/data_provider/src/extended_sources/users/src/users_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/src/users_linux.cpp
@@ -57,25 +57,10 @@ nlohmann::json UsersProvider::genUserJson(const struct passwd* pwd, bool include
     r["uid_signed"] = static_cast<int32_t>(pwd->pw_uid);
     r["gid_signed"] = static_cast<int32_t>(pwd->pw_gid);
 
-    if (pwd->pw_name != nullptr)
-    {
-        r["username"] = pwd->pw_name;
-    }
-
-    if (pwd->pw_gecos != nullptr)
-    {
-        r["description"] = pwd->pw_gecos;
-    }
-
-    if (pwd->pw_dir != nullptr)
-    {
-        r["directory"] = pwd->pw_dir;
-    }
-
-    if (pwd->pw_shell != nullptr)
-    {
-        r["shell"] = pwd->pw_shell;
-    }
+    r["username"] = (pwd->pw_name != nullptr) ? pwd->pw_name : "";
+    r["description"] = (pwd->pw_gecos != nullptr) ? pwd->pw_gecos : "";
+    r["directory"] = (pwd->pw_dir != nullptr) ? pwd->pw_dir : "";
+    r["shell"] = (pwd->pw_shell != nullptr) ? pwd->pw_shell : "";
 
     r["pid_with_namespace"] = "0";
     r["include_remote"] = static_cast<int>(include_remote);

--- a/src/data_provider/src/extended_sources/users/tests/test_sudoers_unix.cpp
+++ b/src/data_provider/src/extended_sources/users/tests/test_sudoers_unix.cpp
@@ -102,7 +102,7 @@ TEST_F(SudoersProviderTest, CollectReturnsExpectedJson)
 
     EXPECT_EQ(result[2]["header"], "someuser");
     EXPECT_EQ(result[2]["source"], filePath);
-    EXPECT_EQ(result[2]["rule_details"], "ALL=(ALL) /dir/bin/apt update, \\/dir/bin/apt upgrade, \\/dir/bin/apt install somepackage, \\/dir/bin/systemctl restart someservice");
+    EXPECT_EQ(result[2]["rule_details"], "ALL=(ALL) /dir/bin/apt update, /dir/bin/apt upgrade, /dir/bin/apt install somepackage, /dir/bin/systemctl restart someservice");
 
     EXPECT_EQ(result[3]["header"], "@includedir");
     EXPECT_EQ(result[3]["source"], filePath);

--- a/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm
+++ b/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm
@@ -76,10 +76,10 @@ namespace od
 
         policyData =
         {
-            {"creation_time", nullptr},
-            {"failed_login_count", nullptr},
-            {"failed_login_timestamp", nullptr},
-            {"password_last_set_time", nullptr}
+            {"creation_time", 0.0},
+            {"failed_login_count", 0},
+            {"failed_login_timestamp", 0.0},
+            {"password_last_set_time", 0.0}
         };
 
         ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -637,7 +637,7 @@ nlohmann::json SysInfo::getGroups() const
         nlohmann::json groupItem {};
 
         groupItem["group_id"] = group["gid"];
-        groupItem["group_name"] = group["groupname"];
+        groupItem["group_name"] = (group.contains("groupname") && !group["groupname"].get<std::string>().empty()) ? group["groupname"] : UNKNOWN_VALUE;
         groupItem["group_description"] = UNKNOWN_VALUE;
         groupItem["group_id_signed"] = group["gid_signed"];
         groupItem["group_uuid"] = UNKNOWN_VALUE;
@@ -693,7 +693,7 @@ nlohmann::json SysInfo::getUsers() const
     {
         nlohmann::json userItem {};
 
-        std::string username = user["username"].get<std::string>();
+        std::string username = (user.contains("username") && !user["username"].get<std::string>().empty()) ? user["username"] : UNKNOWN_VALUE;
 
         userItem["user_id"] = user["uid"];
         userItem["user_full_name"] = user["description"];

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -497,7 +497,7 @@ nlohmann::json SysInfo::getGroups() const
         gid_t currentGid = static_cast<gid_t>(group["gid"].get<int>());
 
         groupItem["group_id"] = group["gid"];
-        groupItem["group_name"] = group["groupname"];
+        groupItem["group_name"] = (group.contains("groupname") && !group["groupname"].get<std::string>().empty()) ? group["groupname"] : UNKNOWN_VALUE;
         groupItem["group_description"] = group["comment"];
         groupItem["group_id_signed"] = group["gid_signed"];
         groupItem["group_uuid"] = UNKNOWN_VALUE;
@@ -554,7 +554,7 @@ nlohmann::json SysInfo::getUsers() const
     {
         nlohmann::json userItem {};
 
-        std::string username = user["username"].get<std::string>();
+        std::string username = (user.contains("username") && !user["username"].get<std::string>().empty()) ? user["username"] : UNKNOWN_VALUE;
 
         userItem["user_id"] = user["uid"];
         userItem["user_full_name"] = user["description"];

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -1008,7 +1008,7 @@ nlohmann::json SysInfo::getGroups() const
         nlohmann::json groupItem {};
 
         groupItem["group_id"] = group["gid"];
-        groupItem["group_name"] = group["groupname"];
+        groupItem["group_name"] = (group.contains("groupname") && !group["groupname"].get<std::string>().empty()) ? group["groupname"] : UNKNOWN_VALUE;
         groupItem["group_description"] = group["comment"];
         groupItem["group_id_signed"] = group["gid_signed"];
         groupItem["group_uuid"] = group["group_sid"];
@@ -1061,7 +1061,7 @@ nlohmann::json SysInfo::getUsers() const
     {
         nlohmann::json userItem {};
 
-        std::string username = user["username"].get<std::string>();
+        std::string username = (user.contains("username") && !user["username"].get<std::string>().empty()) ? user["username"] : UNKNOWN_VALUE;
 
         userItem["user_id"] = user["uid"];
         userItem["user_full_name"] = user["description"];

--- a/src/wazuh_modules/syscollector/testtool/main.cpp
+++ b/src/wazuh_modules/syscollector/testtool/main.cpp
@@ -123,6 +123,7 @@ int main(int argc, const char* argv[])
                                       true,
                                       true,
                                       true,
+                                      true,
                                       true);
 
         if (thread.joinable())


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
Closes #31847

Syscollector is emitting inventory events for the users table on every scan, even when there are no changes. This occurs because, in some cases, collectors return values that `dbsync` does not support. Then, in each scan, differences between the collected value and the stored value are detected, and delta events are generated. Here is an example:

```json
{
    "data":
    {
        "new":
        {
            "checksum": "cf67e1353eb5012cdadf548ae545c0562f469c7b",
            "host_ip": " ",
            "login_status": 0,
            "login_tty": " ",
            "login_type": " ",
            "process_pid": 0,
            "user_auth_failed_count": 0,
            "user_auth_failed_timestamp": 0,
            "user_created": 0,
            "user_full_name": "",
            "user_group_id": 107,
            "user_group_id_signed": 107,
            "user_groups": "tcpdump",
            "user_home": "/nonexistent",
            "user_id": 105,
            "user_is_hidden": 0,
            "user_is_remote": 1,
            "user_last_login": 0,
            "user_name": "tcpdump",
            "user_password_expiration_date": -1,
            "user_password_hash_algorithm": null,
            "user_password_inactive_days": -1,
            "user_password_last_change": 1713830400.0,
            "user_password_max_days_between_changes": -1,
            "user_password_min_days_between_changes": -1,
            "user_password_status": "locked",
            "user_password_warning_days_before_expiration": -1,
            "user_roles": " ",
            "user_shell": "/usr/sbin/nologin",
            "user_type": " ",
            "user_uid_signed": 105,
            "user_uuid": " "
        },
        "old":
        {
            "user_name": "tcpdump",
            "user_password_hash_algorithm": ""
        },
        "scan_time": "2025/09/09 14:20:07"
    },
    "operation": "MODIFIED",
    "type": "dbsync_users"
}
```  

Users collector returns:

```json
 "user_password_hash_algorithm": null 
```
Dbsync does not allow `null` values to be stored; instead, it stores an empty string `“”`: 

```json
"user_password_hash_algorithm": ""
```
Therefore, the delta event is triggered.


## Proposed Changes

- Replace `null` values with an empty string `""` in the users collector events.

### Results and Evidence

#### Linux

Before fix:

<details><summary>Event 'INSERTED'</summary>

```json
{
    "data":
    {
        "checksum": "4f313b38ccd4ae96761d2daa009d384f1b7b48d6",
        "host_ip": " ",
        "login_status": 0,
        "login_tty": " ",
        "login_type": " ",
        "process_pid": 0,
        "scan_time": "2025/09/09 14:19:52",
        "user_auth_failed_count": 0,
        "user_auth_failed_timestamp": 0,
        "user_created": 0,
        "user_full_name": "root",
        "user_group_id": 0,
        "user_group_id_signed": 0,
        "user_groups": "root",
        "user_home": "/root",
        "user_id": 0,
        "user_is_hidden": 0,
        "user_is_remote": 1,
        "user_last_login": 0,
        "user_name": "root",
        "user_password_expiration_date": -1,
        "user_password_hash_algorithm": null,
        "user_password_inactive_days": -1,
        "user_password_last_change": 1713830400.0,
        "user_password_max_days_between_changes": 99999,
        "user_password_min_days_between_changes": 0,
        "user_password_status": "locked",
        "user_password_warning_days_before_expiration": 7,
        "user_roles": "sudo",
        "user_shell": "/bin/bash",
        "user_type": " ",
        "user_uid_signed": 0,
        "user_uuid": " "
    },
    "operation": "INSERTED",
    "type": "dbsync_users"
}

```

</details>

<details><summary>Event 'MODIFIED' (delta)</summary>

```json
{
    "data":
    {
        "new":
        {
            "checksum": "4f313b38ccd4ae96761d2daa009d384f1b7b48d6",
            "host_ip": " ",
            "login_status": 0,
            "login_tty": " ",
            "login_type": " ",
            "process_pid": 0,
            "user_auth_failed_count": 0,
            "user_auth_failed_timestamp": 0,
            "user_created": 0,
            "user_full_name": "root",
            "user_group_id": 0,
            "user_group_id_signed": 0,
            "user_groups": "root",
            "user_home": "/root",
            "user_id": 0,
            "user_is_hidden": 0,
            "user_is_remote": 1,
            "user_last_login": 0,
            "user_name": "root",
            "user_password_expiration_date": -1,
            "user_password_hash_algorithm": null,
            "user_password_inactive_days": -1,
            "user_password_last_change": 1713830400.0,
            "user_password_max_days_between_changes": 99999,
            "user_password_min_days_between_changes": 0,
            "user_password_status": "locked",
            "user_password_warning_days_before_expiration": 7,
            "user_roles": "sudo",
            "user_shell": "/bin/bash",
            "user_type": " ",
            "user_uid_signed": 0,
            "user_uuid": " "
        },
        "old":
        {
            "user_name": "root",
            "user_password_hash_algorithm": ""
        },
        "scan_time": "2025/09/09 14:20:07"
    },
    "operation": "MODIFIED",
    "type": "dbsync_users"
}

```

</details>  

After fix:

<details><summary>Event 'INSERTED'</summary>

```json
{
    "data":
    {
        "checksum": "39a8782c3095a351515bc32a3c9fbe4b51338611",
        "host_ip": " ",
        "login_status": 0,
        "login_tty": " ",
        "login_type": " ",
        "process_pid": 0,
        "scan_time": "2025/09/09 16:15:41",
        "user_auth_failed_count": 0,
        "user_auth_failed_timestamp": 0,
        "user_created": 0,
        "user_full_name": "root",
        "user_group_id": 0,
        "user_group_id_signed": 0,
        "user_groups": "root",
        "user_home": "/root",
        "user_id": 0,
        "user_is_hidden": 0,
        "user_is_remote": 1,
        "user_last_login": 0,
        "user_name": "root",
        "user_password_expiration_date": -1,
        "user_password_inactive_days": -1,
        "user_password_last_change": 1713830400.0,
        "user_password_max_days_between_changes": 99999,
        "user_password_min_days_between_changes": 0,
        "user_password_status": "locked",
        "user_password_warning_days_before_expiration": 7,
        "user_roles": "sudo",
        "user_shell": "/bin/bash",
        "user_type": " ",
        "user_uid_signed": 0,
        "user_uuid": " "
    },
    "operation": "INSERTED",
    "type": "dbsync_users"
}
```

</details> 

#### macOS

Before fix:

<details><summary>Event 'INSERTED'</summary>

```json
{
    "data":
    {
        "checksum": "4b500d67f0538f16d97801ae4557f2346b3dd45c",
        "host_ip": " ",
        "login_status": 0,
        "login_tty": " ",
        "login_type": " ",
        "process_pid": 0,
        "scan_time": "2025/09/10 20:20:54",
        "user_auth_failed_count": null,
        "user_auth_failed_timestamp": null,
        "user_created": null,
        "user_full_name": "Accessory Update Daemon",
        "user_group_id": 278,
        "user_group_id_signed": 278,
        "user_groups": "_accessoryupdater:everyone:localaccounts:com.apple.sharepoint.group.1:_lpoperator",
        "user_home": "/var/db/accessoryupdater",
        "user_id": 278,
        "user_is_hidden": 0,
        "user_is_remote": 0,
        "user_last_login": 0,
        "user_name": "_accessoryupdater",
        "user_password_expiration_date": 0,
        "user_password_hash_algorithm": " ",
        "user_password_inactive_days": 0,
        "user_password_last_change": null,
        "user_password_max_days_between_changes": 0,
        "user_password_min_days_between_changes": 0,
        "user_password_status": " ",
        "user_password_warning_days_before_expiration": 0,
        "user_roles": " ",
        "user_shell": "/usr/bin/false",
        "user_type": " ",
        "user_uid_signed": 278,
        "user_uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000116"
    },
    "operation": "INSERTED",
    "type": "dbsync_users"
}

```

</details>

<details><summary>Event 'MODIFIED' (delta)</summary>

```json
{
    "data":
    {
        "new":
        {
            "checksum": "4b500d67f0538f16d97801ae4557f2346b3dd45c",
            "host_ip": " ",
            "login_status": 0,
            "login_tty": " ",
            "login_type": " ",
            "process_pid": 0,
            "user_auth_failed_count": null,
            "user_auth_failed_timestamp": null,
            "user_created": null,
            "user_full_name": "Accessory Update Daemon",
            "user_group_id": 278,
            "user_group_id_signed": 278,
            "user_groups": "_accessoryupdater:everyone:localaccounts:com.apple.sharepoint.group.1:_lpoperator",
            "user_home": "/var/db/accessoryupdater",
            "user_id": 278,
            "user_is_hidden": 0,
            "user_is_remote": 0,
            "user_last_login": 0,
            "user_name": "_accessoryupdater",
            "user_password_expiration_date": 0,
            "user_password_hash_algorithm": " ",
            "user_password_inactive_days": 0,
            "user_password_last_change": null,
            "user_password_max_days_between_changes": 0,
            "user_password_min_days_between_changes": 0,
            "user_password_status": " ",
            "user_password_warning_days_before_expiration": 0,
            "user_roles": " ",
            "user_shell": "/usr/bin/false",
            "user_type": " ",
            "user_uid_signed": 278,
            "user_uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000116"
        },
        "old":
        {
            "user_auth_failed_count": 0,
            "user_auth_failed_timestamp": 0.0,
            "user_created": 0.0,
            "user_name": "_accessoryupdater",
            "user_password_last_change": 0.0
        },
        "scan_time": "2025/09/10 20:21:10"
    },
    "operation": "MODIFIED",
    "type": "dbsync_users"
}

```

</details>  

After fix:

<details><summary>Event 'INSERTED'</summary>

```json
{
    "data":
    {
        "checksum": "6f59d43d2678691725b3b19b505207565e76b67b",
        "host_ip": " ",
        "login_status": 0,
        "login_tty": " ",
        "login_type": " ",
        "process_pid": 0,
        "scan_time": "2025/09/10 21:00:22",
        "user_auth_failed_count": 0,
        "user_auth_failed_timestamp": 0.0,
        "user_created": 0.0,
        "user_full_name": "Accessory Update Daemon",
        "user_group_id": 278,
        "user_group_id_signed": 278,
        "user_groups": "_accessoryupdater:everyone:localaccounts:com.apple.sharepoint.group.1:_lpoperator",
        "user_home": "/var/db/accessoryupdater",
        "user_id": 278,
        "user_is_hidden": 0,
        "user_is_remote": 0,
        "user_last_login": 0,
        "user_name": "_accessoryupdater",
        "user_password_expiration_date": 0,
        "user_password_hash_algorithm": " ",
        "user_password_inactive_days": 0,
        "user_password_last_change": 0.0,
        "user_password_max_days_between_changes": 0,
        "user_password_min_days_between_changes": 0,
        "user_password_status": " ",
        "user_password_warning_days_before_expiration": 0,
        "user_roles": " ",
        "user_shell": "/usr/bin/false",
        "user_type": " ",
        "user_uid_signed": 278,
        "user_uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000116"
    },
    "operation": "INSERTED",
    "type": "dbsync_users"
}
```

</details> 

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X

### Artifacts Affected

- Data provider module: collector `users`
- Syscollector module: table `users` 

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues


<!--
Include any additional information relevant to the review process.
-->
