### PR TITLE
[SCA] FSX Holdings, LLC | MacOS Sequoia SCA scans with errors

### DIFF
--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -21,9 +21,9 @@ requirements:
   description: "Requirements for running the policy against MacOS 15 Sequoia."
   condition: any
   rules:
-    - 'c:sw_vers -> r:^ProductVersion:\t*\s*15\p'
-    - 'c:system_profiler SPSoftwareDataType -> r:System Version:.*15\p'
-    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*15\p'
+    - 'c:sw_vers -> r:^ProductVersion:\t*\s*15[*!+.-]'
+    - 'c:system_profiler SPSoftwareDataType -> r:System Version:.*15[*!+.-]'
+    - 'c:defaults read loginwindow SystemVersionStampAsString -> r:^\s*15[*!+.-]'
 
 checks:
   ##########################################################################
@@ -50,7 +50,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticCheckEnabled'')" -> r:^1$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticCheckEnabled'')" -> r:\.+'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticCheckEnabled'')" -> r:.+'
 
   # 1.3 Ensure Download New Updates When Available Is Enabled. (Automated)
   - id: 35001
@@ -70,7 +70,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticDownload'')" -> r:^1$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticDownload'')" -> r:\.+'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticDownload'')" -> r:.+'
 
   # 1.4 Ensure Install of macOS Updates Is Enabled. (Automated)
   - id: 35002
@@ -90,7 +90,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticallyInstallMacOSUpdates'')" -> r:^1$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticallyInstallMacOSUpdates'')" -> r:\.+'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticallyInstallMacOSUpdates'')" -> r:.+'
 
   # 1.5 Ensure Install Application Updates from the App Store Is Enabled. (Automated)
   - id: 35003
@@ -157,7 +157,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.applicationaccess'').objectForKey(''enforcedSoftwareUpdateDelay'')" -> n:^(\d+)$ compare <= 30'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.applicationaccess'').objectForKey(''enforcedSoftwareUpdateDelay'')" -> r:\.+'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.applicationaccess'').objectForKey(''enforcedSoftwareUpdateDelay'')" -> r:.+'
 
   # 1.8 Ensure the System is Managed by a Mobile Device Management (MDM) Software. (Manual) - Not Implemented
 
@@ -308,7 +308,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'not c:launchctl list -> r:com.apple.screensharing$'
+      - 'not c:launchctl list -> r:com\.apple\.screensharing$'
 
   # 2.3.3.3 Ensure File Sharing Is Disabled. (Automated)
   - id: 35012
@@ -481,7 +481,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.TimeMachine'').objectForKey(''AutoBackup'')" -> r:^1$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.TimeMachine'').objectForKey(''LastDestinationID'')" -> r:^\.+$'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.TimeMachine'').objectForKey(''LastDestinationID'')" -> r:^.+$'
 
   # 2.3.4.2 Ensure Time Machine Volumes Are Encrypted If Time Machine Is Enabled. (Automated)
   - id: 35020
@@ -532,26 +532,7 @@ checks:
       - 'c:sh -c "launchctl list | grep -c com.apple.locationd" -> r:^1$'
       - 'c:sudo -u _locationd /usr/bin/osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.locationd'').objectForKey(''LocationServicesEnabled'')" -> r:^1$'
 
-  # 2.6.1.2 Ensure 'Show Location Icon in Control Center when System Services Request Your Location' Is Enabled. (Automated)
-  - id: 35022
-    title: "Ensure 'Show Location Icon in Control Center when System Services Request Your Location' Is Enabled."
-    description: "This setting provides the user an understanding of the current status of Location Services and which applications are using it."
-    rationale: 'Apple has fully integrated location services into macOS. When user applications access location an arrow is displayed next to the Control Center in the menu bar to give users an indication when their location is being accessed. By default system services like Time zones, weather, travel times, geolocation, "Find my Mac,"and advertising services do not indicate the location is accessed. Enabling the "Show location icon in the menu bar when System Services request your location" setting will show an arrow in the control center when a system service accesses the location. Although an indication that location was accessed, Control Center will only say that it was accessed by "System Services" and not the individual service. Looking in System Settings > Location Services > System Services > Details... will expose exactly which system services have accessed Location Services in the last 24 hours. Third-party tools will be shown individually when they access location services.'
-    impact: "Users may be provided visibility to a setting they cannot control if organizations control Location Services globally by policy."
-    remediation: "Graphical Method: Perform the following steps to set whether the location services icon is in the menu bar: 1. Open System Settings 2. Select Privacy & Security 3. Select Location Services 4. Select Details... 5. Set Show location icon in menu bar when System Services request your location to enabled Terminal Method: Run the following commands to set the option of the location services icon being in the menu bar: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool true."
-    compliance:
-      - cis: ["2.6.1.2"]
-      - cis_csc_v8: ["4.1", "4.8"]
-      - cis_csc_v7: ["5.1"]
-      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
-      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
-      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
-      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
-      - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
-    condition: all
-    rules:
-      - "c:defaults read /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -> r:^1$|^true$"
+  # 2.6.1.2 Ensure 'Show Location Icon in Control Center when System Services Request Your Location' Is Enabled. (Automated) - Not Implemented
 
   # 2.6.1.3 Audit Location Services Access. (Manual) - Not Implemented
   # 2.6.2.1 Audit Full Disk Access for Applications. (Manual) - Not Implemented
@@ -653,9 +634,9 @@ checks:
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
-    condition: all
+    condition: none
     rules:
-      - 'not c:sh -c "pmset -g custom" -> r:^\s*\t*powernap\s*\t*1'
+      - 'c:sh -c "pmset -g custom" -> r:^\s*\t*powernap\s*\t*1'
 
   # 2.9.3 Ensure Wake for Network Access Is Disabled. (Automated)
   - id: 35027
@@ -680,29 +661,7 @@ checks:
       - 'not c:sh -c "profiles -P -o stdout | grep ''Wake On Modem Ring''" -> n:=\s*(\d) compare != 0'
 
   # 2.10.1 Ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver Is Enabled. (Automated) - Not Implemented
-
-  # 2.10.2 Ensure Require Password After Screen Saver Begins or Display Is Turned Off Is Enabled for 5 Seconds or Immediately. (Automated)
-  - id: 35028
-    title: "Ensure Require Password After Screen Saver Begins or Display Is Turned Off Is Enabled for 5 Seconds or Immediately."
-    description: "Sleep and screen saver modes are low power modes that reduce electrical consumption while the system is not in use."
-    rationale: "Prompting for a password when waking from sleep or screen saver mode mitigates the threat of an unauthorized person gaining access to a system in the user's absence."
-    impact: "Without a screenlock in place, anyone with physical access to the computer would be logged in and able to use the active user's session."
-    remediation: "Graphical Method: Perform the following steps to enable a password for unlock after a screen saver begins or after sleep: 1. Open System Settings 2. Select Lock Screen 3. Set Require password after screensaver begins or display is turned off to either After 0 seconds or After 5 seconds Terminal Method: Run the following command to require a password to unlock the computer after the screen saver engages or the computer sleeps: $ /usr/bin/sudo /usr/sbin/sysadminctl -screenLock immediate -password <administrator password> or $ /usr/bin/sudo /usr/sbin/sysadminctl -screenLock 5 seconds -password <administrator password> Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.screensaver 2. The key to include is askForPassword 3. The key must be set to <true/> 4. The key to also include is askForPasswordDelay 5. The key must be set to <integer><0,5></integer>."
-    references:
-      - "https://blog.kolide.com/screensaver-security-on-macos-10-13-is-broken-a385726e2ae2"
-      - "https://github.com/rtrouton/profiles/blob/master/SetDefaultScreensaver/SetDefaultScreensaver.mobileconfig"
-    compliance:
-      - cis: ["2.10.2"]
-      - cis_csc_v8: ["4.7"]
-      - cis_csc_v7: ["4.2"]
-      - iso_27001-2013: ["A.9.4.3"]
-      - pci_dss_v3.2.1: ["2.1", "2.1.1"]
-      - pci_dss_v4.0: ["2.2.2", "2.3.1"]
-      - soc_2: ["CC6.3"]
-    condition: all
-    rules:
-      - 'c:defaults -currentHost read com.apple.screensaver askForPassword 2>/dev/null -> n:^(\d+)$ compare == 1'
-      - 'c:defaults -currentHost read com.apple.screensaver askForPasswordDelay 2>/dev/null -> n:^(\d+)$ compare <= 5'
+  # 2.10.2 Ensure Require Password After Screen Saver Begins or Display Is Turned Off Is Enabled for 5 Seconds or Immediately. (Automated) - Not Implemented
 
   # 2.10.3 Ensure a Custom Message for the Login Screen Is Enabled. (Automated)
   - id: 35029
@@ -723,7 +682,7 @@ checks:
       - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''LoginwindowText'')" -> r:^\.+$'
+      - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''LoginwindowText'')" -> r:^.+$'
 
   # 2.10.4 Ensure Login Window Displays as Name and Password Is Enabled. (Automated)
   - id: 35030
@@ -765,7 +724,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''RetriesUntilHint'')" -> r:^0$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''RetriesUntilHint'')" -> r:\w+'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''RetriesUntilHint'')" -> r:[\w@-]+'
 
   # 2.11.1 Ensure Users' Accounts Do Not Have a Password Hint. (Automated)
   - id: 35032
@@ -850,7 +809,7 @@ checks:
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''com.apple.login.mcx.DisableAutoLoginClient'')" -> r:^1$'
-      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''autoLoginUser'')" -> r:^\.+$'
+      - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''autoLoginUser'')" -> r:^.+$'
 
   # 2.13.1 Audit Passwords System Preference Setting. (Manual) - Not Implemented
   # 2.14.1 Audit Game Center Settings. (Manual) - Not Implemented
@@ -879,7 +838,7 @@ checks:
       - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - "c:launchctl list -> r:com.apple.auditd"
+      - "c:launchctl list -> r:com\\.apple\\.auditd"
 
   # 3.2 Ensure Security Auditing Flags For User-Attributable Events Are Configured Per Local Organizational Requirements. (Automated)
   - id: 35037
@@ -950,14 +909,14 @@ checks:
       - soc_2: ["A1.1"]
     condition: any
     rules:
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)s compare >= 5184000'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)h compare >= 1440'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)d compare >= 60'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)y compare >= 1'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)b compare >= 5368709120'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)k compare >= 5242880'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)m compare >= 5120'
-      - 'f:/etc/security/audit_control -> n:^\s*expire-after\p\w*(\d+)g compare >= 5'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)s compare >= 5184000'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)h compare >= 1440'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)d compare >= 60'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)y compare >= 1'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)b compare >= 5368709120'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)k compare >= 5242880'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)m compare >= 5120'
+      - 'f:/etc/security/audit_control -> n:^\s*expire-after[*!+-][\w@-]*(\d+)g compare >= 5'
 
   # 3.5 Ensure Access to Audit Records Is Controlled. (Automated) - Not Implemented
   # 3.6 Audit Software Inventory. (Manual) - Not Implemented
@@ -1005,7 +964,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "not c:launchctl list -> r:org.apache.httpd"
+      - "not c:launchctl list -> r:org\\.apache\\.httpd"
 
   # 4.3 Ensure NFS Server Is Disabled. (Automated)
   - id: 35042
@@ -1026,7 +985,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "not c:launchctl list -> r:com.apple.nfsd"
+      - "c:nfsd status -> r:not running"
       - "not f:/etc/exports"
 
   # 5.1.1 Ensure Home Folders Are Secure. (Automated) - Not Implemented
@@ -1053,7 +1012,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.8", "CC7.1"]
     condition: all
     rules:
-      - "c:csrutil status -> r:^System Integrity Protection status: enabled."
+      - "c:csrutil status -> r:^System Integrity Protection status: enabled\\."
 
   # 5.1.3 Ensure Apple Mobile File Integrity (AMFI) Is Enabled. (Automated)
   - id: 35044
@@ -1173,7 +1132,7 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - "c:pwpolicy -getaccountpolicies -> r:Contain at least one number and one alphabetic character."
+      - "c:pwpolicy -getaccountpolicies -> r:Contain at least one number and one alphabetic character\\."
       - 'c:sh  -c "pwpolicy -getaccountpolicies | grep -A1 minimumLetters " -> n:>(\d+)< compare >= 1'
 
   # 5.2.4 Ensure Complex Password Must Contain Numeric Character Is Configured. (Manual)
@@ -1193,7 +1152,7 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - "c:pwpolicy -getaccountpolicies -> r:Contain at least one number and one alphabetic character."
+      - "c:pwpolicy -getaccountpolicies -> r:Contain at least one number and one alphabetic character\\."
       - 'c:sh  -c "pwpolicy -getaccountpolicies | grep -A1 minimumNumericCharacters " -> n:>(\d+)< compare >= 1'
 
   # 5.2.5 Ensure Complex Password Must Contain Special Character Is Configured. (Manual)
@@ -1295,7 +1254,7 @@ checks:
       - pci_dss_v4.0: ["8.2.8"]
     condition: all
     rules:
-      - "c:sudo -V -> r:Authentication timestamp timeout: 0.0 minutes"
+      - "c:sudo -V -> r:Authentication timestamp timeout: 0\\.0 minutes"
       - "c:stat /etc/sudoers.d -> r:root wheel"
 
   # 5.5 Ensure a Separate Timestamp Is Enabled for Each User/tty Combo. (Automated)


### PR DESCRIPTION
# Description 

Team, attached the list of failing SCA checks in an excel file. The last column has the results and my comments regarding unexisting files, wrong expected permissions and N/A checks for the Sequoia of M1/M2 MAC versions.

[SCA MACOS.xlsx](https://github.com/user-attachments/files/22621991/SCA.MACOS.xlsx)

# Solution

| SCA ID | Conclusion |
|---------|--------------|
| 35006 | Rule will not change |
| 35022 | Will mark check as `Not Implemented` |
| 35028 | Will mark check as `Not Implemented` |
| 35037 | Rule will not change |
| 35038 | Rule will not change |
| 35039 | Rule will not change |
| 35040 | Rule will not change |
| 35042 | Rule Improved |
| 35054 | Rule will not change |
| 35058 | Rule will not change |



## CLOUD
CloudID: g74g58b0b594 

# Approved by

DRI name:
- [ ] Miguel Casares.
- [ ] Alexander Bohórquez.
