### PR TITLE
Add user as an alias for the static field dstuser

### DIFF
--- a/ruleset/testing/ruleset/test_rules.xml
+++ b/ruleset/testing/ruleset/test_rules.xml
@@ -519,4 +519,10 @@
   <description>Traffic Denied (group level-2)</description>
 </rule>
 
+<!-- user is considered an alias for the static user field (dstuser). -->
+<rule id="999286" level="10">
+  <user>root</user>
+  <description>Root user detected (static user field: dstuser)</description>
+</rule>
+
 </group>

--- a/ruleset/testing/tests/user.ini
+++ b/ruleset/testing/tests/user.ini
@@ -1,0 +1,5 @@
+[User is considered an alias for the static user field]
+log 1 pass = { "user": "root" }
+rule = 999286
+alert = 10
+decoder = json


### PR DESCRIPTION
## Description

This PR introduces a fix for a bug that occurs when an event is processed by the JSON plugin and contains a "user" key. This key should be an alias for "dstuser," which is a static field, but it's being mapped as a dynamic field, causing the rule to fail.

Closes #31606


## Proposed Changes
We added logic to treat "user" as an alias for "dstuser," and to give "dstuser" priority if both parameters are present. The test was also added to the ruleset.

### Results and Evidence

```
{"user":"root"}
2025-09-24 13:55:57,914 wazuh_logtest[INFO] 
2025-09-24 13:55:57,915 wazuh_logtest[DEBUG] Request: {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location": "stdin", "log_format": "syslog", "event": "{\"user\":\"root\"}"}}

2025-09-24 13:55:59,039 wazuh_logtest[DEBUG] Reply: {"error":0,"data":{"messages":["INFO: (7202): Session initialized with token 'cf5521e1'"],"token":"cf5521e1","output":{"timestamp":"2025-09-24T13:55:59.038+0000","rule":{"level":10,"description":"test user alias","id":"100002","firedtimes":1,"mail":false,"groups":["local","syslog","sshd"]},"agent":{"id":"000","name":"ca37659e68c4"},"manager":{"name":"ca37659e68c4"},"id":"1758722159.831171","full_log":"{\"user\":\"root\"}","decoder":{"name":"json"},"data":{"dstuser":"root"},"location":"stdin"},"alert":true,"codemsg":0}}

2025-09-24 13:55:59,039 wazuh_logtest[DEBUG] {
  "messages": [
    "INFO: (7202): Session initialized with token 'cf5521e1'"
  ],
  "token": "cf5521e1",
  "output": {
    "timestamp": "2025-09-24T13:55:59.038+0000",
    "rule": {
      "level": 10,
      "description": "test user alias",
      "id": "100002",
      "firedtimes": 1,
      "mail": false,
      "groups": [
        "local",
        "syslog",
        "sshd"
      ]
    },
    "agent": {
      "id": "000",
      "name": "ca37659e68c4"
    },
    "manager": {
      "name": "ca37659e68c4"
    },
    "id": "1758722159.831171",
    "full_log": "{\"user\":\"root\"}",
    "decoder": {
      "name": "json"
    },
    "data": {
      "dstuser": "root"
    },
    "location": "stdin"
  },
  "alert": true,
  "codemsg": 0
}
2025-09-24 13:55:59,039 wazuh_logtest[INFO] **Phase 1: Completed pre-decoding.
2025-09-24 13:55:59,039 wazuh_logtest[INFO]     full event: '{"user":"root"}'
2025-09-24 13:55:59,039 wazuh_logtest[INFO] 
2025-09-24 13:55:59,039 wazuh_logtest[INFO] **Phase 2: Completed decoding.
2025-09-24 13:55:59,039 wazuh_logtest[INFO]     name: 'json'
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     dstuser: 'root'
2025-09-24 13:55:59,040 wazuh_logtest[INFO] 
2025-09-24 13:55:59,040 wazuh_logtest[INFO] **Phase 3: Completed filtering (rules).
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     id: '100002'
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     level: '10'
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     description: 'test user alias'
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     groups: '['local', 'syslog', 'sshd']'
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     firedtimes: '1'
2025-09-24 13:55:59,040 wazuh_logtest[INFO]     mail: 'False'
2025-09-24 13:55:59,040 wazuh_logtest[INFO] **Alert to be generated.


{"dstuser":"root"}
2025-09-24 14:01:08,870 wazuh_logtest[INFO] 
2025-09-24 14:01:08,871 wazuh_logtest[DEBUG] Request: {"version": 1, "origin": {"name": "wazuh-logtest", "module": "wazuh-logtest"}, "command": "log_processing", "parameters": {"location": "stdin", "log_format": "syslog", "event": "{\"dstuser\":\"root\"}"}}

2025-09-24 14:01:12,217 wazuh_logtest[DEBUG] Reply: {"error":0,"data":{"messages":["INFO: (7202): Session initialized with token '1ea173fc'"],"token":"1ea173fc","output":{"timestamp":"2025-09-24T14:01:12.214+0000","rule":{"level":10,"description":"test user alias","id":"100002","firedtimes":1,"mail":false,"groups":["local","syslog","sshd"]},"agent":{"id":"000","name":"ca37659e68c4"},"manager":{"name":"ca37659e68c4"},"id":"1758722472.831171","full_log":"{\"dstuser\":\"root\"}","decoder":{"name":"json"},"data":{"dstuser":"root"},"location":"stdin"},"alert":true,"codemsg":0}}

2025-09-24 14:01:12,222 wazuh_logtest[DEBUG] {
  "messages": [
    "INFO: (7202): Session initialized with token '1ea173fc'"
  ],
  "token": "1ea173fc",
  "output": {
    "timestamp": "2025-09-24T14:01:12.214+0000",
    "rule": {
      "level": 10,
      "description": "test user alias",
      "id": "100002",
      "firedtimes": 1,
      "mail": false,
      "groups": [
        "local",
        "syslog",
        "sshd"
      ]
    },
    "agent": {
      "id": "000",
      "name": "ca37659e68c4"
    },
    "manager": {
      "name": "ca37659e68c4"
    },
    "id": "1758722472.831171",
    "full_log": "{\"dstuser\":\"root\"}",
    "decoder": {
      "name": "json"
    },
    "data": {
      "dstuser": "root"
    },
    "location": "stdin"
  },
  "alert": true,
  "codemsg": 0
}
2025-09-24 14:01:12,223 wazuh_logtest[INFO] **Phase 1: Completed pre-decoding.
2025-09-24 14:01:12,223 wazuh_logtest[INFO]     full event: '{"dstuser":"root"}'
2025-09-24 14:01:12,223 wazuh_logtest[INFO] 
2025-09-24 14:01:12,223 wazuh_logtest[INFO] **Phase 2: Completed decoding.
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     name: 'json'
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     dstuser: 'root'
2025-09-24 14:01:12,224 wazuh_logtest[INFO] 
2025-09-24 14:01:12,224 wazuh_logtest[INFO] **Phase 3: Completed filtering (rules).
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     id: '100002'
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     level: '10'
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     description: 'test user alias'
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     groups: '['local', 'syslog', 'sshd']'
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     firedtimes: '1'
2025-09-24 14:01:12,224 wazuh_logtest[INFO]     mail: 'False'
2025-09-24 14:01:12,225 wazuh_logtest[INFO] **Alert to be generated.
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x ] AddressSanitizer


- Decoder/Rule tests _(Wazuh v4.x)_
  - [x ] Added unit testing files ".ini"
  - [x] `runtests.py` executed without errors


### Tests Introduced
- Test in the resuleset

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
