### PR TITLE
Added missing logs in sca_impl.cpp and wm_sca_stop function in wm_sca.c

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -117,6 +117,8 @@ void SecurityConfigurationAssessment::Run()
                 checkResult.policyId, checkResult.checkId, checkResult.result, checkResult.reason);
         };
 
+        LoggingHelper::getInstance().log(LOG_INFO, "SCA scan started.");
+
         for (auto& policy : m_policies)
         {
             if (!m_keepRunning)
@@ -128,6 +130,8 @@ void SecurityConfigurationAssessment::Run()
         }
 
         firstScan = false;
+
+        LoggingHelper::getInstance().log(LOG_INFO, "SCA scan ended.");
     }
 }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -76,6 +76,7 @@ static void * wm_sca_sync_module(__attribute__((unused)) void * args);
 #endif
 static void wm_sca_destroy(wm_sca_t * data);  // Destroy data
 static int wm_sca_start(wm_sca_t * data);  // Start
+static void wm_sca_stop();  // Stop
 
 cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 
@@ -87,7 +88,7 @@ const wm_context WM_SCA_CONTEXT = {
     .destroy = (void(*)(void *))wm_sca_destroy,
     .dump = (cJSON * (*)(const void *))wm_sca_dump,
     .sync = (int(*)(const char*, size_t))wm_sca_sync_message,
-    .stop = NULL,
+    .stop = (void(*)(void *))wm_sca_stop,
     .query = NULL,
 };
 
@@ -277,6 +278,16 @@ void wm_sca_destroy(wm_sca_t * data) {
 
     if (data) {
         os_free(data);
+    }
+}
+
+// Stop
+void wm_sca_stop() {
+    g_shutting_down = 1;
+    sca_sync_module_running = 0;
+
+    if (sca_stop_ptr) {
+        sca_stop_ptr();
     }
 }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -269,13 +269,6 @@ static int wm_sca_start(wm_sca_t *sca) {
 
 // Destroy data
 void wm_sca_destroy(wm_sca_t * data) {
-    g_shutting_down = 1;
-    sca_sync_module_running = 0;
-
-    if (sca_stop_ptr) {
-        sca_stop_ptr();
-    }
-
     if (data) {
         os_free(data);
     }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
- Missing logs when SCA scan start and end.
- Missing call to SCA stop.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #32011 
-->

## Proposed Changes
- Added `"SCA scan started."` before running the policy checks and `"SCA scan ended."` after, inside `SecurityConfigurationAssessment::Run()`.
- Added the function `wm_sca_stop()` to the struct `wm_context WM_SCA_CONTEXT` inside `wm_sca.c` that later calls the function `SecurityConfigurationAssessment::Stop()`.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

Before:
```
...
2025/09/18 14:38:04 rootcheck: INFO: Ending rootcheck scan.
2025/09/18 14:40:20 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/09/18 14:40:20 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/09/18 14:40:20 wazuh-modulesd:syscollector: INFO: Module finished.
...
```

After:

```
...
2025/09/18 14:49:38 wazuh-modulesd:sca: INFO: SCA scan started.
2025/09/18 14:49:38 rootcheck: INFO: Ending rootcheck scan.
2025/09/18 14:49:45 wazuh-modulesd:sca: INFO: SCA scan ended.
2025/09/18 14:54:03 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/09/18 14:54:03 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/09/18 14:54:03 wazuh-modulesd:syscollector: INFO: Module finished.
2025/09/18 14:54:03 wazuh-modulesd:sca: INFO: SCA module stopped.
...
```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
