### PR TITLE
Only lists services from systemd units

### DIFF
--- a/src/data_provider/src/extended_sources/services/src/systemd_units_linux.cpp
+++ b/src/data_provider/src/extended_sources/services/src/systemd_units_linux.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include "dbus_wrapper.hpp"
 #include "systemd_units_linux.hpp"
+#include "stringHelper.h"
 
 SystemdUnitsProvider::SystemdUnitsProvider(std::shared_ptr<IDBusWrapper> dbusWrapper)
     : m_dbusWrapper(std::move(dbusWrapper))
@@ -178,7 +179,14 @@ bool SystemdUnitsProvider::getSystemdUnits(std::vector<SystemdUnit>& output)
             }
         }
 
-        output.emplace_back(std::move(unit));
+        const auto split = Utils::split(unit.id, '.');
+
+        if (split.size() == 2 && split[1] == "service")
+        {
+            unit.id = std::move(split[0]);
+            output.emplace_back(std::move(unit));
+        }
+
         m_dbusWrapper->message_iter_next(&arrayIter);
     }
 

--- a/src/data_provider/src/extended_sources/services/src/systemd_units_linux.cpp
+++ b/src/data_provider/src/extended_sources/services/src/systemd_units_linux.cpp
@@ -179,11 +179,8 @@ bool SystemdUnitsProvider::getSystemdUnits(std::vector<SystemdUnit>& output)
             }
         }
 
-        const auto split = Utils::split(unit.id, '.');
-
-        if (split.size() == 2 && split[1] == "service")
+        if (Utils::endsWith(unit.id, ".service") && Utils::replaceLast(unit.id, ".service", ""))
         {
-            unit.id = std::move(split[0]);
             output.emplace_back(std::move(unit));
         }
 

--- a/src/data_provider/src/extended_sources/services/tests/test_systemd_units_linux.cpp
+++ b/src/data_provider/src/extended_sources/services/tests/test_systemd_units_linux.cpp
@@ -190,7 +190,7 @@ TEST(SystemdUnitsProviderTest, CollectsUnitsSuccessfully)
     nlohmann::json unitsJson = provider.collect();
 
     ASSERT_EQ(unitsJson.size(), 1u);
-    EXPECT_EQ(unitsJson[0]["id"],             "test.service");
+    EXPECT_EQ(unitsJson[0]["id"],             "test");
     EXPECT_EQ(unitsJson[0]["description"],    "Test service description");
     EXPECT_EQ(unitsJson[0]["load_state"],     "loaded");
     EXPECT_EQ(unitsJson[0]["active_state"],   "active");

--- a/src/data_provider/src/extended_sources/services/tests/test_systemd_units_linux.cpp
+++ b/src/data_provider/src/extended_sources/services/tests/test_systemd_units_linux.cpp
@@ -36,13 +36,17 @@ class MockDBusWrapper : public IDBusWrapper
         MOCK_METHOD(bool, getProperty, (DBusConnection*, const std::string&, const std::string&, const std::string&, const std::string&, std::string&), (override));
 };
 
+const char*     servicePath = "/org/freedesktop/systemd1/unit/test_service";
+const char*     devicePath = "/org/freedesktop/systemd1/unit/test_device";
+const char*     secondServicePath = "/org/freedesktop/systemd1/unit/second_test_service";
+
 void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
 {
     DBusConnection* conn  = reinterpret_cast<DBusConnection*>(0x1);
     DBusMessage*    msg   = reinterpret_cast<DBusMessage*>(0x2);
     DBusMessage*    reply = reinterpret_cast<DBusMessage*>(0x3);
-    const char*     objectPath = "/org/freedesktop/systemd1/unit/test_2eservice";
 
+    // Initialization
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
 
     EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
@@ -73,14 +77,6 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     Return(reply)
               ));
 
-    EXPECT_CALL(*mockDbusWrapper, message_unref(_))
-    .Times(testing::AnyNumber());
-
-    EXPECT_CALL(*mockDbusWrapper, error_free(_))
-    .WillRepeatedly(Invoke([](auto) {
-        // do nothing
-    }));
-
     EXPECT_CALL(*mockDbusWrapper, message_iter_init(reply, _))
     .WillOnce(DoAll(
     Invoke([](DBusMessage*, DBusMessageIter*) {}),
@@ -88,11 +84,11 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
               ));
 
     EXPECT_CALL(*mockDbusWrapper, message_iter_get_arg_type(_))
-    .WillOnce(Return(DBUS_TYPE_ARRAY))
-    .WillOnce(Return(DBUS_TYPE_STRUCT))
-
-
-    .WillOnce(Return(DBUS_TYPE_INVALID));
+    .WillOnce(Return(DBUS_TYPE_ARRAY)) // Called at initialization
+    .WillOnce(Return(DBUS_TYPE_STRUCT)) // First unit
+    .WillOnce(Return(DBUS_TYPE_STRUCT)) // Second unit
+    .WillOnce(Return(DBUS_TYPE_STRUCT)) // Third unit
+    .WillOnce(Return(DBUS_TYPE_INVALID)); // End of unit
 
     EXPECT_CALL(*mockDbusWrapper, message_iter_recurse(_, _))
     .WillRepeatedly(DoAll(
@@ -103,7 +99,7 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     EXPECT_CALL(*mockDbusWrapper, message_iter_get_basic(_, _))
     .WillOnce(Invoke([](DBusMessageIter*, void* v)
     {
-        *(const char**)v = "test.service";
+        *(const char**)v = "test_service.service";
     }))
     .WillOnce(Invoke([](DBusMessageIter*, void* v)
     {
@@ -125,9 +121,9 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     {
         *(const char**)v = "";
     }))
-    .WillOnce(Invoke([objectPath](DBusMessageIter*, void* v)
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
     {
-        *(const char**)v = objectPath;
+        *(const char**)v = servicePath;
     }))
     .WillOnce(Invoke([](DBusMessageIter*, void* v)
     {
@@ -140,7 +136,195 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     .WillOnce(Invoke([](DBusMessageIter*, void* v)
     {
         *(const char**)v = "/";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "test_device.device";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "Test device description";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "loaded";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "active";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "running";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = devicePath;
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(uint32_t*)v = 1;
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "/";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "second.test.service.service";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "Another test service description";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "loaded";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "active";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "running";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = secondServicePath;
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(uint32_t*)v = 2;
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "";
+    }))
+    .WillOnce(Invoke([](DBusMessageIter*, void* v)
+    {
+        *(const char**)v = "/";
     }));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            servicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "FragmentPath",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("/lib/systemd/system/test_service.service")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            servicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "SourcePath",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("/etc/systemd/system/test_service.service")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            servicePath,
+                            "org.freedesktop.systemd1.Service",
+                            "User",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("root")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            servicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "UnitFileState",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("enabled")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            devicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "FragmentPath",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("/lib/systemd/system/test_device.device")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            devicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "SourcePath",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("/etc/systemd/system/test_device.device")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            devicePath,
+                            "org.freedesktop.systemd1.Service",
+                            "User",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("root")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            devicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "UnitFileState",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("enabled")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            secondServicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "FragmentPath",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("/lib/systemd/system/second.test.service.service")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            secondServicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "SourcePath",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("/etc/systemd/system/second.test.service.service")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            secondServicePath,
+                            "org.freedesktop.systemd1.Service",
+                            "User",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("root")), Return(true)));
+
+    EXPECT_CALL(*mockDbusWrapper,
+                getProperty(conn,
+                            "org.freedesktop.systemd1",
+                            secondServicePath,
+                            "org.freedesktop.systemd1.Unit",
+                            "UnitFileState",
+                            _))
+    .WillOnce(DoAll(SetArgReferee<5>(std::string("enabled")), Return(true)));
 
     EXPECT_CALL(*mockDbusWrapper, message_iter_next(_))
     .WillOnce(Return(true))
@@ -152,70 +336,81 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     .WillOnce(Return(true))
     .WillOnce(Return(true))
     .WillOnce(Return(true))
-    .WillOnce(Return(false));
+    .WillOnce(Return(true)) // End of first unit
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true)) // End of second unit;
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(true))
+    .WillOnce(Return(false)); // End of last unit;
 
-    EXPECT_CALL(*mockDbusWrapper,
-                getProperty(conn,
-                            "org.freedesktop.systemd1",
-                            objectPath,
-                            "org.freedesktop.systemd1.Unit",
-                            "FragmentPath",
-                            _))
-    .WillOnce(DoAll(SetArgReferee<5>(std::string("/lib/systemd/system/test.service")), Return(true)));
+    EXPECT_CALL(*mockDbusWrapper, message_unref(_))
+    .WillRepeatedly(Invoke([](auto)
+    {
+        // do nothing
+    }));
 
-    EXPECT_CALL(*mockDbusWrapper,
-                getProperty(conn,
-                            "org.freedesktop.systemd1",
-                            objectPath,
-                            "org.freedesktop.systemd1.Unit",
-                            "SourcePath",
-                            _))
-    .WillOnce(DoAll(SetArgReferee<5>(std::string("/etc/systemd/system/test.service")), Return(true)));
-
-    EXPECT_CALL(*mockDbusWrapper,
-                getProperty(conn,
-                            "org.freedesktop.systemd1",
-                            objectPath,
-                            "org.freedesktop.systemd1.Service",
-                            "User",
-                            _))
-    .WillOnce(DoAll(SetArgReferee<5>(std::string("root")), Return(true)));
-
-    EXPECT_CALL(*mockDbusWrapper,
-                getProperty(conn,
-                            "org.freedesktop.systemd1",
-                            objectPath,
-                            "org.freedesktop.systemd1.Unit",
-                            "UnitFileState",
-                            _))
-    .WillOnce(DoAll(SetArgReferee<5>(std::string("enabled")), Return(true)));
+    EXPECT_CALL(*mockDbusWrapper, error_free(_))
+    .WillRepeatedly(Invoke([](auto)
+    {
+        // do nothing
+    }));
 }
 
 TEST(SystemdUnitsProviderTest, CollectsUnitsSuccessfully)
 {
     auto mockDbusWrapper = std::make_shared<MockDBusWrapper>();
 
-    SetUpTestMock(mockDbusWrapper);    
+    SetUpTestMock(mockDbusWrapper);
 
     SystemdUnitsProvider provider(mockDbusWrapper);
 
     nlohmann::json unitsJson = provider.collect();
+    ASSERT_EQ(unitsJson.size(), 2u);
 
-    ASSERT_EQ(unitsJson.size(), 1u);
-    EXPECT_EQ(unitsJson[0]["id"],             "test");
+    EXPECT_EQ(unitsJson[0]["id"],             "test_service");
     EXPECT_EQ(unitsJson[0]["description"],    "Test service description");
     EXPECT_EQ(unitsJson[0]["load_state"],     "loaded");
     EXPECT_EQ(unitsJson[0]["active_state"],   "active");
     EXPECT_EQ(unitsJson[0]["sub_state"],      "running");
     EXPECT_EQ(unitsJson[0]["following"],      "");
-    // EXPECT_EQ(unitsJson[0]["object_path"],    objectPath);
+    EXPECT_EQ(unitsJson[0]["object_path"],    servicePath);
     EXPECT_EQ(unitsJson[0]["job_id"],         0u);
     EXPECT_EQ(unitsJson[0]["job_type"],       "");
     EXPECT_EQ(unitsJson[0]["job_path"],       "/");
-    EXPECT_EQ(unitsJson[0]["fragment_path"],  "/lib/systemd/system/test.service");
-    EXPECT_EQ(unitsJson[0]["source_path"],    "/etc/systemd/system/test.service");
+    EXPECT_EQ(unitsJson[0]["fragment_path"],  "/lib/systemd/system/test_service.service");
+    EXPECT_EQ(unitsJson[0]["source_path"],    "/etc/systemd/system/test_service.service");
     EXPECT_EQ(unitsJson[0]["user"],           "root");
     EXPECT_EQ(unitsJson[0]["unit_file_state"], "enabled");
+
+    EXPECT_EQ(unitsJson[1]["id"],             "second.test.service");
+    EXPECT_EQ(unitsJson[1]["description"],    "Another test service description");
+    EXPECT_EQ(unitsJson[1]["load_state"],     "loaded");
+    EXPECT_EQ(unitsJson[1]["active_state"],   "active");
+    EXPECT_EQ(unitsJson[1]["sub_state"],      "running");
+    EXPECT_EQ(unitsJson[1]["following"],      "");
+    EXPECT_EQ(unitsJson[1]["object_path"],    secondServicePath);
+    EXPECT_EQ(unitsJson[1]["job_id"],         2u);
+    EXPECT_EQ(unitsJson[1]["job_type"],       "");
+    EXPECT_EQ(unitsJson[1]["job_path"],       "/");
+    EXPECT_EQ(unitsJson[1]["fragment_path"],  "/lib/systemd/system/second.test.service.service");
+    EXPECT_EQ(unitsJson[1]["source_path"],    "/etc/systemd/system/second.test.service.service");
+    EXPECT_EQ(unitsJson[1]["user"],           "root");
+    EXPECT_EQ(unitsJson[1]["unit_file_state"], "enabled");
 }
 
 TEST(SystemdUnitsProviderTest, FailsWhenBusConnectionFails)
@@ -232,9 +427,10 @@ TEST(SystemdUnitsProviderTest, FailsWhenBusConnectionFails)
     }),
     Return(nullptr)
               ));
-              
+
     EXPECT_CALL(*mockDbusWrapper, error_free(_))
-    .WillRepeatedly(Invoke([](auto) {
+    .WillRepeatedly(Invoke([](auto)
+    {
         // do nothing
     }));
     auto result = provider.collect();
@@ -250,7 +446,8 @@ TEST(SystemdUnitsProviderTest, FailsWhenMessageCreationFails)
 
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
     EXPECT_CALL(*mockDbusWrapper, error_free(_))
-    .WillRepeatedly(Invoke([](auto) {
+    .WillRepeatedly(Invoke([](auto)
+    {
         // do nothing
     }));
     EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
@@ -306,7 +503,7 @@ TEST(SystemdUnitsProviderTest, FailsWhenReplyIsNotArray)
     DBusMessage* reply = reinterpret_cast<DBusMessage*>(0x3);
 
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
-EXPECT_CALL(*mockDbusWrapper, error_free(_));
+    EXPECT_CALL(*mockDbusWrapper, error_free(_));
     EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
     .WillOnce(Return(conn));
     EXPECT_CALL(*mockDbusWrapper, error_is_set(_)).WillRepeatedly(Return(false));

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -99,6 +99,20 @@ namespace Utils
         return ret;
     }
 
+    static bool replaceLast(std::string& data, const std::string& toSearch, const std::string& toReplace)
+    {
+        auto pos {data.rfind(toSearch)};  // find last occurrence
+        bool ret {false};
+
+        if (pos != std::string::npos)
+        {
+            data.replace(pos, toSearch.size(), toReplace);
+            ret = true;
+        }
+
+        return ret;
+    }
+
     static std::string leftTrim(const std::string& str, const std::string& args = " ")
     {
         const auto pos {str.find_first_not_of(args)};

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -135,6 +135,25 @@ TEST_F(StringUtilsTest, CheckNotFirstReplacement)
     EXPECT_FALSE(retVal);
 }
 
+TEST_F(StringUtilsTest, CheckLastReplacement)
+{
+    std::string string_base {"bye_bye_bye"};
+    const auto retVal1 {Utils::replaceLast(string_base, "bye", "hello")};
+    EXPECT_EQ(string_base, "bye_bye_hello");
+    string_base = "bye_hello_bye";
+    const auto retVal2 = Utils::replaceLast(string_base, "bye", "");
+    EXPECT_EQ(string_base, "bye_hello_");
+    EXPECT_TRUE(retVal1 && retVal2);
+}
+
+TEST_F(StringUtilsTest, CheckNotLastReplacement)
+{
+    std::string string_base {"hello_world"};
+    const auto retVal {Utils::replaceLast(string_base, "nothing_", "bye_")};
+    EXPECT_EQ(string_base, "hello_world");
+    EXPECT_FALSE(retVal);
+}
+
 TEST_F(StringUtilsTest, RightTrim)
 {
     EXPECT_EQ("Hello", Utils::rightTrim("Hello"));


### PR DESCRIPTION
## Description

Closes #32167 

Fixes issue where starting from version 4.14, the Linux Agent inventories multiple systemd unit types (target, socket, device, etc.) along with the relevant services type.

In this PR the provider only lists systemd units of type service.

## Proposed Changes

- [x] Select only units of type service in the systemd collector.
- [x] Remove the .service suffix from the service name before storing it.

### Results and Evidence

**Sample output before fix:**
```
[
    {
        "active_state": "active",
        "description": "/sys/devices/pci0000:00/0000:00:1f.6/ptp/ptp0",
        "following": "",
        "fragment_path": "",
        "id": "sys-devices-pci0000:00-0000:00:1f.6-ptp-ptp0.device",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/sys_2ddevices_2dpci0000_3a00_2d0000_3a00_3a1f_2e6_2dptp_2dptp0_2edevice",
        "source_path": "",
        "sub_state": "plugged",
        "unit_file_state": "",
        "user": ""
    },
    {
        "active_state": "active",
        "description": "Huge Pages File System",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/dev-hugepages.mount",
        "id": "dev-hugepages.mount",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/dev_2dhugepages_2emount",
        "source_path": "/proc/self/mountinfo",
        "sub_state": "mounted",
        "unit_file_state": "static",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "Rotate log files",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/logrotate.service",
        "id": "logrotate.service",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/logrotate_2eservice",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "static",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "Rebuild Journal Catalog",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/systemd-journal-catalog-update.service",
        "id": "systemd-journal-catalog-update.service",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/systemd_2djournal_2dcatalog_2dupdate_2eservice",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "static",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "Network Service Netlink Socket",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/systemd-networkd.socket",
        "id": "systemd-networkd.socket",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/systemd_2dnetworkd_2esocket",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "disabled",
        "user": ""
    },
    {
        "active_state": "active",
        "description": "initctl Compatibility Named Pipe",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/systemd-initctl.socket",
        "id": "systemd-initctl.socket",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/systemd_2dinitctl_2esocket",
        "source_path": "",
        "sub_state": "listening",
        "unit_file_state": "static",
        "user": ""
    },
    {
        "active_state": "active",
        "description": "Legacy Locks Directory /run/lock",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/run-lock.mount",
        "id": "run-lock.mount",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/run_2dlock_2emount",
        "source_path": "/proc/self/mountinfo",
        "sub_state": "mounted",
        "unit_file_state": "disabled",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "System Hibernation",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/hibernate.target",
        "id": "hibernate.target",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/hibernate_2etarget",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "static",
        "user": ""
    }
]
```
**Sample output after fix:**
```
[
    {
        "active_state": "inactive",
        "description": "Daily apt upgrade and clean activities",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/apt-daily-upgrade.service",
        "id": "apt-daily-upgrade",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/apt_2ddaily_2dupgrade_2eservice",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "static",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "systemd-quotacheck.service",
        "following": "",
        "fragment_path": "",
        "id": "systemd-quotacheck",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "not-found",
        "object_path": "/org/freedesktop/systemd1/unit/systemd_2dquotacheck_2eservice",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "Run anacron jobs",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/anacron.service",
        "id": "anacron",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/anacron_2eservice",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "enabled",
        "user": ""
    },
    {
        "active_state": "inactive",
        "description": "Reboot System Userspace",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/systemd-soft-reboot.service",
        "id": "systemd-soft-reboot",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/systemd_2dsoft_2dreboot_2eservice",
        "source_path": "",
        "sub_state": "dead",
        "unit_file_state": "static",
        "user": ""
    },
    {
        "active_state": "active",
        "description": "Switcheroo Control Proxy service",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/switcheroo-control.service",
        "id": "switcheroo-control",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/switcheroo_2dcontrol_2eservice",
        "source_path": "",
        "sub_state": "running",
        "unit_file_state": "enabled",
        "user": ""
    },
    {
        "active_state": "active",
        "description": "Show Plymouth Boot Screen",
        "following": "",
        "fragment_path": "/usr/lib/systemd/system/plymouth-start.service",
        "id": "plymouth-start",
        "job_id": 0,
        "job_path": "/",
        "job_type": "",
        "load_state": "loaded",
        "object_path": "/org/freedesktop/systemd1/unit/plymouth_2dstart_2eservice",
        "source_path": "",
        "sub_state": "exited",
        "unit_file_state": "static",
        "user": ""
    }
]
```
  
### Artifacts Affected

  - data_provider/src/extended_sources/services
  - shared_modules/utils/stringHelper.h

### Configuration Changes

  - NA

### Tests Introduced
New tests:
  - StringUtilsTest.CheckLastReplacement
  - StringUtilsTest.CheckLastReplacement
  
Updated test:
  - SystemdUnitsProviderTest.CollectsUnitsSuccessfully
### Documentation Updates

  - NA
  
## Definition of done

- [x] The systemd collector returns only units of type service.
- [x] The .service suffix is removed from the service name.
- [ ] The Indexer reflects an inventory of Linux services only, without other unit types.
- [ ] Tested and validated a Linux distribution using systemd.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
