### PR TITLE
Remove db state before upgrading from 4.x to 5.x

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/preinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/preinst
@@ -20,6 +20,10 @@ case "$1" in
                 exit 1
             fi
 
+            # Get version information
+            OLD_VERSION=`${DIR}/bin/wazuh-control info -v`
+            MAJOR=$(echo $OLD_VERSION | cut -dv -f2 | cut -d. -f1)
+
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
                 systemctl stop wazuh-agent.service > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
@@ -32,6 +36,16 @@ case "$1" in
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
             ${DIR}/bin/ossec-control stop > /dev/null 2>&1 || ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
+
+            # Remove old databases if upgrading from pre 5.X to 5.X
+            if [ $MAJOR -lt 5 ]; then
+                if [ -f ${DIR}/queue/syscollector/db/local.db ]; then
+                    rm -f ${DIR}/queue/syscollector/db/local.db
+                fi
+                if [ -f ${DIR}/queue/fim/db/fim.db ]; then
+                    rm -f ${DIR}/queue/fim/db/fim.db
+                fi
+            fi
 
             if [ -d ${DIR}/logs/ossec ]; then
                 mv ${DIR}/logs/ossec ${DIR}/logs/wazuh

--- a/packages/macos/package_files/preinstall.sh
+++ b/packages/macos/package_files/preinstall.sh
@@ -47,6 +47,10 @@ if [ -d "${DIR}" ]; then
         rm -f "${DIR}/WAZUH_RESTART"
     fi
 
+    # Get version information
+    OLD_VERSION=`${DIR}/bin/wazuh-control info -v`
+    MAJOR=$(echo $OLD_VERSION | cut -dv -f2 | cut -d. -f1)
+
     # Stops the agent before upgrading it
     if ${DIR}/bin/wazuh-control status | grep "is running" > /dev/null 2>&1; then
         touch "${DIR}/WAZUH_RESTART"
@@ -56,6 +60,16 @@ if [ -d "${DIR}" ]; then
         touch "${DIR}/WAZUH_RESTART"
         ${DIR}/bin/ossec-control stop
         restart="true"
+    fi
+
+    # Remove old databases if upgrading from pre 5.X to 5.X
+    if [ $MAJOR -lt 5 ]; then
+        if [ -f ${DIR}/queue/syscollector/db/local.db ]; then
+          rm -f ${DIR}/queue/syscollector/db/local.db
+        fi
+        if [ -f ${DIR}/queue/fim/db/fim.db ]; then
+          rm -f ${DIR}/queue/fim/db/fim.db
+        fi
     fi
 
     echo "Backing up configuration files to ${DIR}/config_files/"

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -227,6 +227,10 @@ if ! getent passwd wazuh > /dev/null 2>&1; then
   useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
 fi
 
+# Get version information
+OLD_VERSION=`%{_localstatedir}/bin/wazuh-control info -v`
+MAJOR=$(echo $OLD_VERSION | cut -dv -f2 | cut -d. -f1)
+
 # Stop the services to upgrade the package
 if [ $1 = 2 ]; then
   if [ ! -d "%{_localstatedir}" ]; then
@@ -247,6 +251,16 @@ if [ $1 = 2 ]; then
     touch %{_localstatedir}/tmp/wazuh.restart
   fi
   %{_localstatedir}/bin/ossec-control stop > /dev/null 2>&1 || %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
+fi
+
+# Remove old databases if upgrading from pre 5.X to 5.X
+if [ $MAJOR -lt 5 ]; then
+  if [ -f %{_localstatedir}/queue/syscollector/db/local.db ]; then
+    rm -f %{_localstatedir}/queue/syscollector/db/local.db
+  fi
+  if [ -f %{_localstatedir}/queue/fim/db/fim.db ]; then
+    rm -f %{_localstatedir}/queue/fim/db/fim.db
+  fi
 fi
 
 %post

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -192,6 +192,16 @@ WazuhUpgrade()
         rm -f /etc/ossec-init.conf
     fi
 
+    # Remove old databases if upgrading from pre 5.X to 5.X
+    if [ $MAJOR -lt 5 ]; then
+        if [ -f $PREINSTALLEDDIR/queue/syscollector/db/local.db ]; then
+            rm -f $PREINSTALLEDDIR/queue/syscollector/db/local.db
+        fi
+        if [ -f $PREINSTALLEDDIR/queue/fim/db/fim.db ]; then
+            rm -f $PREINSTALLEDDIR/queue/fim/db/fim.db
+        fi
+    fi
+
     # Replace and delete ossec group along with ossec users
     OSSEC_GROUP=ossec
     if (grep "^ossec:" /etc/group > /dev/null 2>&1) || (dscl . -read /Groups/ossec > /dev/null 2>&1)  ; then

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -441,3 +441,25 @@ Public Function CreateDumpRegistryKey()
 
     CreateDumpRegistryKey = 0
 End Function
+
+' Deletes legacy DBs when upgrading from pre-5.x; WiX filters the version.
+Public Function CleanupLegacyDatabases()
+    On Error Resume Next
+    Dim strArgs, args, home_dir
+    Dim fso
+
+    ' Read CustomActionData: "[APPLICATIONFOLDER]"
+    strArgs = Session.Property("CustomActionData")
+    args = Split(strArgs, "/+/")
+    home_dir = Replace(args(0), Chr(34), "")
+
+    Set fso = CreateObject("Scripting.FileSystemObject")
+
+    ' Remove legacy DB files
+    fso.DeleteFile home_dir & "queue\syscollector\db\local.db", True
+    fso.DeleteFile home_dir & "queue\fim\db\fim.db", True
+
+    Set fso = Nothing
+
+    CleanupLegacyDatabases = 0
+End Function

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -117,6 +117,9 @@
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
         <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>
 
+        <CustomAction Id="SetCustomActionDataCleanupLegacyDBs" Return="check" Property="CleanupLegacyDatabases" Value="&quot;[APPLICATIONFOLDER]&quot;" />
+        <CustomAction Id="CleanupLegacyDatabases" BinaryKey="InstallerScripts" VBScriptCall="CleanupLegacyDatabases" Return="check" Execute="deferred" Impersonate="no" />
+
         <!-- Explicitely stopping and deleting the OSSEC service to install new Wazuh service -->
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
         <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
@@ -179,6 +182,10 @@
             <!-- Set Wazuh permissions on upgrade -->
             <Custom Action="SetCustomActionDataForSetWazuhPermissions" After="InstallInitialize">(WIX_UPGRADE_DETECTED) OR (PATCH)</Custom>
             <Custom Action="SetWazuhPermissions" After="SetCustomActionDataForSetWazuhPermissions">(WIX_UPGRADE_DETECTED) OR (PATCH)</Custom>
+
+            <!-- If upgrading from prior to 5.x, remove legacy DBs before service start -->
+            <Custom Action="SetCustomActionDataCleanupLegacyDBs" After="AppSearch">IS_UPGRADING_FROM_PRIOR_TO_5X</Custom>
+            <Custom Action="CleanupLegacyDatabases" After="InstallFiles">IS_UPGRADING_FROM_PRIOR_TO_5X</Custom>
 
             <!-- Start services if necessary -->
             <Custom Action="StartWazuhSvc" After="InstallFinalize">((WIX_UPGRADE_DETECTED) OR (PATCH)) AND ((OSSECRUNNING = "Running") OR (WAZUHRUNNING = "Running"))</Custom>
@@ -693,6 +700,8 @@
             <ComponentRef Id="W2019_CONF_PROFILE" />
         </Feature>
         <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
+        <Upgrade Id="F495AC57-7BDE-4C4B-92D8-DBE40A9AA5A0">
+        <UpgradeVersion Maximum="5.0.0" IncludeMaximum="no" Property="IS_UPGRADING_FROM_PRIOR_TO_5X" /></Upgrade>
     </Product>
     <Fragment>
         <Binary Id="CustomImage" SourceFile="ui\bannrbmp.jpg" />


### PR DESCRIPTION
## Description
After succesfully upgrading a MacOS ARM agent from 4.x to 5.x through WPK, `ossec.log` shows lots of syscollector errors of this kind:
```
2025/09/09 17:25:01 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"3588bdfb289ba01a73ac7080eeeea620254a42db","description":" ","installed":" ","n
ame":"cffi","path":"/opt/homebrew/lib/python3.11/site-packages/cffi-1.17.1.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version":"1.17.1"}],"exception
":"[json.exception.out_of_range.403] key 'location' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
```
This happens because the agent is using the old 4.x `fim.db` and `local.db` .

Closes https://github.com/wazuh/wazuh/issues/31870

## Proposed changes
Remove both `fim.db` and `local.db` on every pre-install step for all OS's package upgrade steps. And also from the manual upgrades from sources (`./install.sh`).

## Testing 
### 4.x to 5.x
All tests performed use a 4.14.0 agent that's running and connected to a manager and is upgraded via a 5.0.0 WPK package generated with the DB cleaning fixes. The agent OS and architecture configurations that were tested were the following:

Centos (RPM) via WPK ✅
MacOS (ARM) via WPK ✅
Ubuntu (DEB) via WPK ✅
MacOS (Intel) via WPK ✅
Windows via WPK ✅
Ubuntu via sources ✅

In all cases after performing an upgrade I see no errors in the syscollector module. Before these changes the `ossec.log` would produce lots of syscollector INFO and ERROR messages like the one shown in the description of this PR.

All scenarios show the `syscollector` module executing without issues inside `ossec.log`:
```
sh-3.2# cat ossec.log | grep syscollector
2025/09/12 12:42:07 wazuh-modulesd:syscollector: INFO: Module started.
2025/09/12 12:42:07 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/09/12 12:42:14 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```
And both `fim.db` and `local.db` being recreated in their respective directories:
```
root@:/var/ossec# ls queue/fim/db/fim.db
queue/fim/db/fim.db

root@:/var/ossec# ls queue/syscollector/db/local.db
queue/syscollector/db/local.db
```
Validating that the old DBs are no longer present (No syscollector errors in `ossec.log`) and the files are recreated corretly.

### 5.x to 5.x
Since we don't want 5.x to 5.x upgrades to remove the databases like we do with 4.x, we tested an update with different revisions of 5.x on an ubuntu machine and checked the database creation dates to validate they aren't getting deleted on the update:

<details>
<summary>fim.db and local.db stats</summary>

```
root@ubuntu1:/var/ossec/queue/fim/db# stat fim.db
  File: fim.db
  Size: 1359872         Blocks: 2656       IO Block: 4096   regular file
Device: 252,0   Inode: 275622      Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (  110/   wazuh)
Access: 2025-09-15 13:57:10.162857453 +0000
Modify: 2025-09-15 13:57:11.108329892 +0000
Change: 2025-09-15 13:57:11.108329892 +0000
 Birth: 2025-09-15 13:50:47.039416584 +0000
```

```
root@ubuntu1:/var/ossec/queue/syscollector/db# stat local.db 
  File: local.db
  Size: 380928          Blocks: 744        IO Block: 4096   regular file
Device: 252,0   Inode: 275643      Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2025-09-15 13:57:11.897724340 +0000
Modify: 2025-09-15 13:57:11.899725340 +0000
Change: 2025-09-15 13:57:11.899725340 +0000
 Birth: 2025-09-15 13:50:47.095444580 +0000

```
</details>

We can observe that, while the access and modification dates change, the birth remains the same. Validating that the dbs aren´t getting deleted on 5.x -> 5.x upgrades.

We also validated this scenario by disabling the `syscollector` and `fim` modules before performing the 5.x -> 5.x upgrade:
```
  <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>yes</disabled>

  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>yes</disabled>
```

We then upgraded and checked for `/var/ossec/queue/fim/db/fim.db` and `/var/ossec/queue/syscollector/db/local.db` and both files were present. Validating that 5.x -> 5.x upgrade doesn't remove these files.
