### PR TITLE
Forward WPK upgrade completion directly from remoted to modulesd

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2084,7 +2084,7 @@ addagent/%.o: addagent/%.c
 
 
 manage_agents: ${addagent_o}
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} ${WAZUH_LDFLAGS} $^ ${OSSEC_LIBS} ${WAZUH_LIBS} -o $@
 
 #### Active Response ####
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2084,7 +2084,7 @@ addagent/%.o: addagent/%.c
 
 
 manage_agents: ${addagent_o}
-	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} ${WAZUH_LDFLAGS} $^ ${OSSEC_LIBS} ${WAZUH_LIBS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@
 
 #### Active Response ####
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -1040,20 +1040,27 @@ void router_message_forward(char* msg, size_t msg_length, const char* agent_id, 
 
         cJSON* parameters_obj = cJSON_GetObjectItem(upgrade_ack_json, "parameters");
 
-        int agent = atoi(agent_id);
-        cJSON* agents = cJSON_CreateIntArray(&agent, 1);
-        cJSON_AddItemToObject(parameters_obj, "agents", agents);
+        if (parameters_obj && cJSON_IsObject(parameters_obj)) {
+            int agent = atoi(agent_id);
+            cJSON* agents = cJSON_CreateIntArray(&agent, 1);
+            cJSON_AddItemToObject(parameters_obj, "agents", agents);
 
-        char *upgrade_message = cJSON_PrintUnformatted(upgrade_ack_json);
-        size_t msg_size = strlen(upgrade_message) + 1; // +1 for null terminator
+            char *upgrade_message = cJSON_PrintUnformatted(upgrade_ack_json);
+            size_t msg_size = strlen(upgrade_message) + 1; // +1 for null terminator
 
-        if (router_provider_send(router_handle, upgrade_message, msg_size) != 0) {
-            mwarn("Unable to forward upgrade-ack message '%s' for agent %s", msg_start, agent_id);
+            if (router_provider_send(router_handle, upgrade_message, msg_size) != 0) {
+                mwarn("Unable to forward upgrade-ack message '%s' for agent %s", msg_start, agent_id);
+            }
+
+            // Free the printed message and JSON object
+            cJSON_free(upgrade_message);
+        }
+        else {
+            mwarn("Could not get parameters from upgrade message: '%s'", msg_start);
         }
 
-        // Free the printed message and JSON object
-        cJSON_free(upgrade_message);
         cJSON_Delete(upgrade_ack_json);
+
     }
 }
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -246,11 +246,11 @@ void HandleSecure()
 
     // Router providers initialization
     if (router_upgrade_ack_handle = router_provider_create("upgrade_notifications", false), !router_upgrade_ack_handle) {
-        mdebug2("Failed to create router handle for 'upgrade_notifications'.");
+        mwarn("Failed to create router handle for 'upgrade_notifications'.");
     }
 
     if (router_sync_handle = router_provider_create("inventory-states", false), !router_sync_handle) {
-        mdebug2("Failed to create router handle for 'inventory synchronization'.");
+        mwarn("Failed to create router handle for 'inventory synchronization'.");
     }
 
     // Create upsert control message thread
@@ -1048,7 +1048,7 @@ void router_message_forward(char* msg, size_t msg_length, const char* agent_id, 
         size_t msg_size = strlen(upgrade_message) + 1; // +1 for null terminator
 
         if (router_provider_send(router_handle, upgrade_message, msg_size) != 0) {
-            mdebug2("Unable to forward upgrade-ack message '%s' for agent %s", msg_start, agent_id);
+            merror("Unable to forward upgrade-ack message '%s' for agent %s", msg_start, agent_id);
         }
 
         // Free the printed message and JSON object

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -246,11 +246,11 @@ void HandleSecure()
 
     // Router providers initialization
     if (router_upgrade_ack_handle = router_provider_create("upgrade_notifications", false), !router_upgrade_ack_handle) {
-        mwarn("Failed to create router handle for 'upgrade_notifications'.");
+        mdebug2("Failed to create router handle for 'upgrade_notifications'.");
     }
 
     if (router_sync_handle = router_provider_create("inventory-states", false), !router_sync_handle) {
-        mwarn("Failed to create router handle for 'inventory synchronization'.");
+        mdebug2("Failed to create router handle for 'inventory synchronization'.");
     }
 
     // Create upsert control message thread
@@ -1034,7 +1034,7 @@ void router_message_forward(char* msg, size_t msg_length, const char* agent_id, 
         cJSON* upgrade_ack_json;
         const char *json_err;
         if (upgrade_ack_json = cJSON_ParseWithOpts(msg_start, &json_err, 0), !upgrade_ack_json) {
-            merror("Failed to parse router message JSON: '%s'", json_err);
+            mwarn("Failed to parse router message JSON: '%s'", json_err);
             return;
         }
 
@@ -1048,7 +1048,7 @@ void router_message_forward(char* msg, size_t msg_length, const char* agent_id, 
         size_t msg_size = strlen(upgrade_message) + 1; // +1 for null terminator
 
         if (router_provider_send(router_handle, upgrade_message, msg_size) != 0) {
-            merror("Unable to forward upgrade-ack message '%s' for agent %s", msg_start, agent_id);
+            mwarn("Unable to forward upgrade-ack message '%s' for agent %s", msg_start, agent_id);
         }
 
         // Free the printed message and JSON object

--- a/src/shared_modules/router/include/router.h
+++ b/src/shared_modules/router/include/router.h
@@ -182,7 +182,9 @@ extern "C"
      * @param isLocal True if the subscriber is local, false otherwise.
      * @return ROUTER_SUBSCRIBER_HANDLE Handle to the router subscriber.
      */
-    EXPORTED ROUTER_SUBSCRIBER_HANDLE router_subscriber_create(const char* topic_name, const char* subscriber_id, bool isLocal);
+    EXPORTED ROUTER_SUBSCRIBER_HANDLE router_subscriber_create(const char* topic_name,
+                                                               const char* subscriber_id,
+                                                               bool isLocal);
 
     /**
      * @brief Subscribe to messages with a callback.
@@ -191,7 +193,8 @@ extern "C"
      * @param callback Callback function to be called when message is received.
      * @return 0 on success, -1 on error.
      */
-    EXPORTED int router_subscriber_subscribe(ROUTER_SUBSCRIBER_HANDLE handle, router_subscriber_callback_t callback);
+    EXPORTED int router_subscriber_subscribe(ROUTER_SUBSCRIBER_HANDLE handle,
+                                             router_subscriber_callback_t callback);
 
     /**
      * @brief Unsubscribe from messages.

--- a/src/shared_modules/router/include/router.h
+++ b/src/shared_modules/router/include/router.h
@@ -53,6 +53,8 @@ enum msg_type
     MT_SYS_DELTAS,
     MT_SYNC,
     MT_SYSCHECK_DELTAS,
+    MT_INV_SYNC,
+    MT_UPGRADE_ACK,
 };
 
 #ifdef __cplusplus
@@ -160,6 +162,51 @@ extern "C"
 
     EXPORTED void router_stop_api(const char* socket_path);
 
+    /**
+     * @brief Represents the handle associated with router subscriber manipulation.
+     */
+    typedef void* ROUTER_SUBSCRIBER_HANDLE;
+
+    /**
+     * @brief Subscriber callback function.
+     *
+     * @param message Message received.
+     */
+    typedef void (*router_subscriber_callback_t)(const char* message);
+
+    /**
+     * @brief Create a router subscriber.
+     *
+     * @param topic_name Name of the topic to subscribe to.
+     * @param subscriber_id Unique subscriber ID.
+     * @param isLocal True if the subscriber is local, false otherwise.
+     * @return ROUTER_SUBSCRIBER_HANDLE Handle to the router subscriber.
+     */
+    EXPORTED ROUTER_SUBSCRIBER_HANDLE router_subscriber_create(const char* topic_name, const char* subscriber_id, bool isLocal);
+
+    /**
+     * @brief Subscribe to messages with a callback.
+     *
+     * @param handle Handle to the router subscriber.
+     * @param callback Callback function to be called when message is received.
+     * @return 0 on success, -1 on error.
+     */
+    EXPORTED int router_subscriber_subscribe(ROUTER_SUBSCRIBER_HANDLE handle, router_subscriber_callback_t callback);
+
+    /**
+     * @brief Unsubscribe from messages.
+     *
+     * @param handle Handle to the router subscriber.
+     */
+    EXPORTED void router_subscriber_unsubscribe(ROUTER_SUBSCRIBER_HANDLE handle);
+
+    /**
+     * @brief Destroy a router subscriber.
+     *
+     * @param handle Handle to the router subscriber.
+     */
+    EXPORTED void router_subscriber_destroy(ROUTER_SUBSCRIBER_HANDLE handle);
+
 #ifdef __cplusplus
 }
 #endif
@@ -194,5 +241,13 @@ typedef void (*router_register_api_endpoint_func)(const char* module,
 typedef void (*router_start_api_func)(const char* socket_path);
 
 typedef void (*router_stop_api_func)(const char* socket_path);
+
+typedef ROUTER_SUBSCRIBER_HANDLE (*router_subscriber_create_func)(const char* topic_name, const char* subscriber_id, bool isLocal);
+
+typedef int (*router_subscriber_subscribe_func)(ROUTER_SUBSCRIBER_HANDLE handle, router_subscriber_callback_t callback);
+
+typedef void (*router_subscriber_unsubscribe_func)(ROUTER_SUBSCRIBER_HANDLE handle);
+
+typedef void (*router_subscriber_destroy_func)(ROUTER_SUBSCRIBER_HANDLE handle);
 
 #endif // _ROUTER_H

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -43,7 +43,6 @@ std::shared_mutex PROVIDERS_MUTEX;
 std::map<ROUTER_SUBSCRIBER_HANDLE, std::shared_ptr<RouterSubscriber>> SUBSCRIBERS;
 std::shared_mutex SUBSCRIBERS_MUTEX;
 
-
 flatbuffers::Parser initSchemaParsers()
 {
     flatbuffers::Parser parser;
@@ -567,11 +566,13 @@ extern "C"
         {
             if (!topic_name || !subscriber_id)
             {
-                logMessage(modules_log_level_t::LOG_ERROR, "Error creating subscriber. Topic name or subscriber ID is empty");
+                logMessage(modules_log_level_t::LOG_ERROR,
+                           "Error creating subscriber. Topic name or subscriber ID is empty");
             }
             else
             {
-                std::shared_ptr<RouterSubscriber> subscriber = std::make_shared<RouterSubscriber>(topic_name, subscriber_id, isLocal);
+                std::shared_ptr<RouterSubscriber> subscriber =
+                    std::make_shared<RouterSubscriber>(topic_name, subscriber_id, isLocal);
                 std::unique_lock<std::shared_mutex> lock(SUBSCRIBERS_MUTEX);
                 SUBSCRIBERS[subscriber.get()] = subscriber;
                 retVal = subscriber.get();
@@ -597,9 +598,8 @@ extern "C"
             else
             {
                 std::unique_lock<std::shared_mutex> lock(SUBSCRIBERS_MUTEX);
-                SUBSCRIBERS.at(handle)->subscribe([callback](const std::vector<char>& message) {
-                    callback(message.data());
-                });
+                SUBSCRIBERS.at(handle)->subscribe([callback](const std::vector<char>& message)
+                                                  { callback(message.data()); });
                 retVal = 0;
             }
         }

--- a/src/shared_modules/router/tests/component/interface_c_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_c_test.cpp
@@ -45,7 +45,26 @@ TEST_F(RouterCInterfaceTest, DISABLED_TestDoubleProviderInit)
 
 TEST_F(RouterCInterfaceTest, TestDoubleSubscriberInit)
 {
-    // TODO - Add C interface for subscribers.
+    const char* topic_name = "test";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle1 = router_subscriber_create(topic_name, subscriber_id, true);
+    EXPECT_NE(handle1, nullptr);
+
+    auto handle2 = router_subscriber_create(topic_name, subscriber_id, true);
+    EXPECT_NE(handle2, nullptr);
+
+    // Both handles should be valid but different
+    EXPECT_NE(handle1, handle2);
+
+    if (handle1 != nullptr)
+    {
+        router_subscriber_destroy(handle1);
+    }
+    if (handle2 != nullptr)
+    {
+        router_subscriber_destroy(handle2);
+    }
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSend)
@@ -55,7 +74,8 @@ TEST_F(RouterCInterfaceTest, TestProviderSend)
 
     EXPECT_EQ(router_provider_send(handle, "test", 4), 0);
 
-    // TODO - Add C interface for subscribers.
+    // Clean up provider
+    EXPECT_NO_THROW(router_provider_destroy(handle));
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSendNull)
@@ -65,7 +85,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendNull)
 
     EXPECT_EQ(router_provider_send(handle, nullptr, 4), -1);
 
-    // TODO - Add C interface for subscribers.
+    EXPECT_NO_THROW(router_provider_destroy(handle));
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSendZero)
@@ -75,7 +95,7 @@ TEST_F(RouterCInterfaceTest, TestProviderSendZero)
 
     EXPECT_EQ(router_provider_send(handle, "test", 0), -1);
 
-    // TODO - Add C interface for subscribers.
+    EXPECT_NO_THROW(router_provider_destroy(handle));
 }
 
 TEST_F(RouterCInterfaceTest, TestProviderSendAndDestroy)
@@ -110,7 +130,7 @@ TEST_F(RouterCInterfaceTest, TestTwoProvidersWithTheSameTopicName)
 
     EXPECT_EQ(handle2, nullptr);
 
-    // TODO - Add C interface for subscribers.
+    EXPECT_NO_THROW(router_provider_destroy(handle1));
 }
 
 /**
@@ -230,4 +250,274 @@ TEST_F(RouterCInterfaceTestNoSetUp, TestSendMessageAfterBrokerRestart)
     {
         FAIL() << "Failed to stop router";
     }
+}
+
+// Global variables for integration testing callbacks
+static std::atomic<int> g_integration_callback_count{0};
+static std::string g_integration_last_message;
+static std::mutex g_integration_message_mutex;
+
+void integration_test_callback(const char* message)
+{
+    if (message != nullptr)
+    {
+        std::lock_guard<std::mutex> lock(g_integration_message_mutex);
+        g_integration_last_message = std::string(message);
+        g_integration_callback_count++;
+    }
+}
+
+/**
+ * @brief Integration test: Provider sends data to C interface subscriber
+ */
+TEST_F(RouterCInterfaceTest, TestProviderToSubscriberCInterface)
+{
+    const char* topic_name = "integration-topic";
+    const char* subscriber_id = "integration-subscriber";
+    const char* test_message = "integration-test-message";
+
+    // Create provider (use local for integration tests)
+    auto provider_handle = router_provider_create(topic_name, true);
+    ASSERT_NE(provider_handle, nullptr);
+
+    // Create subscriber using C interface (use local for integration tests)
+    auto subscriber_handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(subscriber_handle, nullptr);
+
+    // Reset callback counter
+    g_integration_callback_count = 0;
+    g_integration_last_message.clear();
+
+    // Subscribe with callback
+    int subscribe_result = router_subscriber_subscribe(subscriber_handle, integration_test_callback);
+    EXPECT_EQ(subscribe_result, 0);
+
+    // Give some time for subscription to be established
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Send message from provider (include null terminator)
+    int send_result = router_provider_send(provider_handle, test_message, strlen(test_message) + 1);
+    EXPECT_EQ(send_result, 0);
+
+    // Wait for callback to be called
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Verify callback was called with correct message
+    EXPECT_GT(g_integration_callback_count.load(), 0);
+    {
+        std::lock_guard<std::mutex> lock(g_integration_message_mutex);
+        EXPECT_EQ(g_integration_last_message, test_message);
+    }
+
+    // Clean up
+    router_subscriber_unsubscribe(subscriber_handle);
+    router_subscriber_destroy(subscriber_handle);
+    router_provider_destroy(provider_handle);
+}
+
+/**
+ * @brief Integration test: Multiple C interface subscribers on same topic
+ */
+TEST_F(RouterCInterfaceTest, TestMultipleSubscribersSameTopic)
+{
+    const char* topic_name = "multi-subscriber-topic";
+    const char* test_message = "multi-subscriber-message";
+    const int num_subscribers = 3;
+
+    // Create provider (use local)
+    auto provider_handle = router_provider_create(topic_name, true);
+    ASSERT_NE(provider_handle, nullptr);
+
+    // Create multiple subscribers
+    std::vector<ROUTER_SUBSCRIBER_HANDLE> subscriber_handles;
+    std::vector<std::atomic<int>> callback_counts(num_subscribers);
+
+    for (int i = 0; i < num_subscribers; ++i)
+    {
+        std::string subscriber_id = "multi-subscriber-" + std::to_string(i);
+        auto handle = router_subscriber_create(topic_name, subscriber_id.c_str(), true);
+        ASSERT_NE(handle, nullptr);
+        subscriber_handles.push_back(handle);
+
+        callback_counts[i] = 0;
+
+        // Create unique callback for each subscriber
+        static std::vector<std::function<void(const char*)>> callbacks;
+        callbacks.push_back([&callback_counts, i](const char* message) {
+            if (message != nullptr) {
+                callback_counts[i]++;
+            }
+        });
+
+        int result = router_subscriber_subscribe(handle, integration_test_callback);
+        EXPECT_EQ(result, 0);
+    }
+
+    // Reset global counter
+    g_integration_callback_count = 0;
+
+    // Give time for subscriptions to be established
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Send message
+    int send_result = router_provider_send(provider_handle, test_message, strlen(test_message) + 1);
+    EXPECT_EQ(send_result, 0);
+
+    // Wait for callbacks
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Verify at least one callback was called (all subscribers use same callback function)
+    EXPECT_GT(g_integration_callback_count.load(), 0);
+
+    // Clean up
+    for (auto handle : subscriber_handles)
+    {
+        router_subscriber_unsubscribe(handle);
+        router_subscriber_destroy(handle);
+    }
+    EXPECT_NO_THROW(router_provider_destroy(provider_handle));
+}
+
+/**
+ * @brief Integration test: Large message handling through C interface
+ */
+TEST_F(RouterCInterfaceTest, TestLargeMessageCInterface)
+{
+    const char* topic_name = "large-message-topic";
+    const char* subscriber_id = "large-message-subscriber";
+
+    // Create large message (10KB) with null terminator
+    std::string large_message(10 * 1024, 'L');
+    large_message += '\0'; // Add null terminator
+
+    // Create provider and subscriber (use local)
+    auto provider_handle = router_provider_create(topic_name, true);
+    ASSERT_NE(provider_handle, nullptr);
+
+    auto subscriber_handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(subscriber_handle, nullptr);
+
+    // Subscribe
+    g_integration_callback_count = 0;
+    g_integration_last_message.clear();
+
+    int subscribe_result = router_subscriber_subscribe(subscriber_handle, integration_test_callback);
+    EXPECT_EQ(subscribe_result, 0);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Send large message
+    int send_result = router_provider_send(provider_handle, large_message.c_str(), large_message.size());
+    EXPECT_EQ(send_result, 0);
+
+    // Wait for callback
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    // Verify callback was called and message received correctly
+    EXPECT_GT(g_integration_callback_count.load(), 0);
+    {
+        std::lock_guard<std::mutex> lock(g_integration_message_mutex);
+        // The callback receives data without the null terminator
+        EXPECT_EQ(g_integration_last_message.size(), large_message.size() - 1); // -1 for null terminator
+    }
+
+    // Clean up
+    router_subscriber_unsubscribe(subscriber_handle);
+    router_subscriber_destroy(subscriber_handle);
+    router_provider_destroy(provider_handle);
+}
+
+/**
+ * @brief Integration test: Multiple topics with C interface subscribers
+ */
+TEST_F(RouterCInterfaceTest, TestMultipleTopicsCInterface)
+{
+    const char* topic1 = "topic1";
+    const char* topic2 = "topic2";
+    const char* subscriber_id = "multi-topic-subscriber";
+    const char* message1 = "message-for-topic1";
+    const char* message2 = "message-for-topic2";
+
+    // Create providers for different topics (use local)
+    auto provider1 = router_provider_create(topic1, true);
+    auto provider2 = router_provider_create(topic2, true);
+    ASSERT_NE(provider1, nullptr);
+    ASSERT_NE(provider2, nullptr);
+
+    // Create subscribers for different topics (use local)
+    auto subscriber1 = router_subscriber_create(topic1, subscriber_id, true);
+    auto subscriber2 = router_subscriber_create(topic2, subscriber_id, true);
+    ASSERT_NE(subscriber1, nullptr);
+    ASSERT_NE(subscriber2, nullptr);
+
+    // Subscribe both
+    g_integration_callback_count = 0;
+
+    router_subscriber_subscribe(subscriber1, integration_test_callback);
+    router_subscriber_subscribe(subscriber2, integration_test_callback);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Send to topic1
+    router_provider_send(provider1, message1, strlen(message1) + 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    int count_after_topic1 = g_integration_callback_count.load();
+    EXPECT_GT(count_after_topic1, 0);
+
+    // Send to topic2
+    router_provider_send(provider2, message2, strlen(message2) + 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    int count_after_topic2 = g_integration_callback_count.load();
+    EXPECT_GT(count_after_topic2, count_after_topic1);
+
+    // Clean up
+    router_subscriber_destroy(subscriber1);
+    router_subscriber_destroy(subscriber2);
+    router_provider_destroy(provider1);
+    router_provider_destroy(provider2);
+}
+
+/**
+ * @brief Integration test: Function pointer usage in real scenario
+ */
+TEST_F(RouterCInterfaceTest, TestFunctionPointersIntegration)
+{
+    // Get function pointers
+    router_subscriber_create_func create_func = router_subscriber_create;
+    router_subscriber_subscribe_func subscribe_func = router_subscriber_subscribe;
+    router_subscriber_unsubscribe_func unsubscribe_func = router_subscriber_unsubscribe;
+    router_subscriber_destroy_func destroy_func = router_subscriber_destroy;
+
+    const char* topic_name = "function-pointer-topic";
+    const char* subscriber_id = "function-pointer-subscriber";
+    const char* test_message = "function-pointer-message";
+
+    // Create provider (use local)
+    auto provider_handle = router_provider_create(topic_name, true);
+    ASSERT_NE(provider_handle, nullptr);
+
+    // Use function pointers to create and manage subscriber (use local)
+    auto subscriber_handle = create_func(topic_name, subscriber_id, true);
+    ASSERT_NE(subscriber_handle, nullptr);
+
+    // Subscribe using function pointer
+    g_integration_callback_count = 0;
+    int result = subscribe_func(subscriber_handle, integration_test_callback);
+    EXPECT_EQ(result, 0);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Send message
+    router_provider_send(provider_handle, test_message, strlen(test_message) + 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Verify callback was called
+    EXPECT_GT(g_integration_callback_count.load(), 0);
+
+    // Clean up using function pointers
+    unsubscribe_func(subscriber_handle);
+    destroy_func(subscriber_handle);
+    router_provider_destroy(provider_handle);
 }

--- a/src/shared_modules/router/tests/component/interface_c_test.cpp
+++ b/src/shared_modules/router/tests/component/interface_c_test.cpp
@@ -253,7 +253,7 @@ TEST_F(RouterCInterfaceTestNoSetUp, TestSendMessageAfterBrokerRestart)
 }
 
 // Global variables for integration testing callbacks
-static std::atomic<int> g_integration_callback_count{0};
+static std::atomic<int> g_integration_callback_count {0};
 static std::string g_integration_last_message;
 static std::mutex g_integration_message_mutex;
 
@@ -343,11 +343,14 @@ TEST_F(RouterCInterfaceTest, TestMultipleSubscribersSameTopic)
 
         // Create unique callback for each subscriber
         static std::vector<std::function<void(const char*)>> callbacks;
-        callbacks.push_back([&callback_counts, i](const char* message) {
-            if (message != nullptr) {
-                callback_counts[i]++;
-            }
-        });
+        callbacks.push_back(
+            [&callback_counts, i](const char* message)
+            {
+                if (message != nullptr)
+                {
+                    callback_counts[i]++;
+                }
+            });
 
         int result = router_subscriber_subscribe(handle, integration_test_callback);
         EXPECT_EQ(result, 0);

--- a/src/shared_modules/router/tests/unit/router_subscriber_c_interface_test.cpp
+++ b/src/shared_modules/router/tests/unit/router_subscriber_c_interface_test.cpp
@@ -1,0 +1,524 @@
+/*
+ * Wazuh router - Router Subscriber C Interface tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 11, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "router.h"
+#include <atomic>
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+/**
+ * @brief Runs unit tests for Router Subscriber C Interface
+ */
+class RouterSubscriberCInterfaceTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Start router for each test
+        ASSERT_EQ(router_start(), 0);
+    }
+
+    void TearDown() override
+    {
+        // Stop router after each test
+        ASSERT_EQ(router_stop(), 0);
+    }
+};
+
+/**
+ * @brief Test router_subscriber_create with valid parameters
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberValid)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    EXPECT_NE(handle, nullptr);
+
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test router_subscriber_create with remote subscriber
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberRemote)
+{
+    const char* topic_name = "remote-topic";
+    const char* subscriber_id = "remote-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, false);
+    EXPECT_NE(handle, nullptr);
+
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test router_subscriber_create with null topic name
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberNullTopicName)
+{
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(nullptr, subscriber_id, true);
+    EXPECT_EQ(handle, nullptr);
+}
+
+/**
+ * @brief Test router_subscriber_create with null subscriber ID
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberNullSubscriberId)
+{
+    const char* topic_name = "test-topic";
+
+    auto handle = router_subscriber_create(topic_name, nullptr, true);
+    EXPECT_EQ(handle, nullptr);
+}
+
+/**
+ * @brief Test router_subscriber_create with empty topic name
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberEmptyTopicName)
+{
+    const char* topic_name = "";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    // Should handle empty topic name gracefully
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test router_subscriber_create with empty subscriber ID
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberEmptySubscriberId)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    // Should handle empty subscriber ID gracefully
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test router_subscriber_create with very long topic name
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberLongTopicName)
+{
+    std::string long_topic(1000, 'T');
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(long_topic.c_str(), subscriber_id, true);
+    EXPECT_NE(handle, nullptr);
+
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test router_subscriber_create with very long subscriber ID
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberLongSubscriberId)
+{
+    const char* topic_name = "test-topic";
+    std::string long_id(1000, 'S');
+
+    auto handle = router_subscriber_create(topic_name, long_id.c_str(), true);
+    EXPECT_NE(handle, nullptr);
+
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test router_subscriber_create with special characters
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateSubscriberSpecialCharacters)
+{
+    const char* topic_name = "test-topic!@#$%^&*()";
+    const char* subscriber_id = "test-subscriber!@#$%^&*()";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    EXPECT_NE(handle, nullptr);
+
+    if (handle != nullptr)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test multiple subscribers with same topic and ID
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestCreateMultipleSubscribersSameId)
+{
+    const char* topic_name = "same-topic";
+    const char* subscriber_id = "same-id";
+
+    auto handle1 = router_subscriber_create(topic_name, subscriber_id, true);
+    auto handle2 = router_subscriber_create(topic_name, subscriber_id, true);
+
+    EXPECT_NE(handle1, nullptr);
+    EXPECT_NE(handle2, nullptr);
+    EXPECT_NE(handle1, handle2); // Should be different handles
+
+    if (handle1 != nullptr)
+    {
+        router_subscriber_destroy(handle1);
+    }
+    if (handle2 != nullptr)
+    {
+        router_subscriber_destroy(handle2);
+    }
+}
+
+/**
+ * @brief Global callback function for testing
+ */
+static std::atomic<int> g_callback_count{0};
+static std::string g_last_message;
+
+void test_callback(const char* message)
+{
+    if (message != nullptr)
+    {
+        g_last_message = std::string(message);
+        g_callback_count++;
+    }
+}
+
+/**
+ * @brief Test router_subscriber_subscribe with valid handle and callback
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestSubscribeValid)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    g_callback_count = 0;
+    g_last_message.clear();
+
+    int result = router_subscriber_subscribe(handle, test_callback);
+    EXPECT_EQ(result, 0); // Assuming 0 means success
+
+    router_subscriber_destroy(handle);
+}
+
+/**
+ * @brief Test router_subscriber_subscribe with null handle
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestSubscribeNullHandle)
+{
+    int result = router_subscriber_subscribe(nullptr, test_callback);
+    EXPECT_NE(result, 0); // Should return error code
+}
+
+/**
+ * @brief Test router_subscriber_subscribe with null callback
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestSubscribeNullCallback)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    int result = router_subscriber_subscribe(handle, nullptr);
+    EXPECT_NE(result, 0); // Should return error code
+
+    router_subscriber_destroy(handle);
+}
+
+/**
+ * @brief Test router_subscriber_subscribe multiple times on same handle
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestSubscribeMultipleTimes)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    g_callback_count = 0;
+
+    // First subscription
+    int result1 = router_subscriber_subscribe(handle, test_callback);
+    EXPECT_EQ(result1, 0);
+
+    // Second subscription (might overwrite first)
+    int result2 = router_subscriber_subscribe(handle, test_callback);
+    EXPECT_EQ(result2, 0);
+
+    router_subscriber_destroy(handle);
+}
+
+/**
+ * @brief Test router_subscriber_unsubscribe with valid handle
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestUnsubscribeValid)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    g_callback_count = 0;
+    router_subscriber_subscribe(handle, test_callback);
+
+    EXPECT_NO_THROW(router_subscriber_unsubscribe(handle));
+
+    router_subscriber_destroy(handle);
+}
+
+/**
+ * @brief Test router_subscriber_unsubscribe with null handle
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestUnsubscribeNullHandle)
+{
+    // Should not crash with null handle
+    EXPECT_NO_THROW(router_subscriber_unsubscribe(nullptr));
+}
+
+/**
+ * @brief Test router_subscriber_unsubscribe without prior subscribe
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestUnsubscribeWithoutSubscribe)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    // Unsubscribe without subscribing first
+    EXPECT_NO_THROW(router_subscriber_unsubscribe(handle));
+
+    router_subscriber_destroy(handle);
+}
+
+/**
+ * @brief Test router_subscriber_destroy with valid handle
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestDestroyValid)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    EXPECT_NO_THROW(router_subscriber_destroy(handle));
+}
+
+/**
+ * @brief Test router_subscriber_destroy with null handle
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestDestroyNullHandle)
+{
+    // Should not crash with null handle
+    EXPECT_NO_THROW(router_subscriber_destroy(nullptr));
+}
+
+/**
+ * @brief Test router_subscriber_destroy after subscribe
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestDestroyAfterSubscribe)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    g_callback_count = 0;
+    router_subscriber_subscribe(handle, test_callback);
+
+    // Destroy should automatically unsubscribe
+    EXPECT_NO_THROW(router_subscriber_destroy(handle));
+}
+
+/**
+ * @brief Test double destroy (should be safe)
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestDoubleDestroy)
+{
+    const char* topic_name = "test-topic";
+    const char* subscriber_id = "test-subscriber";
+
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    router_subscriber_destroy(handle);
+
+    // Second destroy should be safe
+    EXPECT_NO_THROW(router_subscriber_destroy(handle));
+}
+
+/**
+ * @brief Test full lifecycle: create -> subscribe -> unsubscribe -> destroy
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestFullLifecycle)
+{
+    const char* topic_name = "lifecycle-topic";
+    const char* subscriber_id = "lifecycle-subscriber";
+
+    // Create
+    auto handle = router_subscriber_create(topic_name, subscriber_id, true);
+    ASSERT_NE(handle, nullptr);
+
+    // Subscribe
+    g_callback_count = 0;
+    int subscribe_result = router_subscriber_subscribe(handle, test_callback);
+    EXPECT_EQ(subscribe_result, 0);
+
+    // Unsubscribe
+    EXPECT_NO_THROW(router_subscriber_unsubscribe(handle));
+
+    // Destroy
+    EXPECT_NO_THROW(router_subscriber_destroy(handle));
+}
+
+/**
+ * @brief Test concurrent subscriber creation
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestConcurrentSubscriberCreation)
+{
+    const int num_threads = 4;
+    const int subscribers_per_thread = 10;
+    std::vector<std::thread> threads;
+    std::vector<ROUTER_SUBSCRIBER_HANDLE> handles;
+    std::mutex handles_mutex;
+
+    threads.reserve(num_threads);
+
+    for (int t = 0; t < num_threads; ++t)
+    {
+        threads.emplace_back([&handles, &handles_mutex, t, subscribers_per_thread]()
+        {
+            for (int i = 0; i < subscribers_per_thread; ++i)
+            {
+                std::string topic = "thread-" + std::to_string(t) + "-topic-" + std::to_string(i);
+                std::string subscriber_id = "thread-" + std::to_string(t) + "-subscriber-" + std::to_string(i);
+
+                auto handle = router_subscriber_create(topic.c_str(), subscriber_id.c_str(), true);
+                if (handle != nullptr)
+                {
+                    std::lock_guard<std::mutex> lock(handles_mutex);
+                    handles.push_back(handle);
+                }
+            }
+        });
+    }
+
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    EXPECT_EQ(handles.size(), static_cast<size_t>(num_threads * subscribers_per_thread));
+
+    // Clean up
+    for (auto handle : handles)
+    {
+        router_subscriber_destroy(handle);
+    }
+}
+
+/**
+ * @brief Test function pointer typedefs
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestFunctionPointers)
+{
+    // Test that function pointers can be assigned
+    router_subscriber_create_func create_func = router_subscriber_create;
+    router_subscriber_subscribe_func subscribe_func = router_subscriber_subscribe;
+    router_subscriber_unsubscribe_func unsubscribe_func = router_subscriber_unsubscribe;
+    router_subscriber_destroy_func destroy_func = router_subscriber_destroy;
+
+    EXPECT_NE(create_func, nullptr);
+    EXPECT_NE(subscribe_func, nullptr);
+    EXPECT_NE(unsubscribe_func, nullptr);
+    EXPECT_NE(destroy_func, nullptr);
+
+    // Test using function pointers
+    const char* topic_name = "func-ptr-topic";
+    const char* subscriber_id = "func-ptr-subscriber";
+
+    auto handle = create_func(topic_name, subscriber_id, true);
+    EXPECT_NE(handle, nullptr);
+
+    if (handle != nullptr)
+    {
+        g_callback_count = 0;
+        int result = subscribe_func(handle, test_callback);
+        EXPECT_EQ(result, 0);
+
+        unsubscribe_func(handle);
+        destroy_func(handle);
+    }
+}
+
+/**
+ * @brief Test rapid create/destroy cycles
+ */
+TEST_F(RouterSubscriberCInterfaceTest, TestRapidCreateDestroyCycles)
+{
+    const int num_cycles = 100;
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < num_cycles; ++i)
+    {
+        std::string topic = "rapid-topic-" + std::to_string(i);
+        std::string subscriber_id = "rapid-subscriber-" + std::to_string(i);
+
+        auto handle = router_subscriber_create(topic.c_str(), subscriber_id.c_str(), true);
+        EXPECT_NE(handle, nullptr);
+
+        if (handle != nullptr)
+        {
+            router_subscriber_destroy(handle);
+        }
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    // Should complete in reasonable time (less than 100ms)
+    EXPECT_LT(duration.count(), 100000);
+}

--- a/src/shared_modules/router/tests/unit/router_subscriber_c_interface_test.cpp
+++ b/src/shared_modules/router/tests/unit/router_subscriber_c_interface_test.cpp
@@ -204,7 +204,7 @@ TEST_F(RouterSubscriberCInterfaceTest, TestCreateMultipleSubscribersSameId)
 /**
  * @brief Global callback function for testing
  */
-static std::atomic<int> g_callback_count{0};
+static std::atomic<int> g_callback_count {0};
 static std::string g_last_message;
 
 void test_callback(const char* message)
@@ -428,21 +428,22 @@ TEST_F(RouterSubscriberCInterfaceTest, TestConcurrentSubscriberCreation)
 
     for (int t = 0; t < num_threads; ++t)
     {
-        threads.emplace_back([&handles, &handles_mutex, t, subscribers_per_thread]()
-        {
-            for (int i = 0; i < subscribers_per_thread; ++i)
+        threads.emplace_back(
+            [&handles, &handles_mutex, t, subscribers_per_thread]()
             {
-                std::string topic = "thread-" + std::to_string(t) + "-topic-" + std::to_string(i);
-                std::string subscriber_id = "thread-" + std::to_string(t) + "-subscriber-" + std::to_string(i);
-
-                auto handle = router_subscriber_create(topic.c_str(), subscriber_id.c_str(), true);
-                if (handle != nullptr)
+                for (int i = 0; i < subscribers_per_thread; ++i)
                 {
-                    std::lock_guard<std::mutex> lock(handles_mutex);
-                    handles.push_back(handle);
+                    std::string topic = "thread-" + std::to_string(t) + "-topic-" + std::to_string(i);
+                    std::string subscriber_id = "thread-" + std::to_string(t) + "-subscriber-" + std::to_string(i);
+
+                    auto handle = router_subscriber_create(topic.c_str(), subscriber_id.c_str(), true);
+                    if (handle != nullptr)
+                    {
+                        std::lock_guard<std::mutex> lock(handles_mutex);
+                        handles.push_back(handle);
+                    }
                 }
-            }
-        });
+            });
     }
 
     for (auto& thread : threads)

--- a/src/unit_tests/os_regex/test_os_regex.c
+++ b/src/unit_tests/os_regex/test_os_regex.c
@@ -12,6 +12,7 @@
 #include <cmocka.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "../../os_regex/os_regex.h"
 #include "../../os_regex/os_regex_internal.h"

--- a/src/unit_tests/os_regex/test_os_regex_execute.c
+++ b/src/unit_tests/os_regex/test_os_regex_execute.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "../../external/cJSON/cJSON.h"
 #include "../../os_regex/os_regex.h"

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -73,7 +73,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock -Wl,--wrap,getDefine_Int \
                             -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_evt \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
-                            -Wl,--wrap,router_provider_send_fb ${HASH_OP_WRAPPERS}")
+                            -Wl,--wrap,router_provider_send ${HASH_OP_WRAPPERS}")
 
 list(APPEND remoted_names "test_save_ctrlmsg_thread")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2189,7 +2189,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json(void** 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
 
     // Expect error message for invalid JSON
-    expect_string(__wrap__merror, formatted_msg, "Failed to parse router message JSON: 'nvalid json'");  // Updated expected message
+    expect_string(__wrap__mwarn, formatted_msg, "Failed to parse router message JSON: 'nvalid json'");  // Updated expected message
 
     HandleSecureMessage(&message, control_msg_queue);
 
@@ -2267,7 +2267,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed(void** s
     will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
-    expect_string(__wrap__merror, formatted_msg, "Unable to forward upgrade-ack message '{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}' for agent 042");
+    expect_string(__wrap__mwarn, formatted_msg, "Unable to forward upgrade-ack message '{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}' for agent 042");
 
     // Mock router provider send for upgrade ACK - simulate failure
     expect_string(__wrap_router_provider_send, message, "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\",\"agents\":[42]}}");

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2204,6 +2204,83 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json(void** 
     indexed_queue_free(control_msg_queue);
 }
 
+void test_HandleSecureMessage_router_forwarding_upgrade_ack_json_without_parameters(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"not-parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}";
+    message_t message = {.buffer = buffer, .size = strlen(buffer), .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("test_agent");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    // Mock router handles
+    router_upgrade_ack_handle = (ROUTER_PROVIDER_HANDLE)0x12345;
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedIP
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    // ReadSecMSG
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    // SendMSG
+    expect_string(__wrap_SendMSG, message, "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"not-parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (test_agent) 127.0.0.1");
+    expect_any(__wrap_SendMSG, loc);
+    will_return(__wrap_SendMSG, 0);
+
+    expect_function_call(__wrap_rem_inc_recv_evt);
+
+    // getDefine_Int for router_forwarding_disabled
+    will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not get parameters from upgrade message: '{\"command\":\"upgrade_update_status\",\"not-parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}'");
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Clean up router handle
+    router_upgrade_ack_handle = NULL;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+}
+
 void test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed(void** state)
 {
     char buffer[OS_MAXSTR + 1] = "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}";
@@ -2727,6 +2804,7 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_success),
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_no_handle),
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json),
+        cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_json_without_parameters),
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed),
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_disabled),
         // Tests handle_new_tcp_connection

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2267,7 +2267,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed(void** s
     will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
-    expect_string(__wrap__mdebug2, formatted_msg, "Unable to forward upgrade-ack message '{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}' for agent 042");
+    expect_string(__wrap__merror, formatted_msg, "Unable to forward upgrade-ack message '{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}' for agent 042");
 
     // Mock router provider send for upgrade ACK - simulate failure
     expect_string(__wrap_router_provider_send, message, "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\",\"agents\":[42]}}");

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -50,6 +50,8 @@ extern remoted logr;
 extern wnotify_t* notify;
 extern char* str_family_address[FAMILY_ADDRESS_SIZE];
 extern OSHash* agent_data_hash;
+extern ROUTER_PROVIDER_HANDLE router_upgrade_ack_handle;
+extern ROUTER_PROVIDER_HANDLE router_sync_handle;
 
 void tmp_HandleSecureMessage_invalid_family_address(sa_family_t sin_family);
 
@@ -1221,7 +1223,6 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
-    expect_string(__wrap__mdebug2, formatted_msg, "Router handle for 'inventory synchronization' not available.");
 
     HandleSecureMessage(&message, control_msg_queue);
 
@@ -1320,7 +1321,6 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
-    expect_string(__wrap__mdebug2, formatted_msg, "Router handle for 'inventory synchronization' not available.");
 
     HandleSecureMessage(&message, control_msg_queue);
 
@@ -1878,7 +1878,6 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
-    expect_string(__wrap__mdebug2, formatted_msg, "Router handle for 'inventory synchronization' not available.");
 
     HandleSecureMessage(&message, control_msg_queue);
 
@@ -1955,13 +1954,334 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
 
     expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
-    expect_string(__wrap__mdebug2, formatted_msg, "Router handle for 'inventory synchronization' not available.");
 
     HandleSecureMessage(&message, control_msg_queue);
 
     os_free(key->id);
     os_free(key->ip);
     os_free(key->name);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+}
+
+void test_HandleSecureMessage_router_forwarding_upgrade_ack_success(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}";
+    message_t message = {.buffer = buffer, .size = strlen(buffer), .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("test_agent");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    // Mock router handles
+    router_upgrade_ack_handle = (ROUTER_PROVIDER_HANDLE)0x12345;
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedIP
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    // ReadSecMSG
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    // SendMSG
+    expect_string(__wrap_SendMSG, message, "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (test_agent) 127.0.0.1");
+    expect_any(__wrap_SendMSG, loc);
+    will_return(__wrap_SendMSG, 0);
+
+    expect_function_call(__wrap_rem_inc_recv_evt);
+
+    // getDefine_Int for router_forwarding_disabled
+    will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
+
+    // Mock router provider send for upgrade ACK
+    expect_string(__wrap_router_provider_send, message, "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\",\"agents\":[1]}}");
+    expect_value(__wrap_router_provider_send, message_size, strlen("{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\",\"agents\":[1]}}") + 1);
+    will_return(__wrap_router_provider_send, 0);
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Clean up router handle
+    router_upgrade_ack_handle = NULL;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+}
+
+void test_HandleSecureMessage_router_forwarding_upgrade_ack_no_handle(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}";
+    message_t message = {.buffer = buffer, .size = strlen(buffer), .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("test_agent");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    // Mock router handles - set upgrade handle to NULL
+    router_upgrade_ack_handle = NULL;
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedIP
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    // ReadSecMSG
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    // SendMSG
+    expect_string(__wrap_SendMSG, message, "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\"}}");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (test_agent) 127.0.0.1");
+    expect_any(__wrap_SendMSG, loc);
+    will_return(__wrap_SendMSG, 0);
+
+    expect_function_call(__wrap_rem_inc_recv_evt);
+
+    // getDefine_Int for router_forwarding_disabled
+    will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
+
+    // Expect debug message when router handle is not available
+    expect_string(__wrap__mdebug2, formatted_msg, "Router handle for 'upgrade_notifications' not available.");
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+}
+
+void test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "u:upgrade_module:{invalid json";
+    message_t message = {.buffer = buffer, .size = strlen(buffer), .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("test_agent");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    // Mock router handles
+    router_upgrade_ack_handle = (ROUTER_PROVIDER_HANDLE)0x12345;
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedIP
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    // ReadSecMSG
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    // SendMSG
+    expect_string(__wrap_SendMSG, message, "u:upgrade_module:{invalid json");
+    expect_string(__wrap_SendMSG, locmsg, "[001] (test_agent) 127.0.0.1");
+    expect_any(__wrap_SendMSG, loc);
+    will_return(__wrap_SendMSG, 0);
+
+    expect_function_call(__wrap_rem_inc_recv_evt);
+
+    // getDefine_Int for router_forwarding_disabled
+    will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
+
+    // Expect error message for invalid JSON
+    expect_string(__wrap__merror, formatted_msg, "Failed to parse router message JSON: 'nvalid json'");  // Updated expected message
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Clean up router handle
+    router_upgrade_ack_handle = NULL;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+}
+
+void test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}";
+    message_t message = {.buffer = buffer, .size = strlen(buffer), .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("042");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "192.168.1.100";
+    key->name = strdup("agent_042");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("192.168.1.100");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    // Mock router handles
+    router_upgrade_ack_handle = (ROUTER_PROVIDER_HANDLE)0x12345;
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedIP
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "192.168.1.100");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    // ReadSecMSG
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "192.168.1.100");
+    will_return(__wrap_ReadSecMSG, message.size);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    // SendMSG
+    expect_string(__wrap_SendMSG, message, "u:upgrade_module:{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}");
+    expect_string(__wrap_SendMSG, locmsg, "[042] (agent_042) 192.168.1.100");
+    expect_any(__wrap_SendMSG, loc);
+    will_return(__wrap_SendMSG, 0);
+
+    expect_function_call(__wrap_rem_inc_recv_evt);
+
+    // getDefine_Int for router_forwarding_disabled
+    will_return(__wrap_getDefine_Int, 0); // Router forwarding enabled
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
+    expect_string(__wrap__mdebug2, formatted_msg, "Unable to forward upgrade-ack message '{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}' for agent 042");
+
+    // Mock router provider send for upgrade ACK - simulate failure
+    expect_string(__wrap_router_provider_send, message, "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\",\"agents\":[42]}}");
+    expect_value(__wrap_router_provider_send, message_size, strlen("{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,\"message\":\"Upgrade failed\",\"status\":\"Failed\",\"agents\":[42]}}") + 1);
+    will_return(__wrap_router_provider_send, -1);
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Clean up router handle
+    router_upgrade_ack_handle = NULL;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
     os_free(key);
     os_free(keyentries);
     indexed_queue_free(control_msg_queue);
@@ -2404,6 +2724,10 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_close_idle_sock_control_msg_succes),
         cmocka_unit_test(test_HandleSecureMessage_close_same_sock),
         cmocka_unit_test(test_HandleSecureMessage_close_same_sock_2),
+        cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_success),
+        cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_no_handle),
+        cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json),
+        cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed),
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_disabled),
         // Tests handle_new_tcp_connection
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_success, setup_new_tcp, teardown_new_tcp),

--- a/src/unit_tests/shared/test_rbtree_op.c
+++ b/src/unit_tests/shared/test_rbtree_op.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "../headers/rbtree_op.h"
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -35,8 +35,9 @@ if(${TARGET} STREQUAL "server")
     list(APPEND upgrade_names "test_wm_agent_upgrade_manager")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_BindUnixDomainWithPerms -Wl,--wrap,select -Wl,--wrap,close -Wl,--wrap,accept -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,OS_SendSecureTCP \
                             -Wl,--wrap,wm_agent_upgrade_parse_message -Wl,--wrap,wm_agent_upgrade_process_upgrade_command -Wl,--wrap,wm_agent_upgrade_process_upgrade_custom_command -Wl,--wrap,wm_agent_upgrade_process_agent_result_command \
-                            -Wl,--wrap,wm_agent_upgrade_parse_response -Wl,--wrap,wm_agent_upgrade_cancel_pending_upgrades -Wl,--wrap,wm_agent_upgrade_process_upgrade_result_command -Wl,--wrap,sleep -Wl,--wrap,CreateThread -Wl,--wrap,pthread_exit -Wl,--wrap,getpid \
-                            ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,wm_agent_upgrade_parse_response -Wl,--wrap,wm_agent_upgrade_cancel_pending_upgrades -Wl,--wrap,wm_agent_upgrade_process_upgrade_result_command -Wl,--wrap,sleep -Wl,--wrap,CreateThread \
+                            -Wl,--wrap,pthread_exit -Wl,--wrap,getpid -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,so_get_module_handle -Wl,--wrap,so_get_function_sym -Wl,--wrap,router_subscriber_create -Wl,--wrap,router_subscriber_subscribe \
+                            -Wl,--wrap,router_subscriber_unsubscribe -Wl,--wrap,router_subscriber_destroy ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_parsing")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -37,7 +37,7 @@ if(${TARGET} STREQUAL "server")
                             -Wl,--wrap,wm_agent_upgrade_parse_message -Wl,--wrap,wm_agent_upgrade_process_upgrade_command -Wl,--wrap,wm_agent_upgrade_process_upgrade_custom_command -Wl,--wrap,wm_agent_upgrade_process_agent_result_command \
                             -Wl,--wrap,wm_agent_upgrade_parse_response -Wl,--wrap,wm_agent_upgrade_cancel_pending_upgrades -Wl,--wrap,wm_agent_upgrade_process_upgrade_result_command -Wl,--wrap,sleep -Wl,--wrap,CreateThread \
                             -Wl,--wrap,pthread_exit -Wl,--wrap,getpid -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,so_get_module_handle -Wl,--wrap,so_get_function_sym -Wl,--wrap,router_subscriber_create -Wl,--wrap,router_subscriber_subscribe \
-                            -Wl,--wrap,router_subscriber_unsubscribe -Wl,--wrap,router_subscriber_destroy ${DEBUG_OP_WRAPPERS}")
+                            -Wl,--wrap,router_subscriber_unsubscribe -Wl,--wrap,router_subscriber_destroy -Wl,--wrap,FOREVER ${DEBUG_OP_WRAPPERS}")
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_parsing")
     list(APPEND upgrade_flags "-Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
@@ -1071,7 +1071,9 @@ void test_wm_agent_upgrade_router_subscriber_thread_success(void **state)
     expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mtinfo, formatted_msg, "Successfully subscribed to router topic 'upgrade_notifications'");
 
+    will_return(__wrap_FOREVER, 1);
     expect_value(__wrap_sleep, seconds, 1);
+    will_return(__wrap_FOREVER, 0);
 
     // Mock cleanup functions
     expect_value(__wrap_router_subscriber_unsubscribe, handle, mock_subscriber);

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
@@ -38,3 +38,27 @@ ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name) {
     check_expected(name);
     return mock_ptr_type(ROUTER_PROVIDER_HANDLE);
 }
+
+// Router subscriber wrappers for agent upgrade module
+ROUTER_SUBSCRIBER_HANDLE __wrap_router_subscriber_create(const char* topic_name, const char* subscriber_id, bool is_local) {
+    check_expected(topic_name);
+    check_expected(subscriber_id);
+    check_expected(is_local);
+    return mock_ptr_type(ROUTER_SUBSCRIBER_HANDLE);
+}
+
+int __wrap_router_subscriber_subscribe(__attribute__((unused)) ROUTER_SUBSCRIBER_HANDLE handle,
+                                      __attribute__((unused)) void (*callback)(const char*)) {
+    check_expected(handle);
+    return mock();
+}
+
+int __wrap_router_subscriber_unsubscribe(__attribute__((unused)) ROUTER_SUBSCRIBER_HANDLE handle) {
+    check_expected(handle);
+    return mock();
+}
+
+int __wrap_router_subscriber_destroy(__attribute__((unused)) ROUTER_SUBSCRIBER_HANDLE handle) {
+    check_expected(handle);
+    return mock();
+}

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
@@ -15,6 +15,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "router.h"
 
 int __wrap_router_provider_send(__attribute__((unused)) ROUTER_PROVIDER_HANDLE handle,

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
@@ -22,4 +22,13 @@ int __wrap_router_provider_send_fb(ROUTER_PROVIDER_HANDLE handle, const char* me
 
 ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name);
 
+// Router subscriber wrappers for agent upgrade module
+ROUTER_SUBSCRIBER_HANDLE __wrap_router_subscriber_create(const char* topic_name, const char* subscriber_id, bool is_local);
+
+int __wrap_router_subscriber_subscribe(ROUTER_SUBSCRIBER_HANDLE handle, void (*callback)(const char*));
+
+int __wrap_router_subscriber_unsubscribe(ROUTER_SUBSCRIBER_HANDLE handle);
+
+int __wrap_router_subscriber_destroy(ROUTER_SUBSCRIBER_HANDLE handle);
+
 #endif // ROUTER_WRAPPERS_H

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -262,7 +262,6 @@ STATIC void wm_agent_upgrade_router_callback(const char* message) {
 
         OS_SendSecureTCP(sock, strlen(message), message);
         os_free(message);
-
         close(sock);
     }
 }
@@ -286,7 +285,7 @@ STATIC bool initialize_router_functions(void) {
 }
 
 STATIC void* wm_agent_upgrade_router_subscriber_thread(void) {
-    merror(WM_AGENT_UPGRADE_LOGTAG, "Starting router subscriber thread for upgrade notifications");
+    mtinfo(WM_AGENT_UPGRADE_LOGTAG, "Starting router subscriber thread for upgrade notifications");
 
     if (!initialize_router_functions()) {
         mterror(WM_AGENT_UPGRADE_LOGTAG, "Failed to initialize router functions");
@@ -314,7 +313,6 @@ STATIC void* wm_agent_upgrade_router_subscriber_thread(void) {
 
     mtinfo(WM_AGENT_UPGRADE_LOGTAG, "Successfully subscribed to router topic '%s'", topic_name);
 
-    // TODO: add a shutdown mechanism, not processor consuming thread?
     while (1) {
         sleep(1);
         #ifdef WAZUH_UNIT_TESTING
@@ -322,7 +320,6 @@ STATIC void* wm_agent_upgrade_router_subscriber_thread(void) {
         #endif
     }
 
-    // TODO: check if this part is ever reached
     // Cleanup
     router_subscriber_unsubscribe_ptr(subscriber_handle);
     router_subscriber_destroy_ptr(subscriber_handle);


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes [#31829](https://github.com/wazuh/wazuh/issues/31829#top)


<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

* Enhance remoted for correct handling of ack packages received from agent.
  * modify `secure.c` to emit a message using router (**_publisher_**)
* Enhance wazuh upgrade to react to _remoted_ messages directly.
  * modify `wm_agent_upgrade_manager.c` to receive a message using router (**_subscriber_**).
  * create a thread for listen to incomming messages of router.
  * open upgrade socket and push message when received. Repeat exact same modifications as previously done on `analysis.c`
* Expansion of remoted, router and upgrade modules UTs to match new functionality.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

Unit tests:

<details><summary>Details</summary>
<p>

```console
root@ubuntu2204:/home/workspace/wazuh/src/unit_tests/build# ctest 
Test project /home/workspace/wazuh/src/unit_tests/build
        Start   1: test_manager
  1/138 Test   #1: test_manager ............................................   Passed    0.02 sec
        Start   2: test_secure
  2/138 Test   #2: test_secure .............................................   Passed    0.02 sec
        Start   3: test_save_ctrlmsg_thread
  3/138 Test   #3: test_save_ctrlmsg_thread ................................   Passed    0.01 sec
        Start   4: test_netbuffer
  4/138 Test   #4: test_netbuffer ..........................................   Passed    0.01 sec
        Start   5: test_sendmsg
  5/138 Test   #5: test_sendmsg ............................................   Passed    0.01 sec
        Start   6: test_remote-config
  6/138 Test   #6: test_remote-config ......................................   Passed    0.01 sec
        Start   7: test_syslogtcp
  7/138 Test   #7: test_syslogtcp ..........................................   Passed    0.01 sec
        Start   8: test_remote-state
  8/138 Test   #8: test_remote-state .......................................   Passed    0.01 sec
        Start   9: test_remcom
  9/138 Test   #9: test_remcom .............................................   Passed    0.01 sec
        Start  10: test_wdb_parser
 10/138 Test  #10: test_wdb_parser .........................................   Passed    0.01 sec
        Start  11: test_wdb_global_parser
 11/138 Test  #11: test_wdb_global_parser ..................................   Passed    0.02 sec
        Start  12: test_wdb_global
 12/138 Test  #12: test_wdb_global .........................................   Passed    0.03 sec
        Start  13: test_wdb_global_helpers
 13/138 Test  #13: test_wdb_global_helpers .................................   Passed    0.01 sec
        Start  14: test_wdb
 14/138 Test  #14: test_wdb ................................................   Passed    0.01 sec
        Start  15: test_wdb_upgrade
 15/138 Test  #15: test_wdb_upgrade ........................................   Passed    0.01 sec
        Start  16: test_wdb_metadata
 16/138 Test  #16: test_wdb_metadata .......................................   Passed    0.01 sec
        Start  17: test_wdb_task_parser
 17/138 Test  #17: test_wdb_task_parser ....................................   Passed    0.01 sec
        Start  18: test_wdb_task
 18/138 Test  #18: test_wdb_task ...........................................   Passed    0.01 sec
        Start  19: test_wazuh_db-config
 19/138 Test  #19: test_wazuh_db-config ....................................   Passed    0.01 sec
        Start  20: test_wazuh_db_state
 20/138 Test  #20: test_wazuh_db_state .....................................   Passed    0.01 sec
        Start  21: test_wdb_com
 21/138 Test  #21: test_wdb_com ............................................   Passed    0.01 sec
        Start  22: test_wdb_pool
 22/138 Test  #22: test_wdb_pool ...........................................   Passed    0.01 sec
        Start  23: test_auth_parse
 23/138 Test  #23: test_auth_parse .........................................   Passed    0.01 sec
        Start  24: test_auth_validate
 24/138 Test  #24: test_auth_validate ......................................   Passed    0.01 sec
        Start  25: test_auth_add
 25/138 Test  #25: test_auth_add ...........................................   Passed    0.01 sec
        Start  26: test_ssl
 26/138 Test  #26: test_ssl ................................................   Passed    0.01 sec
        Start  27: test_auth_key_request
 27/138 Test  #27: test_auth_key_request ...................................   Passed    0.01 sec
        Start  28: test_auth
 28/138 Test  #28: test_auth ...............................................   Passed    0.01 sec
        Start  29: test_generate_cert
 29/138 Test  #29: test_generate_cert ......................................   Passed    1.20 sec
        Start  30: test_authd-config
 30/138 Test  #30: test_authd-config .......................................   Passed    0.01 sec
        Start  31: test_aes_op
 31/138 Test  #31: test_aes_op .............................................   Passed    0.01 sec
        Start  32: test_hmac_op
 32/138 Test  #32: test_hmac_op ............................................   Passed    0.01 sec
        Start  33: test_msgs
 33/138 Test  #33: test_msgs ...............................................   Passed    0.01 sec
        Start  34: test_keys
 34/138 Test  #34: test_keys ...............................................   Passed    0.01 sec
        Start  35: test_sha1_op
 35/138 Test  #35: test_sha1_op ............................................   Passed    0.01 sec
        Start  36: test_blowfish_op
 36/138 Test  #36: test_blowfish_op ........................................   Passed    0.01 sec
        Start  37: test_md5_op
 37/138 Test  #37: test_md5_op .............................................   Passed    0.01 sec
        Start  38: test_md5_sha1_sha256_op
 38/138 Test  #38: test_md5_sha1_sha256_op .................................   Passed    0.01 sec
        Start  39: test_sha256_op
 39/138 Test  #39: test_sha256_op ..........................................   Passed    0.01 sec
        Start  40: test_sha512_op
 40/138 Test  #40: test_sha512_op ..........................................   Passed    0.01 sec
        Start  41: test_wm_aws
 41/138 Test  #41: test_wm_aws .............................................   Passed    0.01 sec
        Start  42: test_wm_azure
 42/138 Test  #42: test_wm_azure ...........................................   Passed    0.01 sec
        Start  43: test_wm_command
 43/138 Test  #43: test_wm_command .........................................   Passed    0.02 sec
        Start  44: test_wm_database
 44/138 Test  #44: test_wm_database ........................................   Passed    0.01 sec
        Start  45: test_wm_docker
 45/138 Test  #45: test_wm_docker ..........................................   Passed    0.01 sec
        Start  46: test_wm_gcp
 46/138 Test  #46: test_wm_gcp .............................................   Passed    0.06 sec
        Start  47: test_wmodules_gcp
 47/138 Test  #47: test_wmodules_gcp .......................................   Passed    0.02 sec
        Start  48: test_wmodules_scheduling
 48/138 Test  #48: test_wmodules_scheduling ................................   Passed    0.01 sec
        Start  49: test_wm_vulnerability_detection
 49/138 Test  #49: test_wm_vulnerability_detection .........................   Passed    0.02 sec
        Start  50: test_wm_task_manager
 50/138 Test  #50: test_wm_task_manager ....................................   Passed    0.01 sec
        Start  51: test_wm_task_manager_parsing
 51/138 Test  #51: test_wm_task_manager_parsing ............................   Passed    0.01 sec
        Start  52: test_wm_task_manager_commands
 52/138 Test  #52: test_wm_task_manager_commands ...........................   Passed    0.01 sec
        Start  53: test_wm_agent_upgrade
 53/138 Test  #53: test_wm_agent_upgrade ...................................   Passed    0.01 sec
        Start  54: test_wm_agent_upgrade_manager
 54/138 Test  #54: test_wm_agent_upgrade_manager ...........................   Passed    0.01 sec
        Start  55: test_wm_agent_upgrade_parsing
 55/138 Test  #55: test_wm_agent_upgrade_parsing ...........................   Passed    0.01 sec
        Start  56: test_wm_agent_upgrade_validate
 56/138 Test  #56: test_wm_agent_upgrade_validate ..........................   Passed    0.01 sec
        Start  57: test_wm_agent_upgrade_tasks
 57/138 Test  #57: test_wm_agent_upgrade_tasks .............................   Passed    0.01 sec
        Start  58: test_wm_agent_upgrade_tasks_callbacks
 58/138 Test  #58: test_wm_agent_upgrade_tasks_callbacks ...................   Passed    0.01 sec
        Start  59: test_wm_agent_upgrade_commands
 59/138 Test  #59: test_wm_agent_upgrade_commands ..........................   Passed    0.01 sec
        Start  60: test_wm_agent_upgrade_upgrades
 60/138 Test  #60: test_wm_agent_upgrade_upgrades ..........................   Passed    0.02 sec
        Start  61: test_wmodules
 61/138 Test  #61: test_wmodules ...........................................   Passed    0.01 sec
        Start  62: test_wm_control
 62/138 Test  #62: test_wm_control .........................................   Passed    0.01 sec
        Start  63: test_wm_github
 63/138 Test  #63: test_wm_github ..........................................   Passed    0.02 sec
        Start  64: test_wm_office365
 64/138 Test  #64: test_wm_office365 .......................................   Passed    0.03 sec
        Start  65: test_wm_ms_graph
 65/138 Test  #65: test_wm_ms_graph ........................................   Passed    0.02 sec
        Start  66: test_wm_exec
 66/138 Test  #66: test_wm_exec ............................................   Passed    0.01 sec
        Start  67: test_monitord
 67/138 Test  #67: test_monitord ...........................................   Passed    0.01 sec
        Start  68: test_monitor_actions
 68/138 Test  #68: test_monitor_actions ....................................   Passed    0.01 sec
        Start  69: test_logcollector
 69/138 Test  #69: test_logcollector .......................................   Passed    0.01 sec
        Start  70: test_read_multiline_regex
 70/138 Test  #70: test_read_multiline_regex ...............................   Passed    0.01 sec
        Start  71: test_localfile-config
 71/138 Test  #71: test_localfile-config ...................................   Passed    0.01 sec
        Start  72: test_state
 72/138 Test  #72: test_state ..............................................   Passed    0.01 sec
        Start  73: test_lccom
 73/138 Test  #73: test_lccom ..............................................   Passed    0.46 sec
        Start  74: test_macos_log
 74/138 Test  #74: test_macos_log ..........................................   Passed    0.01 sec
        Start  75: test_read_macos
 75/138 Test  #75: test_read_macos .........................................   Passed    0.01 sec
        Start  76: test_read_multiline
 76/138 Test  #76: test_read_multiline .....................................   Passed    0.01 sec
        Start  77: test_read_journal
 77/138 Test  #77: test_read_journal .......................................   Passed    0.01 sec
        Start  78: test_journal_log
 78/138 Test  #78: test_journal_log ........................................   Passed    0.01 sec
        Start  79: test_read_syslog
 79/138 Test  #79: test_read_syslog ........................................   Passed    0.01 sec
        Start  80: test_execd
 80/138 Test  #80: test_execd ..............................................   Passed    0.01 sec
        Start  81: test_get_command_by_name
 81/138 Test  #81: test_get_command_by_name ................................   Passed    0.01 sec
        Start  82: test_manage_keys
 82/138 Test  #82: test_manage_keys ........................................   Passed    0.01 sec
        Start  83: test_syscom
 83/138 Test  #83: test_syscom .............................................   Passed    0.01 sec
        Start  84: test_fim_diff_changes
 84/138 Test  #84: test_fim_diff_changes ...................................   Passed    0.01 sec
        Start  85: test_run_realtime
 85/138 Test  #85: test_run_realtime .......................................   Passed    0.02 sec
        Start  86: test_config
 86/138 Test  #86: test_config .............................................   Passed    0.02 sec
        Start  87: test_syscheck
 87/138 Test  #87: test_syscheck ...........................................   Passed    0.01 sec
        Start  88: test_run_check
 88/138 Test  #88: test_run_check ..........................................   Passed    0.01 sec
        Start  89: test_fim_scan
 89/138 Test  #89: test_fim_scan ...........................................   Passed    0.03 sec
        Start  90: test_audit_healthcheck
 90/138 Test  #90: test_audit_healthcheck ..................................   Passed    0.01 sec
        Start  91: test_audit_rule_handling
 91/138 Test  #91: test_audit_rule_handling ................................   Passed    0.01 sec
        Start  92: test_syscheck_audit
 92/138 Test  #92: test_syscheck_audit .....................................   Passed    0.06 sec
        Start  93: test_audit_parse
 93/138 Test  #93: test_audit_parse ........................................   Passed    0.02 sec
        Start  94: test_syscheck_ebpf
 94/138 Test  #94: test_syscheck_ebpf ......................................   Passed    0.01 sec
        Start  95: test_list_op
 95/138 Test  #95: test_list_op ............................................   Passed    0.01 sec
        Start  96: test_file_op
 96/138 Test  #96: test_file_op ............................................   Passed    0.01 sec
        Start  97: test_rbtree_op
 97/138 Test  #97: test_rbtree_op ..........................................   Passed    0.01 sec
        Start  98: test_validate_op
 98/138 Test  #98: test_validate_op ........................................   Passed    0.01 sec
        Start  99: test_string_op
 99/138 Test  #99: test_string_op ..........................................   Passed    0.01 sec
        Start 100: test_expression
100/138 Test #100: test_expression .........................................   Passed    0.01 sec
        Start 101: test_version_op
101/138 Test #101: test_version_op .........................................   Passed    0.01 sec
        Start 102: test_queue_op
102/138 Test #102: test_queue_op ...........................................   Passed    0.01 sec
        Start 103: test_queue_linked_op
103/138 Test #103: test_queue_linked_op ....................................   Passed    0.01 sec
        Start 104: test_indexed_queue_op
104/138 Test #104: test_indexed_queue_op ...................................   Passed    0.01 sec
        Start 105: test_agent_op
105/138 Test #105: test_agent_op ...........................................   Passed    0.01 sec
        Start 106: test_enrollment_op
106/138 Test #106: test_enrollment_op ......................................   Passed    0.02 sec
        Start 107: test_time_op
107/138 Test #107: test_time_op ............................................   Passed    0.01 sec
        Start 108: test_buffer_op
108/138 Test #108: test_buffer_op ..........................................   Passed    0.01 sec
        Start 109: test_utf8_op
109/138 Test #109: test_utf8_op ............................................   Passed    0.01 sec
        Start 110: test_log_builder
110/138 Test #110: test_log_builder ........................................   Passed    0.01 sec
        Start 111: test_custom_output_search_replace
111/138 Test #111: test_custom_output_search_replace .......................   Passed    0.01 sec
        Start 112: test_binaries_op
112/138 Test #112: test_binaries_op ........................................   Passed    0.01 sec
        Start 113: test_bzip2_op
113/138 Test #113: test_bzip2_op ...........................................   Passed    0.01 sec
        Start 114: test_schedule_scan
114/138 Test #114: test_schedule_scan ......................................   Passed    0.01 sec
        Start 115: test_rootcheck_op
115/138 Test #115: test_rootcheck_op .......................................   Passed    0.01 sec
        Start 116: test_fs_op
116/138 Test #116: test_fs_op ..............................................   Passed    0.01 sec
        Start 117: test_wazuhdb_op
117/138 Test #117: test_wazuhdb_op .........................................   Passed    0.01 sec
        Start 118: test_syscheck_op
118/138 Test #118: test_syscheck_op ........................................   Passed    0.01 sec
        Start 119: test_json_op
119/138 Test #119: test_json_op ............................................   Passed    0.01 sec
        Start 120: test_audit_op
120/138 Test #120: test_audit_op ...........................................   Passed    0.01 sec
        Start 121: test_privsep_op
121/138 Test #121: test_privsep_op .........................................   Passed    0.01 sec
        Start 122: test_mq_op
122/138 Test #122: test_mq_op ..............................................   Passed    0.01 sec
        Start 123: test_remoted_op
123/138 Test #123: test_remoted_op .........................................   Passed    0.01 sec
        Start 124: test_json-queue
124/138 Test #124: test_json-queue .........................................   Passed    0.01 sec
        Start 125: test_bqueue
125/138 Test #125: test_bqueue .............................................   Passed    0.01 sec
        Start 126: test_atomic
126/138 Test #126: test_atomic .............................................   Passed    0.01 sec
        Start 127: test_url
127/138 Test #127: test_url ................................................   Passed    0.01 sec
        Start 128: test_sysinfo_utils
128/138 Test #128: test_sysinfo_utils ......................................   Passed    0.01 sec
        Start 129: test_rwlock_op
129/138 Test #129: test_rwlock_op ..........................................   Passed    0.01 sec
        Start 130: test_os_xml
130/138 Test #130: test_os_xml .............................................   Passed    0.02 sec
        Start 131: test_os_regex
131/138 Test #131: test_os_regex ...........................................   Passed    0.01 sec
        Start 132: test_os_regex_match
132/138 Test #132: test_os_regex_match .....................................   Passed    0.01 sec
        Start 133: test_os_regex_execute
133/138 Test #133: test_os_regex_execute ...................................   Passed    0.01 sec
        Start 134: test_os_zlib
134/138 Test #134: test_os_zlib ............................................   Passed    0.01 sec
        Start 135: test_client-config_validate_ipv6_link_local_interface
135/138 Test #135: test_client-config_validate_ipv6_link_local_interface ...   Passed    0.01 sec
        Start 136: test_indexer
136/138 Test #136: test_indexer ............................................   Passed    0.01 sec
        Start 137: test_os_net
137/138 Test #137: test_os_net .............................................   Passed    0.01 sec
        Start 138: test_active-response
138/138 Test #138: test_active-response ....................................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 138

Total Test time (real) =   3.34 sec
```

</p>
</details> 


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

#### Steps to reproduce the case

* Install and start Manager:

<details><summary>Details</summary>
<p>

```console
root@ubuntu2204:/home/pm-vagrant# apt install ./wazuh-manager_5.0.0-0_amd64_4a34c5e.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_5.0.0-0_amd64_4a34c5e.deb'
The following packages were automatically installed and are no longer required:
  gcc-12-base gcc-12-base:i386
Use 'apt autoremove' to remove them.
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 144 not upgraded.
Need to get 0 B/435 MB of archives.
After this operation, 1,011 MB of additional disk space will be used.
Get:1 /home/pm-vagrant/wazuh-manager_5.0.0-0_amd64_4a34c5e.deb wazuh-manager amd64 5.0.0-0 [435 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 231103 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_5.0.0-0_amd64_4a34c5e.deb ...
Unpacking wazuh-manager (5.0.0-0) ...
Setting up wazuh-manager (5.0.0-0) ...
Scanning processes...                                                                                                                                                                                              
Scanning candidates...                                                                                                                                                                                             
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
N: Download is performed unsandboxed as root as file '/home/pm-vagrant/wazuh-manager_5.0.0-0_amd64_4a34c5e.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
root@ubuntu2204:/home/pm-vagrant# cd /var/ossec/bin/
root@ubuntu2204:/var/ossec/bin# /var/ossec/bin/wazuh-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...
wazuh-forwarder is running...
```


</p>
</details> 

* Install agent and enroll with manager:

from agent:

```console
root@pm-ubuntu24-server:/home/pm-vagrant# /var/ossec/bin/wazuh-control start
Starting Wazuh v4.12.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
root@pm-ubuntu24-server:/home/pm-vagrant# tail -f /var/ossec/logs/ossec.log 
2025/09/11 18:18:55 wazuh-agentd: INFO: Closing connection to server ([192.168.0.199]:1514/tcp).
2025/09/11 18:18:55 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.199]:1514/tcp).
2025/09/11 18:19:05 wazuh-agentd: INFO: Closing connection to server ([192.168.0.199]:1514/tcp).
2025/09/11 18:19:05 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.199]:1514/tcp).
2025/09/11 18:19:05 wazuh-agentd: INFO: Requesting a key from server: 192.168.0.199
2025/09/11 18:19:05 wazuh-agentd: INFO: No authentication password provided
2025/09/11 18:19:05 wazuh-agentd: INFO: Using agent name as: pm-ubuntu24-server
2025/09/11 18:19:05 wazuh-agentd: INFO: Waiting for server reply
2025/09/11 18:19:05 wazuh-agentd: INFO: Valid key received
2025/09/11 18:19:05 wazuh-agentd: INFO: Waiting 20 seconds before server connection
```

* from manager:

```console
 root@ubuntu2204:/var/ossec/bin# ./agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: ubuntu2204 (server), IP: 127.0.0.1, Active/Local
   ID: 001, Name: pm-ubuntu24-server, IP: any
```

* Download agent-wpk from [here](https://documentation.wazuh.com/current/user-manual/agent/agent-management/remote-upgrading/wpk-files/wpk-list.html):

```console
# wget https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-manager/wazuh-manager_4.12.0-1_amd64.deb
```

* Upgrade:

```console
root@ubuntu2204:/var/ossec/bin# time /var/ossec/bin/agent_upgrade -a 001 -dd -F -f /home/pm-vagrant/wazuh_agent_v4.12.0_linux_amd64.deb.wpk 

Upgrading...

Upgraded agents:
	Agent 001 upgraded: Wazuh v4.12.0 -> Wazuh v4.12.0

real	0m48.599s
user	0m0.452s
sys	0m0.047s
root@ubuntu2204:/var/ossec/bin# 
```

  * To check the fix, the above procedure shouldn't take much more than a minute (depending on the network and the size of the package used).
  * Without the fix by not receiveing an ack the procedure will take approxiamtely 15 minutes.
  * With '-F' there's no problem if the base version of the agent is newer than the one used for upgrading.

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
