### PR TITLE
fix(wazuh-agent.postinst): don't remove installed Debian package files

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -186,11 +186,6 @@ case "$1" in
         rm -f /etc/ossec-init.conf
     fi
 
-    # Delete installation scripts
-    if [ -d ${SCRIPTS_DIR} ]; then
-        rm -rf ${SCRIPTS_DIR}
-    fi
-
     # Delete tmp directory
     if [ -d ${WAZUH_TMP_DIR} ]; then
         rm -rf ${WAZUH_TMP_DIR}


### PR DESCRIPTION
After completing the configure step of wazuh-agent's Debian package, some files are deleted that were installed by the package itself, which should generally not be done as it breaks reconfigure and causes package integrity checks to fail.

Closes #32392 