### PR TITLE
Fix 5.X tests compilation in `macos-14`

### DIFF
--- a/.github/workflows/5_testunit_macos.yml
+++ b/.github/workflows/5_testunit_macos.yml
@@ -62,6 +62,8 @@ jobs:
           make -j$(sysctl -n hw.ncpu)
           sudo make install
       - name: Build wazuh agent for macOS 14 with tests flags
+        env:
+            CMAKE_POLICY_VERSION_MINIMUM: 3.5
         run: |
           make deps -C src TARGET=agent -j3
           C_INCLUDE_PATH=$C_INCLUDE_PATH:/opt/homebrew/include LIBRARY_PATH=/usr/local/lib:/opt/homebrew/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/issues/31904|

## Description

Hi team, 

this PR fixes the compilation of the macos-14 unit test by setting the `CMAKE_POLICY_VERSION_MINIMUM` to `3.5` as suggested in the following documentation [page](https://cmake.org/cmake/help/latest/envvar/CMAKE_POLICY_VERSION_MINIMUM.html#envvar:CMAKE_POLICY_VERSION_MINIMUM).

## Tests

Dispatched failing WF with the following call:
```
gh workflow run .github/workflows/5_testunit_macos.yml -r bug/31904-macos-sonoma-runner-fails-with-cmake-version
```
Result: :green_circle: [5.X - macOS - Unit tests #955](https://github.com/wazuh/wazuh/actions/runs/17823083585)