### PR TITLE
Add gcc version check to macOS generation package script

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -281,9 +281,24 @@ function install_deps() {
 
     echo "Installing build dependencies for $(uname -m) architecture."
     if [ "$(uname -m)" = "arm64" ]; then
-        brew install gcc binutils autoconf automake libtool cmake
+        brew install binutils autoconf automake libtool cmake
     else
         brew install cmake
+    fi
+
+    echo "Checking required gcc version (11)."
+    if brew list --versions gcc >/dev/null 2>&1; then
+        GCC_VER="$(brew list --versions gcc | awk '{print $2}')"
+        GCC_MAJOR="${GCC_VER%%.*}"
+        if [ "${GCC_MAJOR:-0}" -ge 11 ]; then
+            echo "Found gcc installed version ${GCC_VER} >= 11. Nothing to do."
+        else
+            echo "Found gcc installed version ${GCC_VER} < 11. Upgrading."
+            brew upgrade gcc
+        fi
+    else
+        echo "No gcc found. Installing."
+        brew install gcc
     fi
     exit 0
 }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

In this PR, we are going to include a gcc version check in the macOS package generation script. This will prevent unwanted gcc installations or updates, as we have found that this can involve the complete compilation of gcc, which takes too long, so we want to avoid it if it is not strictly necessary.

## Proposed Changes

We use `brew list --versions gcc` to extract the version and compare it with the current minimum requirement (11).

### Results and Evidence

```
vagrant@idr-3094-ventura-sign-2611 ~ % bash wazuh/packages/macos/generate_wazuh_packages.sh -i
Munkipkg already installed installed.
Installing build dependencies for arm64 architecture.
Warning: Calling conflicts_with formula: is deprecated! There is no replacement.
Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake or specify the `--cask` flag. To silence this message, use the `--formula` flag.
Warning: binutils 2.43.1 is already installed and up-to-date.
To reinstall 2.43.1, run:
  brew reinstall binutils
Warning: autoconf 2.72 is already installed and up-to-date.
To reinstall 2.72, run:
  brew reinstall autoconf
Warning: automake 1.17 is already installed and up-to-date.
To reinstall 1.17, run:
  brew reinstall automake
Warning: libtool 2.5.4 is already installed and up-to-date.
To reinstall 2.5.4, run:
  brew reinstall libtool
Warning: cmake 3.31.2 is already installed and up-to-date.
To reinstall 3.31.2, run:
  brew reinstall cmake
Checking required gcc version (11).
Found gcc installed version 14.2.0_1 >= 11. Nothing to do.
```

# Testing WFs executions
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/17941911922/job/51020346333 🟢 
```
Checking required gcc version (11).
Found gcc installed version 14.2.0_1 >= 11. Nothing to do.
```

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
