### PR TITLE
Collect Brave browser extensions for Windows Agents

### DIFF
--- a/src/data_provider/src/extended_sources/browser_extensions/include/chrome.hpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/include/chrome.hpp
@@ -63,6 +63,7 @@ namespace chrome
         EdgeBeta,
         Vivaldi,
         Arc,
+        Comet
     };
 
     /// A list of possible path suffixes for each browser type
@@ -96,7 +97,8 @@ namespace chrome
         {ChromeBrowserType::EdgeBeta, "Library/Application Support/Microsoft Edge Beta"},
         {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"},
         {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"},
-        {ChromeBrowserType::Arc, "Library/Application Support/Arc/User Data"}
+        {ChromeBrowserType::Arc, "Library/Application Support/Arc/User Data"},
+        {ChromeBrowserType::Comet, "Library/Application Support/Comet"}
     };
 
     const ChromePathSuffixMap WINDOWS_PATH_LIST =
@@ -112,7 +114,8 @@ namespace chrome
         {ChromeBrowserType::Edge, "AppData\\Local\\Microsoft\\Edge\\User Data"},
         {ChromeBrowserType::EdgeBeta, "AppData\\Local\\Microsoft\\Edge Beta\\User Data"},
         {ChromeBrowserType::Opera, "AppData\\Roaming\\Opera Software\\Opera Stable"},
-        {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"}
+        {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"},
+        {ChromeBrowserType::Comet, "AppData\\Local\\Perplexity\\Comet\\User Data"}
     };
 
     const std::unordered_map<ChromeBrowserType, std::string>
@@ -130,6 +133,7 @@ namespace chrome
         {ChromeBrowserType::EdgeBeta, "edge_beta"},
         {ChromeBrowserType::Vivaldi, "vivaldi"},
         {ChromeBrowserType::Arc, "arc"},
+        {ChromeBrowserType::Comet, "comet"}
     };
 
     const std::string PREFERENCES_FILE{"Preferences"};


### PR DESCRIPTION
## Description

Closes #32451 

Fixes issue where the Browser Extensions collector was collecting Brave browser extensions from Linux and MacOS machines but not for Windows.

The issue was detected to be due to a wrongly configured installation path for Brave browser on Windows machines.

### Results and Evidence

**Browser Extensions tab before fix:**
<img width="1818" height="988" alt="Screenshot from 2025-10-06 15-30-00" src="https://github.com/user-attachments/assets/ba1576ea-8995-406b-b103-6133d3cb8619" />


**Browser Extensions tab after fix:**
<img width="1818" height="988" alt="Screenshot from 2025-10-06 15-46-24" src="https://github.com/user-attachments/assets/aada4bf6-ca59-4b87-9cc3-602988d3844e" />

### Artifacts Affected

  - data_provider/src/extended_sources/browser_extensions

### Configuration Changes

  - NA

### Tests Introduced
  - NA
  
### Documentation Updates

  - NA

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
