### PR TITLE
Modify AIT agent healthcheck due to agent configuration reload

### DIFF
--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -66,18 +66,18 @@ def get_agent_health_base():
     # depending on the agent version.
 
     shared_conf_restart = os.system(
-        f"grep -q 'agentd: INFO: Agent is restarting due to shared configuration changes.' {OSSEC_LOG_PATH}")
+        f"grep -q 'agentd: INFO: Agent is reloading due to shared configuration changes' {OSSEC_LOG_PATH}")
     agent_connection = os.system(f"grep -q 'agentd: INFO: (4102): Connected to the server' {OSSEC_LOG_PATH}")
 
     if shared_conf_restart == 0 and agent_connection == 0:
         # No -q option as we need the output
         output = os.popen(
-            f"grep -a 'agentd: INFO: Agent is restarting due to shared configuration changes."
+            f"grep -a 'agentd: INFO: Agent is reloading due to shared configuration changes"
             f"\|agentd: INFO: (4102): Connected to the server' {OSSEC_LOG_PATH}").read().split("\n")[:-1]
 
         agent_restarted = False
         for log in output:
-            if not agent_restarted and re.match(r'.*Agent is restarting due to shared configuration changes.*', log):
+            if not agent_restarted and re.match(r'.*Agent is reloading due to shared configuration changes*', log):
                 agent_restarted = True
             if agent_restarted and re.match(r'.*Connected to the server.*', log):
                 # Wait to avoid the worst case scenario:

--- a/api/test/integration/tavern_utils.py
+++ b/api/test/integration/tavern_utils.py
@@ -446,7 +446,7 @@ def check_agentd_started(response, agents_list, restarted=True):
         agentd_started_regex = (
             re.compile(r"agentd.+Started")
             if restarted or agent_id in ["005", "006", "007", "008"]
-            else re.compile(r"agentd.+Reload")
+            else re.compile(r"agentd.+(Reload|Started)")
         )
         while tries < 80:
             try:

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -157,6 +157,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["003", "004"]
+          restarted: False
       status_code: 200
       json:
         error: 2
@@ -187,6 +188,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["001", "003", "004", "007"]  # 009 is not restarted as it is disconnected
+          restarted: False
       status_code: 200
       json:
         error: 0
@@ -218,6 +220,7 @@ stages:
         extra_kwargs:
           agents_list: ["001", "002", "003", "004", "005", "006", "007", "008"]  # 009 and 010 are not restarted as
                                                                                  # they are disconnected
+          restarted: False
       status_code: 200
       json:
         error: 0
@@ -259,6 +262,7 @@ stages:
         extra_kwargs:
           agents_list: ["001", "002", "003", "004", "005", "006", "007", "008"]  # 009 and 010 are not restarted as
                                                                                  # they are disconnected
+          restarted: False
       status_code: 200
 
     # PUT /groups/wrong_group/configuration
@@ -676,6 +680,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["001"]
+          restarted: False
       status_code: 200
       json:
         error: 0
@@ -734,6 +739,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["002"]
+          restarted: False
       status_code: 200
       json:
         error: 0

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -951,6 +951,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["001", "008"]
+          restarted: False
       status_code: 200
       json:
         error: 0
@@ -1299,6 +1300,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["002"]
+          restarted: False
       status_code: 200
       json:
         error: 2
@@ -1359,6 +1361,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["002", "006", "008"]
+          restarted: False
       status_code: 200
 
   - name: Try to update group1 configuration (Denied)
@@ -1392,6 +1395,7 @@ stages:
         function: tavern_utils:healthcheck_agent_restart
         extra_kwargs:
           agents_list: ["004"]
+          restarted: False
       status_code: 200
       json:
         error: 2


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes #32353.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

```console
(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_agent_PUT_endpoints.tavern.yaml
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0 -- /home/wazuh/Git/wazuh/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.8.0-85-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'anyio': '4.1.0', 'cov': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'html': '2.1.1', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 10 items                                                                                                                                                                                                

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                                              [ 10%]
test_agent_PUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                                           [ 20%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                                           [ 30%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                                                          [ 40%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                                            [ 50%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                                        [ 60%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                                 [ 70%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                             [ 80%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                                            [ 90%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED                                                                                                                          [100%]

================================================================================== 10 passed, 11 warnings in 1433.66s (0:23:53) ===================================================================================

---

(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_rbac_white_agent_endpoints.tavern.yaml --nobuild
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0 -- /home/wazuh/Git/wazuh/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.8.0-85-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'anyio': '4.1.0', 'cov': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'html': '2.1.1', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 43 items                                                                                                                                                                                                

test_rbac_white_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                             [  2%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                                        [  4%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                               [  6%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                    [  9%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                              [ 11%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                                                    [ 13%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                                                [ 16%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                             [ 18%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                           [ 20%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                    [ 23%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                            [ 25%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename} PASSED                                                                                                                 [ 27%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                             [ 30%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                    [ 32%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                    [ 34%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                              [ 37%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary PASSED                                                                                                                                     [ 39%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                              [ 41%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                  [ 44%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                              [ 46%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                         [ 48%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id={group_id} PASSED                                                                                                                [ 51%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups?groups_list={group_id} PASSED                                                                                                                   [ 53%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                          [ 55%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id&status=all PASSED                                                                                                          [ 58%]
test_rbac_white_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                          [ 60%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                            [ 62%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                                     [ 65%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                               [ 67%]
test_rbac_white_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                            [ 69%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                                                       [ 72%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                                    [ 74%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                                    [ 76%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                                                   [ 79%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                                     [ 81%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                                 [ 83%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                          [ 86%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                                     [ 88%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                                              [ 90%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                              [ 93%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents (deny cluster:read) PASSED                                                                                                                         [ 95%]
test_rbac_white_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                      [ 97%]
test_rbac_white_agent_endpoints.tavern.yaml::GET /agents/uninstall PASSED                                                                                                                                   [100%]

=================================================================================== 43 passed, 44 warnings in 987.92s (0:16:27) ===================================================================================

---

(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_rbac_black_agent_endpoints.tavern.yaml --nobuild
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0 -- /home/wazuh/Git/wazuh/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.8.0-85-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'anyio': '4.1.0', 'cov': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'html': '2.1.1', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 43 items                                                                                                                                                                                                

test_rbac_black_agent_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                                             [  2%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?agents_list=agent_id PASSED                                                                                                                        [  4%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                                               [  6%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                                                                                    [  9%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                                              [ 11%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                                                    [ 13%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                                                                                [ 16%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                                             [ 18%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                                           [ 20%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                                                    [ 23%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                                            [ 25%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename} PASSED                                                                                                                 [ 27%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                                                                             [ 30%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                                                    [ 32%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                                                    [ 34%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                                              [ 37%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary PASSED                                                                                                                                     [ 39%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                                              [ 41%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                                                  [ 44%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                                              [ 46%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                                              [ 48%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                                                         [ 51%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents/group?group_id=group_id PASSED                                                                                                                  [ 53%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE groups?groups_list=group_id PASSED                                                                                                                      [ 55%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                                          [ 58%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents?agents_list=agent_id PASSED                                                                                                                     [ 60%]
test_rbac_black_agent_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                                          [ 62%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                                            [ 65%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                                                     [ 67%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                                               [ 69%]
test_rbac_black_agent_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                                            [ 72%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group?group_id={group_id} PASSED                                                                                                                   [ 74%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                                                    [ 76%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                                                    [ 79%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                                                   [ 81%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                                                     [ 83%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                                                 [ 86%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                                          [ 88%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                                                     [ 90%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                                              [ 93%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents (allow cluster:read) PASSED                                                                                                                        [ 95%]
test_rbac_black_agent_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                                                      [ 97%]
test_rbac_black_agent_endpoints.tavern.yaml::GET /agents/uninstall PASSED                                                                                                                                   [100%]

=================================================================================== 43 passed, 44 warnings in 909.44s (0:15:09) ===================================================================================
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
