### PR TITLE
Add curl as required dependency in package generation

### DIFF
--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.wazuh.com
 
 Package: wazuh-manager
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser, curl
 Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api


### PR DESCRIPTION
## Description

Closes #31022. Since some OSs might not include the `curl` package, we must add it as a required dependency in the package installation process.

## Proposed Changes

- Add `curl` as a required dependency of the DEB package.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<details><summary>Test having missing dependencies in base OS</summary>

```
root@0649d1d550bb:/# dpkg -i wazuh-manager_5.0.0-0_amd64_3bf7689.deb 
Selecting previously unselected package wazuh-manager.
(Reading database ... 4381 files and directories currently installed.)
Preparing to unpack wazuh-manager_5.0.0-0_amd64_3bf7689.deb ...
Unpacking wazuh-manager (5.0.0-0) ...
dpkg: dependency problems prevent configuration of wazuh-manager:
 wazuh-manager depends on lsb-release; however:
  Package lsb-release is not installed.
 wazuh-manager depends on adduser; however:
  Package adduser is not installed.
 wazuh-manager depends on curl; however:
  Package curl is not installed.

dpkg: error processing package wazuh-manager (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 wazuh-manager
root@0649d1d550bb:/# apt update && apt install curl lsb-release -y
Get:1 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Get:2 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
Get:3 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [1408 kB]
Get:4 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:5 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:6 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
Get:7 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2159 kB]
Get:8 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [23.0 kB]
Get:9 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1135 kB]  
Get:10 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]           
Get:11 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
Get:12 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
Get:13 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1918 kB]
Get:14 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1761 kB]                                                                                                                               
Get:15 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2269 kB]                                                                                                                         
Get:16 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [45.2 kB]                                                                                                                         
Get:17 http://archive.ubuntu.com/ubuntu noble-backports/main amd64 Packages [48.8 kB]                                                                                                                             
Get:18 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [35.6 kB]                                                                                                                         
Fetched 33.0 MB in 8s (4378 kB/s)                                                                                                                                                                                 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 curl : Depends: libcurl4t64 (= 8.5.0-2ubuntu10.6) but it is not going to be installed
 wazuh-manager : Depends: adduser but it is not going to be installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
root@0649d1d550bb:/# apt --fix-broken install
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Correcting dependencies... Done
The following additional packages will be installed:
  adduser ca-certificates curl krb5-locales libbrotli1 libcurl4t64 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-common libldap2 libnghttp2-14 libpsl5t64 librtmp1 libsasl2-2
  libsasl2-modules libsasl2-modules-db libssh-4 lsb-release openssl publicsuffix
Suggested packages:
  liblocale-gettext-perl perl cron quota ecryptfs-utils krb5-doc krb5-user libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql
The following NEW packages will be installed:
  adduser ca-certificates curl krb5-locales libbrotli1 libcurl4t64 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-common libldap2 libnghttp2-14 libpsl5t64 librtmp1 libsasl2-2
  libsasl2-modules libsasl2-modules-db libssh-4 lsb-release openssl publicsuffix
0 upgraded, 23 newly installed, 0 to remove and 1 not upgraded.
1 not fully installed or removed.
Need to get 3675 kB of archives.
After this operation, 9692 kB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 http://archive.ubuntu.com/ubuntu noble/main amd64 lsb-release all 12.0-2 [6564 B]
Get:2 http://archive.ubuntu.com/ubuntu noble/main amd64 adduser all 3.137ubuntu1 [101 kB]
Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 libbrotli1 amd64 1.1.0-2build2 [331 kB]
Get:4 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libkrb5support0 amd64 1.20.1-6ubuntu2.6 [34.4 kB]
Get:5 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libk5crypto3 amd64 1.20.1-6ubuntu2.6 [82.0 kB]
Get:6 http://archive.ubuntu.com/ubuntu noble/main amd64 libkeyutils1 amd64 1.6.3-3build1 [9490 B]
Get:7 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libkrb5-3 amd64 1.20.1-6ubuntu2.6 [348 kB]
Get:8 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libgssapi-krb5-2 amd64 1.20.1-6ubuntu2.6 [143 kB]
Get:9 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libsasl2-modules-db amd64 2.1.28+dfsg1-5ubuntu3.1 [20.4 kB]
Get:10 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libsasl2-2 amd64 2.1.28+dfsg1-5ubuntu3.1 [53.2 kB]
Get:11 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libldap2 amd64 2.6.7+dfsg-1~exp1ubuntu8.2 [196 kB]
Get:12 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libnghttp2-14 amd64 1.59.0-1ubuntu0.2 [74.3 kB]
Get:13 http://archive.ubuntu.com/ubuntu noble/main amd64 libpsl5t64 amd64 0.21.2-1.1build1 [57.1 kB]
Get:14 http://archive.ubuntu.com/ubuntu noble/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build7 [56.3 kB]
Get:15 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-4 amd64 0.10.6-2ubuntu0.1 [188 kB]
Get:16 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4t64 amd64 8.5.0-2ubuntu10.6 [341 kB]
Get:17 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 curl amd64 8.5.0-2ubuntu10.6 [226 kB]
Get:18 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 openssl amd64 3.0.13-0ubuntu3.5 [1002 kB]
Get:19 http://archive.ubuntu.com/ubuntu noble/main amd64 ca-certificates all 20240203 [159 kB]
Get:20 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 krb5-locales all 1.20.1-6ubuntu2.6 [14.8 kB]
Get:21 http://archive.ubuntu.com/ubuntu noble/main amd64 publicsuffix all 20231001.0357-0.1 [129 kB]
Get:22 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libldap-common all 2.6.7+dfsg-1~exp1ubuntu8.2 [31.7 kB]
Get:23 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libsasl2-modules amd64 2.1.28+dfsg1-5ubuntu3.1 [69.9 kB]
Fetched 3675 kB in 4s (924 kB/s)           
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package lsb-release.
(Reading database ... 28600 files and directories currently installed.)
Preparing to unpack .../lsb-release_12.0-2_all.deb ...
Unpacking lsb-release (12.0-2) ...
Selecting previously unselected package adduser.
Preparing to unpack .../adduser_3.137ubuntu1_all.deb ...
Unpacking adduser (3.137ubuntu1) ...
Setting up adduser (3.137ubuntu1) ...
Selecting previously unselected package libbrotli1:amd64.
(Reading database ... 28653 files and directories currently installed.)
Preparing to unpack .../00-libbrotli1_1.1.0-2build2_amd64.deb ...
Unpacking libbrotli1:amd64 (1.1.0-2build2) ...
Selecting previously unselected package libkrb5support0:amd64.
Preparing to unpack .../01-libkrb5support0_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libkrb5support0:amd64 (1.20.1-6ubuntu2.6) ...
Selecting previously unselected package libk5crypto3:amd64.
Preparing to unpack .../02-libk5crypto3_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libk5crypto3:amd64 (1.20.1-6ubuntu2.6) ...
Selecting previously unselected package libkeyutils1:amd64.
Preparing to unpack .../03-libkeyutils1_1.6.3-3build1_amd64.deb ...
Unpacking libkeyutils1:amd64 (1.6.3-3build1) ...
Selecting previously unselected package libkrb5-3:amd64.
Preparing to unpack .../04-libkrb5-3_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libkrb5-3:amd64 (1.20.1-6ubuntu2.6) ...
Selecting previously unselected package libgssapi-krb5-2:amd64.
Preparing to unpack .../05-libgssapi-krb5-2_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libgssapi-krb5-2:amd64 (1.20.1-6ubuntu2.6) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../06-libsasl2-modules-db_2.1.28+dfsg1-5ubuntu3.1_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.28+dfsg1-5ubuntu3.1) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../07-libsasl2-2_2.1.28+dfsg1-5ubuntu3.1_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.28+dfsg1-5ubuntu3.1) ...
Selecting previously unselected package libldap2:amd64.
Preparing to unpack .../08-libldap2_2.6.7+dfsg-1~exp1ubuntu8.2_amd64.deb ...
Unpacking libldap2:amd64 (2.6.7+dfsg-1~exp1ubuntu8.2) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../09-libnghttp2-14_1.59.0-1ubuntu0.2_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.59.0-1ubuntu0.2) ...
Selecting previously unselected package libpsl5t64:amd64.
Preparing to unpack .../10-libpsl5t64_0.21.2-1.1build1_amd64.deb ...
Unpacking libpsl5t64:amd64 (0.21.2-1.1build1) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../11-librtmp1_2.4+20151223.gitfa8646d.1-2build7_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build7) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../12-libssh-4_0.10.6-2ubuntu0.1_amd64.deb ...
Unpacking libssh-4:amd64 (0.10.6-2ubuntu0.1) ...
Selecting previously unselected package libcurl4t64:amd64.
Preparing to unpack .../13-libcurl4t64_8.5.0-2ubuntu10.6_amd64.deb ...
Unpacking libcurl4t64:amd64 (8.5.0-2ubuntu10.6) ...
Selecting previously unselected package curl.
Preparing to unpack .../14-curl_8.5.0-2ubuntu10.6_amd64.deb ...
Unpacking curl (8.5.0-2ubuntu10.6) ...
Selecting previously unselected package openssl.
Preparing to unpack .../15-openssl_3.0.13-0ubuntu3.5_amd64.deb ...
Unpacking openssl (3.0.13-0ubuntu3.5) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../16-ca-certificates_20240203_all.deb ...
Unpacking ca-certificates (20240203) ...
Selecting previously unselected package krb5-locales.
Preparing to unpack .../17-krb5-locales_1.20.1-6ubuntu2.6_all.deb ...
Unpacking krb5-locales (1.20.1-6ubuntu2.6) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../18-publicsuffix_20231001.0357-0.1_all.deb ...
Unpacking publicsuffix (20231001.0357-0.1) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../19-libldap-common_2.6.7+dfsg-1~exp1ubuntu8.2_all.deb ...
Unpacking libldap-common (2.6.7+dfsg-1~exp1ubuntu8.2) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../20-libsasl2-modules_2.1.28+dfsg1-5ubuntu3.1_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.28+dfsg1-5ubuntu3.1) ...
Setting up libkeyutils1:amd64 (1.6.3-3build1) ...
Setting up libbrotli1:amd64 (1.1.0-2build2) ...
Setting up libsasl2-modules:amd64 (2.1.28+dfsg1-5ubuntu3.1) ...
Setting up libpsl5t64:amd64 (0.21.2-1.1build1) ...
Setting up libnghttp2-14:amd64 (1.59.0-1ubuntu0.2) ...
Setting up krb5-locales (1.20.1-6ubuntu2.6) ...
Setting up libldap-common (2.6.7+dfsg-1~exp1ubuntu8.2) ...
Setting up libkrb5support0:amd64 (1.20.1-6ubuntu2.6) ...
Setting up libsasl2-modules-db:amd64 (2.1.28+dfsg1-5ubuntu3.1) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build7) ...
Setting up libk5crypto3:amd64 (1.20.1-6ubuntu2.6) ...
Setting up libsasl2-2:amd64 (2.1.28+dfsg1-5ubuntu3.1) ...
Setting up libkrb5-3:amd64 (1.20.1-6ubuntu2.6) ...
Setting up lsb-release (12.0-2) ...
Setting up openssl (3.0.13-0ubuntu3.5) ...
Setting up publicsuffix (20231001.0357-0.1) ...
Setting up libldap2:amd64 (2.6.7+dfsg-1~exp1ubuntu8.2) ...
Setting up ca-certificates (20240203) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/
lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readli
ne.pm line 8.)
debconf: falling back to frontend: Teletype
Updating certificates in /etc/ssl/certs...
146 added, 0 removed; done.
Setting up libgssapi-krb5-2:amd64 (1.20.1-6ubuntu2.6) ...
Setting up libssh-4:amd64 (0.10.6-2ubuntu0.1) ...
Setting up libcurl4t64:amd64 (8.5.0-2ubuntu10.6) ...
Setting up curl (8.5.0-2ubuntu10.6) ...
Setting up wazuh-manager (5.0.0-0) ...
Processing triggers for libc-bin (2.39-0ubuntu8.5) ...
Processing triggers for ca-certificates (20240203) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
root@0649d1d550bb:/# dpkg -i wazuh-manager_5.0.0-0_amd64_3bf7689.deb 
(Reading database ... 29286 files and directories currently installed.)
Preparing to unpack wazuh-manager_5.0.0-0_amd64_3bf7689.deb ...
Unpacking wazuh-manager (5.0.0-0) over (5.0.0-0) ...
Setting up wazuh-manager (5.0.0-0) ...

```

</details>

<details><summary>Test behavior</summary>

```
root@0649d1d550bb:/# /var/ossec/bin/wazuh-control start
2025/09/10 15:06:53 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/10 15:06:53 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/10 15:06:53 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
Started wazuh-forwarder...
Started wazuh-apid...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2025/09/10 15:07:11 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/10 15:07:11 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/10 15:07:11 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Started wazuh-modulesd...
Completed.
root@0649d1d550bb:/# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...
wazuh-forwarder is running...
```

</details>

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected


- Wazuh Server DEB package


### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
