### PR TITLE
Fix for manager not finding libwazuhext.so

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1933,6 +1933,9 @@ $(WAZUH_LIB): $(WAZUH_DLL) $(WAZUH_DEF)
 else
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
+
+$(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -Wl,-rpath,'$$ORIGIN' -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1932,9 +1932,6 @@ $(WAZUH_LIB): $(WAZUH_DLL) $(WAZUH_DEF)
 
 else
 $(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
-
-$(WAZUH_LIB): $(WAZUHEXT_LIB) $(AR_PROGRAMS_DEPS)
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -Wl,-rpath,'$$ORIGIN' -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
 endif
 endif


### PR DESCRIPTION
## Description
Fixes an issue building the manager that was introduced with https://github.com/wazuh/wazuh/pull/31307, where the `-rpath` library was not being found. Performing `wazuh-control start` on a GCC 13 Ubuntu 22/24 VM shows:
```
dlopen libwazuhshared.so failed: libwazuhext.so: cannot open shared object file: No such file or directory
```

Also removes a block of code that was left over on the agent cleanup PR and was related to a SunOS library step:
```
$(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive ${OSSEC_LIBS}
```
Which was inside:
`ifeq (${uname_S},SunOS)`

and was incorrectly left over.

## Proposed changes
Re-introduce the removed section of code related to `-rpath` from the Makefile.
Remove the SunOS related code that was left over from the agent cleanup PR.

## Testing
Tested by generating an rpm package with the GH actions from this PR, and  installing it in a fresh RockyLinux VM. The manager installs and starts without errors:
```
[root@rockylinux9manager bin]# ./wazuh-control start
2025/09/17 23:47:41 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/17 23:47:41 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/17 23:47:41 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
Started wazuh-forwarder...
Started wazuh-apid...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2025/09/17 23:48:02 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/17 23:48:02 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/17 23:48:02 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Started wazuh-modulesd...
Completed.
```

Then performed `ldd /var/ossec/lib/libwazuhshared.so` and we can see the library showing up:
```
[root@rockylinux9manager ossec]# ldd /var/ossec/lib/libwazuhshared.so
        linux-vdso.so.1 (0x00007ffd1bdb4000)
        libwazuhext.so => /var/ossec/lib/libwazuhext.so (0x00007fd5c1a00000)
        librt.so.1 => /lib64/librt.so.1 (0x00007fd5c2549000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007fd5c2544000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fd5c1925000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fd5c253f000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fd5c1600000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fd5c2581000)
```

And also, analyzing the ELF file:
`readelf -d /var/ossec/lib/libwazuhshared.so | grep -E 'RUNPATH|RPATH'`

We can see the library's rpath:
```
[root@rockylinux9manager ossec]# readelf -d /var/ossec/lib/libwazuhshared.so | grep -E 'RUNPATH|RPATH'
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN]
```
