### PR TITLE
Separate external libraries compilation from main build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1034,7 +1034,7 @@ endif
 check_external_libs: test_external
 	@missing_libs=""; \
 	for lib in $(EXTERNAL_LIBS) $(EXTERNAL_LIBS_NO_WHOLE); do \
-		if [ ! -f "$$lib" ]; then \
+		if [ "$$lib" != "$(MINIZIP_LIB)" ] && [ ! -f "$$lib" ]; then \
 			missing_libs="$$missing_libs $$lib"; \
 		fi; \
 	done; \
@@ -2022,14 +2022,14 @@ libwazuh.a: ${config_o} ${wmodules_dep} ${crypto_o} ${shared_o} ${os_net_o} ${os
 ifeq (${uname_S},Darwin)
 WAZUH_SHFLAGS=-install_name @rpath/libwazuhext.$(SHARED)
 
-$(WAZUHEXT_LIB): | check_external_libs
+$(WAZUHEXT_LIB): $(MINIZIP_LIB) | check_external_libs
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) $(WAZUH_SHFLAGS) -o $@ -Wl,-all_load $(EXTERNAL_LIBS) $(OSSEC_LIBS)
 else
 ifeq (${TARGET}, winagent)
 $(WAZUHEXT_LIB): $(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF)
 	$(DLLTOOL) -D $(WAZUHEXT_DLL) --def $(WAZUHEXT_LIB_DEF) --output-delaylib $@
 
-$(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF): win32/version-dll.o | check_external_libs
+$(WAZUHEXT_DLL) $(WAZUHEXT_LIB_DEF): win32/version-dll.o | $(MINIZIP_LIB) check_external_libs
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $(WAZUHEXT_DLL) -static-libgcc -Wl,--export-all-symbols -Wl,--add-stdcall-alias -Wl,--whole-archive $(EXTERNAL_LIBS) $^ -Wl,--no-whole-archive -Wl,--output-def,$(WAZUHEXT_LIB_DEF) ${OSSEC_LIBS}
 
 
@@ -2041,15 +2041,15 @@ else
 LIBGCC_FLAGS := -Wl,-rpath,\$$ORIGIN
 endif
 ifeq (${uname_P},sparc)
-$(WAZUHEXT_LIB): | check_external_libs
+$(WAZUHEXT_LIB): $(MINIZIP_LIB) | check_external_libs
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -mimpure-text -o $@ $(LIBGCC_FLAGS) -Wl,--whole-archive $(EXTERNAL_LIBS) -Wl,--no-whole-archive ${OSSEC_LIBS}
 else
-$(WAZUHEXT_LIB): | check_external_libs
+$(WAZUHEXT_LIB): $(MINIZIP_LIB) | check_external_libs
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ $(LIBGCC_FLAGS) -Wl,--whole-archive $(EXTERNAL_LIBS) -Wl,--no-whole-archive ${OSSEC_LIBS}
 endif
 else
 ifeq (${uname_S},AIX)
-$(WAZUHEXT_LIB): | check_external_libs
+$(WAZUHEXT_LIB): $(MINIZIP_LIB) | check_external_libs
 	mkdir -p libwazuhext;
 	find external/ -name \*.a -exec cp {} libwazuhext/ \;
 	for lib in libcjson.a libz.a libmsgpack.a libssl.a libcrypto.a libsqlite3.a libyaml.a libpcre2-8.a ; do \
@@ -2059,7 +2059,7 @@ $(WAZUHEXT_LIB): | check_external_libs
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -latomic -lm
 else
 ifeq (${uname_S},HP-UX)
-$(WAZUHEXT_LIB): | check_external_libs
+$(WAZUHEXT_LIB): $(MINIZIP_LIB) | check_external_libs
 	mkdir -p libwazuhext;
 	find external/ -name \*.a -exec cp {} libwazuhext/ \;
 	for lib in libcjson.a libz.a libmsgpack.a libssl.a libcrypto.a libsqlite3.a libyaml.a libpcre2-8.a ; do \
@@ -2068,7 +2068,7 @@ $(WAZUHEXT_LIB): | check_external_libs
 	done
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc
 else
-$(WAZUHEXT_LIB): | check_external_libs
+$(WAZUHEXT_LIB): $(MINIZIP_LIB) | check_external_libs
 	$(OSSEC_SHARED) $(OSSEC_CFLAGS) -o $@ -Wl,--whole-archive $(EXTERNAL_LIBS) -Wl,--no-whole-archive ${OSSEC_LIBS}
 endif
 endif


### PR DESCRIPTION
## Description

This change decouples the compilation of external libraries from the main product build. Previously, `make all` would attempt to rebuild all external dependencies automatically, which could trigger unnecessary recompilations due to timestamp issues or missing precompiled libraries. With this update, external libraries are only built when explicitly requested via the `make external` target.

## Proposed Changes

* Introduced `make external` target for building external libraries independently.
* Updated `Makefile` to allow `make TARGET=server` or `make TARGET=agent` to compile the main product without rebuilding external dependencies.
* Added checks to ensure that missing external libraries prompt a clear message instructing to run `make external` or `make deps`.
* Preserved existing build workflows for all platforms.

### Results and Evidence

* **Compile manager with dependencies**:

```bash
make deps
make TARGET=server
```

Output: 
> Done building server

* **Update all libraries**:

```bash
make clean-internals
find external -name "*.a" -exec touch {} +
make TARGET=server
```

Output:
> Done building server

* **Remove some libraries**:

```bash
make clean-internals
find external -name "*.a" -delete
make TARGET=server
```

Output: 
> Error: The following external libraries do not exist: external/cJSON/libcjson.a external/zlib//libz.a external/openssl/libssl.a external/openssl/libcrypto.a external/sqlite/libsqlite3.a external/libyaml/src/.libs/libyaml.a external/libpcre2/.libs/libpcre2-8.a external/curl/lib/.libs/libcurl.a external/lzma/build/liblzma.a external/zlib//contrib/minizip/libminizip.a external/msgpack/libmsgpack.a external/libffi/server/.libs/libffi.a external/bzip2/libbz2.a external/dbus/lib/libdbus-1.a external/lua/install/lib/liblua.a external/rpm/builddir/librpm.a external/popt/build/output/src/.libs/libpopt.a external/audit-userspace/lib/.libs/libaudit.a external/procps//libproc.a external/pacman/lib/libalpm/libalpm.a external/libarchive/.libs/libarchive.a external/flatbuffers/build/libflatbuffers.a external/simdjson/build/libsimdjson.a 
> Run 'make external' to compile them or verify they are already precompiled

* **Remove all dependencies**:

```bash
make clean-deps
make TARGET=server
```

Output: 

> No external directory found. Run "make deps" before compiling external libraries. Stop.

- **Build Windows agent**:

```bash
make TARGET=winagent deps
make TARGET=winagent
```

Output:
> Done building winagent

### Artifacts Affected

* Makefile (build process)
* All supported platforms

### Configuration Changes

None

### Documentation Updates

N/A

### Tests Introduced

No new tests introduced; existing build process behavior is preserved.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
