### PR TITLE
Fix test compilation with gcc14

### DIFF
--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -28,6 +28,41 @@ jobs:
           target: ${{ matrix.target }}
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      - name: "Install gcc 14.3"
+        run: |
+          echo "Download GCC 14.3 package"
+          cd /tmp
+          for i in {1..3}; do
+            if wget --timeout=30 --tries=3 https://packages.wazuh.com/utils/gcc/gcc_14.3-1_amd64.deb; then
+              break
+            fi
+            echo "Download attempt $i failed, retrying..."
+            sleep 2
+          done
+
+          echo "Verify download succeeded"
+          if [ ! -f gcc_14.3-1_amd64.deb ]; then
+            echo "Failed to download GCC package after 3 attempts"
+            exit 1
+          fi
+
+          sudo dpkg -i gcc_14.3-1_amd64.deb || {
+            echo "Package installation failed, trying to fix dependencies"
+            sudo apt-get update && sudo apt-get install -f -y
+            sudo dpkg -i gcc_14.3-1_amd64.deb
+          }
+
+          # Create symlinks with backup of original
+          sudo mv /usr/bin/gcc /usr/bin/gcc.bak 2>/dev/null || true
+          sudo mv /usr/bin/g++ /usr/bin/g++.bak 2>/dev/null || true
+          sudo mv /usr/bin/c++ /usr/bin/c++.bak 2>/dev/null || true
+          sudo ln -sf /opt/gcc-14/bin/gcc /usr/bin/gcc
+          sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/g++
+          sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/c++
+
+          # Verify compiler works
+          gcc --version
+          g++ --version
       - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:

--- a/src/Makefile
+++ b/src/Makefile
@@ -2067,7 +2067,7 @@ install_api: install_python
 ####################
 #### test ##########
 ####################
-CFLAGS_TEST=-g -O0 --coverage -fPIC -DWAZUH_UNIT_TESTING
+CFLAGS_TEST=-g -O0 --coverage -DWAZUH_UNIT_TESTING
 # Use sanitizers only on linux and when VALGRIND is not set
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
@@ -2104,6 +2104,9 @@ unit_tests/wrappers/externals/procpc/%.o: unit_tests/wrappers/externals/procpc/%
 
 unit_tests/wrappers/externals/sqlite/%.o: unit_tests/wrappers/externals/sqlite/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@
+
+unit_tests/wrappers/externals/pcre2/%.o: unit_tests/wrappers/externals/pcre2/%.c
+	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -fPIC -c $^ -o $@
 
 unit_tests/wrappers/libc/%.o: unit_tests/wrappers/libc/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} ${DEFINES_EVENTCHANNEL} -c $^ -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -759,7 +759,6 @@ ROCKSDB_LIB = $(EXTERNAL_ROCKSDB)build/librocksdb.so
 SIMDJSON_LIB = $(EXTERNAL_SIMDJSON)build/libsimdjson.a
 ABSEILCPP_LIB = $(EXTERNAL_ABSEILCPP)build/build_result/lib*/libabsl_*.a
 RE2_LIB = $(EXTERNAL_RE2)build/libre2.a
-SIMDJSON_LIB = $(EXTERNAL_SIMDJSON)build/libsimdjson.a
 FLATBUFFERS_LIB = $(EXTERNAL_FLATBUFFERS)build/libflatbuffers.a
 SPDLOG_LIB = $(EXTERNAL_SPDLOG)build/libspdlog.a
 YAMLCPP_LIB = $(EXTERNAL_YAMLCPP)build/libyaml-cpp.a
@@ -2068,7 +2067,7 @@ install_api: install_python
 ####################
 #### test ##########
 ####################
-CFLAGS_TEST=-g -O0 --coverage -DWAZUH_UNIT_TESTING
+CFLAGS_TEST=-g -O0 --coverage -fPIC -DWAZUH_UNIT_TESTING
 # Use sanitizers only on linux and when VALGRIND is not set
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -26,6 +26,8 @@
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/libc/string_wrappers.h"
 #include "../wrappers/posix/unistd_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+
 #include "cJSON.h"
 
 /* redefinitons/wrapping */

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.h
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.h
@@ -37,6 +37,7 @@ long int __wrap_ftell(FILE *__stream);
 
 int __wrap_fseek(FILE *stream, long offset, int whence);
 
+size_t __real_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 size_t __wrap_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
 int __wrap_remove(const char *filename);

--- a/src/unit_tests/wrappers/wazuh/remoted/agent_metadata_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/agent_metadata_wrappers.c
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include "agent_metadata_wrappers.h"

--- a/src/unit_tests/wrappers/wazuh/shared/batch_queue_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/batch_queue_op_wrappers.c
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include <time.h>                 /* struct timespec */


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes #32371 

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

* Build corrections for gcc14
  * fPIC issue.
  * Needed declarations and header include.
* gcc upgrade action creation.
  * Used in legacy tests for 5.x.
  * Possible improvements on this action can be performed.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

* gcc versions:

<details><summary>Details</summary>
<p>

```console
╰─# gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/opt/gcc-14/libexec/gcc/x86_64-pc-linux-gnu/14.3.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: ../configure --prefix=/opt/gcc-14 --disable-multilib --enable-default-dwarf=2 --enable-languages=c,c++ --with-system-zlib
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 14.3.0 (GCC) 
╭─root@d7f306e1f628 /workspaces/wazuh-5.x-v1 
╰─# g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/opt/gcc-14/libexec/gcc/x86_64-pc-linux-gnu/14.3.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: ../configure --prefix=/opt/gcc-14 --disable-multilib --enable-default-dwarf=2 --enable-languages=c,c++ --with-system-zlib
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 14.3.0 (GCC) 
╭─root@d7f306e1f628 /workspaces/wazuh-5.x-v1 
╰─# cc -v 
Using built-in specs.
COLLECT_GCC=cc
COLLECT_LTO_WRAPPER=/opt/gcc-14/libexec/gcc/x86_64-pc-linux-gnu/14.3.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: ../configure --prefix=/opt/gcc-14 --disable-multilib --enable-default-dwarf=2 --enable-languages=c,c++ --with-system-zlib
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 14.3.0 (GCC) 
```

</p>
</details> 

* Dependencies download:

<details><summary>Details</summary>
<p>

```console
╰─# make deps TARGET=server  -j 16                     
Makefile:918: warning: overriding recipe for target 'external/simdjson/build/libsimdjson.a'
Makefile:889: warning: ignoring old recipe for target 'external/simdjson/build/libsimdjson.a'
Makefile:2244: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2187: warning: ignoring old recipe for target 'win32/ui_resource.o'
curl -so external/cJSON.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/cJSON.tar.gz || true
curl -so external/curl.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/curl.tar.gz || true
curl -so external/libdb.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libdb.tar.gz || true
curl -so external/libffi.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libffi.tar.gz || true
curl -so external/libyaml.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libyaml.tar.gz || true
curl -so external/openssl.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/openssl.tar.gz || true
curl -so external/procps.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/procps.tar.gz || true
curl -so external/sqlite.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/sqlite.tar.gz || true
curl -so external/zlib.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/zlib.tar.gz || true
curl -so external/audit-userspace.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/audit-userspace.tar.gz || true
curl -so external/msgpack.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/msgpack.tar.gz || true
curl -so external/bzip2.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/bzip2.tar.gz || true
curl -so external/nlohmann.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/nlohmann.tar.gz || true
curl -so external/googletest.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/googletest.tar.gz || true
curl -so external/libpcre2.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libpcre2.tar.gz || true
curl -so external/libplist.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libplist.tar.gz || true
cd external && [ -f bzip2.tar.gz ] && gunzip bzip2.tar.gz || true
cd external && [ -f bzip2.tar ] && tar -xf bzip2.tar || true
[ -f external/bzip2.tar ] && rm external/bzip2.tar || true
curl -so external/pacman.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/pacman.tar.gz || true
cd external && [ -f libffi.tar.gz ] && gunzip libffi.tar.gz || true
cd external && [ -f msgpack.tar.gz ] && gunzip msgpack.tar.gz || true
cd external && [ -f libffi.tar ] && tar -xf libffi.tar || true
cd external && [ -f msgpack.tar ] && tar -xf msgpack.tar || true
[ -f external/libffi.tar ] && rm external/libffi.tar || true
curl -so external/libarchive.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libarchive.tar.gz || true
[ -f external/msgpack.tar ] && rm external/msgpack.tar || true
curl -so external/popt.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/popt.tar.gz || true
cd external && [ -f nlohmann.tar.gz ] && gunzip nlohmann.tar.gz || true
cd external && [ -f audit-userspace.tar.gz ] && gunzip audit-userspace.tar.gz || true
cd external && [ -f nlohmann.tar ] && tar -xf nlohmann.tar || true
[ -f external/nlohmann.tar ] && rm external/nlohmann.tar || true
curl -so external/lua.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/lua.tar.gz || true
cd external && [ -f audit-userspace.tar ] && tar -xf audit-userspace.tar || true
[ -f external/audit-userspace.tar ] && rm external/audit-userspace.tar || true
cd external && [ -f cJSON.tar.gz ] && gunzip cJSON.tar.gz || true
curl -so external/rpm.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/rpm.tar.gz || true
cd external && [ -f cJSON.tar ] && tar -xf cJSON.tar || true
[ -f external/cJSON.tar ] && rm external/cJSON.tar || true
curl -so external/rocksdb.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/rocksdb.tar.gz || true
cd external && [ -f procps.tar.gz ] && gunzip procps.tar.gz || true
cd external && [ -f procps.tar ] && tar -xf procps.tar || true
[ -f external/procps.tar ] && rm external/procps.tar || true
curl -so external/lzma.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/lzma.tar.gz || true
cd external && [ -f libyaml.tar.gz ] && gunzip libyaml.tar.gz || true
cd external && [ -f libplist.tar.gz ] && gunzip libplist.tar.gz || true
cd external && [ -f libplist.tar ] && tar -xf libplist.tar || true
[ -f external/libplist.tar ] && rm external/libplist.tar || true
curl -so external/cpp-httplib.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/cpp-httplib.tar.gz || true
cd external && [ -f libyaml.tar ] && tar -xf libyaml.tar || true
[ -f external/libyaml.tar ] && rm external/libyaml.tar || true
curl -so external/benchmark.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/benchmark.tar.gz || true
cd external && [ -f lua.tar.gz ] && gunzip lua.tar.gz || true
cd external && [ -f lua.tar ] && tar -xf lua.tar || true
[ -f external/lua.tar ] && rm external/lua.tar || true
curl -so external/libbpf-bootstrap.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libbpf-bootstrap.tar.gz || true
cd external && [ -f popt.tar.gz ] && gunzip popt.tar.gz || true
cd external && [ -f popt.tar ] && tar -xf popt.tar || true
[ -f external/popt.tar ] && rm external/popt.tar || true
curl -so external/dbus.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/dbus.tar.gz || true
cd external && [ -f zlib.tar.gz ] && gunzip zlib.tar.gz || true
cd external && [ -f zlib.tar ] && tar -xf zlib.tar || true
[ -f external/zlib.tar ] && rm external/zlib.tar || true
curl -so external/flatbuffers.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/flatbuffers.tar.gz || true
cd external && [ -f rpm.tar.gz ] && gunzip rpm.tar.gz || true
cd external && [ -f rpm.tar ] && tar -xf rpm.tar || true
[ -f external/rpm.tar ] && rm external/rpm.tar || true
curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/cpython.tar.gz || true
cd external && [ -f googletest.tar.gz ] && gunzip googletest.tar.gz || true
cd external && [ -f googletest.tar ] && tar -xf googletest.tar || true
cd external && [ -f libdb.tar.gz ] && gunzip libdb.tar.gz || true
[ -f external/googletest.tar ] && rm external/googletest.tar || true
curl -so external/jemalloc.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/jemalloc.tar.gz || true
cd external && [ -f pacman.tar.gz ] && gunzip pacman.tar.gz || true
cd external && [ -f curl.tar.gz ] && gunzip curl.tar.gz || true
cd external && [ -f libbpf-bootstrap.tar.gz ] && gunzip libbpf-bootstrap.tar.gz || true
cd external && [ -f pacman.tar ] && tar -xf pacman.tar || true
cd external && [ -f libbpf-bootstrap.tar ] && tar -xf libbpf-bootstrap.tar || true
[ -f external/libbpf-bootstrap.tar ] && rm external/libbpf-bootstrap.tar || true
curl -so external/simdjson.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/simdjson.tar.gz || true
cd external && [ -f libdb.tar ] && tar -xf libdb.tar || true
[ -f external/pacman.tar ] && rm external/pacman.tar || true
curl -so external/spdlog.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/spdlog.tar.gz || true
[ -f external/libdb.tar ] && rm external/libdb.tar || true
curl -so external/yaml-cpp.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/yaml-cpp.tar.gz || true
cd external && [ -f curl.tar ] && tar -xf curl.tar || true
cd external && [ -f libpcre2.tar.gz ] && gunzip libpcre2.tar.gz || true
[ -f external/curl.tar ] && rm external/curl.tar || true
cd external && [ -f libpcre2.tar ] && tar -xf libpcre2.tar || true
curl -so external/pugixml.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/pugixml.tar.gz || true
[ -f external/libpcre2.tar ] && rm external/libpcre2.tar || true
curl -so external/libmaxminddb.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/libmaxminddb.tar.gz || true
cd external && [ -f flatbuffers.tar.gz ] && gunzip flatbuffers.tar.gz || true
cd external && [ -f lzma.tar.gz ] && gunzip lzma.tar.gz || true
cd external && [ -f libmaxminddb.tar.gz ] && gunzip libmaxminddb.tar.gz || true
cd external && [ -f lzma.tar ] && tar -xf lzma.tar || true
cd external && [ -f libmaxminddb.tar ] && tar -xf libmaxminddb.tar || true
[ -f external/libmaxminddb.tar ] && rm external/libmaxminddb.tar || true
curl -so external/date.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/date.tar.gz || true
[ -f external/lzma.tar ] && rm external/lzma.tar || true
curl -so external/fmt.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/fmt.tar.gz || true
cd external && [ -f cpp-httplib.tar.gz ] && gunzip cpp-httplib.tar.gz || true
cd external && [ -f flatbuffers.tar ] && tar -xf flatbuffers.tar || true
cd external && [ -f cpp-httplib.tar ] && tar -xf cpp-httplib.tar || true
[ -f external/cpp-httplib.tar ] && rm external/cpp-httplib.tar || true
curl -so external/abseil-cpp.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/abseil-cpp.tar.gz || true
cd external && [ -f sqlite.tar.gz ] && gunzip sqlite.tar.gz || true
[ -f external/flatbuffers.tar ] && rm external/flatbuffers.tar || true
curl -so external/re2.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/re2.tar.gz || true
cd external && [ -f sqlite.tar ] && tar -xf sqlite.tar || true
cd external && [ -f date.tar.gz ] && gunzip date.tar.gz || true
[ -f external/sqlite.tar ] && rm external/sqlite.tar || true
curl -so external/protobuf.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/protobuf.tar.gz || true
cd external && [ -f date.tar ] && tar -xf date.tar || true
[ -f external/date.tar ] && rm external/date.tar || true
curl -so external/rapidjson.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/rapidjson.tar.gz || true
cd external && [ -f fmt.tar.gz ] && gunzip fmt.tar.gz || true
cd external && [ -f fmt.tar ] && tar -xf fmt.tar || true
[ -f external/fmt.tar ] && rm external/fmt.tar || true
curl -so external/taskflow.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/taskflow.tar.gz || true
cd external && [ -f yaml-cpp.tar.gz ] && gunzip yaml-cpp.tar.gz || true
cd external && [ -f yaml-cpp.tar ] && tar -xf yaml-cpp.tar || true
[ -f external/yaml-cpp.tar ] && rm external/yaml-cpp.tar || true
curl -so external/RxCpp.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/RxCpp.tar.gz || true
cd external && [ -f abseil-cpp.tar.gz ] && gunzip abseil-cpp.tar.gz || true
cd external && [ -f abseil-cpp.tar ] && tar -xf abseil-cpp.tar || true
cd external && [ -f RxCpp.tar.gz ] && gunzip RxCpp.tar.gz || true
[ -f external/abseil-cpp.tar ] && rm external/abseil-cpp.tar || true
cd external && [ -f RxCpp.tar ] && tar -xf RxCpp.tar || true
curl -so external/concurrentqueue.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/concurrentqueue.tar.gz || true
[ -f external/RxCpp.tar ] && rm external/RxCpp.tar || true
curl -so external/fast_float.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/linux/amd64/fast_float.tar.gz || true
cd external && [ -f re2.tar.gz ] && gunzip re2.tar.gz || true
cd external && [ -f re2.tar ] && tar -xf re2.tar || true
[ -f external/re2.tar ] && rm external/re2.tar || true
find shared_modules/http-request -type f -exec false {} + &&\
((test -e shared_modules/http-request.tar || curl -so shared_modules/http-request.tar.gz -L https://github.com/wazuh/wazuh-http-request/tarball/ef2cb3029b4b7649791951268c13baeb1de6085e) &&\
(gunzip shared_modules/http-request.tar.gz || (rm -f shared_modules/http-request.tar.gz && echo "Error decompressing shared_modules/http-request.tar.gz maybe wrong branch was supplied!" && false)) &&\
tar -xf shared_modules/http-request.tar --strip-components=1 -C shared_modules/http-request &&\
rm shared_modules/http-request.tar) || true
cd external && [ -f rapidjson.tar.gz ] && gunzip rapidjson.tar.gz || true
cd external && [ -f rapidjson.tar ] && tar -xf rapidjson.tar || true
[ -f external/rapidjson.tar ] && rm external/rapidjson.tar || true
test -d external/cJSON ||\
(curl -so external/cJSON.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/cJSON.tar.gz &&\
cd external && gunzip cJSON.tar.gz && tar -xf cJSON.tar && rm cJSON.tar)
test -d external/curl ||\
(curl -so external/curl.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/curl.tar.gz &&\
cd external && gunzip curl.tar.gz && tar -xf curl.tar && rm curl.tar)
test -d external/libdb ||\
(curl -so external/libdb.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libdb.tar.gz &&\
cd external && gunzip libdb.tar.gz && tar -xf libdb.tar && rm libdb.tar)
test -d external/libffi ||\
(curl -so external/libffi.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libffi.tar.gz &&\
cd external && gunzip libffi.tar.gz && tar -xf libffi.tar && rm libffi.tar)
test -d external/libyaml ||\
(curl -so external/libyaml.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libyaml.tar.gz &&\
cd external && gunzip libyaml.tar.gz && tar -xf libyaml.tar && rm libyaml.tar)
test -d external/procps ||\
(curl -so external/procps.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/procps.tar.gz &&\
cd external && gunzip procps.tar.gz && tar -xf procps.tar && rm procps.tar)
test -d external/sqlite ||\
(curl -so external/sqlite.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/sqlite.tar.gz &&\
cd external && gunzip sqlite.tar.gz && tar -xf sqlite.tar && rm sqlite.tar)
test -d external/zlib ||\
(curl -so external/zlib.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/zlib.tar.gz &&\
cd external && gunzip zlib.tar.gz && tar -xf zlib.tar && rm zlib.tar)
test -d external/audit-userspace ||\
(curl -so external/audit-userspace.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/audit-userspace.tar.gz &&\
cd external && gunzip audit-userspace.tar.gz && tar -xf audit-userspace.tar && rm audit-userspace.tar)
test -d external/msgpack ||\
(curl -so external/msgpack.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/msgpack.tar.gz &&\
cd external && gunzip msgpack.tar.gz && tar -xf msgpack.tar && rm msgpack.tar)
test -d external/bzip2 ||\
(curl -so external/bzip2.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/bzip2.tar.gz &&\
cd external && gunzip bzip2.tar.gz && tar -xf bzip2.tar && rm bzip2.tar)
test -d external/nlohmann ||\
(curl -so external/nlohmann.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/nlohmann.tar.gz &&\
cd external && gunzip nlohmann.tar.gz && tar -xf nlohmann.tar && rm nlohmann.tar)
test -d external/googletest ||\
(curl -so external/googletest.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/googletest.tar.gz &&\
cd external && gunzip googletest.tar.gz && tar -xf googletest.tar && rm googletest.tar)
test -d external/libpcre2 ||\
(curl -so external/libpcre2.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libpcre2.tar.gz &&\
cd external && gunzip libpcre2.tar.gz && tar -xf libpcre2.tar && rm libpcre2.tar)
test -d external/libplist ||\
(curl -so external/libplist.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libplist.tar.gz &&\
cd external && gunzip libplist.tar.gz && tar -xf libplist.tar && rm libplist.tar)
test -d external/pacman ||\
(curl -so external/pacman.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/pacman.tar.gz &&\
cd external && gunzip pacman.tar.gz && tar -xf pacman.tar && rm pacman.tar)
test -d external/popt ||\
(curl -so external/popt.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/popt.tar.gz &&\
cd external && gunzip popt.tar.gz && tar -xf popt.tar && rm popt.tar)
test -d external/lua ||\
(curl -so external/lua.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/lua.tar.gz &&\
cd external && gunzip lua.tar.gz && tar -xf lua.tar && rm lua.tar)
test -d external/rpm ||\
(curl -so external/rpm.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/rpm.tar.gz &&\
cd external && gunzip rpm.tar.gz && tar -xf rpm.tar && rm rpm.tar)
test -d external/lzma ||\
(curl -so external/lzma.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/lzma.tar.gz &&\
cd external && gunzip lzma.tar.gz && tar -xf lzma.tar && rm lzma.tar)
test -d external/cpp-httplib ||\
(curl -so external/cpp-httplib.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/cpp-httplib.tar.gz &&\
cd external && gunzip cpp-httplib.tar.gz && tar -xf cpp-httplib.tar && rm cpp-httplib.tar)
test -d external/libbpf-bootstrap ||\
(curl -so external/libbpf-bootstrap.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libbpf-bootstrap.tar.gz &&\
cd external && gunzip libbpf-bootstrap.tar.gz && tar -xf libbpf-bootstrap.tar && rm libbpf-bootstrap.tar)
test -d external/flatbuffers ||\
(curl -so external/flatbuffers.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/flatbuffers.tar.gz &&\
cd external && gunzip flatbuffers.tar.gz && tar -xf flatbuffers.tar && rm flatbuffers.tar)
test -d external/yaml-cpp ||\
(curl -so external/yaml-cpp.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/yaml-cpp.tar.gz &&\
cd external && gunzip yaml-cpp.tar.gz && tar -xf yaml-cpp.tar && rm yaml-cpp.tar)
test -d external/libmaxminddb ||\
(curl -so external/libmaxminddb.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libmaxminddb.tar.gz &&\
cd external && gunzip libmaxminddb.tar.gz && tar -xf libmaxminddb.tar && rm libmaxminddb.tar)
test -d external/date ||\
(curl -so external/date.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/date.tar.gz &&\
cd external && gunzip date.tar.gz && tar -xf date.tar && rm date.tar)
test -d external/fmt ||\
(curl -so external/fmt.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/fmt.tar.gz &&\
cd external && gunzip fmt.tar.gz && tar -xf fmt.tar && rm fmt.tar)
test -d external/abseil-cpp ||\
(curl -so external/abseil-cpp.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/abseil-cpp.tar.gz &&\
cd external && gunzip abseil-cpp.tar.gz && tar -xf abseil-cpp.tar && rm abseil-cpp.tar)
test -d external/re2 ||\
(curl -so external/re2.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/re2.tar.gz &&\
cd external && gunzip re2.tar.gz && tar -xf re2.tar && rm re2.tar)
test -d external/rapidjson ||\
(curl -so external/rapidjson.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/rapidjson.tar.gz &&\
cd external && gunzip rapidjson.tar.gz && tar -xf rapidjson.tar && rm rapidjson.tar)
test -d external/RxCpp ||\
(curl -so external/RxCpp.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/RxCpp.tar.gz &&\
cd external && gunzip RxCpp.tar.gz && tar -xf RxCpp.tar && rm RxCpp.tar)
cd external && [ -f fast_float.tar.gz ] && gunzip fast_float.tar.gz || true
cd external && [ -f fast_float.tar ] && tar -xf fast_float.tar || true
[ -f external/fast_float.tar ] && rm external/fast_float.tar || true
test -d external/fast_float ||\
(curl -so external/fast_float.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/fast_float.tar.gz &&\
cd external && gunzip fast_float.tar.gz && tar -xf fast_float.tar && rm fast_float.tar)
cd external && [ -f concurrentqueue.tar.gz ] && gunzip concurrentqueue.tar.gz || true
cd external && [ -f concurrentqueue.tar ] && tar -xf concurrentqueue.tar || true
[ -f external/concurrentqueue.tar ] && rm external/concurrentqueue.tar || true
test -d external/concurrentqueue ||\
(curl -so external/concurrentqueue.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/concurrentqueue.tar.gz &&\
cd external && gunzip concurrentqueue.tar.gz && tar -xf concurrentqueue.tar && rm concurrentqueue.tar)
cd external && [ -f pugixml.tar.gz ] && gunzip pugixml.tar.gz || true
cd external && [ -f pugixml.tar ] && tar -xf pugixml.tar || true
[ -f external/pugixml.tar ] && rm external/pugixml.tar || true
test -d external/pugixml ||\
(curl -so external/pugixml.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/pugixml.tar.gz &&\
cd external && gunzip pugixml.tar.gz && tar -xf pugixml.tar && rm pugixml.tar)
cd external && [ -f jemalloc.tar.gz ] && gunzip jemalloc.tar.gz || true
cd external && [ -f openssl.tar.gz ] && gunzip openssl.tar.gz || true
cd external && [ -f jemalloc.tar ] && tar -xf jemalloc.tar || true
[ -f external/jemalloc.tar ] && rm external/jemalloc.tar || true
test -d external/jemalloc ||\
(curl -so external/jemalloc.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/jemalloc.tar.gz &&\
cd external && gunzip jemalloc.tar.gz && tar -xf jemalloc.tar && rm jemalloc.tar)
cd external && [ -f openssl.tar ] && tar -xf openssl.tar || true
[ -f external/openssl.tar ] && rm external/openssl.tar || true
test -d external/openssl ||\
(curl -so external/openssl.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/openssl.tar.gz &&\
cd external && gunzip openssl.tar.gz && tar -xf openssl.tar && rm openssl.tar)
cd external && [ -f dbus.tar.gz ] && gunzip dbus.tar.gz || true
cd external && [ -f dbus.tar ] && tar -xf dbus.tar || true
[ -f external/dbus.tar ] && rm external/dbus.tar || true
test -d external/dbus ||\
(curl -so external/dbus.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/dbus.tar.gz &&\
cd external && gunzip dbus.tar.gz && tar -xf dbus.tar && rm dbus.tar)
cd external && [ -f benchmark.tar.gz ] && gunzip benchmark.tar.gz || true
cd external && [ -f rocksdb.tar.gz ] && gunzip rocksdb.tar.gz || true
cd external && [ -f benchmark.tar ] && tar -xf benchmark.tar || true
[ -f external/benchmark.tar ] && rm external/benchmark.tar || true
test -d external/benchmark ||\
(curl -so external/benchmark.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/benchmark.tar.gz &&\
cd external && gunzip benchmark.tar.gz && tar -xf benchmark.tar && rm benchmark.tar)
cd external && [ -f libarchive.tar.gz ] && gunzip libarchive.tar.gz || true
cd external && [ -f simdjson.tar.gz ] && gunzip simdjson.tar.gz || true
cd external && [ -f simdjson.tar ] && tar -xf simdjson.tar || true
[ -f external/simdjson.tar ] && rm external/simdjson.tar || true
test -d external/simdjson ||\
(curl -so external/simdjson.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/simdjson.tar.gz &&\
cd external && gunzip simdjson.tar.gz && tar -xf simdjson.tar && rm simdjson.tar)
cd external && [ -f rocksdb.tar ] && tar -xf rocksdb.tar || true
cd external && [ -f libarchive.tar ] && tar -xf libarchive.tar || true
[ -f external/rocksdb.tar ] && rm external/rocksdb.tar || true
test -d external/rocksdb ||\
(curl -so external/rocksdb.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/rocksdb.tar.gz &&\
cd external && gunzip rocksdb.tar.gz && tar -xf rocksdb.tar && rm rocksdb.tar)
[ -f external/libarchive.tar ] && rm external/libarchive.tar || true
test -d external/libarchive ||\
(curl -so external/libarchive.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/libarchive.tar.gz &&\
cd external && gunzip libarchive.tar.gz && tar -xf libarchive.tar && rm libarchive.tar)
cd external && [ -f taskflow.tar.gz ] && gunzip taskflow.tar.gz || true
cd external && [ -f protobuf.tar.gz ] && gunzip protobuf.tar.gz || true
cd external && [ -f taskflow.tar ] && tar -xf taskflow.tar || true
cd external && [ -f protobuf.tar ] && tar -xf protobuf.tar || true
[ -f external/taskflow.tar ] && rm external/taskflow.tar || true
test -d external/taskflow ||\
(curl -so external/taskflow.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/taskflow.tar.gz &&\
cd external && gunzip taskflow.tar.gz && tar -xf taskflow.tar && rm taskflow.tar)
[ -f external/protobuf.tar ] && rm external/protobuf.tar || true
test -d external/protobuf ||\
(curl -so external/protobuf.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/protobuf.tar.gz &&\
cd external && gunzip protobuf.tar.gz && tar -xf protobuf.tar && rm protobuf.tar)
cd external && [ -f cpython.tar.gz ] && gunzip cpython.tar.gz || true
cd external && [ -f spdlog.tar.gz ] && gunzip spdlog.tar.gz || true
cd external && [ -f spdlog.tar ] && tar -xf spdlog.tar || true
[ -f external/spdlog.tar ] && rm external/spdlog.tar || true
test -d external/spdlog ||\
(curl -so external/spdlog.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/spdlog.tar.gz &&\
cd external && gunzip spdlog.tar.gz && tar -xf spdlog.tar && rm spdlog.tar)
test -e external/cpython.tar ||\
(curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/cpython_x86_64.tar.gz &&\
cd external && gunzip cpython.tar.gz && tar -xf cpython.tar && rm cpython.tar)
test -d external/cpython || (cd external && gzip cpython.tar)
```

</p>
</details> 


* Building with TEST and DEBUG:

<details><summary>Details</summary>
<p>

```console
╰─# make  TARGET=server TEST=1 DEBUG=1 -j 16
...
make[3]: Leaving directory '/workspaces/wazuh-5.x-v1/wazuh/src/syscheckd/build'
make[2]: Leaving directory '/workspaces/wazuh-5.x-v1/wazuh/src/syscheckd/build'
make[1]: Leaving directory '/workspaces/wazuh-5.x-v1/wazuh/src'
make settings
make[1]: Entering directory '/workspaces/wazuh-5.x-v1/wazuh/src'
Makefile:820: TEST is defined; skipping CMake engine test option
Makefile:918: warning: overriding recipe for target 'external/simdjson/build/libsimdjson.a'
Makefile:889: warning: ignoring old recipe for target 'external/simdjson/build/libsimdjson.a'
Makefile:2244: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2187: warning: ignoring old recipe for target 'win32/ui_resource.o'

General settings:
    TARGET:             server
    V:                  
    DEBUG:              1
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ef2cb3029b4b7649791951268c13baeb1de6085e
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -g  -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/sync_protocol/include -Iwazuh_modules/syscollector/include -Iwazuh_modules/sca/include -Idata_provider/include -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include -Ishared_modules/router/include -Ishared_modules/content_manager/include -Ishared_modules/file_helper/file_io/include -Ishared_modules/file_helper/filesystem/include -Iwazuh_modules/vulnerability_scanner/include -I./shared_modules/  -g -O0 --coverage -fPIC -DWAZUH_UNIT_TESTING
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl  -Lshared_modules/dbsync/build/lib -Lshared_modules/sync_protocol/build/lib -Lshared_modules/file_helper/build/lib  -Lwazuh_modules/syscollector/build/lib -Lwazuh_modules/sca/build/lib -Ldata_provider/build/lib -Lsyscheckd/build/lib -g -O0 --coverage -fPIC -DWAZUH_UNIT_TESTING
    LIBS              -lrt -ldl -lm  -lcmocka
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/wazuh-5.x-v1/wazuh/src'

Done building server
```

</p>
</details> 

* Unit Tests execution:

<details><summary>Details</summary>
<p>

```console

╭─root@d7f306e1f628 /workspaces/wazuh-5.x-v1/wazuh/src/unit_tests/build ‹bug/32371-build-server-with-test-in-gcc-14› 
╰─# ctest 
Test project /workspaces/wazuh-5.x-v1/wazuh/src/unit_tests/build
        Start   1: test_manager
  1/141 Test   #1: test_manager ............................................   Passed    0.04 sec
        Start   2: test_secure
  2/141 Test   #2: test_secure .............................................   Passed    0.02 sec
        Start   3: test_save_ctrlmsg_thread
  3/141 Test   #3: test_save_ctrlmsg_thread ................................   Passed    0.01 sec
        Start   4: test_netbuffer
  4/141 Test   #4: test_netbuffer ..........................................   Passed    0.01 sec
        Start   5: test_bulk
  5/141 Test   #5: test_bulk ...............................................   Passed    0.01 sec
        Start   6: test_sendmsg
  6/141 Test   #6: test_sendmsg ............................................   Passed    0.01 sec
        Start   7: test_remote-config
  7/141 Test   #7: test_remote-config ......................................   Passed    0.01 sec
        Start   8: test_syslogtcp
  8/141 Test   #8: test_syslogtcp ..........................................   Passed    0.01 sec
        Start   9: test_remote-state
  9/141 Test   #9: test_remote-state .......................................   Passed    0.01 sec
        Start  10: test_remcom
 10/141 Test  #10: test_remcom .............................................   Passed    0.01 sec
        Start  11: test_wdb_parser
 11/141 Test  #11: test_wdb_parser .........................................   Passed    0.01 sec
        Start  12: test_wdb_global_parser
 12/141 Test  #12: test_wdb_global_parser ..................................   Passed    0.02 sec
        Start  13: test_wdb_global
 13/141 Test  #13: test_wdb_global .........................................   Passed    0.05 sec
        Start  14: test_wdb_global_helpers
 14/141 Test  #14: test_wdb_global_helpers .................................   Passed    0.02 sec
        Start  15: test_wdb
 15/141 Test  #15: test_wdb ................................................   Passed    0.01 sec
        Start  16: test_wdb_upgrade
 16/141 Test  #16: test_wdb_upgrade ........................................   Passed    0.01 sec
        Start  17: test_wdb_metadata
 17/141 Test  #17: test_wdb_metadata .......................................   Passed    0.01 sec
        Start  18: test_wdb_task_parser
 18/141 Test  #18: test_wdb_task_parser ....................................   Passed    0.01 sec
        Start  19: test_wdb_task
 19/141 Test  #19: test_wdb_task ...........................................   Passed    0.01 sec
        Start  20: test_wazuh_db-config
 20/141 Test  #20: test_wazuh_db-config ....................................   Passed    0.01 sec
        Start  21: test_wazuh_db_state
 21/141 Test  #21: test_wazuh_db_state .....................................   Passed    0.01 sec
        Start  22: test_wdb_com
 22/141 Test  #22: test_wdb_com ............................................   Passed    0.01 sec
        Start  23: test_wdb_pool
 23/141 Test  #23: test_wdb_pool ...........................................   Passed    0.01 sec
        Start  24: test_auth_parse
 24/141 Test  #24: test_auth_parse .........................................   Passed    0.01 sec
        Start  25: test_auth_validate
 25/141 Test  #25: test_auth_validate ......................................   Passed    0.01 sec
        Start  26: test_auth_add
 26/141 Test  #26: test_auth_add ...........................................   Passed    0.01 sec
        Start  27: test_ssl
 27/141 Test  #27: test_ssl ................................................   Passed    0.01 sec
        Start  28: test_auth_key_request
 28/141 Test  #28: test_auth_key_request ...................................   Passed    0.01 sec
        Start  29: test_auth
 29/141 Test  #29: test_auth ...............................................   Passed    0.01 sec
        Start  30: test_generate_cert
 30/141 Test  #30: test_generate_cert ......................................   Passed    0.48 sec
        Start  31: test_authd-config
 31/141 Test  #31: test_authd-config .......................................   Passed    0.01 sec
        Start  32: test_aes_op
 32/141 Test  #32: test_aes_op .............................................   Passed    0.01 sec
        Start  33: test_hmac_op
 33/141 Test  #33: test_hmac_op ............................................   Passed    0.01 sec
        Start  34: test_msgs
 34/141 Test  #34: test_msgs ...............................................   Passed    0.01 sec
        Start  35: test_keys
 35/141 Test  #35: test_keys ...............................................   Passed    0.01 sec
        Start  36: test_sha1_op
 36/141 Test  #36: test_sha1_op ............................................   Passed    0.01 sec
        Start  37: test_blowfish_op
 37/141 Test  #37: test_blowfish_op ........................................   Passed    0.01 sec
        Start  38: test_md5_op
 38/141 Test  #38: test_md5_op .............................................   Passed    0.01 sec
        Start  39: test_md5_sha1_sha256_op
 39/141 Test  #39: test_md5_sha1_sha256_op .................................   Passed    0.01 sec
        Start  40: test_sha256_op
 40/141 Test  #40: test_sha256_op ..........................................   Passed    0.01 sec
        Start  41: test_sha512_op
 41/141 Test  #41: test_sha512_op ..........................................   Passed    0.01 sec
        Start  42: test_wm_aws
 42/141 Test  #42: test_wm_aws .............................................   Passed    0.01 sec
        Start  43: test_wm_azure
 43/141 Test  #43: test_wm_azure ...........................................   Passed    0.02 sec
        Start  44: test_wm_command
 44/141 Test  #44: test_wm_command .........................................   Passed    0.02 sec
        Start  45: test_wm_database
 45/141 Test  #45: test_wm_database ........................................   Passed    0.01 sec
        Start  46: test_wm_docker
 46/141 Test  #46: test_wm_docker ..........................................   Passed    0.01 sec
        Start  47: test_wm_gcp
 47/141 Test  #47: test_wm_gcp .............................................   Passed    0.06 sec
        Start  48: test_wmodules_gcp
 48/141 Test  #48: test_wmodules_gcp .......................................   Passed    0.02 sec
        Start  49: test_wmodules_scheduling
 49/141 Test  #49: test_wmodules_scheduling ................................   Passed    0.01 sec
        Start  50: test_wm_vulnerability_detection
 50/141 Test  #50: test_wm_vulnerability_detection .........................   Passed    0.02 sec
        Start  51: test_wm_task_manager
 51/141 Test  #51: test_wm_task_manager ....................................   Passed    0.01 sec
        Start  52: test_wm_task_manager_parsing
 52/141 Test  #52: test_wm_task_manager_parsing ............................   Passed    0.01 sec
        Start  53: test_wm_task_manager_commands
 53/141 Test  #53: test_wm_task_manager_commands ...........................   Passed    0.01 sec
        Start  54: test_wm_agent_upgrade
 54/141 Test  #54: test_wm_agent_upgrade ...................................   Passed    0.01 sec
        Start  55: test_wm_agent_upgrade_manager
 55/141 Test  #55: test_wm_agent_upgrade_manager ...........................   Passed    0.01 sec
        Start  56: test_wm_agent_upgrade_parsing
 56/141 Test  #56: test_wm_agent_upgrade_parsing ...........................   Passed    0.01 sec
        Start  57: test_wm_agent_upgrade_validate
 57/141 Test  #57: test_wm_agent_upgrade_validate ..........................   Passed    0.01 sec
        Start  58: test_wm_agent_upgrade_tasks
 58/141 Test  #58: test_wm_agent_upgrade_tasks .............................   Passed    0.01 sec
        Start  59: test_wm_agent_upgrade_tasks_callbacks
 59/141 Test  #59: test_wm_agent_upgrade_tasks_callbacks ...................   Passed    0.01 sec
        Start  60: test_wm_agent_upgrade_commands
 60/141 Test  #60: test_wm_agent_upgrade_commands ..........................   Passed    0.01 sec
        Start  61: test_wm_agent_upgrade_upgrades
 61/141 Test  #61: test_wm_agent_upgrade_upgrades ..........................   Passed    0.02 sec
        Start  62: test_wmodules
 62/141 Test  #62: test_wmodules ...........................................   Passed    0.01 sec
        Start  63: test_wm_control
 63/141 Test  #63: test_wm_control .........................................   Passed    0.01 sec
        Start  64: test_wm_github
 64/141 Test  #64: test_wm_github ..........................................   Passed    0.02 sec
        Start  65: test_wm_office365
 65/141 Test  #65: test_wm_office365 .......................................   Passed    0.03 sec
        Start  66: test_wm_ms_graph
 66/141 Test  #66: test_wm_ms_graph ........................................   Passed    0.03 sec
        Start  67: test_wm_exec
 67/141 Test  #67: test_wm_exec ............................................   Passed    0.01 sec
        Start  68: test_monitord
 68/141 Test  #68: test_monitord ...........................................   Passed    0.01 sec
        Start  69: test_monitor_actions
 69/141 Test  #69: test_monitor_actions ....................................   Passed    0.01 sec
        Start  70: test_logcollector
 70/141 Test  #70: test_logcollector .......................................   Passed    0.01 sec
        Start  71: test_read_multiline_regex
 71/141 Test  #71: test_read_multiline_regex ...............................   Passed    0.01 sec
        Start  72: test_localfile-config
 72/141 Test  #72: test_localfile-config ...................................   Passed    0.01 sec
        Start  73: test_state
 73/141 Test  #73: test_state ..............................................   Passed    0.01 sec
        Start  74: test_lccom
 74/141 Test  #74: test_lccom ..............................................   Passed    0.46 sec
        Start  75: test_macos_log
 75/141 Test  #75: test_macos_log ..........................................   Passed    0.01 sec
        Start  76: test_read_macos
 76/141 Test  #76: test_read_macos .........................................   Passed    0.01 sec
        Start  77: test_read_multiline
 77/141 Test  #77: test_read_multiline .....................................   Passed    0.01 sec
        Start  78: test_read_journal
 78/141 Test  #78: test_read_journal .......................................   Passed    0.01 sec
        Start  79: test_journal_log
 79/141 Test  #79: test_journal_log ........................................   Passed    0.02 sec
        Start  80: test_read_syslog
 80/141 Test  #80: test_read_syslog ........................................   Passed    0.01 sec
        Start  81: test_execd
 81/141 Test  #81: test_execd ..............................................   Passed    0.01 sec
        Start  82: test_get_command_by_name
 82/141 Test  #82: test_get_command_by_name ................................   Passed    0.01 sec
        Start  83: test_manage_keys
 83/141 Test  #83: test_manage_keys ........................................   Passed    0.01 sec
        Start  84: test_syscom
 84/141 Test  #84: test_syscom .............................................   Passed    0.01 sec
        Start  85: test_fim_diff_changes
 85/141 Test  #85: test_fim_diff_changes ...................................   Passed    0.02 sec
        Start  86: test_run_realtime
 86/141 Test  #86: test_run_realtime .......................................   Passed    0.02 sec
        Start  87: test_config
 87/141 Test  #87: test_config .............................................   Passed    0.03 sec
        Start  88: test_syscheck
 88/141 Test  #88: test_syscheck ...........................................   Passed    0.02 sec
        Start  89: test_run_check
 89/141 Test  #89: test_run_check ..........................................   Passed    0.02 sec
        Start  90: test_fim_scan
 90/141 Test  #90: test_fim_scan ...........................................   Passed    0.03 sec
        Start  91: test_audit_healthcheck
 91/141 Test  #91: test_audit_healthcheck ..................................   Passed    0.01 sec
        Start  92: test_audit_rule_handling
 92/141 Test  #92: test_audit_rule_handling ................................   Passed    0.02 sec
        Start  93: test_syscheck_audit
 93/141 Test  #93: test_syscheck_audit .....................................   Passed    0.07 sec
        Start  94: test_audit_parse
 94/141 Test  #94: test_audit_parse ........................................   Passed    0.02 sec
        Start  95: test_syscheck_ebpf
 95/141 Test  #95: test_syscheck_ebpf ......................................   Passed    0.02 sec
        Start  96: test_list_op
 96/141 Test  #96: test_list_op ............................................   Passed    0.01 sec
        Start  97: test_file_op
 97/141 Test  #97: test_file_op ............................................   Passed    0.01 sec
        Start  98: test_rbtree_op
 98/141 Test  #98: test_rbtree_op ..........................................   Passed    0.01 sec
        Start  99: test_validate_op
 99/141 Test  #99: test_validate_op ........................................   Passed    0.01 sec
        Start 100: test_string_op
100/141 Test #100: test_string_op ..........................................   Passed    0.01 sec
        Start 101: test_expression
101/141 Test #101: test_expression .........................................   Passed    0.01 sec
        Start 102: test_version_op
102/141 Test #102: test_version_op .........................................   Passed    0.02 sec
        Start 103: test_queue_op
103/141 Test #103: test_queue_op ...........................................   Passed    0.01 sec
        Start 104: test_queue_linked_op
104/141 Test #104: test_queue_linked_op ....................................   Passed    0.01 sec
        Start 105: test_batch_queue_op
105/141 Test #105: test_batch_queue_op .....................................   Passed    0.01 sec
        Start 106: test_hashmap_op
106/141 Test #106: test_hashmap_op .........................................   Passed    0.01 sec
        Start 107: test_indexed_queue_op
107/141 Test #107: test_indexed_queue_op ...................................   Passed    0.01 sec
        Start 108: test_agent_op
108/141 Test #108: test_agent_op ...........................................   Passed    0.01 sec
        Start 109: test_enrollment_op
109/141 Test #109: test_enrollment_op ......................................   Passed    0.02 sec
        Start 110: test_time_op
110/141 Test #110: test_time_op ............................................   Passed    0.01 sec
        Start 111: test_buffer_op
111/141 Test #111: test_buffer_op ..........................................   Passed    0.01 sec
        Start 112: test_utf8_op
112/141 Test #112: test_utf8_op ............................................   Passed    0.01 sec
        Start 113: test_log_builder
113/141 Test #113: test_log_builder ........................................   Passed    0.01 sec
        Start 114: test_custom_output_search_replace
114/141 Test #114: test_custom_output_search_replace .......................   Passed    0.01 sec
        Start 115: test_binaries_op
115/141 Test #115: test_binaries_op ........................................   Passed    0.01 sec
        Start 116: test_bzip2_op
116/141 Test #116: test_bzip2_op ...........................................   Passed    0.01 sec
        Start 117: test_schedule_scan
117/141 Test #117: test_schedule_scan ......................................   Passed    0.01 sec
        Start 118: test_rootcheck_op
118/141 Test #118: test_rootcheck_op .......................................   Passed    0.01 sec
        Start 119: test_fs_op
119/141 Test #119: test_fs_op ..............................................   Passed    0.01 sec
        Start 120: test_wazuhdb_op
120/141 Test #120: test_wazuhdb_op .........................................   Passed    0.01 sec
        Start 121: test_syscheck_op
121/141 Test #121: test_syscheck_op ........................................   Passed    0.01 sec
        Start 122: test_json_op
122/141 Test #122: test_json_op ............................................   Passed    0.01 sec
        Start 123: test_audit_op
123/141 Test #123: test_audit_op ...........................................   Passed    0.01 sec
        Start 124: test_privsep_op
124/141 Test #124: test_privsep_op .........................................   Passed    0.01 sec
        Start 125: test_mq_op
125/141 Test #125: test_mq_op ..............................................   Passed    0.01 sec
        Start 126: test_remoted_op
126/141 Test #126: test_remoted_op .........................................   Passed    0.01 sec
        Start 127: test_json-queue
127/141 Test #127: test_json-queue .........................................   Passed    0.01 sec
        Start 128: test_bqueue
128/141 Test #128: test_bqueue .............................................   Passed    0.01 sec
        Start 129: test_atomic
129/141 Test #129: test_atomic .............................................   Passed    0.01 sec
        Start 130: test_url
130/141 Test #130: test_url ................................................   Passed    0.01 sec
        Start 131: test_sysinfo_utils
131/141 Test #131: test_sysinfo_utils ......................................   Passed    0.01 sec
        Start 132: test_rwlock_op
132/141 Test #132: test_rwlock_op ..........................................   Passed    0.01 sec
        Start 133: test_os_xml
133/141 Test #133: test_os_xml .............................................   Passed    0.02 sec
        Start 134: test_os_regex
134/141 Test #134: test_os_regex ...........................................   Passed    0.01 sec
        Start 135: test_os_regex_match
135/141 Test #135: test_os_regex_match .....................................   Passed    0.01 sec
        Start 136: test_os_regex_execute
136/141 Test #136: test_os_regex_execute ...................................   Passed    0.01 sec
        Start 137: test_os_zlib
137/141 Test #137: test_os_zlib ............................................   Passed    0.01 sec
        Start 138: test_client-config_validate_ipv6_link_local_interface
138/141 Test #138: test_client-config_validate_ipv6_link_local_interface ...   Passed    0.01 sec
        Start 139: test_indexer
139/141 Test #139: test_indexer ............................................   Passed    0.01 sec
        Start 140: test_os_net
140/141 Test #140: test_os_net .............................................   Passed    0.01 sec
        Start 141: test_active-response
141/141 Test #141: test_active-response ....................................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 141

Total Test time (real) =   2.81 sec
```



</p>
</details> 

* Workflow check:

<img width="1194" height="718" alt="image" src="https://github.com/user-attachments/assets/497eb234-b17b-4608-961c-9537863faa34" />

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
