### PR TITLE
In memory merge to reduce the flushes number

### DIFF
--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -66,6 +66,7 @@ public:
         options.write_buffer_size = 64 * 1024 * 1024;
         options.max_write_buffer_number = 4;
         options.max_background_jobs = 8;
+        options.min_write_buffer_number_to_merge = 2;
 
         rocksdb::DB* db;
 


### PR DESCRIPTION
## Description

In an attempt to reduce even more the number of flushes (also number of compactions) the number of mem tables merged before flush was increased from 1 (default) to 2. 
