### PR TITLE
Implement changes to deal with new mac OS 26 SCA files

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -503,6 +503,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/ruleset/sca/cis_apple_macOS_13.x.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_apple_macOS_14.x.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_apple_macOS_15.x.yml*,root,wazuh,640,file,-rw-r-----,,
+/var/ossec/ruleset/sca/cis_apple_macOS_26.x.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_centos6_linux.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_centos7_linux.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_centos8_linux.yml*,root,wazuh,640,file,-rw-r-----,,

--- a/etc/templates/config/darwin/26/sca.files
+++ b/etc/templates/config/darwin/26/sca.files
@@ -1,0 +1,1 @@
+darwin/26/cis_apple_macOS_26.x.yml

--- a/etc/templates/config/generic/sca.manager.files
+++ b/etc/templates/config/generic/sca.manager.files
@@ -31,6 +31,7 @@ darwin/21/cis_apple_macOS_12.0.yml
 darwin/22/cis_apple_macOS_13.x.yml
 darwin/23/cis_apple_macOS_14.x.yml
 darwin/24/cis_apple_macOS_15.x.yml
+darwin/26/cis_apple_macOS_26.x.yml
 debian/cis_debian7.yml
 debian/cis_debian8.yml
 debian/cis_debian9.yml

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -134,6 +134,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/22
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/23
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/24
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/26
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/8
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/9
@@ -190,6 +191,7 @@ override_dh_install:
 	cp etc/templates/config/darwin/22/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/22
 	cp etc/templates/config/darwin/23/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/23
 	cp etc/templates/config/darwin/24/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/24
+	cp etc/templates/config/darwin/26/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/darwin/26
 
 	cp etc/templates/config/debian/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian
 	cp etc/templates/config/debian/7/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/7

--- a/packages/macos/package_files/build.sh
+++ b/packages/macos/package_files/build.sh
@@ -72,13 +72,14 @@ function build() {
     find ${SOURCES_PATH}/src/init/ -name *.sh -type f -exec install -m 0640 {} ${INSTALLATION_SCRIPTS_DIR}/src/init \;
 
     mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/generic
-    mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/{15,16,17,18,20,21,22,23,24}
+    FOLDER_LIST="15 16 17 18 20 21 22 23 24 26"
+    mkdir -p ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/{$(echo $FOLDER_LIST | tr ' ' ',')}
 
     cp -r ${SOURCES_PATH}/ruleset/sca/darwin ${INSTALLATION_SCRIPTS_DIR}/sca
     cp -r ${SOURCES_PATH}/ruleset/sca/generic ${INSTALLATION_SCRIPTS_DIR}/sca
     cp ${SOURCES_PATH}/etc/templates/config/generic/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/generic/
 
-    for n in $(seq 15 24); do
+    for n in $FOLDER_LIST; do
         cp ${SOURCES_PATH}/etc/templates/config/darwin/$n/sca.files ${INSTALLATION_SCRIPTS_DIR}/sca/darwin/$n/
     done
 }

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -122,7 +122,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/{applications,generic}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/{1,2,2023}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/{10,9,8,7,6,5}
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/{15,16,17,18,19,20,21,22,23,24}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/{15,16,17,18,19,20,21,22,23,24,26}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/{7,8,9,10,11,12,13}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9,10}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/{12,14,16,18,20,22,24}/04
@@ -891,6 +891,8 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/23/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/24
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/24/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/26
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/26/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9


### PR DESCRIPTION
|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/issues/32381|

## Description

Hi team,

this PR updates the SPECS files related to the newly added SCA policy file for the mac OS 26 system.

## Tests
Workflow triggered with:
```console
gh workflow run 4_builderpackage_agent-macos.yml -r 4.14.1 -f source_reference=enhancement/32381-specs-fo
r-default-settings-of-mac-os-26-tahoe-sca -f architecture=arm64 -f is_stage=false -f checksum=true
```
:green_circle: [Packages - Build Wazuh agent macOS packages - arm64 - checksum #293](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18159381932)

```console
gh workflow run 4_builderpackage_agent-macos.yml -r 4.14.1 -f source_reference=enhancement/32381-specs-fo
r-default-settings-of-mac-os-26-tahoe-sca -f architecture=intel64 -f is_stage=false -f checksum=true
```
:green_circle: [Packages - Build Wazuh agent macOS packages - intel64 - checksum #294](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18159384587)
