### PR TITLE
Add helper function date_to_epoch

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -65,6 +65,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [concat](#concat)
 - [concat_any](#concat_any)
 - [date_from_epoch](#date_from_epoch)
+- [date_to_epoch](#date_to_epoch)
 - [decode_base16](#decode_base16)
 - [downcase](#downcase)
 - [float_calculate](#float_calculate)
@@ -6515,6 +6516,904 @@ normalize:
 ```
 
 *The operation was successful*
+
+
+
+---
+# date_to_epoch
+
+## Signature
+
+```
+
+field: date_to_epoch(date, format)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| date | string | reference | Any string |
+| format | string | value | Any string |
+
+
+## Outputs
+
+| Type | Possible values |
+| ---- | --------------- |
+| double |
+
+
+## Description
+
+Converts a date/time string to its UNIX epoch (seconds since 1970-01-01T00:00:00Z), returned as a double.
+Parsing is strict and driven entirely by a format:
+  - If a second argument `format` is provided (string literal), it is used verbatim by the parser.
+  - If `format` is omitted, the default format "%Y-%m-%dT%H:%M:%SZ" (ISO 8601, UTC with trailing 'Z') is used.
+To support other ISO-8601 variants (offsets, basic format, space instead of 'T', etc.), pass the appropriate format.
+
+
+## Keywords
+
+- `date` 
+
+- `time` 
+
+- `epoch` 
+
+- `timestamp` 
+
+## Examples
+
+### Example 1
+
+Default format → epoch start
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "1970-01-01T00:00:00Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "1970-01-01T00:00:00Z",
+  "target_field": 0.0
+}
+```
+
+*The operation was successful*
+
+### Example 2
+
+Default format → UTC with trailing Z
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 3
+
+Default format → fractional seconds preserved
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-09-24T23:03:00.597629Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-09-24T23:03:00.597629Z",
+  "target_field": 1727218980.597629
+}
+```
+
+*The operation was successful*
+
+### Example 4
+
+Default format → negative epoch
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "1969-12-31T23:59:59Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "1969-12-31T23:59:59Z",
+  "target_field": -1.0
+}
+```
+
+*The operation was successful*
+
+### Example 5
+
+Default format requires 'Z' → fails without timezone
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 6
+
+Offset with colon (−03:00)
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%FT%T%Ez')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T12:10:58-03:00"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T12:10:58-03:00",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 7
+
+Offset without colon (−0300)
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%FT%T%z')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T12:10:58-0300"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T12:10:58-0300",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 8
+
+Space instead of 'T' + offset
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%F %T%Ez')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17 15:10:58+00:00"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17 15:10:58+00:00",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 9
+
+Basic (no-extended) format with 'Z'
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y%m%dT%H%M%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "20240517T151058Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "20240517T151058Z",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 10
+
+Basic format with offset (−0300)
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y%m%dT%H%M%S%z')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "20240517T121058-0300"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "20240517T121058-0300",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 11
+
+No timezone in input; format without timezone
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%FT%T')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 12
+
+IANA zone America/Argentina/Buenos_Aires, UTC−03) → 2024-05-17T15:10:58Z
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%F %T %Z')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17 12:10:58 America/Argentina/Buenos_Aires"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17 12:10:58 America/Argentina/Buenos_Aires",
+  "target_field": 1715958658.0
+}
+```
+
+*The operation was successful*
+
+### Example 13
+
+IANA zone (Europe/Berlin, CEST UTC+02) → 2024-07-01T08:00:00Z
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%F %T %Z')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-07-01 10:00:00 Europe/Berlin"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-07-01 10:00:00 Europe/Berlin",
+  "target_field": 1719820800.0
+}
+```
+
+*The operation was successful*
+
+### Example 14
+
+Unknown IANA zone → tzdb lookup fails
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%F %T %Z')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17 15:10:58 Mars/Phobos"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17 15:10:58 Mars/Phobos"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 15
+
+DST spring-forward gap (nonexistent local time in New York)
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%F %T %Z')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-03-10 02:30:00 America/New_York"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-03-10 02:30:00 America/New_York"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 16
+
+Reject non-string input for 'date'
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": 123456789
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": 123456789
+}
+```
+
+*The operation was performed with errors*
+
+### Example 17
+
+Reject null input for 'date'
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": null
+}
+```
+
+#### Outcome Event
+
+```json
+{}
+```
+
+*The operation was performed with errors*
+
+### Example 18
+
+Invalid format format with unknown specifier
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%invalid_format')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 19
+
+Empty format format
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 20
+
+Null format format
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, None)
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 21
+
+Non-string format format
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, 123)
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 22
+
+Date string doesn't match format (has time, format expects only date)
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%d')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 23
+
+format expects time, date string has only date
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-17"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-17"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 24
+
+Completely malformed date string
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "not-a-date"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "not-a-date"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 25
+
+Empty date string
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": ""
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": ""
+}
+```
+
+*The operation was performed with errors*
+
+### Example 26
+
+Invalid date - February 30th doesn't exist
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-02-30T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-02-30T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 27
+
+Invalid date - 13th month doesn't exist
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-13-17T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-13-17T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
+
+### Example 28
+
+Invalid date - 32nd day doesn't exist
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: date_to_epoch($date, '%Y-%m-%dT%H:%M:%SZ')
+```
+
+#### Input Event
+
+```json
+{
+  "date": "2024-05-32T15:10:58Z"
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "date": "2024-05-32T15:10:58Z"
+}
+```
+
+*The operation was performed with errors*
 
 
 

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
@@ -311,6 +311,17 @@ MapOp opBuilderHelperDateFromEpochTime(const std::vector<OpArg>& opArgs,
                                        const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
+ * @brief Convert an ISO-8601 date/time string to UNIX epoch seconds as a double (UTC).
+ *
+ * @param opArgs One argument: string reference to the date field.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @throws std::runtime_error on signature/type mismatch.
+ * @return base::Expression
+ */
+MapOp opBuilderHelperDateToEpochTime(const std::vector<OpArg>& opArgs,
+                                     const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
  * @brief Builds an operation to generate the current date in ISO 8601 format.
  *
  * This function returns a callable operation that produces the current date

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -214,6 +214,8 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const builder
         "date_from_epoch",
         {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperDateFromEpochTime});
     registry->template add<builders::OpBuilderEntry>(
+        "date_to_epoch", {schemf::STypeToken::create(schemf::Type::DOUBLE), builders::opBuilderHelperDateToEpochTime});
+    registry->template add<builders::OpBuilderEntry>(
         "get_date", {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperGetDate});
 
     // Transform builders
@@ -363,7 +365,8 @@ void registerStageBuilders(const std::shared_ptr<Registry>& registry, const Buil
     registry->template add<builders::StageBuilder>(syntax::asset::PARSE_KEY,
                                                    builders::getParseBuilder(deps.logpar, deps.logparDebugLvl));
     registry->template add<builders::StageBuilder>(syntax::asset::OUTPUTS_KEY, builders::outputsBuilder);
-    registry->template add<builders::StageBuilder>(syntax::asset::FILE_OUTPUT_KEY, builders::getFileOutputBuilder(deps.logManager));
+    registry->template add<builders::StageBuilder>(syntax::asset::FILE_OUTPUT_KEY,
+                                                   builders::getFileOutputBuilder(deps.logManager));
     // TODO: Until the indexer connector is unified with the rest of wazuh-manager
     // registry->template add<builders::StageBuilder>(syntax::asset::INDEXER_OUTPUT_KEY,
     //                                                builders::getIndexerOutputBuilder(deps.iConnector));

--- a/src/engine/source/builder/test/src/unit/builders/opmap/time_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/time_test.cpp
@@ -28,6 +28,17 @@ auto customRefExpected(json::Json value)
     };
 }
 
+auto stypeRefExpected(schemf::Type sType)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, validator()).Times(testing::AtLeast(1));
+        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, getType(DotPath("ref"))).WillRepeatedly(testing::Return(sType));
+        return None {};
+    };
+}
+
 auto jTypeRefExpected(json::Json::Type jType)
 {
     return [=](const BuildersMocks& mocks)
@@ -66,7 +77,32 @@ INSTANTIATE_TEST_SUITE_P(
         MapT({makeRef("ref")}, opBuilderHelperDateFromEpochTime, FAILURE(jTypeRefExpected(json::Json::Type::Object))),
         MapT({makeRef("ref")}, opBuilderHelperDateFromEpochTime, FAILURE(jTypeRefExpected(json::Json::Type::Array))),
         MapT({makeRef("ref")}, opBuilderHelperDateFromEpochTime, FAILURE(jTypeRefExpected(json::Json::Type::Boolean))),
-        MapT({makeRef("ref")}, opBuilderHelperDateFromEpochTime, FAILURE(jTypeRefExpected(json::Json::Type::Null)))),
+        MapT({makeRef("ref")}, opBuilderHelperDateFromEpochTime, FAILURE(jTypeRefExpected(json::Json::Type::Null))),
+        /*** Date To Epoch ***/
+        MapT({}, opBuilderHelperDateToEpochTime, FAILURE()),
+        MapT({makeValue(R"("2024-05-17T15:10:58Z")")}, opBuilderHelperDateToEpochTime, FAILURE()),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, SUCCESS(customRefExpected())),
+        // ok: ref + format literal
+        MapT({makeRef("ref"), makeValue(R"("%FT%TZ")")}, opBuilderHelperDateToEpochTime, SUCCESS(customRefExpected())),
+        // fail: format must be value, not ref
+        MapT({makeRef("ref"), makeRef("ref")}, opBuilderHelperDateToEpochTime, FAILURE()),
+        // input type checks for ref
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, SUCCESS(stypeRefExpected(schemf::Type::DATE))),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, SUCCESS(stypeRefExpected(schemf::Type::DATE_NANOS))),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, FAILURE(stypeRefExpected(schemf::Type::INTEGER))),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, FAILURE(stypeRefExpected(schemf::Type::OBJECT))),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, FAILURE(stypeRefExpected(schemf::Type::BOOLEAN))),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, FAILURE(stypeRefExpected(schemf::Type::WILDCARD))),
+        MapT({makeRef("ref")}, opBuilderHelperDateToEpochTime, FAILURE(stypeRefExpected(schemf::Type::TEXT))),
+        // empty format literal → build-time FAILURE
+        MapT({makeRef("ref"), makeValue(R"("")")}, opBuilderHelperDateToEpochTime, FAILURE()),
+        MapT({makeRef("ref"), makeValue(R"("%FT%TZ%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")")},
+             opBuilderHelperDateToEpochTime,
+             FAILURE()),
+        // format with exactly 64 chars
+        MapT({makeRef("ref"), makeValue(R"("%FT%TZ%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")")},
+             opBuilderHelperDateToEpochTime,
+             SUCCESS(customRefExpected()))),
     testNameFormatter<MapBuilderTest>("Time"));
 } // namespace mapbuildtest
 
@@ -112,6 +148,252 @@ INSTANTIATE_TEST_SUITE_P(
         MapT(R"({"ref": []})", opBuilderHelperDateFromEpochTime, {makeRef("ref")}, FAILURE(customRefExpected())),
         MapT(R"({"ref": {}})", opBuilderHelperDateFromEpochTime, {makeRef("ref")}, FAILURE(customRefExpected())),
         MapT(R"({"ref": true})", opBuilderHelperDateFromEpochTime, {makeRef("ref")}, FAILURE(customRefExpected())),
-        MapT(R"({"ref": null})", opBuilderHelperDateFromEpochTime, {makeRef("ref")}, FAILURE(customRefExpected()))),
+        MapT(R"({"ref": null})", opBuilderHelperDateFromEpochTime, {makeRef("ref")}, FAILURE(customRefExpected())),
+        /*** Date To Epoch ***/
+        // Epoch start
+        MapT(R"({"ref": "1970-01-01T00:00:00Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(0.0);
+                     return j;
+                 }()))),
+        // UTC with 'Z'
+        MapT(R"({"ref": "2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Same instant with offset -03:00
+        MapT(R"({"ref": "2024-05-17T12:10:58-03:00"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%T%Ez")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Offset without colon (+hhmm)
+        MapT(R"({"ref": "2024-05-17T12:10:58-0300"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%T%z")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Space instead of 'T' + offset
+        MapT(R"({"ref": "2024-05-17 15:10:58+00:00"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%F %T%Ez")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Space + offset without colon
+        MapT(R"({"ref": "2024-05-17 12:10:58-0300"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%F %T%z")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // No timezone → assume UTC
+        MapT(R"({"ref": "2024-05-17T15:10:58"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%T")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Negative epoch
+        MapT(R"({"ref": "1969-12-31T23:59:59Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(-1.0);
+                     return j;
+                 }()))),
+        // Basic (no extended) with Z
+        MapT(R"({"ref": "20240517T151058Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%Y%m%dT%H%M%SZ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Basic with offset (colon)
+        MapT(R"({"ref": "20240517T121058-03:00"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%Y%m%dT%H%M%S%Ez")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Basic with offset (no colon)
+        MapT(R"({"ref": "20240517T121058-0300"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%Y%m%dT%H%M%S%z")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Basic + fractional seconds with Z
+        MapT(R"({"ref": "20240924T230300.597629Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%Y%m%dT%H%M%SZ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     const long long us = 1727218980LL * 1000000LL + 597629LL;
+                     json::Json j;
+                     j.setDouble(static_cast<double>(us) / 1'000'000.0);
+                     return j;
+                 }()))),
+        // Date-only with explicit format (%F) → success at midnight UTC
+        MapT(R"({"ref": "1970-01-02"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%F")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(86400.0);
+                     return j;
+                 }()))),
+        // Success without format
+        MapT(R"({"ref": "1970-01-01T00:00:00Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(0.0);
+                     return j;
+                 }()))),
+        MapT(R"({"ref": "2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // format with space
+        MapT(R"({"ref": " 2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"(" %FT%TZ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        MapT(R"({"ref": "2024-05-17T15:10:58Z "})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ ")")},
+             SUCCESS(customRefExpected(
+                 []
+                 {
+                     json::Json j;
+                     j.setDouble(1715958658.0);
+                     return j;
+                 }()))),
+        // Without format but offset present → should fail
+        MapT(R"({"ref": "2024-05-17T12:10:58-03:00"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref")},
+             FAILURE(customRefExpected())),
+        // Invalid format token → parse fails
+        MapT(R"({"ref": "2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%Q")")},
+             FAILURE(customRefExpected())),
+        // format ok but not matching → parse fails
+        MapT(R"({"ref": "2024/05/17 15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": 1706172785})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": []})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": {}})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": true})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": null})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"notRef": "2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": "aaaa2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": "2024-05-17T15:10:58Zaaaa"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": "2024-05-17T15:10:58Z "})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": " 2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref"), makeValue(R"("%FT%TZ")")},
+             FAILURE(customRefExpected())),
+        MapT(R"({"ref": "2024-05-17T15:10:58Z2024-05-17T15:10:58Z"})",
+             opBuilderHelperDateToEpochTime,
+             {makeRef("ref")},
+             FAILURE(customRefExpected()))),
     testNameFormatter<MapOperationTest>("Time"));
 } // namespace mapoperatestest

--- a/src/engine/test/helper_tests/helpers_description/map/date_to_epoch.yml
+++ b/src/engine/test/helper_tests/helpers_description/map/date_to_epoch.yml
@@ -1,0 +1,192 @@
+# Name of the helper function
+name: date_to_epoch
+
+metadata:
+  description: |
+    Converts a date/time string to its UNIX epoch (seconds since 1970-01-01T00:00:00Z), returned as a double.
+    Parsing is strict and driven entirely by a format:
+      - If a second argument `format` is provided (string literal), it is used verbatim by the parser.
+      - If `format` is omitted, the default format "%Y-%m-%dT%H:%M:%SZ" (ISO 8601, UTC with trailing 'Z') is used.
+    To support other ISO-8601 variants (offsets, basic format, space instead of 'T', etc.), pass the appropriate format.
+  keywords:
+    - date
+    - time
+    - epoch
+    - timestamp
+
+helper_type: map
+
+# Arguments expected by the helper function
+arguments:
+  date:
+    type: string
+    generate: string
+    source: reference
+  format:
+    type: string
+    generate: string
+    source: value
+
+skipped:
+  - success_cases
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: False
+
+output:
+  type: double
+  subset: double
+
+test:
+  - arguments:
+      date: "1970-01-01T00:00:00Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: true
+    expected: 0.0
+    description: Default format → epoch start
+  - arguments:
+      date: "2024-05-17T15:10:58Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: true
+    expected: 1715958658.0
+    description: Default format → UTC with trailing Z
+  - arguments:
+      date: "2024-09-24T23:03:00.597629Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: true
+    expected: 1727218980.597629
+    description: Default format → fractional seconds preserved
+  - arguments:
+      date: "1969-12-31T23:59:59Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: true
+    expected: -1.0
+    description: Default format → negative epoch
+  - arguments:
+      date: "2024-05-17T15:10:58"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Default format requires 'Z' → fails without timezone
+  - arguments:
+      date: "2024-05-17T12:10:58-03:00"
+      format: "%FT%T%Ez"
+    should_pass: true
+    expected: 1715958658.0
+    description: Offset with colon (−03:00)
+  - arguments:
+      date: "2024-05-17T12:10:58-0300"
+      format: "%FT%T%z"
+    should_pass: true
+    expected: 1715958658.0
+    description: Offset without colon (−0300)
+  - arguments:
+      date: "2024-05-17 15:10:58+00:00"
+      format: "%F %T%Ez"
+    should_pass: true
+    expected: 1715958658.0
+    description: Space instead of 'T' + offset
+  - arguments:
+      date: "20240517T151058Z"
+      format: "%Y%m%dT%H%M%SZ"
+    should_pass: true
+    expected: 1715958658.0
+    description: Basic (no-extended) format with 'Z'
+  - arguments:
+      date: "20240517T121058-0300"
+      format: "%Y%m%dT%H%M%S%z"
+    should_pass: true
+    expected: 1715958658.0
+    description: Basic format with offset (−0300)
+  - arguments:
+      date: "2024-05-17T15:10:58"
+      format: "%FT%T"
+    should_pass: true
+    expected: 1715958658.0
+    description: No timezone in input; format without timezone
+  - arguments:
+      date: "2024-05-17 12:10:58 America/Argentina/Buenos_Aires"
+      format: "%F %T %Z"
+    should_pass: true
+    expected: 1715958658.0
+    description: IANA zone America/Argentina/Buenos_Aires, UTC−03) → 2024-05-17T15:10:58Z
+  - arguments:
+      date: "2024-07-01 10:00:00 Europe/Berlin"
+      format: "%F %T %Z"
+    should_pass: true
+    expected: 1719820800.0
+    description: IANA zone (Europe/Berlin, CEST UTC+02) → 2024-07-01T08:00:00Z
+  - arguments:
+      date: "2024-05-17 15:10:58 Mars/Phobos"
+      format: "%F %T %Z"
+    should_pass: false
+    description: Unknown IANA zone → tzdb lookup fails
+  - arguments:
+      date: "2024-03-10 02:30:00 America/New_York"
+      format: "%F %T %Z"
+    should_pass: false
+    description: DST spring-forward gap (nonexistent local time in New York)
+  - arguments:
+      date: 123456789
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Reject non-string input for 'date'
+  - arguments:
+      date: null
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Reject null input for 'date'
+  - arguments:
+      date: "2024-05-17T15:10:58Z"
+      format: "%invalid_format"
+    should_pass: false
+    description: Invalid format format with unknown specifier
+  - arguments:
+      date: "2024-05-17T15:10:58Z"
+      format: ""
+    should_pass: false
+    description: Empty format format
+  - arguments:
+      date: "2024-05-17T15:10:58Z"
+      format: null
+    should_pass: false
+    description: Null format format
+  - arguments:
+      date: "2024-05-17T15:10:58Z"
+      format: 123
+    should_pass: false
+    description: Non-string format format
+  - arguments:
+      date: "2024-05-17T15:10:58Z"
+      format: "%Y-%m-%d"
+    should_pass: false
+    description: Date string doesn't match format (has time, format expects only date)
+  - arguments:
+      date: "2024-05-17"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: format expects time, date string has only date
+  - arguments:
+      date: "not-a-date"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Completely malformed date string
+  - arguments:
+      date: ""
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Empty date string
+  - arguments:
+      date: "2024-02-30T15:10:58Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Invalid date - February 30th doesn't exist
+  - arguments:
+      date: "2024-13-17T15:10:58Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Invalid date - 13th month doesn't exist
+  - arguments:
+      date: "2024-05-32T15:10:58Z"
+      format: "%Y-%m-%dT%H:%M:%SZ"
+    should_pass: false
+    description: Invalid date - 32nd day doesn't exist


### PR DESCRIPTION
## Description

Adds a `date_to_epoch` map helper that converts a date/time string field into UNIX epoch seconds (double, microsecond precision).

Closes 2798

## Proposed Changes
- Implement `date_to_epoch($date_ref, format)` map helper.
  - **$date_ref**: required reference to a field containing the date/time string.
  - **format**: optional string literal. Defaults to `%Y-%m-%dT%H:%M:%SZ`.
- Deterministic parsing: the input stream is imbued with `std::locale::classic()`.
- Build-time validation of `format`:
  - Must be a **non-empty** string literal.
  - Maximum length **64** characters.
- Time zone support:
  - `%Z` accepts **IANA zone names** (e.g., `America/Argentina/Buenos_Aires`, `Europe/Berlin`).
  - Unknown zones fail with a clear trace.
  - Numeric offsets `%z` / `%Ez` are supported; if both a zone (`%Z`) and an offset are present, the **zone takes precedence**.
- DST handling:
  - Nonexistent local times (spring-forward gaps) and ambiguous local times (fall-back folds) are caught and return the standard *Invalid date/time per format* failure trace.
- Output:
  - Epoch seconds as `double` (microsecond precision).
- Unit tests for builder and operation paths, including fractional seconds and multiple ISO-8601 patterns.

### Results and Evidence

- **Builder unit tests**: compile-time–like checks at build stage (argument count, argument kinds, schema type expectations).
- **Operation unit tests**: runtime behavior on concrete events; correct parsing → expected epoch double; malformed inputs → failure traces.
- **Integration tests**: end-to-end validation via the engine’s helper-test runner with YAML spec; ensures helper contracts and docs stay in sync.


#### Builder tests (Time group)
**Command**
```bash
./builder_utest --gtest_filter="*Builds/Time*"
```
**Output (excerpt)**
```text
[==========] Running 32 tests from 1 test suite.
...
[==========] 32 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 32 tests.
```

#### Operation tests (Time group)
**Command**
```bash
./builder_utest --gtest_filter="*Operates/Time*"
```
**Output (excerpt)**
```text
[==========] Running 44 tests from 1 test suite.
...
[==========] 44 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 44 tests.
```

#### Integration tests (helper YAML)
**Command**
```bash
engine-helper-test -e /tmp/environment run --input-dir /tmp/helper_tests --show-failure 
```
**Output (summary)**
```text
- Total test cases executed: 9932
- Successful test cases: 9932
- Failed test cases: 0
```

**Sample decoder run**
```
name: decoder/test-date-to-epoch/0

parse|event.original:
  - '<tmp.start_raw> <message>'

normalize:
  - map:
      - event.start: parse_date($tmp.start_raw, %FT%TZ)
      - tmp.start_epoch: date_to_epoch($event.start)
      - event.end: date_from_epoch($tmp.start_epoch)
      - wazuh.decoders: array_append(test-date-to-epoch)
```
**Input**
```
2025-09-08T12:34:56Z hello world
```

**Run**
```bash
echo '2025-09-08T12:34:56Z hello world' \
| engine-test -c /workspaces/wazuh-5.x/engine-test.json run test -n wazuh -j | jq
```

**Output**
```
  "event": {
    "end": "2025-09-08T12:34:56.000000Z",
    "original": "2025-09-08T12:34:56Z hello world",
    "start": "2025-09-08T12:34:56.000Z"
  },
  "tmp": {
    "start_epoch": 1757334896,
    "start_raw": "2025-09-08T12:34:56Z"
  }
  
```

**Documentation rendering (evidence):** 
<img width="753" height="831" alt="image" src="https://github.com/user-attachments/assets/474489c7-b02a-4788-bd6a-98dff103bb74" />
<img width="755" height="572" alt="image" src="https://github.com/user-attachments/assets/f8fea6dd-2b57-4ae4-b1a9-e5f6ad6446c5" />


### Manual tests with their corresponding evidence
**Workflow: Engine Health Test** -> run: 17752243307
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
    - [X] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [X] AddressSanitizer
- Memory tests for Windows
    - [ ] Coverity
    - [ ] UMDH
- Memory tests for macOS
    - [ ] Leaks
    - [ ] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
    - [ ] Test run in parallel
    - [X] ASAN for test (utest/ctest)
    - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

- `wazuh-engine` (builder helpers)
- Documentation: helper reference for `date_to_epoch`

### Configuration Changes

N/A

### Tests Introduced

- **Unit tests (builders/opmap):**
    - Builder validation (arg count, ref vs. value, JType validator integration).
    - Operation success cases: default pattern, explicit patterns (`%FT%TZ`, `%FT%T%Ez`, `%FT%T%z`, `%F %T%Ez`, basic forms), fractional seconds.
    - Operation failure cases: missing ref, non-string, parse failure, out-of-range.
- **Integration tests (YAML):** minimal success matrix demonstrating default pattern and explicit pattern usage.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
