### PR TITLE
Support for non-UT8 characters in windows registries

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -35,7 +35,7 @@
 #define FIM_WARN_WHODATA_EVENT_OVERFLOW         "(6917): Real-time Whodata events queue for Windows has more than %d elements."
 #define FIM_WARN_NFS_INOTIFY                    "(6918): '%s' NFS Directories do not support iNotify."
 #define FIM_INV_REG                             "(6919): Invalid syscheck registry entry: '%s' arch: '%s'."
-#define FIM_REG_OPEN                            "(6920): Unable to open registry key: '%s' arch: '%s'."
+#define FIM_REG_OPEN                            "(6920): Failed to open registry key: '%s' (arch: '%s'). Error code: %ld."
 #define FIM_WARN_FILE_REALTIME                  "(6921): Unable to configure real-time option for file: '%s'"
 #define FIM_PATH_NOT_OPEN                       "(6922): Cannot open '%s': %s"
 

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -842,7 +842,7 @@ void fim_read_values(HKEY key_handle,
                      TXN_HANDLE regval_txn_handler,
                      fim_val_txn_context_t *txn_ctx_regval) {
     fim_registry_value_data value_data;
-    TCHAR *value_buffer;
+    WCHAR *value_name_buffer;
     BYTE *data_buffer;
     DWORD i;
     fim_entry new;
@@ -858,7 +858,7 @@ void fim_read_values(HKEY key_handle,
     new.registry_entry.value = &value_data;
     new.registry_entry.key = NULL;
 
-    os_calloc(max_value_length + 1, sizeof(TCHAR), value_buffer);
+    os_calloc(max_value_length + 1, sizeof(WCHAR), value_name_buffer);
     os_calloc(max_value_data_length, sizeof(BYTE), data_buffer);
 
     for (i = 0; i < value_count; i++) {
@@ -868,15 +868,17 @@ void fim_read_values(HKEY key_handle,
 
         configuration = fim_registry_configuration(path, arch);
         if (configuration == NULL) {
+            os_free(value_name_buffer);
+            os_free(data_buffer);
             return;
         }
 
-        if (RegEnumValue(key_handle, i, value_buffer, &value_size, NULL, &data_type, data_buffer, &data_size) !=
+        if (RegEnumValueW(key_handle, i, value_name_buffer, &value_size, NULL, &data_type, data_buffer, &data_size) !=
             ERROR_SUCCESS) {
             break;
         }
 
-        new.registry_entry.value->name = value_buffer;
+        new.registry_entry.value->name = wide_to_utf8(value_name_buffer);
         new.registry_entry.value->type = data_type <= REG_QWORD ? data_type : REG_UNKNOWN;
         new.registry_entry.value->size = data_size;
         new.registry_entry.value->last_event = time(NULL);
@@ -927,6 +929,7 @@ void fim_read_values(HKEY key_handle,
 
     new.registry_entry.value = NULL;
     os_free(value_data.name);
+    os_free(value_name_buffer);
     os_free(data_buffer);
 }
 
@@ -991,8 +994,14 @@ void fim_open_key(HKEY root_key_handle,
 
     access_rights = KEY_READ | (arch == ARCH_32BIT ? KEY_WOW64_32KEY : KEY_WOW64_64KEY);
 
-    if (RegOpenKeyEx(root_key_handle, sub_key, 0, access_rights, &current_key_handle) != ERROR_SUCCESS) {
-        mdebug1(FIM_REG_OPEN, sub_key, arch == ARCH_32BIT ? "[x32]" : "[x64]");
+    WCHAR *sub_key_wide;
+    sub_key_wide = auto_to_wide(sub_key);
+
+    LONG reg_result = RegOpenKeyExW(root_key_handle, sub_key_wide, 0, access_rights, &current_key_handle);
+    os_free(sub_key_wide);
+
+    if (reg_result != ERROR_SUCCESS) {
+        mdebug1(FIM_REG_OPEN, sub_key, arch == ARCH_32BIT ? "[x32]" : "[x64]", reg_result);
         return;
     }
 
@@ -1008,19 +1017,23 @@ void fim_open_key(HKEY root_key_handle,
         char *new_full_key;
         char *new_sub_key;
         size_t new_full_key_length;
-        TCHAR sub_key_name_b[MAX_KEY_LENGTH + 1];
-        DWORD sub_key_name_s = MAX_KEY_LENGTH;
+        WCHAR sub_key_name_b[MAX_KEY_LENGTH + 1];
+        DWORD sub_key_name_s = MAX_KEY_LENGTH + 1;
 
-        if (RegEnumKeyEx(current_key_handle, i, sub_key_name_b, &sub_key_name_s, NULL, NULL, NULL, NULL) !=
+        if (RegEnumKeyExW(current_key_handle, i, sub_key_name_b, &sub_key_name_s, NULL, NULL, NULL, NULL) !=
             ERROR_SUCCESS) {
             continue;
         }
 
-        new_full_key_length = strlen(full_key) + sub_key_name_s + 2;
+        char *sub_key_name_utf8 = wide_to_utf8(sub_key_name_b);
+
+        new_full_key_length = strlen(full_key) + strlen(sub_key_name_utf8) + 2;
 
         os_malloc(new_full_key_length, new_full_key);
 
-        snprintf(new_full_key, new_full_key_length, "%s\\%s", full_key, sub_key_name_b);
+        snprintf(new_full_key, new_full_key_length, "%s\\%s", full_key, sub_key_name_utf8);
+
+        os_free(sub_key_name_utf8);
 
         if (new_sub_key = strchr(new_full_key, '\\'), new_sub_key) {
             new_sub_key++;

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -663,7 +663,7 @@ static void test_fim_registry_scan_base_line_generation(void **state) {
     syscheck.registry[0].opts = CHECK_REGISTRY_ALL;
 
     // Set value of FirstSubKey
-    char *value_name = "test_value";
+    wchar_t *value_name = L"test_value";
     unsigned int value_type = REG_DWORD;
     unsigned int value_size = 4;
     DWORD value_data = 123456;
@@ -679,13 +679,13 @@ static void test_fim_registry_scan_base_line_generation(void **state) {
     expect_any_always(__wrap__mdebug2, formatted_msg);
 
     // Scan a subkey of batfile
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile", 0, KEY_READ | KEY_WOW64_64KEY, NULL,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\Classes\\batfile", 0, KEY_READ | KEY_WOW64_64KEY, NULL,
                              ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(1, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("FirstSubKey", 12, ERROR_SUCCESS);
+    expect_RegEnumKeyExW_call(L"FirstSubKey", ERROR_SUCCESS);
 
     // Scan a value of FirstSubKey
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile\\FirstSubKey", 0,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\Classes\\batfile\\FirstSubKey", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(0, 1, &last_write_time, ERROR_SUCCESS);
 
@@ -696,7 +696,7 @@ static void test_fim_registry_scan_base_line_generation(void **state) {
     will_return(__wrap_fim_db_transaction_sync_row, -1);
     expect_string(__wrap__merror, formatted_msg, "Dbsync registry transaction failed due to -1");
     will_return(__wrap_fim_db_transaction_sync_row, -1);
-    expect_RegEnumValue_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
+    expect_RegEnumValueW_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
 
     expect_fim_registry_value_diff("HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile\\FirstSubKey", "test_value",
                                    (const char *)&value_data, 4, REG_DWORD, NULL);
@@ -723,7 +723,7 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     syscheck.registry = default_config;
 
     // Set value of FirstSubKey
-    char *value_name = "test_value";
+    wchar_t *value_name = L"test_value";
     unsigned int value_type = REG_DWORD;
     unsigned int value_size = 4;
     DWORD value_data = 123456;
@@ -741,12 +741,12 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     expect_any_always(__wrap__merror, formatted_msg);
 
     // Scan a subkey of batfile
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile", 0,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\Classes\\batfile", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(1, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("FirstSubKey", 12, ERROR_SUCCESS);
+    expect_RegEnumKeyExW_call(L"FirstSubKey", ERROR_SUCCESS);
 
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile\\FirstSubKey", 0,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\Classes\\batfile\\FirstSubKey", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(0, 1, &last_write_time, ERROR_SUCCESS);
 
@@ -758,7 +758,7 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     will_return(__wrap_fim_db_transaction_sync_row, -1);
     will_return(__wrap_fim_db_transaction_sync_row, -1);
 
-    expect_RegEnumValue_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
+    expect_RegEnumValueW_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
 
 
     expect_fim_registry_value_diff("HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile\\FirstSubKey", "test_value",
@@ -773,9 +773,9 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     will_return(__wrap_fim_db_transaction_sync_row, -1);
 
     // Scan a subkey of RecursionLevel0
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\RecursionLevel0", 0, KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\RecursionLevel0", 0, KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(1, 0, &last_write_time, ERROR_SUCCESS);
-    expect_RegEnumKeyEx_call("depth0", 7, ERROR_SUCCESS);
+    expect_RegEnumKeyExW_call(L"depth0", ERROR_SUCCESS);
 
     // Inside fim_registry_get_key_data
     expect_fim_registry_get_key_data_call(usid, gsid, "username2", "groupname2",
@@ -784,7 +784,7 @@ static void test_fim_registry_scan_regular_scan(void **state) {
 
     will_return(__wrap_fim_db_transaction_sync_row, -1);
 
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\FailToInsert", 0,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\FailToInsert", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(0, 0, &last_write_time, ERROR_SUCCESS);
 
@@ -802,7 +802,7 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     fim_registry_scan();
 }
 
-static void test_fim_registry_scan_RegOpenKeyEx_fail(void **state) {
+static void test_fim_registry_scan_RegOpenKeyExW_fail(void **state) {
     syscheck.registry = one_entry_config;
     syscheck.registry[0].opts = CHECK_REGISTRY_ALL;
     TXN_HANDLE mock_handle;
@@ -810,12 +810,12 @@ static void test_fim_registry_scan_RegOpenKeyEx_fail(void **state) {
     will_return(__wrap_fim_db_transaction_start, mock_handle);
     will_return(__wrap_fim_db_transaction_start, mock_handle);
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_START);
-    expect_string(__wrap__mdebug1, formatted_msg, "(6920): Unable to open registry key: 'Software\\Classes\\batfile' arch: '[x64]'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "(6920): Failed to open registry key: 'Software\\Classes\\batfile' (arch: '[x64]'). Error code: -1.");
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
     expect_any_always(__wrap__mdebug2, formatted_msg);
 
     // Scan a subkey of batfile
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile", 0,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\Classes\\batfile", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, -1);
 
     expect_function_call(__wrap_fim_db_transaction_deleted_rows);
@@ -839,7 +839,7 @@ static void test_fim_registry_scan_RegQueryInfoKey_fail(void **state) {
     expect_any_always(__wrap__mdebug2, formatted_msg);
 
     // Scan a subkey of batfile
-    expect_RegOpenKeyEx_call(HKEY_LOCAL_MACHINE, "Software\\Classes\\batfile", 0,
+    expect_RegOpenKeyExW_call(HKEY_LOCAL_MACHINE, L"Software\\Classes\\batfile", 0,
                              KEY_READ | KEY_WOW64_64KEY, NULL, ERROR_SUCCESS);
     expect_RegQueryInfoKey_call(1, 0, &last_write_time, -1);
 
@@ -1158,7 +1158,7 @@ int main(void) {
         /* fim_registry_scan tests */
         cmocka_unit_test(test_fim_registry_scan_base_line_generation),
         cmocka_unit_test(test_fim_registry_scan_regular_scan),
-        cmocka_unit_test(test_fim_registry_scan_RegOpenKeyEx_fail),
+        cmocka_unit_test(test_fim_registry_scan_RegOpenKeyExW_fail),
         cmocka_unit_test(test_fim_registry_scan_RegQueryInfoKey_fail),
 
         /* fim registry key transaction callback tests */

--- a/src/unit_tests/wrappers/windows/winreg_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winreg_wrappers.h
@@ -19,10 +19,16 @@
 #define RegQueryInfoKeyA wrap_RegQueryInfoKeyA
 #undef RegEnumKeyEx
 #define RegEnumKeyEx wrap_RegEnumKeyEx
+#undef RegEnumKeyExW
+#define RegEnumKeyExW wrap_RegEnumKeyExW
 #undef RegOpenKeyEx
 #define RegOpenKeyEx wrap_RegOpenKeyEx
+#undef RegOpenKeyExW
+#define RegOpenKeyExW wrap_RegOpenKeyExW
 #undef RegEnumValue
 #define RegEnumValue wrap_RegEnumValue
+#undef RegEnumValueW
+#define RegEnumValueW wrap_RegEnumValueW
 #undef RegCloseKey
 #define RegCloseKey wrap_RegCloseKey
 #undef RegQueryValueEx
@@ -71,6 +77,17 @@ LONG wrap_RegEnumKeyEx(HKEY hKey,
 
 void expect_RegEnumKeyEx_call(LPSTR name, DWORD name_length, LONG return_value);
 
+LONG wrap_RegEnumKeyExW(HKEY hKey,
+                       DWORD dwIndex,
+                       LPWSTR lpName,
+                       LPDWORD lpcchName,
+                       LPDWORD lpReserved,
+                       LPWSTR lpClass,
+                       LPDWORD lpcchClass,
+                       PFILETIME lpftLastWriteTime);
+
+void expect_RegEnumKeyExW_call(const wchar_t *name, LONG return_value);
+
 LONG wrap_RegOpenKeyEx(HKEY hKey,
                        LPCSTR lpSubKey,
                        DWORD ulOptions,
@@ -78,6 +95,14 @@ LONG wrap_RegOpenKeyEx(HKEY hKey,
                        PHKEY phkResult);
 
 void expect_RegOpenKeyEx_call(HKEY hKey, LPCSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value);
+
+LONG wrap_RegOpenKeyExW(HKEY hKey,
+                       LPCWSTR lpSubKey,
+                       DWORD ulOptions,
+                       REGSAM samDesired,
+                       PHKEY phkResult);
+
+void expect_RegOpenKeyExW_call(HKEY hKey, LPCWSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value);
 
 LONG wrap_RegQueryValueEx(HKEY hKey,
                           LPCSTR lpValueName,
@@ -95,6 +120,16 @@ LONG wrap_RegEnumValue(HKEY hKey,
                        LPBYTE lpData,LPDWORD lpcbData);
 
 void expect_RegEnumValue_call(LPSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value);
+
+LONG wrap_RegEnumValueW(HKEY hKey,
+                       DWORD dwIndex,
+                       LPWSTR lpValueName,
+                       LPDWORD lpcchValueName,
+                       LPDWORD lpReserved,
+                       LPDWORD lpType,
+                       LPBYTE lpData,LPDWORD lpcbData);
+
+void expect_RegEnumValueW_call(LPWSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value);
 
 LONG wrap_RegCloseKey(HKEY hKey);
 


### PR DESCRIPTION
## Description

|Related issue|
|---|
|Closes #31909|

## Proposed Changes

- When reading registries, `RegOpenKeyExW()` is used instead of `RegOpenKeyEx()`, as it allows for non-UTF8 chars to be used.
- The debug message generated when registry reading fails now indicates the type of error.

## Testing

To demonstrate the correct functionality, additional debug messages (not included in the PR) have been added. These indicate how the conversion from str to wstr is successfully performed, and no error is generated when reading the registry, both for 32-bit and 64-bit:

```
2025/09/18 12:59:24 wazuh-agent[12700] config.c:465 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2025/09/18 12:59:24 rootcheck[12700] rootcheck.c:225 at rootcheck_init(): INFO: Started (pid: 12700).
2025/09/18 12:59:24 wazuh-agent[12700] syscheck.c:201 at Start_win32_Syscheck(): INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Clé_de_test_française', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | reg_value_type'
2025/09/18 12:59:24 wazuh-agent[12700] syscheck.c:205 at Start_win32_Syscheck(): DEBUG: (6356): Maximum file size limit to generate diff information configured to '51200 KB' for 'HKEY_LOCAL_MACHINE\Software\Clé_de_test_française'.
2025/09/18 12:59:24 wazuh-agent[12700] syscheck.c:233 at Start_win32_Syscheck(): DEBUG: (6357): Maximum disk quota size limit configured to '1048576 KB'.
2025/09/18 12:59:24 wazuh-agent[12700] syscheck.c:288 at Start_win32_Syscheck(): INFO: Started (pid: 12700).

...


2025/09/18 13:18:34 wazuh-agent[18552] syscheck.c:201 at Start_win32_Syscheck(): INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Clé_de_test_française [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | reg_value_type'
2025/09/18 13:18:34 wazuh-agent[18552] syscheck.c:205 at Start_win32_Syscheck(): DEBUG: (6356): Maximum file size limit to generate diff information configured to '51200 KB' for 'HKEY_LOCAL_MACHINE\Software\Clé_de_test_française'

...

2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1128 at fim_registry_scan(): DEBUG: (6031): Registry integrity monitoring scan started
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1137 at fim_registry_scan(): DEBUG: (6207): Attempt to read: '[x64] HKEY_LOCAL_MACHINE\Software\Clé_de_test_française'
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1010 at fim_open_key(): DEBUG: Converting registry key to wide character: 'Software\Clé_de_test_française'
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1020 at fim_open_key(): DEBUG: Successfully converted to wide character
2025/09/18 13:18:39 wazuh-agent[18552] cryptography.c:543 at verify_hash_and_pe_signature(): DEBUG: PE signature verification succeeded for C:\WINDOWS\SYSTEM32\ntmarta.dll
2025/09/18 13:18:39 wazuh-agent[18552] dll_load_notify.c:101 at dll_notification(): DEBUG: The file 'C:\WINDOWS\SYSTEM32\ntmarta.dll' is signed and its signature is valid.
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1137 at fim_registry_scan(): DEBUG: (6207): Attempt to read: '[x32] HKEY_LOCAL_MACHINE\Software\Clé_de_test_française'
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1010 at fim_open_key(): DEBUG: Converting registry key to wide character: 'Software\Clé_de_test_française'
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1020 at fim_open_key(): DEBUG: Successfully converted to wide character
2025/09/18 13:18:39 wazuh-agent[18552] registry.c:1156 at fim_registry_scan(): DEBUG: (6032): Registry integrity monitoring scan ended
```

