### PR TITLE
Update offset DB only after processing

### DIFF
--- a/src/shared_modules/content_manager/doc/components/CTI_OFFSET_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/CTI_OFFSET_DOWNLOADER.md
@@ -10,8 +10,8 @@ The output content files will be stored in any of the following output directori
 
 The download process can be summarized as follows:
 1. Get the last CTI API consumer offset. This is done by performing an HTTP GET query to CTI. This value will be used as the last possible offset to query.
-2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`. 
-3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset. The download will be retried indefinitely if the server responds with an 5xx HTTP error code.
+2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`.
+3. Download the offsets range from **step 2**. The download will be retried indefinitely if the server responds with an 5xx HTTP error code. The `currentOffset` isn't updated in this phase but in the processing callback.
 4. Dump the downloaded offsets into an output file. This file path will be generated as `<output-folder>/<currentOffset>-<contentFileName>`.
 5. Push the new file path (from **step 4**) to the context [data paths](../../src/components/updaterContext.hpp).
 6. If the last possible offset (from **step 1**) has been downloaded, the process finishes. Otherwise, the process continues with the **step 2**.
@@ -20,7 +20,7 @@ The download process can be summarized as follows:
 
 Given the following conditions:
 - Last possible offset: `3200`.
-- Initial current offset: `0` (first execution ever). 
+- Initial current offset: `0` (first execution ever).
 - Content compressed: No.
 - Output folder: `/tmp/`.
 - Content filename: `data.json`.
@@ -43,4 +43,4 @@ The context fields related to this stage are:
 - `contentsFolder`: Used as output folder when the input file is not compressed.
 - `data`: Used to read and update the paths under the `paths` key. The stage status is also updated on this member.
 - `outputFolder`: Used as the destination file path base.
-- `currentOffset`: Used as the first offset that will be fetched from the API. It is also updated with the last offset fetched, so next time the download begins with the new offset value.
+- `currentOffset`: Used as the first offset that will be fetched from the API. The next time the download begins from the offset read from the DB, only the processing data callback after a successful operation updates the value in the context.

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -63,7 +63,7 @@ private:
             // Update the offset and hash
             context.currentOffset = offset;
             context.spUpdaterBaseContext->downloadedFileHash = hash;
-            logDebug2(WM_CONTENTUPDATER, "Data published");
+            logDebug2(WM_CONTENTUPDATER, "Data published. Offset: '%d', Hash: '%s'", offset, hash.c_str());
         }
         else
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -212,6 +212,7 @@ public:
             }
 
             // Return the current offset and an empty hash.
+            logDebug2(WM_VULNSCAN_LOGTAG, "Last offset processed: %lld", currentOffset);
             return {currentOffset, "", true};
         }
         else if (parsedMessage.at("type") == "raw")
@@ -357,6 +358,10 @@ public:
                     // If the process was interrupted or it failed, we return prematurely.
                     if (shouldStop->check() || !std::get<FileProcessingResultFields::STATUS>(processMessageResult))
                     {
+                        logDebug2(WM_VULNSCAN_LOGTAG,
+                                  "Feed update process interrupted or failed. Offset: %d, Hash: %s.",
+                                  std::get<FileProcessingResultFields::OFFSET>(processMessageResult),
+                                  std::get<FileProcessingResultFields::HASH>(processMessageResult).c_str());
                         return processMessageResult;
                     }
 


### PR DESCRIPTION
## Description

This fix is a backport of PR #29179, which was originally introduced in version 4.12.0.

## Test scenario

1. **Clean up databases and download the compressed DB**
```bash
root@vm-ubuntu20:/home/vagrant/wazuh# rm -rf /var/ossec/queue/vd/
root@vm-ubuntu20:/home/vagrant/wazuh# wget http://packages.wazuh.com/deps/vulnerability_model_database/vd_1.0.0_vd_4.10.0.tar.xz
--2025-09-24 14:48:22--  http://packages.wazuh.com/deps/vulnerability_model_database/vd_1.0.0_vd_4.10.0.tar.xz
Resolving packages.wazuh.com (packages.wazuh.com)... 99.84.9.126, 99.84.9.62, 99.84.9.57, ...
Connecting to packages.wazuh.com (packages.wazuh.com)|99.84.9.126|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 303576656 (290M) [application/x-tar]
Saving to: ‘vd_1.0.0_vd_4.10.0.tar.xz’

vd_1.0.0_vd_4.10.0.tar.xz   100%[========================================>] 289.51M  11.1MB/s    in 27s     

2025-09-24 14:48:49 (10.7 MB/s) - ‘vd_1.0.0_vd_4.10.0.tar.xz’ saved [303576656/303576656]

root@vm-ubuntu20:/home/vagrant/wazuh# cp vd_1.0.0_vd_4.10.0.tar.xz /var/ossec/tmp/
```

2. **Start Wazuh**
```bash
/var/ossec/bin/wazuh-control start
```

3. **Check for initial API offset**
```bash
# tail -f /var/ossec/logs/ossec.log | grep "Initial API"
2025/09/24 14:51:17 ... DEBUG: Initial API offset: 2813807
```

4. **Check for downloading offsets**
```bash
# tail -f /var/ossec/logs/ossec.log | grep "Downloading offsets"
2025/09/24 14:51:17 ... DEBUG: Downloading offsets from ...from_offset=2813807&to_offset=2814807
2025/09/24 14:51:20 ... DEBUG: Downloading offsets from ...from_offset=2814807&to_offset=2815807
```

5. **Stop Wazuh immediately after downloading begins (before processing)**
```bash
/var/ossec/bin/wazuh-control stop
```

6. **Query RocksDB**
```bash
./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata -c current_offset
20250924004143 ==> 0
20250924005936 ==> 2813807
20250924145124 ==> 2813807
```
A new entry appears with offset `2813807` (not yet processed).

---

7. **Restart Wazuh and check downloading again**
```bash
2025/09/24 14:52:19 ... DEBUG: Downloading offsets from ...from_offset=2814807&to_offset=2815807
2025/09/24 14:52:22 ... DEBUG: Downloading offsets from ...from_offset=2815807&to_offset=2816807
```

8. **Stop Wazuh again before processing**
```bash
/var/ossec/bin/wazuh-control stop
```

9. **Query RocksDB**
```bash
./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata -c current_offset
20250924004143 ==> 0
20250924005936 ==> 2813807
20250924145124 ==> 2813807
20250924145225 ==> 2813807
```
A new entry is created again with `2813807`, which is correct.

---

10. **Start Wazuh (this time let it process)**
```bash
/var/ossec/bin/wazuh-control start
```

11. **Check downloaded contents**
```bash
ls /var/ossec/queue/vd_updater/tmp/contents/
2814807-api_file.json  2815807-api_file.json  2816807-api_file.json
```

12. **Check for downloading and processing logs**
```bash
2025/09/24 14:54:32 ... DEBUG: Downloading offsets from ...from_offset=2814807&to_offset=2815807
2025/09/24 14:54:34 ... DEBUG: Downloading offsets from ...from_offset=2815807&to_offset=2816807
2025/09/24 14:54:35 ... DEBUG: Downloading offsets from ...from_offset=2816807&to_offset=2817007

# tail -f /var/ossec/logs/ossec.log | grep "Processing file: queue/vd_updater/tmp/contents/"
2025/09/24 14:54:36 ... DEBUG: Processing file: queue/vd_updater/tmp/contents/2814807-api_file.json
```

13. **Query RocksDB again (should reflect the new offset)**
```bash
./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata -c current_offset
20250924004143 ==> 0
20250924005936 ==> 2813807
20250924145124 ==> 2813807
20250924145225 ==> 2813807
20250924145440 ==> 2813814
```

The database offset is successfully updated to `2813814` after processing.
