### PR TITLE
Fix logging C++ mechanism to avoid heap allocations

### DIFF
--- a/src/shared_modules/content_manager/include/contentManager.hpp
+++ b/src/shared_modules/content_manager/include/contentManager.hpp
@@ -41,13 +41,9 @@ public:
      * @param logFunction Log function.
      *
      */
-    void start(const std::function<void(const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        va_list)>& logFunction);
+    void
+    start(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+              logFunction);
 
     /**
      * @brief Stop module facade.

--- a/src/shared_modules/content_manager/src/contentModule.cpp
+++ b/src/shared_modules/content_manager/src/contentModule.cpp
@@ -16,8 +16,7 @@
 #include <utility>
 
 void ContentModule::start(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction)
 {
     ContentModuleFacade::instance().start(logFunction);

--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -12,10 +12,9 @@
 #include "contentModuleFacade.hpp"
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 void ContentModuleFacade::start(
     const std::function<void(

--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -17,8 +17,7 @@ namespace Log
 }; // namespace Log
 
 void ContentModuleFacade::start(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction)
 {
     Log::assignLogFunction(logFunction);

--- a/src/shared_modules/content_manager/src/contentModuleFacade.hpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.hpp
@@ -33,13 +33,9 @@ public:
      *
      * @param logFunction Log function.
      */
-    void start(const std::function<void(const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        va_list)>& logFunction);
+    void
+    start(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+              logFunction);
 
     /**
      * @brief Clear providers.

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -19,10 +19,9 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 /*
  * @brief Tests the instantiation of the ActionOrchestratorTest class

--- a/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/zipDecompressor_test.cpp
@@ -19,10 +19,9 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 // Folder containing all the input files.
 const auto INPUT_FILES_DIR {std::filesystem::current_path() / "input_files" / "zipDecompressor"};

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -114,10 +114,9 @@ void logFunction(const int logLevel,
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 /**
  * @brief Performs a PUT query to the on-demand manager, requesting an offset update.

--- a/src/shared_modules/content_manager/testtool/main.cpp
+++ b/src/shared_modules/content_manager/testtool/main.cpp
@@ -65,19 +65,19 @@ static const auto OFFSET_UPDATE_VALUE {100000};
  * @param message Message to log.
  */
 void logFunction(const int logLevel,
-                 const std::string& tag,
-                 const std::string& file,
+                 const char* tag,
+                 const char* file,
                  const int line,
-                 const std::string& func,
-                 const std::string& message,
+                 const char* func,
+                 const char* message,
                  va_list args)
 {
-    auto pos {file.find_last_of('/')};
+    auto pos {std::string(file).find_last_of('/')};
     if (pos != std::string::npos)
     {
         pos++;
     }
-    const auto fileName {file.substr(pos, file.size() - pos)};
+    const auto fileName {std::string(file).substr(pos, std::string(file).size() - pos)};
 
     // Set log level tag.
     static const std::map<int, std::string> LOG_LEVEL_TAGS {{LOGLEVEL_DEBUG_VERBOSE, "DEBUG_VERBOSE"},
@@ -89,7 +89,7 @@ void logFunction(const int logLevel,
     const auto levelTag {"[" + LOG_LEVEL_TAGS.at(logLevel) + "]"};
 
     char formattedStr[OS_MAXSTR] = {0};
-    vsnprintf(formattedStr, OS_MAXSTR, message.c_str(), args);
+    vsnprintf(formattedStr, OS_MAXSTR, message, args);
 
     if (logLevel == LOGLEVEL_ERROR || logLevel == LOGLEVEL_CRITICAL)
     {

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -107,14 +107,10 @@ class EXPORTED IndexerConnector final
      * @param logFunction Callback function to be called when trying to log a message.
      * @param config Indexer configuration, including database_path and servers.
      */
-    void preInitialization(const std::function<void(const int,
-                                                    const std::string&,
-                                                    const std::string&,
-                                                    const int,
-                                                    const std::string&,
-                                                    const std::string&,
-                                                    va_list)>& logFunction,
-                           const nlohmann::json& config);
+    void preInitialization(
+        const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+            logFunction,
+        const nlohmann::json& config);
 
     /*
      * @brief Send bulk reactive, this method is used to send a bulk request to the indexer.
@@ -139,18 +135,14 @@ public:
      * @param logFunction Callback function to be called when trying to log a message.
      * @param timeout Server selector time interval.
      */
-    explicit IndexerConnector(const nlohmann::json& config,
-                              const std::string& templatePath,
-                              const std::string& updateMappingsPath,
-                              bool useSeekDelete = true,
-                              const std::function<void(const int,
-                                                       const std::string&,
-                                                       const std::string&,
-                                                       const int,
-                                                       const std::string&,
-                                                       const std::string&,
-                                                       va_list)>& logFunction = {},
-                              const uint32_t& timeout = DEFAULT_INTERVAL);
+    explicit IndexerConnector(
+        const nlohmann::json& config,
+        const std::string& templatePath,
+        const std::string& updateMappingsPath,
+        bool useSeekDelete = true,
+        const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+            logFunction = {},
+        const uint32_t& timeout = DEFAULT_INTERVAL);
 
     /**
      * @brief Class constructor that initializes the publisher in a simplified state that doesn't index the data and
@@ -160,15 +152,11 @@ public:
      * @param useSeekDelete If true, the connector will index the seek method to delete operation.
      * @param logFunction Callback function to be called when trying to log a message.
      */
-    explicit IndexerConnector(const nlohmann::json& config,
-                              bool useSeekDelete = true,
-                              const std::function<void(const int,
-                                                       const std::string&,
-                                                       const std::string&,
-                                                       const int,
-                                                       const std::string&,
-                                                       const std::string&,
-                                                       va_list)>& logFunction = {});
+    explicit IndexerConnector(
+        const nlohmann::json& config,
+        bool useSeekDelete = true,
+        const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+            logFunction = {});
 
     ~IndexerConnector();
 

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -39,10 +39,9 @@ constexpr auto RECURSIVE_MAX_DEPTH {20};
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 constexpr auto MAX_WAIT_TIME {60};
 constexpr auto START_TIME {1};
 constexpr auto DOUBLE_FACTOR {2};
@@ -498,8 +497,7 @@ void IndexerConnector::initialize(const nlohmann::json& templateData,
 }
 
 void IndexerConnector::preInitialization(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     const nlohmann::json& config)
 {
@@ -525,8 +523,7 @@ IndexerConnector::IndexerConnector(
     const std::string& templatePath,
     const std::string& updateMappingsPath,
     const bool useSeekDelete,
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     const uint32_t& timeout)
     : m_useSeekDelete(useSeekDelete)
@@ -858,8 +855,7 @@ IndexerConnector::IndexerConnector(
 IndexerConnector::IndexerConnector(
     const nlohmann::json& config,
     const bool useSeekDelete,
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction)
     : m_useSeekDelete(useSeekDelete)
 {

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -27,8 +27,7 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 }; // namespace Log
 

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -21,8 +21,7 @@ constexpr auto SERVER_SELECTOR_HEALTH_CHECK_INTERVAL {5u};
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 }; // namespace Log
 

--- a/src/shared_modules/indexer_connector/testtool/main.cpp
+++ b/src/shared_modules/indexer_connector/testtool/main.cpp
@@ -11,8 +11,7 @@ static std::mt19937 ENG(RD());
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 }; // namespace Log
 

--- a/src/shared_modules/keystore/src/main.cpp
+++ b/src/shared_modules/keystore/src/main.cpp
@@ -20,10 +20,9 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 int main(int argc, char* argv[])
 {

--- a/src/shared_modules/keystore/src/main.cpp
+++ b/src/shared_modules/keystore/src/main.cpp
@@ -16,7 +16,6 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
-#include <fstream>
 
 namespace Log
 {

--- a/src/shared_modules/keystore/tests/component/main.cpp
+++ b/src/shared_modules/keystore/tests/component/main.cpp
@@ -14,10 +14,9 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 int main(int argc, char** argv)
 {

--- a/src/shared_modules/keystore/testtool/main.cpp
+++ b/src/shared_modules/keystore/testtool/main.cpp
@@ -16,10 +16,9 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 int main(int argc, char* argv[])
 {

--- a/src/shared_modules/rsync/include/rsync.hpp
+++ b/src/shared_modules/rsync/include/rsync.hpp
@@ -50,7 +50,7 @@ class EXPORTED RemoteSync
          *
          * @param logFunction Log function.
          */
-        static void initializeFullLogFunction(const std::function<void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>& logFunction);
+        static void initializeFullLogFunction(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>& logFunction);
 
         /**
          * @brief Remote sync initializes the instance.

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -19,8 +19,7 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
     GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/shared_modules/rsync/src/rsync.cpp
+++ b/src/shared_modules/rsync/src/rsync.cpp
@@ -52,14 +52,14 @@ EXPORTED void rsync_initialize_full_log_function(full_log_fnc_t logFunction)
 {
     RemoteSync::initializeFullLogFunction(
         [logFunction](const int logLevel,
-                      const std::string & tag,
-                      const std::string & file,
+                      const char* tag,
+                      const char* file,
                       const int line,
-                      const std::string & func,
-                      const std::string & logMessage,
+                      const char* func,
+                      const char* logMessage,
                       va_list args)
     {
-        logFunction(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str(), args);
+        logFunction(logLevel, tag, file, line, func, logMessage, args);
     });
 }
 
@@ -242,9 +242,7 @@ void RemoteSync::initialize(std::function<void(const std::string&)> logFunction)
 }
 
 void RemoteSync::initializeFullLogFunction(
-    const std::function <
-    void(const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list) > &
-    logFunction)
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>& logFunction)
 {
     Log::assignLogFunction(logFunction);
 }

--- a/src/shared_modules/utils/benchmark/rocksdbqueue_test.cpp
+++ b/src/shared_modules/utils/benchmark/rocksdbqueue_test.cpp
@@ -7,10 +7,9 @@ constexpr auto TEST_DB = "test.db";
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 static void pushBenchmark(benchmark::State& state)
 {

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -54,8 +54,7 @@ namespace Log
 // Remove visibility of this extern function
 #pragma GCC visibility push(hidden)
 
-    extern std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    extern std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 #pragma GCC visibility pop
 
@@ -67,13 +66,10 @@ namespace Log
      *
      * @param logFunction callback function that is going to be called on every message logging operation.
      */
-    static void assignLogFunction(const std::function<void(const int,
-                                                           const std::string&,
-                                                           const std::string&,
-                                                           const int,
-                                                           const std::string&,
-                                                           const std::string&,
-                                                           va_list)>& logFunction)
+    static void assignLogFunction(
+        const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+            logFunction)
+
     {
         if (!GLOBAL_LOG_FUNCTION)
         {

--- a/src/shared_modules/utils/tests/loggerHelper_test.cpp
+++ b/src/shared_modules/utils/tests/loggerHelper_test.cpp
@@ -16,8 +16,7 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 
@@ -41,8 +40,8 @@ void debugVerboseTestFunction(
     char buffer[MAXLEN];
     vsnprintf(buffer, MAXLEN, msg, args);
 
-    ssOutput << "debug_verbose"
-             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
+    ssOutput << "debug_verbose" << " " << tag << " " << file << " " << line << " " << func << " " << buffer
+             << std::endl;
 }
 
 void debugTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
@@ -50,8 +49,7 @@ void debugTestFunction(const char* tag, const char* file, int line, const char* 
     char buffer[MAXLEN];
     vsnprintf(buffer, MAXLEN, msg, args);
 
-    ssOutput << "debug"
-             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
+    ssOutput << "debug" << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
 void infoTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
@@ -59,8 +57,7 @@ void infoTestFunction(const char* tag, const char* file, int line, const char* f
     char buffer[MAXLEN];
     vsnprintf(buffer, MAXLEN, msg, args);
 
-    ssOutput << "info"
-             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
+    ssOutput << "info" << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
 void warningTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
@@ -68,8 +65,7 @@ void warningTestFunction(const char* tag, const char* file, int line, const char
     char buffer[MAXLEN];
     vsnprintf(buffer, MAXLEN, msg, args);
 
-    ssOutput << "warning"
-             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
+    ssOutput << "warning" << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
 void errorTestFunction(const char* tag, const char* file, int line, const char* func, const char* msg, va_list args)
@@ -77,8 +73,7 @@ void errorTestFunction(const char* tag, const char* file, int line, const char* 
     char buffer[MAXLEN];
     vsnprintf(buffer, MAXLEN, msg, args);
 
-    ssOutput << "error"
-             << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
+    ssOutput << "error" << " " << tag << " " << file << " " << line << " " << func << " " << buffer << std::endl;
 }
 
 void logFunctionWrapper(

--- a/src/shared_modules/utils/tests/loggerHelper_test.h
+++ b/src/shared_modules/utils/tests/loggerHelper_test.h
@@ -35,13 +35,13 @@ protected:
     {
         Log::assignLogFunction(
             [](const int logLevel,
-               const std::string& tag,
-               const std::string& file,
+               const char* tag,
+               const char* file,
                const int line,
-               const std::string& func,
-               const std::string& logMessage,
+               const char* func,
+               const char* logMessage,
                va_list args)
-            { logFunctionWrapper(logLevel, tag.c_str(), file.c_str(), line, func.c_str(), logMessage.c_str(), args); });
+            { logFunctionWrapper(logLevel, tag, file, line, func, logMessage, args); });
     }
 
     virtual void SetUp()

--- a/src/wazuh_modules/inventory_harvester/include/inventoryHarvester.hpp
+++ b/src/wazuh_modules/inventory_harvester/include/inventoryHarvester.hpp
@@ -36,14 +36,10 @@ public:
      * @param logFunction Log function to be used.
      * @param configuration Harvester configuration.
      */
-    void start(const std::function<void(const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        va_list)>& logFunction,
-               const nlohmann::json& configuration) const;
+    void
+    start(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+              logFunction,
+          const nlohmann::json& configuration) const;
     /**
      * @brief Stops Inventory scanner.
      *

--- a/src/wazuh_modules/inventory_harvester/src/inventoryHarvester.cpp
+++ b/src/wazuh_modules/inventory_harvester/src/inventoryHarvester.cpp
@@ -23,8 +23,7 @@ namespace Log
 }; // namespace Log
 
 void InventoryHarvester::start(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     const nlohmann::json& configuration) const
 {

--- a/src/wazuh_modules/inventory_harvester/src/inventoryHarvester.cpp
+++ b/src/wazuh_modules/inventory_harvester/src/inventoryHarvester.cpp
@@ -18,10 +18,9 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log
 
 void InventoryHarvester::start(
     const std::function<void(

--- a/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.cpp
+++ b/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.cpp
@@ -302,8 +302,7 @@ void InventoryHarvesterFacade::initSystemEventDispatcher() const
 
 // LCOV_EXCL_START
 void InventoryHarvesterFacade::start(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     const nlohmann::json& configuration)
 {

--- a/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/inventoryHarvesterFacade.hpp
@@ -41,14 +41,10 @@ public:
      * @param logFunction Log function.
      * @param configuration Facade configuration.
      */
-    void start(const std::function<void(const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        va_list)>& logFunction,
-               const nlohmann::json& configuration);
+    void
+    start(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+              logFunction,
+          const nlohmann::json& configuration);
 
     /**
      * @brief Stops facade.

--- a/src/wazuh_modules/inventory_harvester/tests/component/logger.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/component/logger.cpp
@@ -14,7 +14,6 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log

--- a/src/wazuh_modules/inventory_harvester/tests/unit/logger.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/logger.cpp
@@ -14,7 +14,6 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
-};
+}; // namespace Log

--- a/src/wazuh_modules/inventory_harvester/testtool/main.cpp
+++ b/src/wazuh_modules/inventory_harvester/testtool/main.cpp
@@ -76,14 +76,14 @@ int main(const int argc, const char* argv[])
         }
 
         const auto logFunction = [&logFile](const int logLevel,
-                                            const std::string& tag,
+                                            const char* tag,
                                             std::string_view file,
                                             const int line,
-                                            const std::string& func,
-                                            const std::string& message,
+                                            const char* func,
+                                            const char* message,
                                             va_list args)
         {
-            auto pos = file.find_last_of('/');
+            auto pos = std::string(file).find_last_of('/');
             if (pos != std::string::npos)
             {
                 pos++;
@@ -94,7 +94,7 @@ int main(const int argc, const char* argv[])
             }
             std::string_view fileName = file.substr(pos, file.size() - pos);
             char formattedStr[MAX_LEN] = {0};
-            vsnprintf(formattedStr, MAX_LEN, message.c_str(), args);
+            vsnprintf(formattedStr, MAX_LEN, message, args);
 
             std::lock_guard lock(G_MUTEX);
             // Create a timestamp for the log

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
@@ -53,17 +53,13 @@ public:
      * @param initContentUpdater If true, the content updater will be initialized.
      * feed manager.
      */
-    void start(const std::function<void(const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        va_list)>& logFunction,
-               const nlohmann::json& configuration,
-               bool noWaitToStop = true,
-               bool reloadGlobalMapsStartup = true,
-               bool initContentUpdater = true);
+    void
+    start(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+              logFunction,
+          const nlohmann::json& configuration,
+          bool noWaitToStop = true,
+          bool reloadGlobalMapsStartup = true,
+          bool initContentUpdater = true);
     /**
      * @brief Stops vulnerability scanner.
      *

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp
@@ -23,8 +23,7 @@ using ReportDispatcher = ThreadEventDispatcher<std::string, std::function<void(s
 
 namespace Log
 {
-    inline std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    inline std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
@@ -19,8 +19,7 @@
 // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
 // LCOV_EXCL_START
 void VulnerabilityScanner::start(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     const nlohmann::json& configuration,
     const bool noWaitToStop,

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -469,8 +469,7 @@ void VulnerabilityScannerFacade::handlePolicyChanges() const
 
 // LCOV_EXCL_START
 void VulnerabilityScannerFacade::start(
-    const std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>&
+    const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     const nlohmann::json& configuration,
     const bool noWaitToStop,

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -41,17 +41,13 @@ public:
      * @param reloadGlobalMapsStartup If true, the global maps will be reloaded at startup of the database feed manager.
      * @param initContentUpdater If true, the content updater will be initialized.
      */
-    void start(const std::function<void(const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        const int,
-                                        const std::string&,
-                                        const std::string&,
-                                        va_list)>& logFunction,
-               const nlohmann::json& configuration,
-               bool noWaitToStop = true,
-               bool reloadGlobalMapsStartup = true,
-               bool initContentUpdater = true);
+    void
+    start(const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
+              logFunction,
+          const nlohmann::json& configuration,
+          bool noWaitToStop = true,
+          bool reloadGlobalMapsStartup = true,
+          bool initContentUpdater = true);
 
     /**
      * @brief Stops facade.

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -202,15 +202,15 @@ int main(const int argc, const char* argv[])
         // LOGLEVEL_INFO, tag, sourceFile.file, sourceFile.line, sourceFile.func, formattedStr
         Log::assignLogFunction(
             [](const int,
-               const std::string& tag,
-               const std::string& file,
+               const char* tag,
+               const char* file,
                const int line,
-               const std::string&,
-               const std::string& str,
+               const char* /*func*/,
+               const char* str,
                va_list args)
             {
                 char formattedStr[MAXLEN] = {0};
-                vsnprintf(formattedStr, MAXLEN, str.c_str(), args);
+                vsnprintf(formattedStr, MAXLEN, str, args);
                 std::cout << tag << "->" << file << ":" << line << " " << formattedStr << std::endl;
             });
         // Reset required directories

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -20,8 +20,7 @@
 
 namespace Log
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
 }; // namespace Log
 

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -318,21 +318,21 @@ int main(const int argc, const char* argv[])
         const auto getOnlyDownloadContent = cmdLineArgs.getOnlyDownloadContent();
         std::cout << "Only download content flag: " << getOnlyDownloadContent << std::endl;
         const auto logFunction = [&logFile, &getOnlyDownloadContent, &contentProcessed](const int logLevel,
-                                                                                        const std::string& tag,
-                                                                                        const std::string& file,
+                                                                                        const char* tag,
+                                                                                        const char* file,
                                                                                         const int line,
-                                                                                        const std::string& func,
-                                                                                        const std::string& message,
+                                                                                        const char* func,
+                                                                                        const char* message,
                                                                                         va_list args)
         {
-            auto pos = file.find_last_of('/');
+            auto pos = std::string(file).find_last_of('/');
             if (pos != std::string::npos)
             {
                 pos++;
             }
-            std::string fileName = file.substr(pos, file.size() - pos);
+            std::string fileName = std::string(file).substr(pos, std::string(file).size() - pos);
             char formattedStr[MAX_LEN] = {0};
-            vsnprintf(formattedStr, MAX_LEN, message.c_str(), args);
+            vsnprintf(formattedStr, MAX_LEN, message, args);
 
             std::lock_guard<std::mutex> lock(G_MUTEX);
             if (logLevel != LOG_ERROR)


### PR DESCRIPTION
# Description  
Closes #31914   

This PR refactors the logger logic to improve performance, memory and scalability. 

---

## Proposed Changes  

Change the `const char* msg` parameter (3rd argument) is not longer converted into a `std::string` during the call to `GLOBAL_LOG_FUNCTION`.  

This conversion can trigger **unnecessary memory allocations** when the message size exceeds the **SSO (Small String Optimization)** threshold (~16–21 bytes, depending on the standard library implementation)

---

## Results and Evidence  
- Benchmarking

```console
Running ./src/build/shared_modules/utils/benchmark/utils_benchmark_test
Run on (16 X 4700 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1280 KiB (x8)
  L3 Unified 24576 KiB (x1)
Load Average: 3.18, 2.85, 2.23
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
---------------------------------------------------------
Benchmark               Time             CPU   Iterations
---------------------------------------------------------
BM_Log_CString       45.7 ns         44.8 ns     13584149
BM_Log_String         160 ns          160 ns      4234197
```

---

## Tests and Validation  

### Automated Tests  
- [ ] Unit tests updated/added where necessary.  
- [ ] Integration tests reviewed for feature disablement.  

### Manual Tests  
- [x] Compilation without warnings (Linux).  
- [x] Memory checks (Valgrind / ASAN).  

---

## Artifacts Affected  
- [ ] Configurations.  
- [ ] Documentation.  

---

## Review Checklist  
- [ ] Code reviewed (correctness, clarity).  
- [ ] Security implications reviewed.  
- [ ] Performance validated.  
- [ ] Documentation updated (marking feature disabled).  
- [ ] CI/CD pipeline green.  