### PR TITLE
Update expected size for libwazuhext.so in check_files (Linux)

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -8,7 +8,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,597472,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.1
 /var/ossec/lib/libwazuhshared.so,root,wazuh,750,file,-rwxr-x---,164800,0.1
-/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,10920856,0.1
+/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,1088824,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -8,7 +8,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,916748,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,1011784,0.1
 /var/ossec/lib/libwazuhshared.so,root,wazuh,750,file,-rwxr-x---,215664,0.1
-/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,10846576,0.1
+/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12358288,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,525380,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,1142112,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2792476,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -70,7 +70,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,564896,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhshared.so,root,wazuh,750,file,-rwxr-x---,156152,0.1
-/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,10959704,0.1
+/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,1088920,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -70,7 +70,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-modulesd,root,root,750,file,-rwxr-x---,711912,0.1
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,789888,0.1
 /var/ossec/lib/libwazuhshared.so,root,wazuh,750,file,-rwxr-x---,174668,0.1
-/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,10847760,0.1
+/var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12362096,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,492352,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,1138084,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2717844,0.1


### PR DESCRIPTION
## Description

The expected sizes for the shared library `libwazuhext.so` have been updated in the integrity check files used by CI workflows for Linux packages. These changes correct outdated values and prevent false positives in integrity checks.

## Proposed Changes

- Updated entries for `/var/ossec/lib/libwazuhext.so` in the following files:
  - `.github/actions/check_files/deb_linux_agent_amd64.csv`: 10920856 -> 12374168
  - `.github/actions/check_files/deb_linux_agent_i386.csv`: 10846576 -> 12358288
  - `.github/actions/check_files/rpm_linux_agent_amd64.csv`: 10959704 -> 12417720
  - `.github/actions/check_files/rpm_linux_agent_i386.csv`: 10847760 -> 12362096

## Results and Evidence

To provide operational evidence, the GitHub Actions workflows that run the `check_files` validation will be re-run.

### Artifacts Affected

- `.github/actions/check_files/deb_linux_agent_amd64.csv`
- `.github/actions/check_files/deb_linux_agent_i386.csv`
- `.github/actions/check_files/rpm_linux_agent_amd64.csv`
- `.github/actions/check_files/rpm_linux_agent_i386.csv`

### Configuration Changes

No configuration changes.

### Documentation Updates

No documentation changes.

### Tests Introduced

No tests introduced.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided (workflows will be re-run)
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
