### PR TITLE
After fixing the false positive, I had to revert and fix some workflows

### DIFF
--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -64,6 +64,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -65,6 +65,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_analysisd-tier-2.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-2.yml
@@ -54,6 +54,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -61,6 +61,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -54,6 +54,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -64,6 +64,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -84,6 +84,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -65,6 +65,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -63,6 +63,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -61,6 +61,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
@@ -59,6 +59,10 @@ jobs:
             echo "" >> ./etc/preloaded-vars.conf
             echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
             echo "" >> ./etc/preloaded-vars.conf
+            echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+            echo "" >> ./etc/preloaded-vars.conf
+            echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+            echo "" >> ./etc/preloaded-vars.conf
             echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
             echo "" >> ./etc/preloaded-vars.conf
             echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-lin.yml
@@ -52,6 +52,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -63,6 +63,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -63,6 +63,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -61,6 +61,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
@@ -59,6 +59,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -64,6 +64,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -73,6 +73,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -63,6 +63,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -61,6 +61,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -64,6 +64,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_remoted-tier-2.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-2.yml
@@ -54,6 +54,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -67,6 +67,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -66,6 +66,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_vulnerability_detector-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_vulnerability_detector-tier-0-1.yml
@@ -63,6 +63,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_vulnerability_detector-tier-2.yml
+++ b/.github/workflows/4_testintegration_vulnerability_detector-tier-2.yml
@@ -54,6 +54,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -63,6 +63,10 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ACTIVE_RESPONSE="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_CA_STORE="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf

--- a/packages/aix/generate_wazuh_packages.sh
+++ b/packages/aix/generate_wazuh_packages.sh
@@ -259,10 +259,6 @@ build_package() {
   --define "_init_scripts ${init_scripts}" --define "_sysconfdir ${sysconfdir}" --define "_version ${wazuh_version}" \
   --define "_release ${revision}" -bb ${rpm_build_dir}/SPECS/${package_name}-aix.spec
 
-  if [[ ${aix_major} = "6" ]]; then
-    mv ${ignored_lib}.backup ${ignored_lib}
-  fi
-
   # If they exist, remove the installed files in ${install_path}
   rm -rf ${install_path} /etc/ossec-init.conf
   find /etc/ -name "*wazuh*" -exec rm {} \;

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -14,6 +14,7 @@
 # ./src/init/template-select.sh
 
 ## Templates
+set -e
 . ./src/init/template-select.sh
 
 HEADER_TEMPLATE="./etc/templates/config/generic/header-comments.template"
@@ -240,7 +241,7 @@ GenerateAuthCert()
 WriteLogs()
 {
   LOCALFILES_TMP=`cat ${LOCALFILES_TEMPLATE}`
-  HAS_JOURNALD=`command -v journalctl`
+  HAS_JOURNALD=`command -v journalctl || true`
 
   # If has journald, add journald to the configuration file
   if [ "X$HAS_JOURNALD" != "X" ]; then
@@ -279,7 +280,7 @@ WriteLogs()
       fi
 
       # If journald is not available, change the log_format from '[!journald] ${log_type}' to '${log_type}'
-      NEGATE_JOURNALD=$(echo "$LOG_FORMAT" | grep "\[!journald\] ")
+      NEGATE_JOURNALD=$(echo "$LOG_FORMAT" | grep "\[!journald\] " || true)
       if [ "X$HAS_JOURNALD" = "X" ]; then
         if [ -n "$NEGATE_JOURNALD" ]; then
           LOG_FORMAT=$(echo "$LOG_FORMAT" | sed -e "s|\[!journald\] ||g")
@@ -748,7 +749,6 @@ WriteLocal()
 
 InstallCommon()
 {
-
     WAZUH_GROUP='wazuh'
     WAZUH_USER='wazuh'
     INSTALL="install"
@@ -1251,7 +1251,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} external/jemalloc/lib/libjemalloc.so.2 ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libjemalloc.so.2
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libjemalloc.so.2 || true
         fi
     fi
     if [ -f build/shared_modules/router/librouter.so ]
@@ -1259,7 +1259,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} build/shared_modules/router/librouter.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/librouter.so
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/librouter.so || true
         fi
     fi
     if [ -f build/shared_modules/content_manager/libcontent_manager.so ]
@@ -1267,7 +1267,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} build/shared_modules/content_manager/libcontent_manager.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libcontent_manager.so
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libcontent_manager.so || true
         fi
     fi
     if [ -f build/wazuh_modules/vulnerability_scanner/libvulnerability_scanner.so ]
@@ -1275,7 +1275,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} build/wazuh_modules/vulnerability_scanner/libvulnerability_scanner.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libvulnerability_scanner.so
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libvulnerability_scanner.so || true
         fi
     fi
     if [ -f build/wazuh_modules/inventory_harvester/libinventory_harvester.so ]
@@ -1283,7 +1283,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} build/wazuh_modules/inventory_harvester/libinventory_harvester.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libinventory_harvester.so
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libinventory_harvester.so || true
         fi
     fi
     if [ -f build/shared_modules/indexer_connector/libindexer_connector.so ]
@@ -1291,7 +1291,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} build/shared_modules/indexer_connector/libindexer_connector.so ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libindexer_connector.so
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/libindexer_connector.so || true
         fi
     fi
     if [ -f external/rocksdb/build/librocksdb.so.8 ]
@@ -1299,7 +1299,7 @@ InstallServer()
         ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} external/rocksdb/build/librocksdb.so.8 ${INSTALLDIR}/lib
 
         if ([ "X${DIST_NAME}" = "Xrhel" ] || [ "X${DIST_NAME}" = "Xcentos" ] || [ "X${DIST_NAME}" = "XCentOS" ]); then
-            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/librocksdb.so.8
+            chcon -t textrel_shlib_t ${INSTALLDIR}/lib/librocksdb.so.8 || true
         fi
     fi
 


### PR DESCRIPTION
## Description
This PR addresses a bug (closes wazuh/wazuh-agent-packages#392) where the agent build process was incorrectly reporting a false positive status, specifically when a build was successful. This led to confusion and unnecessary intervention in the build pipeline.

**Note:** Removes `ignored_lib` from aix package generation, as it's an undefined variable, which means the related code block for restoring the file is ineffective. This cleanup simplifies the script without changing its behavior. This should be done on the [following commit](https://github.com/wazuh/wazuh-packages/commit/e41778abc381d24e631b086fd7ffb80b0bbde301). 

### Results and Evidence

To confirm the issue and validate the fix, I created three separate commits.

1. Demonstrating the Error:

This commit was created to intentionally trigger the false positive error. The build appears successful at first, but it fails later due to missing files.

Commit: [74afea86dd7bf2c44dd8a5cbfc81a9d1df484d81](https://github.com/wazuh/wazuh/commit/74afea86dd7bf2c44dd8a5cbfc81a9d1df484d81)

The error is:

```bash
...
Done building agent

make[2]: Leaving directory `/build_wazuh/agent/wazuh-agent-4.14.1/src'
Wait for success...
success
install: cannot stat `wazuh-logcollector': No such file or directory
install: cannot stat `syscheckd/build/bin/wazuh-syscheckd': No such file or directory
install: cannot stat `wazuh-execd': No such file or directory
install: cannot stat `manage_agents': No such file or directory
install: cannot stat `wazuh-modulesd': No such file or directory
...
```
Workflow: https://github.com/wazuh/wazuh-agent-packages/actions/runs/16662061663/job/47161237012

2. Applying the Solution:

This commit applies the proposed solution and demonstrates that the build now fails as expected, correctly reporting the issue.

Commit with the solution: [d2f3adcff4006ea9dcbbe22e6392bc43ddb7ddc7](https://github.com/wazuh/wazuh/commit/d2f3adcff4006ea9dcbbe22e6392bc43ddb7ddc7)


```bash
make[2]: Leaving directory `/build_wazuh/agent/wazuh-agent-4.14.1/src'
Wait for success...
success
install: cannot stat `wazuh-logcollector': No such file or directory
install.sh failed! Aborting.
make[1]: *** [override_dh_install] Error 1
make[1]: Leaving directory `/build_wazuh/agent/wazuh-agent-4.14.1'
make: *** [binary] Error 2
dpkg-buildpackage: error: sudo debian/rules binary gave error exit status 2
debuild: fatal error at line 1357:
dpkg-buildpackage -rsudo -D -us -uc -b -nc failed
```

Workflow: https://github.com/wazuh/wazuh-agent-packages/actions/runs/16662304250/job/47161948245

3. Final Commit:
This final commit removes the temporary code used for testing, leaving the branch ready for review.

Commit: [a1606d41dc443678fd238286b3d418c79b4675de](https://github.com/wazuh/wazuh/commit/a1606d41dc443678fd238286b3d418c79b4675de)

:green_circle: [Packages - Build Wazuh agent Linux amd - agent packages - deb - amd64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16662334722/job/47162038568#logs)
:green_circle: [Packages - Build Wazuh agent packages - deb - arm64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837247149/job/47699632395#logs)
:green_circle: [Packages - Build Wazuh agent packages - rpm - arm64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837265691/job/47699699801#logs)
:green_circle: [Packages - Build Wazuh agent packages - deb - armhf](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837281934/job/47699750818#logs)
:green_circle: [Packages - Build Wazuh agent Linux arm - rpm - armhf ](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837298768/job/47699805669#logs)
:green_circle: [Packages - Build Wazuh agent Linux amd - agent packages - deb - i386 ](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837318070/job/47699869013#logs)
:green_circle: [Packages - Build Wazuh agent Linux amd - agent packages - rpm - i386](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837328583/job/47699903068#logs)
:green_circle: [Packages - Build Wazuh agent Linux amd - agent packages - rpm - x86_64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/16837340118/job/47699946041#logs)
:green_circle: [Build rpm wazuh-manager on x86_64](https://github.com/wazuh/wazuh/actions/runs/16838641053/job/47704203879?pr=31285#logs)
:green_circle: [Build rpm wazuh-manager on aarch64](https://github.com/wazuh/wazuh/actions/runs/16838641053/job/47704203877?pr=31285#logs)
:green_circle: [Build deb wazuh-manager on amd64](https://github.com/wazuh/wazuh/actions/runs/16838641053/job/47704203875?pr=31285#logs)
:green_circle: [Build deb wazuh-manager on arm64](https://github.com/wazuh/wazuh/actions/runs/16838641053/job/47704203873?pr=31285#logs)
:green_circle: [Packages - Build Wazuh agent special package - HPUX](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17325175705/job/49187332975#logs)
:green_circle: [Packages - Build Wazuh agent special package - System solaris10 -](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17326667162)
:green_circle: [Packages - Build Wazuh agent special package - System aix -](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17328667805)
:green_circle: [Packages - Build Wazuh agent Solaris 11 i386 -](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17377565517)
:green_circle: [Packages - Build Wazuh agent special package - System solaris11 -](https://github.com/wazuh/wazuh-agent-packages/actions/runs/17405885345)


> [!Note]
> The output of the chcon command was ignored because this is a known behavior, ex.:
> 2025-08-08T18:31:01.1113044Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/libjemalloc.so.2'
> 2025-08-08T18:31:01.1218411Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/librouter.so'
> 2025-08-08T18:31:01.1386485Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/libcontent_manager.so'
> 2025-08-08T18:31:01.1598142Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/libvulnerability_scanner.so'
> 2025-08-08T18:31:01.1720763Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/libinventory_harvester.so'
> 2025-08-08T18:31:01.1803129Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/libindexer_connector.so'
> 2025-08-08T18:31:01.1890311Z chcon: can't apply partial context to unlabeled file '/var/ossec/lib/librocksdb.so.8'

# Fix Workflows
