### PR TITLE
SCA rules for Oracle 9.6 Fix

### DIFF
--- a/ruleset/sca/ol/9/cis_oracle_linux_9.yml
+++ b/ruleset/sca/ol/9/cis_oracle_linux_9.yml
@@ -842,8 +842,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - f:/boot/grub2/user.cfg
-      - f:/boot/grub2/user.cfg -> r:^\s*GRUB2_PASSWORD=grub.pbkdf2.sha512'
+      - 'f:/boot/grub2/user.cfg'
+      - 'f:/boot/grub2/user.cfg -> r:^\s*GRUB2_PASSWORD=grub.pbkdf2.sha512'
 
   # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
   - id: 33532
@@ -4322,7 +4322,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- -> r:\s0 0/root 0/root'
 
   # 6.1.7 Ensure permissions on /etc/gshadow are configured. (Automated)
   - id: 33675
@@ -4346,7 +4346,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow -> r:\s0 0/root 0/root'
 
   # 6.1.8 Ensure permissions on /etc/gshadow- are configured. (Automated)
   - id: 33676
@@ -4370,7 +4370,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- -> r:\s0 0/root 0/root'
 
   # 6.1.9 Ensure no world writable files exist. (Automated) - Not Implemented
   # 6.1.10 Ensure no unowned files or directories exist. (Automated) - Not Implemented


### PR DESCRIPTION
# Description 

Two SCA checks in `ruleset/sca/cis_oracle_linux_9.yml` contain small typos that cause the SCA engine to report false negatives on Oracle Linux 9.6 agents. The problems are:

- **ID 33531** (Ensure bootloader password is set) — trailing single-quote in the regex.
- **ID 33674** (Ensure permissions on /etc/shadow- are configured) — extra space after the `->` operator.

# Information 

These typos prevent the `osregex` SCA engine from matching outputs that, when tested manually, clearly meet the required conditions.

## Environment / versions observed
- OS: Oracle Linux Server **9.6**
- Agent: `wazuh-agent-4.12.0-1.x86_64`

# Detailed description & evidence

### 1) Check **ID 33531** — Bootloader password
- **Rule as shipped** (excerpt):
`f:/boot/grub2/user.cfg -> r:^\s*GRUB2_PASSWORD=grub.pbkdf2.sha512'`
- **Problem**: There is a **trailing single-quote (`'`)** at the end of the regex. This breaks the regex evaluation in the SCA engine.
- **Manual verification** on agent (example commands that match):
```bash
grep -Po '^\s*GRUB2_PASSWORD=grub.pbkdf2.sha512' /boot/grub2/user.cfg
```
Output:
```bash
GRUB2_PASSWORD=grub.pbkdf2.sha512
```

### 2) Check ID 33674 — /etc/shadow- permissions
- **Rule as shipped** (excerpt):
`'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- ->  r:\s0 0/root 0/root'`
- **Problem**: There is an extra space after the -> operator: -> r: instead of -> r:. The SCA parser/engine does not treat this as equivalent, so the pattern test fails.
- **Manual verifications on agent**:
```bash
stat -Lc "%n %a %u/%U %g/%G" /etc/shadow-
```
Output:
```bash
/etc/shadow- 0 0/root 0/root
```
```bash
stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- | grep -Po '\s0 0/root 0/root'
```
Output:
```bash
0 0/root 0/root
```

# Proposed fixes (minimal patch)

Apply these textual fixes in `cis_oracle_linux_9.yml`:

For 33531:

-  `- f:/boot/grub2/user.cfg -> r:^\s*GRUB2_PASSWORD=grub.pbkdf2.sha512`

For 33674:

-  `- 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- -> r:\s0 0/root 0/root'`

# Note: 

It may be worth scanning the whole `cis_oracle_linux_9.yml` for similar whitespace/quote typos because these small formatting issues can cause many false negatives across different checks.

# Approved by

DRI name:
- [*] @MarcosBuslaiman 