### PR TITLE
Revert Prevent upgrading agents with obsolete configurations through WPK

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -50,28 +50,6 @@ STATUS = 'status'
 COUNT = 'count'
 GROUP_CONFIG_STATUS = 'group_config_status'
 
-def _validate_agent_configuration(agent_conf: dict) -> list:
-    """Validate agent configuration for upgrade compatibility by looking for invalid configurations.
-
-    Args:
-        agent_conf (dict): Agent configuration dictionary
-    Returns:
-        list: List of invalid configuration messages
-
-    """
-    invalid_configs = []
-
-    # Check for UDP protocol in any server configuration
-    for server in agent_conf.get('client', {}).get('server', []):
-        if server.get('protocol') == 'udp':
-            invalid_configs.append('[protocol: udp]')
-        break
-
-    # Check for blowfish encryption method
-    if agent_conf.get('client', {}).get('crypto_method') == 'blowfish':
-        invalid_configs.append('[crypto_method: blowfish]')
-
-    return invalid_configs
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
 def get_distinct_agents(agent_list: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: dict = None,
@@ -1172,8 +1150,9 @@ def get_outdated_agents(agent_list: list = None, offset: int = 0, limit: int = c
 
     return result
 
+
 @expose_resources(actions=["agent:upgrade"], resources=["agent:id:{agent_list}"],
-                  post_proc_kwargs={'exclude_codes': [1701, 1703, 1707, 1731, 1761] + ERROR_CODES_UPGRADE_SOCKET})
+                  post_proc_kwargs={'exclude_codes': [1701, 1703, 1707, 1731] + ERROR_CODES_UPGRADE_SOCKET})
 def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str = None, force: bool = False,
                    use_http: bool = False, package_type: str = None, file_path: str = None, installer: str = None,
                    filters: dict = None, q: str = None) -> AffectedItemsWazuhResult:
@@ -1224,10 +1203,10 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
         rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=agent_list,
                                         filters=filters)
 
-        with WazuhDBQueryAgents(limit=None, select=["id", "status", "version"], query=q, **rbac_filters) as db_query:
+        with WazuhDBQueryAgents(limit=None, select=["id", "status"], query=q, **rbac_filters) as db_query:
             data = db_query.run()
 
-        included_agents = set([agent['id'] for agent in data['items']])
+        filtered_agents = set([agent['id'] for agent in data['items']])
         agent_list = set(agent_list)
 
         try:
@@ -1240,34 +1219,22 @@ def upgrade_agents(agent_list: list = None, wpk_repo: str = None, version: str =
         not_found_agents = agent_list - system_agents
         [result.add_failed_item(id_=agent, error=WazuhResourceNotFound(1701)) for agent in not_found_agents]
 
-        # Add agents that don´t pass the filters to failed_items
-        excluded_agents = agent_list - included_agents - not_found_agents
+        # Add non active agents to failed_items
+        non_active_agents = [agent['id'] for agent in data['items'] if agent['status'] != 'active']
+        [result.add_failed_item(id_=agent, error=WazuhError(1707)) for agent in non_active_agents]
+        non_active_agents = set(non_active_agents)
+
+        # Add non eligible agents to failed_items
+        non_eligible_agents = agent_list - not_found_agents - non_active_agents - filtered_agents
         [result.add_failed_item(id_=ag, error=WazuhError(
             1731,
             extra_message="some of the requirements are not met -> {}".format(
                 ', '.join(f"{key}: {value}" for key, value in filters.items() if key != 'rbac_ids') +
                 (f', q: {q}' if q else '')
             )
-        )) for ag in excluded_agents]
+        )) for ag in non_eligible_agents]
 
-        non_active_agents = set()
-        invalid_config_agents = set()
-        for agent in data['items']:
-            if agent['id'] != '000':
-                # Add non active agents to failed_items
-                if agent['status'] != 'active':
-                    result.add_failed_item(id_=agent['id'], error=WazuhError(1707))
-                    non_active_agents.add(agent['id'])
-
-                # Add agents with invalid config options to failed_items
-                else:
-                    agent_conf = Agent(agent['id']).get_config('agent', 'client', agent['version'])
-                    invalid_configs = _validate_agent_configuration(agent_conf)
-                    if invalid_configs:
-                        invalid_config_agents.add(agent['id'])
-                        result.add_failed_item(id_=agent['id'], error=WazuhError(1761, extra_message = ",".join(invalid_configs)))
-
-        eligible_agents = agent_list - not_found_agents - non_active_agents - excluded_agents - invalid_config_agents
+        eligible_agents = agent_list - not_found_agents - non_active_agents - non_eligible_agents
 
         # Transform the format of the agent ids to the general format
         eligible_agents = [int(agent) for agent in eligible_agents]

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -354,8 +354,6 @@ class WazuhException(Exception):
                },
         1760: {'message': 'Feature only available for older agent versions, it doesn\'t apply for more recent ones.'
                },
-        1761: {'message': 'The next set of configuration values are no longer supported',
-               'remediation': 'Please choose supported values and try again'},
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_agent/schema_global_test.sql
@@ -80,7 +80,7 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','16.04.1 LTS','16','04',
                    'Xenial','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
-                   'Wazuh v3.7.0','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
+                   'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-10 minutes'),'updated','active', 'synced');
 
@@ -112,7 +112,7 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    last_keepalive, status, connection_status, group_config_status) VALUES (6,'agent-6','172.19.0.157',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Windows','5.2','5','2',
                    'XP','windows','x86_64',
-                   'Wazuh v3.7.0','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
+                   'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-15 minutes'),'updated','active', 'synced');
 

--- a/framework/wazuh/core/tests/data/test_database/schema_global_test.sql
+++ b/framework/wazuh/core/tests/data/test_database/schema_global_test.sql
@@ -80,7 +80,7 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','16.04.1 LTS','16','04',
                    'Xenial','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
-                   'Wazuh v3.7.0','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
+                   'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-10 minutes'),'updated','active');
 
@@ -112,7 +112,7 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    last_keepalive, status, connection_status) VALUES (6,'agent-6','172.19.0.157',
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Windows','5.2','5','2',
                    'XP','windows','x86_64',
-                   'Wazuh v3.7.0','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
+                   'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-15 minutes'),'updated','active');
 

--- a/framework/wazuh/tests/data/schema_global_test.sql
+++ b/framework/wazuh/tests/data/schema_global_test.sql
@@ -80,7 +80,7 @@ INSERT INTO agent (id, name, register_ip, internal_key, os_name, os_version, os_
                    'b3650e11eba2f27er4d160c69de533ee7eed6016fga85ba2455d53a90927747f', 'Ubuntu','16.04.1 LTS','16','04',
                    'Xenial','ubuntu',
                    'Linux |agent-1 |4.15.0-43-generic |#46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 |x86_64','x86_64',
-                   'Wazuh v3.7.0','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
+                   'Wazuh v3.6.2','ab73af41699f13fgt81903b5f23d8d00','f8d49771911ed9d5c45bdfa40babd065','master',
                    'node01',strftime('%s','now','-3 days'),
                     strftime('%s','now','-10 minutes'),'updated','active', 'default,group-0', 'synced');
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -71,7 +71,7 @@ def send_msg_to_wdb(msg, raw=False):
     (
             ['version'],
             [{'version': 'Wazuh v3.9.0', 'count': 1}, {'version': 'Wazuh v3.8.2', 'count': 2},
-             {'version': 'Wazuh v3.7.0', 'count': 1}, {'version': 'N/A', 'count': 2}]
+             {'version': 'Wazuh v3.6.2', 'count': 1}, {'version': 'N/A', 'count': 2}]
     ),
     (
             ['os.platform', 'os.major'],
@@ -423,7 +423,7 @@ def test_agent_get_agents_keys(socket_mock, send_mock, agent_list, expected_item
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'ip': '172.17.0.202'}, None, 1731, ['001']),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'name': 'agent-6'}, None, 1731, ['006']),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'node_name': 'random'}, None, 1731, []),
-    (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'version': 'Wazuh v3.7.0'}, None, 1731, ['002']),
+    (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'version': 'Wazuh v3.6.2'}, None, 1731, ['002']),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'manager': 'master'}, None, 1731,
      ['001', '002', '005', '006', '007', '008', '009']),
     (full_agent_list[1:], {'status': 'all', 'older_than': '1s', 'os.name': 'ubuntu'}, None, 1731,
@@ -1055,7 +1055,7 @@ def test_agent_get_outdated_agents(socket_mock, send_mock):
     assert result.total_failed_items == 0
 
 
-@pytest.mark.parametrize('agent_set, expected_errors_and_items, result_from_socket, filters, raise_error, agent_conf', [
+@pytest.mark.parametrize('agent_set, expected_errors_and_items, result_from_socket, filters, raise_error', [
     (
             {'000', '001', '002', '003', '004', '999'},
             {'1703': {'000'}, '1701': {'999'}, '1822': {'002'}, '1707': {'003', '004'}},
@@ -1067,16 +1067,14 @@ def test_agent_get_outdated_agents(socket_mock, send_mock):
                       ],
              'message': 'Success'},
             None,
-            False,
-            {"client": {"server": []}}
+            False
     ),
     (
             {'000', '001', '002'},
             {'1703': {'000'}, '1731': {'001', '002'}},
             {},
             {'os.version': 'unknown_version'},
-            False,
-            {"client": {"server": []}}
+            False
     ),
     (
             {'001', '006'},
@@ -1085,8 +1083,7 @@ def test_agent_get_outdated_agents(socket_mock, send_mock):
              'data': [{'error': 0, 'message': 'Success', 'agent': 6, 'task_id': 1}],
              'message': 'Success'},
             {'group': 'group-1'},
-            False,
-            {"client": {"server": []}}
+            False
     ),
     (
             {'001'},
@@ -1098,8 +1095,7 @@ def test_agent_get_outdated_agents(socket_mock, send_mock):
                       ],
              'message': 'Error'},
             None,
-            True,
-            {"client": {"server": []}}
+            True
     ),
     (
             {'001'},
@@ -1111,25 +1107,15 @@ def test_agent_get_outdated_agents(socket_mock, send_mock):
                       ],
              'message': 'Error'},
             None,
-            True,
-            {"client": {"server": []}}
-    ),
-    (
-            {'001'},
-            {'1761': {'001'}},
-            {},
-            None,
-            False,
-            {"client": {"server": [{"protocol": "udp"}], "crypto_method": "blowfish"}}
+            True
     )
 ])
 @patch('wazuh.agent.get_agents_info', return_value=set(full_agent_list))
 @patch('wazuh.core.common.CLIENT_KEYS', new=os.path.join(test_agent_path, 'client.keys'))
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
-@patch('wazuh.core.wazuh_socket.WazuhSocket')
 @patch('socket.socket.connect')
-def test_agent_upgrade_agents(mock_socket, mock_wazuh_socket, mock_wdb, mock_client_keys, agent_set, expected_errors_and_items,
-                              result_from_socket, filters, raise_error, agent_conf):
+def test_agent_upgrade_agents(mock_socket, mock_wdb, mock_client_keys, agent_set, expected_errors_and_items,
+                              result_from_socket, filters, raise_error):
     """Test `upgrade_agents` function from agent module.
 
     Parameters
@@ -1144,14 +1130,9 @@ def test_agent_upgrade_agents(mock_socket, mock_wazuh_socket, mock_wdb, mock_cli
         Defines required field filters. Format: {"field1":"value1", "field2":["value2","value3"]}
     raise_error : bool
         Boolean variable used to indicate that the
-    agent_conf : dict
-        Dictionary containing the configuration used by the agents.
     """
     with patch('wazuh.core.agent.core_upgrade_agents') as core_upgrade_agents_mock:
         core_upgrade_agents_mock.return_value = result_from_socket
-        # Mock an agent config for upgrade_agent's call to Agent.get_config():
-        socket_response = f'ok {dumps(agent_conf)}'.encode('utf-8')
-        mock_wazuh_socket.return_value.receive.return_value = socket_response
 
         if raise_error:
             # Upgrade expecting a Wazuh Exception


### PR DESCRIPTION
Removes the obsolete configuration logic from the `upgrade_agents` script. As it was determined that the UDP and Blowfish configurations being present in a agent's config won't prevent an upgrade to 5.X.

This reverts commit 2747f7addfb6c1b1b92539cad21dbcb9a736b15c, reversing changes made to dc75d8d5d08737d8169ce23994d996bf61911936.