### PR TITLE
Reduce log verbosity for new connections and SSL handshake failures in wazuh-authd

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -820,7 +820,7 @@ static int handle_ssl_handshake(struct client *client) {
             mdebug2("SSL handshake in progress for socket=%d", client->socket);
             return 0;
         } else {
-            merror("SSL handshake failed for socket=%d: %s", client->socket, ERR_error_string(ERR_get_error(), NULL));
+            mdebug2("SSL handshake failed for socket=%d: %s", client->socket, ERR_error_string(ERR_get_error(), NULL));
             return -1;
         }
     }
@@ -974,7 +974,7 @@ void* run_remote_server(__attribute__((unused)) void *arg) {
                         continue;
                     }
 
-                    minfo("New connection from %s", new_client->ip);
+                    mdebug2("New connection from %s", new_client->ip);
 
                     new_client->ssl = SSL_new(ctx);
                     if (!new_client->ssl) {


### PR DESCRIPTION
## Description

This pull request changes the log level for new client connections and SSL handshake failures in `wazuh-authd` from INFO/ERROR to DEBUG. This ensures that invalid or non-compliant client connections do not produce unnecessary log noise at the default log level.

## Proposed Changes

- Changed the log statements for:
  - New client connections
  - SSL handshake failures
- Both log events now use the DEBUG level instead of INFO/ERROR.

### Results and Evidence

- When running `wazuh-authd` with `debug=2`, both log messages appear as DEBUG:
  ```
  2025/10/10 11:35:55 wazuh-authd[38963] main-server.c:977 at run_remote_server(): DEBUG: New connection from 127.0.0.1
  2025/10/10 11:35:55 wazuh-authd[38963] main-server.c:823 at handle_ssl_handshake(): DEBUG: SSL handshake failed for socket=9: error:0A000126:SSL routines::unexpected eof while reading
  ```
- When running with default log settings, these messages do not appear.
- Tested by making connections/disconnections to port 1515.

### Artifacts Affected

- `wazuh-authd` (manager)

### Configuration Changes

- None

### Documentation Updates

- No documentation changes required.

### Tests Introduced

- No related tests found or modified.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues