### PR TITLE
Fix 4.X tests compilation in `macos-13`

### DIFF
--- a/.github/workflows/4_testunit_macos.yml
+++ b/.github/workflows/4_testunit_macos.yml
@@ -13,15 +13,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Install compatible CMake version
-        run: |
-          cmake --version || echo "CMake not found"
-          brew uninstall --ignore-dependencies cmake || true
-          wget https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-macos-universal.tar.gz
-          tar -xzf cmake-3.31.6-macos-universal.tar.gz
-          sudo cp -R cmake-3.31.6-macos-universal/CMake.app/Contents/bin/* /usr/local/bin/
-          sudo cp -R cmake-3.31.6-macos-universal/CMake.app/Contents/share/* /usr/local/share/
-          cmake --version
       - name: Install cmocka 1.1.7 and lcov
         run: |
           brew install lcov
@@ -33,6 +24,8 @@ jobs:
           make -j$(sysctl -n hw.ncpu)
           sudo make install
       - name: Build wazuh agent for macOS 13 with tests flags
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
         run: |
           make deps -C src TARGET=agent -j4
           LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j4 DEBUG=1 TEST=1


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/issues/31904|

## Description

Hi team, 

this PR fixes the compilation of the macos-13 unit test by setting the `CMAKE_POLICY_VERSION_MINIMUM` to `3.5` as suggested in the following documentation [page](https://cmake.org/cmake/help/latest/envvar/CMAKE_POLICY_VERSION_MINIMUM.html#envvar:CMAKE_POLICY_VERSION_MINIMUM).

## Tests

Dispatched failing WF with the following call:
```
gh workflow run .github/workflows/4_testunit_macos.yml -r bug/31904-4X-macos-ventura-runner-fails-with-cmake-version
```
Result: :green_circle: [4.X - macOS - Unit tests #1215](https://github.com/wazuh/wazuh/actions/runs/17770178758)