### PR TITLE
Use RTR to run checks for shared_modules/file_helper

### DIFF
--- a/.github/workflows/5_testunit_shared_modules_file_helper.yml
+++ b/.github/workflows/5_testunit_shared_modules_file_helper.yml
@@ -1,92 +1,44 @@
-name: 5.X - Shared Modules - File Helper - Unit tests
+name: 5.X - Running RTR. Shared Modules - File Helper - Unit tests
 
 on:
   workflow_dispatch:
   pull_request:
-  # Pull request events
-    types: [synchronize, opened, reopened, ready_for_review]
-  # Path filtering
     paths:
+      - "src/ci/**"
+      - "src/build.py"
+      - ".github/actions/**"
       - ".github/workflows/5_testunit_shared_modules_file_helper.yml"
       - "src/shared_modules/file_helper/**"
 
 jobs:
-  shared_modules_file_helper-modules:
+  rtr:
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [shared_modules/file_helper]
+        target: [agent, winagent]
     runs-on: ubuntu-22.04
     steps:
-      - name: Cancel previous runs
-        uses: fkirc/skip-duplicate-actions@master
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: "Install dependencies"
+        uses: ./.github/actions/install_build_deps
         with:
-          cancel_others: 'true'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          skip_after_successful_duplicate: 'false'
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          target: ${{ matrix.target }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          submodules: recursive
-
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Shared modules file_helper - Build filesystem tests
-        uses: ./.github/actions/build_target_cpp
+          python-version-file: ".github/workflows/.python-version"
+          architecture: x64
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
+      - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
+        run: |
+          cd src/
+          python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
+      - name: Uploading coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          target: "filesystem_unit_test"
-          test: "true"
-          asan: "false"
-
-      - name: Shared modules file_helper - Build file_io tests
-        uses: ./.github/actions/build_target_cpp
-        with:
-          target: "file_io_unit_test"
-          test: "true"
-          asan: "false"
-
-      - name: Shared modules file_helper - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "file_helper_utest"
-
-      - name: Shared modules file_helper - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/shared_modules/file_helper
-          id: file_helper_utest
-          threshold: "60"
-          validate_function_coverage: "false"
-
-  shared_modules_file_helper-asan:
-    strategy:
-      matrix:
-        os: [ ubuntu-24.04, ubuntu-22.04 ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Shared modules file_helper - Build filesystem tests
-        uses: ./.github/actions/build_target_cpp
-        with:
-          target: "filesystem_unit_test"
-          test: "true"
-          asan: "true"
-
-      - name: Shared modules file_helper - Build file_io tests
-        uses: ./.github/actions/build_target_cpp
-        with:
-          target: "file_io_unit_test"
-          test: "true"
-          asan: "true"
-
-      - name: Shared modules file_helper - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          target: "file_helper_utest"
-          valgrind: "false"
+          name: coverage_report ${{ matrix.target }}
+          path: ./**/coverage_report/**

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -180,6 +180,8 @@ def getFoldersToAStyle(moduleName):
     elif str(moduleName) == "syscheckd":
         foldersToScan = "\"{0}/src/db/src/*.hpp\" \"{0}/src/db/src/*.cpp\""\
                         .format(moduleName)
+    elif str(moduleName) == "shared_modules/file_helper":
+        foldersToScan = "'{0}/*.cpp' '{0}/*.hpp'".format(moduleName)
     else:
         foldersToScan = "{0}/*.h {0}/*.cpp {0}/*.hpp".format(moduleName)
 

--- a/src/shared_modules/file_helper/file_io/include/file_io_utils.hpp
+++ b/src/shared_modules/file_helper/file_io/include/file_io_utils.hpp
@@ -13,21 +13,21 @@ namespace file_io
     /// @copydoc IFileIOUtils
     class FileIOUtils : public IFileIOUtils
     {
-    public:
-        /// @brief  FileIOUtils constructor
-        FileIOUtils(std::shared_ptr<IFileIOWrapper> fileIOWrapper = nullptr);
+        public:
+            /// @brief  FileIOUtils constructor
+            FileIOUtils(std::shared_ptr<IFileIOWrapper> fileIOWrapper = nullptr);
 
-        /// @copydoc IFileIOUtils::readLineByLine
-        void readLineByLine(const std::filesystem::path& filePath,
-                            const std::function<bool(const std::string&)>& callback) const override;
+            /// @copydoc IFileIOUtils::readLineByLine
+            void readLineByLine(const std::filesystem::path& filePath,
+                                const std::function<bool(const std::string&)>& callback) const override;
 
-        /// @copydoc IFileIOUtils::getFileContent
-        std::string getFileContent(const std::string& filePath) const override;
+            /// @copydoc IFileIOUtils::getFileContent
+            std::string getFileContent(const std::string& filePath) const override;
 
-        /// @copydoc IFileIOUtils::getBinaryContent
-        std::vector<char> getBinaryContent(const std::string& filePath) const override;
+            /// @copydoc IFileIOUtils::getBinaryContent
+            std::vector<char> getBinaryContent(const std::string& filePath) const override;
 
-    private:
-        std::shared_ptr<IFileIOWrapper> m_fileIOWrapper;
+        private:
+            std::shared_ptr<IFileIOWrapper> m_fileIOWrapper;
     };
 } // namespace file_io

--- a/src/shared_modules/file_helper/file_io/include/file_io_wrapper.hpp
+++ b/src/shared_modules/file_helper/file_io/include/file_io_wrapper.hpp
@@ -9,18 +9,18 @@ namespace file_io
     /// @copydoc IFileIOWrapper
     class FileIOWrapper : public IFileIOWrapper
     {
-    public:
-        /// @copydoc IFileIOWrapper::get_line
-        bool get_line(std::istream& file, std::string& line) const override;
+        public:
+            /// @copydoc IFileIOWrapper::get_line
+            bool get_line(std::istream& file, std::string& line) const override;
 
-        /// @copydoc IFileIOWrapper::create_ifstream
-        std::unique_ptr<std::ifstream> create_ifstream(const std::string& filePath,
-                                                       std::ios_base::openmode mode = std::ios_base::in) const override;
+            /// @copydoc IFileIOWrapper::create_ifstream
+            std::unique_ptr<std::ifstream> create_ifstream(const std::string& filePath,
+                                                           std::ios_base::openmode mode = std::ios_base::in) const override;
 
-        /// @copydoc IFileIOWrapper::get_rdbuf
-        std::streambuf* get_rdbuf(const std::ifstream& file) const override;
+            /// @copydoc IFileIOWrapper::get_rdbuf
+            std::streambuf* get_rdbuf(const std::ifstream& file) const override;
 
-        /// @copydoc IFileIOWrapper::is_open
-        bool is_open(const std::ifstream& file) const override;
+            /// @copydoc IFileIOWrapper::is_open
+            bool is_open(const std::ifstream& file) const override;
     };
 } // namespace file_io

--- a/src/shared_modules/file_helper/file_io/include/ifile_io_utils.hpp
+++ b/src/shared_modules/file_helper/file_io/include/ifile_io_utils.hpp
@@ -10,25 +10,25 @@
 /// getting the content of a file, and getting the binary content of a file.
 class IFileIOUtils
 {
-public:
-    /// @brief Virtual destructor for IFileIOUtils.
-    ///
-    /// Ensures that any derived classes with their own resources are correctly cleaned up.
-    virtual ~IFileIOUtils() = default;
+    public:
+        /// @brief Virtual destructor for IFileIOUtils.
+        ///
+        /// Ensures that any derived classes with their own resources are correctly cleaned up.
+        virtual ~IFileIOUtils() = default;
 
-    /// @brief Reads lines from a file and calls a callback for each line.
-    /// @param filePath The path to the file to read.
-    /// @param callback The callback function to call for each line.
-    virtual void readLineByLine(const std::filesystem::path& filePath,
-                                const std::function<bool(const std::string&)>& callback) const = 0;
+        /// @brief Reads lines from a file and calls a callback for each line.
+        /// @param filePath The path to the file to read.
+        /// @param callback The callback function to call for each line.
+        virtual void readLineByLine(const std::filesystem::path& filePath,
+                                    const std::function<bool(const std::string&)>& callback) const = 0;
 
-    /// @brief Gets the content of a file as a string.
-    /// @param filePath The path to the file to read.
-    /// @return The content of the file as a string.
-    virtual std::string getFileContent(const std::string& filePath) const = 0;
+        /// @brief Gets the content of a file as a string.
+        /// @param filePath The path to the file to read.
+        /// @return The content of the file as a string.
+        virtual std::string getFileContent(const std::string& filePath) const = 0;
 
-    /// @brief Gets the binary content of a file as a vector of bytes.
-    /// @param filePath The path to the file to read.
-    /// @return The binary content of the file as a vector of bytes.
-    virtual std::vector<char> getBinaryContent(const std::string& filePath) const = 0;
+        /// @brief Gets the binary content of a file as a vector of bytes.
+        /// @param filePath The path to the file to read.
+        /// @return The binary content of the file as a vector of bytes.
+        virtual std::vector<char> getBinaryContent(const std::string& filePath) const = 0;
 };

--- a/src/shared_modules/file_helper/file_io/include/ifile_io_wrapper.hpp
+++ b/src/shared_modules/file_helper/file_io/include/ifile_io_wrapper.hpp
@@ -10,32 +10,32 @@
 /// getting the content of a file, and getting the binary content of a file.
 class IFileIOWrapper
 {
-public:
-    /// @brief Virtual destructor for IFileIOWrapper.
-    ///
-    /// Ensures that any derived classes with their own resources are correctly cleaned up.
-    virtual ~IFileIOWrapper() = default;
+    public:
+        /// @brief Virtual destructor for IFileIOWrapper.
+        ///
+        /// Ensures that any derived classes with their own resources are correctly cleaned up.
+        virtual ~IFileIOWrapper() = default;
 
-    /// @brief Creates an ifstream for a file.
-    /// @param filePath The path to the file.
-    /// @param mode The mode to open the file.
-    /// @return An ifstream for the file.
-    virtual std::unique_ptr<std::ifstream> create_ifstream(const std::string& filePath,
-                                                           std::ios_base::openmode mode = std::ios_base::in) const = 0;
+        /// @brief Creates an ifstream for a file.
+        /// @param filePath The path to the file.
+        /// @param mode The mode to open the file.
+        /// @return An ifstream for the file.
+        virtual std::unique_ptr<std::ifstream> create_ifstream(const std::string& filePath,
+                                                               std::ios_base::openmode mode = std::ios_base::in) const = 0;
 
-    /// @brief Gets the stream buffer for a file.
-    /// @param file The file to get the stream buffer for.
-    /// @return The stream buffer for the file.
-    virtual std::streambuf* get_rdbuf(const std::ifstream& file) const = 0;
+        /// @brief Gets the stream buffer for a file.
+        /// @param file The file to get the stream buffer for.
+        /// @return The stream buffer for the file.
+        virtual std::streambuf* get_rdbuf(const std::ifstream& file) const = 0;
 
-    /// @brief Checks if a file is open.
-    /// @param file The file to check.
-    /// @return True if the file is open, false otherwise.
-    virtual bool is_open(const std::ifstream& file) const = 0;
+        /// @brief Checks if a file is open.
+        /// @param file The file to check.
+        /// @return True if the file is open, false otherwise.
+        virtual bool is_open(const std::ifstream& file) const = 0;
 
-    /// @brief Reads a line from a file.
-    /// @param file The file to read from.
-    /// @param line A reference to a string where the read line will be stored.
-    /// @return True if a line was read, false otherwise.
-    virtual bool get_line(std::istream& file, std::string& line) const = 0;
+        /// @brief Reads a line from a file.
+        /// @param file The file to read from.
+        /// @param line A reference to a string where the read line will be stored.
+        /// @return True if a line was read, false otherwise.
+        virtual bool get_line(std::istream& file, std::string& line) const = 0;
 };

--- a/src/shared_modules/file_helper/file_io/src/file_io_utils.cpp
+++ b/src/shared_modules/file_helper/file_io/src/file_io_utils.cpp
@@ -60,10 +60,12 @@ namespace file_io
             {
                 // Get file size using buffer's members
                 size = buffer->pubseekoff(0, file->end, file->in);
+
                 if (size < 0)
                 {
                     return std::vector<char> {};
                 }
+
                 buffer->pubseekpos(0, file->in);
                 // Allocate memory to contain file data
                 auto size_t_size = static_cast<std::size_t>(size);

--- a/src/shared_modules/file_helper/file_io/tests/file_io_utils_test.cpp
+++ b/src/shared_modules/file_helper/file_io/tests/file_io_utils_test.cpp
@@ -8,46 +8,46 @@ using namespace testing;
 
 class FileIOUtilsTest : public ::testing::Test
 {
-protected:
-    void TearDown() override
-    {
-        mockFileIO.reset();
-        mockFileIOWrapper.reset();
-        fakeStream.reset();
-    }
+    protected:
+        void TearDown() override
+        {
+            mockFileIO.reset();
+            mockFileIOWrapper.reset();
+            fakeStream.reset();
+        }
 
-    void SetUp() override
-    {
-        mockFileIOWrapper = std::make_shared<MockFileIOWrapper>();
-        mockFileIO = std::make_shared<file_io::FileIOUtils>(mockFileIOWrapper);
-        fakeStream = std::make_unique<std::ifstream>();
-    }
+        void SetUp() override
+        {
+            mockFileIOWrapper = std::make_shared<MockFileIOWrapper>();
+            mockFileIO = std::make_shared<file_io::FileIOUtils>(mockFileIOWrapper);
+            fakeStream = std::make_unique<std::ifstream>();
+        }
 
-public:
-    std::shared_ptr<MockFileIOWrapper> mockFileIOWrapper;
-    std::shared_ptr<file_io::FileIOUtils> mockFileIO;
-    std::unique_ptr<std::ifstream> fakeStream;
+    public:
+        std::shared_ptr<MockFileIOWrapper> mockFileIOWrapper;
+        std::shared_ptr<file_io::FileIOUtils> mockFileIO;
+        std::unique_ptr<std::ifstream> fakeStream;
 
-    const std::string filePath = "fakepath.txt";
+        const std::string filePath = "fakepath.txt";
 };
 
 TEST_F(FileIOUtilsTest, ReadLineByLine_CallsCallbackForEachLine)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, std::ios_base::in))
-        .WillOnce(testing::Return(ByMove(std::move(fakeStream))));
+    .WillOnce(testing::Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(testing::_)).WillOnce(testing::Return(true));
     EXPECT_CALL(*mockFileIOWrapper, get_line(testing::_, testing::_))
-        .WillOnce(testing::DoAll(testing::SetArgReferee<1>("line1"), testing::Return(true)))
-        .WillOnce(testing::DoAll(testing::SetArgReferee<1>("line2"), testing::Return(true)))
-        .WillOnce(testing::Return(false));
+    .WillOnce(testing::DoAll(testing::SetArgReferee<1>("line1"), testing::Return(true)))
+    .WillOnce(testing::DoAll(testing::SetArgReferee<1>("line2"), testing::Return(true)))
+    .WillOnce(testing::Return(false));
 
     std::vector<std::string> collected;
     mockFileIO->readLineByLine(filePath,
-                               [&](const std::string& line)
-                               {
-                                   collected.push_back(line);
-                                   return true;
-                               });
+                               [&](const std::string & line)
+    {
+        collected.push_back(line);
+        return true;
+    });
 
     EXPECT_EQ(collected, (std::vector<std::string> {"line1", "line2"}));
 }
@@ -55,38 +55,46 @@ TEST_F(FileIOUtilsTest, ReadLineByLine_CallsCallbackForEachLine)
 TEST_F(FileIOUtilsTest, ReadLineByLine_CreateIfstreamFails_ThrowsException)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, std::ios_base::in))
-        .WillOnce(Return(ByMove(std::unique_ptr<std::ifstream>(nullptr))));
+    .WillOnce(Return(ByMove(std::unique_ptr<std::ifstream>(nullptr))));
 
     EXPECT_THROW(
-        { mockFileIO->readLineByLine(filePath, [](const std::string& /*line*/) { return true; }); },
-        std::runtime_error);
+    {
+        mockFileIO->readLineByLine(filePath, [](const std::string& /*line*/)
+        {
+            return true;
+        }); },
+    std::runtime_error);
 }
 
 TEST_F(FileIOUtilsTest, ReadLineByLine_FileNotOpen_ThrowsException)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, std::ios_base::in))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(_)).WillOnce(Return(false));
 
     EXPECT_THROW(
-        { mockFileIO->readLineByLine(filePath, [](const std::string& /*line*/) { return true; }); },
-        std::runtime_error);
+    {
+        mockFileIO->readLineByLine(filePath, [](const std::string& /*line*/)
+        {
+            return true;
+        }); },
+    std::runtime_error);
 }
 
 TEST_F(FileIOUtilsTest, ReadLineByLine_EmptyFile_NoCallbackCalled)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, std::ios_base::in))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(_)).WillOnce(Return(true));
     EXPECT_CALL(*mockFileIOWrapper, get_line(_, _)).WillOnce(Return(false));
 
     bool callbackCalled = false;
     mockFileIO->readLineByLine(filePath,
                                [&](const std::string& /*line*/)
-                               {
-                                   callbackCalled = true;
-                                   return true;
-                               });
+    {
+        callbackCalled = true;
+        return true;
+    });
 
     EXPECT_FALSE(callbackCalled);
 }
@@ -94,7 +102,7 @@ TEST_F(FileIOUtilsTest, ReadLineByLine_EmptyFile_NoCallbackCalled)
 TEST_F(FileIOUtilsTest, GetFileContent_CreateIfstreamFails_ReturnsEmptyString)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, std::ios_base::in))
-        .WillOnce(Return(ByMove(std::unique_ptr<std::ifstream>(nullptr))));
+    .WillOnce(Return(ByMove(std::unique_ptr<std::ifstream>(nullptr))));
 
     const std::string content = mockFileIO->getFileContent(filePath);
     EXPECT_EQ(content, "");
@@ -103,7 +111,7 @@ TEST_F(FileIOUtilsTest, GetFileContent_CreateIfstreamFails_ReturnsEmptyString)
 TEST_F(FileIOUtilsTest, GetFileContent_FileNotOpen_ReturnsEmptyString)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, std::ios_base::in))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(testing::_)).WillOnce(Return(false));
     const std::string content = mockFileIO->getFileContent(filePath);
     EXPECT_EQ(content, "");
@@ -114,7 +122,7 @@ TEST_F(FileIOUtilsTest, GetFileContent_FileIsOpen_ReturnsContent)
     const std::string fakeData = "fakepath content";
 
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, testing::_))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(testing::_)).WillOnce(Return(true));
 
     const std::istringstream iss(fakeData);
@@ -128,7 +136,7 @@ TEST_F(FileIOUtilsTest, GetFileContent_FileIsOpen_ReturnsContent)
 TEST_F(FileIOUtilsTest, GetBinaryContent_FileIsNotOpen_ReturnsEmptyVector)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, testing::_))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(testing::_)).WillOnce(Return(false));
 
     const std::vector<char> content = mockFileIO->getBinaryContent(filePath);
@@ -138,7 +146,7 @@ TEST_F(FileIOUtilsTest, GetBinaryContent_FileIsNotOpen_ReturnsEmptyVector)
 TEST_F(FileIOUtilsTest, GetBinaryContent_CreateIfstreamFails_ReturnsEmptyVector)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, testing::_))
-        .WillOnce(Return(ByMove(std::unique_ptr<std::ifstream>(nullptr))));
+    .WillOnce(Return(ByMove(std::unique_ptr<std::ifstream>(nullptr))));
 
     const std::vector<char> content = mockFileIO->getBinaryContent(filePath);
     EXPECT_EQ(content.size(), 0);
@@ -147,7 +155,7 @@ TEST_F(FileIOUtilsTest, GetBinaryContent_CreateIfstreamFails_ReturnsEmptyVector)
 TEST_F(FileIOUtilsTest, GetBinaryContent_FileIsOpen_BufferIsNull_ReturnsEmptyVector)
 {
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, testing::_))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(testing::_)).WillOnce(Return(true));
     EXPECT_CALL(*mockFileIOWrapper, get_rdbuf(testing::_)).WillOnce(Return(nullptr));
 
@@ -163,7 +171,7 @@ TEST_F(FileIOUtilsTest, GetBinaryContent_FileIsOpen_BufferIsNotNull_ReturnsConte
     std::streambuf* fakeBuf = iss.rdbuf();
 
     EXPECT_CALL(*mockFileIOWrapper, create_ifstream(filePath, testing::_))
-        .WillOnce(Return(ByMove(std::move(fakeStream))));
+    .WillOnce(Return(ByMove(std::move(fakeStream))));
     EXPECT_CALL(*mockFileIOWrapper, is_open(testing::_)).WillOnce(Return(true));
     EXPECT_CALL(*mockFileIOWrapper, get_rdbuf(testing::_)).WillOnce(Return(fakeBuf));
 

--- a/src/shared_modules/file_helper/file_io/tests/mocks/mock_file_io_utils.hpp
+++ b/src/shared_modules/file_helper/file_io/tests/mocks/mock_file_io_utils.hpp
@@ -4,11 +4,11 @@
 
 class MockFileIOUtils : public IFileIOUtils
 {
-public:
-    MOCK_METHOD(void,
-                readLineByLine,
-                (const std::filesystem::path& filePath, const std::function<bool(const std::string&)>& callback),
-                (const, override));
-    MOCK_METHOD(std::string, getFileContent, (const std::string& filePath), (const, override));
-    MOCK_METHOD(std::vector<char>, getBinaryContent, (const std::string& filePath), (const, override));
+    public:
+        MOCK_METHOD(void,
+                    readLineByLine,
+                    (const std::filesystem::path& filePath, const std::function<bool(const std::string&)>& callback),
+                    (const, override));
+        MOCK_METHOD(std::string, getFileContent, (const std::string& filePath), (const, override));
+        MOCK_METHOD(std::vector<char>, getBinaryContent, (const std::string& filePath), (const, override));
 };

--- a/src/shared_modules/file_helper/file_io/tests/mocks/mock_file_io_wrapper.hpp
+++ b/src/shared_modules/file_helper/file_io/tests/mocks/mock_file_io_wrapper.hpp
@@ -4,12 +4,12 @@
 
 class MockFileIOWrapper : public IFileIOWrapper
 {
-public:
-    MOCK_METHOD(std::unique_ptr<std::ifstream>,
-                create_ifstream,
-                (const std::string& filePath, std::ios_base::openmode mode),
-                (const, override));
-    MOCK_METHOD(std::streambuf*, get_rdbuf, (const std::ifstream& file), (const, override));
-    MOCK_METHOD(bool, is_open, (const std::ifstream& file), (const, override));
-    MOCK_METHOD(bool, get_line, (std::istream & file, std::string& line), (const, override));
+    public:
+        MOCK_METHOD(std::unique_ptr<std::ifstream>,
+                    create_ifstream,
+                    (const std::string& filePath, std::ios_base::openmode mode),
+                    (const, override));
+        MOCK_METHOD(std::streambuf*, get_rdbuf, (const std::ifstream& file), (const, override));
+        MOCK_METHOD(bool, is_open, (const std::ifstream& file), (const, override));
+        MOCK_METHOD(bool, get_line, (std::istream& file, std::string& line), (const, override));
 };

--- a/src/shared_modules/file_helper/filesystem/include/filesystem_utils.hpp
+++ b/src/shared_modules/file_helper/filesystem/include/filesystem_utils.hpp
@@ -13,14 +13,14 @@ namespace file_system
     /// to be used as a concrete implementation of the IFileSystemUtils interface.
     class FileSystemUtils : public IFileSystemUtils
     {
-    public:
-        /// @brief Constructor for the FileSystemUtils class.
-        FileSystemUtils(std::shared_ptr<IFileSystemWrapper> fsWrapper = nullptr);
+        public:
+            /// @brief Constructor for the FileSystemUtils class.
+            FileSystemUtils(std::shared_ptr<IFileSystemWrapper> fsWrapper = nullptr);
 
-        /// @copydoc IFileSystemUtils::expand_absolute_path
-        void expand_absolute_path(const std::string& path, std::deque<std::string>& output) const override;
+            /// @copydoc IFileSystemUtils::expand_absolute_path
+            void expand_absolute_path(const std::string& path, std::deque<std::string>& output) const override;
 
-    private:
-        std::shared_ptr<IFileSystemWrapper> m_fsWrapper;
+        private:
+            std::shared_ptr<IFileSystemWrapper> m_fsWrapper;
     };
 } // namespace file_system

--- a/src/shared_modules/file_helper/filesystem/include/filesystem_wrapper.hpp
+++ b/src/shared_modules/file_helper/filesystem/include/filesystem_wrapper.hpp
@@ -12,53 +12,53 @@ namespace file_system
     /// file system operations.
     class FileSystemWrapper : public IFileSystemWrapper
     {
-    public:
-        /// @copydoc IFileSystemWrapper::exists
-        bool exists(const std::filesystem::path& path) const override;
+        public:
+            /// @copydoc IFileSystemWrapper::exists
+            bool exists(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::is_directory
-        bool is_directory(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::is_directory
+            bool is_directory(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::is_regular_file
-        bool is_regular_file(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::is_regular_file
+            bool is_regular_file(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::is_socket
-        bool is_socket(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::is_socket
+            bool is_socket(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::is_symlink
-        bool is_symlink(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::is_symlink
+            bool is_symlink(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::is_absolute
-        bool is_absolute(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::is_absolute
+            bool is_absolute(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::canonical
-        std::filesystem::path canonical(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::canonical
+            std::filesystem::path canonical(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::remove_all
-        std::uintmax_t remove_all(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::remove_all
+            std::uintmax_t remove_all(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::temp_directory_path
-        std::filesystem::path temp_directory_path() const override;
+            /// @copydoc IFileSystemWrapper::temp_directory_path
+            std::filesystem::path temp_directory_path() const override;
 
-        /// @copydoc IFileSystemWrapper::create_directories
-        bool create_directories(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::create_directories
+            bool create_directories(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::list_directory
-        std::vector<std::filesystem::path> list_directory(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::list_directory
+            std::vector<std::filesystem::path> list_directory(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::rename
-        void rename(const std::filesystem::path& from, const std::filesystem::path& to) const override;
+            /// @copydoc IFileSystemWrapper::rename
+            void rename(const std::filesystem::path& from, const std::filesystem::path& to) const override;
 
-        /// @copydoc IFileSystemWrapper::remove
-        bool remove(const std::filesystem::path& path) const override;
+            /// @copydoc IFileSystemWrapper::remove
+            bool remove(const std::filesystem::path& path) const override;
 
-        /// @copydoc IFileSystemWrapper::open
-        int open(const char* path, int flags, int mode) const override;
+            /// @copydoc IFileSystemWrapper::open
+            int open(const char* path, int flags, int mode) const override;
 
-        /// @copydoc IFileSystemWrapper::flock
-        int flock(int fd, int operation) const override;
+            /// @copydoc IFileSystemWrapper::flock
+            int flock(int fd, int operation) const override;
 
-        /// @copydoc IFileSystemWrapper::close
-        int close(int fd) const override;
+            /// @copydoc IFileSystemWrapper::close
+            int close(int fd) const override;
     };
 } // namespace file_system

--- a/src/shared_modules/file_helper/filesystem/include/ifilesystem_utils.hpp
+++ b/src/shared_modules/file_helper/filesystem/include/ifilesystem_utils.hpp
@@ -6,14 +6,14 @@
 /// @brief Interface for file system utils.
 class IFileSystemUtils
 {
-public:
-    /// @brief Virtual destructor for IFileSystemUtils.
-    ///
-    /// Ensures that any derived classes with their own resources are correctly cleaned up.
-    virtual ~IFileSystemUtils() = default;
+    public:
+        /// @brief Virtual destructor for IFileSystemUtils.
+        ///
+        /// Ensures that any derived classes with their own resources are correctly cleaned up.
+        virtual ~IFileSystemUtils() = default;
 
-    /// @brief Expands the absolute path of a file or directory.
-    /// @param path The path to expand.
-    /// @param output The deque to store the expanded path.
-    virtual void expand_absolute_path(const std::string& path, std::deque<std::string>& output) const = 0;
+        /// @brief Expands the absolute path of a file or directory.
+        /// @param path The path to expand.
+        /// @param output The deque to store the expanded path.
+        virtual void expand_absolute_path(const std::string& path, std::deque<std::string>& output) const = 0;
 };

--- a/src/shared_modules/file_helper/filesystem/include/ifilesystem_wrapper.hpp
+++ b/src/shared_modules/file_helper/filesystem/include/ifilesystem_wrapper.hpp
@@ -11,92 +11,92 @@
 /// operations. This allows for abstraction and easier testing or swapping of file system implementations.
 class IFileSystemWrapper
 {
-public:
-    /// @brief Virtual destructor for IFileSystemWrapper.
-    ///
-    /// Ensures that any derived classes with their own resources are correctly cleaned up.
-    virtual ~IFileSystemWrapper() = default;
+    public:
+        /// @brief Virtual destructor for IFileSystemWrapper.
+        ///
+        /// Ensures that any derived classes with their own resources are correctly cleaned up.
+        virtual ~IFileSystemWrapper() = default;
 
-    /// @brief Checks if the specified path exists in the file system.
-    /// @param path The path to check.
-    /// @return Returns true if the path exists, otherwise false.
-    virtual bool exists(const std::filesystem::path& path) const = 0;
+        /// @brief Checks if the specified path exists in the file system.
+        /// @param path The path to check.
+        /// @return Returns true if the path exists, otherwise false.
+        virtual bool exists(const std::filesystem::path& path) const = 0;
 
-    /// @brief Checks if the specified path is a directory.
-    /// @param path The path to check.
-    /// @return Returns true if the path is a directory, otherwise false.
-    virtual bool is_directory(const std::filesystem::path& path) const = 0;
+        /// @brief Checks if the specified path is a directory.
+        /// @param path The path to check.
+        /// @return Returns true if the path is a directory, otherwise false.
+        virtual bool is_directory(const std::filesystem::path& path) const = 0;
 
-    /// @brief Checks if the specified path is a regular file.
-    /// @param path The path to check.
-    /// @return Returns true if the path is a regular file, otherwise false.
-    virtual bool is_regular_file(const std::filesystem::path& path) const = 0;
+        /// @brief Checks if the specified path is a regular file.
+        /// @param path The path to check.
+        /// @return Returns true if the path is a regular file, otherwise false.
+        virtual bool is_regular_file(const std::filesystem::path& path) const = 0;
 
-    /// @brief Checks if the specified path is a socket.
-    /// @param path The path to check.
-    /// @return Returns true if the path is a socket, otherwise false.
-    virtual bool is_socket(const std::filesystem::path& path) const = 0;
+        /// @brief Checks if the specified path is a socket.
+        /// @param path The path to check.
+        /// @return Returns true if the path is a socket, otherwise false.
+        virtual bool is_socket(const std::filesystem::path& path) const = 0;
 
-    /// @brief Checks if the specified path is a symbolic link.
-    /// @param path The path to check.
-    /// @return Returns true if the path is a symbolic link, otherwise false.
-    virtual bool is_symlink(const std::filesystem::path& path) const = 0;
+        /// @brief Checks if the specified path is a symbolic link.
+        /// @param path The path to check.
+        /// @return Returns true if the path is a symbolic link, otherwise false.
+        virtual bool is_symlink(const std::filesystem::path& path) const = 0;
 
-    /// @brief Checks if the specified path is absolute.
-    /// @param path The path to check.
-    /// @return Returns true if the path is absolute, otherwise false.
-    virtual bool is_absolute(const std::filesystem::path& path) const = 0;
+        /// @brief Checks if the specified path is absolute.
+        /// @param path The path to check.
+        /// @return Returns true if the path is absolute, otherwise false.
+        virtual bool is_absolute(const std::filesystem::path& path) const = 0;
 
-    /// @brief Converts the specified path to a canonical absolute path, i.e. an absolute path that has no dot, dot-dot
-    /// elements or symbolic links in its generic format representation.
-    /// @param path The path to convert.
-    /// @return Returns the canonical absolute path.
-    virtual std::filesystem::path canonical(const std::filesystem::path& path) const = 0;
+        /// @brief Converts the specified path to a canonical absolute path, i.e. an absolute path that has no dot, dot-dot
+        /// elements or symbolic links in its generic format representation.
+        /// @param path The path to convert.
+        /// @return Returns the canonical absolute path.
+        virtual std::filesystem::path canonical(const std::filesystem::path& path) const = 0;
 
-    /// @brief Removes all files and subdirectories in the specified directory.
-    /// @param path The directory path to remove.
-    /// @return Returns the number of files and directories removed.
-    virtual std::uintmax_t remove_all(const std::filesystem::path& path) const = 0;
+        /// @brief Removes all files and subdirectories in the specified directory.
+        /// @param path The directory path to remove.
+        /// @return Returns the number of files and directories removed.
+        virtual std::uintmax_t remove_all(const std::filesystem::path& path) const = 0;
 
-    /// @brief Retrieves the system's temporary directory path.
-    /// @return Returns the path of the system's temporary directory.
-    virtual std::filesystem::path temp_directory_path() const = 0;
+        /// @brief Retrieves the system's temporary directory path.
+        /// @return Returns the path of the system's temporary directory.
+        virtual std::filesystem::path temp_directory_path() const = 0;
 
-    /// @brief Creates a new directory at the specified path.
-    /// @param path The path of the directory to create.
-    /// @return Returns true if the directory was successfully created, otherwise false.
-    virtual bool create_directories(const std::filesystem::path& path) const = 0;
+        /// @brief Creates a new directory at the specified path.
+        /// @param path The path of the directory to create.
+        /// @return Returns true if the directory was successfully created, otherwise false.
+        virtual bool create_directories(const std::filesystem::path& path) const = 0;
 
-    /// @brief Returns a vector containing the elements of a directory
-    /// @param path Path to the directory
-    /// @return The vector containing the elements of the directory
-    virtual std::vector<std::filesystem::path> list_directory(const std::filesystem::path& path) const = 0;
+        /// @brief Returns a vector containing the elements of a directory
+        /// @param path Path to the directory
+        /// @return The vector containing the elements of the directory
+        virtual std::vector<std::filesystem::path> list_directory(const std::filesystem::path& path) const = 0;
 
-    /// @brief Renames a file or directory from the 'from' path to the 'to' path.
-    /// @param from The current path of the file or directory.
-    /// @param to The new path for the file or directory.
-    virtual void rename(const std::filesystem::path& from, const std::filesystem::path& to) const = 0;
+        /// @brief Renames a file or directory from the 'from' path to the 'to' path.
+        /// @param from The current path of the file or directory.
+        /// @param to The new path for the file or directory.
+        virtual void rename(const std::filesystem::path& from, const std::filesystem::path& to) const = 0;
 
-    /// @brief Removes the specified file or directory.
-    /// @param path The file or directory to remove.
-    /// @return Returns true if the file or directory was successfully removed, otherwise false.
-    virtual bool remove(const std::filesystem::path& path) const = 0;
+        /// @brief Removes the specified file or directory.
+        /// @param path The file or directory to remove.
+        /// @return Returns true if the file or directory was successfully removed, otherwise false.
+        virtual bool remove(const std::filesystem::path& path) const = 0;
 
-    /// @brief Opens a file
-    /// @param path The file to open
-    /// @param flags Flags to use when opening the file
-    /// @param mode Mode to use when opening the file
-    /// @return File descriptor or -1 on error
-    virtual int open(const char* path, int flags, int mode) const = 0;
+        /// @brief Opens a file
+        /// @param path The file to open
+        /// @param flags Flags to use when opening the file
+        /// @param mode Mode to use when opening the file
+        /// @return File descriptor or -1 on error
+        virtual int open(const char* path, int flags, int mode) const = 0;
 
-    /// @brief Applies or removes a lock on an open file descriptor
-    /// @param fd File descriptor
-    /// @param operation Lock operation
-    /// @return 0 on success, -1 on error
-    virtual int flock(int fd, int operation) const = 0;
+        /// @brief Applies or removes a lock on an open file descriptor
+        /// @param fd File descriptor
+        /// @param operation Lock operation
+        /// @return 0 on success, -1 on error
+        virtual int flock(int fd, int operation) const = 0;
 
-    /// @brief Closes a file descriptor
-    /// @param fd File descriptor
-    /// @return 0 on success, -1 on error
-    virtual int close(int fd) const = 0;
+        /// @brief Closes a file descriptor
+        /// @param fd File descriptor
+        /// @return 0 on success, -1 on error
+        virtual int close(int fd) const = 0;
 };

--- a/src/shared_modules/file_helper/filesystem/src/filesystem_utils.cpp
+++ b/src/shared_modules/file_helper/filesystem/src/filesystem_utils.cpp
@@ -38,7 +38,8 @@ namespace file_system
 
             // The parent directory is the part of the path before the first wildcard.
             // If the wildcard is the first character, then the parent directory is the root directory.
-            const auto nextDirectoryPos {
+            const auto nextDirectoryPos
+            {
                 wildcardPos == 0 ? 0 : path.find_first_of(std::filesystem::path::preferred_separator, wildcardPos)};
 
             if (parentDirectoryPos == std::string::npos)
@@ -64,11 +65,12 @@ namespace file_system
             // If the wildcard is the last character, then the pattern is the rest of the string.
             // If the wildcard is the first character, then the pattern is the rest of the string, minus the next '\'.
             // If there is no next '\', then the pattern is the rest of the string.
-            const auto pattern {
+            const auto pattern
+            {
                 path.substr(parentDirectoryPos == 0 ? 0 : parentDirectoryPos + 1,
                             nextDirectoryPos == std::string::npos
-                                ? std::string::npos
-                                : nextDirectoryPos - (parentDirectoryPos == 0 ? 0 : parentDirectoryPos + 1))};
+                            ? std::string::npos
+                            : nextDirectoryPos - (parentDirectoryPos == 0 ? 0 : parentDirectoryPos + 1))};
 
             if (m_fsWrapper->exists(baseDir))
             {

--- a/src/shared_modules/file_helper/filesystem/src/filesystem_wrapper.cpp
+++ b/src/shared_modules/file_helper/filesystem/src/filesystem_wrapper.cpp
@@ -55,10 +55,12 @@ namespace file_system
     std::vector<std::filesystem::path> FileSystemWrapper::list_directory(const std::filesystem::path& path) const
     {
         std::vector<std::filesystem::path> result;
+
         for (const auto& entry : std::filesystem::directory_iterator(path))
         {
             result.push_back(entry.path());
         }
+
         return result;
     }
 

--- a/src/shared_modules/file_helper/filesystem/tests/mocks/mock_filesystem_utils.hpp
+++ b/src/shared_modules/file_helper/filesystem/tests/mocks/mock_filesystem_utils.hpp
@@ -4,9 +4,9 @@
 
 class MockFileSystemUtils : public IFileSystemUtils
 {
-public:
-    MOCK_METHOD(void,
-                expand_absolute_path,
-                (const std::string& path, std::deque<std::string>& output),
-                (const, override));
+    public:
+        MOCK_METHOD(void,
+                    expand_absolute_path,
+                    (const std::string& path, std::deque<std::string>& output),
+                    (const, override));
 };

--- a/src/shared_modules/file_helper/filesystem/tests/mocks/mock_filesystem_wrapper.hpp
+++ b/src/shared_modules/file_helper/filesystem/tests/mocks/mock_filesystem_wrapper.hpp
@@ -6,24 +6,24 @@
 
 class MockFileSystemWrapper : public IFileSystemWrapper
 {
-public:
-    MOCK_METHOD(bool, exists, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(bool, is_directory, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(bool, is_regular_file, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(bool, is_socket, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(bool, is_symlink, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(bool, is_absolute, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(std::filesystem::path, canonical, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(std::uintmax_t, remove_all, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(std::filesystem::path, temp_directory_path, (), (const, override));
-    MOCK_METHOD(bool, create_directories, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(std::vector<std::filesystem::path>,
-                list_directory,
-                (const std::filesystem::path& path),
-                (const, override));
-    MOCK_METHOD(void, rename, (const std::filesystem::path& from, const std::filesystem::path& to), (const, override));
-    MOCK_METHOD(bool, remove, (const std::filesystem::path& path), (const, override));
-    MOCK_METHOD(int, open, (const char* path, int flags, int mode), (const, override));
-    MOCK_METHOD(int, flock, (int fd, int operation), (const, override));
-    MOCK_METHOD(int, close, (int fd), (const, override));
+    public:
+        MOCK_METHOD(bool, exists, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(bool, is_directory, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(bool, is_regular_file, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(bool, is_socket, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(bool, is_symlink, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(bool, is_absolute, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(std::filesystem::path, canonical, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(std::uintmax_t, remove_all, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(std::filesystem::path, temp_directory_path, (), (const, override));
+        MOCK_METHOD(bool, create_directories, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(std::vector<std::filesystem::path>,
+                    list_directory,
+                    (const std::filesystem::path& path),
+                    (const, override));
+        MOCK_METHOD(void, rename, (const std::filesystem::path& from, const std::filesystem::path& to), (const, override));
+        MOCK_METHOD(bool, remove, (const std::filesystem::path& path), (const, override));
+        MOCK_METHOD(int, open, (const char* path, int flags, int mode), (const, override));
+        MOCK_METHOD(int, flock, (int fd, int operation), (const, override));
+        MOCK_METHOD(int, close, (int fd), (const, override));
 };


### PR DESCRIPTION

## Description

This PR adds changes so that the workflow uses RTR when running shared_modules/file_helper tests. 

## Proposed Changes

- Adaptation of workflow 5_testunit_shared_modules_file_helper.yml.
- Apply astyle formatting to file_helper.
- Coverage flags have been added to file_helper.

### Results and Evidence

WIP

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
