### PR TITLE
Fix RTR eBPF UT flaky due to global `bpf_helpers` being reset while a detached thread is still running

### DIFF
--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
@@ -11,25 +11,41 @@ extern time_t (*w_time)(time_t*);
 
 class EbpfWhodataTest : public ::testing::Test {
 protected:
-
-    virtual void SetUp() {
+    static void SetUpTestSuite() {
         MockFimebpf::mock_loggingFunction = mock_loggingFunction;
         MockFimebpf::mock_abspath = mock_abspath;
+        MockFimebpf::mock_get_user = mock_get_user;
+        MockFimebpf::mock_get_group = mock_get_group;
+        MockFimebpf::mock_fim_conf = mock_fim_conf_success;
         MockFimebpf::SetMockFunctions();
-        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
-        bpf_helpers->ebpf_pop_events = (ebpf_pop_events_t)mock_ebpf_pop_events;
-        bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
-        bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success;
-        bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
-        bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
-        bpf_helpers->check_invalid_kernel_version = (check_invalid_kernel_version_t)mock_check_invalid_kernel_version;
-        bpf_helpers->init_libbpf = (init_libbpf_t)mock_init_libbpf;
-        bpf_helpers->init_bpfobj = (init_bpfobj_t)mock_init_bpfobj;
     }
 
-    virtual void TearDown() {
+    static void TearDownTestSuite() {
         bpf_helpers.reset();
     }
+
+    void SetUp() override {
+        event_received  = false;
+        ebpf_hc_created = false;
+
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+        bpf_helpers->init_ring_buffer            = (init_ring_buffer_t)mock_init_ring_buffer_success;
+        bpf_helpers->ring_buffer_free            = (ring_buffer__free_t)mock_ring_buffer_free;
+        bpf_helpers->bpf_object_close            = (bpf_object__close_t)mock_bpf_object_close;
+        bpf_helpers->bpf_object_open_file        = mock_bpf_object_open_file_success;
+        bpf_helpers->bpf_object_load             = mock_bpf_object_load_success;
+        bpf_helpers->bpf_object_next_program     = mock_bpf_object_next_program;
+        bpf_helpers->bpf_program_attach          = mock_bpf_program_attach_success;
+        bpf_helpers->bpf_object_find_map_fd_by_name = mock_bpf_object_find_map_fd_by_name_success;
+        bpf_helpers->ring_buffer_new             = mock_ring_buffer_new_success;
+        bpf_helpers->check_invalid_kernel_version= (check_invalid_kernel_version_t)mock_check_invalid_kernel_version;
+        bpf_helpers->init_libbpf                 = (init_libbpf_t)mock_init_libbpf;
+        bpf_helpers->init_bpfobj                 = (init_bpfobj_t)mock_init_bpfobj;
+        bpf_helpers->ebpf_pop_events             = mock_ebpf_pop_events;
+        bpf_helpers->ring_buffer_poll            = (ring_buffer__poll_t)mock_ring_buffer_poll_success_barrier;
+    }
+
+    void TearDown() override {}
 };
 
 time_t mock_time(time_t* t) {
@@ -42,63 +58,54 @@ time_t mock_time(time_t* t) {
 int ebpf_whodata();
 
 TEST_F(EbpfWhodataTest, SuccessfulRun) {
-
-    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
-    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success;
+    reset_pop_barrier();
+    bpf_helpers->ebpf_pop_events  = mock_ebpf_pop_events_barrier;
+    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success_barrier;
 
     EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
         .WillOnce(::testing::Return(false))
         .WillOnce(::testing::Return(true));
 
     int result = ebpf_whodata();
-
     EXPECT_EQ(result, 0);
 }
 
 TEST_F(EbpfWhodataTest, RingBufferInitError) {
-
     bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_failure;
 
     int result = ebpf_whodata();
-
     EXPECT_EQ(result, 1);
 }
 
 TEST_F(EbpfWhodataTest, RingBufferPollError) {
-
-    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure;
+    reset_pop_barrier();
+    bpf_helpers->ebpf_pop_events  = mock_ebpf_pop_events_barrier;
+    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure_barrier;
 
     EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
         .WillOnce(::testing::Return(false));
 
     int result = ebpf_whodata();
-
     EXPECT_EQ(result, 0);
 }
 
 TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestSuccess) {
-
     event_received = true;
-
     EXPECT_FALSE(ebpf_whodata_healthcheck());
 }
 
 TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestFailInitRingBuffer) {
-
     bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_failure;
-
     EXPECT_TRUE(ebpf_whodata_healthcheck());
 }
 
 TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestFailNoEventReceived) {
-
     event_received = false;
     w_time = mock_time;
     bpf_helpers->ring_buffer_poll = [](ring_buffer*, int) {
         fake_time_now += 5;
         return 0;
     };
-
     EXPECT_TRUE(ebpf_whodata_healthcheck());
 }
 


### PR DESCRIPTION
## Description
Intermittent crashes when running `ebpf_whodata_test`. The failure typically shows up in either SuccessfulRun or RingBufferInitError (nondeterministically), with a stack like:

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==60296==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000080 (pc 0xffffb29361f8 bp 0xffffaeefe6b0 sp 0xffffaeefe6b0 T1)
==60296==The signal is caused by a READ memory access.
==60296==Hint: address points to the zero page.
    #0 0xffffb29361f8 in operator() /home/vagrant/wazuh/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp:422
```

Sometimes the crash happens even before assertions, or in the next test case after a previous one “passed”.

## Root cause

- `ebpf_whodata()` spawns a detached worker thread:
```
    std::thread ebpf_pop_thread([&]() {
        bpf_helpers->ebpf_pop_events(kernelEventQueue);
    });
    ebpf_pop_thread.detach();
```

- The main thread then runs the cleanup path:
```
    bpf_helpers->ring_buffer_free(rb);
    bpf_helpers->bpf_object_close(global_obj);
    global_obj = nullptr;
    w_bpf_deinit(bpf_helpers);
    close_libbpf(std::move(sym_load));

    return 0;
```

- Because the worker thread is detached, there was a race: it could still be starting or running when the main thread resets/nulls bpf_helpers. In the tests, bpf_helpers was also reused across test cases with partial re-mocking of function pointers. The combination led to a classic lifetime mismatch: the worker dereferenced (or read from) a pointer that had been reset or was in an inconsistent state. Timing noise made this failure flaky.

# Fix
- Deterministic thread-start barrier for the test. Introduce a small barrier using `std::promise/std::shared_future` in the test helpers (`g_pop_started_promise` / `g_pop_started_future`):

```
inline std::shared_ptr<std::promise<void>> g_pop_started_promise;
inline std::shared_future<void> g_pop_started_future;
```

```
inline int mock_ring_buffer_poll_success_barrier([[maybe_unused]] ring_buffer* rb, [[maybe_unused]] int timeout_ms) {
    if (g_pop_started_future.valid()) { g_pop_started_future.wait(); }
    return 1;
}

inline int mock_ring_buffer_poll_failure_barrier([[maybe_unused]] ring_buffer* rb, [[maybe_unused]] int timeout_ms) {
    if (g_pop_started_future.valid()) { g_pop_started_future.wait(); }
    return -1;
}
```

```
TEST_F(EbpfWhodataTest, SuccessfulRun) {
    reset_pop_barrier();
    bpf_helpers->ebpf_pop_events  = mock_ebpf_pop_events_barrier;
    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success_barrier;
    ...
```

- `reset_pop_barrier()` resets the promise/future.
- `mock_ebpf_pop_events_barrier(...)` signals the barrier immediately when the worker thread starts.
- `mock_ring_buffer_poll_success_barrier(...)` and `mock_ring_buffer_poll_failure_barrier(...)` wait on that signal before returning.
- This makes the test wait until the detached thread actually enters the mocked `ebpf_pop_events` (which returns immediately), removing the race without arbitrary sleeps.




## Extra cleaning tests code
- Set up some generic functions in a test-suite global fixture.
```
    static void SetUpTestSuite() {
        MockFimebpf::mock_loggingFunction = mock_loggingFunction;
        MockFimebpf::mock_abspath = mock_abspath;
        MockFimebpf::mock_get_user = mock_get_user;
        MockFimebpf::mock_get_group = mock_get_group;
        MockFimebpf::mock_fim_conf = mock_fim_conf_success;
        MockFimebpf::SetMockFunctions();
    }
```

- Reset global test flags in SetUp():
```
        event_received  = false;
        ebpf_hc_created = false;
```

- Move the reset of the bpf_helpers structure to a general teardown at the end of all tests, and do not reset the structure in each test.

```
        static void TearDownTestSuite() { 
                bpf_helpers.reset(); 
        }
        void TearDown() override {}
```
- Multiple format and clean code changes.

# Testing (Multiple times same test to ensure no more flaky behavior)
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822464830) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822467135) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822469385) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822471331) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822472994) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822474659) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822956608) 🟢 
- [5.X - Running RTR. Module syscheck for agent/winagent targets](https://github.com/wazuh/wazuh/actions/runs/17822958466) 🟢 
