### PR TITLE
Call stop in Controller dtor to release RxCpp subscriptions

### DIFF
--- a/.github/workflows/5_testunit_engine.yml
+++ b/.github/workflows/5_testunit_engine.yml
@@ -13,16 +13,30 @@ concurrency:
 
 env:
   BUILD_DIR: ${{github.workspace}}/src/build
+  ENGINE_CMAKE: src/engine/CMakeLists.txt
 
 jobs:
   build:
     name: Build Server
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install CMake
         uses: ./.github/actions/reinstall_cmake
+
+      - name: Force ENGINE_ENABLE_ASAN=ON in CMakeLists
+
+        run: |
+          file="${ENGINE_CMAKE}"
+          grep -qE 'option\(\s*ENGINE_ENABLE_ASAN\b' "$file" || {
+            echo "ERROR: ENGINE_ENABLE_ASAN option not found in ${file}"; exit 1; }
+
+          sed -i -E 's/^(option\(\s*ENGINE_ENABLE_ASAN\b[^)]*\b)OFF(\b[^)]*\))/\1ON\2/' "$file" || {
+            echo "ERROR: sed failed setting ENGINE_ENABLE_ASAN=ON"; exit 1; }
+
+          grep -nE 'option\(\s*ENGINE_ENABLE_ASAN\b.*\bON\b' "$file" || {
+            echo "ERROR: ENGINE_ENABLE_ASAN not set to ON in ${file}"; exit 1; }
 
       - name: Build Wazuh server
         run: |
@@ -32,4 +46,17 @@ jobs:
       - name: Unit Test
         # Run unit tests using CTest
         working-directory: ${{env.BUILD_DIR}}/engine
+        env:
+          ASAN_OPTIONS: malloc_context_size=8:print_stats=0:fast_unwind_on_malloc=1:log_path=${{ runner.temp }}/asan
+          LSAN_OPTIONS: report_objects=0:log_path=${{ runner.temp }}/asan
         run: MALLOC_CHECK_=2 ctest -T test --output-on-failure -j$(nproc)
+
+      - name: Upload ASAN/LSAN logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitizer-logs
+          path: |
+            ${{ runner.temp }}/asan*
+          if-no-files-found: ignore
+          retention-days: 7

--- a/src/engine/source/bk/include/bk/rx/controller.hpp
+++ b/src/engine/source/bk/include/bk/rx/controller.hpp
@@ -42,7 +42,7 @@ public:
     Controller() = delete;
     Controller(const Controller&) = delete;
 
-    ~Controller() = default;
+    ~Controller() { stop(); }
 
     /**
      * @brief Construct a new Controller from an expression and a set of traceables
@@ -116,7 +116,7 @@ public:
     const std::unordered_set<std::string>& getTraceables() const override { return m_traceables; }
 
     /**
-     * @copydoc bk::IController::getTraces
+     * @copydoc bk::IController::subscribe
      */
     base::RespOrError<Subscription> subscribe(const std::string& traceable, const Subscriber& subscriber) override;
 

--- a/src/engine/source/bk/test/src/component/bk_test.cpp
+++ b/src/engine/source/bk/test/src/component/bk_test.cpp
@@ -73,7 +73,7 @@ TEST_P(PipelineTest, TfProcessTraces)
     GTEST_SKIP(); // TODO
 }
 
-TEST_P(PipelineTest, RxProessEvent)
+TEST_P(PipelineTest, RxProcessEvent)
 {
     auto [name, expression, expectedPath] = GetParam();
     auto testExpression = getTestExpression(expression);

--- a/src/engine/source/router/test/src/unit/tester_test.cpp
+++ b/src/engine/source/router/test/src/unit/tester_test.cpp
@@ -41,7 +41,7 @@ public:
             .WillOnce(::testing::Return(m_mockController));
 
         EXPECT_CALL(*m_mockPolicy, expression()).WillOnce(::testing::ReturnRefOfCopy(base::Expression {}));
-        EXPECT_CALL(*m_mockPolicy, hash()).WillOnce(::testing::ReturnRef(hash));
+        EXPECT_CALL(*m_mockPolicy, hash()).WillOnce(::testing::ReturnRefOfCopy(hash));
     }
 
     void stopControllerCall(size_t times = 1) { EXPECT_CALL(*m_mockController, stop()).Times(times); }
@@ -61,7 +61,7 @@ public:
             .WillOnce(::testing::Return(m_mockController));
 
         EXPECT_CALL(*m_mockPolicy, expression()).WillOnce(::testing::ReturnRefOfCopy(base::Expression {}));
-        EXPECT_CALL(*m_mockPolicy, hash()).WillOnce(::testing::ReturnRef(hash));
+        EXPECT_CALL(*m_mockPolicy, hash()).WillOnce(::testing::ReturnRefOfCopy(hash));
     }
 
     void ingestTestCallersSuccess(const char* event)


### PR DESCRIPTION
## Description

This PR addresses a memory leak detected by AddressSanitizer when running the engine tests that exercise the Rx backend with a Broadcast expression. The issue was caused by RxCpp subscriptions not being completed/disposed when `bk::rx::Controller` objects were destroyed without an explicit `stop()` call.

**Closes #31488**

## Proposed Changes

- **Lifecycle fix:** Call `stop()` from `bk::rx::Controller` destructor to guarantee the Rx pipeline is completed on destruction (emits `on_completed()` on the policy subject and tears down subscribers/subscriptions).
- **Test typo fix:** Rename test case from `RxProessEvent` to `RxProcessEvent` for clarity and consistency.
- **Fix stack-use-after-scope in tests:** Use `::testing::ReturnRefOfCopy` to return safe values from mocks instead of `::testing::ReturnRef` for references that would outlive their scope.
- **CI: Enable ASAN in the workflow and export logs as an artifact:** Build with ASAN, run tests with symbolized backtraces, and upload the captured logs.


### Results and Evidence

#### Fix RxCpp memory leak 

- **Before (ASAN):** running component tests with a Broadcast pipeline reported indirect leaks stemming from RxCpp subscriptions (e.g., allocations under `rxcpp::subscription` / `composite_subscription_state`). Example excerpt:

```console
(venv) ╭─root@fe4d49e55ea8 /workspaces/wazuh-5.x/wazuh/src/build/engine/source ‹bug/31488-engine-rx-unsubscribe-on-dtor●›
╰─# bk/bk_ctest --gtest_filter="*RxProcessEvent*"
```
```text
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
  rxcpp::detail::composite_subscription_inner::composite_subscription_state::add(rxcpp::subscription)
  ... (map/lift/ref_count/publish stack in ExprBuilder) ...
....
ing::internal::UnitTestImpl::*)(), char const*) /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest.cc:2607
    #21 0xd35994 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest.cc:2643
    #22 0xd1bb3c in testing::UnitTest::Run() /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest.cc:5438
    #23 0xa2b4f9 in RUN_ALL_TESTS() /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/include/gtest/gtest.h:2490
    #24 0xa2b4e5 in main /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest_main.cc:52
    #25 0x70046ec00d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 852668 byte(s) leaked in 10788 allocation(s).
```

- **After:** with the destructor invoking `stop()`, the same test suite finishes **without ASAN-reported leaks**.

```console
(venv) ╭─root@fe4d49e55ea8 /workspaces/wazuh-5.x/wazuh/src/build/engine/source ‹bug/31488-engine-rx-unsubscribe-on-dtor●›
╰─# bk/bk_ctest --gtest_filter="*RxProcessEvent*"
```
```text
Running main() from /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *RxProcessEvent*
[==========] Running 103 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 103 tests from BK/PipelineTest
[ RUN      ] BK/PipelineTest.RxProcessEvent/0
[       OK ] BK/PipelineTest.RxProcessEvent/0 (0 ms)
...
[  PASSED  ] 103 tests.
```

#### Fix Router tests with stack-use-after-scope
```console
(venv) ╭─root@fe4d49e55ea8 /workspaces/wazuh-5.x/wazuh/src/build/engine/source ‹bug/31488-engine-rx-unsubscribe-on-dtor●›
╰─# ./router/router_utest --gtest_filter="*TesterTest.*"   
```

- **Before Fix (ASAN):**
```console
[ RUN      ] TesterTest.SuccessGetEntry
=================================================================
==175759==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7df7bcd31620 at pc 0x0000006002a9 bp 0x7ffe0260bca0 sp 0x7ffe0260bc98
READ of size 8 at 0x7df7bcd31620 thread T0
    #0 0x6002a8 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const /opt/gcc-14/include/c++/14.3.0/bits/basic_string.h:228
    #1 0x6002a8 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /opt/gcc-14/include/c++/14.3.0/bits/basic_string.h:556
    #2 0x6002a8 in std::pair<std::shared_ptr<bk::IController>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::pair<std::shared_ptr<bk::IController>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, true>(std::shared_ptr<bk::IController>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /opt/gcc-14/include/c++/14.3.0/bits/stl_pair.h:882
    #3 0x6002a8 in router::EnvironmentBuilder::makeController[abi:cxx11](base::Name const&, bool, bool) /workspaces/wazuh-5.x/wazuh/src/engine/source/router/src/environmentBuilder.hpp:110
    #4 0x9e9148 in router::Tester::addEntry(router::test::EntryPost const&, bool) /workspaces/wazuh-5.x/wazuh/src/engine/source/router/src/tester.cpp:72
    #5 0x6705f8 in TesterTest_SuccessGetEntry_Test::TestBody() /workspaces/wazuh-5.x/wazuh/src/engine/source/router/test/src/unit/tester_test.cpp:265
    #6 0xa8e0f3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa8e0f3)
    #7 0xa870f8 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa870f8)
    #8 0xa5fa2d in testing::Test::Run() (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa5fa2d)
    #9 0xa6039f in testing::TestInfo::Run() (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa6039f)
    #10 0xa60b9d in testing::TestSuite::Run() (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa60b9d)
    #11 0xa6f9d0 in testing::internal::UnitTestImpl::RunAllTests() (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa6f9d0)
    #12 0xa8f108 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa8f108)
    #13 0xa882de in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa882de)
    #14 0xa6e29e in testing::UnitTest::Run() (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0xa6e29e)
    #15 0x8a6052 in RUN_ALL_TESTS() (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0x8a6052)
    #16 0x8a603e in main (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0x8a603e)
    #17 0x7df7be800d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #18 0x7df7be800e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #19 0x44b974 in _start (/workspaces/wazuh-5.x/wazuh/src/build/engine/source/router/router_utest+0x44b974)
```


- **After Fix (ASAN):** `ReturnRefOfCopy(hash)` stores a copy inside the action and returns a reference to that internal copy each time the mock is invoked, avoiding dangling references.
```console
./router_utest --gtest_filter="*TesterTest.*"
Running main() from gmock_main.cc
Note: Google Test filter = *TesterTest.*
[==========] Running 22 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 22 tests from TesterTest
[ RUN      ] TesterTest.AddEntryRepeatdly
[       OK ] TesterTest.AddEntryRepeatdly (0 ms)
[ RUN      ] TesterTest.AddEntrySuccess
[       OK ] TesterTest.AddEntrySuccess (0 ms)
[ RUN      ] TesterTest.FailedCreatingEnvironment
[       OK ] TesterTest.FailedCreatingEnvironment (0 ms)
[ RUN      ] TesterTest.FailedRemovingEnvironment
[       OK ] TesterTest.FailedRemovingEnvironment (0 ms)
[ RUN      ] TesterTest.SuccessRemovingEnvironment
[       OK ] TesterTest.SuccessRemovingEnvironment (0 ms)
[ RUN      ] TesterTest.FaildedRebuildingEnvironment
[       OK ] TesterTest.FaildedRebuildingEnvironment (0 ms)
[ RUN      ] TesterTest.FaildedRebuildingEnvironmentMakeControllerError
[       OK ] TesterTest.FaildedRebuildingEnvironmentMakeControllerError (0 ms)
[ RUN      ] TesterTest.SuccessRebuildingEnvironment
[       OK ] TesterTest.SuccessRebuildingEnvironment (0 ms)
[ RUN      ] TesterTest.FailedEnableEntry
[       OK ] TesterTest.FailedEnableEntry (0 ms)
[ RUN      ] TesterTest.SuccessEnableEntry
[       OK ] TesterTest.SuccessEnableEntry (0 ms)
[ RUN      ] TesterTest.SuccessGetEntries
[       OK ] TesterTest.SuccessGetEntries (0 ms)
[ RUN      ] TesterTest.FailtureGetEntry
[       OK ] TesterTest.FailtureGetEntry (0 ms)
[ RUN      ] TesterTest.SuccessGetEntry

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: stop()
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
[       OK ] TesterTest.SuccessGetEntry (0 ms)
[ RUN      ] TesterTest.SuccessIngestTest
[       OK ] TesterTest.SuccessIngestTest (0 ms)
[ RUN      ] TesterTest.FailtureIngestTestNameNotExist
[       OK ] TesterTest.FailtureIngestTestNameNotExist (0 ms)
[ RUN      ] TesterTest.FailtureIngestTestNotEnabled
[       OK ] TesterTest.FailtureIngestTestNotEnabled (0 ms)
[ RUN      ] TesterTest.FailtureIngestTestNotSubscribe
[       OK ] TesterTest.FailtureIngestTestNotSubscribe (0 ms)
[ RUN      ] TesterTest.FailtureGetAssetsNameNotExist
[       OK ] TesterTest.FailtureGetAssetsNameNotExist (0 ms)
[ RUN      ] TesterTest.FailtureGetAssetsNameNotEnabled
[       OK ] TesterTest.FailtureGetAssetsNameNotEnabled (0 ms)
[ RUN      ] TesterTest.SuccessGetAssets
[       OK ] TesterTest.SuccessGetAssets (0 ms)
[ RUN      ] TesterTest.FailtureUpdateLastUsedNameNotExist
[       OK ] TesterTest.FailtureUpdateLastUsedNameNotExist (0 ms)
[ RUN      ] TesterTest.SucessUpdateLast
[       OK ] TesterTest.SucessUpdateLast (0 ms)
[----------] 22 tests from TesterTest (5 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 22 tests.
```

#### CI: Enable ASAN and upload logs as artifact

- **Push with memory leak:**
<img width="1881" height="797" alt="image" src="https://github.com/user-attachments/assets/53f7d038-b9c2-4cb4-be40-a3368d8d7f8d" />

- **Downloaded logs:**
```text
=================================================================
==13587==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 624 byte(s) in 3 object(s) allocated from:
    #0 0x7fd779efe548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x5569400e9c5a in std::__new_allocator<std::_Sp_counted_ptr_inplace<rxcpp::detail::specific_observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::operators::detail::map<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, bk::rx::detail::ExprBuilder::recBuild(rxcpp::observable<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::dynamic_observable<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > > > > const&, std::shared_ptr<base::Formula> const&, bk::rx::detail::ExprBuilder::BuildParams&)::{lambda(std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >)#6}>::map_observer<rxcpp::subscriber<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, void, void, void, void> > >, void, void, void> >, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/include/c++/13/bits/new_allocator.h:151
    #2 0x5569400e9c5a in std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<rxcpp::detail::specific_observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::operators::detail::map<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, bk::rx::detail::ExprBuilder::recBuild(rxcpp::observable<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::dynamic_observable<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > > > > const&, std::shared_ptr<base::Formula> const&, bk::rx::detail::ExprBuilder::BuildParams&)::{lambda(std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >)#6}>::map_observer<rxcpp::subscriber<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, void, void, void, void> > >, void, void, void> >, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<rxcpp::detail::specific_observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::observer<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::operators::detail::map<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, bk::rx::detail::ExprBuilder::recBuild(rxcpp::observable<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >, rxcpp::dynamic_observable<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > > > > const&, std::shared_ptr<base::Formula> const&, bk::rx::detail::ExprBuilder::BuildParams&)::{lambda(std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >)#6}>::map_observer<rxcpp::subscriber<std::shared_ptr<base::result::Result<std::shared_ptr<json::Json> > >,
```

- **Push with ASAN checks Ok:**
<img width="1879" height="535" alt="image" src="https://github.com/user-attachments/assets/392be228-c8e2-4dcc-8db8-e6ff3f7c23fb" />



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [X] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [X] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

- **Engine**: `bk::rx::Controller` (lifecycle handling on destruction)
- **Tests**: 
    - Component test name typo corrected (`RxProcessEvent`). 
    - `::testing::ReturnRef` to `::testing::ReturnRefOfCopy` in tester_test
- **CI: Engine Unit Tests**: Build with ASAN, run tests with symbolized backtraces, and upload the captured logs

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
