### PR TITLE
Renamed the syscollector event provider topic to the expected name

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -181,7 +181,7 @@ int main(const int argc, const char* argv[])
         routerModule.start();
 
         auto routerProviderDbSync = RouterProvider("deltas-syscollector", true);
-        auto routerProviderRSync = RouterProvider("rsync-syscollector", true);
+        auto routerProviderRSync = RouterProvider("rsync", true);
         auto routerProviderDbUpdate = RouterProvider("wdb-agent-events", true);
         routerProviderDbSync.start();
         routerProviderRSync.start();

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -231,7 +231,7 @@ void* wm_sys_main(wm_sys_t *sys) {
                 mdebug2("Failed to create router handle for 'syscollector'.");
             }
 
-            if (rsync_handle = router_provider_create_func_ptr("rsync-syscollector", true), !rsync_handle) {
+            if (rsync_handle = router_provider_create_func_ptr("rsync", true), !rsync_handle) {
                 mdebug2("Failed to create router handle for 'rsync'.");
             }
         }


### PR DESCRIPTION
## Description

After enabling the manager vulnerability scan, it won't be scanned anyway because the message forward redirects the message to a topic without subscribers. 

The current topic vulnerability scanner is subscribed to (among others) is "rsync" (for rsync events)


