### PR TITLE
Add validation for duplicate custom fields in 6.0.0

### DIFF
--- a/src/engine/test/health_test/engine-health-test/src/health_test/schema_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/schema_validate.py
@@ -118,6 +118,26 @@ def get_validation_function(field_type):
 
     return lambda value: False
 
+def is_template_file(custom_fields_data: list) -> bool:
+    """
+    Check if the given custom fields data is a template file.
+    """
+    if len(custom_fields_data) == 1:
+        item = custom_fields_data[0]
+        field_name = (item.get('field') or '').strip()
+        ftype = (item.get('type') or '').strip()
+        if field_name == "" and ftype == "":
+            return True
+    return False
+
+def _format_yaml_parse_error(raw_msg: str, file_path: str) -> str:
+    """
+    Produce a concise, user-friendly YAML error message.
+    Extracts 'line X, column Y' when present.
+    """
+    line_candidates = [int(m) for m in re.findall(r'line\s+(\d+)', raw_msg, flags=re.IGNORECASE)]
+    line_no = min(line_candidates) if line_candidates else 1
+    return f"Malformed YAML: {file_path}:{line_no}"
 
 def load_custom_fields(custom_fields_path, reporter: ErrorReporter, allowed_custom_fields_type):
     """
@@ -126,34 +146,74 @@ def load_custom_fields(custom_fields_path, reporter: ErrorReporter, allowed_cust
     custom_fields_map = {}
     try:
         custom_fields_data = rs.ResourceHandler().load_file(custom_fields_path.as_posix())
+        seen_by_field = {}
+        empty_entry_error_reported = False
+
+        if is_template_file(custom_fields_data):
+            reporter.add_warning(
+                "Custom Fields",
+                custom_fields_path,
+                "The 'custom_fields.yml' appears to be a template file. No fields were loaded."
+            )
+            return {}
+
         for item in custom_fields_data:
-            if item['field']:
-                if item['type'] not in allowed_custom_fields_type:
+            field_name = (item.get('field') or '').strip()
+            ftype = (item.get('type') or '').strip()
+
+            if field_name == "" or ftype == "":
+                if not empty_entry_error_reported:
                     reporter.add_error(
-                        "Custom Fields", custom_fields_path,
-                        f"Invalid type '{item['type']}' for field '{item['field']}'. Allowed types: {allowed_custom_fields_type}"
+                        "Custom Fields",
+                        custom_fields_path,
+                        "Empty entries detected. Missing 'field' or 'type'."
                     )
-                    continue
+                    empty_entry_error_reported = True
+                continue
 
-                declared_array_flag = bool(item.get('array', False))
+            if field_name in seen_by_field:
+                reporter.add_error(
+                    "Custom Fields",
+                    custom_fields_path,
+                    f"Duplicate field '{field_name}'. Field names must be unique."
+                )
+                continue
 
-                if item['type'] == 'nested':
-                    if declared_array_flag:
-                        reporter.add_warning(
-                        "Load Custom Fields", custom_fields_path,
-                        f"Field '{item['field']}': 'type: nested' implies array; 'array: true' is redundant."
-                        )
-                    array_flag = True
-                else:
-                    array_flag = declared_array_flag
+            seen_by_field[field_name] = True
 
-                validation_fn = get_validation_function(item['type'])
-                custom_fields_map[item['field']] = (item['type'], array_flag, validation_fn)
+            if ftype not in allowed_custom_fields_type:
+                reporter.add_error(
+                    "Custom Fields",
+                    custom_fields_path,
+                    f"Invalid type '{ftype}' for field '{field_name}'. "
+                    f"Allowed types: {allowed_custom_fields_type}"
+                )
+                continue
+
+            declared_array_flag = bool(item.get('array', False))
+            if ftype == 'nested':
+                if declared_array_flag:
+                    reporter.add_warning(
+                        "Custom Fields", custom_fields_path,
+                        f"Field '{field_name}': 'type: nested' implies array; 'array: true' is redundant."
+                    )
+                array_flag = True
+            else:
+                array_flag = declared_array_flag
+
+            validation_fn = get_validation_function(ftype)
+            custom_fields_map[field_name] = (ftype, array_flag, validation_fn)
 
         return custom_fields_map
+
     except Exception as e:
-        reporter.add_error("Load Custom Fields", str(custom_fields_path), f"Error loading custom fields: {e}")
-        return {}
+
+        reporter.add_error(
+            "Load Custom Fields",
+            str(custom_fields_path),
+            _format_yaml_parse_error(str(e), str(custom_fields_path))
+        )
+        return None
 
 
 def transform_dict_to_list(d):
@@ -177,23 +237,10 @@ def transform_dict_to_list(d):
     return extract_keys(d)
 
 
-def get_value_from_hierarchy(data, field):
-    keys = field.split('.')
-    value = data
-
-    for key in keys:
-        if isinstance(value, dict) and key in value:
-            value = value[key]
-        else:
-            return None
-
-    return value
-
-
 def ancestors(field: str):
     """
     Returns hierarchical prefixes of a field.
-    Ej: 'a.b.c.d' -> ['a', 'a.b', 'a.b.c']
+    E.g.: 'a.b.c.d' -> ['a', 'a.b', 'a.b.c']
     """
     parts = field.split('.')
     acc = []
@@ -237,7 +284,38 @@ def verify_schema_types(schema, expected_json_files, custom_fields_map, integrat
             if inv_c == parent_c or inv_c.startswith(parent_c + '.'):
                 candidates.discard(inv)
 
+    def _get_all_values_from_hierarchy(data, field):
+        """
+        Return a list with all values found at 'field', traversing lists-of-objects implicitly.
+        If nothing is found, return None.
+        """
+        keys = field.split('.')
+
+        def rec(node, i):
+            if i == len(keys):
+                return [node]
+            key = keys[i]
+            out = []
+            if isinstance(node, dict):
+                if key in node:
+                    out.extend(rec(node[key], i + 1))
+            elif isinstance(node, list):
+                for el in node:
+                    out.extend(rec(el, i))
+            return out
+
+        vals = rec(data, 0)
+        return vals if vals else None
+
     def _validate_array(field, ftype, validate_fn, value, add_err):
+        """
+        Validate an array-typed custom field.
+        Nulls (None) are treated as non-fatal: they raise a warning and are ignored.
+        """
+        if value is None:
+            reporter.add_warning(integration_name, json_file, f"Field '{field}': null array value ignored")
+            return True
+
         if ftype == 'nested' and isinstance(value, dict):
             value = [value]
         if not isinstance(value, list):
@@ -246,6 +324,9 @@ def verify_schema_types(schema, expected_json_files, custom_fields_map, integrat
 
         is_valid = True
         for el in value:
+            if el is None:
+                reporter.add_warning(integration_name, json_file, f"Field '{field}': null array element ignored")
+                continue
             if ftype == 'nested':
                 if not isinstance(el, dict):
                     got_t = infer_type_name_for_error(el, ftype)
@@ -265,6 +346,14 @@ def verify_schema_types(schema, expected_json_files, custom_fields_map, integrat
         return is_valid
 
     def _validate_scalar(field, ftype, validate_fn, value, add_err):
+        """
+        Validate a scalar-typed custom field.
+        Null (None) is treated as non-fatal: it raises a warning and is ignored.
+        """
+        if value is None:
+            reporter.add_warning(integration_name, json_file, f"Field '{field}': null value ignored")
+            return True
+
         if isinstance(value, list):
             add_err(f"Field '{field}' declared scalar, but schema emits an array")
             return False
@@ -315,22 +404,31 @@ def verify_schema_types(schema, expected_json_files, custom_fields_map, integrat
                             filtered_invalid_fields.discard(inv)
 
                     for field, (ftype, is_array, validate_function) in custom_fields_map.items():
-                        expected_value = get_value_from_hierarchy(expected, field)
-                        if expected_value is None:
-                            filtered_invalid_fields.discard(field)
+                        occurrences = _get_all_values_from_hierarchy(expected, field)
+                        if not occurrences:
                             continue
+                        if is_array:
+                            had_json_list_leaf = any(isinstance(v, list) for v in occurrences)
 
-                        is_valid = _validate_array(field, ftype, validate_function, expected_value, add_err) if is_array \
-                             else _validate_scalar(field, ftype, validate_function, expected_value, add_err)
+                            if (not had_json_list_leaf) and len(occurrences) == 1 and ftype != 'nested':
+                                only = occurrences[0]
+                                if only is not None and not isinstance(only, list):
+                                    add_err(
+                                        f"Field '{field}' declared as array, but JSON emits a scalar value: {repr(only)}"
+                                    )
 
-                        if not is_valid:
-                            filtered_invalid_fields.discard(field)
-                            continue
-
-                        if ftype in {'object', 'nested', 'flattened'}:
-                            _remove_children(filtered_invalid_fields, field)
+                            agg = []
+                            for v in occurrences:
+                                if isinstance(v, list):
+                                    agg.extend(v)
+                                else:
+                                    agg.append(v)
+                            _ = _validate_array(field, ftype, validate_function, agg, add_err)
                         else:
-                            filtered_invalid_fields.discard(field)
+                            for v in occurrences:
+                                _ = _validate_scalar(field, ftype, validate_function, v, add_err)
+
+                        _remove_children(filtered_invalid_fields, field)
 
                     if filtered_invalid_fields:
                         file_unknowns.update(_canon(f) for f in filtered_invalid_fields)
@@ -352,6 +450,45 @@ def find_expected_json_files(test_folder):
     return list(test_folder.rglob('*_expected.json'))
 
 
+def _collect_unknown_fields_from_expected(expected_json_files, schema_field_names, schema_field_types, reporter=None, integration_name=None):
+    """
+    Lightweight pre-scan to decide whether custom fields are required.
+    Returns a set of canonical unknown field paths (indices stripped).
+    """
+    _CANON_RE = re.compile(r"\[\d+\]")
+
+    def _canon(p: str) -> str:
+        return _CANON_RE.sub("", p)
+
+    def _is_under_geopoint(field_path: str) -> bool:
+        parts = field_path.split('.')
+        acc = []
+        for p in parts[:-1]:
+            acc.append(p)
+            anc = '.'.join(acc)
+            if schema_field_types.get(anc) == 'geo_point':
+                return True
+        return False
+
+    unknowns = set()
+    for json_file in expected_json_files:
+        try:
+            with open(json_file, 'r') as f:
+                data = json.load(f)
+        except Exception as e:
+            if reporter and integration_name:
+                reporter.add_error(integration_name, str(json_file), f"Error reading the file: {e}")
+            continue
+
+        for expected in data:
+            extracted_fields = transform_dict_to_list(expected)
+            for field in extracted_fields:
+                if field not in schema_field_names and not _is_under_geopoint(field):
+                    unknowns.add(_canon(field))
+
+    return unknowns
+
+
 def verify(schema, integration: Path, reporter):
     try:
         with open(schema, 'r') as schema_file:
@@ -359,16 +496,14 @@ def verify(schema, integration: Path, reporter):
     except Exception as e:
         sys.exit(f"Error reading the JSON schema file: {e}")
 
-    allowed_custom_fields_type = {field_info["type"] for field_info in schema_data["fields"].values()}
+    fields_info = schema_data.get("fields", {})
+    allowed_custom_fields_type = {field_info.get("type") for field_info in fields_info.values()}
+    schema_field_names = set(fields_info.keys())
+    schema_field_types = {k: v.get("type") for k, v in fields_info.items()}
 
     if integration.name != 'wazuh-core':
         custom_fields_path = integration / 'test' / 'custom_fields.yml'
-        if not custom_fields_path.exists():
-            reporter.add_error(integration.name, str(custom_fields_path),
-                               "Error: custom_fields.yml file does not exist.")
-            return
 
-        custom_fields = load_custom_fields(custom_fields_path, reporter, allowed_custom_fields_type)
         test_folder = integration / 'test'
         if not test_folder.exists() or not test_folder.is_dir():
             reporter.add_error(integration.name, str(test_folder), "Error: No 'test' folder found.")
@@ -379,6 +514,25 @@ def verify(schema, integration: Path, reporter):
             reporter.add_error(integration.name, str(test_folder), "Error: No '_expected.json' files found.")
             return
 
+        # If custom_fields.yml is missing, only skip when no custom fields are required.
+        if not custom_fields_path.exists():
+            unknowns = _collect_unknown_fields_from_expected(
+                expected_json_files, schema_field_names, schema_field_types, reporter, integration.name
+            )
+            if unknowns:
+                missing_rel = (integration / 'test' / 'custom_fields.yml').as_posix()
+                msg = "Missing 'custom_fields.yml' but expected JSONs contain fields outside the schema:\n" + \
+                      "".join(f"      - {u}\n" for u in sorted(unknowns))
+                reporter.add_error(integration.name, missing_rel, msg.rstrip())
+                return
+            # No unknowns => no custom fields required. It's valid to skip.
+            return
+
+        # custom_fields.yml exists (maybe empty/template): proceed with the full validation flow.
+        custom_fields = load_custom_fields(custom_fields_path, reporter, allowed_custom_fields_type)
+        if custom_fields is None:
+            # Fatal parse/load error already reported; abort to avoid noisy "Unknown fields".
+            return
         verify_schema_types(schema, expected_json_files, custom_fields, integration.name, reporter, custom_fields_path)
 
 
@@ -449,12 +603,12 @@ def run(args):
             rules_validator(schema, ruleset_path, integration_rule, reporter)
 
         reporter.print_warnings(
-        "Non-fatal issues detected (redundant configuration or permissive values)",
-        ruleset_path)
+            "Non-fatal issues detected (redundant configuration or permissive values)",
+            ruleset_path)
         reporter.report_title = "VALIDATION ERRORS:"
         reporter.exit_with_errors(
-        "Schema mismatches detected (unknown fields, type errors, or array/scalar cardinality)",
-        ruleset_path)
+            "Schema mismatches detected (unknown fields, type errors, or array/scalar cardinality)",
+            ruleset_path)
 
         print("Success execution")
     except Exception as e:

--- a/src/engine/tools/engine-suite/src/shared/resource_handler.py
+++ b/src/engine/tools/engine-suite/src/shared/resource_handler.py
@@ -53,7 +53,7 @@ class ResourceHandler:
         try:
             read = yaml.load(content, Loader=Loader)  # yaml.SafeLoader
         except yaml.YAMLError as e:
-            print(f"Error while reading YAML file:{e}")
+            raise e
         return read
 
     def _read(self, content: str, format: Format) -> dict:
@@ -110,8 +110,9 @@ class ResourceHandler:
         read = {}
         try:
             read = self._read(content, format)
-        except:
-            raise Exception(f'Failed to read {path.name}')
+        except Exception as e:
+            print(f'Failed to read {path.name}')
+            raise e
         return read
 
     def load_file(self, path_str: str, format: Format = Format.YML):


### PR DESCRIPTION
## Description

Introduce stricter validation in the schema validation, focused on `custom_fields.yml` handling:
- **Report an error** when a custom field is **defined more than once**.
- **Template-only file**: **warn** and **skip** (no fields loaded).
- **Empty entries mixed with valid rows** (`field` or `type` empty alongside valid items): indicating empty entries were detected.
- **Missing `test/custom_fields.yml`**: integrations are **skipped** only when custom fields are **not required** by the expected JSONs; otherwise an **error** lists the unknown fields.
- **Null handling in expected JSONs**: `null` scalar values and `null` elements inside arrays are **non-fatal** → logged as **warnings** and ignored.
- **Nested traversal across arrays of objects**: child fields can be validated even if the parent array field is not explicitly declared as a custom field.

Closes **2942**

## Proposed Changes

- Added duplicate-field detection in `load_custom_fields(...)`: duplicate names are flagged as **errors**.
- Added **template-only detection**: emit a **warning** and skip when the file contains exactly the empty stub.
- When **`test/custom_fields.yml` is absent**:
  - If the expected JSONs contain **no fields outside the schema** → **silently skip**.
  - If they do contain unknown fields → **error** with a **list** of required custom fields.
- Validate **children inside arrays-of-objects** without requiring the **parent** field to be declared.
- Treat **`null`** values as **warnings** (scalar `null` and `null` elements in arrays) to reduce noise while keeping signals.

### Results and Evidence

**Static schema validation (engine-health-test):**

```text
╰─# engine-health-test static -r ruleset schema_validate            
Running schema tests.
Validating both integration and rules.

VALIDATION WARNINGS:
Warnings: Non-fatal issues detected (redundant configuration or permissive values)

Validation: azure
  File: integrations/azure/test/provisioning/provisioninglogs-raw_expected.json
   Notes:
    - Field 'azure.provisioning.properties.source_system.details': empty object value '{}'
    - Field 'azure.provisioning.properties.target_identity.details': empty object value '{}'

Validation: gcp
  File: integrations/gcp/test/audit/gcp-audit_expected.json
   Notes:
    - Field 'gcp_audit.authenticationinfo.serviceaccountdelegationinfo': empty object value '{}'

Validation: Custom Fields
  File: integrations/system/test/custom_fields.yml
   Notes:
    - The 'custom_fields.yml' appears to be a template file. No fields were loaded.
  File: integrations/wazuh-dashboard/test/custom_fields.yml
   Notes:
    - The 'custom_fields.yml' appears to be a template file. No fields were loaded.
  File: integrations/apache-http/test/custom_fields.yml
   Notes:
    - The 'custom_fields.yml' appears to be a template file. No fields were loaded.
  File: integrations/aws-fargate/test/custom_fields.yml
   Notes:
    - The 'custom_fields.yml' appears to be a template file. No fields were loaded.

VALIDATION ERRORS:
Failed: Schema mismatches detected (unknown fields, type errors, or array/scalar cardinality).

Validation: Custom Fields
  File: integrations/microsoft-exchange-server/test/custom_fields.yml
   Fields:
    - Duplicate field 'microsoft.exchange.connector_id'. Field names must be unique.
    - Duplicate field 'microsoft.exchange.context'. Field names must be unique.
    - Duplicate field 'microsoft.exchange.sequence_number'. Field names must be unique.
    - Duplicate field 'microsoft.exchange.session_id'. Field names must be unique.
  File: integrations/apache-tomcat/test/custom_fields.yml
   Fields:
    - Duplicate field 'apache_tomcat.thread_pool.thread.current.cpu.time.enabled'. Field names must be unique.
  File: integrations/microsoft-dhcp/test/custom_fields.yml
   Fields:
    - Duplicate field 'microsoft.dhcp.user_string'. Field names must be unique.
  File: integrations/azure-metrics/test/custom_fields.yml
   Fields:
    - Duplicate field 'azure.compute_vm.disk_read_bytes.total'. Field names must be unique.
    - Duplicate field 'azure.compute_vm.percentage_cpu.avg'. Field names must be unique.
    - Duplicate field 'azure.database_account.availability.avg'. Field names must be unique.
    - Duplicate field 'azure.resource.group'. Field names must be unique.
  File: integrations/microsoft-dnsserver/test/custom_fields.yml
   Fields:
    - Duplicate field 'microsoft.dnsserver_audit_name_server'. Field names must be unique.
    - Duplicate field 'microsoft.dnsserver_audit_zone'. Field names must be unique.
  File: integrations/auditd/test/custom_fields.yml
   Fields:
    - Duplicate field 'auditd.ino'. Field names must be unique.
    - Duplicate field 'auditd.key'. Field names must be unique.
    - Duplicate field 'auditd.key_enforce'. Field names must be unique.
    - Duplicate field 'auditd.nametype'. Field names must be unique.
    - Duplicate field 'auditd.saddr'. Field names must be unique.
    - Duplicate field 'auditd.spid'. Field names must be unique.

Validation: auditd
  File: integrations/auditd/test/auditd_expected.json
   Fields:
    - Errors in: 'integrations/auditd/test/custom_fields.yml'
      - Field 'auditd.ino' declared as 'long' has incompatible scalar value (got type 'keyword', value='188578')
      - Field 'auditd.ino' declared as 'long' has incompatible scalar value (got type 'keyword', value='188999')
      - Field 'auditd.ino' declared as 'long' has incompatible scalar value (got type 'keyword', value='402139')
      - Field 'auditd.key_enforce' declared as 'keyword' has incompatible scalar value (got type 'boolean', value=False)
      - Field 'auditd.saddr' declared as 'ip' has incompatible scalar value (got type 'keyword', value='0200028F000000000000000000000000')
      - Field 'auditd.spid' declared as 'long' has incompatible scalar value (got type 'keyword', value='3161')
      - Field 'auditd.spid' declared as 'long' has incompatible scalar value (got type 'keyword', value='8860')
```

**Duplicate detection example (`microsoft-exchange-server`):**

```text
Validation: Custom Fields
  File: integrations/microsoft-exchange-server/test/custom_fields.yml
   Fields:
    - Duplicate field 'microsoft.exchange.connector_id'. Field names must be unique.
    - Duplicate field 'microsoft.exchange.context'. Field names must be unique.
    - Duplicate field 'microsoft.exchange.sequence_number'. Field names must be unique.
    - Duplicate field 'microsoft.exchange.session_id'. Field names must be unique.
```

**Excerpt from** `integrations/microsoft-exchange-server/test/custom_fields.yml` *(first occurrence, lines 317–320)*:
```yaml
- field: microsoft.exchange.connector_id
  type: keyword
  description: |
    Identifies the Send or Receive connector responsible for handling the message.
```

**Excerpt** *(duplicate occurrence, lines 397–400)*:
```yaml
- field: microsoft.exchange.connector_id
  type: keyword
  description: |
    The distinguished name (DN) of the connector associated with the SMTP event, identifying the specific connector used for mail flow.
```

**Warning example for template file:**

```text
Validation: Custom Fields
  File: integrations/system/test/custom_fields.yml
   Notes:
    - The 'custom_fields.yml' appears to be a template file. No fields were loaded.
```

`integrations/system/test/custom_fields.yml` (excerpt):
```yaml
- field: ""
  type: ""
  description: ""
```

**Error example for empty entries detected:**
```text
VALIDATION ERRORS:
Failed: Schema mismatches detected (unknown fields, type errors, or array/scalar cardinality).

Validation: Custom Fields
  File: integrations/microsoft-exchange-server/test/custom_fields.yml
   Fields:
    - Empty entries detected. Missing 'field' or 'type'.
```

`integrations/microsoft-exchange-server/test/custom_fields.yml` (excerpt):
```yaml
- field: microsoft.exchange.source
  type: keyword
  description: |
    Specifies the Exchange transport component responsible for the logged event.
- field: ""
  type: ""
  description: ""
- field: microsoft.exchange.event_id
  type: keyword
  description: |
    Represents the type of event being tracked in the log. Common examples include RECEIVE, SEND, and DELIVER.
```

**Warnings for `null` values in arrays and scalars:**
```text
VALIDATION WARNINGS:
Warnings: Non-fatal issues detected (redundant configuration or permissive values)

Validation: aws
  File: integrations/aws/test/guardduty/aws-guardduty_expected.json
   Notes:
    - Field 'aws.guardduty.resource.container_details.image.prefix': null value ignored
    - Field 'aws.guardduty.resource.container_details.name': null value ignored
    - Field 'aws.guardduty.resource.container_details.volume_mounts': null array element ignored
    - Field 'aws.guardduty.resource.instance_details.outpost_arn': null value ignored
    - Field 'aws.guardduty.resource.instance_details.platform': null value ignored

Validation: cisco-ftd
  File: integrations/cisco-ftd/test/security-event/security-event_expected.json
   Notes:
    - Field 'cisco.ftd.security_event.ingress_zone': null value ignored
```

**YAML format error (malformed `custom_fields.yml`):**

```yaml
- field: aws.elb_error_reason
  type: keyword
  description: |
    The reason for the error.
- field: aws.elb_classification
  type: keyword
  array
  description: |
    The classification of the request.
- field: aws.elb_classification_reason
  type: keyword
  description: |
    The reason for the classification.
```

```text
VALIDATION ERRORS:
Failed: Schema mismatches detected (unknown fields, type errors, or array/scalar cardinality).

Validation: Load Custom Fields
  File: integrations/aws/test/custom_fields.yml
   Fields:
    - Malformed YAML: integrations/aws/test/custom_fields.yml:415
```

**Missing `custom_fields.yml` when fields are required:**
```text
Validation: iis
  File: integrations/iis/test/custom_fields.yml
   Fields:
    - Missing 'custom_fields.yml' but expected JSONs contain fields outside the schema:
      - iis.bytes_received_by_client
      - iis.bytes_sent_by_server
      - iis.sub_status
      - iis.win32_status
```

**Child validation inside arrays-of-objects (no need to predefine the parent):**
```json
"conditions": [
  {
    "devicePolicy": {
      "allowedDeviceManagementLevels": ["NONE"],
      "allowedEncryptionStatuses": ["ENCRYPTION_UNSPECIFIED"],
      "osConstraints": [
        {
          "minimumVersion": "string",
          "osType": "IOS",
          "requireVerifiedChromeOs": true
        }
      ],
      "requireAdminApproval": true,
      "requireCorpOwned": true,
      "requireScreenlock": true
    },
    "ipSubnetworks": ["10.0.0.0/24", "10.0.0.1/25"],
    "members": ["string"],
    "negate": true,
    "regions": ["string"],
    "requiredAccessLevels": ["string"]
  }
]
```

**Validation output:**

```text
Validation: google-scc
  File: integrations/google-scc/test/asset/asset_expected.json
   Fields:
    - Errors in: 'integrations/google-scc/test/custom_fields.yml'
      - Field 'google_scc.asset.access_level.basic.conditions.devicePolicy' declared as array, but JSON emits a scalar value: {'allowedDeviceManagementLevels': ['NONE'], 'allowedEncryptionStatuses': ['ENCRYPTION_UNSPECIFIED'], 'osConstraints': [{'minimumVersion': 'string', 'osType': 'IOS', 'requireVerifiedChromeOs': True}], 'requireAdminApproval': True, 'requireCorpOwned': True, 'requireScreenlock': True}
      - Field 'google_scc.asset.access_level.basic.conditions.devicePolicy.allowedDeviceManagementLevels' declared scalar, but schema emits an array
      - Field 'google_scc.asset.access_level.basic.conditions.devicePolicy.allowedEncryptionStatuses' declared scalar, but schema emits an array
      - Field 'google_scc.asset.access_level.basic.conditions.ipSubnetworks' declared scalar, but schema emits an array
      - Field 'google_scc.asset.access_level.basic.conditions.members' declared scalar, but schema emits an array
      - Field 'google_scc.asset.access_level.basic.conditions.regions' declared scalar, but schema emits an array
```

**Note:** It is **not required** to declare `google_scc.asset.access_level.basic.conditions` itself to validate its children. Example custom fields:

```yaml
- field: google_scc.asset.access_level.basic.conditions.devicePolicy
  type: object
  array: true
  description: |
    This field defines the parent for all device policy-related conditions.
- field: google_scc.asset.access_level.basic.conditions.devicePolicy.allowedDeviceManagementLevels
  type: keyword
  description: |
    Lists the acceptable device management levels (e.g., unmanaged, basic, advanced) for devices to access the resource.
- field: google_scc.asset.access_level.basic.conditions.devicePolicy.allowedEncryptionStatuses
  type: keyword
  description: |
    Specifies the required device encryption states (e.g., ENCRYPTED, UNENCRYPTED) for compliant access.
```

**CI evidence:**
- Health Test workflow run: **18292441148** — static and dynamic checks passed.

### Artifacts Affected

- Static Health tests: **schema_validate**

### Configuration Changes

- N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...