### PR TITLE
Windows Server 2016 SCA Bug Fixes for id 16028 and 16033

### DIFF
--- a/ruleset/sca/windows/cis_win2016.yml
+++ b/ruleset/sca/windows/cis_win2016.yml
@@ -149,13 +149,13 @@ checks:
     impact: "All network users will need to authenticate before they can access shared resources. If you disable the Guest account and the Network Access: Sharing and Security Model option is set to Guest Only, network logons, such as those performed by the Microsoft Network Server (SMB Service), will fail. This policy setting should have little impact on most organizations because it is the default setting in Microsoft Windows 2000, Windows XP, and Windows Server™ 2003."
     remediation: "To establish the recommended configuration via GP, set the following UI path to Disabled: Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Local Policies\\Security Options\\Accounts: Guest account status."
     compliance:
-     - cis: ["2.3.1.2"]
-     - cis_csc_v8: ["4.7"]
-     - cis_csc_v7: ["16.8"]
-     - iso_27001-2013: ["A.9.2.1"]
-     - pci_dss_v3.2.1: ["2.1", "2.1.1"]
-     - pci_dss_v4.0: ["2.2.2", "2.3.1"]
-     - soc_2: ["CC6.3"]
+      - cis: ["2.3.1.2"]
+      - cis_csc_v8: ["4.7"]
+      - cis_csc_v7: ["16.8"]
+      - iso_27001-2013: ["A.9.2.1"]
+      - pci_dss_v3.2.1: ["2.1", "2.1.1"]
+      - pci_dss_v4.0: ["2.2.2", "2.3.1"]
+      - soc_2: ["CC6.3"]
     condition: all
     rules:
       - 'c:powershell -NoProfile -Command "[bool](Get-CimInstance -Query ''SELECT * FROM Win32_UserAccount WHERE LocalAccount = TRUE AND SID LIKE ''''S-1-5-21-%-501'''''' | Where-Object -Property Disabled)" -> r:True'
@@ -665,11 +665,11 @@ checks:
       - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
       - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
       - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
-    condition: all
+    condition: any
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters'
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword'
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword -> 1'
+      - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters'
+      - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword -> 0'
 
   ############################################
   # 2.3.9 Microsoft network server
@@ -766,9 +766,9 @@ checks:
       - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters'
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> SMBServerNameHardeningLevel'
-      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters -> SMBServerNameHardeningLevel -> n:^(\d+) compare >= 1'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> SMBServerNameHardeningLevel'
+      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters -> SMBServerNameHardeningLevel -> r:^1$|^2$'
 
   ##################################
   # 2.3.10 Network access


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
User reported wrong checks [here](https://github.com/wazuh/external-devel-requests/issues/6511) in id 16028 and 16033 which affect the SCA result.
## Proposed Changes

<details>
<summary> 16028 </summary>

```
    condition: any
    rules:
      - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters'
      - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword'
      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters -> EnablePlainTextPassword -> 0'
```

</details>

<details>

<summary> 16033 </summary>

```
    condition: all
    rules:
      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters'
      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> SMBServerNameHardeningLevel'
      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters -> SMBServerNameHardeningLevel -> r:^1$|^2$'
```
</details>

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->
## Test Output after Applying the Fix

<details>
<summary>ID - 16028 🟢 </summary>

<img width="1014" height="448" alt="Image" src="https://github.com/user-attachments/assets/4b3f6487-b971-456e-a55a-7f5fc232b0cd" />


</details>

<details>
<summary>ID - 16033 🟢  </summary>

### Passed as expected

<img width="1057" height="400" alt="Image" src="https://github.com/user-attachments/assets/aab25069-2e72-4cd7-b60f-a9fdf438e0d9" />

### Failed as expected
<img width="965" height="402" alt="Image" src="https://github.com/user-attachments/assets/f6659a46-8409-46e8-b569-5564609f1ee4" />


</details>
