### PR TITLE
Fix tests in `test_experimental_endpoints.tavern.yaml` - Implementation

### DIFF
--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -553,3 +553,23 @@ def validate_update_check_response(response, current_version, update_check):
         if available_update_data != {}:
             for key, value_type in keys_to_check:
                 assert isinstance(available_update_data[key], value_type)
+
+
+def test_agent_ports(response, agents_list):
+    """Check that syscollector ports results belongs to certain agents.
+
+    Parameters
+    ----------
+    response : Request response.
+    agents_list : list
+        List of expected agents that should have port information.
+    """
+
+    data = response.json()['data']
+
+    expected_agents_with_ports =  set(agents_list.split(","))
+    current_agents_with_ports = { port_info["agent_id"] for port_info in data.get('affected_items', []) }
+
+    assert expected_agents_with_ports == current_agents_with_ports, \
+        f'Current agents listing ports ({current_agents_with_ports})  \
+            is different than expected ({expected_agents_with_ports}).'

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -534,6 +534,10 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_agent_ports
+        extra_kwargs:
+          agents_list: '000,001,002,003,004,005,006,007,008'
       json:
         error: !anyint
         data:
@@ -554,24 +558,6 @@ stages:
                   time: !anystr
                 state: !anystr
                 tx_queue: !anyint
-            - <<: *ports_response
-              agent_id: '000'
-            - <<: *ports_response
-              agent_id: '001'
-            - <<: *ports_response
-              agent_id: '002'
-            - <<: *ports_response
-              agent_id: '003'
-            - <<: *ports_response
-              agent_id: '004'
-            - <<: *ports_response
-              agent_id: '005'
-            - <<: *ports_response
-              agent_id: '006'
-            - <<: *ports_response
-              agent_id: '007'
-            - <<: *ports_response
-              agent_id: '008'
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -588,24 +574,17 @@ stages:
         agents_list: '001,003,005,007'
     response:
       status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_agent_ports
+        extra_kwargs:
+          agents_list: '001,003,005,007'
       json:
         error: !anyint
         data:
           affected_items:
             - <<: *ports_response
-              agent_id: '001'
-            - <<: *ports_response
-              agent_id: '001'
-            - <<: *ports_response
-              agent_id: '003'
-            - <<: *ports_response
-              agent_id: '003'
-            - <<: *ports_response
-              agent_id: '005'
-            - <<: *ports_response
-              agent_id: '007'
           failed_items: []
-          total_affected_items: 6
+          total_affected_items: !anyint
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -466,16 +466,30 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_agent_ports
+        extra_kwargs:
+          agents_list: '000,002,004,006,008'
       json:
         error: 0
         data:
           affected_items:
-            # The answer must include at least one item whose agent is shown below
-            - agent_id: '000'
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
+            - &ports_response
+              agent_id: !anystr
+                inode: !anyint
+                local:
+                  ip: !anystr
+                  port: !anyint
+                protocol: !anystr
+                remote:
+                  ip: !anystr
+                  port: !anyint
+                rx_queue: !anyint
+                scan:
+                  id: !anyint
+                  time: !anystr
+                state: !anystr
+                tx_queue: !anyint
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -491,18 +505,17 @@ stages:
         agents_list: '002,004,006,008'
     response:
       status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_agent_ports
+        extra_kwargs:
+          agents_list: '002,004,006,008'
       json:
         error: 0
         data:
           affected_items:
-            - agent_id: '002'
-            - agent_id: '002'
-            - agent_id: '004'
-            - agent_id: '004'
-            - agent_id: '006'
-            - agent_id: '008'
+            - <<: *ports_response
           failed_items: []
-          total_affected_items: 6
+          total_affected_items: !anyint
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -497,18 +497,32 @@ stages:
         Authorization: "Bearer {test_login_token}"
     response:
       status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_agent_ports
+        extra_kwargs:
+          agents_list: '001,003,005,007'
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
-            - agent_id: '001'
-            - agent_id: '001'
-            - agent_id: '003'
-            - agent_id: '003'
-            - agent_id: '005'
-            - agent_id: '007'
+            - &ports_response
+              agent_id: !anystr
+                inode: !anyint
+                local:
+                  ip: !anystr
+                  port: !anyint
+                protocol: !anystr
+                remote:
+                  ip: !anystr
+                  port: !anyint
+                rx_queue: !anyint
+                scan:
+                  id: !anyint
+                  time: !anystr
+                state: !anystr
+                tx_queue: !anyint
           failed_items: []
-          total_affected_items: 6
+          total_affected_items: !anyint
           total_failed_items: 0
 
   - name: Request
@@ -522,18 +536,17 @@ stages:
         agents_list: '001,003,005,007'
     response:
       status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_agent_ports
+        extra_kwargs:
+          agents_list: '001,003,005,007'
       json:
-        error: !anyint
+        error: 0
         data:
           affected_items:
-            - agent_id: '001'
-            - agent_id: '001'
-            - agent_id: '003'
-            - agent_id: '003'
-            - agent_id: '005'
-            - agent_id: '007'
+            - <<: *ports_response
           failed_items: []
-          total_affected_items: 6
+          total_affected_items: !anyint
           total_failed_items: 0
 
 ---


### PR DESCRIPTION

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes  #31836

This PR aims to fix API IT related to the syscollector port experimental endpoints

The fix was a consequence of https://github.com/wazuh/wazuh/pull/31740 implementation that increased the port count  and, in some environments, the Docker DNS resolution port can appear.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- API IT checks that the experimental syscollector port scan results contain certain expected agents, but not the port count for each one
- A custom handler has developed for such task
### Results and Evidence

<details><summary>test_experimental_endpoints.tavern.yaml</summary>

```
root@wazuh-dev:~/repos/wazuh/api/test/integration# pytest  --nobuild -vvv "test_experimental_endpoints.tavern.yaml" --html=report.html
============================================================================ test session starts =============================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.15.0-153-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'cov': '4.1.0', 'trio': '0.8.0', 'tornasync': '0.6.0', 'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '2.0.4', 'anyio': '3.7.1'}}
rootdir: /root/repos/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, cov-4.1.0, trio-0.8.0, tornasync-0.6.0, testinfra-5.0.0, html-3.1.1, metadata-2.0.4, anyio-3.7.1
asyncio: mode=auto
collected 12 items                                                                                                                                                           

test_experimental_endpoints.tavern.yaml::DELETE /experimental/rootcheck PASSED                                                                                         [  8%]
test_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                                          [ 16%]
test_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                                                                                       [ 25%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                                                [ 33%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                                                 [ 41%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                                                [ 50%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                                                [ 58%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                                                      [ 66%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                                                [ 75%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                                                   [ 83%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                                               [ 91%]
test_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                                                [100%]

============================================================================== warnings summary ==============================================================================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642
  /usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_experimental_endpoints.tavern.yaml: 12 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------------------------------- generated html file: file:///root/repos/wazuh/api/test/integration/report.html -----------------------------------------------
================================================================ 12 passed, 13 warnings in 258.59s (0:04:18) =================================================================
```
</details>


<details><summary>test_rbac_black_experimental_endpoints.tavern.yaml</summary>

```
root@wazuh-dev:~/repos/wazuh/api/test/integration# pytest  --nobuild -vvv "test_rbac_black_experimental_endpoints.tavern.yaml" --html=report.html
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.15.0-153-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'cov': '4.1.0', 'trio': '0.8.0', 'tornasync': '0.6.0', 'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '2.0.4', 'anyio': '3.7.1'}}
rootdir: /root/repos/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, cov-4.1.0, trio-0.8.0, tornasync-0.6.0, testinfra-5.0.0, html-3.1.1, metadata-2.0.4, anyio-3.7.1
asyncio: mode=auto
collected 12 items                                                                                                                                              

test_rbac_black_experimental_endpoints.tavern.yaml::DELETE /experimental/rootcheck PASSED                                                                 [  8%]
test_rbac_black_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                  [ 16%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                                                               [ 25%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                        [ 33%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                         [ 41%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                        [ 50%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                        [ 58%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                              [ 66%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                        [ 75%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                           [ 83%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                       [ 91%]
test_rbac_black_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                        [100%]

======================================================================= warnings summary ========================================================================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642
  /usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_black_experimental_endpoints.tavern.yaml: 12 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------- generated html file: file:///root/repos/wazuh/api/test/integration/report.html -----------------------------------------
========================================================== 12 passed, 13 warnings in 248.62s (0:04:08) ==========================================================

```
</details>

<details><summary>test_rbac_white_experimental_endpoints.tavern.yaml</summary>

```
root@wazuh-dev:~/repos/wazuh/api/test/integration# pytest  --nobuild -vvv "test_rbac_white_experimental_endpoints.tavern.yaml" --html=report.html
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.15.0-153-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'cov': '4.1.0', 'trio': '0.8.0', 'tornasync': '0.6.0', 'testinfra': '5.0.0', 'html': '3.1.1', 'metadata': '2.0.4', 'anyio': '3.7.1'}}
rootdir: /root/repos/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, cov-4.1.0, trio-0.8.0, tornasync-0.6.0, testinfra-5.0.0, html-3.1.1, metadata-2.0.4, anyio-3.7.1
asyncio: mode=auto
collected 12 items                                                                                                                                              

test_rbac_white_experimental_endpoints.tavern.yaml::DELETE /experimental/rootcheck PASSED                                                                 [  8%]
test_rbac_white_experimental_endpoints.tavern.yaml::DELETE /experimental/syscheck PASSED                                                                  [ 16%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/ciscat/results PASSED                                                               [ 25%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hardware PASSED                                                        [ 33%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netaddr PASSED                                                         [ 41%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netiface PASSED                                                        [ 50%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/netproto PASSED                                                        [ 58%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/os PASSED                                                              [ 66%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/packages PASSED                                                        [ 75%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/ports PASSED                                                           [ 83%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/processes PASSED                                                       [ 91%]
test_rbac_white_experimental_endpoints.tavern.yaml::GET /experimental/syscollector/hotfixes PASSED                                                        [100%]

======================================================================= warnings summary ========================================================================
../../../../../../usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642
  /usr/local/lib/python3.10/dist-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_white_experimental_endpoints.tavern.yaml: 12 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------- generated html file: file:///root/repos/wazuh/api/test/integration/report.html -----------------------------------------
========================================================== 12 passed, 13 warnings in 224.23s (0:03:44) ==========================================================

```
</details>

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
