### PR TITLE
Add `host.os.kernel.release` for Windows agents in IT Hygiene

### DIFF
--- a/src/data_provider/src/osinfo/sysOsInfoInterface.h
+++ b/src/data_provider/src/osinfo/sysOsInfoInterface.h
@@ -42,14 +42,16 @@ class SysOsInfo
         static void setOsInfo(const std::shared_ptr<ISysOsInfoProvider>& osInfoProvider,
                               nlohmann::json& output)
         {
+            const auto version = osInfoProvider->version();
             output["os_name"] = osInfoProvider->name();
             output["os_major"] = osInfoProvider->majorVersion();
             output["os_minor"] = osInfoProvider->minorVersion();
             output["os_build"] = osInfoProvider->build();
-            output["os_version"] = osInfoProvider->version();
+            output["os_version"] = version;
             output["hostname"] = osInfoProvider->nodeName();
             output["os_release"] = osInfoProvider->release();
             output["os_display_version"] = osInfoProvider->displayVersion();
+            output["release"] = version;
             output["architecture"] = osInfoProvider->machine();
             output["os_platform"] = "windows";
         }

--- a/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysOsInfo_test.cpp
@@ -62,4 +62,5 @@ TEST_F(SysOsInfoTest, setOsInfoSchema)
     EXPECT_EQ("1903", output.at("os_release"));
     EXPECT_EQ("19H1", output.at("os_display_version"));
     EXPECT_EQ("10.0.18362", output.at("os_version"));
+    EXPECT_EQ("10.0.18362", output.at("release"));
 }


### PR DESCRIPTION
## Description

This pull request introduces the `release` field in Syscollector for Windows environments. The field is now exposed as `host.os.kernel.release` within the IT Hygiene dashboard panel.

## Proposed Changes

- Added the `release` field to Syscollector for Windows.
- Ensured the field is displayed as `host.os.kernel.release` on the IT Hygiene dashboard.

### Results and Evidence

The attached screenshot demonstrates the IT Hygiene dashboard displaying the new `host.os.kernel.release` field.

|Before|After|
|--|--|
|<img width="1700" height="665" alt="Screenshot 2025-10-02 135240" src="https://github.com/user-attachments/assets/5789ce88-d7a9-4d21-8b4c-76b583640aa3" />|<img width="1703" height="675" alt="Screenshot 2025-10-02 141242" src="https://github.com/user-attachments/assets/169bc40b-6d7c-48b9-95dc-88f96d5fad05" />|

### Artifacts Affected

- Agent for Windows

### Configuration Changes

No configuration changes are required.

### Documentation Updates

No documentation updates are needed; the field is already documented.

### Tests Introduced

Component tests for DataProvider have been adapted to cover this change.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues