### PR TITLE
Fixed rpath of libwazuhshared

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2188,7 +2188,7 @@ $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $^ ${OSSEC_LIBS} -o $@ -static-libgcc
 else
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -Wl,-rpath,'$$ORIGIN' -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
 endif
 endif
 endif


### PR DESCRIPTION
## Description

Closes #31951


## Proposed Changes

- Added the `$ORIGIN` RPATH to `libwazuhshared`

### Results and Evidence

Source installation:

```bash
╭─root@459f1769a590 /workspaces/wazuh-5.x/wazuh ‹main●› 
╰─# ldd /var/ossec/lib/libwazuhshared.so
        linux-vdso.so.1 (0x00007f6b4295a000)
        libwazuhext.so => /var/ossec/lib/libwazuhext.so (0x00007f6b41e4c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6b41c34000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6b41b4b000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f6b4295c000)
╭─root@459f1769a590 /workspaces/wazuh-5.x/wazuh ‹main●› 
╰─# readelf -d /var/ossec/lib/libwazuhshared.so | grep -i runpath
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
╭─root@459f1769a590 /workspaces/wazuh-5.x/wazuh ‹main●› 
╰─# /var/ossec/bin/wazuh-control start                           
2025/09/13 00:13:24 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/13 00:13:24 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/13 00:13:24 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
wazuh-forwarder already running...
wazuh-apid already running...
wazuh-authd already running...
wazuh-db already running...
wazuh-execd already running...
wazuh-analysisd already running...
wazuh-syscheckd already running...
wazuh-remoted already running...
wazuh-logcollector already running...
wazuh-monitord already running...
wazuh-modulesd already running...
Completed.
```

Package isntallation:

```
╭─root@459f1769a590 /workspaces/wazuh-5.x 
╰─# apt install ./wazuh-manager_5.0.0-0_amd64_843eddc.deb                                                                                                                                                    130 ↵
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_5.0.0-0_amd64_843eddc.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/435 MB of archives.
After this operation, 1,011 MB of additional disk space will be used.
Get:1 /workspaces/wazuh-5.x/wazuh-manager_5.0.0-0_amd64_843eddc.deb wazuh-manager amd64 5.0.0-0 [435 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 40463 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_5.0.0-0_amd64_843eddc.deb ...
Unpacking wazuh-manager (5.0.0-0) ...
Setting up wazuh-manager (5.0.0-0) ...
╭─root@459f1769a590 /workspaces/wazuh-5.x 
╰─# git status                                           
fatal: not a git repository (or any parent up to mount point /workspaces)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
╭─root@459f1769a590 /workspaces/wazuh-5.x 
╰─# service wazuh-manager status                                                                                                                                                                             128 ↵
wazuh-clusterd not running...
wazuh-modulesd not running...
wazuh-monitord not running...
wazuh-logcollector not running...
wazuh-remoted not running...
wazuh-syscheckd not running...
wazuh-analysisd not running...
wazuh-execd not running...
wazuh-db not running...
wazuh-authd not running...
wazuh-apid not running...
wazuh-forwarder not running...
╭─root@459f1769a590 /workspaces/wazuh-5.x 
╰─# service wazuh-manager start                                                                                                                                                                                1 ↵
2025/09/15 14:18:41 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/15 14:18:41 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/15 14:18:41 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
Started wazuh-forwarder...
Started wazuh-apid...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2025/09/15 14:19:01 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/15 14:19:01 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/15 14:19:01 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Started wazuh-modulesd...
Completed.
╰─# service wazuh-manager status                                                                                                                                                                               1 ↵
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...
wazuh-forwarder is running...
```

### Manual tests with their corresponding evidence


<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

- Makefile

### Configuration Changes

None

### Tests Introduced

None

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
