### PR TITLE
Add single node awareness

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -683,6 +683,8 @@ class APIRequestQueue(WazuhRequestQueue):
 
     async def run(self):
         while True:
+            await self.server.tasks_event.wait()
+
             names, request = (await self.request_queue.get()).split(' ', 1)
             names = names.split('*', 1)
             # name    -> node name the request must be sent to. None if called from a worker node.
@@ -730,6 +732,8 @@ class SendSyncRequestQueue(WazuhRequestQueue):
 
     async def run(self):
         while True:
+            await self.server.tasks_event.wait()
+
             names, request = (await self.request_queue.get()).split(' ', 1)
             names = names.split('*', 1)
             # name    -> node name the request must be sent to. None if called from a worker node.

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -766,6 +766,8 @@ async def test_APIRequestQueue_run(loop_mock, import_module_mock):
     class ServerMock:
         def __init__(self):
             self.clients = {"names": ["w1", "w2"]}
+            self.tasks_event = asyncio.Event()
+            self.tasks_event.set()
 
     class RequestQueueMock:
         async def get(self):
@@ -813,6 +815,8 @@ async def test_SendSyncRequestQueue_run(loop_mock, contexlib_mock):
     class ServerMock:
         def __init__(self):
             self.clients = {"names": ["w1", "w2"]}
+            self.tasks_event = asyncio.Event()
+            self.tasks_event.set()
 
     class RequestQueueMock:
         async def get(self):

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -403,7 +403,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                                  set_data_command='global set-agent-groups',
                                                  set_payload={'mode': 'override', 'sync_status': 'synced'})
 
-        if len(self.server.clients) == 0:
+        if not self.server.tasks_event.is_set():
             self.logger.info("Starting cluster tasks.")
             self.server.tasks_event.set()
 

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -620,6 +620,9 @@ def test_master_handler_hello_ok(super_hello_mock, mkdir_with_mode_mock, join_mo
 
         def __init__(self):
             self.configuration = {}
+            self.clients = {}
+            self.tasks_event = asyncio.Event()
+            self.tasks_event.set()
 
     master_handler.server = Server()
     master_handler.server.configuration["name"] = "cluster_name"
@@ -1430,6 +1433,9 @@ def test_master_handler_connection_lost(clean_up_mock, connection_lost_mock, log
     master_handler = get_master_handler()
     master_handler.logger = logging.getLogger("wazuh")
     master_handler.name = worker_name
+    master_handler.server.clients = {}
+    master_handler.server.tasks_event = asyncio.Event()
+    master_handler.server.tasks_event.set()
 
     class PendingTaskMock:
         """Auxiliary class."""
@@ -1589,6 +1595,7 @@ async def test_agent_groups_update(sleep_mock, perf_counter_mock):
 
     logger_mock = LoggerMock()
     master_class = get_master()
+    master_class.tasks_event.set()
 
     with patch("wazuh.core.cluster.master.Master.setup_task_logger",
                return_value=logger_mock) as setup_task_logger_mock:
@@ -1616,6 +1623,7 @@ async def test_master_file_status_update_ok(sleep_mock):
     """Check if the file status is properly obtained."""
 
     master_class = get_master()
+    master_class.tasks_event.set()
 
     class LoggerMock:
         """Auxiliary class."""
@@ -1673,6 +1681,7 @@ async def test_master_file_status_update_ok(run_in_pool_mock, asyncio_sleep_mock
                                                 "node_type": "master"},
                                  cluster_items=cluster_items,
                                  enable_ssl=False)
+    master_class.tasks_event.set()
 
     class LoggerMock:
         """Auxiliary class."""

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -452,6 +452,7 @@ async def test_AbstractServer_check_clients_keepalive(sleep_mock):
                        return_value=logger):
                 abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
                                                  cluster_items={"test4": 4}, enable_ssl=True, logger=logger)
+                abstract_server.tasks_event.set()
                 tester = "check_clients_keepalive"
                 abstract_server.cluster_items = {"intervals": {"master": {"check_worker_lastkeepalive": tester}}}
                 try:

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -326,19 +326,6 @@ start_service()
         echo -n '{"error":0,"data":['
     fi
     for i in ${SDAEMONS}; do
-        ## If wazuh-clusterd is disabled, don't try to start it.
-        if [ X"$i" = "Xwazuh-clusterd" ]; then
-             start_config="$(grep -n "<cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
-             end_config="$(grep -n "</cluster>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"
-             if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
-                sed -n "${start_config},${end_config}p" ${DIR}/etc/ossec.conf | grep "<disabled>yes" >/dev/null 2>&1
-                if [ $? = 0 ]; then
-                    continue
-                fi
-             else
-                continue
-             fi
-        fi
         ## If wazuh-authd is disabled, don't try to start it.
         if [ X"$i" = "Xwazuh-authd" ]; then
              start_config="$(grep -n "<auth>" ${DIR}/etc/ossec.conf | cut -d':' -f 1)"


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/31586.

## Proposed Changes

Adds a tasks coordination event to the server to start and stop tasks depending on whether there are clients connected or not.

### Manual tests with their corresponding evidence

WIP, blocked by a compilation error in the epic branch.

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
