### PR TITLE
Add new UT for the function os_write_agent_info

### DIFF
--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -19,6 +19,9 @@
 
 #ifdef WAZUH_UNIT_TESTING
 #define static
+#ifdef WIN32
+#include "../unit_tests/wrappers/windows/libc/stdio_wrappers.h"
+#endif
 #endif
 
 static pthread_mutex_t restart_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -133,10 +133,18 @@ if(${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_flags "-Wl,--wrap,wdb_get_agent_info -Wl,--wrap,_mdebug1 -Wl,--wrap,getpid \
                                 -Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                                -Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,external_socket_connect \
+                                -Wl,--wrap,sleep -Wl,--wrap,strerror -Wl,--wrap,getpid -Wl,--wrap,close \
+                                -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,wfopen -Wl,--wrap,_merror \
+                                -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fopen -Wl,--wrap,fread \
+                                -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,popen \
                                 -Wl,--wrap=_imp__rsync_initialize -Wl,--wrap=fim_db_teardown ${DEBUG_OP_WRAPPERS}")
 else()
 list(APPEND shared_tests_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,external_socket_connect \
                                 -Wl,--wrap,sleep -Wl,--wrap,strerror -Wl,--wrap,getpid -Wl,--wrap,close \
+                                -Wl,--wrap,fclose -Wl,--wrap,fprintf -Wl,--wrap,wfopen -Wl,--wrap,_merror \
+                                -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos -Wl,--wrap,fopen -Wl,--wrap,fread \
+                                -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc -Wl,--wrap,popen \
                                 -Wl,--wrap,OS_SendSecureTCPCluster -Wl,--wrap,OS_RecvSecureClusterTCP ${DEBUG_OP_WRAPPERS}")
 endif()
 

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -572,11 +572,55 @@ static void test_parse_agent_add_response(void **state) {
     assert_int_equal(err, -2);
     assert_string_equal(err_response, "ERROR: Invalid message format");
 }
+static void test_os_write_agent_info_success(void **state) {
+    FILE *fp = (FILE*)0x1234;
+
+    test_mode = 1;
+
+    expect_string(__wrap_wfopen, path, AGENT_INFO_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, fp);
+
+    expect_fprintf(fp, "agent\n-\n001\n-\n", 0);
+
+    expect_value(__wrap_fclose, _File, fp);
+    will_return(__wrap_fclose, 0);
+
+    int ret = os_write_agent_info("agent", "192.168.56.10", "001", NULL);
+
+    test_mode = 0;
+    assert_int_equal(ret, 1);
+}
+
+static void test_os_write_agent_info_no_success(void **state) {
+    test_mode = 1;
+
+    expect_string(__wrap_wfopen, path, AGENT_INFO_FILE);
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
+
+    errno = 1;
+
+    will_return(__wrap_strerror, "Operation not permitted");
+    char response[OS_MAXSTR];
+    snprintf(response, sizeof(response),
+         "(1103): Could not open file '%s' due to [(%d)-(%s)].",
+         AGENT_INFO_FILE, errno, "Operation not permitted");
+
+    expect_string(__wrap__merror, formatted_msg, response);    
+    int ret = os_write_agent_info("agent", "192.168.56.10", "001", NULL);
+
+    errno = 0;
+    test_mode = 0;
+    assert_int_equal(ret, 0);
+}
 
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_create_agent_add_payload),
         cmocka_unit_test(test_parse_agent_add_response),
+        cmocka_unit_test(test_os_write_agent_info_success),
+        cmocka_unit_test(test_os_write_agent_info_no_success),
         #ifndef WIN32
         cmocka_unit_test(test_create_agent_remove_payload),
         cmocka_unit_test(test_create_sendsync_payload),


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
This PR updates the test_agent_op.c file by adding a new UT for the os_write_agent_info function.
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>


-->
Closes https://github.com/wazuh/internal-devel-requests/issues/2965

PR check that fails, from macOS, Unit Tests, is due to this known issue: [macOS Ventura runner fails with CMake version error during the execution of unit tests #31904](https://github.com/wazuh/wazuh/issues/31904)
## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- **Code changes**
  - **Update src/shared/agent_op.c**
Added:
```c
#ifdef WIN32
#include "../unit_tests/wrappers/windows/libc/stdio_wrappers.h"
#endif
```
I added the lines above because, when running the unit tests on Windows, the call to fprintf did not use the wrap and produced the error:
`[  ERROR   ] --- EXCEPTION_ACCESS_VIOLATION occurred at 7bd0f3da`
On Windows, fprintf is an alias that actually calls mingw_fprintf (i.e., resolves to __mingw_fprintf), so the wrap was never invoked and the native Windows function executed instead. By adding this include, I use a predefined helper function that solves the issue. The function is expect_fprintf, which ensures the wrap is executed. Moreover, it allows us to anticipate Windows’ behavior by mapping the function ourselves to the wrapper. That’s why inside stdio_wrappers.h you’ll find the following:
`#define fprintf wrap_fprintf`

  - **Update /src/unit_tests/shared/CMakeLists.txt**
 In the CMakeLists.txt file for test_agent_op.c I had to add many wrappers. The reason is that the wrapper files (e.g., stdio_wrappers.c) not only define the wrap_ versions of functions but also rely on CMocka’s mechanism of declaring the corresponding __real_ functions.

For example:
```
extern FILE* __real_fopen(const char* path, const char* mode);

FILE* __wrap_fopen(const char* path, const char* mode) {
    if (test_mode) {
        check_expected_ptr(path);
        check_expected(mode);
        return mock_ptr_type(FILE*);
    } else {
        return __real_fopen(path, mode);
    }
}
```
The symbol `__real_fopen` is only defined if CMocka finds the linker flag `-Wl,--wrap,fopen` in the `CMakeLists.txt`. That means that whenever you need to use one of these wrapper files, you must also include all the corresponding `--wrap` flags for every function that makes use of a `__real_` implementation.

If you don’t do that, the compiler will fail with an **undefined reference** error. By explicitly adding the necessary wrappers in the CMake configuration, the linker resolves both the `__wrap_` and the `__real_` functions correctly, and the tests build without errors.

- **Unit tests**
  - Add `test_os_write_agent_info_no_success`
  - Add `test_os_write_agent_info_success`
  - File: `src/unit_test/shared/test_agent_op.

Regarding the unit test **test_os_write_agent_info_no_success**: when it reaches `fopen`, I added the line
```c
expect_string(__wrap_wfopen, path, AGENT_INFO_FILE);
```
The value I pass for path is AGENT_INFO_FILE because, depending on whether you compile for Windows or Linux, the path to the agent information file changes. On Linux it is `queue/sockets/.agent_info`, while on Windows it is `.agent_info`. This variable is defined in src/headers/defs.h and is assigned based on the target platform you compile for. If you hardcode the path, you will get a runtime error on one of the operating systems because the path won’t be recognized.

Next, before asserting on __wrap__merror, I wrote these two lines:
```c
char response[OS_MAXSTR];
snprintf(response, sizeof(response),
         "(1103): Could not open file '%s' due to [(%d)-(%s)].",
         AGENT_INFO_FILE, errno, "Operation not permitted");
```
response is the **char **that merror expects. **OS_MAXSTR** is a variable defined in **src/headers/defs.h** that contains the maximum size used for logs, sockets, etc. I then call snprintf to fill the response buffer with the message corresponding to AGENT_INFO_FILE. If you don’t do this and you run on an OS whose path doesn’t match, the test will fail.

Regarding **test_os_write_agent_info_success**, you must take into account the previously mentioned `expect_fprintf` for cases where the tests are run on Windows. The function signature is:

```c
void expect_fprintf(FILE *__stream, const char *formatted_msg, int ret)
``` 
It automatically invokes the appropriate wrap for the operating system where the tests are executed. 
Also, in both tests I used the test_mode variable. This variable is used across all wrappers and basically controls how we want to execute special functions like fclose, fprintf, etc.—whether with mock() or with the real binary function.
test_mode = 1 means we want to execute the mock, and test_mode = 0 means the real function should run.

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->


<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced
   - test_os_write_agent_info_no_success
   - test_os_write_agent_info_success
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
