### PR TITLE
Set CC and CXX env variables in DEB packages Docker images

### DIFF
--- a/packages/debs/armhf/agent/Dockerfile
+++ b/packages/debs/armhf/agent/Dockerfile
@@ -31,6 +31,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib/"
 ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+ENV CC="/usr/local/gcc-9.4.0/bin/gcc"
+ENV CXX="/usr/local/gcc-9.4.0/bin/g++"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \

--- a/packages/debs/i386/agent/Dockerfile
+++ b/packages/debs/i386/agent/Dockerfile
@@ -29,6 +29,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib:${LD_LIBRARY_PATH}"
 ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+ENV CC="/usr/local/gcc-9.4.0/bin/gcc"
+ENV CXX="/usr/local/gcc-9.4.0/bin/g++"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxvf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \

--- a/packages/debs/ppc64le/agent/Dockerfile
+++ b/packages/debs/ppc64le/agent/Dockerfile
@@ -29,6 +29,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
 ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
 ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64:${LD_LIBRARY_PATH}"
 ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+ENV CC="/usr/local/gcc-9.4.0/bin/gcc"
+ENV CXX="/usr/local/gcc-9.4.0/bin/g++"
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/468|

## Description

Hi team, this PR updates the DEB packages Dockerfiles to set the `CC` and `CXX` env variables.

Images are being updated with this WF run:
* [Packages - Upload docker images pkg_deb_agent_builder_i386 #5](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17641068953)
* [Packages - Upload docker images pkg_deb_agent_builder_armhf #6](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17641073344)
* [Packages - Upload docker images pkg_deb_agent_builder_ppc64le #1](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17641076765)

### Evidences

* https://github.com/wazuh/wazuh-agent-packages/actions/runs/17632745485 - :green_circle: 
* https://github.com/wazuh/wazuh-agent-packages/actions/runs/17632745517 - :green_circle: 
* https://github.com/wazuh/wazuh-agent-packages/actions/runs/17632745722 - :green_circle: 