### PR TITLE
Update ECS to version v9.1.0 in 6.0.0

### DIFF
--- a/src/engine/ruleset/schemas/engine-schema.json
+++ b/src/engine/ruleset/schemas/engine-schema.json
@@ -1,6809 +1,6809 @@
 {
-  "name": "schema/engine-schema/0",
   "fields": {
     "@timestamp": {
-      "type": "date",
-      "array": false
+      "array": false,
+      "type": "date"
     },
     "agent.build.original": {
-      "type": "keyword",
-      "array": false
+      "array": false,
+      "type": "keyword"
     },
     "agent.ephemeral_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "agent.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "agent.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "agent.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "agent.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.as.number": {
-      "type": "long",
-      "array": false
-    },
-    "client.as.organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "client.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "client.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "client.mac": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.nat.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "client.nat.port": {
-      "type": "long",
-      "array": false
-    },
-    "client.packets": {
-      "type": "long",
-      "array": false
-    },
-    "client.port": {
-      "type": "long",
-      "array": false
-    },
-    "client.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "client.user.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "cloud.account.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.account.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.availability_zone": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.instance.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.instance.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.machine.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.account.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.account.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.availability_zone": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.instance.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.instance.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.machine.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.project.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.project.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.provider": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.region": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.origin.service.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.project.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.project.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.provider": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.region": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.service.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.account.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.account.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.availability_zone": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.instance.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.instance.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.machine.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.project.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.project.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.provider": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.region": {
-      "type": "keyword",
-      "array": false
-    },
-    "cloud.target.service.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "container.cpu.usage": {
-      "type": "scaled_float",
-      "array": false
-    },
-    "container.disk.read.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "container.disk.write.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "container.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "container.image.hash.all": {
-      "type": "keyword",
-      "array": true
-    },
-    "container.image.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "container.image.tag": {
-      "type": "keyword",
-      "array": true
-    },
-    "container.labels": {
-      "type": "object",
-      "array": false
-    },
-    "container.memory.usage": {
-      "type": "scaled_float",
-      "array": false
-    },
-    "container.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "container.network.egress.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "container.network.ingress.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "container.runtime": {
-      "type": "keyword",
-      "array": false
-    },
-    "container.security_context.privileged": {
-      "type": "boolean",
-      "array": false
-    },
-    "data_stream.dataset": {
-      "type": "keyword",
-      "array": false
-    },
-    "data_stream.namespace": {
-      "type": "keyword",
-      "array": false
-    },
-    "data_stream.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.as.number": {
-      "type": "long",
-      "array": false
-    },
-    "destination.as.organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "destination.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "destination.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "destination.mac": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.nat.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "destination.nat.port": {
-      "type": "long",
-      "array": false
-    },
-    "destination.packets": {
-      "type": "long",
-      "array": false
-    },
-    "destination.port": {
-      "type": "long",
-      "array": false
-    },
-    "destination.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "destination.user.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "device.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "device.manufacturer": {
-      "type": "keyword",
-      "array": false
-    },
-    "device.model.identifier": {
-      "type": "keyword",
-      "array": false
-    },
-    "device.model.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "device.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.digest_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.exists": {
-      "type": "boolean",
-      "array": false
-    },
-    "dll.code_signature.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.signing_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.status": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.subject_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.team_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.code_signature.timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "dll.code_signature.trusted": {
-      "type": "boolean",
-      "array": false
-    },
-    "dll.code_signature.valid": {
-      "type": "boolean",
-      "array": false
-    },
-    "dll.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.company": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.file_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "dll.pe.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "dll.pe.imphash": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.imports": {
-      "type": "object",
-      "array": true
-    },
-    "dll.pe.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.original_file_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.pehash": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "dll.pe.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "dll.pe.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "dll.pe.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "dns.answers": {
-      "type": "object",
-      "array": true
-    },
-    "dns.answers.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.answers.data": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.answers.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.answers.ttl": {
-      "type": "long",
-      "array": false
-    },
-    "dns.answers.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.header_flags": {
-      "type": "keyword",
-      "array": true
-    },
-    "dns.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.op_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.question.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.question.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.question.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.question.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.question.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.question.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.resolved_ip": {
-      "type": "ip",
-      "array": true
-    },
-    "dns.response_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "dns.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "ecs.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments": {
-      "type": "nested",
-      "array": true
-    },
-    "email.attachments.file.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.mime_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.attachments.file.size": {
-      "type": "long",
-      "array": false
-    },
-    "email.bcc.address": {
-      "type": "keyword",
-      "array": true
-    },
-    "email.cc.address": {
-      "type": "keyword",
-      "array": true
-    },
-    "email.content_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.delivery_timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "email.direction": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.from.address": {
-      "type": "keyword",
-      "array": true
-    },
-    "email.local_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.message_id": {
-      "type": "wildcard",
-      "array": false
-    },
-    "email.origination_timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "email.reply_to.address": {
-      "type": "keyword",
-      "array": true
-    },
-    "email.sender.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.subject": {
-      "type": "keyword",
-      "array": false
-    },
-    "email.to.address": {
-      "type": "keyword",
-      "array": true
-    },
-    "email.x_mailer": {
-      "type": "keyword",
-      "array": false
-    },
-    "error.code": {
-      "type": "keyword",
-      "array": false
-    },
-    "error.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "error.message": {
-      "type": "text",
-      "array": false
-    },
-    "error.stack_trace": {
-      "type": "wildcard",
-      "array": false
-    },
-    "error.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.action": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.agent_id_status": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.category": {
-      "type": "keyword",
-      "array": true
-    },
-    "event.code": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.created": {
-      "type": "date",
-      "array": false
-    },
-    "event.dataset": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.duration": {
-      "type": "long",
-      "array": false
-    },
-    "event.end": {
-      "type": "date",
-      "array": false
-    },
-    "event.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.ingested": {
-      "type": "date",
-      "array": false
-    },
-    "event.kind": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.module": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.original": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.outcome": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.provider": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.reason": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.risk_score": {
-      "type": "float",
-      "array": false
-    },
-    "event.risk_score_norm": {
-      "type": "float",
-      "array": false
-    },
-    "event.sequence": {
-      "type": "long",
-      "array": false
-    },
-    "event.severity": {
-      "type": "long",
-      "array": false
-    },
-    "event.start": {
-      "type": "date",
-      "array": false
-    },
-    "event.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "event.type": {
-      "type": "keyword",
-      "array": true
-    },
-    "event.url": {
-      "type": "keyword",
-      "array": false
-    },
-    "faas.coldstart": {
-      "type": "boolean",
-      "array": false
-    },
-    "faas.execution": {
-      "type": "keyword",
-      "array": false
-    },
-    "faas.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "faas.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "faas.trigger.request_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "faas.trigger.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "faas.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.accessed": {
-      "type": "date",
-      "array": false
-    },
-    "file.attributes": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.code_signature.digest_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.code_signature.exists": {
-      "type": "boolean",
-      "array": false
-    },
-    "file.code_signature.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.code_signature.signing_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.code_signature.status": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.code_signature.subject_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.code_signature.team_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.code_signature.timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "file.code_signature.trusted": {
-      "type": "boolean",
-      "array": false
-    },
-    "file.code_signature.valid": {
-      "type": "boolean",
-      "array": false
-    },
-    "file.created": {
-      "type": "date",
-      "array": false
-    },
-    "file.ctime": {
-      "type": "date",
-      "array": false
-    },
-    "file.device": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.drive_letter": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.byte_order": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.cpu_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.creation_date": {
-      "type": "date",
-      "array": false
-    },
-    "file.elf.exports": {
-      "type": "object",
-      "array": true
-    },
-    "file.elf.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "file.elf.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "file.elf.header.abi_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.header.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.header.data": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.header.entrypoint": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.header.object_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.header.os_abi": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.header.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.header.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.imports": {
-      "type": "object",
-      "array": true
-    },
-    "file.elf.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "file.elf.sections.chi2": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.sections.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.sections.physical_offset": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.sections.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.sections.virtual_address": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.elf.segments": {
-      "type": "nested",
-      "array": true
-    },
-    "file.elf.segments.sections": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.segments.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.elf.shared_libraries": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.elf.telfhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.fork_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.gid": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.group": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.inode": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.macho.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.macho.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "file.macho.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "file.macho.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.macho.imports": {
-      "type": "object",
-      "array": true
-    },
-    "file.macho.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "file.macho.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.macho.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.macho.symhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.mime_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.mode": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.mtime": {
-      "type": "date",
-      "array": false
-    },
-    "file.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.owner": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.company": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.file_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "file.pe.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "file.pe.imphash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.imports": {
-      "type": "object",
-      "array": true
-    },
-    "file.pe.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.original_file_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.pehash": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "file.pe.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.pe.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "file.pe.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.size": {
-      "type": "long",
-      "array": false
-    },
-    "file.target_path": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.uid": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "file.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "file.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "file.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "file.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "file.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "file.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.boot.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.cpu.usage": {
-      "type": "scaled_float",
-      "array": false
-    },
-    "host.disk.read.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "host.disk.write.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "host.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "host.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.hostname": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.ip": {
-      "type": "ip",
-      "array": true
-    },
-    "host.mac": {
-      "type": "keyword",
-      "array": true
-    },
-    "host.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.network.egress.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "host.network.egress.packets": {
-      "type": "long",
-      "array": false
-    },
-    "host.network.ingress.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "host.network.ingress.packets": {
-      "type": "long",
-      "array": false
-    },
-    "host.os.family": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.os.full": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.os.kernel": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.os.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.os.platform": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.os.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.os.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.pid_ns_ino": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.risk.calculated_level": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.risk.calculated_score": {
-      "type": "float",
-      "array": false
-    },
-    "host.risk.calculated_score_norm": {
-      "type": "float",
-      "array": false
-    },
-    "host.risk.static_level": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.risk.static_score": {
-      "type": "float",
-      "array": false
-    },
-    "host.risk.static_score_norm": {
-      "type": "float",
-      "array": false
-    },
-    "host.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "host.uptime": {
-      "type": "long",
-      "array": false
-    },
-    "http.request.body.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "http.request.body.content": {
-      "type": "wildcard",
-      "array": false
-    },
-    "http.request.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "http.request.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "http.request.method": {
-      "type": "keyword",
-      "array": false
-    },
-    "http.request.mime_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "http.request.referrer": {
-      "type": "keyword",
-      "array": false
-    },
-    "http.response.body.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "http.response.body.content": {
-      "type": "wildcard",
-      "array": false
-    },
-    "http.response.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "http.response.mime_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "http.response.status_code": {
-      "type": "long",
-      "array": false
-    },
-    "http.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "labels": {
-      "type": "object",
-      "array": false
-    },
-    "log.file.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.level": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.logger": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.origin.file.line": {
-      "type": "long",
-      "array": false
-    },
-    "log.origin.file.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.origin.function": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog": {
-      "type": "object",
-      "array": false
-    },
-    "log.syslog.appname": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog.facility.code": {
-      "type": "long",
-      "array": false
-    },
-    "log.syslog.facility.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog.hostname": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog.msgid": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog.priority": {
-      "type": "long",
-      "array": false
-    },
-    "log.syslog.procid": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog.severity.code": {
-      "type": "long",
-      "array": false
-    },
-    "log.syslog.severity.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "log.syslog.structured_data": {
-      "type": "object",
-      "array": false
-    },
-    "log.syslog.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "message": {
-      "type": "text",
-      "array": false
-    },
-    "network.application": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "network.community_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.direction": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.forwarded_ip": {
-      "type": "ip",
-      "array": false
-    },
-    "network.iana_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.inner": {
-      "type": "object",
-      "array": false
-    },
-    "network.inner.vlan.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.inner.vlan.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.packets": {
-      "type": "long",
-      "array": false
-    },
-    "network.protocol": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.transport": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.vlan.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "network.vlan.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.egress": {
-      "type": "object",
-      "array": false
-    },
-    "observer.egress.interface.alias": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.egress.interface.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.egress.interface.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.egress.vlan.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.egress.vlan.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.egress.zone": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "observer.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.hostname": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ingress": {
-      "type": "object",
-      "array": false
-    },
-    "observer.ingress.interface.alias": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ingress.interface.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ingress.interface.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ingress.vlan.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ingress.vlan.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ingress.zone": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.ip": {
-      "type": "ip",
-      "array": true
-    },
-    "observer.mac": {
-      "type": "keyword",
-      "array": true
-    },
-    "observer.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.family": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.full": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.kernel": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.platform": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.os.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.vendor": {
-      "type": "keyword",
-      "array": false
-    },
-    "observer.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.api_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.cluster.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.cluster.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.cluster.url": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.cluster.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.namespace": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.organization": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.resource.annotation": {
-      "type": "keyword",
-      "array": true
-    },
-    "orchestrator.resource.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.resource.ip": {
-      "type": "ip",
-      "array": true
-    },
-    "orchestrator.resource.label": {
-      "type": "keyword",
-      "array": true
-    },
-    "orchestrator.resource.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.resource.parent.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.resource.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "orchestrator.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "organization.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.build_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.checksum": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.install_scope": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.installed": {
-      "type": "date",
-      "array": false
-    },
-    "package.license": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.size": {
-      "type": "long",
-      "array": false
-    },
-    "package.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "package.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.args": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.args_count": {
-      "type": "long",
-      "array": false
-    },
-    "process.code_signature.digest_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.code_signature.exists": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.code_signature.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.code_signature.signing_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.code_signature.status": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.code_signature.subject_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.code_signature.team_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.code_signature.timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "process.code_signature.trusted": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.code_signature.valid": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.command_line": {
-      "type": "wildcard",
-      "array": false
-    },
-    "process.elf.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.byte_order": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.cpu_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.creation_date": {
-      "type": "date",
-      "array": false
-    },
-    "process.elf.exports": {
-      "type": "object",
-      "array": true
-    },
-    "process.elf.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "process.elf.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.elf.header.abi_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.header.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.header.data": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.header.entrypoint": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.header.object_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.header.os_abi": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.header.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.header.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.imports": {
-      "type": "object",
-      "array": true
-    },
-    "process.elf.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "process.elf.sections.chi2": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.sections.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.sections.physical_offset": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.sections.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.sections.virtual_address": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.elf.segments": {
-      "type": "nested",
-      "array": true
-    },
-    "process.elf.segments.sections": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.segments.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.elf.shared_libraries": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.elf.telfhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.end": {
-      "type": "date",
-      "array": false
-    },
-    "process.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.args": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.entry_leader.args_count": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.attested_groups.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.attested_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.attested_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.command_line": {
-      "type": "wildcard",
-      "array": false
-    },
-    "process.entry_leader.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.entry_meta.source.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "process.entry_leader.entry_meta.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.executable": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.interactive": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.entry_leader.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.parent.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.parent.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.parent.session_leader.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.parent.session_leader.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.parent.session_leader.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.entry_leader.parent.session_leader.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.parent.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.entry_leader.parent.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.real_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.real_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.real_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.real_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.same_as_process": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.entry_leader.saved_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.saved_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.saved_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.saved_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.entry_leader.supplemental_groups.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.supplemental_groups.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.tty": {
-      "type": "object",
-      "array": false
-    },
-    "process.entry_leader.tty.char_device.major": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.tty.char_device.minor": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.entry_leader.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.entry_leader.working_directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.env_vars": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.executable": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.exit_code": {
-      "type": "long",
-      "array": false
-    },
-    "process.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.args": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.group_leader.args_count": {
-      "type": "long",
-      "array": false
-    },
-    "process.group_leader.command_line": {
-      "type": "wildcard",
-      "array": false
-    },
-    "process.group_leader.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.executable": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.interactive": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.group_leader.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.group_leader.real_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.real_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.real_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.real_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.same_as_process": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.group_leader.saved_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.saved_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.saved_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.saved_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.group_leader.supplemental_groups.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.supplemental_groups.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.tty": {
-      "type": "object",
-      "array": false
-    },
-    "process.group_leader.tty.char_device.major": {
-      "type": "long",
-      "array": false
-    },
-    "process.group_leader.tty.char_device.minor": {
-      "type": "long",
-      "array": false
-    },
-    "process.group_leader.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.group_leader.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.group_leader.working_directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.interactive": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.io": {
-      "type": "object",
-      "array": false
-    },
-    "process.io.bytes_skipped": {
-      "type": "object",
-      "array": true
-    },
-    "process.io.bytes_skipped.length": {
-      "type": "long",
-      "array": false
-    },
-    "process.io.bytes_skipped.offset": {
-      "type": "long",
-      "array": false
-    },
-    "process.io.max_bytes_per_process_exceeded": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.io.text": {
-      "type": "wildcard",
-      "array": false
-    },
-    "process.io.total_bytes_captured": {
-      "type": "long",
-      "array": false
-    },
-    "process.io.total_bytes_skipped": {
-      "type": "long",
-      "array": false
-    },
-    "process.io.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.macho.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.macho.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "process.macho.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.macho.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.macho.imports": {
-      "type": "object",
-      "array": true
-    },
-    "process.macho.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "process.macho.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.macho.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.macho.symhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.args": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.parent.args_count": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.code_signature.digest_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.code_signature.exists": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.code_signature.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.code_signature.signing_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.code_signature.status": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.code_signature.subject_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.code_signature.team_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.code_signature.timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "process.parent.code_signature.trusted": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.code_signature.valid": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.command_line": {
-      "type": "wildcard",
-      "array": false
-    },
-    "process.parent.elf.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.byte_order": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.cpu_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.creation_date": {
-      "type": "date",
-      "array": false
-    },
-    "process.parent.elf.exports": {
-      "type": "object",
-      "array": true
-    },
-    "process.parent.elf.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "process.parent.elf.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.elf.header.abi_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.header.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.header.data": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.header.entrypoint": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.header.object_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.header.os_abi": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.header.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.header.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.imports": {
-      "type": "object",
-      "array": true
-    },
-    "process.parent.elf.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "process.parent.elf.sections.chi2": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.sections.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.sections.physical_offset": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.sections.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.sections.virtual_address": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.elf.segments": {
-      "type": "nested",
-      "array": true
-    },
-    "process.parent.elf.segments.sections": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.segments.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.elf.shared_libraries": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.parent.elf.telfhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.end": {
-      "type": "date",
-      "array": false
-    },
-    "process.parent.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.executable": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.exit_code": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.group_leader.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.group_leader.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.group_leader.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.parent.group_leader.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.interactive": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.macho.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.macho.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "process.parent.macho.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.macho.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.macho.imports": {
-      "type": "object",
-      "array": true
-    },
-    "process.parent.macho.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "process.parent.macho.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.macho.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.macho.symhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.company": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.file_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "process.parent.pe.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.parent.pe.imphash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.imports": {
-      "type": "object",
-      "array": true
-    },
-    "process.parent.pe.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.original_file_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.pehash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "process.parent.pe.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.pe.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pe.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pgid": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.real_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.real_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.real_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.real_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.saved_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.saved_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.saved_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.saved_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.parent.supplemental_groups.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.supplemental_groups.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.thread.capabilities.effective": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.parent.thread.capabilities.permitted": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.parent.thread.id": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.thread.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.title": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.tty": {
-      "type": "object",
-      "array": false
-    },
-    "process.parent.tty.char_device.major": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.tty.char_device.minor": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.uptime": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.parent.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.parent.working_directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.company": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.file_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "process.pe.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.pe.imphash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.imports": {
-      "type": "object",
-      "array": true
-    },
-    "process.pe.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.original_file_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.pehash": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "process.pe.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.pe.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "process.pe.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "process.pgid": {
-      "type": "long",
-      "array": false
-    },
-    "process.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.previous.args": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.previous.args_count": {
-      "type": "long",
-      "array": false
-    },
-    "process.previous.executable": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.real_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.real_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.real_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.real_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.saved_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.saved_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.saved_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.saved_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.args": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.session_leader.args_count": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.command_line": {
-      "type": "wildcard",
-      "array": false
-    },
-    "process.session_leader.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.executable": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.interactive": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.session_leader.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.parent.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.parent.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.parent.session_leader.entity_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.parent.session_leader.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.parent.session_leader.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.session_leader.parent.session_leader.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.parent.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.session_leader.parent.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.pid": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.real_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.real_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.real_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.real_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.same_as_process": {
-      "type": "boolean",
-      "array": false
-    },
-    "process.session_leader.saved_group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.saved_group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.saved_user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.saved_user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.session_leader.supplemental_groups.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.supplemental_groups.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.tty": {
-      "type": "object",
-      "array": false
-    },
-    "process.session_leader.tty.char_device.major": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.tty.char_device.minor": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.session_leader.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.session_leader.working_directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.start": {
-      "type": "date",
-      "array": false
-    },
-    "process.supplemental_groups.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.supplemental_groups.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.thread.capabilities.effective": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.thread.capabilities.permitted": {
-      "type": "keyword",
-      "array": true
-    },
-    "process.thread.id": {
-      "type": "long",
-      "array": false
-    },
-    "process.thread.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.title": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.tty": {
-      "type": "object",
-      "array": false
-    },
-    "process.tty.char_device.major": {
-      "type": "long",
-      "array": false
-    },
-    "process.tty.char_device.minor": {
-      "type": "long",
-      "array": false
-    },
-    "process.tty.columns": {
-      "type": "long",
-      "array": false
-    },
-    "process.tty.rows": {
-      "type": "long",
-      "array": false
-    },
-    "process.uptime": {
-      "type": "long",
-      "array": false
-    },
-    "process.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "process.vpid": {
-      "type": "long",
-      "array": false
-    },
-    "process.working_directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "registry.data.bytes": {
-      "type": "keyword",
-      "array": false
-    },
-    "registry.data.strings": {
-      "type": "wildcard",
-      "array": true
-    },
-    "registry.data.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "registry.hive": {
-      "type": "keyword",
-      "array": false
-    },
-    "registry.key": {
-      "type": "keyword",
-      "array": false
-    },
-    "registry.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "registry.value": {
-      "type": "keyword",
-      "array": false
-    },
-    "related.hash": {
-      "type": "keyword",
-      "array": true
-    },
-    "related.hosts": {
-      "type": "keyword",
-      "array": true
-    },
-    "related.ip": {
-      "type": "ip",
-      "array": true
-    },
-    "related.user": {
-      "type": "keyword",
-      "array": true
-    },
-    "rule.author": {
-      "type": "keyword",
-      "array": true
-    },
-    "rule.category": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.license": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.ruleset": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.uuid": {
-      "type": "keyword",
-      "array": false
-    },
-    "rule.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.as.number": {
-      "type": "long",
-      "array": false
-    },
-    "server.as.organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "server.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "server.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "server.mac": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.nat.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "server.nat.port": {
-      "type": "long",
-      "array": false
-    },
-    "server.packets": {
-      "type": "long",
-      "array": false
-    },
-    "server.port": {
-      "type": "long",
-      "array": false
-    },
-    "server.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "server.user.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "service.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.environment": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.ephemeral_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.node.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.node.role": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.node.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "service.origin.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.environment": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.ephemeral_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.node.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.node.role": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.node.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "service.origin.state": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.origin.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.state": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.environment": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.ephemeral_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.node.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.node.role": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.node.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "service.target.state": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.target.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "service.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.as.number": {
-      "type": "long",
-      "array": false
-    },
-    "source.as.organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.bytes": {
-      "type": "long",
-      "array": false
-    },
-    "source.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "source.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "source.mac": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.nat.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "source.nat.port": {
-      "type": "long",
-      "array": false
-    },
-    "source.packets": {
-      "type": "long",
-      "array": false
-    },
-    "source.port": {
-      "type": "long",
-      "array": false
-    },
-    "source.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "source.user.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "span.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "tags": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.enrichments.indicator": {
-      "type": "object",
-      "array": false
-    },
-    "threat.enrichments.indicator.as.number": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.as.organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.confidence": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.email.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.accessed": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.attributes": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.code_signature.digest_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.exists": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.signing_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.status": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.subject_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.team_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.trusted": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.code_signature.valid": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.created": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.ctime": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.device": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.drive_letter": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.byte_order": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.cpu_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.creation_date": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.exports": {
-      "type": "object",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.elf.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.abi_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.data": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.entrypoint": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.object_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.os_abi": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.header.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.imports": {
-      "type": "object",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.elf.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.elf.sections.chi2": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.physical_offset": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.virtual_address": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.segments": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.elf.segments.sections": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.segments.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.elf.shared_libraries": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.elf.telfhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.fork_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.gid": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.group": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.inode": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.mime_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.mode": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.mtime": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.owner": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.company": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.file_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.imphash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.imports": {
-      "type": "object",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.pe.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.original_file_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.pehash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.pe.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.pe.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.target_path": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.uid": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.file.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.file.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.first_seen": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "threat.enrichments.indicator.last_seen": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.marking.tlp": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.marking.tlp_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.modified_at": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.port": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.provider": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.registry.data.bytes": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.registry.data.strings": {
-      "type": "wildcard",
-      "array": true
-    },
-    "threat.enrichments.indicator.registry.data.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.registry.hive": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.registry.key": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.registry.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.registry.value": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.scanner_stats": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.sightings": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.fragment": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.full": {
-      "type": "wildcard",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.original": {
-      "type": "wildcard",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.password": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.path": {
-      "type": "wildcard",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.port": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.query": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.scheme": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.url.username": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.indicator.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.enrichments.indicator.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.matched.atomic": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.matched.field": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.matched.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.matched.index": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.enrichments.matched.occurred": {
-      "type": "date",
-      "array": false
-    },
-    "threat.enrichments.matched.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.feed.dashboard_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.feed.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.feed.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.feed.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.framework": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.group.alias": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.group.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.as.number": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.as.organization.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.confidence": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.email.address": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.accessed": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.attributes": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.code_signature.digest_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.exists": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.signing_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.status": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.subject_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.team_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.timestamp": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.trusted": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.indicator.file.code_signature.valid": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.indicator.file.created": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.ctime": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.device": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.directory": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.drive_letter": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.byte_order": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.cpu_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.creation_date": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.elf.exports": {
-      "type": "object",
-      "array": true
-    },
-    "threat.indicator.file.elf.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "threat.indicator.file.elf.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.abi_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.class": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.data": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.entrypoint": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.object_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.os_abi": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.header.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.imports": {
-      "type": "object",
-      "array": true
-    },
-    "threat.indicator.file.elf.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.indicator.file.elf.sections.chi2": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.flags": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.physical_offset": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.virtual_address": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.elf.segments": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.indicator.file.elf.segments.sections": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.segments.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.elf.shared_libraries": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.elf.telfhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.fork_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.gid": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.group": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.cdhash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.sha384": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.sha512": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.ssdeep": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.hash.tlsh": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.inode": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.mime_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.mode": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.mtime": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.owner": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.architecture": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.company": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.file_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.go_import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.go_imports": {
-      "type": "object",
-      "array": false
-    },
-    "threat.indicator.file.pe.go_imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.go_imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.go_stripped": {
-      "type": "boolean",
-      "array": false
-    },
-    "threat.indicator.file.pe.imphash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.import_hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.imports": {
-      "type": "object",
-      "array": true
-    },
-    "threat.indicator.file.pe.imports_names_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.imports_names_var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.original_file_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.pehash": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.product": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.sections": {
-      "type": "nested",
-      "array": true
-    },
-    "threat.indicator.file.pe.sections.entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.sections.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.pe.sections.physical_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.sections.var_entropy": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.pe.sections.virtual_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.target_path": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.uid": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.file.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.file.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.file.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.file.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.first_seen": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.geo.city_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.continent_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.continent_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.country_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.country_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.location": {
-      "type": "geo_point",
-      "array": false
-    },
-    "threat.indicator.geo.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.postal_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.region_iso_code": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.region_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.geo.timezone": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.id": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.ip": {
-      "type": "ip",
-      "array": false
-    },
-    "threat.indicator.last_seen": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.marking.tlp": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.marking.tlp_version": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.modified_at": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.port": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.provider": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.registry.data.bytes": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.registry.data.strings": {
-      "type": "wildcard",
-      "array": true
-    },
-    "threat.indicator.registry.data.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.registry.hive": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.registry.key": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.registry.path": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.registry.value": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.scanner_stats": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.sightings": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.fragment": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.full": {
-      "type": "wildcard",
-      "array": false
-    },
-    "threat.indicator.url.original": {
-      "type": "wildcard",
-      "array": false
-    },
-    "threat.indicator.url.password": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.path": {
-      "type": "wildcard",
-      "array": false
-    },
-    "threat.indicator.url.port": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.url.query": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.scheme": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.url.username": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "threat.indicator.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "threat.indicator.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.indicator.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.indicator.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.software.alias": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.software.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.software.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.software.platforms": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.software.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.software.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "threat.tactic.id": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.tactic.name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.tactic.reference": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.technique.id": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.technique.name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.technique.reference": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.technique.subtechnique.id": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.technique.subtechnique.name": {
-      "type": "keyword",
-      "array": true
-    },
-    "threat.technique.subtechnique.reference": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.cipher": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.certificate": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.certificate_chain": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.issuer": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.ja3": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "tls.client.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "tls.client.server_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.subject": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.supported_ciphers": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "tls.client.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "tls.client.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "tls.client.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "tls.client.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.client.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.client.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.established": {
-      "type": "boolean",
-      "array": false
-    },
-    "tls.next_protocol": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.resumed": {
-      "type": "boolean",
-      "array": false
-    },
-    "tls.server.certificate": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.certificate_chain": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.hash.md5": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.hash.sha1": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.hash.sha256": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.issuer": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.ja3s": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "tls.server.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "tls.server.subject": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.alternative_names": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.issuer.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.issuer.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.issuer.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.issuer.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.issuer.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.issuer.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.issuer.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.not_after": {
-      "type": "date",
-      "array": false
-    },
-    "tls.server.x509.not_before": {
-      "type": "date",
-      "array": false
-    },
-    "tls.server.x509.public_key_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.public_key_curve": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.public_key_exponent": {
-      "type": "long",
-      "array": false
-    },
-    "tls.server.x509.public_key_size": {
-      "type": "long",
-      "array": false
-    },
-    "tls.server.x509.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.signature_algorithm": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.subject.common_name": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.subject.country": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.subject.distinguished_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.server.x509.subject.locality": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.subject.organization": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.subject.organizational_unit": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.subject.state_or_province": {
-      "type": "keyword",
-      "array": true
-    },
-    "tls.server.x509.version_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "tls.version_protocol": {
-      "type": "keyword",
-      "array": false
-    },
-    "trace.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "transaction.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.extension": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.fragment": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.full": {
-      "type": "wildcard",
-      "array": false
-    },
-    "url.original": {
-      "type": "wildcard",
-      "array": false
-    },
-    "url.password": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.path": {
-      "type": "wildcard",
-      "array": false
-    },
-    "url.port": {
-      "type": "long",
-      "array": false
-    },
-    "url.query": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.registered_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.scheme": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.subdomain": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.top_level_domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "url.username": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.changes.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "user.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.effective.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "user.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.risk.calculated_level": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.risk.calculated_score": {
-      "type": "float",
-      "array": false
-    },
-    "user.risk.calculated_score_norm": {
-      "type": "float",
-      "array": false
-    },
-    "user.risk.static_level": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.risk.static_score": {
-      "type": "float",
-      "array": false
-    },
-    "user.risk.static_score_norm": {
-      "type": "float",
-      "array": false
-    },
-    "user.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "user.target.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.email": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.full_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.group.domain": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.group.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.group.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.hash": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user.target.roles": {
-      "type": "keyword",
-      "array": true
-    },
-    "user_agent.device.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.original": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.family": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.full": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.kernel": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.name": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.platform": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.type": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.os.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "user_agent.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.bus_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.default_access": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.device_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.device_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.dos_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.file_system_type": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.mount_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.nt_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.product_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.product_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.removable": {
-      "type": "boolean",
-      "array": false
-    },
-    "volume.serial_number": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.size": {
-      "type": "long",
-      "array": false
-    },
-    "volume.vendor_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.vendor_name": {
-      "type": "keyword",
-      "array": false
-    },
-    "volume.writable": {
-      "type": "boolean",
-      "array": false
-    },
-    "vulnerability.category": {
-      "type": "keyword",
-      "array": true
-    },
-    "vulnerability.classification": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.description": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.enumeration": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.id": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.reference": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.report_id": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.scanner.vendor": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.score.base": {
-      "type": "float",
-      "array": false
-    },
-    "vulnerability.score.environmental": {
-      "type": "float",
-      "array": false
-    },
-    "vulnerability.score.temporal": {
-      "type": "float",
-      "array": false
-    },
-    "vulnerability.score.version": {
-      "type": "keyword",
-      "array": false
-    },
-    "vulnerability.severity": {
-      "type": "keyword",
-      "array": false
+      "array": false,
+      "type": "keyword"
     },
     "agent.groups": {
-      "type": "keyword",
-      "array": true
-    },
-    "agent.host.hostname": {
-      "type": "keyword",
-      "array": false
-    },
-    "agent.host.os.platform": {
-      "type": "keyword",
-      "array": false
-    },
-    "agent.host.os.name": {
-      "type": "keyword",
-      "array": false
+      "array": true,
+      "type": "keyword"
     },
     "agent.host.architecture": {
-      "type": "keyword",
-      "array": false
+      "array": false,
+      "type": "keyword"
+    },
+    "agent.host.hostname": {
+      "array": false,
+      "type": "keyword"
     },
     "agent.host.ip": {
-      "type": "ip",
-      "array": true
+      "array": true,
+      "type": "ip"
+    },
+    "agent.host.os.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "agent.host.os.platform": {
+      "array": false,
+      "type": "keyword"
+    },
+    "agent.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "agent.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "agent.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "agent.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.as.number": {
+      "array": false,
+      "type": "long"
+    },
+    "client.as.organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "client.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "client.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "client.mac": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.nat.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "client.nat.port": {
+      "array": false,
+      "type": "long"
+    },
+    "client.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "client.port": {
+      "array": false,
+      "type": "long"
+    },
+    "client.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "client.user.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "cloud.account.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.account.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.availability_zone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.instance.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.instance.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.machine.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.account.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.account.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.availability_zone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.instance.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.instance.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.machine.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.project.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.project.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.provider": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.region": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.origin.service.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.project.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.project.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.provider": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.region": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.service.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.account.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.account.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.availability_zone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.instance.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.instance.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.machine.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.project.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.project.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.provider": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.region": {
+      "array": false,
+      "type": "keyword"
+    },
+    "cloud.target.service.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "container.cpu.usage": {
+      "array": false,
+      "type": "scaled_float"
+    },
+    "container.disk.read.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "container.disk.write.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "container.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "container.image.hash.all": {
+      "array": true,
+      "type": "keyword"
+    },
+    "container.image.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "container.image.tag": {
+      "array": true,
+      "type": "keyword"
+    },
+    "container.labels": {
+      "array": false,
+      "type": "object"
+    },
+    "container.memory.usage": {
+      "array": false,
+      "type": "scaled_float"
+    },
+    "container.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "container.network.egress.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "container.network.ingress.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "container.runtime": {
+      "array": false,
+      "type": "keyword"
+    },
+    "container.security_context.privileged": {
+      "array": false,
+      "type": "boolean"
+    },
+    "data_stream.dataset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "data_stream.namespace": {
+      "array": false,
+      "type": "keyword"
+    },
+    "data_stream.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.as.number": {
+      "array": false,
+      "type": "long"
+    },
+    "destination.as.organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "destination.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "destination.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "destination.mac": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.nat.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "destination.nat.port": {
+      "array": false,
+      "type": "long"
+    },
+    "destination.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "destination.port": {
+      "array": false,
+      "type": "long"
+    },
+    "destination.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "destination.user.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "device.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "device.manufacturer": {
+      "array": false,
+      "type": "keyword"
+    },
+    "device.model.identifier": {
+      "array": false,
+      "type": "keyword"
+    },
+    "device.model.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "device.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.digest_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.exists": {
+      "array": false,
+      "type": "boolean"
+    },
+    "dll.code_signature.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.signing_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.subject_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.team_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.code_signature.timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "dll.code_signature.trusted": {
+      "array": false,
+      "type": "boolean"
+    },
+    "dll.code_signature.valid": {
+      "array": false,
+      "type": "boolean"
+    },
+    "dll.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.company": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.file_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "dll.pe.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "dll.pe.imphash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "dll.pe.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.original_file_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.pehash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "dll.pe.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.pe.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "dll.pe.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "dns.answers": {
+      "array": true,
+      "type": "object"
+    },
+    "dns.answers.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.answers.data": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.answers.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.answers.ttl": {
+      "array": false,
+      "type": "long"
+    },
+    "dns.answers.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.header_flags": {
+      "array": true,
+      "type": "keyword"
+    },
+    "dns.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.op_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.question.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.question.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.question.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.question.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.question.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.question.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.resolved_ip": {
+      "array": true,
+      "type": "ip"
+    },
+    "dns.response_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dns.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "ecs.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments": {
+      "array": true,
+      "type": "nested"
+    },
+    "email.attachments.file.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.mime_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.attachments.file.size": {
+      "array": false,
+      "type": "long"
+    },
+    "email.bcc.address": {
+      "array": true,
+      "type": "keyword"
+    },
+    "email.cc.address": {
+      "array": true,
+      "type": "keyword"
+    },
+    "email.content_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.delivery_timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "email.direction": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.from.address": {
+      "array": true,
+      "type": "keyword"
+    },
+    "email.local_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.message_id": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "email.origination_timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "email.reply_to.address": {
+      "array": true,
+      "type": "keyword"
+    },
+    "email.sender.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.subject": {
+      "array": false,
+      "type": "keyword"
+    },
+    "email.to.address": {
+      "array": true,
+      "type": "keyword"
+    },
+    "email.x_mailer": {
+      "array": false,
+      "type": "keyword"
+    },
+    "error.code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "error.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "error.message": {
+      "array": false,
+      "type": "text"
+    },
+    "error.stack_trace": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "error.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.action": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.agent_id_status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.category": {
+      "array": true,
+      "type": "keyword"
+    },
+    "event.code": {
+      "array": false,
+      "type": "keyword"
     },
     "event.collector": {
-      "type": "keyword",
-      "array": false
+      "array": false,
+      "type": "keyword"
+    },
+    "event.created": {
+      "array": false,
+      "type": "date"
+    },
+    "event.dataset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.duration": {
+      "array": false,
+      "type": "long"
+    },
+    "event.end": {
+      "array": false,
+      "type": "date"
+    },
+    "event.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.ingested": {
+      "array": false,
+      "type": "date"
+    },
+    "event.kind": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.module": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.original": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.outcome": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.provider": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.reason": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.risk_score": {
+      "array": false,
+      "type": "float"
+    },
+    "event.risk_score_norm": {
+      "array": false,
+      "type": "float"
+    },
+    "event.sequence": {
+      "array": false,
+      "type": "long"
+    },
+    "event.severity": {
+      "array": false,
+      "type": "long"
+    },
+    "event.start": {
+      "array": false,
+      "type": "date"
+    },
+    "event.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "event.type": {
+      "array": true,
+      "type": "keyword"
+    },
+    "event.url": {
+      "array": false,
+      "type": "keyword"
+    },
+    "faas.coldstart": {
+      "array": false,
+      "type": "boolean"
+    },
+    "faas.execution": {
+      "array": false,
+      "type": "keyword"
+    },
+    "faas.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "faas.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "faas.trigger.request_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "faas.trigger.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "faas.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.accessed": {
+      "array": false,
+      "type": "date"
+    },
+    "file.attributes": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.code_signature.digest_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.code_signature.exists": {
+      "array": false,
+      "type": "boolean"
+    },
+    "file.code_signature.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.code_signature.signing_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.code_signature.status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.code_signature.subject_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.code_signature.team_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.code_signature.timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "file.code_signature.trusted": {
+      "array": false,
+      "type": "boolean"
+    },
+    "file.code_signature.valid": {
+      "array": false,
+      "type": "boolean"
+    },
+    "file.created": {
+      "array": false,
+      "type": "date"
+    },
+    "file.ctime": {
+      "array": false,
+      "type": "date"
+    },
+    "file.device": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.drive_letter": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.byte_order": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.cpu_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.creation_date": {
+      "array": false,
+      "type": "date"
+    },
+    "file.elf.exports": {
+      "array": true,
+      "type": "object"
+    },
+    "file.elf.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "file.elf.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "file.elf.header.abi_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.header.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.header.data": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.header.entrypoint": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.header.object_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.header.os_abi": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.header.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.header.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "file.elf.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "file.elf.sections.chi2": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.sections.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.sections.physical_offset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.sections.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.sections.virtual_address": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.elf.segments": {
+      "array": true,
+      "type": "nested"
+    },
+    "file.elf.segments.sections": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.segments.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.elf.shared_libraries": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.elf.telfhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.fork_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.gid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.group": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.inode": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.macho.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.macho.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "file.macho.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "file.macho.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.macho.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "file.macho.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "file.macho.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.macho.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.macho.symhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.mime_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.mode": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.mtime": {
+      "array": false,
+      "type": "date"
+    },
+    "file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.owner": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.company": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.file_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "file.pe.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "file.pe.imphash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "file.pe.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.original_file_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.pehash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "file.pe.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.pe.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "file.pe.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.target_path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.uid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "file.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "file.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "file.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "file.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "file.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.boot.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.cpu.usage": {
+      "array": false,
+      "type": "scaled_float"
+    },
+    "host.disk.read.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "host.disk.write.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "host.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "host.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.hostname": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.ip": {
+      "array": true,
+      "type": "ip"
+    },
+    "host.mac": {
+      "array": true,
+      "type": "keyword"
+    },
+    "host.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.network.egress.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "host.network.egress.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "host.network.ingress.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "host.network.ingress.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "host.os.family": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.os.full": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.os.kernel": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.os.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.os.platform": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.os.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.os.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.pid_ns_ino": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.risk.calculated_level": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.risk.calculated_score": {
+      "array": false,
+      "type": "float"
+    },
+    "host.risk.calculated_score_norm": {
+      "array": false,
+      "type": "float"
+    },
+    "host.risk.static_level": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.risk.static_score": {
+      "array": false,
+      "type": "float"
+    },
+    "host.risk.static_score_norm": {
+      "array": false,
+      "type": "float"
+    },
+    "host.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "host.uptime": {
+      "array": false,
+      "type": "long"
+    },
+    "http.request.body.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "http.request.body.content": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "http.request.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "http.request.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "http.request.method": {
+      "array": false,
+      "type": "keyword"
+    },
+    "http.request.mime_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "http.request.referrer": {
+      "array": false,
+      "type": "keyword"
+    },
+    "http.response.body.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "http.response.body.content": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "http.response.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "http.response.mime_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "http.response.status_code": {
+      "array": false,
+      "type": "long"
+    },
+    "http.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "labels": {
+      "array": false,
+      "type": "object"
+    },
+    "log.file.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.level": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.logger": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.origin.file.line": {
+      "array": false,
+      "type": "long"
+    },
+    "log.origin.file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.origin.function": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog": {
+      "array": false,
+      "type": "object"
+    },
+    "log.syslog.appname": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog.facility.code": {
+      "array": false,
+      "type": "long"
+    },
+    "log.syslog.facility.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog.hostname": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog.msgid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog.priority": {
+      "array": false,
+      "type": "long"
+    },
+    "log.syslog.procid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog.severity.code": {
+      "array": false,
+      "type": "long"
+    },
+    "log.syslog.severity.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "log.syslog.structured_data": {
+      "array": false,
+      "type": "object"
+    },
+    "log.syslog.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "message": {
+      "array": false,
+      "type": "text"
+    },
+    "network.application": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "network.community_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.direction": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.forwarded_ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "network.iana_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.inner": {
+      "array": false,
+      "type": "object"
+    },
+    "network.inner.vlan.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.inner.vlan.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "network.protocol": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.transport": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.vlan.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "network.vlan.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.egress": {
+      "array": false,
+      "type": "object"
+    },
+    "observer.egress.interface.alias": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.egress.interface.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.egress.interface.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.egress.vlan.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.egress.vlan.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.egress.zone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "observer.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.hostname": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ingress": {
+      "array": false,
+      "type": "object"
+    },
+    "observer.ingress.interface.alias": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ingress.interface.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ingress.interface.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ingress.vlan.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ingress.vlan.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ingress.zone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.ip": {
+      "array": true,
+      "type": "ip"
+    },
+    "observer.mac": {
+      "array": true,
+      "type": "keyword"
+    },
+    "observer.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.family": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.full": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.kernel": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.platform": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.os.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.vendor": {
+      "array": false,
+      "type": "keyword"
+    },
+    "observer.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.api_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.cluster.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.cluster.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.cluster.url": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.cluster.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.namespace": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.organization": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.resource.annotation": {
+      "array": true,
+      "type": "keyword"
+    },
+    "orchestrator.resource.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.resource.ip": {
+      "array": true,
+      "type": "ip"
+    },
+    "orchestrator.resource.label": {
+      "array": true,
+      "type": "keyword"
+    },
+    "orchestrator.resource.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.resource.parent.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.resource.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "orchestrator.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "organization.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.build_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.checksum": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.install_scope": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.installed": {
+      "array": false,
+      "type": "date"
+    },
+    "package.license": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.size": {
+      "array": false,
+      "type": "long"
+    },
+    "package.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "package.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.args": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.args_count": {
+      "array": false,
+      "type": "long"
+    },
+    "process.code_signature.digest_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.code_signature.exists": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.code_signature.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.code_signature.signing_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.code_signature.status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.code_signature.subject_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.code_signature.team_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.code_signature.timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "process.code_signature.trusted": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.code_signature.valid": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.command_line": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "process.elf.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.byte_order": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.cpu_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.creation_date": {
+      "array": false,
+      "type": "date"
+    },
+    "process.elf.exports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.elf.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "process.elf.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.elf.header.abi_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.header.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.header.data": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.header.entrypoint": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.header.object_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.header.os_abi": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.header.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.header.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.elf.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.elf.sections.chi2": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.sections.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.sections.physical_offset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.sections.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.sections.virtual_address": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.elf.segments": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.elf.segments.sections": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.segments.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.elf.shared_libraries": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.elf.telfhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.end": {
+      "array": false,
+      "type": "date"
+    },
+    "process.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.args": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.entry_leader.args_count": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.attested_groups.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.attested_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.attested_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.command_line": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "process.entry_leader.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.entry_meta.source.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "process.entry_leader.entry_meta.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.executable": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.interactive": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.entry_leader.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.parent.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.parent.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.parent.session_leader.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.parent.session_leader.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.parent.session_leader.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.entry_leader.parent.session_leader.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.parent.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.entry_leader.parent.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.real_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.real_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.real_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.real_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.same_as_process": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.entry_leader.saved_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.saved_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.saved_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.saved_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.entry_leader.supplemental_groups.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.supplemental_groups.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.tty": {
+      "array": false,
+      "type": "object"
+    },
+    "process.entry_leader.tty.char_device.major": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.tty.char_device.minor": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.entry_leader.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.entry_leader.working_directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.env_vars": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.executable": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.exit_code": {
+      "array": false,
+      "type": "long"
+    },
+    "process.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.args": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.group_leader.args_count": {
+      "array": false,
+      "type": "long"
+    },
+    "process.group_leader.command_line": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "process.group_leader.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.executable": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.interactive": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.group_leader.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.group_leader.real_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.real_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.real_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.real_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.same_as_process": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.group_leader.saved_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.saved_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.saved_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.saved_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.group_leader.supplemental_groups.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.supplemental_groups.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.tty": {
+      "array": false,
+      "type": "object"
+    },
+    "process.group_leader.tty.char_device.major": {
+      "array": false,
+      "type": "long"
+    },
+    "process.group_leader.tty.char_device.minor": {
+      "array": false,
+      "type": "long"
+    },
+    "process.group_leader.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.group_leader.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.group_leader.working_directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.interactive": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.io": {
+      "array": false,
+      "type": "object"
+    },
+    "process.io.bytes_skipped": {
+      "array": true,
+      "type": "object"
+    },
+    "process.io.bytes_skipped.length": {
+      "array": false,
+      "type": "long"
+    },
+    "process.io.bytes_skipped.offset": {
+      "array": false,
+      "type": "long"
+    },
+    "process.io.max_bytes_per_process_exceeded": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.io.text": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "process.io.total_bytes_captured": {
+      "array": false,
+      "type": "long"
+    },
+    "process.io.total_bytes_skipped": {
+      "array": false,
+      "type": "long"
+    },
+    "process.io.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.macho.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.macho.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "process.macho.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.macho.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.macho.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.macho.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.macho.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.macho.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.macho.symhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.args": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.parent.args_count": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.code_signature.digest_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.code_signature.exists": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.code_signature.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.code_signature.signing_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.code_signature.status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.code_signature.subject_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.code_signature.team_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.code_signature.timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "process.parent.code_signature.trusted": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.code_signature.valid": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.command_line": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "process.parent.elf.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.byte_order": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.cpu_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.creation_date": {
+      "array": false,
+      "type": "date"
+    },
+    "process.parent.elf.exports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.parent.elf.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "process.parent.elf.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.elf.header.abi_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.header.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.header.data": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.header.entrypoint": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.header.object_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.header.os_abi": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.header.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.header.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.parent.elf.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.parent.elf.sections.chi2": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.sections.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.sections.physical_offset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.sections.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.sections.virtual_address": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.elf.segments": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.parent.elf.segments.sections": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.segments.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.elf.shared_libraries": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.parent.elf.telfhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.end": {
+      "array": false,
+      "type": "date"
+    },
+    "process.parent.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.executable": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.exit_code": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.group_leader.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.group_leader.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.group_leader.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.parent.group_leader.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.interactive": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.macho.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.macho.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "process.parent.macho.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.macho.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.macho.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.parent.macho.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.parent.macho.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.macho.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.macho.symhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.company": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.file_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "process.parent.pe.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.parent.pe.imphash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.parent.pe.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.original_file_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.pehash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.parent.pe.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.pe.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pe.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pgid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.real_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.real_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.real_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.real_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.saved_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.saved_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.saved_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.saved_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.parent.supplemental_groups.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.supplemental_groups.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.thread.capabilities.effective": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.parent.thread.capabilities.permitted": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.parent.thread.id": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.thread.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.title": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.tty": {
+      "array": false,
+      "type": "object"
+    },
+    "process.parent.tty.char_device.major": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.tty.char_device.minor": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.uptime": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.parent.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.parent.working_directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.company": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.file_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "process.pe.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.pe.imphash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "process.pe.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.original_file_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.pehash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "process.pe.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.pe.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pe.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pgid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.previous.args": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.previous.args_count": {
+      "array": false,
+      "type": "long"
+    },
+    "process.previous.executable": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.real_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.real_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.real_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.real_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.saved_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.saved_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.saved_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.saved_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.args": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.session_leader.args_count": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.command_line": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "process.session_leader.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.executable": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.interactive": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.session_leader.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.parent.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.parent.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.parent.session_leader.entity_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.parent.session_leader.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.parent.session_leader.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.session_leader.parent.session_leader.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.parent.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.session_leader.parent.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.pid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.real_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.real_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.real_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.real_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.same_as_process": {
+      "array": false,
+      "type": "boolean"
+    },
+    "process.session_leader.saved_group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.saved_group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.saved_user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.saved_user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.session_leader.supplemental_groups.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.supplemental_groups.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.tty": {
+      "array": false,
+      "type": "object"
+    },
+    "process.session_leader.tty.char_device.major": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.tty.char_device.minor": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.session_leader.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.session_leader.working_directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.start": {
+      "array": false,
+      "type": "date"
+    },
+    "process.supplemental_groups.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.supplemental_groups.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.thread.capabilities.effective": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.thread.capabilities.permitted": {
+      "array": true,
+      "type": "keyword"
+    },
+    "process.thread.id": {
+      "array": false,
+      "type": "long"
+    },
+    "process.thread.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.title": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.tty": {
+      "array": false,
+      "type": "object"
+    },
+    "process.tty.char_device.major": {
+      "array": false,
+      "type": "long"
+    },
+    "process.tty.char_device.minor": {
+      "array": false,
+      "type": "long"
+    },
+    "process.tty.columns": {
+      "array": false,
+      "type": "long"
+    },
+    "process.tty.rows": {
+      "array": false,
+      "type": "long"
+    },
+    "process.uptime": {
+      "array": false,
+      "type": "long"
+    },
+    "process.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "process.vpid": {
+      "array": false,
+      "type": "long"
+    },
+    "process.working_directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "registry.data.bytes": {
+      "array": false,
+      "type": "keyword"
+    },
+    "registry.data.strings": {
+      "array": true,
+      "type": "wildcard"
+    },
+    "registry.data.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "registry.hive": {
+      "array": false,
+      "type": "keyword"
+    },
+    "registry.key": {
+      "array": false,
+      "type": "keyword"
+    },
+    "registry.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "registry.value": {
+      "array": false,
+      "type": "keyword"
+    },
+    "related.hash": {
+      "array": true,
+      "type": "keyword"
+    },
+    "related.hosts": {
+      "array": true,
+      "type": "keyword"
+    },
+    "related.ip": {
+      "array": true,
+      "type": "ip"
+    },
+    "related.user": {
+      "array": true,
+      "type": "keyword"
+    },
+    "rule.author": {
+      "array": true,
+      "type": "keyword"
+    },
+    "rule.category": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.license": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.ruleset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.uuid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "rule.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.as.number": {
+      "array": false,
+      "type": "long"
+    },
+    "server.as.organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "server.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "server.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "server.mac": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.nat.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "server.nat.port": {
+      "array": false,
+      "type": "long"
+    },
+    "server.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "server.port": {
+      "array": false,
+      "type": "long"
+    },
+    "server.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "server.user.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "service.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.environment": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.ephemeral_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.node.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.node.role": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.node.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "service.origin.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.environment": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.ephemeral_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.node.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.node.role": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.node.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "service.origin.state": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.origin.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.state": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.environment": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.ephemeral_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.node.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.node.role": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.node.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "service.target.state": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.target.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "service.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.as.number": {
+      "array": false,
+      "type": "long"
+    },
+    "source.as.organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.bytes": {
+      "array": false,
+      "type": "long"
+    },
+    "source.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "source.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "source.mac": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.nat.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "source.nat.port": {
+      "array": false,
+      "type": "long"
+    },
+    "source.packets": {
+      "array": false,
+      "type": "long"
+    },
+    "source.port": {
+      "array": false,
+      "type": "long"
+    },
+    "source.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "source.user.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "span.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tags": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.enrichments.indicator": {
+      "array": false,
+      "type": "object"
+    },
+    "threat.enrichments.indicator.as.number": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.as.organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.confidence": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.email.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.accessed": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.attributes": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.digest_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.exists": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.enrichments.indicator.file.code_signature.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.signing_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.subject_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.team_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.code_signature.timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.code_signature.trusted": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.enrichments.indicator.file.code_signature.valid": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.enrichments.indicator.file.created": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.ctime": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.device": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.drive_letter": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.byte_order": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.cpu_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.creation_date": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.elf.exports": {
+      "array": true,
+      "type": "object"
+    },
+    "threat.enrichments.indicator.file.elf.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "threat.enrichments.indicator.file.elf.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.enrichments.indicator.file.elf.header.abi_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.header.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.header.data": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.header.entrypoint": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.header.object_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.header.os_abi": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.header.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.header.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "threat.enrichments.indicator.file.elf.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.enrichments.indicator.file.elf.sections.chi2": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.sections.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.sections.physical_offset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.sections.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.sections.virtual_address": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.elf.segments": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.enrichments.indicator.file.elf.segments.sections": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.segments.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.shared_libraries": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.elf.telfhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.fork_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.gid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.group": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.inode": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.mime_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.mode": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.mtime": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.owner": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.company": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.file_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "threat.enrichments.indicator.file.pe.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.enrichments.indicator.file.pe.imphash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "threat.enrichments.indicator.file.pe.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.original_file_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.pehash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.enrichments.indicator.file.pe.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.pe.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.pe.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.target_path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.uid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.file.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.file.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.first_seen": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "threat.enrichments.indicator.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "threat.enrichments.indicator.last_seen": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.marking.tlp": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.marking.tlp_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.modified_at": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.port": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.provider": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.registry.data.bytes": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.registry.data.strings": {
+      "array": true,
+      "type": "wildcard"
+    },
+    "threat.enrichments.indicator.registry.data.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.registry.hive": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.registry.key": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.registry.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.registry.value": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.scanner_stats": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.sightings": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.fragment": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.full": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "threat.enrichments.indicator.url.original": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "threat.enrichments.indicator.url.password": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.path": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "threat.enrichments.indicator.url.port": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.url.query": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.scheme": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.url.username": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.indicator.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.enrichments.indicator.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.matched.atomic": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.matched.field": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.matched.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.matched.index": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.matched.occurred": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.enrichments.matched.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.feed.dashboard_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.feed.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.feed.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.feed.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.framework": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.group.alias": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.group.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.as.number": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.as.organization.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.confidence": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.email.address": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.accessed": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.attributes": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.digest_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.exists": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.indicator.file.code_signature.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.signing_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.status": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.subject_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.team_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.code_signature.timestamp": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.code_signature.trusted": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.indicator.file.code_signature.valid": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.indicator.file.created": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.ctime": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.device": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.directory": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.drive_letter": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.byte_order": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.cpu_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.creation_date": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.elf.exports": {
+      "array": true,
+      "type": "object"
+    },
+    "threat.indicator.file.elf.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "threat.indicator.file.elf.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.indicator.file.elf.header.abi_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.header.class": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.header.data": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.header.entrypoint": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.header.object_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.header.os_abi": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.header.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.header.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "threat.indicator.file.elf.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.indicator.file.elf.sections.chi2": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.sections.flags": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.sections.physical_offset": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.sections.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.sections.virtual_address": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.elf.segments": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.indicator.file.elf.segments.sections": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.segments.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.shared_libraries": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.elf.telfhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.fork_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.gid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.group": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.cdhash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.sha384": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.sha512": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.ssdeep": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.hash.tlsh": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.inode": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.mime_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.mode": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.mtime": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.owner": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.architecture": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.company": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.file_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.go_import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.go_imports": {
+      "array": false,
+      "type": "object"
+    },
+    "threat.indicator.file.pe.go_imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.go_imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.go_stripped": {
+      "array": false,
+      "type": "boolean"
+    },
+    "threat.indicator.file.pe.imphash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.import_hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.imports": {
+      "array": true,
+      "type": "object"
+    },
+    "threat.indicator.file.pe.imports_names_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.imports_names_var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.original_file_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.pehash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.product": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.sections": {
+      "array": true,
+      "type": "nested"
+    },
+    "threat.indicator.file.pe.sections.entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.sections.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.pe.sections.physical_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.sections.var_entropy": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.pe.sections.virtual_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.target_path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.uid": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.file.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.file.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.file.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.first_seen": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.geo.city_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.continent_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.continent_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.country_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.country_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.location": {
+      "array": false,
+      "type": "geo_point"
+    },
+    "threat.indicator.geo.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.postal_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.region_iso_code": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.region_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.geo.timezone": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.id": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.ip": {
+      "array": false,
+      "type": "ip"
+    },
+    "threat.indicator.last_seen": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.marking.tlp": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.marking.tlp_version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.modified_at": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.port": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.provider": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.registry.data.bytes": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.registry.data.strings": {
+      "array": true,
+      "type": "wildcard"
+    },
+    "threat.indicator.registry.data.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.registry.hive": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.registry.key": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.registry.path": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.registry.value": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.scanner_stats": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.sightings": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.fragment": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.full": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "threat.indicator.url.original": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "threat.indicator.url.password": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.path": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "threat.indicator.url.port": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.url.query": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.scheme": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.url.username": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "threat.indicator.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "threat.indicator.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.indicator.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.software.alias": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.software.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.software.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.software.platforms": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.software.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.software.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.tactic.id": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.tactic.name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.tactic.reference": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.technique.id": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.technique.name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.technique.reference": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.technique.subtechnique.id": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.technique.subtechnique.name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "threat.technique.subtechnique.reference": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.cipher": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.certificate": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.certificate_chain": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.issuer": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.ja3": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.client.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.client.server_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.subject": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.supported_ciphers": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.client.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.client.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "tls.client.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "tls.client.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.client.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.established": {
+      "array": false,
+      "type": "boolean"
+    },
+    "tls.next_protocol": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.resumed": {
+      "array": false,
+      "type": "boolean"
+    },
+    "tls.server.certificate": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.certificate_chain": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.hash.md5": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.hash.sha1": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.hash.sha256": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.issuer": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.ja3s": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.server.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.server.subject": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.alternative_names": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.issuer.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.not_after": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.server.x509.not_before": {
+      "array": false,
+      "type": "date"
+    },
+    "tls.server.x509.public_key_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.public_key_curve": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.public_key_exponent": {
+      "array": false,
+      "type": "long"
+    },
+    "tls.server.x509.public_key_size": {
+      "array": false,
+      "type": "long"
+    },
+    "tls.server.x509.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.signature_algorithm": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.common_name": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.country": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.distinguished_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.locality": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.organization": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.organizational_unit": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.subject.state_or_province": {
+      "array": true,
+      "type": "keyword"
+    },
+    "tls.server.x509.version_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "tls.version_protocol": {
+      "array": false,
+      "type": "keyword"
+    },
+    "trace.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "transaction.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.extension": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.fragment": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.full": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "url.original": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "url.password": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.path": {
+      "array": false,
+      "type": "wildcard"
+    },
+    "url.port": {
+      "array": false,
+      "type": "long"
+    },
+    "url.query": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.registered_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.scheme": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.subdomain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.top_level_domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "url.username": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.changes.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "user.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.effective.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "user.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.risk.calculated_level": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.risk.calculated_score": {
+      "array": false,
+      "type": "float"
+    },
+    "user.risk.calculated_score_norm": {
+      "array": false,
+      "type": "float"
+    },
+    "user.risk.static_level": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.risk.static_score": {
+      "array": false,
+      "type": "float"
+    },
+    "user.risk.static_score_norm": {
+      "array": false,
+      "type": "float"
+    },
+    "user.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "user.target.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.email": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.full_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.group.domain": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.group.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.group.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.hash": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user.target.roles": {
+      "array": true,
+      "type": "keyword"
+    },
+    "user_agent.device.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.original": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.family": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.full": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.kernel": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.platform": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.os.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "user_agent.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.bus_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.default_access": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.device_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.device_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.dos_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.file_system_type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.mount_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.nt_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.product_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.product_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.removable": {
+      "array": false,
+      "type": "boolean"
+    },
+    "volume.serial_number": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.size": {
+      "array": false,
+      "type": "long"
+    },
+    "volume.vendor_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.vendor_name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "volume.writable": {
+      "array": false,
+      "type": "boolean"
+    },
+    "vulnerability.category": {
+      "array": true,
+      "type": "keyword"
+    },
+    "vulnerability.classification": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.enumeration": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.reference": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.report_id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.scanner.vendor": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.score.base": {
+      "array": false,
+      "type": "float"
+    },
+    "vulnerability.score.environmental": {
+      "array": false,
+      "type": "float"
+    },
+    "vulnerability.score.temporal": {
+      "array": false,
+      "type": "float"
+    },
+    "vulnerability.score.version": {
+      "array": false,
+      "type": "keyword"
+    },
+    "vulnerability.severity": {
+      "array": false,
+      "type": "keyword"
     },
     "wazuh.decoders": {
-      "type": "keyword",
-      "array": true
+      "array": true,
+      "type": "keyword"
     },
     "wazuh.rules": {
-      "type": "keyword",
-      "array": true
+      "array": true,
+      "type": "keyword"
     }
-  }
+  },
+  "name": "schema/engine-schema/0"
 }

--- a/src/engine/ruleset/schemas/engine-schema.json
+++ b/src/engine/ruleset/schemas/engine-schema.json
@@ -580,6 +580,10 @@
       "array": false,
       "type": "keyword"
     },
+    "dll.code_signature.thumbprint_sha256": {
+      "array": false,
+      "type": "keyword"
+    },
     "dll.code_signature.timestamp": {
       "array": false,
       "type": "date"
@@ -625,6 +629,14 @@
       "type": "keyword"
     },
     "dll.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.origin_referrer_url": {
+      "array": false,
+      "type": "keyword"
+    },
+    "dll.origin_url": {
       "array": false,
       "type": "keyword"
     },
@@ -1100,6 +1112,10 @@
       "array": false,
       "type": "keyword"
     },
+    "file.code_signature.thumbprint_sha256": {
+      "array": false,
+      "type": "keyword"
+    },
     "file.code_signature.timestamp": {
       "array": false,
       "type": "date"
@@ -1416,6 +1432,14 @@
       "array": false,
       "type": "keyword"
     },
+    "file.origin_referrer_url": {
+      "array": false,
+      "type": "keyword"
+    },
+    "file.origin_url": {
+      "array": false,
+      "type": "keyword"
+    },
     "file.owner": {
       "array": false,
       "type": "keyword"
@@ -1627,6 +1651,110 @@
     "file.x509.version_number": {
       "array": false,
       "type": "keyword"
+    },
+    "gen_ai.agent.description": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.agent.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.agent.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.operation.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.output.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.request.choice.count": {
+      "array": false,
+      "type": "integer"
+    },
+    "gen_ai.request.encoding_formats": {
+      "array": false,
+      "type": "nested"
+    },
+    "gen_ai.request.frequency_penalty": {
+      "array": false,
+      "type": "double"
+    },
+    "gen_ai.request.max_tokens": {
+      "array": false,
+      "type": "integer"
+    },
+    "gen_ai.request.model": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.request.presence_penalty": {
+      "array": false,
+      "type": "double"
+    },
+    "gen_ai.request.seed": {
+      "array": false,
+      "type": "integer"
+    },
+    "gen_ai.request.stop_sequences": {
+      "array": false,
+      "type": "nested"
+    },
+    "gen_ai.request.temperature": {
+      "array": false,
+      "type": "double"
+    },
+    "gen_ai.request.top_k": {
+      "array": false,
+      "type": "double"
+    },
+    "gen_ai.request.top_p": {
+      "array": false,
+      "type": "double"
+    },
+    "gen_ai.response.finish_reasons": {
+      "array": false,
+      "type": "nested"
+    },
+    "gen_ai.response.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.response.model": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.system": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.token.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.tool.call.id": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.tool.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.tool.type": {
+      "array": false,
+      "type": "keyword"
+    },
+    "gen_ai.usage.input_tokens": {
+      "array": false,
+      "type": "integer"
+    },
+    "gen_ai.usage.output_tokens": {
+      "array": false,
+      "type": "integer"
     },
     "group.domain": {
       "array": false,
@@ -2324,6 +2452,10 @@
       "array": false,
       "type": "keyword"
     },
+    "process.code_signature.thumbprint_sha256": {
+      "array": false,
+      "type": "keyword"
+    },
     "process.code_signature.timestamp": {
       "array": false,
       "type": "date"
@@ -2980,6 +3112,10 @@
       "array": false,
       "type": "keyword"
     },
+    "process.parent.code_signature.thumbprint_sha256": {
+      "array": false,
+      "type": "keyword"
+    },
     "process.parent.code_signature.timestamp": {
       "array": false,
       "type": "date"
@@ -3384,10 +3520,6 @@
       "array": false,
       "type": "long"
     },
-    "process.parent.pgid": {
-      "array": false,
-      "type": "long"
-    },
     "process.parent.pid": {
       "array": false,
       "type": "long"
@@ -3577,10 +3709,6 @@
       "type": "long"
     },
     "process.pe.sections.virtual_size": {
-      "array": false,
-      "type": "long"
-    },
-    "process.pgid": {
       "array": false,
       "type": "long"
     },
@@ -4420,6 +4548,10 @@
       "array": false,
       "type": "keyword"
     },
+    "threat.enrichments.indicator.file.code_signature.thumbprint_sha256": {
+      "array": false,
+      "type": "keyword"
+    },
     "threat.enrichments.indicator.file.code_signature.timestamp": {
       "array": false,
       "type": "date"
@@ -4669,6 +4801,14 @@
       "type": "date"
     },
     "threat.enrichments.indicator.file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.origin_referrer_url": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.enrichments.indicator.file.origin_url": {
       "array": false,
       "type": "keyword"
     },
@@ -5276,6 +5416,10 @@
       "array": false,
       "type": "keyword"
     },
+    "threat.indicator.file.code_signature.thumbprint_sha256": {
+      "array": false,
+      "type": "keyword"
+    },
     "threat.indicator.file.code_signature.timestamp": {
       "array": false,
       "type": "date"
@@ -5525,6 +5669,14 @@
       "type": "date"
     },
     "threat.indicator.file.name": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.origin_referrer_url": {
+      "array": false,
+      "type": "keyword"
+    },
+    "threat.indicator.file.origin_url": {
       "array": false,
       "type": "keyword"
     },

--- a/src/engine/ruleset/schemas/fields_decoder.json
+++ b/src/engine/ruleset/schemas/fields_decoder.json
@@ -1,9 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "fields_decoder.json",
-  "name": "schema/fields-decoder/0",
-  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "name": "schema/fields-decoder/0",
   "patternProperties": {
     "^_.+": {
       "description": "Custom variable.",
@@ -25,6 +24,56 @@
     },
     "agent.ephemeral_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nEphemeral identifier of this agent (if one exists).\nThis id normally changes across restarts, but `agent.id` does not.",
+      "type": [
+        "string"
+      ]
+    },
+    "agent.groups": {
+      "description": "Module: schemas\nIndexerType: keyword\nArray: True\n\n",
+      "items": {
+        "type": [
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "agent.host.architecture": {
+      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
+      "type": [
+        "string"
+      ]
+    },
+    "agent.host.hostname": {
+      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
+      "type": [
+        "string"
+      ]
+    },
+    "agent.host.ip": {
+      "description": "Module: schemas\nIndexerType: ip\nArray: True\n\nTrace of the decoders used to decode the event in order",
+      "items": {
+        "type": [
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "agent.host.os.name": {
+      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
+      "type": [
+        "string"
+      ]
+    },
+    "agent.host.os.platform": {
+      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
       "type": [
         "string"
       ]
@@ -53,56 +102,6 @@
         "string"
       ]
     },
-    "agent.groups": {
-      "description": "Module: schemas\nIndexerType: keyword\nArray: True\n\n",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
-        "type": [
-          "string"
-        ]
-      }
-    },
-    "agent.host.hostname": {
-      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
-      "type": [
-        "string"
-      ]
-    },
-    "agent.host.os.platform": {
-      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
-      "type": [
-        "string"
-      ]
-    },
-    "agent.host.os.name": {
-      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
-      "type": [
-        "string"
-      ]
-    },
-    "agent.host.architecture": {
-      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\n",
-      "type": [
-        "string"
-      ]
-    },
-    "agent.host.ip": {
-      "description": "Module: schemas\nIndexerType: ip\nArray: True\n\nTrace of the decoders used to decode the event in order",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
-        "type": [
-          "string"
-        ]
-      }
-    },
     "client.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nSome event client addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.",
       "type": [
@@ -111,11 +110,11 @@
     },
     "client.as.number": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nUnique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "client.as.organization.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOrganization name.",
@@ -125,11 +124,11 @@
     },
     "client.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nBytes sent from the client to the server.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "client.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe domain name of the client system.\nThis value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.",
@@ -223,27 +222,27 @@
     },
     "client.nat.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTranslated port of source based NAT sessions (e.g. internal client to internet).\nTypically connections traversing load balancers, firewalls, or routers.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "client.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPackets sent from the client to the server.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "client.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the client.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "client.registered_domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe highest registered client domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
@@ -319,16 +318,16 @@
     },
     "client.user.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "cloud.account.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier.",
@@ -530,27 +529,27 @@
     },
     "container.cpu.usage": {
       "description": "Module: ecs\nIndexerType: scaled_float\nArray: False\n\nPercent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1. Scaling factor: 1000.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.disk.read.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.disk.write.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique container id.",
@@ -560,16 +559,16 @@
     },
     "container.image.hash.all": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nAn array of digests of the image the container was built on. Each digest consists of the hash algorithm and value in this format: `algorithm:value`. Algorithm names should align with the field names in the ECS hash field set.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "container.image.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the image the container was built on.",
@@ -579,32 +578,32 @@
     },
     "container.image.tag": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nContainer image tags.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "container.labels": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nImage labels.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.memory.usage": {
       "description": "Module: ecs\nIndexerType: scaled_float\nArray: False\n\nMemory usage percentage and it ranges from 0 to 1. Scaling factor: 1000.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nContainer name.",
@@ -614,19 +613,19 @@
     },
     "container.network.egress.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of bytes (gauge) sent out on all network interfaces by the container since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.network.ingress.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of bytes received (gauge) on all network interfaces by the container since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "container.runtime": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nRuntime managing this container.",
@@ -636,11 +635,11 @@
     },
     "container.security_context.privileged": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nIndicates whether the container is running in privileged mode.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "data_stream.dataset": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe field can contain anything that makes sense to signify the source of the data.\nExamples include `nginx.access`, `prometheus`, `endpoint` etc. For data streams that otherwise fit, but that do not have dataset set we use the value \"generic\" for the dataset value. `event.dataset` should have the same value as `data_stream.dataset`.\nBeyond the Elasticsearch data stream naming criteria noted above, the `dataset` value has additional restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters",
@@ -668,11 +667,11 @@
     },
     "destination.as.number": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nUnique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "destination.as.organization.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOrganization name.",
@@ -682,11 +681,11 @@
     },
     "destination.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nBytes sent from the destination to the source.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "destination.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe domain name of the destination system.\nThis value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.",
@@ -780,27 +779,27 @@
     },
     "destination.nat.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort the source session is translated to by NAT Device.\nTypically used with load balancers, firewalls, or routers.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "destination.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPackets sent from the destination to the source.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "destination.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the destination.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "destination.registered_domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe highest registered destination domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
@@ -876,16 +875,16 @@
     },
     "destination.user.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "device.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe unique identifier of a device. The identifier must not change across application sessions but stay fixed for an instance of a (mobile) device.\nOn iOS, this value must be equal to the vendor identifier (https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android, this value must be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application.\nFor GDPR and data protection law reasons this identifier should not carry information that would allow to identify a user.",
@@ -925,11 +924,11 @@
     },
     "dll.code_signature.exists": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if a signature is present.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.code_signature.flags": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
@@ -969,19 +968,19 @@
     },
     "dll.code_signature.trusted": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nStores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.code_signature.valid": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.hash.cdhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCode directory hash, utilized to uniquely identify and authenticate the integrity of the executable code.",
@@ -1075,35 +1074,35 @@
     },
     "dll.pe.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.pe.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.pe.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.pe.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.pe.imphash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
@@ -1119,34 +1118,34 @@
     },
     "dll.pe.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "dll.pe.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.pe.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "dll.pe.original_file_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInternal name of the file, provided at compile-time.",
@@ -1168,26 +1167,17 @@
     },
     "dll.pe.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the PE file.\nThe keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPE Section List name.",
@@ -1197,45 +1187,45 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
-    },
-    "dns.answers": {
-      "description": "Module: ecs\nIndexerType: object\nArray: True\n\nAn array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
+        },
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "dns.answers": {
+      "description": "Module: ecs\nIndexerType: object\nArray: True\n\nAn array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields.",
+      "items": {
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "class": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe class of DNS data contained in this resource record.",
@@ -1257,11 +1247,11 @@
           },
           "ttl": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "type": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe type of data contained in this resource record.",
@@ -1269,21 +1259,30 @@
               "string"
             ]
           }
-        }
-      }
-    },
-    "dns.header_flags": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of 2 letter DNS header flags.",
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "string",
         "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      ]
+    },
+    "dns.header_flags": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of 2 letter DNS header flags.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "dns.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.",
@@ -1335,16 +1334,16 @@
     },
     "dns.resolved_ip": {
       "description": "Module: ecs\nIndexerType: ip\nArray: True\n\nArray containing all IPs seen in `answers.data`.\nThe `answers` array can be difficult to use, because of the variety of data formats it can contain. Extracting all IP addresses seen in there to `dns.resolved_ip` makes it possible to index them as IP addresses, and makes them easier to visualize and query for.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "dns.response_code": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe DNS response code.",
@@ -1366,18 +1365,9 @@
     },
     "email.attachments": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nA list of objects describing the attachment files sent along with an email message.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "file.extension": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nAttachment file extension, excluding the leading dot.",
@@ -1447,40 +1437,49 @@
           },
           "file.size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nAttachment file size in bytes.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "email.bcc.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe email address of BCC recipient",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "email.cc.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe email address of CC recipient",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "email.content_type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInformation about how the message is to be displayed.\nTypically a MIME type.",
@@ -1502,16 +1501,16 @@
     },
     "email.from.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe email address of the sender, typically from the RFC 5322 `From:` header field.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "email.local_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier given to the email by the source that created the event.\nIdentifier is not persistent across hops.",
@@ -1533,16 +1532,16 @@
     },
     "email.reply_to.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe address that replies should be delivered to based on the value in the RFC 5322 `Reply-To:` header.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "email.sender.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPer RFC 5322, specifies the address responsible for the actual transmission of the message.",
@@ -1558,16 +1557,16 @@
     },
     "email.to.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe email address of recipient",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "email.x_mailer": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the application that was used to draft and send the original email message.",
@@ -1619,19 +1618,25 @@
     },
     "event.category": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThis is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.\n`event.category` represents the \"big buckets\" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory.\nThis field is an array. This will allow proper categorization of some events that fall in multiple categories.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "event.code": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nIdentification code for this event, if one exists.\nSome event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.",
+      "type": [
+        "string"
+      ]
+    },
+    "event.collector": {
+      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\nName of the collector, source of data",
       "type": [
         "string"
       ]
@@ -1650,11 +1655,11 @@
     },
     "event.duration": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nDuration of the event in nanoseconds.\nIf `event.start` and `event.end` are known this value should be the difference between the end and start time.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "event.end": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\n`event.end` contains the date when the event ended or when the activity was last observed.",
@@ -1724,19 +1729,19 @@
     },
     "event.sequence": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSequence number of the event.\nThe sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "event.severity": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe numeric severity of the event according to your event source.\nWhat the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "event.start": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\n`event.start` contains the date when the event started or when the activity was first observed.",
@@ -1752,16 +1757,16 @@
     },
     "event.type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThis is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.\n`event.type` represents a categorization \"sub-bucket\" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization.\nThis field is an array. This will allow proper categorization of some events that fall in multiple event types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "event.url": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nURL linking to an external system to continue investigation of this event.\nThis URL links to another system where in-depth investigation of the specific occurrence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.",
@@ -1769,19 +1774,13 @@
         "string"
       ]
     },
-    "event.collector": {
-      "description": "Module: schemas\nIndexerType: keyword\nArray: False\n\nName of the collector, source of data",
-      "type": [
-        "string"
-      ]
-    },
     "faas.coldstart": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean value indicating a cold start of a function.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "faas.execution": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe execution ID of the current function execution.",
@@ -1827,16 +1826,16 @@
     },
     "file.attributes": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of file attributes.\nAttributes names will vary by platform. Here's a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.code_signature.digest_algorithm": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe hashing algorithm used to sign the process.\nThis value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.",
@@ -1846,11 +1845,11 @@
     },
     "file.code_signature.exists": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if a signature is present.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.code_signature.flags": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
@@ -1890,19 +1889,19 @@
     },
     "file.code_signature.trusted": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nStores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.code_signature.valid": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.created": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nFile creation time.\nNote that not all filesystems store the creation time.",
@@ -1960,18 +1959,18 @@
     },
     "file.elf.exports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of exported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.elf.go_import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -1981,35 +1980,35 @@
     },
     "file.elf.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.header.abi_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of the ELF Application Binary Interface (ABI).",
@@ -2031,11 +2030,11 @@
     },
     "file.elf.header.entrypoint": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nHeader entrypoint of the ELF file.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.header.object_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\n\"0x1\" for original ELF files.",
@@ -2069,65 +2068,56 @@
     },
     "file.elf.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.elf.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.elf.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "chi2": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nChi-square probability distribution of the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "flags": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List flags.",
@@ -2149,11 +2139,11 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "type": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List type.",
@@ -2163,45 +2153,45 @@
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_address": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual address.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
-    },
-    "file.elf.segments": {
-      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
+        },
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "file.elf.segments": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
+      "items": {
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "sections": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF object segment sections.",
@@ -2215,21 +2205,30 @@
               "string"
             ]
           }
-        }
-      }
-    },
-    "file.elf.shared_libraries": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "string",
         "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      ]
+    },
+    "file.elf.shared_libraries": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.elf.telfhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\ntelfhash symbol hash for ELF file.",
@@ -2323,35 +2322,35 @@
     },
     "file.macho.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.macho.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.macho.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.macho.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.macho.import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThis is a synonym for symhash.",
@@ -2361,57 +2360,48 @@
     },
     "file.macho.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.macho.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.macho.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.macho.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the Mach-O file.\nThe keys that should be present in these objects are defined by sub-fields underneath `macho.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMach-O Section List name.",
@@ -2421,30 +2411,39 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nMach-O Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nMach-O Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.macho.symhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThis is a Mach-O implementation of the Windows PE imphash",
@@ -2520,35 +2519,35 @@
     },
     "file.pe.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.pe.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.pe.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.pe.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.pe.imphash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
@@ -2564,34 +2563,34 @@
     },
     "file.pe.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.pe.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.pe.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.pe.original_file_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInternal name of the file, provided at compile-time.",
@@ -2613,26 +2612,17 @@
     },
     "file.pe.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the PE file.\nThe keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPE Section List name.",
@@ -2642,38 +2632,47 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nFile size in bytes.\nOnly relevant when `file.type` is \"file\".",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.target_path": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nTarget path for symlinks.",
@@ -2695,42 +2694,42 @@
     },
     "file.x509.alternative_names": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.issuer.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.issuer.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.issuer.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -2740,55 +2739,55 @@
     },
     "file.x509.issuer.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.issuer.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.issuer.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.issuer.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.not_after": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -2816,19 +2815,19 @@
     },
     "file.x509.public_key_exponent": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.x509.public_key_size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "file.x509.serial_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -2844,29 +2843,29 @@
     },
     "file.x509.subject.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.subject.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.subject.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -2876,55 +2875,55 @@
     },
     "file.x509.subject.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.subject.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.subject.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.subject.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "file.x509.version_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -2964,27 +2963,27 @@
     },
     "host.cpu.usage": {
       "description": "Module: ecs\nIndexerType: scaled_float\nArray: False\n\nPercent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1.\nScaling factor: 1000.\nFor example: For a two core host, this value should be the average of the two cores, between 0 and 1.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.disk.read.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.disk.write.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider.",
@@ -3072,29 +3071,29 @@
     },
     "host.ip": {
       "description": "Module: ecs\nIndexerType: ip\nArray: True\n\nHost ip addresses.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "host.mac": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nHost MAC addresses.\nThe notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "host.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the host.\nIt can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.",
@@ -3104,35 +3103,35 @@
     },
     "host.network.egress.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of bytes (gauge) sent out on all network interfaces by the host since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.network.egress.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of packets (gauge) sent out on all network interfaces by the host since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.network.ingress.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of bytes received (gauge) on all network interfaces by the host since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.network.ingress.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of packets (gauge) received on all network interfaces by the host since the last metric collection.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.os.family": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOS family (such as redhat, debian, freebsd, windows).",
@@ -3190,19 +3189,19 @@
     },
     "host.uptime": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSeconds the host has been up.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "http.request.body.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSize in bytes of the request body.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "http.request.body.content": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nThe full HTTP request body.",
@@ -3212,11 +3211,11 @@
     },
     "http.request.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTotal size in bytes of the request (body and headers).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "http.request.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA unique identifier for each HTTP request to correlate logs between clients and servers in transactions.\nThe id may be contained in a non-standard HTTP header, such as `X-Request-ID` or `X-Correlation-ID`.",
@@ -3244,11 +3243,11 @@
     },
     "http.response.body.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSize in bytes of the response body.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "http.response.body.content": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nThe full HTTP response body.",
@@ -3258,11 +3257,11 @@
     },
     "http.response.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTotal size in bytes of the response (body and headers).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "http.response.mime_type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMime type of the body of the response.\nThis value must only be populated based on the content of the response body, not on the `Content-Type` header. Comparing the mime type of a response with the response's Content-Type header can be helpful in detecting misconfigured servers.",
@@ -3272,11 +3271,11 @@
     },
     "http.response.status_code": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nHTTP response status code.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "http.version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nHTTP version.",
@@ -3286,11 +3285,11 @@
     },
     "labels": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nCustom key/value pairs.\nCan be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.\nExample: `docker` and `k8s` labels.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "log.file.path": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nFull path to the log file this event came from, including the file name. It should include the drive letter, when appropriate.\nIf the event wasn't read from a log file, do not populate this field.",
@@ -3312,11 +3311,11 @@
     },
     "log.origin.file.line": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe line number of the file containing the source code which originated the log event.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "log.origin.file.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the file containing the source code which originated the log event.\nNote that this field is not meant to capture the log file. The correct field to capture the log file is `log.file.path`.",
@@ -3331,13 +3330,9 @@
       ]
     },
     "log.syslog": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nThe Syslog metadata of the event, if the event was transmitted via Syslog. Please see RFCs 5424 or 3164.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nThe Syslog metadata of the event, if the event was transmitted via Syslog. Please see RFCs 5424 or 3164.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "appname": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe device or application that originated the Syslog message, if available.",
@@ -3347,11 +3342,11 @@
         },
         "facility.code": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe Syslog numeric facility of the log event, if available.\nAccording to RFCs 5424 and 3164, this value should be an integer between 0 and 23.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "facility.name": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe Syslog text-based facility of the log event, if available.",
@@ -3373,11 +3368,11 @@
         },
         "priority": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSyslog numeric priority of the event, if available.\nAccording to RFCs 5424 and 3164, the priority is 8 * facility + severity. This number is therefore expected to contain a value between 0 and 191.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "procid": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe process name or ID that originated the Syslog message, if available.",
@@ -3387,11 +3382,11 @@
         },
         "severity.code": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe Syslog numeric severity of the log event, if available.\nIf the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "severity.name": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe Syslog numeric severity of the log event, if available.\nIf the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.",
@@ -3401,11 +3396,11 @@
         },
         "structured_data": {
           "description": "Module: ecs\nIndexerType: object\nArray: False\n\nStructured data expressed in RFC 5424 messages, if available. These are key-value pairs formed from the structured data portion of the syslog message, as defined in RFC 5424 Section 6.3.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "object",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "version": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe version of the Syslog protocol specification. Only applicable for RFC 5424 messages.",
@@ -3413,7 +3408,11 @@
             "string"
           ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "message": {
       "description": "Module: ecs\nIndexerType: text\nArray: False\n\nFor log events the message field contains the log message, optimized for viewing in a log viewer.\nFor structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.\nIf multiple messages exist, they can be combined into one message.",
@@ -3429,11 +3428,11 @@
     },
     "network.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTotal bytes transferred in both directions.\nIf `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "network.community_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.\nLearn more at https://github.com/corelight/community-id-spec.",
@@ -3460,13 +3459,9 @@
       ]
     },
     "network.inner": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nNetwork.inner fields are added in addition to network.vlan fields to describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nNetwork.inner fields are added in addition to network.vlan fields to describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "vlan.id": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVLAN ID as reported by the observer.",
@@ -3480,7 +3475,11 @@
             "string"
           ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "network.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName given by operators to sections of their network.",
@@ -3490,11 +3489,11 @@
     },
     "network.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTotal packets transferred in both directions.\nIf `source.packets` and `destination.packets` are known, `network.packets` is their sum.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "network.protocol": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nIn the OSI Model this would be the Application Layer protocol. For example, `http`, `dns`, or `ssh`.\nThe field value must be normalized to lowercase for querying.",
@@ -3527,13 +3526,9 @@
       ]
     },
     "observer.egress": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nObserver.egress holds information like interface number and name, vlan, and zone information to classify egress traffic.  Single armed monitoring such as a network sensor on a span port should only use observer.ingress to categorize traffic.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nObserver.egress holds information like interface number and name, vlan, and zone information to classify egress traffic.  Single armed monitoring such as a network sensor on a span port should only use observer.ingress to categorize traffic.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "interface.alias": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInterface alias as reported by the system, typically used in firewall implementations for e.g. inside, outside, or dmz logical interface naming.",
@@ -3571,7 +3566,11 @@
             "string"
           ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "observer.geo.city_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCity name.",
@@ -3646,13 +3645,9 @@
       ]
     },
     "observer.ingress": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nObserver.ingress holds information like interface number and name, vlan, and zone information to classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should only use observer.ingress to categorize traffic.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nObserver.ingress holds information like interface number and name, vlan, and zone information to classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should only use observer.ingress to categorize traffic.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "interface.alias": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInterface alias as reported by the system, typically used in firewall implementations for e.g. inside, outside, or dmz logical interface naming.",
@@ -3690,33 +3685,37 @@
             "string"
           ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "observer.ip": {
       "description": "Module: ecs\nIndexerType: ip\nArray: True\n\nIP addresses of the observer.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "observer.mac": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nMAC addresses of the observer.\nThe notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "observer.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCustom name of the observer.\nThis is a name that can be given to an observer. This can be helpful for example if multiple firewalls of the same model are used in an organization.\nIf no custom name is needed, the field can be left empty.",
@@ -3840,16 +3839,16 @@
     },
     "orchestrator.resource.annotation": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe list of annotations added to the resource.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "orchestrator.resource.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique ID of the resource being acted upon.",
@@ -3859,29 +3858,29 @@
     },
     "orchestrator.resource.ip": {
       "description": "Module: ecs\nIndexerType: ip\nArray: True\n\nIP address assigned to the resource associated with the event being observed. In the case of a Kubernetes Pod, this array would contain only one element: the IP of the Pod (as opposed to the Node on which the Pod is running).",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "orchestrator.resource.label": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe list of labels added to the resource.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "orchestrator.resource.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the resource being acted upon.",
@@ -3981,11 +3980,11 @@
     },
     "package.size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPackage size in bytes.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "package.type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nType of package.\nThis should contain the package file type, rather than the package manager name. Examples: rpm, dpkg, brew, npm, gem, nupkg, jar.",
@@ -4001,24 +4000,24 @@
     },
     "process.args": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.args_count": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nLength of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.code_signature.digest_algorithm": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe hashing algorithm used to sign the process.\nThis value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.",
@@ -4028,11 +4027,11 @@
     },
     "process.code_signature.exists": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if a signature is present.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.code_signature.flags": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
@@ -4072,19 +4071,19 @@
     },
     "process.code_signature.trusted": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nStores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.code_signature.valid": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.command_line": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nFull command line that started the process, including the absolute path to the executable, and all arguments.\nSome arguments may be filtered to protect sensitive information.",
@@ -4118,18 +4117,18 @@
     },
     "process.elf.exports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of exported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.elf.go_import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -4139,35 +4138,35 @@
     },
     "process.elf.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.header.abi_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of the ELF Application Binary Interface (ABI).",
@@ -4189,11 +4188,11 @@
     },
     "process.elf.header.entrypoint": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nHeader entrypoint of the ELF file.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.header.object_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\n\"0x1\" for original ELF files.",
@@ -4227,65 +4226,56 @@
     },
     "process.elf.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.elf.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.elf.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "chi2": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nChi-square probability distribution of the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "flags": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List flags.",
@@ -4307,11 +4297,11 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "type": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List type.",
@@ -4321,45 +4311,45 @@
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_address": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual address.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
-    },
-    "process.elf.segments": {
-      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
+        },
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "process.elf.segments": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
+      "items": {
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "sections": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF object segment sections.",
@@ -4373,21 +4363,30 @@
               "string"
             ]
           }
-        }
-      }
-    },
-    "process.elf.shared_libraries": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "string",
         "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      ]
+    },
+    "process.elf.shared_libraries": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.elf.telfhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\ntelfhash symbol hash for ELF file.",
@@ -4409,24 +4408,24 @@
     },
     "process.entry_leader.args": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.entry_leader.args_count": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nLength of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.attested_groups.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the group.",
@@ -4490,11 +4489,11 @@
     },
     "process.entry_leader.interactive": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nWhether the process is connected to an interactive shell.\nProcess interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.\nNote: A non-interactive process can belong to an interactive session and is simply one that does not have open file descriptors reading the controlling TTY on FD 0 (stdin) or writing to the controlling TTY on FD 2 (stderr). A backgrounded process is still considered interactive if stdin and stderr are connected to the controlling TTY.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nProcess name.\nSometimes called program name or similar.",
@@ -4510,11 +4509,11 @@
     },
     "process.entry_leader.parent.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.parent.session_leader.entity_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the process.\nThe implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.\nConstructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.",
@@ -4524,11 +4523,11 @@
     },
     "process.entry_leader.parent.session_leader.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.parent.session_leader.start": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nThe time the process started.",
@@ -4538,11 +4537,11 @@
     },
     "process.entry_leader.parent.session_leader.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.parent.start": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nThe time the process started.",
@@ -4552,19 +4551,19 @@
     },
     "process.entry_leader.parent.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.real_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -4592,11 +4591,11 @@
     },
     "process.entry_leader.same_as_process": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nThis boolean is used to identify if a leader process is the same as the top level process.\nFor example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.\nThis field exists to the benefit of EQL and other rule engines since it's not possible to compare equality between two fields in a single document. e.g `process.entity_id` = `process.group_leader.entity_id` (top level process is the process group leader) OR `process.entity_id` = `process.entry_leader.entity_id` (top level process is the entry session leader)\nInstead these rules could be written like: `process.group_leader.same_as_process: true` OR `process.entry_leader.same_as_process: true`\nNote: This field is only set on `process.entry_leader`, `process.session_leader` and `process.group_leader`.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.saved_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -4641,31 +4640,31 @@
       ]
     },
     "process.entry_leader.tty": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "char_device.major": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as \"ttyS0\" and \"pts/0\". For more details, please refer to the Linux kernel documentation.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "char_device.minor": {
-          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don\u2019t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "process.entry_leader.user.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier of the user.",
@@ -4681,11 +4680,11 @@
     },
     "process.entry_leader.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.entry_leader.working_directory": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe working directory of the process.",
@@ -4695,16 +4694,16 @@
     },
     "process.env_vars": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of environment variable bindings. Captured from a snapshot of the environment at the time of execution.\nMay be filtered to protect sensitive information.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.executable": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nAbsolute path to the process executable.",
@@ -4714,11 +4713,11 @@
     },
     "process.exit_code": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe exit code of the process, if this is a termination event.\nThe field should be absent if there is no exit code for the event (e.g. process start).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -4734,24 +4733,24 @@
     },
     "process.group_leader.args": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.group_leader.args_count": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nLength of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.group_leader.command_line": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nFull command line that started the process, including the absolute path to the executable, and all arguments.\nSome arguments may be filtered to protect sensitive information.",
@@ -4785,11 +4784,11 @@
     },
     "process.group_leader.interactive": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nWhether the process is connected to an interactive shell.\nProcess interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.\nNote: A non-interactive process can belong to an interactive session and is simply one that does not have open file descriptors reading the controlling TTY on FD 0 (stdin) or writing to the controlling TTY on FD 2 (stderr). A backgrounded process is still considered interactive if stdin and stderr are connected to the controlling TTY.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.group_leader.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nProcess name.\nSometimes called program name or similar.",
@@ -4799,11 +4798,11 @@
     },
     "process.group_leader.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.group_leader.real_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -4831,11 +4830,11 @@
     },
     "process.group_leader.same_as_process": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nThis boolean is used to identify if a leader process is the same as the top level process.\nFor example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.\nThis field exists to the benefit of EQL and other rule engines since it's not possible to compare equality between two fields in a single document. e.g `process.entity_id` = `process.group_leader.entity_id` (top level process is the process group leader) OR `process.entity_id` = `process.entry_leader.entity_id` (top level process is the entry session leader)\nInstead these rules could be written like: `process.group_leader.same_as_process: true` OR `process.entry_leader.same_as_process: true`\nNote: This field is only set on `process.entry_leader`, `process.session_leader` and `process.group_leader`.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.group_leader.saved_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -4880,31 +4879,31 @@
       ]
     },
     "process.group_leader.tty": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "char_device.major": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as \"ttyS0\" and \"pts/0\". For more details, please refer to the Linux kernel documentation.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "char_device.minor": {
-          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don\u2019t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "process.group_leader.user.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier of the user.",
@@ -4920,11 +4919,11 @@
     },
     "process.group_leader.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.group_leader.working_directory": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe working directory of the process.",
@@ -4982,62 +4981,58 @@
     },
     "process.interactive": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nWhether the process is connected to an interactive shell.\nProcess interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.\nNote: A non-interactive process can belong to an interactive session and is simply one that does not have open file descriptors reading the controlling TTY on FD 0 (stdin) or writing to the controlling TTY on FD 2 (stderr). A backgrounded process is still considered interactive if stdin and stderr are connected to the controlling TTY.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.io": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nA chunk of input or output (IO) from a single process.\nThis field only appears on the top level process object, which is the process that wrote the output or read the input.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nA chunk of input or output (IO) from a single process.\nThis field only appears on the top level process object, which is the process that wrote the output or read the input.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "bytes_skipped": {
           "description": "Module: ecs\nIndexerType: object\nArray: True\n\nAn array of byte offsets and lengths denoting where IO data has been skipped.",
-          "type": [
-            "string",
-            "array"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "items": {
-            "type": [
-              "object",
-              "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "additionalProperties": false,
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "properties": {
               "length": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe length of bytes skipped.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "offset": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               }
-            }
-          }
+            },
+            "type": [
+              "object",
+              "string"
+            ]
+          },
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+          "type": [
+            "string",
+            "array"
+          ]
         },
         "max_bytes_per_process_exceeded": {
           "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nIf true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "boolean",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "text": {
           "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nA chunk of output or input sanitized to UTF-8.\nBest efforts are made to ensure complete lines are captured in these events. Assumptions should NOT be made that multiple lines will appear in the same event. TTY output may contain terminal control codes such as for cursor movement, so some string queries may not match due to terminal codes inserted between characters of a word.",
@@ -5047,19 +5042,19 @@
         },
         "total_bytes_captured": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe total number of bytes captured in this event.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "total_bytes_skipped": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "type": {
           "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe type of object on which the IO action (read or write) was taken.\nCurrently only 'tty' is supported. Other types may be added in the future for 'file' and 'socket' support.",
@@ -5067,7 +5062,11 @@
             "string"
           ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "process.macho.go_import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in a Mach-O file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -5077,35 +5076,35 @@
     },
     "process.macho.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.macho.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.macho.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.macho.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.macho.import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThis is a synonym for symhash.",
@@ -5115,57 +5114,48 @@
     },
     "process.macho.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.macho.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.macho.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.macho.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the Mach-O file.\nThe keys that should be present in these objects are defined by sub-fields underneath `macho.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMach-O Section List name.",
@@ -5175,30 +5165,39 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nMach-O Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nMach-O Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.macho.symhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThis is a Mach-O implementation of the Windows PE imphash",
@@ -5214,24 +5213,24 @@
     },
     "process.parent.args": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.args_count": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nLength of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.code_signature.digest_algorithm": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe hashing algorithm used to sign the process.\nThis value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.",
@@ -5241,11 +5240,11 @@
     },
     "process.parent.code_signature.exists": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if a signature is present.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.code_signature.flags": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
@@ -5285,19 +5284,19 @@
     },
     "process.parent.code_signature.trusted": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nStores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.code_signature.valid": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.command_line": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nFull command line that started the process, including the absolute path to the executable, and all arguments.\nSome arguments may be filtered to protect sensitive information.",
@@ -5331,18 +5330,18 @@
     },
     "process.parent.elf.exports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of exported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.elf.go_import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -5352,35 +5351,35 @@
     },
     "process.parent.elf.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.header.abi_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of the ELF Application Binary Interface (ABI).",
@@ -5402,11 +5401,11 @@
     },
     "process.parent.elf.header.entrypoint": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nHeader entrypoint of the ELF file.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.header.object_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\n\"0x1\" for original ELF files.",
@@ -5440,65 +5439,56 @@
     },
     "process.parent.elf.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.elf.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.elf.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "chi2": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nChi-square probability distribution of the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "flags": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List flags.",
@@ -5520,11 +5510,11 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "type": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List type.",
@@ -5534,45 +5524,45 @@
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_address": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual address.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
-    },
-    "process.parent.elf.segments": {
-      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
+        },
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "process.parent.elf.segments": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
+      "items": {
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "sections": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF object segment sections.",
@@ -5586,21 +5576,30 @@
               "string"
             ]
           }
-        }
-      }
-    },
-    "process.parent.elf.shared_libraries": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "string",
         "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      ]
+    },
+    "process.parent.elf.shared_libraries": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.elf.telfhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\ntelfhash symbol hash for ELF file.",
@@ -5628,11 +5627,11 @@
     },
     "process.parent.exit_code": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe exit code of the process, if this is a termination event.\nThe field should be absent if there is no exit code for the event (e.g. process start).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -5654,11 +5653,11 @@
     },
     "process.parent.group_leader.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.group_leader.start": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nThe time the process started.",
@@ -5668,11 +5667,11 @@
     },
     "process.parent.group_leader.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.hash.cdhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCode directory hash, utilized to uniquely identify and authenticate the integrity of the executable code.",
@@ -5724,11 +5723,11 @@
     },
     "process.parent.interactive": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nWhether the process is connected to an interactive shell.\nProcess interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.\nNote: A non-interactive process can belong to an interactive session and is simply one that does not have open file descriptors reading the controlling TTY on FD 0 (stdin) or writing to the controlling TTY on FD 2 (stderr). A backgrounded process is still considered interactive if stdin and stderr are connected to the controlling TTY.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.go_import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in a Mach-O file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -5738,35 +5737,35 @@
     },
     "process.parent.macho.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThis is a synonym for symhash.",
@@ -5776,57 +5775,48 @@
     },
     "process.parent.macho.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.macho.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.macho.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the Mach-O file.\nThe keys that should be present in these objects are defined by sub-fields underneath `macho.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMach-O Section List name.",
@@ -5836,30 +5826,39 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nMach-O Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nMach-O Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.macho.symhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThis is a Mach-O implementation of the Windows PE imphash",
@@ -5905,35 +5904,35 @@
     },
     "process.parent.pe.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pe.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pe.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pe.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pe.imphash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
@@ -5949,34 +5948,34 @@
     },
     "process.parent.pe.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.pe.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pe.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pe.original_file_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInternal name of the file, provided at compile-time.",
@@ -5998,26 +5997,17 @@
     },
     "process.parent.pe.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the PE file.\nThe keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPE Section List name.",
@@ -6027,46 +6017,55 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.pgid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nDeprecated for removal in next major version release. This field is superseded by `process.group_leader.pid`.\nIdentifier of the group of processes the process belongs to.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.real_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -6136,37 +6135,37 @@
     },
     "process.parent.thread.capabilities.effective": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThis is the set of capabilities used by the kernel to perform permission checks for the thread.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.thread.capabilities.permitted": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThis is a limiting superset for the effective capabilities that the thread may assume.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.parent.thread.id": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThread ID.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.thread.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThread name.",
@@ -6181,39 +6180,39 @@
       ]
     },
     "process.parent.tty": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "char_device.major": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as \"ttyS0\" and \"pts/0\". For more details, please refer to the Linux kernel documentation.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "char_device.minor": {
-          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don\u2019t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "process.parent.uptime": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSeconds the process has been up.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.user.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier of the user.",
@@ -6229,11 +6228,11 @@
     },
     "process.parent.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.parent.working_directory": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe working directory of the process.",
@@ -6273,35 +6272,35 @@
     },
     "process.pe.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.pe.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.pe.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.pe.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.pe.imphash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
@@ -6317,34 +6316,34 @@
     },
     "process.pe.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.pe.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.pe.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.pe.original_file_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInternal name of the file, provided at compile-time.",
@@ -6366,26 +6365,17 @@
     },
     "process.pe.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the PE file.\nThe keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPE Section List name.",
@@ -6395,67 +6385,76 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
-    },
-    "process.pgid": {
-      "description": "Module: ecs\nIndexerType: long\nArray: False\n\nDeprecated for removal in next major version release. This field is superseded by `process.group_leader.pid`.\nIdentifier of the group of processes the process belongs to.",
-      "type": [
-        "number",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-    },
-    "process.pid": {
-      "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
-      "type": [
-        "number",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-    },
-    "process.previous.args": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "string",
         "array"
-      ],
+      ]
+    },
+    "process.pgid": {
+      "description": "Module: ecs\nIndexerType: long\nArray: False\n\nDeprecated for removal in next major version release. This field is superseded by `process.group_leader.pid`.\nIdentifier of the group of processes the process belongs to.",
       "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "process.pid": {
+      "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "process.previous.args": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.previous.args_count": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nLength of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.previous.executable": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nAbsolute path to the process executable.",
@@ -6513,24 +6512,24 @@
     },
     "process.session_leader.args": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.session_leader.args_count": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nLength of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.command_line": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: False\n\nFull command line that started the process, including the absolute path to the executable, and all arguments.\nSome arguments may be filtered to protect sensitive information.",
@@ -6564,11 +6563,11 @@
     },
     "process.session_leader.interactive": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nWhether the process is connected to an interactive shell.\nProcess interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.\nNote: A non-interactive process can belong to an interactive session and is simply one that does not have open file descriptors reading the controlling TTY on FD 0 (stdin) or writing to the controlling TTY on FD 2 (stderr). A backgrounded process is still considered interactive if stdin and stderr are connected to the controlling TTY.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nProcess name.\nSometimes called program name or similar.",
@@ -6584,11 +6583,11 @@
     },
     "process.session_leader.parent.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.parent.session_leader.entity_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the process.\nThe implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.\nConstructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.",
@@ -6598,11 +6597,11 @@
     },
     "process.session_leader.parent.session_leader.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.parent.session_leader.start": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nThe time the process started.",
@@ -6612,11 +6611,11 @@
     },
     "process.session_leader.parent.session_leader.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.parent.start": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nThe time the process started.",
@@ -6626,19 +6625,19 @@
     },
     "process.session_leader.parent.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.real_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -6666,11 +6665,11 @@
     },
     "process.session_leader.same_as_process": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nThis boolean is used to identify if a leader process is the same as the top level process.\nFor example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.\nThis field exists to the benefit of EQL and other rule engines since it's not possible to compare equality between two fields in a single document. e.g `process.entity_id` = `process.group_leader.entity_id` (top level process is the process group leader) OR `process.entity_id` = `process.entry_leader.entity_id` (top level process is the entry session leader)\nInstead these rules could be written like: `process.group_leader.same_as_process: true` OR `process.entry_leader.same_as_process: true`\nNote: This field is only set on `process.entry_leader`, `process.session_leader` and `process.group_leader`.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.saved_group.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier for the group on the system/platform.",
@@ -6715,31 +6714,31 @@
       ]
     },
     "process.session_leader.tty": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "char_device.major": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as \"ttyS0\" and \"pts/0\". For more details, please refer to the Linux kernel documentation.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "char_device.minor": {
-          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don\u2019t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "process.session_leader.user.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier of the user.",
@@ -6755,11 +6754,11 @@
     },
     "process.session_leader.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.session_leader.working_directory": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe working directory of the process.",
@@ -6787,37 +6786,37 @@
     },
     "process.thread.capabilities.effective": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThis is the set of capabilities used by the kernel to perform permission checks for the thread.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.thread.capabilities.permitted": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThis is a limiting superset for the effective capabilities that the thread may assume.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "process.thread.id": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThread ID.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.thread.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThread name.",
@@ -6832,55 +6831,55 @@
       ]
     },
     "process.tty": {
-      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
-      "type": [
-        "object",
-        "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "additionalProperties": false,
+      "description": "Module: ecs\nIndexerType: object\nArray: False\n\nInformation about the controlling TTY device. If set, the process belongs to an interactive session.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "properties": {
         "char_device.major": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as \"ttyS0\" and \"pts/0\". For more details, please refer to the Linux kernel documentation.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "char_device.minor": {
-          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don\u2019t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "columns": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of character columns per line. e.g terminal width\nTerminal sizes can change, so this value reflects the maximum value for a given IO event. i.e. where event.action = 'text_output'",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         },
         "rows": {
           "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe number of character rows in the terminal. e.g terminal height\nTerminal sizes can change, so this value reflects the maximum value for a given IO event. i.e. where event.action = 'text_output'",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
             "number",
             "string"
-          ],
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+          ]
         }
-      }
+      },
+      "type": [
+        "object",
+        "string"
+      ]
     },
     "process.uptime": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSeconds the process has been up.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.user.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier of the user.",
@@ -6896,11 +6895,11 @@
     },
     "process.vpid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVirtual process id.\nThe process id within a pid namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "process.working_directory": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe working directory of the process.",
@@ -6916,16 +6915,16 @@
     },
     "registry.data.strings": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: True\n\nContent when writing string types.\nPopulated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `\"1\"`).",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "registry.data.type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nStandard registry type for encoding contents",
@@ -6959,55 +6958,55 @@
     },
     "related.hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nAll the hashes seen on your event. Populating this field, then using it to search for hashes can help in situations where you're unsure what the hash algorithm is (and therefore which key name to search).",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "related.hosts": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nAll hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "related.ip": {
       "description": "Module: ecs\nIndexerType: ip\nArray: True\n\nAll of the IPs seen on your event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "related.user": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nAll the user names or other user identifiers seen on the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "server.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nSome event server addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.",
@@ -7017,11 +7016,11 @@
     },
     "server.as.number": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nUnique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "server.as.organization.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOrganization name.",
@@ -7031,11 +7030,11 @@
     },
     "server.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nBytes sent from the server to the client.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "server.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe domain name of the server system.\nThis value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.",
@@ -7129,27 +7128,27 @@
     },
     "server.nat.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTranslated port of destination based NAT sessions (e.g. internet to private DMZ)\nTypically used with load balancers, firewalls, or routers.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "server.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPackets sent from the server to the client.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "server.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the server.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "server.registered_domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe highest registered server domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
@@ -7225,16 +7224,16 @@
     },
     "server.user.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "service.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nAddress where data about this service was collected from.\nThis should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets).",
@@ -7280,16 +7279,16 @@
     },
     "service.node.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nRoles of a service node.\nThis allows for distinction between different running roles of the same service.\nIn the case of Kibana, the `service.node.role` could be `ui` or `background_tasks` or both.\nIn the case of Elasticsearch, the `service.node.role` could be `master` or `data` or both.\nOther services could use this to distinguish between a `web` and `worker` role running as part of the service.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "service.origin.address": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nAddress where data about this service was collected from.\nThis should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets).",
@@ -7335,16 +7334,16 @@
     },
     "service.origin.node.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nRoles of a service node.\nThis allows for distinction between different running roles of the same service.\nIn the case of Kibana, the `service.node.role` could be `ui` or `background_tasks` or both.\nIn the case of Elasticsearch, the `service.node.role` could be `master` or `data` or both.\nOther services could use this to distinguish between a `web` and `worker` role running as part of the service.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "service.origin.state": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCurrent state of the service.",
@@ -7414,16 +7413,16 @@
     },
     "service.target.node.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nRoles of a service node.\nThis allows for distinction between different running roles of the same service.\nIn the case of Kibana, the `service.node.role` could be `ui` or `background_tasks` or both.\nIn the case of Elasticsearch, the `service.node.role` could be `master` or `data` or both.\nOther services could use this to distinguish between a `web` and `worker` role running as part of the service.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "service.target.state": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCurrent state of the service.",
@@ -7463,11 +7462,11 @@
     },
     "source.as.number": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nUnique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "source.as.organization.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOrganization name.",
@@ -7477,11 +7476,11 @@
     },
     "source.bytes": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nBytes sent from the source to the destination.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "source.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe domain name of the source system.\nThis value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.",
@@ -7575,27 +7574,27 @@
     },
     "source.nat.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nTranslated port of source based NAT sessions. (e.g. internal client to internet)\nTypically used with load balancers, firewalls, or routers.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "source.packets": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPackets sent from the source to the destination.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "source.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the source.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "source.registered_domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe highest registered source domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
@@ -7671,16 +7670,16 @@
     },
     "source.user.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "span.id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique identifier of the span within the scope of its trace.\nA span represents an operation within a transaction, such as a request to another service, or a database query.",
@@ -7690,16 +7689,16 @@
     },
     "tags": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of keywords used to tag each event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.cipher": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nString indicating the cipher used during the current connection.",
@@ -7715,16 +7714,16 @@
     },
     "tls.client.certificate_chain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.hash.md5": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.",
@@ -7782,55 +7781,55 @@
     },
     "tls.client.supported_ciphers": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of ciphers offered by the client during the client hello.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.alternative_names": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.issuer.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.issuer.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.issuer.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -7840,55 +7839,55 @@
     },
     "tls.client.x509.issuer.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.issuer.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.issuer.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.issuer.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.not_after": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -7916,19 +7915,19 @@
     },
     "tls.client.x509.public_key_exponent": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "tls.client.x509.public_key_size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "tls.client.x509.serial_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -7944,29 +7943,29 @@
     },
     "tls.client.x509.subject.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.subject.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.subject.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -7976,55 +7975,55 @@
     },
     "tls.client.x509.subject.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.subject.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.subject.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.subject.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.client.x509.version_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -8040,11 +8039,11 @@
     },
     "tls.established": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "tls.next_protocol": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nString indicating the protocol being tunneled. Per the values in the IANA registry (https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case.",
@@ -8054,11 +8053,11 @@
     },
     "tls.resumed": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "tls.server.certificate": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.",
@@ -8068,16 +8067,16 @@
     },
     "tls.server.certificate_chain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.hash.md5": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.",
@@ -8129,42 +8128,42 @@
     },
     "tls.server.x509.alternative_names": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.issuer.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.issuer.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.issuer.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -8174,55 +8173,55 @@
     },
     "tls.server.x509.issuer.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.issuer.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.issuer.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.issuer.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.not_after": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -8250,19 +8249,19 @@
     },
     "tls.server.x509.public_key_exponent": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "tls.server.x509.public_key_size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "tls.server.x509.serial_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -8278,29 +8277,29 @@
     },
     "tls.server.x509.subject.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.subject.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.subject.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -8310,55 +8309,55 @@
     },
     "tls.server.x509.subject.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.subject.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.subject.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.subject.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "tls.server.x509.version_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -8434,11 +8433,11 @@
     },
     "url.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the request, such as 443.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "url.query": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe query field describes the query string of the request, such as \"q=elasticsearch\".\nThe `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.",
@@ -8532,16 +8531,16 @@
     },
     "user.changes.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "user.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
@@ -8605,16 +8604,16 @@
     },
     "user.effective.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "user.email": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUser email address.",
@@ -8666,16 +8665,16 @@
     },
     "user.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "user.target.domain": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
@@ -8733,16 +8732,16 @@
     },
     "user.target.roles": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of user roles at the time of the event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "user_agent.device.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the device.",
@@ -8872,11 +8871,11 @@
     },
     "volume.removable": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nIndicates if the volume is removable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "volume.serial_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nSerial number identifier for the volume device.\nThe serial number is provided by the vendor of the device, if any.",
@@ -8886,11 +8885,11 @@
     },
     "volume.size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nSize of the volume device in bytes.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "volume.vendor_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVendorID of the volume device.\nThe volume device vendor provides this value.",
@@ -8906,24 +8905,24 @@
     },
     "volume.writable": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nIndicates if the volume is writable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "vulnerability.category": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe type of system or architecture that the vulnerability affects. These may be platform-specific (for example, Debian or SUSE) or general (for example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)\nThis field must be an array.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "vulnerability.classification": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe classification of the vulnerability scoring system. For example (https://www.first.org/cvss/)",
@@ -8969,27 +8968,27 @@
     },
     "vulnerability.score.base": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nScores can range from 0.0 to 10.0, with 10.0 being the most severe.\nBase scores cover an assessment for exploitability metrics (attack vector, complexity, privileges, and user interaction), impact metrics (confidentiality, integrity, and availability), and scope. For example (https://www.first.org/cvss/specification-document)",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "vulnerability.score.environmental": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nScores can range from 0.0 to 10.0, with 10.0 being the most severe.\nEnvironmental scores cover an assessment for any modified Base metrics, confidentiality, integrity, and availability requirements. For example (https://www.first.org/cvss/specification-document)",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "vulnerability.score.temporal": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nScores can range from 0.0 to 10.0, with 10.0 being the most severe.\nTemporal scores cover an assessment for code maturity, remediation level, and confidence. For example (https://www.first.org/cvss/specification-document)",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "vulnerability.score.version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe National Vulnerability Database (NVD) provides qualitative severity rankings of \"Low\", \"Medium\", and \"High\" for CVSS v2.0 base score ranges in addition to the severity ratings for CVSS v3.0 as they are defined in the CVSS v3.0 specification.\nCVSS is owned and managed by FIRST.Org, Inc. (FIRST), a US-based non-profit organization, whose mission is to help computer security incident response teams across the world. For example (https://nvd.nist.gov/vuln-metrics/cvss)",
@@ -8999,16 +8998,17 @@
     },
     "wazuh.decoders": {
       "description": "Module: schemas\nIndexerType: keyword\nArray: True\n\nTrace of the decoders used to decode the event in order",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     }
-  }
+  },
+  "type": "object"
 }

--- a/src/engine/ruleset/schemas/fields_decoder.json
+++ b/src/engine/ruleset/schemas/fields_decoder.json
@@ -960,6 +960,12 @@
         "string"
       ]
     },
+    "dll.code_signature.thumbprint_sha256": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate SHA256 hash that uniquely identifies the code signer.",
+      "type": [
+        "string"
+      ]
+    },
     "dll.code_signature.timestamp": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nDate and time when the code signature was generated and signed.",
       "type": [
@@ -1032,6 +1038,18 @@
     },
     "dll.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the library.\nThis generally maps to the name of the file on disk.",
+      "type": [
+        "string"
+      ]
+    },
+    "dll.origin_referrer_url": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL of the webpage that linked to the dll file.",
+      "type": [
+        "string"
+      ]
+    },
+    "dll.origin_url": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL where the dll file is hosted.",
       "type": [
         "string"
       ]
@@ -1881,6 +1899,12 @@
         "string"
       ]
     },
+    "file.code_signature.thumbprint_sha256": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate SHA256 hash that uniquely identifies the code signer.",
+      "type": [
+        "string"
+      ]
+    },
     "file.code_signature.timestamp": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nDate and time when the code signature was generated and signed.",
       "type": [
@@ -2452,7 +2476,7 @@
       ]
     },
     "file.mime_type": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMIME type should identify the format of the file or stream of bytes using IANA official types: https://www.iana.org/assignments/media-types/media-types.xhtml, where possible. When more than one type is applicable, the most specific type should be used.",
       "type": [
         "string"
       ]
@@ -2471,6 +2495,18 @@
     },
     "file.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the file including the extension, without the directory.",
+      "type": [
+        "string"
+      ]
+    },
+    "file.origin_referrer_url": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL of the webpage that linked to the file.",
+      "type": [
+        "string"
+      ]
+    },
+    "file.origin_url": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL where the file is hosted.",
       "type": [
         "string"
       ]
@@ -2830,7 +2866,7 @@
       ]
     },
     "file.x509.serial_number": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
       "type": [
         "string"
       ]
@@ -2928,6 +2964,188 @@
     "file.x509.version_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
       "type": [
+        "string"
+      ]
+    },
+    "gen_ai.agent.description": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nFree-form description of the GenAI agent provided by the application.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.agent.id": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe unique identifier of the GenAI agent.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.agent.name": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nHuman-readable name of the GenAI agent provided by the application.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.operation.name": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the operation being performed.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.output.type": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nRepresents the content type requested by the client.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.request.choice.count": {
+      "description": "Module: ecs\nIndexerType: integer\nArray: False\n\nThe target number of candidate completions to return.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.encoding_formats": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: False\n\nThe encoding formats requested in an embeddings operation, if specified.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "object",
+        "string"
+      ]
+    },
+    "gen_ai.request.frequency_penalty": {
+      "description": "Module: ecs\nIndexerType: double\nArray: False\n\nThe frequency penalty setting for the GenAI request.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.max_tokens": {
+      "description": "Module: ecs\nIndexerType: integer\nArray: False\n\nThe maximum number of tokens the model generates for a request.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.model": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the GenAI model a request is being made to.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.request.presence_penalty": {
+      "description": "Module: ecs\nIndexerType: double\nArray: False\n\nThe presence penalty setting for the GenAI request.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.seed": {
+      "description": "Module: ecs\nIndexerType: integer\nArray: False\n\nRequests with same seed value more likely to return same result.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.stop_sequences": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: False\n\nList of sequences that the model will use to stop generating further tokens.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "object",
+        "string"
+      ]
+    },
+    "gen_ai.request.temperature": {
+      "description": "Module: ecs\nIndexerType: double\nArray: False\n\nThe temperature setting for the GenAI request.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.top_k": {
+      "description": "Module: ecs\nIndexerType: double\nArray: False\n\nThe top_k sampling setting for the GenAI request.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.request.top_p": {
+      "description": "Module: ecs\nIndexerType: double\nArray: False\n\nThe top_p sampling setting for the GenAI request.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.response.finish_reasons": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: False\n\nArray of reasons the model stopped generating tokens, corresponding to each generation received.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "object",
+        "string"
+      ]
+    },
+    "gen_ai.response.id": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe unique identifier for the completion.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.response.model": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the model that generated the response.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.system": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe Generative AI product as identified by the client or server instrumentation.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.token.type": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe type of token being counted.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.tool.call.id": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe tool call identifier.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.tool.name": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the tool utilized by the agent.",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.tool.type": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nType of the tool utilized by the agent",
+      "type": [
+        "string"
+      ]
+    },
+    "gen_ai.usage.input_tokens": {
+      "description": "Module: ecs\nIndexerType: integer\nArray: False\n\nThe number of tokens used in the GenAI input (prompt).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "gen_ai.usage.output_tokens": {
+      "description": "Module: ecs\nIndexerType: integer\nArray: False\n\nThe number of tokens used in the GenAI response (completion).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "number",
         "string"
       ]
     },
@@ -4059,6 +4277,12 @@
     },
     "process.code_signature.team_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe team identifier used to sign the process.\nThis is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.",
+      "type": [
+        "string"
+      ]
+    },
+    "process.code_signature.thumbprint_sha256": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate SHA256 hash that uniquely identifies the code signer.",
       "type": [
         "string"
       ]
@@ -5276,6 +5500,12 @@
         "string"
       ]
     },
+    "process.parent.code_signature.thumbprint_sha256": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate SHA256 hash that uniquely identifies the code signer.",
+      "type": [
+        "string"
+      ]
+    },
     "process.parent.code_signature.timestamp": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nDate and time when the code signature was generated and signed.",
       "type": [
@@ -6051,14 +6281,6 @@
         "array"
       ]
     },
-    "process.parent.pgid": {
-      "description": "Module: ecs\nIndexerType: long\nArray: False\n\nDeprecated for removal in next major version release. This field is superseded by `process.group_leader.pid`.\nIdentifier of the group of processes the process belongs to.",
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "type": [
-        "number",
-        "string"
-      ]
-    },
     "process.parent.pid": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nProcess id.",
       "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
@@ -6417,14 +6639,6 @@
       "type": [
         "string",
         "array"
-      ]
-    },
-    "process.pgid": {
-      "description": "Module: ecs\nIndexerType: long\nArray: False\n\nDeprecated for removal in next major version release. This field is superseded by `process.group_leader.pid`.\nIdentifier of the group of processes the process belongs to.",
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "type": [
-        "number",
-        "string"
       ]
     },
     "process.pid": {
@@ -7700,6 +7914,49 @@
         "array"
       ]
     },
+    "threat.indicator.file.code_signature.flags": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
+      "type": [
+        "string"
+      ]
+    },
+    "threat.indicator.file.code_signature.thumbprint_sha256": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate SHA256 hash that uniquely identifies the code signer.",
+      "type": [
+        "string"
+      ]
+    },
+    "threat.indicator.file.hash.cdhash": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCode directory hash, utilized to uniquely identify and authenticate the integrity of the executable code.",
+      "type": [
+        "string"
+      ]
+    },
+    "threat.indicator.file.origin_referrer_url": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL of the webpage that linked to the file.",
+      "type": [
+        "string"
+      ]
+    },
+    "threat.indicator.file.origin_url": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL where the file is hosted.",
+      "type": [
+        "string"
+      ]
+    },
+    "threat.indicator.id": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe ID of the indicator used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. This field can have multiple values to allow for the identification of the same indicator across systems that use different ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator ID.",
+      "items": {
+        "type": [
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
     "tls.cipher": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nString indicating the cipher used during the current connection.",
       "type": [
@@ -7930,7 +8187,7 @@
       ]
     },
     "tls.client.x509.serial_number": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
       "type": [
         "string"
       ]
@@ -8264,7 +8521,7 @@
       ]
     },
     "tls.server.x509.serial_number": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
       "type": [
         "string"
       ]

--- a/src/engine/ruleset/schemas/fields_rule.json
+++ b/src/engine/ruleset/schemas/fields_rule.json
@@ -1,9 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "fields_rule.json",
-  "name": "schema/fields-rule/0",
-  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "name": "schema/fields-rule/0",
   "patternProperties": {
     "^_.+": {
       "description": "Custom variable.",
@@ -13,19 +12,19 @@
   "properties": {
     "event.risk_score": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nRisk score or priority of the event (e.g. security solutions). Use your system's original value here.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "event.risk_score_norm": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nNormalized risk score or priority of the event, on a scale of 0 to 100.\nThis is mainly useful if you use more than one system that assigns risk scores, and you want to see a normalized value across all systems.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.risk.calculated_level": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.",
@@ -35,19 +34,19 @@
     },
     "host.risk.calculated_score": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.risk.calculated_score_norm": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.risk.static_level": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform.",
@@ -57,32 +56,32 @@
     },
     "host.risk.static_score": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "host.risk.static_score_norm": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "rule.author": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nName, organization, or pseudonym of the author or authors who created the rule used to generate this event.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "rule.category": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA categorization value keyword used by the entity using the rule for detection of this event.",
@@ -140,35 +139,22 @@
     },
     "threat.enrichments": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nA list of associated indicators objects enriching the event, and the context of that association/enrichment.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "indicator": {
-            "description": "Module: ecs\nIndexerType: object\nArray: False\n\nObject containing associated indicators enriching the event.",
-            "type": [
-              "object",
-              "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "additionalProperties": false,
+            "description": "Module: ecs\nIndexerType: object\nArray: False\n\nObject containing associated indicators enriching the event.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "properties": {
               "as.number": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nUnique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "as.organization.name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOrganization name.",
@@ -202,16 +188,16 @@
               },
               "file.attributes": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of file attributes.\nAttributes names will vary by platform. Here's a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.code_signature.digest_algorithm": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe hashing algorithm used to sign the process.\nThis value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.",
@@ -221,11 +207,11 @@
               },
               "file.code_signature.exists": {
                 "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if a signature is present.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "boolean",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.code_signature.flags": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
@@ -265,19 +251,19 @@
               },
               "file.code_signature.trusted": {
                 "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nStores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "boolean",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.code_signature.valid": {
                 "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "boolean",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.created": {
                 "description": "Module: ecs\nIndexerType: date\nArray: False\n\nFile creation time.\nNote that not all filesystems store the creation time.",
@@ -335,18 +321,18 @@
               },
               "file.elf.exports": {
                 "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of exported element names and types.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
+                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "type": [
                     "object",
                     "string"
-                  ],
-                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-                }
+                  ]
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.elf.go_import_hash": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -356,35 +342,35 @@
               },
               "file.elf.go_imports": {
                 "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "object",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.go_imports_names_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.go_imports_names_var_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.go_stripped": {
                 "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "boolean",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.header.abi_version": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of the ELF Application Binary Interface (ABI).",
@@ -406,11 +392,11 @@
               },
               "file.elf.header.entrypoint": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nHeader entrypoint of the ELF file.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.header.object_version": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\n\"0x1\" for original ELF files.",
@@ -444,65 +430,56 @@
               },
               "file.elf.imports": {
                 "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
+                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "type": [
                     "object",
                     "string"
-                  ],
-                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-                }
+                  ]
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.elf.imports_names_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.imports_names_var_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.elf.sections": {
                 "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "additionalProperties": false,
+                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "properties": {
                     "chi2": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nChi-square probability distribution of the section.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "entropy": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "flags": {
                       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List flags.",
@@ -524,11 +501,11 @@
                     },
                     "physical_size": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List physical size.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "type": {
                       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List type.",
@@ -538,45 +515,45 @@
                     },
                     "var_entropy": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "virtual_address": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual address.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "virtual_size": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual size.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     }
-                  }
-                }
-              },
-              "file.elf.segments": {
-                "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-                "items": {
+                  },
                   "type": [
                     "object",
                     "string"
-                  ],
-                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                  ]
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
+              },
+              "file.elf.segments": {
+                "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
+                "items": {
                   "additionalProperties": false,
+                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "properties": {
                     "sections": {
                       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF object segment sections.",
@@ -590,21 +567,30 @@
                         "string"
                       ]
                     }
-                  }
-                }
-              },
-              "file.elf.shared_libraries": {
-                "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
+                  },
+                  "type": [
+                    "object",
+                    "string"
+                  ]
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "string",
                   "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                ]
+              },
+              "file.elf.shared_libraries": {
+                "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.elf.telfhash": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\ntelfhash symbol hash for ELF file.",
@@ -758,35 +744,35 @@
               },
               "file.pe.go_imports": {
                 "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "object",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.pe.go_imports_names_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.pe.go_imports_names_var_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.pe.go_stripped": {
                 "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "boolean",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.pe.imphash": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
@@ -802,34 +788,34 @@
               },
               "file.pe.imports": {
                 "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
+                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "type": [
                     "object",
                     "string"
-                  ],
-                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-                }
+                  ]
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.pe.imports_names_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.pe.imports_names_var_entropy": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.pe.original_file_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInternal name of the file, provided at compile-time.",
@@ -851,26 +837,17 @@
               },
               "file.pe.sections": {
                 "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the PE file.\nThe keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
-                  "type": [
-                    "object",
-                    "string"
-                  ],
-                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "additionalProperties": false,
+                  "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                   "properties": {
                     "entropy": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "name": {
                       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPE Section List name.",
@@ -880,38 +857,47 @@
                     },
                     "physical_size": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List physical size.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "var_entropy": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     },
                     "virtual_size": {
                       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List virtual size. This is always the same as `physical_size`.",
+                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                       "type": [
                         "number",
                         "string"
-                      ],
-                      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                      ]
                     }
-                  }
-                }
+                  },
+                  "type": [
+                    "object",
+                    "string"
+                  ]
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.size": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nFile size in bytes.\nOnly relevant when `file.type` is \"file\".",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.target_path": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nTarget path for symlinks.",
@@ -933,42 +919,42 @@
               },
               "file.x509.alternative_names": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.issuer.common_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.issuer.country": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.issuer.distinguished_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -978,55 +964,55 @@
               },
               "file.x509.issuer.locality": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.issuer.organization": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.issuer.organizational_unit": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.issuer.state_or_province": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.not_after": {
                 "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -1054,19 +1040,19 @@
               },
               "file.x509.public_key_exponent": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.x509.public_key_size": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "file.x509.serial_number": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -1082,29 +1068,29 @@
               },
               "file.x509.subject.common_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.subject.country": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.subject.distinguished_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -1114,55 +1100,55 @@
               },
               "file.x509.subject.locality": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.subject.organization": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.subject.organizational_unit": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.subject.state_or_province": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "file.x509.version_number": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -1280,11 +1266,11 @@
               },
               "port": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nIdentifies a threat indicator as a port number (irrespective of direction).",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "provider": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the indicator's provider.",
@@ -1306,16 +1292,16 @@
               },
               "registry.data.strings": {
                 "description": "Module: ecs\nIndexerType: wildcard\nArray: True\n\nContent when writing string types.\nPopulated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `\"1\"`).",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "registry.data.type": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nStandard registry type for encoding contents",
@@ -1349,19 +1335,19 @@
               },
               "scanner_stats": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nCount of AV/EDR vendors that successfully detected malicious file or URL.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "sightings": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nNumber of times this indicator was observed conducting threat activity.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "type": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nType of indicator as represented by Cyber Observable in STIX 2.0.",
@@ -1413,11 +1399,11 @@
               },
               "url.port": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the request, such as 443.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "url.query": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe query field describes the query string of the request, such as \"q=elasticsearch\".\nThe `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.",
@@ -1457,42 +1443,42 @@
               },
               "x509.alternative_names": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.issuer.common_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.issuer.country": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.issuer.distinguished_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -1502,55 +1488,55 @@
               },
               "x509.issuer.locality": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.issuer.organization": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.issuer.organizational_unit": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.issuer.state_or_province": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.not_after": {
                 "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -1578,19 +1564,19 @@
               },
               "x509.public_key_exponent": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "x509.public_key_size": {
                 "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "type": [
                   "number",
                   "string"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+                ]
               },
               "x509.serial_number": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -1606,29 +1592,29 @@
               },
               "x509.subject.common_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.subject.country": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.subject.distinguished_name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -1638,55 +1624,55 @@
               },
               "x509.subject.locality": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.subject.organization": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.subject.organizational_unit": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.subject.state_or_province": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-                "type": [
-                  "string",
-                  "array"
-                ],
-                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
                 "items": {
                   "type": [
                     "string"
                   ]
-                }
+                },
+                "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+                "type": [
+                  "string",
+                  "array"
+                ]
               },
               "x509.version_number": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -1694,7 +1680,11 @@
                   "string"
                 ]
               }
-            }
+            },
+            "type": [
+              "object",
+              "string"
+            ]
           },
           "matched.atomic": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nIdentifies the atomic indicator value that matched a local environment endpoint or network event.",
@@ -1732,8 +1722,17 @@
               "string"
             ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.feed.dashboard_id": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe saved object ID of the dashboard belonging to the threat feed for displaying dashboard links to threat feeds in Kibana.",
@@ -1766,43 +1765,43 @@
       ]
     },
     "threat.group.alias": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK\u00ae group alias(es).",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK® group alias(es).",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.group.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe id of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK\u00ae group id.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe id of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK® group id.",
       "type": [
         "string"
       ]
     },
     "threat.group.name": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK\u00ae group name.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK® group name.",
       "type": [
         "string"
       ]
     },
     "threat.group.reference": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK\u00ae group reference URL.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK® group reference URL.",
       "type": [
         "string"
       ]
     },
     "threat.indicator.as.number": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nUnique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.as.organization.name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nOrganization name.",
@@ -1836,16 +1835,16 @@
     },
     "threat.indicator.file.attributes": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nArray of file attributes.\nAttributes names will vary by platform. Here's a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.code_signature.digest_algorithm": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe hashing algorithm used to sign the process.\nThis value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.",
@@ -1855,11 +1854,11 @@
     },
     "threat.indicator.file.code_signature.exists": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if a signature is present.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.code_signature.flags": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
@@ -1899,19 +1898,19 @@
     },
     "threat.indicator.file.code_signature.trusted": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nStores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.code_signature.valid": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nBoolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.created": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nFile creation time.\nNote that not all filesystems store the creation time.",
@@ -1969,18 +1968,18 @@
     },
     "threat.indicator.file.elf.exports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of exported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.elf.go_import_hash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nThe algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma",
@@ -1990,35 +1989,35 @@
     },
     "threat.indicator.file.elf.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.header.abi_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of the ELF Application Binary Interface (ABI).",
@@ -2040,11 +2039,11 @@
     },
     "threat.indicator.file.elf.header.entrypoint": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nHeader entrypoint of the ELF file.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.header.object_version": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\n\"0x1\" for original ELF files.",
@@ -2078,65 +2077,56 @@
     },
     "threat.indicator.file.elf.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.elf.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.elf.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "chi2": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nChi-square probability distribution of the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "flags": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List flags.",
@@ -2158,11 +2148,11 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "type": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF Section List type.",
@@ -2172,45 +2162,45 @@
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_address": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual address.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nELF Section List virtual size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
-    },
-    "threat.indicator.file.elf.segments": {
-      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "items": {
+        },
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "threat.indicator.file.elf.segments": {
+      "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each segment of the ELF file.\nThe keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`.",
+      "items": {
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "sections": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nELF object segment sections.",
@@ -2224,21 +2214,30 @@
               "string"
             ]
           }
-        }
-      }
-    },
-    "threat.indicator.file.elf.shared_libraries": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "string",
         "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      ]
+    },
+    "threat.indicator.file.elf.shared_libraries": {
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of shared libraries used by this ELF object.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.elf.telfhash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\ntelfhash symbol hash for ELF file.",
@@ -2392,35 +2391,35 @@
     },
     "threat.indicator.file.pe.go_imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: False\n\nList of imported Go language element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "object",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.pe.go_imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.pe.go_imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of Go imports.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.pe.go_stripped": {
       "description": "Module: ecs\nIndexerType: boolean\nArray: False\n\nSet to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.pe.imphash": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
@@ -2436,34 +2435,34 @@
     },
     "threat.indicator.file.pe.imports": {
       "description": "Module: ecs\nIndexerType: object\nArray: True\n\nList of imported element names and types.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "type": [
           "object",
           "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
-      }
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.pe.imports_names_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.pe.imports_names_var_entropy": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the list of imported element names and types.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.pe.original_file_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nInternal name of the file, provided at compile-time.",
@@ -2485,26 +2484,17 @@
     },
     "threat.indicator.file.pe.sections": {
       "description": "Module: ecs\nIndexerType: nested\nArray: True\n\nAn array containing an object for each section of the PE file.\nThe keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
-        "type": [
-          "object",
-          "string"
-        ],
-        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "additionalProperties": false,
+        "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
         "properties": {
           "entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nShannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "name": {
             "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nPE Section List name.",
@@ -2514,38 +2504,47 @@
           },
           "physical_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List physical size.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "var_entropy": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nVariance for Shannon entropy calculation from the section.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           },
           "virtual_size": {
             "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPE Section List virtual size. This is always the same as `physical_size`.",
+            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
             "type": [
               "number",
               "string"
-            ],
-            "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+            ]
           }
-        }
-      }
+        },
+        "type": [
+          "object",
+          "string"
+        ]
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nFile size in bytes.\nOnly relevant when `file.type` is \"file\".",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.target_path": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nTarget path for symlinks.",
@@ -2567,42 +2566,42 @@
     },
     "threat.indicator.file.x509.alternative_names": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.issuer.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.issuer.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.issuer.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -2612,55 +2611,55 @@
     },
     "threat.indicator.file.x509.issuer.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.issuer.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.issuer.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.issuer.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.not_after": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -2688,19 +2687,19 @@
     },
     "threat.indicator.file.x509.public_key_exponent": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.x509.public_key_size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.file.x509.serial_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -2716,29 +2715,29 @@
     },
     "threat.indicator.file.x509.subject.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.subject.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.subject.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -2748,55 +2747,55 @@
     },
     "threat.indicator.file.x509.subject.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.subject.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.subject.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.subject.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.file.x509.version_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -2877,17 +2876,17 @@
       ]
     },
     "threat.indicator.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe ID of the indicator used by this threat to conduct behavior commonly modeled using MITRE ATT&CK\u00ae. This field can have multiple values to allow for the identification of the same indicator across systems that use different ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator ID.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe ID of the indicator used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. This field can have multiple values to allow for the identification of the same indicator across systems that use different ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator ID.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.ip": {
       "description": "Module: ecs\nIndexerType: ip\nArray: False\n\nIdentifies a threat indicator as an IP address (irrespective of direction).",
@@ -2927,11 +2926,11 @@
     },
     "threat.indicator.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nIdentifies a threat indicator as a port number (irrespective of direction).",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.provider": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the indicator's provider.",
@@ -2953,16 +2952,16 @@
     },
     "threat.indicator.registry.data.strings": {
       "description": "Module: ecs\nIndexerType: wildcard\nArray: True\n\nContent when writing string types.\nPopulated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `\"1\"`).",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.registry.data.type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nStandard registry type for encoding contents",
@@ -2996,19 +2995,19 @@
     },
     "threat.indicator.scanner_stats": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nCount of AV/EDR vendors that successfully detected malicious file or URL.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.sightings": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nNumber of times this indicator was observed conducting threat activity.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.type": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nType of indicator as represented by Cyber Observable in STIX 2.0.",
@@ -3060,11 +3059,11 @@
     },
     "threat.indicator.url.port": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nPort of the request, such as 443.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.url.query": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe query field describes the query string of the request, such as \"q=elasticsearch\".\nThe `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.",
@@ -3104,42 +3103,42 @@
     },
     "threat.indicator.x509.alternative_names": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.issuer.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common name (CN) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.issuer.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) codes",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.issuer.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of issuing certificate authority.",
@@ -3149,55 +3148,55 @@
     },
     "threat.indicator.x509.issuer.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.issuer.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.issuer.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of issuing certificate authority.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.issuer.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.not_after": {
       "description": "Module: ecs\nIndexerType: date\nArray: False\n\nTime at which the certificate is no longer considered valid.",
@@ -3225,19 +3224,19 @@
     },
     "threat.indicator.x509.public_key_exponent": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nExponent used to derive the public key. This is algorithm specific.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.x509.public_key_size": {
       "description": "Module: ecs\nIndexerType: long\nArray: False\n\nThe size of the public key space in bits.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "threat.indicator.x509.serial_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
@@ -3253,29 +3252,29 @@
     },
     "threat.indicator.x509.subject.common_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of common names (CN) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.subject.country": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of country \\(C) code",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.subject.distinguished_name": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nDistinguished name (DN) of the certificate subject entity.",
@@ -3285,55 +3284,55 @@
     },
     "threat.indicator.x509.subject.locality": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of locality names (L)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.subject.organization": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizations (O) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.subject.organizational_unit": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of organizational units (OU) of subject.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.subject.state_or_province": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nList of state or province names (ST, S, or P)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.indicator.x509.version_number": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nVersion of x509 format.",
@@ -3342,171 +3341,171 @@
       ]
     },
     "threat.software.alias": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe alias(es) of the software for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK\u00ae associated software description.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe alias(es) of the software for a set of related intrusion activity that are tracked by a common name in the security community.\nWhile not required, you can use a MITRE ATT&CK® associated software description.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.software.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK\u00ae.\nWhile not required, you can use a MITRE ATT&CK\u00ae software id.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.\nWhile not required, you can use a MITRE ATT&CK® software id.",
       "type": [
         "string"
       ]
     },
     "threat.software.name": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK\u00ae.\nWhile not required, you can use a MITRE ATT&CK\u00ae software name.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.\nWhile not required, you can use a MITRE ATT&CK® software name.",
       "type": [
         "string"
       ]
     },
     "threat.software.platforms": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK\u00ae.\nWhile not required, you can use MITRE ATT&CK\u00ae software platform values.",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.\nWhile not required, you can use MITRE ATT&CK® software platform values.",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.software.reference": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK\u00ae.\nWhile not required, you can use a MITRE ATT&CK\u00ae software reference URL.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.\nWhile not required, you can use a MITRE ATT&CK® software reference URL.",
       "type": [
         "string"
       ]
     },
     "threat.software.type": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK\u00ae.\nWhile not required, you can use a MITRE ATT&CK\u00ae software type.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.\nWhile not required, you can use a MITRE ATT&CK® software type.",
       "type": [
         "string"
       ]
     },
     "threat.tactic.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe id of tactic used by this threat. You can use a MITRE ATT&CK\u00ae tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.tactic.name": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nName of the type of tactic used by this threat. You can use a MITRE ATT&CK\u00ae tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nName of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.tactic.reference": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe reference url of tactic used by this threat. You can use a MITRE ATT&CK\u00ae tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.technique.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe id of technique used by this threat. You can use a MITRE ATT&CK\u00ae technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.technique.name": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe name of technique used by this threat. You can use a MITRE ATT&CK\u00ae technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.technique.reference": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe reference url of technique used by this threat. You can use a MITRE ATT&CK\u00ae technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.technique.subtechnique.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe full id of subtechnique used by this threat. You can use a MITRE ATT&CK\u00ae subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe full id of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.technique.subtechnique.name": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe name of subtechnique used by this threat. You can use a MITRE ATT&CK\u00ae subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "threat.technique.subtechnique.reference": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe reference url of subtechnique used by this threat. You can use a MITRE ATT&CK\u00ae subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe reference url of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     },
     "user.risk.calculated_level": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.",
@@ -3516,19 +3515,19 @@
     },
     "user.risk.calculated_score": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "user.risk.calculated_score_norm": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "user.risk.static_level": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nA risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform.",
@@ -3538,19 +3537,19 @@
     },
     "user.risk.static_score": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "user.risk.static_score_norm": {
       "description": "Module: ecs\nIndexerType: float\nArray: False\n\nA risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100.",
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "number",
         "string"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$"
+      ]
     },
     "vulnerability.severity": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe severity of the vulnerability can help with metrics and internal prioritization regarding remediation. For example (https://nvd.nist.gov/vuln-metrics/cvss)",
@@ -3560,16 +3559,17 @@
     },
     "wazuh.rules": {
       "description": "Module: schemas\nIndexerType: keyword\nArray: True\n\nTrace of the rules that matched for the event in order",
-      "type": [
-        "string",
-        "array"
-      ],
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "items": {
         "type": [
           "string"
         ]
-      }
+      },
+      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
+      "type": [
+        "string",
+        "array"
+      ]
     }
-  }
+  },
+  "type": "object"
 }

--- a/src/engine/ruleset/schemas/fields_rule.json
+++ b/src/engine/ruleset/schemas/fields_rule.json
@@ -243,6 +243,12 @@
                   "string"
                 ]
               },
+              "file.code_signature.thumbprint_sha256": {
+                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCertificate SHA256 hash that uniquely identifies the code signer.",
+                "type": [
+                  "string"
+                ]
+              },
               "file.code_signature.timestamp": {
                 "description": "Module: ecs\nIndexerType: date\nArray: False\n\nDate and time when the code signature was generated and signed.",
                 "type": [
@@ -677,7 +683,7 @@
                 ]
               },
               "file.mime_type": {
-                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used.",
+                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMIME type should identify the format of the file or stream of bytes using IANA official types: https://www.iana.org/assignments/media-types/media-types.xhtml, where possible. When more than one type is applicable, the most specific type should be used.",
                 "type": [
                   "string"
                 ]
@@ -696,6 +702,18 @@
               },
               "file.name": {
                 "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nName of the file including the extension, without the directory.",
+                "type": [
+                  "string"
+                ]
+              },
+              "file.origin_referrer_url": {
+                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL of the webpage that linked to the file.",
+                "type": [
+                  "string"
+                ]
+              },
+              "file.origin_url": {
+                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe URL where the file is hosted.",
                 "type": [
                   "string"
                 ]
@@ -1055,7 +1073,7 @@
                 ]
               },
               "file.x509.serial_number": {
-                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
                 "type": [
                   "string"
                 ]
@@ -1579,7 +1597,7 @@
                 ]
               },
               "x509.serial_number": {
-                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+                "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
                 "type": [
                   "string"
                 ]
@@ -1857,12 +1875,6 @@
       "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
       "type": [
         "boolean",
-        "string"
-      ]
-    },
-    "threat.indicator.file.code_signature.flags": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe flags used to sign the process.",
-      "type": [
         "string"
       ]
     },
@@ -2269,12 +2281,6 @@
         "string"
       ]
     },
-    "threat.indicator.file.hash.cdhash": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nCode directory hash, utilized to uniquely identify and authenticate the integrity of the executable code.",
-      "type": [
-        "string"
-      ]
-    },
     "threat.indicator.file.hash.md5": {
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMD5 hash.",
       "type": [
@@ -2324,7 +2330,7 @@
       ]
     },
     "threat.indicator.file.mime_type": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nMIME type should identify the format of the file or stream of bytes using IANA official types: https://www.iana.org/assignments/media-types/media-types.xhtml, where possible. When more than one type is applicable, the most specific type should be used.",
       "type": [
         "string"
       ]
@@ -2702,7 +2708,7 @@
       ]
     },
     "threat.indicator.file.x509.serial_number": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
       "type": [
         "string"
       ]
@@ -2873,19 +2879,6 @@
       "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nThe time zone of the location, such as IANA time zone name.",
       "type": [
         "string"
-      ]
-    },
-    "threat.indicator.id": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: True\n\nThe ID of the indicator used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. This field can have multiple values to allow for the identification of the same indicator across systems that use different ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator ID.",
-      "items": {
-        "type": [
-          "string"
-        ]
-      },
-      "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-      "type": [
-        "string",
-        "array"
       ]
     },
     "threat.indicator.ip": {
@@ -3239,7 +3232,7 @@
       ]
     },
     "threat.indicator.x509.serial_number": {
-      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.",
+      "description": "Module: ecs\nIndexerType: keyword\nArray: False\n\nUnique serial number issued by the certificate authority. For consistency, this must be encoded in base 16 and formatted without colons and uppercase characters.",
       "type": [
         "string"
       ]

--- a/src/engine/ruleset/schemas/wazuh-decoders.json
+++ b/src/engine/ruleset/schemas/wazuh-decoders.json
@@ -153,7 +153,7 @@
       }
     },
     "_normalizeBlock": {
-      "description": "Normalization block. Valid formats: (1) map, (2) check+map, (3) check+parse|…+map, (4) check+parse|…",
+      "description": "Normalization block. Valid formats: (1) map, (2) check+map, (3) check+parse|…+map, (4) check+parse|…, (5) parse-only",
       "oneOf": [
         {
           "type": "object",
@@ -173,7 +173,7 @@
           },
           "additionalProperties": false,
           "patternProperties": {
-            "^parse\\|\\S+$": { "not": {} }
+            "^parse\\|\\S+$": { "$ref": "#/definitions/_parse" }
           }
         },
         {
@@ -194,33 +194,9 @@
             }
           },
           "additionalProperties": false,
-          "patternProperties": {
-            "^parse\\|\\S+$": { "not": {} }
-          }
-        },
-        {
-          "type": "object",
-          "required": ["check", "map"],
-          "minProperties": 3,
-          "properties": {
-            "check": { "$ref": "#/definitions/_check" },
-            "map": {
-              "description": "List of assignments - field: value",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "allOf": [
-                  { "$ref": "./fields_decoder.json#" },
-                  { "maxProperties": 1 }
-                ]
-              }
-            }
-          },
           "patternProperties": {
             "^parse\\|\\S+$": { "$ref": "#/definitions/_parse" }
-          },
-          "additionalProperties": false,
-          "description": "Must include at least one key parse|<field>: [...]."
+          }
         },
         {
           "type": "object",
@@ -234,6 +210,15 @@
           },
           "additionalProperties": false,
           "description": "Must include at least one key parse|<field>: [...]. 'map' is not allowed."
+        },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "patternProperties": {
+            "^parse\\|\\S+$": { "$ref": "#/definitions/_parse" }
+          },
+          "additionalProperties": false,
+          "description": "Must include at least one key parse|<field>: [...]."
         }
       ]
     }

--- a/src/engine/ruleset/schemas/wazuh-logpar-overrides.json
+++ b/src/engine/ruleset/schemas/wazuh-logpar-overrides.json
@@ -1,4 +1,4 @@
 {
-  "name": "schema/wazuh-logpar-overrides/0",
-  "fields": {}
+  "fields": {},
+  "name": "schema/wazuh-logpar-overrides/0"
 }

--- a/src/engine/tools/engine-suite/src/engine_schema/field.py
+++ b/src/engine/tools/engine-suite/src/engine_schema/field.py
@@ -9,19 +9,40 @@ HELPER_REF_STR_PATTERN = f'{REF_STR_PATTERN}|{HELPER_STR_PATTERN}'
 
 
 class IndexerType(Enum):
+    # String-like
     KEYWORD = auto()
-    IP = auto()
-    LONG = auto()
-    OBJECT = auto()
-    GEO_POINT = auto()
-    NESTED = auto()
-    SCALED_FLOAT = auto()
     TEXT = auto()
-    BOOLEAN = auto()
-    DATE = auto()
-    FLOAT = auto()
-    ARRAY = auto()
+    MATCH_ONLY_TEXT = auto()
     WILDCARD = auto()
+    CONSTANT_KEYWORD = auto()
+
+    # IP / Geo / Date
+    IP = auto()
+    GEO_POINT = auto()
+    DATE = auto()
+    DATE_NANOS = auto()
+
+    # Boolean
+    BOOLEAN = auto()
+
+    # Numeric
+    LONG = auto()
+    INTEGER = auto()
+    SHORT = auto()
+    BYTE = auto()
+    UNSIGNED_LONG = auto()
+    FLOAT = auto()
+    HALF_FLOAT = auto()
+    DOUBLE = auto()
+    SCALED_FLOAT = auto()
+
+    # Objects
+    OBJECT = auto()
+    NESTED = auto()
+    FLATTENED = auto()
+
+    # Misc (not an ES mapping type, used internally elsewhere)
+    ARRAY = auto()
 
     def __str__(self):
         return f'{self.name}'.lower()
@@ -30,30 +51,61 @@ class IndexerType(Enum):
     def from_str(cls, name: str):
         if name == str(cls.KEYWORD):
             return cls.KEYWORD
-        elif name == str(cls.IP):
-            return cls.IP
-        elif name == str(cls.LONG):
-            return cls.LONG
-        elif name == str(cls.OBJECT):
-            return cls.OBJECT
-        elif name == str(cls.GEO_POINT):
-            return cls.GEO_POINT
-        elif name == str(cls.NESTED):
-            return cls.NESTED
-        elif name == str(cls.SCALED_FLOAT):
-            return cls.SCALED_FLOAT
         elif name == str(cls.TEXT):
             return cls.TEXT
-        elif name == str(cls.BOOLEAN):
-            return cls.BOOLEAN
-        elif name == str(cls.DATE):
-            return cls.DATE
-        elif name == str(cls.FLOAT):
-            return cls.FLOAT
-        elif name == str(cls.ARRAY):
-            return cls.ARRAY
+        elif name == str(cls.MATCH_ONLY_TEXT):
+            return cls.MATCH_ONLY_TEXT
         elif name == str(cls.WILDCARD):
             return cls.WILDCARD
+        elif name == str(cls.CONSTANT_KEYWORD):
+            return cls.CONSTANT_KEYWORD
+
+        # IP / Geo / Date
+        elif name == str(cls.IP):
+            return cls.IP
+        elif name == str(cls.GEO_POINT):
+            return cls.GEO_POINT
+        elif name == str(cls.DATE):
+            return cls.DATE
+        elif name == str(cls.DATE_NANOS):
+            return cls.DATE_NANOS
+
+        # Boolean
+        elif name == str(cls.BOOLEAN):
+            return cls.BOOLEAN
+
+        # Numeric
+        elif name == str(cls.LONG):
+            return cls.LONG
+        elif name == str(cls.INTEGER):
+            return cls.INTEGER
+        elif name == str(cls.SHORT):
+            return cls.SHORT
+        elif name == str(cls.BYTE):
+            return cls.BYTE
+        elif name == str(cls.UNSIGNED_LONG):
+            return cls.UNSIGNED_LONG
+        elif name == str(cls.FLOAT):
+            return cls.FLOAT
+        elif name == str(cls.HALF_FLOAT):
+            return cls.HALF_FLOAT
+        elif name == str(cls.DOUBLE):
+            return cls.DOUBLE
+        elif name == str(cls.SCALED_FLOAT):
+            return cls.SCALED_FLOAT
+
+        # Objects
+        elif name == str(cls.OBJECT):
+            return cls.OBJECT
+        elif name == str(cls.NESTED):
+            return cls.NESTED
+        elif name == str(cls.FLATTENED):
+            return cls.FLATTENED
+
+        # Misc
+        elif name == str(cls.ARRAY):
+            return cls.ARRAY
+
         else:
             raise Exception(f'"{name}" is not a valid IndexerType')
 
@@ -86,31 +138,35 @@ class JsonType(Enum):
 
 def indexer_to_json_type(indexer_type: IndexerType) -> JsonType:
     # Object types
-    if indexer_type == IndexerType.OBJECT:
-        return JsonType.OBJECT
-    if indexer_type == IndexerType.NESTED:
+    if indexer_type in {IndexerType.OBJECT, IndexerType.NESTED, IndexerType.FLATTENED}:
         return JsonType.OBJECT
 
     # String types
-    if indexer_type == IndexerType.DATE:
-        return JsonType.STRING
-    if indexer_type == IndexerType.IP:
-        return JsonType.STRING
-    if indexer_type == IndexerType.TEXT:
-        return JsonType.STRING
-    if indexer_type == IndexerType.GEO_POINT:
-        return JsonType.STRING
-    if indexer_type == IndexerType.KEYWORD:
-        return JsonType.STRING
-    if indexer_type == IndexerType.WILDCARD:
+    if indexer_type in {
+        IndexerType.DATE,
+        IndexerType.DATE_NANOS,
+        IndexerType.IP,
+        IndexerType.TEXT,
+        IndexerType.MATCH_ONLY_TEXT,
+        IndexerType.GEO_POINT,
+        IndexerType.KEYWORD,
+        IndexerType.WILDCARD,
+        IndexerType.CONSTANT_KEYWORD,
+    }:
         return JsonType.STRING
 
     # Numeric types
-    if indexer_type == IndexerType.LONG:
-        return JsonType.NUMBER
-    if indexer_type == IndexerType.SCALED_FLOAT:
-        return JsonType.NUMBER
-    if indexer_type == IndexerType.FLOAT:
+    if indexer_type in {
+        IndexerType.LONG,
+        IndexerType.INTEGER,
+        IndexerType.SHORT,
+        IndexerType.BYTE,
+        IndexerType.UNSIGNED_LONG,
+        IndexerType.SCALED_FLOAT,
+        IndexerType.FLOAT,
+        IndexerType.HALF_FLOAT,
+        IndexerType.DOUBLE,
+    }:
         return JsonType.NUMBER
 
     # Boolean types


### PR DESCRIPTION
## Description

Updates Wazuh Engine ECS support from **v8.17** to **v9.1.0**. This PR refreshes the schema/tooling to understand new ECS field types and fields, removes deprecated ones, and regenerates the ruleset schemas so decoding/mapping stay consistent with the official ECS documentation.

Closes: **2965**

## Proposed Changes

- **engine-suite**: extend `IndexerType` and conversions to cover ECS 9.1.0 types
  - Added: `integer`, `short`, `byte`, `unsigned_long`, `half_float`, `double`, `date_nanos`, `match_only_text`, `constant_keyword`, `flattened`.
  - Normalized `indexer_to_json_type` for new numeric/string/object types.
- **Schemas regenerated (v9.1.0)**
  - `engine-schema.json`, `fields_decoder.json`, `fields_rule.json`.
  - New fields: `*.code_signature.thumbprint_sha256`, `*.origin_url`, `*.origin_referrer_url`, and **`gen_ai.*`**.
  - Removed deprecated: `process.pgid`, `process.parent.pgid`.
  - Text tweaks aligned with ECS (e.g., x509 serial number wording).
- **Backward compatibility**
  - Existing rules and mappings remain compatible; deprecated fields are removed per ECS guidance. If legacy pipelines still emit `process.pgid`, they should migrate to `process.group_leader.pid` or keep a custom mapping downstream.


### Results and Evidence

**Generation succeeds with ECS v9.1.0**
```console
engine-schema generate \                                                                                                                           
  --output-dir /tmp/schema_9_1 \                                                  
  --allowed-fields-path ./src/engine/ruleset/schemas/allowed-fields.json \
  --ecs-version=v9.1.0 integration ./ruleset/schemas
  
Using target ECS version: v9.1.0
Loading resources...
Downloading https://raw.githubusercontent.com/elastic/ecs/v9.1.0/generated/ecs/ecs_flat.yml...
Loading schema template...
Loading mappings template...
Loading logpar overrides template...
Building field tree from ecs definition...
Success.
Generating engine schema...
Adding module ../intelligence-data/ruleset/schemas...
Loading resources...
Generating field tree...
Adding logpar overrides...
Merging module...
Adding to engine schema...
Success.
Generating fields schema properties...
Success.
Generating indexer mappings...
Success.
Generating logpar configuration...
Success.
Saving files to "/tmp/schema_9_1"...
Success.
```

Engine Health Test with ruleset ok: 18327882243
Engine Health Test in decoders_development: 18327278023


### Artifacts Affected
-**engine-schema** tool
-**schema ruleset**: `engine-schema.json`, `fields_decoder.json`, `fields_rule.json`.

### Configuration Changes

- N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
