### PR TITLE
Workers API processes removal

### DIFF
--- a/etc/templates/config/generic/cluster.template
+++ b/etc/templates/config/generic/cluster.template
@@ -2,7 +2,7 @@
     <name>wazuh</name>
     <node_name>node01</node_name>
     <node_type>master</node_type>
-    <key>971aac4b720480a78a43e13d0c95fc54</key>
+    <key></key>
     <port>1516</port>
     <bind_addr>localhost</bind_addr>
     <nodes>

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -153,7 +153,7 @@ class LocalClient(client.AbstractClientManager):
                                              path=os.path.join(common.WAZUH_PATH, 'queue', 'cluster', 'c-internal.sock'))
         except MemoryError:
             raise exception.WazuhInternalError(1119)
-        except (ConnectionRefusedError, FileNotFoundError, Exception) as e:
+        except Exception as e:
             raise exception.WazuhInternalError(3009, str(e))
 
     async def wait_for_response(self, timeout: int) -> str:


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/32067.

Introduces changes to the control script to avoid running the API in worker nodes.

### Manual tests with their corresponding evidence

<details><summary>Worker cluster logs</summary>

```console
root@wazuh-worker1:/# cat /var/ossec/logs/cluster.log
2025/09/26 07:49:16 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2025/09/26 07:49:16 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
2025/09/26 07:49:26 INFO: [Worker wazuh-worker1] [Main] Successfully connected to master.
2025/09/26 07:49:35 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2025/09/26 07:49:35 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.007s. Sync required.
2025/09/26 07:49:35 INFO: [Worker wazuh-worker1] [Integrity sync] Starting.
2025/09/26 07:49:35 INFO: [Worker wazuh-worker1] [Integrity sync] Files to create: 1 | Files to update: 0 | Files to delete: 0
2025/09/26 07:49:35 INFO: [Worker wazuh-worker1] [Integrity sync] Finished in 0.002s.
2025/09/26 07:49:36 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/09/26 07:49:36 INFO: [Worker wazuh-worker1] [Agent-info sync] No synchronization required, skipping.
2025/09/26 07:49:44 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2025/09/26 07:49:44 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.006s. Sync not required.
2025/09/26 07:49:46 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/09/26 07:49:46 INFO: [Worker wazuh-worker1] [Agent-info sync] No synchronization required, skipping.
2025/09/26 07:49:47 INFO: [Worker wazuh-worker1] [Agent-groups recv] Starting.
2025/09/26 07:49:47 INFO: [Worker wazuh-worker1] [Agent-groups recv] Finished in 0.003s. Updated 1 chunks.
```

</details>

<details><summary>Cluster processes</summary>

```console
root@wazuh-worker1:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4324  3376 ?        Ss   07:49   0:00 bash /scripts/entrypoint.sh wazuh-master worker1 worker
root          66  0.0  0.0 165208 11536 ?        Sl   07:49   0:00 /var/ossec/bin/wazuh-authd
wazuh         74  0.0  0.0 1439012 11148 ?       Sl   07:49   0:00 /var/ossec/bin/wazuh-db
root          90  0.0  0.0  25404  2216 ?        Sl   07:49   0:00 /var/ossec/bin/wazuh-execd
root          98  0.3  0.8 2610692 138472 ?      Sl   07:49   0:00 /var/ossec/bin/wazuh-analysisd
root         198  1.5  0.0 130428 13148 ?        SNl  07:49   0:01 /var/ossec/bin/wazuh-syscheckd
wazuh        207  0.0  0.0 1292924 10228 ?       Sl   07:49   0:00 /var/ossec/bin/wazuh-remoted
root         218  0.0  0.0 402572  8304 ?        Sl   07:49   0:00 /var/ossec/bin/wazuh-logcollector
wazuh        251  0.0  0.0  25396  2908 ?        Sl   07:49   0:00 /var/ossec/bin/wazuh-monitord
root         257  0.6  0.3 416288 62696 ?        Sl   07:49   0:00 /var/ossec/bin/wazuh-modulesd
wazuh        312  0.1  0.4 368108 75608 ?        Sl   07:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py
wazuh        314  0.0  0.3 141068 64468 ?        S    07:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py
root        1085  0.0  0.0   4588  4176 pts/0    Ss   07:49   0:00 bash
root        2568  0.0  0.0   2696  1072 ?        S    07:50   0:00 sleep 10
root        2620  0.0  0.0   7888  4016 pts/0    R+   07:51   0:00 ps aux
```

</details>

<details><summary>Worker control status</summary>

```console
root@wazuh-worker1:/# /var/ossec/bin/wazuh-control status
wazuh-clusterd is running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid not running...
```

</details>

<details><summary>Worker control start</summary>

```console
root@wazuh-worker1:/# /var/ossec/bin/wazuh-control stop
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-apid not running...
Wazuh v5.0.0 Stopped
root@wazuh-worker1:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4324  3380 ?        Ss   07:49   0:00 bash /scripts/entrypoint.sh wazuh-master worker1 worker
root        1085  0.0  0.0   4588  4176 pts/0    Ss   07:49   0:00 bash
root        6082  0.0  0.0   2696  1052 ?        S    07:55   0:00 sleep 10
root        6083  0.0  0.0   7888  4028 pts/0    R+   07:55   0:00 ps aux
```

</details>

<details><summary>Worker control stop</summary>

```console
root@wazuh-worker1:/# /var/ossec/bin/wazuh-control start
2025/09/26 07:56:09 wazuh-db: WARNING: Detected a deprecated configuration for cluster. The 'disabled' option is not longer available.
2025/09/26 07:56:09 wazuh-db[6165] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/09/26 07:56:09 wazuh-remoted[6169] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/09/26 07:56:09 wazuh-remoted[6169] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/09/26 07:56:09 wazuh-remoted[6169] main.c:152 at main(): DEBUG: Cluster worker node: Disabling the merged.mg creation
2025/09/26 07:56:09 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/26 07:56:09 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/26 07:56:09 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
2025/09/26 07:56:09 wazuh-authd[6200] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/09/26 07:56:09 wazuh-authd[6200] config.c:24 at authd_read_config(): DEBUG: Reading configuration 'etc/ossec.conf'
2025/09/26 07:56:09 wazuh-authd[6200] authd-config.c:276 at Read_Authd(): DEBUG: The tag <force><after_registration_time> is not defined. Applied default value: '3600'
2025/09/26 07:56:09 wazuh-authd[6200] authd-config.c:278 at Read_Authd(): DEBUG: The tag <force><key_mismatch> is not defined. Applied default value: 'true'
2025/09/26 07:56:09 wazuh-authd[6200] main-server.c:454 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-authd...
2025/09/26 07:56:09 wazuh-db: WARNING: Detected a deprecated configuration for cluster. The 'disabled' option is not longer available.
2025/09/26 07:56:09 wazuh-db[6206] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
2025/09/26 07:56:10 wazuh-remoted[6327] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/09/26 07:56:10 wazuh-remoted[6327] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/09/26 07:56:10 wazuh-remoted[6327] main.c:152 at main(): DEBUG: Cluster worker node: Disabling the merged.mg creation
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2025/09/26 07:56:10 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/26 07:56:10 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/26 07:56:10 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
root@wazuh-worker1:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4324  3260 ?        Ss   07:49   0:00 bash /scripts/entrypoint.sh wazuh-master worker1 worker
root        1085  0.0  0.0   4588  4176 pts/0    Ss   07:49   0:00 bash
root        6146  0.0  0.0   2696  1020 ?        S    07:56   0:00 sleep 10
root        6202  0.0  0.0 165208  7844 ?        Sl   07:56   0:00 /var/ossec/bin/wazuh-authd
wazuh       6210  0.0  0.0 980264 10708 ?        Sl   07:56   0:00 /var/ossec/bin/wazuh-db
root        6226  0.0  0.0  25400  3040 ?        Sl   07:56   0:00 /var/ossec/bin/wazuh-execd
root        6234  1.7  0.8 2595028 132284 ?      Sl   07:56   0:00 /var/ossec/bin/wazuh-analysisd
root        6322 19.4  0.0 130216 12744 ?        SNl  07:56   0:00 /var/ossec/bin/wazuh-syscheckd
wazuh       6332  0.0  0.1 1227576 19208 ?       Sl   07:56   0:00 /var/ossec/bin/wazuh-remoted
root        6347  0.0  0.0 337036  8264 ?        Sl   07:56   0:00 /var/ossec/bin/wazuh-logcollector
wazuh       6375  0.0  0.0  17204  2924 ?        S    07:56   0:00 /var/ossec/bin/wazuh-monitord
root        6381 14.5  0.6 390168 107084 ?       Sl   07:56   0:00 /var/ossec/bin/wazuh-modulesd
wazuh       6554  3.5  0.4 362244 74568 ?        Sl   07:56   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py
wazuh       6629  0.0  0.3 141048 62120 ?        S    07:56   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py
root        7182  0.0  0.0   7888  4028 pts/0    R+   07:56   0:00 ps aux
```

</details>

<details><summary>Trying to start the node with an invalid configuration</summary>

```console
root@wazuh-worker1:/# tail -n 15 /var/ossec/etc/ossec.conf

  <cluster>
    <name>wazuh</name>
        <node_name>wazuh-worker1</node_name>
        <key>9d273b53510fef702b54a92e9cffc82e</key>
        <port>1516</port>
        <bind_addr>0.0.0.0</bind_addr>
        <nodes>
            <node>wazuh-master</node>
        </nodes>
        <hidden>no</hidden>
        <disabled>no</disabled>
    </cluster>

</ossec_config>
root@wazuh-worker1:/# /var/ossec/bin/wazuh-control start
2025/09/26 08:05:15 wazuh-db: WARNING: Detected a deprecated configuration for cluster. The 'disabled' option is not longer available.
2025/09/26 08:05:15 wazuh-db[17948] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/09/26 08:05:15 wazuh-remoted[17952] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/09/26 08:05:15 wazuh-remoted[17952] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/09/26 08:05:15 wazuh-remoted[17952] main.c:148 at main(): DEBUG: This is not a worker
2025/09/26 08:05:15 wazuh-modulesd:router: INFO: Loaded router module.
2025/09/26 08:05:15 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2025/09/26 08:05:15 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
Invalid cluster configuration, check the /var/ossec/etc/ossec.conf file.
```

</details>

<details><summary>Worker without API stats</summary>

```console
TIMESTAMP CPU %     MEM USAGE     MEM %     NET I/O         BLOCK I/O         PIDS
1         9.33%     327.6MiB      2.05%     734kB / 239kB   17.4MB / 68.1MB   151
2         1.65%     333.9MiB      2.09%     737kB / 243kB   17.4MB / 68.1MB   152
3         8.86%     333.9MiB      2.09%     737kB / 243kB   17.4MB / 68.1MB   152
4         0.35%     334MiB        2.09%     737kB / 243kB   17.4MB / 68.1MB   152
5         0.41%     334MiB        2.09%     738kB / 245kB   17.4MB / 68.8MB   152
6         0.32%     334.1MiB      2.09%     740kB / 246kB   17.4MB / 68.8MB   152
7         0.31%     334.1MiB      2.09%     740kB / 246kB   17.4MB / 68.8MB   152
8         8.40%     334.1MiB      2.09%     741kB / 249kB   17.4MB / 68.8MB   152
9         0.38%     343.4MiB      2.15%     743kB / 251kB   17.4MB / 68.8MB   156
10        0.44%     343.4MiB      2.15%     743kB / 251kB   17.4MB / 68.9MB   156
11        0.29%     343.4MiB      2.15%     745kB / 254kB   17.4MB / 68.9MB   156
12        0.79%     343.5MiB      2.15%     746kB / 255kB   17.4MB / 68.9MB   156
13        8.80%     343.8MiB      2.15%     746kB / 255kB   17.4MB / 68.9MB   156
14        0.30%     343.6MiB      2.15%     748kB / 257kB   17.4MB / 68.9MB   156
15        0.40%     343.6MiB      2.15%     748kB / 257kB   17.4MB / 68.9MB   156
16        0.36%     343.7MiB      2.15%     749kB / 259kB   17.4MB / 68.9MB   156
17        0.29%     343.7MiB      2.15%     750kB / 261kB   17.4MB / 68.9MB   156
18        0.31%     343.7MiB      2.15%     750kB / 261kB   17.4MB / 68.9MB   156
19        0.29%     343.9MiB      2.15%     752kB / 263kB   17.4MB / 69MB     156
20        9.18%     343.9MiB      2.15%     753kB / 265kB   17.4MB / 69MB     156
21        0.24%     343.6MiB      2.15%     753kB / 265kB   17.4MB / 69.2MB   156
22        0.24%     343.3MiB      2.15%     755kB / 266kB   17.4MB / 69.4MB   156
23        0.35%     343.3MiB      2.15%     756kB / 269kB   17.4MB / 69.5MB   156
24        0.28%     343.3MiB      2.15%     756kB / 269kB   17.4MB / 69.5MB   156
25        9.30%     343.4MiB      2.15%     757kB / 270kB   17.4MB / 69.5MB   156
26        0.33%     343.4MiB      2.15%     759kB / 273kB   17.4MB / 69.5MB   156
27        0.33%     343.4MiB      2.15%     759kB / 273kB   17.4MB / 69.5MB   156
28        0.37%     343.4MiB      2.15%     759kB / 273kB   17.4MB / 69.5MB   156
29        0.33%     343.4MiB      2.15%     761kB / 276kB   17.4MB / 69.6MB   156
30        8.92%     343.4MiB      2.15%     761kB / 276kB   17.4MB / 69.6MB   156
31        0.27%     343.4MiB      2.15%     761kB / 276kB   17.4MB / 69.6MB   156
32        0.73%     343.5MiB      2.15%     764kB / 280kB   17.4MB / 69.6MB   156
33        0.45%     343.6MiB      2.15%     764kB / 280kB   17.4MB / 69.6MB   156
34        0.31%     343.5MiB      2.15%     764kB / 280kB   17.4MB / 69.6MB   156
35        0.90%     343.5MiB      2.15%     767kB / 284kB   17.4MB / 69.6MB   156
36        0.36%     343.5MiB      2.15%     767kB / 284kB   17.4MB / 69.6MB   156
37        8.90%     343.5MiB      2.15%     767kB / 284kB   17.4MB / 69.6MB   156
38        0.35%     343.4MiB      2.15%     769kB / 286kB   17.4MB / 69.6MB   156
39        0.31%     343.5MiB      2.15%     770kB / 288kB   17.4MB / 69.6MB   156
40        0.31%     343.4MiB      2.15%     770kB / 288kB   17.4MB / 69.6MB   156
41        0.39%     347.7MiB      2.17%     773kB / 291kB   17.4MB / 69.6MB   156
42        8.81%     347.9MiB      2.18%     774kB / 292kB   17.4MB / 69.7MB   156
43        0.45%     347.8MiB      2.18%     774kB / 292kB   17.4MB / 69.7MB   156
44        0.25%     347.8MiB      2.18%     776kB / 295kB   17.4MB / 69.7MB   156
45        0.88%     348MiB        2.18%     777kB / 296kB   17.4MB / 69.7MB   156
46        0.25%     347.9MiB      2.18%     777kB / 296kB   17.4MB / 69.7MB   156
47        8.68%     349.2MiB      2.18%     779kB / 298kB   17.4MB / 69.7MB   156
48        0.33%     348MiB        2.18%     779kB / 298kB   17.4MB / 69.7MB   156
49        8.27%     348.1MiB      2.18%     780kB / 299kB   17.4MB / 69.8MB   156
50        0.32%     348.1MiB      2.18%     781kB / 302kB   17.4MB / 69.8MB   156
```

</details>


<details><summary>Worker with API stats</summary>

```console
TIMESTAMP CPU %     MEM USAGE     MEM %     NET I/O         BLOCK I/O         PIDS
1         19.87%    483.5MiB      3.02%     827kB / 446kB   25.2MB / 55.3MB   162
2         0.37%     489.9MiB      3.06%     830kB / 450kB   25.2MB / 55.3MB   163
3         0.38%     489.9MiB      3.06%     830kB / 450kB   25.2MB / 55.3MB   163
4         0.38%     489.9MiB      3.06%     830kB / 450kB   25.2MB / 55.3MB   163
5         0.82%     490.1MiB      3.06%     833kB / 454kB   25.2MB / 56MB     163
6         9.36%     490.1MiB      3.06%     833kB / 454kB   25.2MB / 56MB     163
7         0.39%     490.1MiB      3.06%     833kB / 454kB   25.2MB / 56MB     163
8         0.63%     490.1MiB      3.06%     835kB / 457kB   25.2MB / 56MB     163
9         0.53%     491.4MiB      3.07%     837kB / 459kB   25.2MB / 56MB     167
10        0.31%     491.4MiB      3.07%     837kB / 459kB   25.2MB / 56MB     167
11        0.41%     491.4MiB      3.07%     838kB / 461kB   25.2MB / 56MB     167
12        0.38%     491.5MiB      3.07%     839kB / 463kB   25.2MB / 56MB     167
13        8.89%     491.6MiB      3.07%     839kB / 463kB   25.2MB / 56MB     167
14        0.36%     491.6MiB      3.07%     841kB / 465kB   25.2MB / 56MB     167
15        0.86%     492MiB        3.08%     842kB / 466kB   25.2MB / 56MB     167
16        0.39%     491.7MiB      3.07%     842kB / 466kB   25.2MB / 56MB     167
17        0.36%     491.8MiB      3.07%     843kB / 469kB   25.2MB / 56.1MB   167
18        9.48%     491.8MiB      3.08%     845kB / 470kB   25.2MB / 56.1MB   167
19        0.41%     491.9MiB      3.08%     845kB / 470kB   25.2MB / 56.1MB   167
20        0.36%     491.7MiB      3.07%     846kB / 473kB   25.2MB / 56.3MB   167
21        0.55%     490.8MiB      3.07%     847kB / 474kB   25.2MB / 57.1MB   167
22        0.32%     490.7MiB      3.07%     848kB / 474kB   25.2MB / 57.2MB   167
23        7.97%     491.2MiB      3.07%     849kB / 477kB   25.2MB / 57.2MB   167
24        0.45%     490.7MiB      3.07%     849kB / 477kB   25.2MB / 57.2MB   167
25        10.01%    490.8MiB      3.07%     850kB / 478kB   25.2MB / 57.2MB   167
26        0.33%     490.8MiB      3.07%     852kB / 480kB   25.2MB / 57.2MB   167
27        0.37%     490.8MiB      3.07%     852kB / 480kB   25.2MB / 57.3MB   167
28        0.43%     490.8MiB      3.07%     853kB / 481kB   25.2MB / 57.3MB   167
29        0.55%     490.8MiB      3.07%     855kB / 484kB   25.2MB / 57.3MB   167
30        9.38%     490.8MiB      3.07%     855kB / 484kB   25.2MB / 57.3MB   167
31        0.65%     490.8MiB      3.07%     856kB / 485kB   25.2MB / 57.3MB   167
32        0.38%     490.8MiB      3.07%     857kB / 488kB   25.2MB / 57.3MB   167
33        0.40%     490.8MiB      3.07%     857kB / 488kB   25.2MB / 57.3MB   167
34        0.43%     490.8MiB      3.07%     857kB / 488kB   25.2MB / 57.3MB   167
35        9.84%     490.8MiB      3.07%     860kB / 492kB   25.2MB / 57.3MB   167
36        0.38%     490.8MiB      3.07%     860kB / 492kB   25.2MB / 57.3MB   167
37        0.39%     490.8MiB      3.07%     860kB / 492kB   25.2MB / 57.3MB   167
38        0.43%     490.8MiB      3.07%     863kB / 495kB   25.2MB / 57.3MB   167
39        0.50%     490.9MiB      3.07%     863kB / 496kB   25.2MB / 57.4MB   167
40        0.46%     490.9MiB      3.07%     863kB / 496kB   25.2MB / 57.4MB   167
41        0.69%     495.2MiB      3.10%     867kB / 500kB   25.2MB / 57.4MB   167
42        9.24%     495.3MiB      3.10%     868kB / 500kB   25.2MB / 57.4MB   167
43        0.36%     495.3MiB      3.10%     868kB / 500kB   25.2MB / 57.4MB   167
44        0.46%     495.3MiB      3.10%     869kB / 503kB   25.2MB / 57.4MB   167
45        0.88%     495.4MiB      3.10%     870kB / 504kB   25.2MB / 57.4MB   167
46        0.46%     495.4MiB      3.10%     870kB / 504kB   25.2MB / 57.4MB   167
47        9.37%     495.4MiB      3.10%     872kB / 507kB   25.2MB / 57.4MB   167
48        0.45%     495.5MiB      3.10%     873kB / 508kB   25.2MB / 57.4MB   167
49        0.47%     495.6MiB      3.10%     873kB / 508kB   25.2MB / 57.4MB   167
50        0.36%     495.6MiB      3.07%     870kB / 504kB   25.2MB / 56.1MB   167
```

</details>

<details><summary>Charts</summary>

> WORKER1 = No API running
> WORKER2 = API running

<img width="907" height="551" alt="workers_cpu" src="https://github.com/user-attachments/assets/2d7d1c83-618b-4505-bd3d-7d10caeeea1a" />

<img width="1693" height="896" alt="workers_mem_pct" src="https://github.com/user-attachments/assets/d459e80e-32f2-4d5c-bd33-7baa69587d2f" />

<img width="1431" height="937" alt="workers_mem_usage" src="https://github.com/user-attachments/assets/d090f1f2-e927-4f71-b8fc-c5f651486e07" />

<img width="1336" height="914" alt="workers_pids" src="https://github.com/user-attachments/assets/342193c0-61e7-4a49-9160-4aee511d0c97" />

</details>

> [!Note]
> Footprint tests were performed in a low load environment, which I think illustrates pretty well the difference between each node. If we want to measure their performance under heavy load we should run the workload benchmarks metrics, probably to be done for https://github.com/wazuh/wazuh/issues/31590.

<!--

## Review Checklist

- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...


Include any additional information relevant to the review process.
-->
