### PR TITLE
Checksum verification before command executions

### DIFF
--- a/src/unit_tests/wazuh_modules/command/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/command/CMakeLists.txt
@@ -8,7 +8,9 @@
 # Tests list and flags
 list(APPEND tests_names "test_wm_command")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
-                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER")
+                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=_mtdebug1 \
+                         -Wl,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER \
+                         -Wl,--wrap=wm_validate_command")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.c
@@ -38,3 +38,11 @@ int __wrap_wm_state_io(const char * tag,
     }
     return ret;
 }
+
+int __wrap_wm_validate_command(const char *command, const char *digest, crypto_type ctype) {
+    check_expected(command);
+    check_expected(digest);
+    check_expected(ctype);
+    
+    return mock_type(int);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.c
@@ -43,6 +43,13 @@ int __wrap_wm_validate_command(const char *command, const char *digest, crypto_t
     check_expected(command);
     check_expected(digest);
     check_expected(ctype);
-    
+
     return mock_type(int);
+}
+
+void expect_wm_validate_command(const char *command, const char *digest, crypto_type ctype, int ret) {
+    expect_string(__wrap_wm_validate_command, command, command);
+    expect_string(__wrap_wm_validate_command, digest, digest);
+    expect_value(__wrap_wm_validate_command, ctype, ctype);
+    will_return(__wrap_wm_validate_command, ret);
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.h
@@ -25,6 +25,13 @@ int __wrap_wm_state_io(const char * tag,
                        void *state,
                        size_t size);
 
-int __wrap_wm_validate_command(const char *command, const char *digest, crypto_type ctype);
+int __wrap_wm_validate_command(const char *command,
+                               const char *digest,
+                               crypto_type ctype);
+
+void expect_wm_validate_command(const char *command,
+                                const char *digest,
+                                crypto_type ctype,
+                                int ret);
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_modules/wmodules_wrappers.h
@@ -12,6 +12,7 @@
 #define WMODULES_WRAPPERS_H
 
 #include <stddef.h>
+#include "../../wazuh_modules/wmodules.h"
 
 int __wrap_wm_sendmsg(int usec,
                       int queue,
@@ -23,5 +24,7 @@ int __wrap_wm_state_io(const char * tag,
                        int op,
                        void *state,
                        size_t size);
+
+int __wrap_wm_validate_command(const char *command, const char *digest, crypto_type ctype);
 
 #endif

--- a/src/wazuh_modules/wm_command.c
+++ b/src/wazuh_modules/wm_command.c
@@ -18,7 +18,7 @@ static void * wm_command_main(wm_command_t * command);    // Module main functio
 #endif
 static void wm_command_destroy(wm_command_t * command);   // Destroy data
 cJSON *wm_command_dump(const wm_command_t * command);
-int validate_command_checksums(wm_command_t * command); // Validate checksums
+int validate_command_checksums(wm_command_t * command, const char * full_path); // Validate checksums
 
 // Command module context definition
 
@@ -45,9 +45,10 @@ void * wm_command_main(wm_command_t * command) {
     int usec = 1000000 / wm_max_eps;
     char *command_cpy;
     char *binary;
-    char *full_path;
+    char *full_path = NULL;
     char **argv;
     char * timestamp = NULL;
+    bool verify_command = command->md5_hash || command->sha1_hash || command->sha256_hash;
 
     if (!command->enabled) {
         mtinfo(WM_COMMAND_LOGTAG, "Module command:%s is disabled. Exiting.", command->tag);
@@ -61,9 +62,7 @@ void * wm_command_main(wm_command_t * command) {
     }
 #endif
 
-    // Verify command
-    if (command->md5_hash || command->sha1_hash || command->sha256_hash) {
-
+    if (verify_command) {
         command_cpy = strdup(command->command);
 
         argv = w_strtok(command_cpy);
@@ -87,12 +86,12 @@ void * wm_command_main(wm_command_t * command) {
         snprintf(command->full_command, strlen(full_path) + strlen(command->command) - strlen(binary) + 1, "%s %s", full_path, command->command + strlen(binary) + 1);
         free_strarray(argv);
 
-        if (validate_command_checksums(command) != 0) {
+        if (validate_command_checksums(command, full_path) != 0) {
+            os_free(full_path);
             pthread_exit(NULL);
         }
 
         free(command_cpy);
-        free(full_path);
 
     } else {
         command->full_command = strdup(command->command);
@@ -119,6 +118,10 @@ void * wm_command_main(wm_command_t * command) {
 
         if (command->queue_fd < 0) {
             mterror(WM_COMMAND_LOGTAG, "Can't connect to queue.");
+            if (verify_command) {
+                os_free(full_path);
+            }
+
             pthread_exit(NULL);
         }
     }
@@ -139,10 +142,12 @@ void * wm_command_main(wm_command_t * command) {
             w_sleep_until(next_scan_time);
         }
 
-        mtinfo(WM_COMMAND_LOGTAG, "Verifying command checksum '%s'.", command->tag);
-
-        if (validate_command_checksums(command) != 0 && !command->skip_verification) {
-            pthread_exit(NULL);
+        if (full_path != NULL && verify_command && !command->skip_verification) {
+            mtinfo(WM_COMMAND_LOGTAG, "Verifying command checksum '%s'.", command->tag);
+            if (validate_command_checksums(command, full_path) != 0) {
+                os_free(full_path);
+                pthread_exit(NULL);
+            }
         }
 
         mtinfo(WM_COMMAND_LOGTAG, "Starting command '%s'.", command->tag);
@@ -185,6 +190,7 @@ void * wm_command_main(wm_command_t * command) {
         mtdebug1(WM_COMMAND_LOGTAG, "Command '%s' finished.", command->tag);
     } while (FOREVER());
 
+    os_free(full_path);
     free(extag);
 #ifdef WIN32
     return 0;
@@ -193,9 +199,9 @@ void * wm_command_main(wm_command_t * command) {
 #endif
 }
 
-int validate_command_checksums(wm_command_t * command) {
+int validate_command_checksums(wm_command_t * command, const char * full_path) {
     if (command->md5_hash && command->md5_hash[0]) {
-        if (wm_validate_command(command->full_command, command->md5_hash, MD5SUM) != 1) {
+        if (wm_validate_command(full_path, command->md5_hash, MD5SUM) != 1) {
             if (command->skip_verification) {
                 mtwarn(WM_COMMAND_LOGTAG, "MD5 checksum verification failed for command '%s'. Skipping...", command->full_command);
                 return 0;
@@ -203,10 +209,11 @@ int validate_command_checksums(wm_command_t * command) {
             mterror(WM_COMMAND_LOGTAG, "MD5 checksum verification failed for command '%s'.", command->full_command);
             return -1;
         }
+        mtdebug1(WM_COMMAND_LOGTAG, "MD5 checksum verification was successful for command '%s'.", command->full_command);
     }
 
     if (command->sha1_hash && command->sha1_hash[0]) {
-        if (wm_validate_command(command->full_command, command->sha1_hash, SHA1SUM) != 1) {
+        if (wm_validate_command(full_path, command->sha1_hash, SHA1SUM) != 1) {
             if (command->skip_verification) {
                 mtwarn(WM_COMMAND_LOGTAG, "SHA1 checksum verification failed for command '%s'. Skipping...", command->full_command);
                 return 0;
@@ -214,10 +221,11 @@ int validate_command_checksums(wm_command_t * command) {
             mterror(WM_COMMAND_LOGTAG, "SHA1 checksum verification failed for command '%s'.", command->full_command);
             return -1;
         }
+        mtdebug1(WM_COMMAND_LOGTAG, "SHA1 checksum verification was successful for command '%s'.", command->full_command);
     }
 
     if (command->sha256_hash && command->sha256_hash[0]) {
-        if (wm_validate_command(command->full_command, command->sha256_hash, SHA256SUM) != 1) {
+        if (wm_validate_command(full_path, command->sha256_hash, SHA256SUM) != 1) {
             if (command->skip_verification) {
                 mtwarn(WM_COMMAND_LOGTAG, "SHA256 checksum verification failed for command '%s'. Skipping...", command->full_command);
                 return 0;
@@ -225,9 +233,9 @@ int validate_command_checksums(wm_command_t * command) {
             mterror(WM_COMMAND_LOGTAG, "SHA256 checksum verification failed for command '%s'.", command->full_command);
             return -1;
         }
+        mtdebug1(WM_COMMAND_LOGTAG, "SHA256 checksum verification was successful for command '%s'.", command->full_command);
     }
 
-    mtdebug1(WM_COMMAND_LOGTAG, "Checksum verification was successful for command '%s'.", command->full_command);
     return 0;
 }
 

--- a/src/wazuh_modules/wm_command.h
+++ b/src/wazuh_modules/wm_command.h
@@ -42,4 +42,7 @@ extern const wm_context WM_COMMAND_CONTEXT;   // Context
 // Parse XML
 int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg);
 
+// Validate checksums
+int validate_checksum(wm_command_t * command, crypto_type ctype);
+
 #endif // WM_COMMAND_H

--- a/src/wazuh_modules/wm_command.h
+++ b/src/wazuh_modules/wm_command.h
@@ -43,6 +43,6 @@ extern const wm_context WM_COMMAND_CONTEXT;   // Context
 int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg);
 
 // Validate checksums
-int validate_checksum(wm_command_t * command, crypto_type ctype);
+int validate_command_checksums(wm_command_t * command);
 
 #endif // WM_COMMAND_H

--- a/src/wazuh_modules/wm_command.h
+++ b/src/wazuh_modules/wm_command.h
@@ -43,6 +43,6 @@ extern const wm_context WM_COMMAND_CONTEXT;   // Context
 int wm_command_read(xml_node **nodes, wmodule *module, int agent_cfg);
 
 // Validate checksums
-int validate_command_checksums(wm_command_t * command);
+int validate_command_checksums(wm_command_t * command, const char * full_path);
 
 #endif // WM_COMMAND_H

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -473,9 +473,9 @@ int wm_relative_path(const char * path) {
 }
 
 /**
- Check the binary wich executes a command has the specified hash.
+ Check the binary which executes a command has the specified hash.
  Returns:
-     1 if the binary matchs with the specified digest, 0 if not.
+     1 if the binary matches with the specified digest, 0 if not.
     -1 invalid parameters.
 */
 int wm_validate_command(const char *command, const char *digest, crypto_type ctype) {

--- a/src/wazuh_modules/wmodules.c
+++ b/src/wazuh_modules/wmodules.c
@@ -473,7 +473,7 @@ int wm_relative_path(const char * path) {
 }
 
 /**
- Check the binary wich executes a commad has the specified hash.
+ Check the binary wich executes a command has the specified hash.
  Returns:
      1 if the binary matchs with the specified digest, 0 if not.
     -1 invalid parameters.

--- a/src/wazuh_modules/wmodules.h
+++ b/src/wazuh_modules/wmodules.h
@@ -183,9 +183,9 @@ int wm_sendmsg_ex(int usec, int queue, const char *message, const char *locmsg, 
 int wm_relative_path(const char * path);
 
 /**
- Check the binary wich executes a commad has the specified hash.
+ Check the binary which executes a command has the specified hash.
  Returns:
-     1 if the binary matchs with the specified digest, 0 if not.
+     1 if the binary matches with the specified digest, 0 if not.
     -1 if the binary doesn't exist.
     -2 invalid parameters.
 */


### PR DESCRIPTION
## Description
|Related issues|
|---|
|Closes #19145|

## Proposed Changes

The command's checksum should be verified before its execution.

### Results and Evidence

Now, the checksum verification is always performed before executing the command, so the process will exit if the monitored command has been modified.
_(Note: WARNING messages in these logs are used for debugging, to verify that the command is executed correctly after the changes.)_

<details><summary>Logs after the fix</summary>

```
2025/09/19 17:20:20 wazuh-modulesd:command: INFO: Verifying command checksum 'test'.
2025/09/19 17:20:20 wazuh-modulesd:command: INFO: Starting command 'test'.
2025/09/19 17:20:20 wazuh-modulesd:command: WARNING: THIS IS A TEST COMMAND

2025/09/19 17:20:22 wazuh-modulesd:command: INFO: Verifying command checksum 'test'.
2025/09/19 17:20:22 wazuh-modulesd:command: INFO: Starting command 'test'.
2025/09/19 17:20:22 wazuh-modulesd:command: WARNING: THIS IS A TEST COMMAND

...


2025/09/19 17:21:02 wazuh-modulesd:command: INFO: Verifying command checksum 'test'.
2025/09/19 17:21:02 wazuh-modulesd:command: INFO: Starting command 'test'.
2025/09/19 17:21:02 wazuh-modulesd:command: WARNING: THIS IS A TEST COMMAND

2025/09/19 17:21:04 wazuh-modulesd:command: INFO: Verifying command checksum 'test'.
2025/09/19 17:21:04 wazuh-modulesd:command: ERROR: 'SHA256' checksum verification failed for command '/test/file.sh'.
```

</details>

## Analysis of behaviour:

The program's behaviour has remained the same as the original, where only the checksum of the first term entered in the ‘command’ section was checked. This means that, if you follow the examples in the documentation, where `/bin/bash` is placed in front of the executable to be monitored, you will need to enter the hash of `/bin/bash`, because if you try to enter the hash of the executable, the program will detect it as an error. 

Using the hash of `/bin/bash` could cause security issues, as if the executable is modified, the modification will not be detected and it will be executed periodically regardless of the cause of the modification. This means that the only effective way to monitor the command is to enter it directly as the first term in the ‘command’ section, followed by its parameters.

<details><summary>Only binary path 🟢</summary>

```console
2025/10/01 17:28:32 wazuh-modulesd:command[122147] wm_command.c:141 at wm_command_main(): INFO: Verifying command checksum 'test'.
2025/10/01 17:28:32 wazuh-modulesd[122147] wmodules.c:518 at wm_validate_command(): DEBUG: Comparing SHA256 hash: 'b55c140a2d47692ca3e537a77647d8b94c20921720a90edda06f618018d69db2' | 'b55c140a2d47692ca3e537a77647d8b94c20921720a90edda06f618018d69db2'
2025/10/01 17:28:32 wazuh-modulesd:command[122147] wm_command.c:231 at validate_command_checksums(): DEBUG: SHA256 checksum verification was successful for command '/test/test.sh'.
2025/10/01 17:28:32 wazuh-modulesd:command[122147] wm_command.c:147 at wm_command_main(): INFO: Starting command 'test'.
2025/10/01 17:28:32 wazuh-modulesd:command[122147] wm_command.c:148 at wm_command_main(): INFO: Full command = '/test/test.sh'.
2025/10/01 17:28:32 wazuh-modulesd:command[122147] wm_command.c:170 at wm_command_main(): DEBUG: OUTPUT: No param call

2025/10/01 17:28:32 wazuh-modulesd:command[122147] wm_command.c:185 at wm_command_main(): DEBUG: Command 'test' finished.
```

</details>

<details><summary>Binary path with params 🟢</summary>

```console
2025/10/01 17:30:20 wazuh-modulesd:command[123257] wm_command.c:141 at wm_command_main(): INFO: Verifying command checksum 'test'.
2025/10/01 17:30:20 wazuh-modulesd[123257] wmodules.c:518 at wm_validate_command(): DEBUG: Comparing SHA256 hash: 'b55c140a2d47692ca3e537a77647d8b94c20921720a90edda06f618018d69db2' | 'b55c140a2d47692ca3e537a77647d8b94c20921720a90edda06f618018d69db2'
2025/10/01 17:30:20 wazuh-modulesd:command[123257] wm_command.c:231 at validate_command_checksums(): DEBUG: SHA256 checksum verification was successful for command '/test/test.sh test_param'.
2025/10/01 17:30:20 wazuh-modulesd:command[123257] wm_command.c:147 at wm_command_main(): INFO: Starting command 'test'.
2025/10/01 17:30:20 wazuh-modulesd:command[123257] wm_command.c:148 at wm_command_main(): INFO: Full command = '/test/test.sh test_param'.
2025/10/01 17:30:20 wazuh-modulesd:command[123257] wm_command.c:170 at wm_command_main(): DEBUG: OUTPUT: Param 1 = test_param

2025/10/01 17:30:20 wazuh-modulesd:command[123257] wm_command.c:185 at wm_command_main(): DEBUG: Command 'test' finished.
```

</details>


<details><summary>/bin/bash with binary path and params 🟡 </summary>

```console
2025/10/01 17:31:29 wazuh-modulesd[124383] wmodules.c:518 at wm_validate_command(): DEBUG: Comparing SHA256 hash: 'bc5945feb8bd26203ebfafea5ce1878bb2e32cb8fb50ab7ae395cfb1e1aaaef1' | 'b55c140a2d47692ca3e537a77647d8b94c20921720a90edda06f618018d69db2'
2025/10/01 17:31:29 wazuh-modulesd:command[124383] wm_command.c:228 at validate_command_checksums(): ERROR: SHA256 checksum verification failed for command '/bin/bash /test/test.sh test_param'.
```

</details>