### PR TITLE
Fix for macOS in SCA process rule evaluator to allow full path process

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -2518,7 +2518,7 @@ checks:
       - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003"]
     condition: all
     rules:
-      - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare compare > 0'
+      - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare > 0'
       - 'c:sshd -T -> n:ClientAliveCountMax\s*\t*(\d+) compare > 0'
 
   # 5.1.8 Ensure sshd DisableForwarding is enabled. (Automated)

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -76,6 +76,15 @@ static nlohmann::json getProcessInfo(const ProcessTaskInfo& taskInfo, const pid_
     jsProcessInfo["state"]      = UNKNOWN_VALUE;
     jsProcessInfo["parent_pid"] = taskInfo.pbsd.pbi_ppid;
     jsProcessInfo["start"]      = taskInfo.pbsd.pbi_start_tvsec;
+
+    char pathBuffer[PROC_PIDPATHINFO_MAXSIZE] = {0};
+    const auto pathLen
+    { 
+        proc_pidpath(pid, pathBuffer, sizeof(pathBuffer)) 
+    };
+
+    jsProcessInfo["command_line"] = pathLen > 0 ? std::string(pathBuffer) : "";
+
     return jsProcessInfo;
 }
 

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -79,8 +79,8 @@ static nlohmann::json getProcessInfo(const ProcessTaskInfo& taskInfo, const pid_
 
     char pathBuffer[PROC_PIDPATHINFO_MAXSIZE] = {0};
     const auto pathLen
-    { 
-        proc_pidpath(pid, pathBuffer, sizeof(pathBuffer)) 
+    {
+        proc_pidpath(pid, pathBuffer, sizeof(pathBuffer))
     };
 
     jsProcessInfo["command_line"] = pathLen > 0 ? std::string(pathBuffer) : "";

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -561,7 +561,7 @@ ProcessRuleEvaluator::ProcessRuleEvaluator(PolicyEvaluationContext ctx,
 
         if (procJson.contains("command_line") && procJson["command_line"].is_string())
         {
-            const auto & cmd = procJson["command_line"].get_ref<const std::string&>();
+            const auto& cmd = procJson["command_line"].get_ref<const std::string&>();
 
             if (!cmd.empty() && cmd != "none")
             {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -558,6 +558,16 @@ ProcessRuleEvaluator::ProcessRuleEvaluator(PolicyEvaluationContext ctx,
         {
             processNames.emplace_back(procJson["name"]);
         }
+
+        if (procJson.contains("command_line") && procJson["command_line"].is_string())
+        {
+            const auto & cmd = procJson["command_line"].get_ref<const std::string&>();
+
+            if (!cmd.empty() && cmd != "none")
+            {
+                processNames.emplace_back(cmd);
+            }
+        }
     });
 
     return processNames;

--- a/src/wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
@@ -122,3 +122,43 @@ TEST_F(ProcessRuleEvaluatorTest, NegatedProcessFoundReturnsNotFound)
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
 }
+TEST_F(ProcessRuleEvaluatorTest, FullPathMatchReturnsFound)
+{
+    m_ctx.rule = "/usr/sbin/httpd";
+
+    m_processesMock = []
+    {
+        return std::vector<std::string>{"init", "/usr/sbin/httpd", "sshd"};
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+}
+
+TEST_F(ProcessRuleEvaluatorTest, NegatedFullPathPresentReturnsNotFound)
+{
+    m_ctx.rule = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent";
+    m_ctx.isNegated = true;
+
+    m_processesMock = []
+    {
+        return std::vector<std::string>{"ARDAgent", "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent"};
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotFound);
+}
+
+TEST_F(ProcessRuleEvaluatorTest, NegatedFullPathAbsentReturnsFound)
+{
+    m_ctx.rule = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent";
+    m_ctx.isNegated = true;
+
+    m_processesMock = []
+    {
+        return std::vector<std::string>{"launchd", "WindowServer"};
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::Found);
+}


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
Changes in SCA process rule evaluator for macOS to allow full path process, now it's allow to use either process name or process path.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #31956 
-->

## Proposed Changes
- getProcessInfo now also fill the "command_line" section for macOS using proc_pidpath inside sysInfoMac.cpp, this allows to retrieve full path of a process.
- ProcessRuleEvaluator now also add the full path of a process (if available) to the list processName that is later used to compare with the rule. 

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence
#### Before
```
- id: 35015
    rules:
      - "not p:/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent"
```
- Process rule with full path ->  Not found with full path.

```
2025/09/15 10:40:03 wazuh-modulesd:sca[32096] wm_sca.c:114 at sca_log_callback(): DEBUG: Process '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent' was not found
2025/09/15 10:40:03 wazuh-modulesd:sca[32096] wm_sca.c:114 at sca_log_callback(): DEBUG: Policy check "35015" evaluation completed for policy "cis_macOS_15.Sequoia.yml", result: Passed
```

```
- id: 35016
    rules:
      - "not p:ARDAgent"
```
- Process rule with name ->  Found with name.

```
2025/09/15 10:40:03 wazuh-modulesd:sca[32096] wm_sca.c:114 at sca_log_callback(): DEBUG: Process 'ARDAgent' was found
2025/09/15 10:40:03 wazuh-modulesd:sca[32096] wm_sca.c:114 at sca_log_callback(): DEBUG: Policy check "35016" evaluation completed for policy "cis_macOS_15.Sequoia.yml", result: Failed
```

#### After
```
- id: 35015
    rules:
      - "not p:/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent"
```
- Process rule with full path -> Found with full path.

```
2025/09/17 13:34:06 wazuh-modulesd:sca[24492] wm_sca.c:114 at sca_log_callback(): DEBUG: Process '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent' was found
2025/09/17 13:34:06 wazuh-modulesd:sca[24492] wm_sca.c:114 at sca_log_callback(): DEBUG: Policy check "35015" evaluation completed for policy "cis_macOS_15.Sequoia.yml", result: Failed
```

```
- id: 35016
    rules:
      - "not p:ARDAgent"
```
- Process rule with name -> Found with name.

```
2025/09/17 13:34:06 wazuh-modulesd:sca[24492] wm_sca.c:114 at sca_log_callback(): DEBUG: Process 'ARDAgent' was found
2025/09/17 13:34:06 wazuh-modulesd:sca[24492] wm_sca.c:114 at sca_log_callback(): DEBUG: Policy check "35016" evaluation completed for policy "cis_macOS_15.Sequoia.yml", result: Failed
```
Note: ARDAgent is running.

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Tests Introduced
- wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
  FullPathMatchReturnsFound
  NegatedFullPathPresentReturnsNotFound
  NegatedFullPathAbsentReturnsFound

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
