### PR TITLE
Default sshd PAM logins not being properly decoded fix

### DIFF
--- a/ruleset/decoders/0205-pam_decoders.xml
+++ b/ruleset/decoders/0205-pam_decoders.xml
@@ -43,7 +43,7 @@
 <decoder name="pam-user">
   <parent>pam</parent>
   <prematch>\)\p* session \w+ |^session \w+ </prematch>
-  <regex offset="after_prematch">^for user (\S+)</regex>
+  <regex offset="after_prematch">^for user (\w+)</regex>
   <order>user</order>
 </decoder>
 


### PR DESCRIPTION
# Description 
Hello Team,

A customer has reported that a custom active response script was not working. Upon further inspection, we found that the `user` value was not being properly decoded for the following log:
`Sep  4 11:49:01 ecr-siem-03 login[55767]: pam_unix(login:session): session opened for user root(uid=0) by LOGIN(uid=0)`

This is due to the `\S+` used in the default PAM session decoder which captures `()*+,-.:;<=>?[]!"'#$%&|{}`:
```
<decoder name="pam-user">
  <parent>pam</parent>
  <prematch>\)\p* session \w+ |^session \w+ </prematch>
  <regex offset="after_prematch">^for user (\S+)</regex>
  <order>user</order>
</decoder>
```
## Test Output

Before the fix
```
**Phase 1: Completed pre-decoding.
        full event: 'Sep  4 11:49:01 ecr-siem-03 login[55767]: pam_unix(login:session): session opened for user root(uid=0) by LOGIN(uid=0)'
        timestamp: 'Sep  4 11:49:01'
        hostname: 'ecr-siem-03'
        program_name: 'login'

**Phase 2: Completed decoding.
        name: 'pam'
        parent: 'pam'
        dstuser: 'root(uid=0)'
        srcuser: 'LOGIN'
        uid: '0'
```

After the fix

```
**Phase 1: Completed pre-decoding.
        full event: 'Sep  4 11:49:01 ecr-siem-03 login[55767]: pam_unix(login:session): session opened for user root(uid=0) by LOGIN(uid=0)'
        timestamp: 'Sep  4 11:49:01'
        hostname: 'ecr-siem-03'
        program_name: 'login'

**Phase 2: Completed decoding.
        name: 'pam'
        parent: 'pam'
        dstuser: 'root'
        srcuser: 'LOGIN'
        uid: '0'
```
