### PR TITLE
Fix uninitialized errno in syscheck/audit unit tests

### DIFF
--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -676,6 +676,8 @@ void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
 
     expect_string(__wrap__merror, formatted_msg, "(1103): Could not open file 'etc/af_wazuh.conf' due to [(0)-(Success)].");
 
+    errno = 0;
+
     int ret;
     ret = set_auditd_config();
 
@@ -727,6 +729,8 @@ void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) 
     will_return(__wrap_fclose, -1);
 
     expect_string(__wrap__merror, formatted_msg, "(1140): Could not close file 'etc/af_wazuh.conf' due to [(0)-(Success)].");
+
+    errno = 0;
 
     int ret;
     ret = set_auditd_config();


### PR DESCRIPTION
## Description

Closes #32375.

Unit tests in the syscheck/audit (whodata) suite were intermittently failing inside Docker due to unexpected `errno` values (e.g., 95: Operation not supported) being retained from prior library calls. The tests expected messages showing `(0)-(Success)`, but `errno` was not explicitly initialized before exercising mocked failure paths (fopen/fclose). This led to nondeterministic formatted error output assertions.

## Proposed Changes
- Explicitly set `errno = 0;` in the affected test cases before invoking code paths that generate error messages for simulated fopen/fclose failures.
- Ensure deterministic comparison for `__wrap__merror` expectations in `debug_op_wrappers.c`.
- No changes to production code, only to unit tests.

### Results and Evidence

```
[ RUN      ] test_set_auditd_config_audit_plugin_not_created_fopen_error
[       OK ] test_set_auditd_config_audit_plugin_not_created_fopen_error
[ RUN      ] test_set_auditd_config_audit_plugin_not_created_fclose_error
[       OK ] test_set_auditd_config_audit_plugin_not_created_fclose_error
```

### Artifacts Affected
- Test file(s): `test_syscheck_audit`
- No binaries, configs, docs, or runtime components affected.

### Configuration Changes
None.

### Documentation Updates
Not applicable (test stability improvement only).

### Tests Introduced
No new tests added; existing tests stabilized and corrected.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality (stabilized behavior)
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues