### PR TITLE
Add file path to FIM checksum

### DIFF
--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -278,6 +278,7 @@ typedef struct fim_file_data {
 #ifdef WIN32
     cJSON * perm_json;
 #endif
+    char * path;
     char * permissions;
     char * attributes;
     char * uid;

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -431,8 +431,9 @@ void fim_get_checksum(fim_file_data * data) {
 
     size = snprintf(0,
             0,
-            "%llu:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
+            "%llu:%s:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
             data->size,
+            data->path,
             data->permissions ? data->permissions : "",
             data->attributes ? data->attributes : "",
             data->uid ? data->uid : "",
@@ -448,8 +449,9 @@ void fim_get_checksum(fim_file_data * data) {
     os_calloc(size + 1, sizeof(char), checksum);
     snprintf(checksum,
             size + 1,
-            "%llu:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
+            "%llu:%s:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
             data->size,
+            data->path,
             data->permissions ? data->permissions : "",
             data->attributes ? data->attributes : "",
             data->uid ? data->uid : "",
@@ -468,6 +470,7 @@ void fim_get_checksum(fim_file_data * data) {
 
 void init_fim_data_entry(fim_file_data *data) {
     data->size = 0;
+    data->path = NULL;
     data->permissions = NULL;
 #ifdef WIN32
     data->perm_json = NULL;
@@ -492,6 +495,7 @@ void free_file_data(fim_file_data * data) {
 #ifdef WIN32
     cJSON_Delete(data->perm_json);
 #endif
+    os_free(data->path);
     os_free(data->permissions);
     os_free(data->attributes);
     os_free(data->uid);
@@ -596,6 +600,7 @@ fim_file_data *fim_get_data(const char *file, const directory_t *configuration, 
 
     data->inode = statbuf->st_ino;
     data->device = statbuf->st_dev;
+    os_strdup(file, data->path);
     fim_get_checksum(data);
 
     return data;

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -84,6 +84,7 @@ static OSList *removed_entries;
 fim_file_data DEFAULT_FILE_DATA = {
     // Checksum attributes
     .size = 0,
+    .path = "/var/test",
     .attributes = NULL,
     .uid = "1000",
     .gid = "1000",
@@ -891,9 +892,9 @@ static void test_fim_get_checksum(void **state) {
 
     fim_get_checksum(entry.file_entry.data);
 #ifdef TEST_WINAGENT
-    assert_string_equal(entry.file_entry.data->checksum, "6ec831114b5d930f19a90d7c34996e0fce4e7b84");
+    assert_string_equal(entry.file_entry.data->checksum, "579e3e74428e3926ea6952ff6945d43582d9eb95");
 #else
-    assert_string_equal(entry.file_entry.data->checksum, "98e039efc1b8490965e7e1247a9dc31cf7379051");
+    assert_string_equal(entry.file_entry.data->checksum, "6d10f63e2dc5d0d398ca53063d84e8ca3a3366f1");
 #endif
 }
 
@@ -903,6 +904,7 @@ static void test_fim_get_checksum_wrong_size(void **state) {
     fim_data->local_data = calloc(1, sizeof(fim_file_data));
 
     fim_data->local_data->size = -1;
+    fim_data->local_data->path = strdup("/var/test");
     fim_data->local_data->permissions = strdup("0664");
     fim_data->local_data->attributes = strdup("r--r--r--");
     fim_data->local_data->uid = strdup("100");
@@ -919,7 +921,7 @@ static void test_fim_get_checksum_wrong_size(void **state) {
 
     fim_get_checksum(fim_data->local_data);
 
-    assert_string_equal(fim_data->local_data->checksum, "0a0070d140761418be81531ad48f5909f410e161");
+    assert_string_equal(fim_data->local_data->checksum, "cabc9a9c81819b011164c0f908127b9f56b4c666");
 }
 
 static void test_fim_check_depth_success(void **state) {


### PR DESCRIPTION
## Description
The checksum calculation used in FIM doesn't consider the monitored file's path as part of it. This becomes an issue when dealing with sets of files that have the same contents but different paths, since their checksum values will be identical. Such cases can lead to inconsistencies in the database and prevent certain file events from triggering alerts.
Closes https://github.com/wazuh/wazuh/issues/29668

## Proposed Changes
Include the file path in the checksum calculation. In contrast with some of the other fields that are considered for the checksum, like the size, modification date, etc, the filepath will always be taken into account. There will be no flag inside `ossec.log` to determine it's inclusion in the checksum since we consider it should always be part of it to prevent the kind of inconsistencies mentioned above.

Update the unit tests related to checksums so that they use new values generated by considering the file path.

## Testing
### Manager
Tested by setting up a FIM directory inside `ossec.log`:
```
    <directories realtime="yes">/home/juan/fim_tests</directories>
```
Added a `test1.txt` file into it.
Then we take a look at the db. Taking note of the checksum value for the file:
```
root@:/var/ossec# sqlite3 queue/fim/db/fim.db
sqlite> select path, checksum from file_entry where path like '/home/juan/fim_tests/%';
/home/juan/fim_tests/test1.txt|f6574a1dce3b18f0183f1f608dc2b0364c89b7eb
```
Renamed the file: `juan@:~/fim_tests$ mv test1.txt test2.txt`
Restarted the server: `root@:/var/ossec# bin/wazuh-control restart`
Ran the query again, we can see the new file with a new checksum present and no sign of the old file:
```
sqlite> select path, checksum from file_entry where path like '/home/juan/fim_tests/%';
/home/juan/fim_tests/test2.txt|e93b93117d6803a842f96712979556c7e3cbf95e
```
And by looking inside `alerts.json`, we can see two alerts generated. One for the deletion of the old file, and one for the creation of the new one:
<details> <summary>`alerts.json`</summary>
```
{"wazuh":{"queue":56,"location":"syscheck"},"agent":{"name":"juan-IdeaPad-3-15ITL6","id":"000"},"host":{"os":{"name":"Ubuntu","version":"24.04.3 LTS (Noble Numbat)","full":"noble","platform":"ubuntu","kernel":"Linux |juan-IdeaPad-3-15ITL6 |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2 |x86_64"},"ip":["127.0.1.1"],"architecture":"x86_64"},"event":{"original":"{\"collector\":\"file\",\"module\":\"fim\",\"data\":{\"event\":{\"created\":\"2025-10-08T13:19:38.345Z\",\"type\":\"deleted\"},\"file\":{\"size\":0,\"permissions\":[\"rw-rw-r--\"],\"uid\":\"1000\",\"owner\":\"juan\",\"gid\":\"1000\",\"group\":\"juan\",\"inode\":\"5286127\",\"device\":66309,\"mtime\":1759929538,\"hash\":{\"md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"},\"path\":\"/home/juan/fim_tests/file1.txt\",\"mode\":\"realtime\"}}}"},"@timestamp":"2025-10-08T13:19:38Z","tmp_json":{"collector":"file","module":"fim","data":{"event":{"created":"2025-10-08T13:19:38.345Z","type":"deleted"},"file":{"size":0,"permissions":["rw-rw-r--"],"uid":"1000","owner":"juan","gid":"1000","group":"juan","inode":"5286127","device":66309,"mtime":1759929538,"hash":{"md5":"d41d8cd98f00b204e9800998ecf8427e","sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},"path":"/home/juan/fim_tests/file1.txt","mode":"realtime"}}}}
{"wazuh":{"queue":56,"location":"syscheck"},"agent":{"name":"juan-IdeaPad-3-15ITL6","id":"000"},"host":{"os":{"name":"Ubuntu","version":"24.04.3 LTS (Noble Numbat)","full":"noble","platform":"ubuntu","kernel":"Linux |juan-IdeaPad-3-15ITL6 |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 19 17:02:30 UTC 2 |x86_64"},"ip":["127.0.1.1"],"architecture":"x86_64"},"event":{"original":"{\"collector\":\"file\",\"module\":\"fim\",\"data\":{\"event\":{\"created\":\"2025-10-08T13:19:38.350Z\",\"type\":\"added\"},\"file\":{\"size\":0,\"permissions\":[\"rw-rw-r--\"],\"uid\":\"1000\",\"owner\":\"juan\",\"gid\":\"1000\",\"group\":\"juan\",\"inode\":\"5286127\",\"device\":66309,\"mtime\":1759929538,\"hash\":{\"md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"},\"path\":\"/home/juan/fim_tests/file2.txt\",\"mode\":\"realtime\"}}}"},"@timestamp":"2025-10-08T13:19:38Z","tmp_json":{"collector":"file","module":"fim","data":{"event":{"created":"2025-10-08T13:19:38.350Z","type":"added"},"file":{"size":0,"permissions":["rw-rw-r--"],"uid":"1000","owner":"juan","gid":"1000","group":"juan","inode":"5286127","device":66309,"mtime":1759929538,"hash":{"md5":"d41d8cd98f00b204e9800998ecf8427e","sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},"path":"/home/juan/fim_tests/file2.txt","mode":"realtime"}}}}
```

</details>

### Agent
Tested on a Windows agent since the issue mentions Windows doesn't check some of the file attributes that linux does, and that might make it easier to detect a problem if the changes aren't working properly.

Tested by setting up a FIM directory inside `ossec.log`:
```
    <directories realtime="yes">c:/Users/Administrator/Desktop/fim_tests</directories>
```
And adding a `test1.txt` file into it.
`C:\Users\Administrator\Desktop>touch test.txt`
Then taking a look at the db: 
```
c:\Program Files (x86)\ossec-agent>sqlite3 queue/fim/db/fim.db
sqlite> select path, checksum from file_entry where path like 'c:\Users\Administrator\Desktop\fim_tests\%';
c:\users\administrator\desktop\fim_tests\test1.txt|87aae039c3d72a6815e367f64878ee01a4f8ce98
```
Renamed the file: `C:\Users\Administrator\Desktop\fim_tests>mv test1.txt test2.txt`
Restarted the server: 
```
c:\Program Files (x86)\ossec-agent>net stop WazuhSvc
c:\Program Files (x86)\ossec-agent>net start WazuhSvc
The Wazuh service is starting.
The Wazuh service was started successfully.
```

Ran the query again, we can see the new file with a new checksum present and no sign of the old file:
```
sqlite> select path, checksum from file_entry where path like 'c:/Users/Administrator/Desktop/fim_tests/%';
c:\users\administrator\desktop\fim_tests\test2.txt|dc1c1156710eea7e17260581f4e9a8e32645a2d9   
```


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
