### PR TITLE
Port to_bool helper onto 6.0.0

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -78,6 +78,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [regex_extract](#regex_extract)
 - [sha1](#sha1)
 - [system_epoch](#system_epoch)
+- [to_bool](#to_bool)
 - [to_int](#to_int)
 - [to_string](#to_string)
 - [upcase](#upcase)
@@ -2755,7 +2756,7 @@ check:
 
 ### Example 3
 
-Not null (array)
+Not null (boolean)
 
 #### Asset
 
@@ -2767,14 +2768,39 @@ check:
 #### Input Event
 
 ```json
-{}
+{
+  "target_field": true
+}
 ```
 
 *The check was successful*
 
 ### Example 4
 
-Not null (object)
+Not null (array, non-empty)
+
+#### Asset
+
+```yaml
+check:
+  - target_field: is_not_null()
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": [
+    1
+  ]
+}
+```
+
+*The check was successful*
+
+### Example 5
+
+Not null (object, non-empty)
 
 #### Asset
 
@@ -2795,9 +2821,9 @@ check:
 
 *The check was successful*
 
-### Example 5
+### Example 6
 
-Is null
+Missing (empty object is unmapped)
 
 #### Asset
 
@@ -2890,7 +2916,7 @@ check:
 
 ### Example 3
 
-Not number (array)
+number (array not empty)
 
 #### Asset
 
@@ -2902,7 +2928,11 @@ check:
 #### Input Event
 
 ```json
-{}
+{
+  "target_field": [
+    1
+  ]
+}
 ```
 
 *The check was successful*
@@ -3202,7 +3232,7 @@ check:
 {}
 ```
 
-*The check was successful*
+*The check was performed with errors*
 
 ### Example 2
 
@@ -4338,7 +4368,7 @@ check:
 
 ### Example 3
 
-Field exists (array)
+Field exists (array non-empty)
 
 #### Asset
 
@@ -4350,14 +4380,18 @@ check:
 #### Input Event
 
 ```json
-{}
+{
+  "target_field": [
+    1
+  ]
+}
 ```
 
 *The check was performed with errors*
 
 ### Example 4
 
-Field exists (object)
+Field exists (object non-empty)
 
 #### Asset
 
@@ -4377,6 +4411,65 @@ check:
 ```
 
 *The check was performed with errors*
+
+### Example 5
+
+Field exists (boolean)
+
+#### Asset
+
+```yaml
+check:
+  - target_field: not_exists()
+```
+
+#### Input Event
+
+```json
+{
+  "target_field": true
+}
+```
+
+*The check was performed with errors*
+
+### Example 6
+
+Field absent via empty array
+
+#### Asset
+
+```yaml
+check:
+  - target_field: not_exists()
+```
+
+#### Input Event
+
+```json
+{}
+```
+
+*The check was successful*
+
+### Example 7
+
+Field absent via empty object
+
+#### Asset
+
+```yaml
+check:
+  - target_field: not_exists()
+```
+
+#### Input Event
+
+```json
+{}
+```
+
+*The check was successful*
 
 
 
@@ -5231,28 +5324,29 @@ check:
 
 ```
 
-field: regex_not_match(regexp)
+field: regex_not_match(regxp)
 ```
 
 ## Arguments
 
 | parameter | Type | Source | Accepted values |
 | --------- | ---- | ------ | --------------- |
-| regexp | string | value | Any string |
+| regxp | string | value | Any regex |
 
 
 ## Target Field
 
 | Type | Possible values |
 | ---- | --------------- |
-| [number, string, boolean, array, object] | - |
+| string | Any string |
 
 
 ## Description
 
-Checks that the field string does not match the given regular expression (partial match).
-If the regex matches, the function evaluates to false. If the field is missing or not a string, it evaluates to false.
-This helper function is typically used in the check stage
+Checks that the target field (string) does NOT match the given regular expression (RE2).
+If it matches, evaluates to false. If the field is missing or not a string, evaluates to false.
+Keep in mind YAML escaping rules. RE2 syntax: https://github.com/google/re2/wiki/Syntax
+Typically used in the check stage.
 
 
 ## Keywords
@@ -5284,7 +5378,7 @@ check:
 
 ### Example 2
 
-Matches (regex finds a prefix 'abc')
+Matches (prefix 'abc')
 
 #### Asset
 
@@ -5305,55 +5399,13 @@ check:
 
 ### Example 3
 
-Does not match (no 'error' or 'fail')
+Not a string -> fails
 
 #### Asset
 
 ```yaml
 check:
-  - target_field: regex_not_match('error|fail')
-```
-
-#### Input Event
-
-```json
-{
-  "target_field": "Status OK"
-}
-```
-
-*The check was successful*
-
-### Example 4
-
-Matches (contains 'fail')
-
-#### Asset
-
-```yaml
-check:
-  - target_field: regex_not_match('error|fail')
-```
-
-#### Input Event
-
-```json
-{
-  "target_field": "critical failure detected"
-}
-```
-
-*The check was performed with errors*
-
-### Example 5
-
-Not a string → fails
-
-#### Asset
-
-```yaml
-check:
-  - target_field: regex_not_match('^abc')
+  - target_field: regex_not_match('^(bye pcre\\d)$')
 ```
 
 #### Input Event
@@ -5673,7 +5725,7 @@ field: string_greater_or_equal(any_string)
 
 | parameter | Type | Source | Accepted values |
 | --------- | ---- | ------ | --------------- |
-| any_string | string | value | Any string |
+| any_string | string | value or reference | Any string |
 
 
 ## Target Field
@@ -5685,9 +5737,9 @@ field: string_greater_or_equal(any_string)
 
 ## Description
 
-Checks whether the string stored in field is lexicographically greater than or equal to the provided value.
-If it is less, the function evaluates to false. In case of error, the function will evaluate to false.
-This helper function is typically used in the check stage
+Checks whether the string stored in field is lexicographically greater than or equal
+to the provided value. If it is less, evaluates to false. On error, evaluates to false.
+Typically used in the check stage.
 
 
 ## Keywords
@@ -5721,19 +5773,20 @@ check:
 
 ### Example 2
 
-Target > argument → passes
+Target >= argument (world >= hello) → passes
 
 #### Asset
 
 ```yaml
 check:
-  - target_field: string_greater_or_equal('hello')
+  - target_field: string_greater_or_equal($any_string)
 ```
 
 #### Input Event
 
 ```json
 {
+  "any_string": "hello",
   "target_field": "world"
 }
 ```
@@ -5742,7 +5795,7 @@ check:
 
 ### Example 3
 
-Target < argument → fails
+Target < argument (abc < def) → fails
 
 #### Asset
 
@@ -5769,13 +5822,14 @@ Not a string → fails
 
 ```yaml
 check:
-  - target_field: string_greater_or_equal('abc')
+  - target_field: string_greater_or_equal($any_string)
 ```
 
 #### Input Event
 
 ```json
 {
+  "any_string": "abc",
   "target_field": 123
 }
 ```
@@ -9198,6 +9252,265 @@ If the “field” already exists, then it will be replaced.
 - `time` 
 
 ---
+# to_bool
+
+## Signature
+
+```
+
+field: to_bool(number_to_convert)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| number_to_convert | number | reference |
+
+
+## Outputs
+
+| Type | Possible values |
+| ---- | --------------- |
+| boolean |
+
+
+## Description
+
+Converts a numeric reference to boolean.
+Rule: non-zero → true, zero → false.
+In case of errors “target_field” will not be modified.
+This helper function is typically used in the map stage.
+
+
+## Keywords
+
+- `boolean` 
+
+- `number` 
+
+## Examples
+
+### Example 1
+
+Converts integer 1 to true.
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": 1
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": 1,
+  "target_field": true
+}
+```
+
+*The operation was successful*
+
+### Example 2
+
+Converts float 1.0 to true.
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": 1.0
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": 1.0,
+  "target_field": true
+}
+```
+
+*The operation was successful*
+
+### Example 3
+
+Converts integer 0 to false.
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": 0
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": 0,
+  "target_field": false
+}
+```
+
+*The operation was successful*
+
+### Example 4
+
+Converts float 0.0 to false.
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": 0.0
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": 0.0,
+  "target_field": false
+}
+```
+
+*The operation was successful*
+
+### Example 5
+
+Converts integer 2 to true (positive numbers are true).
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": 2
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": 2,
+  "target_field": true
+}
+```
+
+*The operation was successful*
+
+### Example 6
+
+Converts integer -1 to true (non-positives are true).
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": -1
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": -1,
+  "target_field": true
+}
+```
+
+*The operation was successful*
+
+### Example 7
+
+Converts float 0.5 to true (positive numbers are true).
+
+#### Asset
+
+```yaml
+normalize:
+  - map:
+      - target_field: to_bool($number_to_convert)
+```
+
+#### Input Event
+
+```json
+{
+  "number_to_convert": 0.5
+}
+```
+
+#### Outcome Event
+
+```json
+{
+  "number_to_convert": 0.5,
+  "target_field": true
+}
+```
+
+*The operation was successful*
+
+
+
+---
 # to_int
 
 ## Signature
@@ -11011,7 +11324,7 @@ No deletions when argument is null but target has no nulls
 ```yaml
 normalize:
   - map:
-      - target_field: delete_fields_with_value(null)
+      - target_field: delete_fields_with_value(None)
 ```
 
 #### Input Event
@@ -12607,7 +12920,7 @@ normalize:
 
 ```
 
-field: parse_binary(input_field, [...])
+field: parse_binary(input_field)
 ```
 
 ## Arguments
@@ -12814,7 +13127,7 @@ normalize:
 
 ```
 
-field: parse_bool(input_field, [...])
+field: parse_bool(input_field)
 ```
 
 ## Arguments
@@ -12988,7 +13301,7 @@ normalize:
 
 ```
 
-field: parse_byte(input_field, [...])
+field: parse_byte(input_field)
 ```
 
 ## Arguments
@@ -13369,7 +13682,7 @@ ISO-8601 with timezone (explicit format)
 ```yaml
 normalize:
   - map:
-      - target_field: parse_date($input_field, '%Y-%m-%dT%H:%M:%S%z', '_auto')
+      - target_field: parse_date($input_field, '%Y-%m-%dT%H:%M:%S%Ez', '_auto')
 ```
 
 #### Input Event
@@ -13386,7 +13699,7 @@ normalize:
 ```json
 {
   "input_field": "2025-09-01T10:30:00-05:00",
-  "target_field": "2025-09-01T15:30:00Z"
+  "target_field": "2025-09-01T15:30:00.000Z"
 }
 ```
 
@@ -13418,7 +13731,7 @@ normalize:
 ```json
 {
   "input_field": "01/09/2025 10:30",
-  "target_field": "2025-09-01T10:30:00Z"
+  "target_field": "2025-09-01T10:30:00.000Z"
 }
 ```
 
@@ -13426,7 +13739,7 @@ normalize:
 
 ### Example 3
 
-Invalid date -> error
+Format mismatch -> error
 
 #### Asset
 
@@ -13440,7 +13753,7 @@ normalize:
 
 ```json
 {
-  "input_field": "2025-13-99 99:99",
+  "input_field": "2025/09/01 10:30",
   "target_field": "any_value"
 }
 ```
@@ -13449,7 +13762,7 @@ normalize:
 
 ```json
 {
-  "input_field": "2025-13-99 99:99",
+  "input_field": "2025/09/01 10:30",
   "target_field": "any_value"
 }
 ```
@@ -13465,7 +13778,7 @@ normalize:
 
 ```
 
-field: parse_double(input_field, [...])
+field: parse_double(input_field)
 ```
 
 ## Arguments
@@ -13804,7 +14117,7 @@ normalize:
 
 ```
 
-field: parse_float(input_field, [...])
+field: parse_float(input_field)
 ```
 
 ## Arguments
@@ -14700,7 +15013,7 @@ normalize:
 
 ```
 
-field: parse_long(input_field, [...])
+field: parse_long(input_field)
 ```
 
 ## Arguments

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -137,6 +137,7 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opmap/floatCalc_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/intCalc_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/toInt_test.cpp
+    ${UNIT_SRC_DIR}/builders/opmap/toBool_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/regex_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/ip_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/time_test.cpp

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
@@ -61,6 +61,17 @@ TransformOp opBuilderHelperStringTrim(const Reference& targetField,
 MapOp opBuilderHelperToInt(const std::vector<OpArg>& opArgs, const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
+ * @brief Helper that converts a numeric value to a boolean (JSON boolean).
+ *        Rule: values  != 0 map to true otherwise false.
+ *
+ * @param opArgs Vector of operation arguments containing the numeric value to be converted.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @return MapOp operation
+ * @throw std::runtime_error if the parameter is not a number.
+ */
+MapOp opBuilderHelperToBool(const std::vector<OpArg>& opArgs, const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
  * @brief Helper function to build a MapOp that concatenates strings from OpArgs.
  *
  * This function constructs a MapOp that concatenates strings from OpArgs, either directly

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -255,6 +255,9 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "trim", {schemf::JTypeToken::create(json::Json::Type::String), builders::opBuilderHelperStringTrim});
     registry->template add<builders::OpBuilderEntry>(
         "to_int", {schemf::JTypeToken::create(json::Json::Type::Number), builders::opBuilderHelperToInt});
+    // Register the to_bool helper (boolean result)
+    registry->template add<builders::OpBuilderEntry>(
+        "to_bool", {schemf::STypeToken::create(schemf::Type::BOOLEAN), builders::opBuilderHelperToBool});
     // Transform helpers: Definition functions
     registry->template add<builders::OpBuilderEntry>(
         "get_key_in", {schemf::runtimeValidation(), builders::opBuilderHelperGetValue}); // TODO: add validation

--- a/src/engine/source/builder/test/src/unit/builders/opmap/toBool_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/toBool_test.cpp
@@ -1,0 +1,77 @@
+#include "builders/baseBuilders_test.hpp"
+#include "builders/opmap/opBuilderHelperMap.hpp"
+
+using namespace builder::builders;
+
+namespace
+{
+auto customRefExpected(bool times = false)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        if (times)
+        {
+            EXPECT_CALL(*mocks.ctx, validator()).Times(testing::AtLeast(1));
+            EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillRepeatedly(testing::Return(false));
+        }
+        else
+        {
+            EXPECT_CALL(*mocks.ctx, validator());
+            EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillOnce(testing::Return(false));
+        }
+        return None {};
+    };
+}
+
+auto customRefExpected(json::Json jValue)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, validator());
+        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillOnce(testing::Return(false));
+        return jValue;
+    };
+}
+
+} // namespace
+
+namespace mapbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(Builders,
+                         MapBuilderTest,
+                         testing::Values(MapT({}, opBuilderHelperToBool, FAILURE()),
+                                         MapT({makeValue(R"("true")")}, opBuilderHelperToBool, FAILURE()),
+                                         MapT({makeRef("ref")}, opBuilderHelperToBool, SUCCESS()),
+                                         MapT({makeRef("ref"), makeRef("ref")}, opBuilderHelperToBool, FAILURE())),
+                         testNameFormatter<MapBuilderTest>("ToBool"));
+}
+
+namespace mapoperatestest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    MapOperationTest,
+    testing::Values(
+        /*** to_bool ***/
+        /*** invalid type reference field ***/
+        MapT(R"({"ref": "some"})", opBuilderHelperToBool, {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapT(R"({"ref": "[1,2,3,4]"})", opBuilderHelperToBool, {makeRef("ref")}, FAILURE(customRefExpected())),
+        MapT(R"({"ref": {"key": "value"}})", opBuilderHelperToBool, {makeRef("ref")}, FAILURE(customRefExpected())),
+        /*** success cases ***/
+        MapT(R"({"ref": 1})", opBuilderHelperToBool, {makeRef("ref")}, SUCCESS(customRefExpected(json::Json("true")))),
+        MapT(
+            R"({"ref": 1.0})", opBuilderHelperToBool, {makeRef("ref")}, SUCCESS(customRefExpected(json::Json("true")))),
+        MapT(R"({"ref": 0})", opBuilderHelperToBool, {makeRef("ref")}, SUCCESS(customRefExpected(json::Json("false")))),
+        MapT(R"({"ref": 0.0})",
+             opBuilderHelperToBool,
+             {makeRef("ref")},
+             SUCCESS(customRefExpected(json::Json("false")))),
+        /*** additional numeric values now supported ***/
+        MapT(R"({"ref": 2})", opBuilderHelperToBool, {makeRef("ref")}, SUCCESS(customRefExpected(json::Json("true")))),
+        MapT(R"({"ref": -1})", opBuilderHelperToBool, {makeRef("ref")}, SUCCESS(customRefExpected(json::Json("true")))),
+        MapT(R"({"ref": 0.5})",
+             opBuilderHelperToBool,
+             {makeRef("ref")},
+             SUCCESS(customRefExpected(json::Json("true"))))),
+    testNameFormatter<MapOperationTest>("ToBool"));
+}

--- a/src/engine/test/helper_tests/helpers_description/map/to_bool.yml
+++ b/src/engine/test/helper_tests/helpers_description/map/to_bool.yml
@@ -1,0 +1,64 @@
+name: to_bool
+metadata:
+  description: |
+    Converts a numeric reference to boolean.
+    Rule: non-zero → true, zero → false.
+    In case of errors “target_field” will not be modified.
+    This helper function is typically used in the map stage.
+  keywords:
+    - boolean
+    - number
+helper_type: map
+is_variadic: false
+
+arguments:
+  number_to_convert:
+    type: number
+    generate:
+      - integer
+      - float
+      - double
+    source: reference
+
+skipped:
+  - success_cases
+
+output:
+  type: boolean
+
+test:
+  - arguments:
+      number_to_convert: 1
+    should_pass: true
+    expected: true
+    description: Converts integer 1 to true.
+  - arguments:
+      number_to_convert: 1.0
+    should_pass: true
+    expected: true
+    description: Converts float 1.0 to true.
+  - arguments:
+      number_to_convert: 0
+    should_pass: true
+    expected: false
+    description: Converts integer 0 to false.
+  - arguments:
+      number_to_convert: 0.0
+    should_pass: true
+    expected: false
+    description: Converts float 0.0 to false.
+  - arguments:
+      number_to_convert: 2
+    should_pass: true
+    expected: true
+    description: Converts integer 2 to true (positive numbers are true).
+  - arguments:
+      number_to_convert: -1
+    should_pass: true
+    expected: true
+    description: Converts integer -1 to true (non-positives are true).
+  - arguments:
+      number_to_convert: 0.5
+    should_pass: true
+    expected: true
+    description: Converts float 0.5 to true (positive numbers are true).


### PR DESCRIPTION

## Description

This PR introduces a new map helper called to_bool_str, which converts a numeric boolean (0 or 1) into its corresponding string values "false" or "true".

## Proposed Changes

1. New helper implementation

    - Added function opBuilderHelperToBoolStr in _engine/source/builder/.../opBuilderHelperMap.cpp._
    - Validates input reference is a number.
    - Accepts only exact values 0 or 1.
    - Produces "false" or "true" accordingly.
    - Returns failure for invalid or non-numeric inputs.

2. Unit tests

1. Created test cases in:

      - /builders/opmap/toBool_test.cpp

2. Helper description

    - Added YAML spec:
  
        - src/engine/test/helper_tests/helpers_description/map/to_bool_str.yml

4. Documentation

      - Generated engine reference docs using engine-helper-test generate-doc.
      - New helper appears under docs/ref/modules/engine/.

### Results and Evidence

Unit tes:

```console
─root@110363455a17 /workspaces/Wazuh_5x/wazuh/src/build/engine/source/builder ‹enhancement/31542-Add-helper-numericBool-to-String●› 
╰─# ./builder_utest --gtest_filter='*ToBool*'
Running main() from /workspaces/Wazuh_5x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *ToBool*
[==========] Running 14 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from Builders/MapBuilderTest
[ RUN      ] Builders/MapBuilderTest.Builds/ToBool_0
[       OK ] Builders/MapBuilderTest.Builds/ToBool_0 (32 ms)
[ RUN      ] Builders/MapBuilderTest.Builds/ToBool_1
[       OK ] Builders/MapBuilderTest.Builds/ToBool_1 (0 ms)
[ RUN      ] Builders/MapBuilderTest.Builds/ToBool_2

GMOCK WARNING:
Uninteresting mock function call - taking default action specified at:
/workspaces/Wazuh_5x/wazuh/src/engine/source/builder/test/src/unit/builders/baseBuilders_test.hpp:62:
    Function call: validator()
          Returns: @0x55d16687fdd0 8-byte object <78-96 D8-60 D1-55 00-00>
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

GMOCK WARNING:
Uninteresting mock function call - returning default value.
    Function call: hasField(@0x7fff2497d5a0 ref)
          Returns: false
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
[       OK ] Builders/MapBuilderTest.Builds/ToBool_2 (0 ms)
[ RUN      ] Builders/MapBuilderTest.Builds/ToBool_3
[       OK ] Builders/MapBuilderTest.Builds/ToBool_3 (0 ms)
[----------] 4 tests from Builders/MapBuilderTest (33 ms total)

[----------] 10 tests from Builders/MapOperationTest
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_0
[       OK ] Builders/MapOperationTest.Operates/ToBool_0 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_1
[       OK ] Builders/MapOperationTest.Operates/ToBool_1 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_2
[       OK ] Builders/MapOperationTest.Operates/ToBool_2 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_3
[       OK ] Builders/MapOperationTest.Operates/ToBool_3 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_4
[       OK ] Builders/MapOperationTest.Operates/ToBool_4 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_5
[       OK ] Builders/MapOperationTest.Operates/ToBool_5 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_6
[       OK ] Builders/MapOperationTest.Operates/ToBool_6 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_7
[       OK ] Builders/MapOperationTest.Operates/ToBool_7 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_8
[       OK ] Builders/MapOperationTest.Operates/ToBool_8 (0 ms)
[ RUN      ] Builders/MapOperationTest.Operates/ToBool_9
[       OK ] Builders/MapOperationTest.Operates/ToBool_9 (0 ms)
[----------] 10 tests from Builders/MapOperationTest (3 ms total)

[----------] Global test environment tear-down
[==========] 14 tests from 2 test suites ran. (37 ms total)
[  PASSED  ] 14 tests.

```
validate .yml

```console
─# engine-helper-test -e /tmp/engine validate --input-file /workspaces/Wazuh_5x/wazuh/src/engine/test/helper_tests/helpers_description/map/to_bool_str.yml
Validating input...
Input validated successfully.
Validating helper descriptions...
/workspaces/Wazuh_5x/wazuh/src/engine/test/helper_tests/helpers_description/map/to_bool_str.yml
Files validated successfully.

```

Generate test and run:


```console
╰─# engine-helper-test -e /tmp/engine generate-tests --input-file /workspaces/Wazuh_5x/wazuh/src/engine/test/helper_tests/helpers_description/map/to_bool.yml -o /tmp/output
Validating input...
Input validated successfully.
Cleaning output folder: /tmp/output
Output folder cleaned.
Scanning and verifying input files...
/workspaces/Wazuh_5x/wazuh/src/engine/test/helper_tests/helpers_description/map/to_bool_str.yml
Input files scanned and verified.
Generating output files...
Generating output file: /tmp/output/to_bool_str.yml
Output files generated in /tmp/output

(venv) ╭─root@110363455a17 /workspaces/Wazuh_5x/wazuh/src/engine ‹enhancement/31542-Add-helper-numericBool-to-String●› 
╰─# engine-helper-test -e /tmp/engine run --input-file /tmp/output/to_bool.yml --show-failure  

### General Summary

- Total test cases executed: 25
- Successful test cases: 25
- Failed test cases: 0

```

Documentation

```console

(venv) ╭─root@110363455a17 /workspaces/Wazuh_5x/wazuh/src/engine ‹enhancement/31542-Add-helper-numericBool-to-String●› 
╰─# engine-helper-test -e /tmp/engine generate-doc --input-dir /workspaces/Wazuh_5x/wazuh/src/engine/test/helper_tests/helpers_description -o /workspaces/Wazuh_5x/wazuh/docs/ref/modules/engine 

```

run :

```console
(venv) ╭─root@110363455a17 /workspaces/Wazuh_5x/wazuh ‹enhancement/31542-Add-helper-numericBool-to-String●› 
╰─# cd docs && ./build.sh && ./server.sh 

```

<img width="804" height="737" alt="image" src="https://github.com/user-attachments/assets/6907e2a2-f71f-4896-9475-2439e576d357" />

<img width="852" height="893" alt="image" src="https://github.com/user-attachments/assets/18ca1d8b-a95b-4664-b780-824e2c68b305" />

<img width="788" height="580" alt="image" src="https://github.com/user-attachments/assets/b8582302-3e01-4c44-ad8a-a6221eb852d2" />



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
