### PR TITLE
Filter out unwanted events for vulnerability scanner

### DIFF
--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -63,9 +63,9 @@ public:
         options.write_buffer_manager = m_writeManager;
         options.num_levels = 4;
 
-        options.write_buffer_size = 32 * 1024 * 1024;
+        options.write_buffer_size = 64 * 1024 * 1024;
         options.max_write_buffer_number = 4;
-        options.max_background_jobs = 4;
+        options.max_background_jobs = 8;
 
         rocksdb::DB* db;
 

--- a/src/shared_modules/utils/rocksDBSharedBuffers.hpp
+++ b/src/shared_modules/utils/rocksDBSharedBuffers.hpp
@@ -25,8 +25,8 @@ public:
         return instance;
     }
 
-    static constexpr size_t SHARED_BUFFER_SIZE {128 * 1024 * 1024};    // 128MB
-    static constexpr size_t SHARED_READ_CACHE_SIZE {32 * 1024 * 1024}; // 32MB
+    static constexpr size_t SHARED_BUFFER_SIZE {256 * 1024 * 1024};    // 256MB
+    static constexpr size_t SHARED_READ_CACHE_SIZE {64 * 1024 * 1024}; // 64MB
 
     std::shared_ptr<rocksdb::Cache> getReadCache()
     {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -217,7 +217,20 @@ void VulnerabilityScannerFacade::initDeltasSubscription()
         std::make_unique<RouterSubscriber>("deltas-syscollector", "vulnerability_scanner_deltas");
     m_syscollectorDeltasSubscription->subscribe(
         // coverity[copy_constructor_call]
-        [this](const std::vector<char>& message) { pushEvent(message, BufferType::BufferType_DBSync); });
+        [this](const std::vector<char>& message)
+        {
+            flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(message.data()), message.size());
+            if (SyscollectorDeltas::VerifyDeltaBuffer(verifier))
+            {
+                const auto delta = SyscollectorDeltas::GetDelta(message.data());
+                if (delta->data_type() && (delta->data_type() == SyscollectorDeltas::Provider_dbsync_osinfo ||
+                                           delta->data_type() == SyscollectorDeltas::Provider_dbsync_packages ||
+                                           delta->data_type() == SyscollectorDeltas::Provider_dbsync_hotfixes))
+                {
+                    pushEvent(message, BufferType::BufferType_DBSync);
+                }
+            }
+        });
 }
 
 /**


### PR DESCRIPTION
## Description

Added filter in Vulnerability Scanner queue to avoid write to disk events that won't be processed by the scanner. 
