### PR TITLE
modify functions to remove false negatives

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -845,13 +845,13 @@ static void HandleCheckEvent(Eventinfo *lf,int *socket,cJSON *event) {
                             value = comp->valuestring;
                         } else if (cJSON_IsNumber(comp)) {
                             os_calloc(OS_SIZE_1024, sizeof(char), value);
-                        
+
                             if(comp->valuedouble == (double)comp->valueint) {
-                                snprintf(value, sizeof(value), "%d", comp->valueint);
+                                snprintf(value, OS_SIZE_1024, "%d", comp->valueint);
                             } else {
-                                snprintf(value, sizeof(value), "%lf", comp->valuedouble);
+                                snprintf(value, OS_SIZE_1024, "%lf", comp->valuedouble);
                             }
-                            
+
                             free_value = 1;
                         } else {
                             value = NULL;
@@ -1358,15 +1358,13 @@ static int CheckEventJSON(cJSON *event, cJSON **scan_id, cJSON **id, cJSON **nam
 
     } else {
 
-        if ((*id = cJSON_GetObjectItem(*check, "id")) == NULL)
-        {
+        if ((*id = cJSON_GetObjectItem(*check, "id")) == NULL) {
             merror("Malformed JSON: field 'id' not found.");
             return retval;
         }
 
         obj = *id;
-        if (!cJSON_IsNumber(obj))
-        {
+        if (!cJSON_IsNumber(obj)) {
             merror("Malformed JSON: field 'id' must be a number.");
             return retval;
         }
@@ -1591,7 +1589,7 @@ static void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *
     if(id && cJSON_IsNumber(id)) {
         char value[OS_SIZE_128];
 
-        if(id->valuedouble == (double)id->valueint){
+        if(id->valuedouble == (double)id->valueint) {
             snprintf(value, sizeof(value), "%d", id->valueint);
         } else {
             snprintf(value, sizeof(value), "%lf", id->valuedouble);
@@ -1625,20 +1623,15 @@ static void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *
             char *value = NULL;
             int free_value = 0;
 
-            if (cJSON_IsString(comp))
-            {
+            if (cJSON_IsString(comp)) {
                 value = comp->valuestring;
-            }
-            else if (cJSON_IsNumber(comp))
-            {
+            } else if (cJSON_IsNumber(comp)) {
                 os_calloc(OS_SIZE_1024, sizeof(char), value);
-                sprintf(value, "%g", comp->valuedouble);
+                snprintf(value, OS_SIZE_1024, "%g", comp->valuedouble);
                 free_value = 1;
-            }
-            else
-            {
+            } else {
                 mwarn("Unexpected type for compliance field: %s", comp->string);
-                value = NULL; // lo marcamos como inválido
+                value = NULL;
             }
 
             char compliance_key[OS_SIZE_1024];
@@ -1712,8 +1705,8 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
     if(scan_id) {
         char value[OS_SIZE_128];
 
-        if(cJSON_IsNumber(scan_id)){
-            if(scan_id->valuedouble == (double)scan_id->valueint){
+        if(cJSON_IsNumber(scan_id)) {
+            if(scan_id->valuedouble == (double)scan_id->valueint) {
                 snprintf(value, sizeof(value), "%d", scan_id->valueint);
             } else {
                 snprintf(value, sizeof(value), "%lf", scan_id->valuedouble);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1714,9 +1714,9 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
 
         if(cJSON_IsNumber(scan_id)){
             if(scan_id->valuedouble == (double)scan_id->valueint){
-                sprintf(value, "%d", scan_id->valueint);
+                snprintf(value, sizeof(value), "%d", scan_id->valueint);
             } else {
-                sprintf(value, "%lf", scan_id->valuedouble);
+                snprintf(value, sizeof(value), "%lf", scan_id->valuedouble);
             }
         } else {
             mdebug1("Unexpected 'sca.scan_id' type: %d.", scan_id->type);

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1318,8 +1318,7 @@ static int CheckEventJSON(cJSON *event, cJSON **scan_id, cJSON **id, cJSON **nam
     int retval = 1;
     cJSON *obj;
 
-    *scan_id = cJSON_GetObjectItem(event, "id");
-    if (*scan_id == NULL) {
+    if (*scan_id = cJSON_GetObjectItem(event, "id"), !*scan_id) {
         merror("Malformed JSON: field 'id' not found.");
         return retval;
     }
@@ -1627,10 +1626,16 @@ static void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *
                 value = comp->valuestring;
             } else if (cJSON_IsNumber(comp)) {
                 os_calloc(OS_SIZE_1024, sizeof(char), value);
-                snprintf(value, OS_SIZE_1024, "%g", comp->valuedouble);
+
+                if (comp->valuedouble == (double)(comp->valueint)) {
+                    snprintf(value, OS_SIZE_1024, "%d", comp->valueint);
+                } else {
+                    snprintf(value, OS_SIZE_1024, "%lf", comp->valuedouble);
+                }
+
                 free_value = 1;
             } else {
-                mwarn("Unexpected type for compliance field: %s", comp->string);
+                mwarn("Unexpected type for compliance field: %s. Expected string or number.", comp->string);
                 value = NULL;
             }
 

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2373,7 +2373,7 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
                 return OS_INVALID;
             }
 
-            if (!id->valueint) {
+            if (!cJSON_IsString(id)) {
                 mdebug1("Malformed JSON: field 'id' must be a string");
                 cJSON_Delete(event);
                 return OS_INVALID;

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -2373,8 +2373,8 @@ int wdb_parse_sca(wdb_t * wdb, char * input, char * output) {
                 return OS_INVALID;
             }
 
-            if (!cJSON_IsString(id)) {
-                mdebug1("Malformed JSON: field 'id' must be a string");
+            if (!cJSON_IsNumber(id)) {
+                mdebug1("Malformed JSON: field 'id' must be a number");
                 cJSON_Delete(event);
                 return OS_INVALID;
             }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2868,7 +2868,7 @@ static int wm_sca_check_hash(OSHash * const cis_db_hash, const char * const resu
         return 0;
     }
     if (cJSON_IsNumber(pm_id)) {
-        sprintf(id_hashed, "%g", pm_id->valuedouble);
+        snprintf(id_hashed, sizeof(id_hashed), "%g", pm_id->valuedouble);
     } else {
         return 0;
     }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2864,13 +2864,14 @@ static int wm_sca_check_hash(OSHash * const cis_db_hash, const char * const resu
     cJSON *pm_id = cJSON_GetObjectItem(check, "id");
     int alert = 1;
 
-    if (!pm_id) {
+    if (!pm_id || !cJSON_IsNumber(pm_id)) {
         return 0;
     }
-    if (cJSON_IsNumber(pm_id)) {
-        snprintf(id_hashed, sizeof(id_hashed), "%g", pm_id->valuedouble);
+
+    if(pm_id->valuedouble == (double)pm_id->valueint) {
+        snprintf(id_hashed, sizeof(id_hashed), "%d", pm_id->valueint);
     } else {
-        return 0;
+        snprintf(id_hashed, sizeof(id_hashed), "%lf", pm_id->valuedouble);
     }
 
     hashed_result = OSHash_Get(cis_db_hash, id_hashed);

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -983,7 +983,7 @@ static int wm_sca_do_scan(cJSON * checks,
             snprintf(_check_id_str, sizeof(_check_id_str), "Requirements check");
         } else {
             const cJSON * const c_id = cJSON_GetObjectItem(check, "id");
-            if (!c_id || !c_id->valueint) {
+            if (!c_id || !cJSON_IsNumber(c_id)) {
                 merror("Skipping check. Check ID is invalid. Offending check number: %d", check_count);
                 ret_val = 1;
                 continue;
@@ -2645,7 +2645,7 @@ static cJSON *wm_sca_build_event(const cJSON * const check, const cJSON * const 
         goto error;
     }
 
-    if(!pm_id->valueint) {
+    if(!cJSON_IsNumber(pm_id)) {
         mdebug1("Field 'id' must be a number.");
         goto error;
     }
@@ -2872,15 +2872,14 @@ static int wm_sca_check_hash(OSHash * const cis_db_hash, const char * const resu
     cJSON *pm_id = cJSON_GetObjectItem(check, "id");
     int alert = 1;
 
-    if(!pm_id) {
+    if (!pm_id) {
         return 0;
     }
-
-    if(!pm_id->valueint) {
+    if (cJSON_IsNumber(pm_id)) {
+        sprintf(id_hashed, "%g", pm_id->valuedouble);
+    } else {
         return 0;
     }
-
-    sprintf(id_hashed, "%d", pm_id->valueint);
 
     hashed_result = OSHash_Get(cis_db_hash, id_hashed);
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -628,16 +628,8 @@ static int wm_sca_check_policy(const cJSON * const policy, const cJSON * const c
             return 1;
         }
 
-        if (!cJSON_IsNumber(check_id))
-        {
+        if (!cJSON_IsNumber(check_id)) {
             mwarn("Invalid check ID type: must be a number.");
-            free(read_id);
-            return 1;
-        }
-
-        if (check_id->valueint <= 0) {
-            // Invalid ID
-            mwarn("Invalid check ID: %d", check_id->valueint);
             free(read_id);
             return 1;
         }

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -628,6 +628,13 @@ static int wm_sca_check_policy(const cJSON * const policy, const cJSON * const c
             return 1;
         }
 
+        if (!cJSON_IsNumber(check_id))
+        {
+            mwarn("Invalid check ID type: must be a number.");
+            free(read_id);
+            return 1;
+        }
+
         if (check_id->valueint <= 0) {
             // Invalid ID
             mwarn("Invalid check ID: %d", check_id->valueint);


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
|Related issue|
|---|
|Closes #16669 |

Hi team.
This PR addresses some potential false negatives that may occur when validating specific cJSON fields.
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes
- src/wazuh_modules/wm_sca.c
- src/wazuh_db/wdb_parser.c
- src/analysisd/decoders/security_configuration_assessment.c


The modifications consisted of updating each `if` condition by replacing the check `if (id->valueint)` with a validation using the `cJSON_IsNumber` function.  
This change ensures that a value of `0` is now considered valid for an ID, instead of being ignored.


<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence
In branch **4.14.1**, I successfully reproduced the issue.  
To simulate the problem, I installed both a manager and an agent, then modified a policy in: `/var/ossec/ruleset/sca/cis_ubuntu24-04.yml` 
by assigning it an ID of `0`.

```
policy:
  id: "cis_ubuntu24-04"
  file: "cis_ubuntu24-04.yml"
  name: "CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0."
  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Ubuntu Linux 24.04 LTS based on CIS benchmark for Ubuntu Linux 24.04 LTS."
  references:
    - https://www.cisecurity.org/cis-benchmarks/

requirements:
  title: "Check Ubuntu version."
  description: "Requirements for running the SCA scan against Ubuntu Linux 24.04 LTS"
  condition: all
  rules:
      - "f:/etc/os-release -> r:Ubuntu 24.04"
      - "f:/proc/sys/kernel/ostype -> Linux"

# variables:

checks:

  # 1.1.1.1 Ensure cramfs kernel module is not available (Automated)
   - id: 0
     title: "Ensure mounting of cramfs filesystems is disabled."
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
     remediation: "Run the following script to unload and disable the cramfs module: - IF - the cramfs kernel module is available in ANY installed kernel: - Create a file ending in .conf with install cramfs /bin/false in the /etc/modprobe.d/ directory - Create a file ending in .conf with blacklist cramfs in the /etc/modprobe.d/ directory - Run modprobe -r cramfs 2>/dev/null; rmmod cramfs 2>/dev/null to remove cramfs from the kernel - IF - the cramfs kernel module is not available on the system, or pre-compiled into the kernel, no remediation is necessary #!/usr/bin/env bash."
     compliance:
       - cis: ["1.1.1.1"]
       - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
       - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
       - mitre_mitigations: ["M1050"]
       - mitre_tactics: ["TA0005"]
       - mitre_techniques: ["T1005"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
     condition: any
     rules:
      - "c:modprobe -n -v cramfs -> r:install /bin/false|install /bin/true|Module cramfs not found"
      - "not c:lsmod -> r:cramfs"
      - 'd:/etc/modprobe.d/ -> r:\.*.conf -> r:^blacklist\s+cramfs'
```

Upon reviewing the logs in `/var/ossec/logs/ossec.log`, the following warning was observed:
`2025/10/01 09:53:13 sca: WARNING: Invalid check ID: 0`


This confirmed that the problem could be reproduced in version **4.14.1**.

After applying the proposed changes, I repeated the same test (installing a manager and an agent and modifying the Ubuntu 24.04 policy with an ID of `0`).  

In this case, the warning did not reappear, which validates that the issue has been resolved.
```
2025/10/02 08:54:28 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2025/10/02 08:54:28 sca: INFO: Security Configuration Assessment scan finished. Duration: 7 seconds.
2025/10/02 08:55:21 sca: INFO: Starting Security Configuration Assessment scan.
2025/10/02 08:55:21 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2025/10/02 08:55:28 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2025/10/02 08:55:28 sca: INFO: Security Configuration Assessment scan finished. Duration: 7 seconds.

```
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues



