### PR TITLE
Update `/var/ossec/lib/libwazuhext.so` size in `rpm5_linux_agent_i386.csv` checkfile

### DIFF
--- a/.github/actions/check_files/rpm5_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_i386.csv
@@ -90,7 +90,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,1175029,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,1275711,0.1
 /var/ossec/lib/libwazuhshared.so,root,wazuh,750,file,-rwxr-x---,236571,0.1
-/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,10625929,0.1
+/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,14078274,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,549908,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2324836,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,504212,0.1


### PR DESCRIPTION
|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/491|

## Description
Hi team, 
this PR updates the `/var/ossec/lib/libwazuhext.so` size in `rpm5_linux_agent_i386.csv` checkfile to properly match its new value.

## Tests
The following WF has been launched using the following `CLI` call:
```console
gh workflow run 4_builderpackage_agent-linux.yml -r 4.14.0 -f source_reference=bug/491-rpm5-i386-output-is-not-correct-v4140-alpha1 -f system=rpm -f architecture=i386 -f is_stage=false -f checksum=true -f legacy=true
```
Result: :green_circle: [Packages - Build Wazuh agent Linux amd - legacy packages - rpm - i386 - checksum #692](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18036385563/job/51324184353)
 
