### PR TITLE
Update 0393-fortiauth_rules.xml

### DIFF
--- a/ruleset/rules/0393-fortiauth_rules.xml
+++ b/ruleset/rules/0393-fortiauth_rules.xml
@@ -7,7 +7,7 @@
     FortiAuth ID: 44730 - 44739
 -->
 
-<group name="fortiauth">
+<group name="fortiauth,">
 
   <rule id="44730" level="0">
     <decoded_as>fortiauth</decoded_as>


### PR DESCRIPTION
Added missing commas

Related issue: https://github.com/wazuh/wazuh/issues/32024

As reported by @mimugmail,
The rule group configuration block in `0393-fortiauth_rules.xml` is missing a comma.
```
<group name="fortiauth">
```
The fix proposed in https://github.com/wazuh/wazuh/pull/29831 is applied:
```
<group name="fortiauth,">
```
This PR aims to fix the issue