### PR TITLE
2873-Add helper Array-obj-to-mapKV for 6.0.0

### DIFF
--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -145,6 +145,8 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opmap/kvdb_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/mmdb_test.cpp
     ${UNIT_SRC_DIR}/builders/opmap/networkCommunityId_test.cpp
+    ${UNIT_SRC_DIR}/builders/opmap/arrayObj_to_MapKv_test.cpp
+    ${UNIT_SRC_DIR}/builders/opmap/array_extract_key_obj_test.cpp
 
     # Transform Builders
     ${UNIT_SRC_DIR}/builders/optransform/strTransform_test.cpp

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
@@ -296,6 +296,37 @@ TransformOp opBuilderHelperAppendSplitString(const Reference& targetField,
                                              const std::vector<OpArg>& opArgs,
                                              const std::shared_ptr<const IBuildCtx>& buildCtx);
 
+/**
+ * @brief Builds a helper that turns an array of objects into a key/value map.
+ *
+ * @param opArgs Operation arguments:
+ *        - `opArgs[0]`: reference to the array to iterate.
+ *        - `opArgs[1]`: string JSON Pointer used to extract the key from each element.
+ *        - `opArgs[2]`: string JSON Pointer used to extract the value.
+ *        - `opArgs[3]` (optional): boolean flag `skipSerializer`; when true keeps the key verbatim,
+ *          otherwise it is normalized to lowercase snake_case.
+ * @param buildCtx Build context.
+ * @return MapOp mapper that emits the resulting object.
+ */
+MapOp opBuilderHelperArrayObjToMapkv(const std::vector<OpArg>& opArgs,
+                                     const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
+ * @brief Builds a helper that turns an array of objects representing changes into a map of old/new values.
+ *
+ * @param opArgs Operation arguments:
+ *        - `opArgs[0]`: reference to the array to iterate.
+ *        - `opArgs[1]`: string JSON Pointer used to extract the key from each element.
+ *        - `opArgs[2]`: string JSON Pointer used to extract the new value.
+ *        - `opArgs[3]`: string JSON Pointer used to extract the old value.
+ *        - `opArgs[4]` (optional): boolean flag `skipSerializer`; when true keeps the key verbatim,
+ *          otherwise it is normalized to lowercase snake_case.
+ * @param buildCtx Build context.
+ * @return MapOp mapper that emits the resulting object.
+ */
+MapOp opBuilderHelperArrayExtractKeyObj(const std::vector<OpArg>& opArgs,
+                                        const std::shared_ptr<const IBuildCtx>& buildCtx);
+
 //*************************************************
 //*              IP tranform                      *
 //*************************************************

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -248,6 +248,12 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "split",
         {schemf::JTypeToken::create(json::Json::Type::String, true), builders::opBuilderHelperAppendSplitString});
     registry->template add<builders::OpBuilderEntry>(
+        "array_obj_to_mapkv",
+        {schemf::JTypeToken::create(json::Json::Type::String, true), builders::opBuilderHelperArrayObjToMapkv});
+    registry->template add<builders::OpBuilderEntry>(
+        "array_extract_key_obj",
+        {schemf::JTypeToken::create(json::Json::Type::String, true), builders::opBuilderHelperArrayExtractKeyObj});
+    registry->template add<builders::OpBuilderEntry>(
         "concat", {schemf::JTypeToken::create(json::Json::Type::String), builders::opBuilderHelperStringConcat()});
     registry->template add<builders::OpBuilderEntry>(
         "concat_any",

--- a/src/engine/source/builder/test/src/unit/builders/opmap/arrayObj_to_MapKv_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/arrayObj_to_MapKv_test.cpp
@@ -1,0 +1,274 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opmap/opBuilderHelperMap.hpp"
+
+using namespace builder::builders;
+
+namespace
+{
+void expectValidatorAccess(const BuildersMocks& mocks)
+{
+    EXPECT_CALL(*mocks.ctx, validator()).Times(testing::AnyNumber());
+}
+
+auto builderArrayRefNotInSchema(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+auto builderArrayRefNotArray(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+auto builderArrayRefWrongElement(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, getJsonType(DotPath(refName)))
+            .WillRepeatedly(testing::Return(json::Json::Type::String));
+        return None {};
+    };
+}
+
+auto opArrayRefNotInSchemaSuccess(const std::string& refName, const json::Json& expectedJson)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return expectedJson;
+    };
+}
+
+auto opArrayRefNotInSchemaFailure(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+auto opArrayRefNotArray(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+} // namespace
+
+namespace mapbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(
+    ArrayObjToMapKv,
+    MapBuilderTest,
+    testing::Values(MapT({makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         SUCCESS(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({}, opBuilderHelperArrayObjToMapkv, FAILURE()),
+                    MapT({makeValue(R"("ExtendedProperties")"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE()),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"(1)"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"(1)")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("")"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("Name")"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotInSchema("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefNotArray("ExtendedProperties"))),
+                    MapT({makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+                         opBuilderHelperArrayObjToMapkv,
+                         FAILURE(builderArrayRefWrongElement("ExtendedProperties")))),
+    testNameFormatter<MapBuilderTest>("ArrayObjToMapKv"));
+} // namespace mapbuildtest
+
+namespace mapoperatestest
+{
+INSTANTIATE_TEST_SUITE_P(
+    ArrayObjToMapKv,
+    MapOperationTest,
+    testing::Values(
+        MapT(
+            R"({
+                    "ExtendedProperties": [
+                        {"Name": "UserAgent", "Value": "Mozilla/5.0"},
+                        {"Name": "Age", "Value": 42},
+                        {"Name": "KeepMeSignedIn", "Value": true},
+                        {"Name": "OptionalField", "Value": null},
+                        {"Name": "Roles", "Value": ["admin", "user"]},
+                        {"Name": "Meta", "Value": {"os": "linux", "arch": "x64"}}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("ExtendedProperties", json::Json(R"({
+                    "useragent": "Mozilla/5.0",
+                    "age": 42,
+                    "keepmesignedin": true,
+                    "optionalfield": null,
+                    "roles": ["admin", "user"],
+                    "meta": {"os": "linux", "arch": "x64"}
+                })")))),
+        MapT(
+            R"({
+                    "ExtendedProperties": [
+                        {"Name": "UserAgent", "Value": "Mozilla/5.0"},
+                        {"Name": "Age", "Value": 42},
+                        {"Name": "KeepMeSignedIn", "Value": true},
+                        {"Name": "OptionalField", "Value": null},
+                        {"Name": "Roles", "Value": ["admin", "user"]},
+                        {"Name": "Meta", "Value": {"os": "linux", "arch": "x64"}}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")"), makeValue(R"(true)")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("ExtendedProperties", json::Json(R"({
+                    "UserAgent": "Mozilla/5.0",
+                    "Age": 42,
+                    "KeepMeSignedIn": true,
+                    "OptionalField": null,
+                    "Roles": ["admin", "user"],
+                    "Meta": {"os": "linux", "arch": "x64"}
+                })")))),
+        MapT(
+            R"({
+                    "ExtendedProperties": [
+                        {"Name": "SCL/Reject", "Value": "value1"},
+                        {"Name": "tilde~value", "Value": "value2"},
+                        {"Name": "weird~slash/tilde.name", "Value": "value3"}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")"), makeValue(R"(true)")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("ExtendedProperties", json::Json(R"({
+                    "SCL/Reject": "value1",
+                    "tilde~value": "value2",
+                    "weird~slash/tilde.name": "value3"
+                })")))),
+        MapT(
+            R"({
+                    "ExtendedProperties": [
+                        {"Name": "UserAgent", "Value": "Mozilla/5.0"},
+                        {"Name": "Request.Type", "Value": "OAuth2:Authorize"},
+                        {"Name": "Included Updated Properties", "Value": "RequiredResourceAccess"},
+                        {"Name": "tilde~value", "Value": "data"},
+                        {"Name": "SCL/Reject", "Value": "False"}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("ExtendedProperties", json::Json(R"({
+                    "useragent": "Mozilla/5.0",
+                    "request_type": "OAuth2:Authorize",
+                    "included_updated_properties": "RequiredResourceAccess",
+                    "tildevalue": "data",
+                    "scl_reject": "False"
+                })")))),
+        MapT(
+            R"({
+                    "ExtendedProperties": [
+                        {"Name": "already_snake", "Value": "value1"},
+                        {"Name": "SCL_Reject", "Value": "value2"},
+                        {"Name": "__meta__", "Value": "value3"}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("ExtendedProperties", json::Json(R"({
+                    "already_snake": "value1",
+                    "scl_reject": "value2",
+                    "meta": "value3"
+                })")))),
+        MapT(
+            R"({
+                    "ModifiedProperties": [
+                        {"Name": "RequiredResourceAccess", "NewValue": "new-data"},
+                        {"Name": "Included Updated Properties", "NewValue": "RequiredResourceAccess"}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ModifiedProperties"), makeValue(R"("/Name")"), makeValue(R"("/NewValue")")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("ModifiedProperties", json::Json(R"({
+                    "requiredresourceaccess": "new-data",
+                    "included_updated_properties": "RequiredResourceAccess"
+                })")))),
+        MapT(
+            R"({
+                    "Parameters": [
+                        "Only Flag",
+                        {"Name": "Other", "Value": "42"}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("Parameters"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            SUCCESS(opArrayRefNotInSchemaSuccess("Parameters", json::Json(R"({
+                    "other": "42"
+                })")))),
+        MapT(
+            R"({
+                    "Parameters": [
+                        "Only Flag"
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("Parameters"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            FAILURE(opArrayRefNotInSchemaFailure("Parameters"))),
+        MapT(
+            R"({
+                    "ModifiedProperties": [
+                        {"Name": "", "Value": "empty"},
+                        {"Name": "MissingValue"},
+                        {"Other": "value"}
+                    ]
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ModifiedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            FAILURE(opArrayRefNotInSchemaFailure("ModifiedProperties"))),
+        MapT("{}",
+             opBuilderHelperArrayObjToMapkv,
+             {makeRef("Parameters"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+             FAILURE(opArrayRefNotInSchemaFailure("Parameters"))),
+        MapT(
+            R"({
+                    "ExtendedProperties": {"Name": "not-an-array"}
+                })",
+            opBuilderHelperArrayObjToMapkv,
+            {makeRef("ExtendedProperties"), makeValue(R"("/Name")"), makeValue(R"("/Value")")},
+            FAILURE(opArrayRefNotInSchemaFailure("ExtendedProperties")))),
+    testNameFormatter<MapOperationTest>("ArrayObjToMapKv"));
+} // namespace mapoperatestest

--- a/src/engine/source/builder/test/src/unit/builders/opmap/array_extract_key_obj_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/array_extract_key_obj_test.cpp
@@ -1,0 +1,265 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opmap/opBuilderHelperMap.hpp"
+
+using namespace builder::builders;
+
+namespace
+{
+void expectValidatorAccess(const BuildersMocks& mocks)
+{
+    EXPECT_CALL(*mocks.ctx, validator()).Times(testing::AnyNumber());
+}
+
+auto builderArrayRefNotInSchema(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+auto builderArrayRefNotArray(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+auto builderArrayRefWrongElement(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, getJsonType(DotPath(refName)))
+            .WillRepeatedly(testing::Return(json::Json::Type::String));
+        return None {};
+    };
+}
+
+auto opArrayRefNotInSchemaSuccess(const std::string& refName, const json::Json& expectedJson)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return expectedJson;
+    };
+}
+
+auto opArrayRefNotInSchemaFailure(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+auto opArrayRefNotArray(const std::string& refName)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        expectValidatorAccess(mocks);
+        EXPECT_CALL(*mocks.validator, hasField(DotPath(refName))).WillRepeatedly(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath(refName))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+
+} // namespace
+
+namespace mapbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(
+    ArrayExtractKeyObj,
+    MapBuilderTest,
+    testing::Values(
+        MapT({makeRef("ModifiedProperties"),
+              makeValue(R"("/Name")"),
+              makeValue(R"("/NewValue")"),
+              makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             SUCCESS(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({}, opBuilderHelperArrayExtractKeyObj, FAILURE()),
+        MapT({makeValue(R"("ModifiedProperties")"),
+              makeValue(R"("/Name")"),
+              makeValue(R"("/NewValue")"),
+              makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE()),
+        MapT({makeRef("ModifiedProperties"),
+              makeValue(R"(1)"),
+              makeValue(R"("/NewValue")"),
+              makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"), makeValue(R"("/Name")"), makeValue(R"(1)"), makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"), makeValue(R"("/Name")"), makeValue(R"("/NewValue")"), makeValue(R"(1)")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"),
+              makeValue(R"("")"),
+              makeValue(R"("/NewValue")"),
+              makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"), makeValue(R"("/Name")"), makeValue(R"("")"), makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"), makeValue(R"("/Name")"), makeValue(R"("/NewValue")"), makeValue(R"("")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotInSchema("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"),
+              makeValue(R"("/Name")"),
+              makeValue(R"("/NewValue")"),
+              makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefNotArray("ModifiedProperties"))),
+        MapT({makeRef("ModifiedProperties"),
+              makeValue(R"("/Name")"),
+              makeValue(R"("/NewValue")"),
+              makeValue(R"("/OldValue")")},
+             opBuilderHelperArrayExtractKeyObj,
+             FAILURE(builderArrayRefWrongElement("ModifiedProperties")))),
+    testNameFormatter<MapBuilderTest>("ArrayExtractKeyObj"));
+} // namespace mapbuildtest
+
+namespace mapoperatestest
+{
+INSTANTIATE_TEST_SUITE_P(ArrayExtractKeyObj,
+                         MapOperationTest,
+                         testing::Values(MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        {"Name": "RequiredResourceAccess", "NewValue": "new-data", "OldValue": "old-data"},
+                        {"Name": "Included Updated Properties", "NewValue": "RequiredResourceAccess", "OldValue": ""}
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")")},
+                                             SUCCESS(opArrayRefNotInSchemaSuccess("ModifiedProperties", json::Json(R"({
+                    "requiredresourceaccess": {"NewValue": "new-data", "OldValue": "old-data"},
+                    "included_updated_properties": {"NewValue": "RequiredResourceAccess"}
+                })")))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        {"Name": "RequiredResourceAccess", "NewValue": "new-data", "OldValue": "old-data"},
+                        {"Name": "Included Updated Properties", "NewValue": "RequiredResourceAccess", "OldValue": ""}
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")"),
+                                              makeValue(R"(true)")},
+                                             SUCCESS(opArrayRefNotInSchemaSuccess("ModifiedProperties", json::Json(R"({
+                    "RequiredResourceAccess": {"NewValue": "new-data", "OldValue": "old-data"},
+                    "Included Updated Properties": {"NewValue": "RequiredResourceAccess"}
+                })")))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        {"Name": "SCL/Reject", "NewValue": "value1", "OldValue": "previous"},
+                        {"Name": "tilde~value", "NewValue": "value2", "OldValue": null},
+                        {"Name": "weird~slash/tilde.name", "NewValue": "value3", "OldValue": ""}
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")"),
+                                              makeValue(R"(true)")},
+                                             SUCCESS(opArrayRefNotInSchemaSuccess("ModifiedProperties", json::Json(R"({
+                    "SCL/Reject": {"NewValue": "value1", "OldValue": "previous"},
+                    "tilde~value": {"NewValue": "value2", "OldValue": null},
+                    "weird~slash/tilde.name": {"NewValue": "value3"}
+                })")))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        {"Name": "RequiredResourceAccess", "NewValue": "new-data"}
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")")},
+                                             SUCCESS(opArrayRefNotInSchemaSuccess("ModifiedProperties", json::Json(R"({
+                    "requiredresourceaccess": {"NewValue": "new-data"}
+                })")))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        {"Name": "FeatureFlag", "NewValue": true, "OldValue": "   "}
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")")},
+                                             SUCCESS(opArrayRefNotInSchemaSuccess("ModifiedProperties", json::Json(R"({
+                    "featureflag": {"NewValue": true}
+                })")))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        {"Name": "RequiredResourceAccess", "OldValue": "old-data"}
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")")},
+                                             FAILURE(opArrayRefNotInSchemaFailure("ModifiedProperties"))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": [
+                        "Only Flag"
+                    ]
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")")},
+                                             FAILURE(opArrayRefNotInSchemaFailure("ModifiedProperties"))),
+                                         MapT("{}",
+                                              opBuilderHelperArrayExtractKeyObj,
+                                              {makeRef("ModifiedProperties"),
+                                               makeValue(R"("/Name")"),
+                                               makeValue(R"("/NewValue")"),
+                                               makeValue(R"("/OldValue")")},
+                                              FAILURE(opArrayRefNotInSchemaFailure("ModifiedProperties"))),
+                                         MapT(
+                                             R"({
+                    "ModifiedProperties": {"Name": "not-an-array"}
+                })",
+                                             opBuilderHelperArrayExtractKeyObj,
+                                             {makeRef("ModifiedProperties"),
+                                              makeValue(R"("/Name")"),
+                                              makeValue(R"("/NewValue")"),
+                                              makeValue(R"("/OldValue")")},
+                                             FAILURE(opArrayRefNotInSchemaFailure("ModifiedProperties")))),
+                         testNameFormatter<MapOperationTest>("ArrayExtractKeyObj"));
+} // namespace mapoperatestest

--- a/src/engine/test/helper_tests/helpers_description/map/arrayObj_to_MapKv.yml
+++ b/src/engine/test/helper_tests/helpers_description/map/arrayObj_to_MapKv.yml
@@ -1,0 +1,142 @@
+# Name of the helper function
+name: array_obj_to_mapkv
+
+metadata:
+  description: |
+    Builds a map (object) from an array of objects. Each element provides the key
+    (via a JSON pointer) and the value (another pointer, optionally `/` for the full object).
+    Keys are normalized to lowercase snake_case unless `skipSerializer` is true, in which
+    case keys are kept verbatim. Entries missing a key/value or producing an empty key
+    are skipped. The helper returns an error when no entries are inserted.
+  keywords:
+    - array
+    - map
+    - key-value
+
+helper_type: map
+
+skipped:
+  - success_cases
+
+is_variadic: false
+
+arguments:
+  source_array:
+    type: array
+    source: reference
+  key_pointer:
+    type: string
+    source: value
+  value_pointer:
+    type: string
+    source: value
+  skip_serializer:
+    type: boolean
+    source: value
+    optional: true
+
+output:
+  type: object
+
+test:
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: UserAgent
+            Value: Mozilla/5.0
+          - Name: Request.Type
+            Value: OAuth2:Authorize
+          - Name: Included Updated Properties
+            Value: RequiredResourceAccess
+      key_pointer:
+        source: value
+        value: "/Name"
+      value_pointer:
+        source: value
+        value: "/Value"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: true
+    expected:
+      useragent: Mozilla/5.0
+      request_type: OAuth2:Authorize
+      included_updated_properties: RequiredResourceAccess
+    description: Normalizes keys and extracts values using `/Value` pointer
+    context: |
+      {
+        "ExtendedProperties": [
+          {"Name": "UserAgent", "Value": "Mozilla/5.0"},
+          {"Name": "Request.Type", "Value": "OAuth2:Authorize"},
+          {"Name": "Included Updated Properties", "Value": "RequiredResourceAccess"}
+        ]
+      }
+
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: UserAgent
+            Value: Mozilla/5.0
+          - Name: KeepMeSignedIn
+            Value: true
+          - Name: OptionalField
+            Value: null
+          - Name: Roles
+            Value:
+              - admin
+              - user
+          - Name: Meta
+            Value:
+              os: linux
+              arch: x64
+      key_pointer:
+        source: value
+        value: "/Name"
+      value_pointer:
+        source: value
+        value: "/Value"
+      skip_serializer:
+        source: value
+        value: true
+    should_pass: true
+    expected:
+      UserAgent: Mozilla/5.0
+      KeepMeSignedIn: true
+      OptionalField: null
+      Roles:
+        - admin
+        - user
+      Meta:
+        os: linux
+        arch: x64
+    description: Keeps keys verbatim when `skipSerializer` is true
+    context: |
+      {
+        "ExtendedProperties": [
+          {"Name": "UserAgent", "Value": "Mozilla/5.0"},
+          {"Name": "KeepMeSignedIn", "Value": true},
+          {"Name": "OptionalField", "Value": null},
+          {"Name": "Roles", "Value": ["admin", "user"]},
+          {"Name": "Meta", "Value": {"os": "linux", "arch": "x64"}}
+        ]
+      }
+
+  - arguments:
+      source_array:
+        source: reference
+        value: null
+      key_pointer:
+        source: value
+        value: "/Name"
+      value_pointer:
+        source: value
+        value: "/Value"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: false
+    description: Fails when array does not exist in the context
+    context: |
+      {}

--- a/src/engine/test/helper_tests/helpers_description/map/array_extract_key_obj.yml
+++ b/src/engine/test/helper_tests/helpers_description/map/array_extract_key_obj.yml
@@ -1,0 +1,228 @@
+# Name of the helper function
+name: array_extract_key_obj
+
+metadata:
+  description: |
+    Builds a map of extracted key objects from an array. Each element provides the key
+    (via a JSON pointer) and both the new and old values (as JSON pointers, `/` for the full object).
+    Keys are normalized to lowercase snake_case unless `skipSerializer` is true, in which
+    case keys are kept verbatim. Entries missing a key or new value, or producing an empty key, are skipped.
+    Old values that resolve to empty strings are omitted from the result.
+    The helper returns an error when no entries are inserted.
+  keywords:
+    - array
+    - map
+    - extract
+    - changes
+
+helper_type: map
+
+skipped:
+  - success_cases
+
+is_variadic: false
+
+arguments:
+  source_array:
+    type: array
+    source: reference
+  key_pointer:
+    type: string
+    source: value
+  new_value_pointer:
+    type: string
+    source: value
+  old_value_pointer:
+    type: string
+    source: value
+  skip_serializer:
+    type: boolean
+    source: value
+    optional: true
+
+output:
+  type: object
+
+test:
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: RequiredResourceAccess
+            NewValue: new-data
+            OldValue: old-data
+          - Name: Included Updated Properties
+            NewValue: RequiredResourceAccess
+            OldValue: ""
+      key_pointer:
+        source: value
+        value: "/Name"
+      new_value_pointer:
+        source: value
+        value: "/NewValue"
+      old_value_pointer:
+        source: value
+        value: "/OldValue"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: true
+    expected:
+      requiredresourceaccess:
+        NewValue: new-data
+        OldValue: old-data
+      included_updated_properties:
+        NewValue: RequiredResourceAccess
+    description: Builds map with normalized keys and both new/old values
+    context: |
+      {
+        "ModifiedProperties": [
+          {"Name": "RequiredResourceAccess", "NewValue": "new-data", "OldValue": "old-data"},
+          {"Name": "Included Updated Properties", "NewValue": "RequiredResourceAccess", "OldValue": ""}
+        ]
+      }
+
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: RequiredResourceAccess
+            NewValue: new-data
+            OldValue: old-data
+          - Name: Included Updated Properties
+            NewValue: RequiredResourceAccess
+            OldValue: ""
+      key_pointer:
+        source: value
+        value: "/Name"
+      new_value_pointer:
+        source: value
+        value: "/NewValue"
+      old_value_pointer:
+        source: value
+        value: "/OldValue"
+      skip_serializer:
+        source: value
+        value: true
+    should_pass: true
+    expected:
+      RequiredResourceAccess:
+        NewValue: new-data
+        OldValue: old-data
+      Included Updated Properties:
+        NewValue: RequiredResourceAccess
+    description: Keeps keys verbatim when `skipSerializer` is true
+    context: |
+      {
+        "ModifiedProperties": [
+          {"Name": "RequiredResourceAccess", "NewValue": "new-data", "OldValue": "old-data"},
+          {"Name": "Included Updated Properties", "NewValue": "RequiredResourceAccess", "OldValue": ""}
+        ]
+      }
+
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: AzurePolicyChange
+            NewValue: Enabled
+      key_pointer:
+        source: value
+        value: "/Name"
+      new_value_pointer:
+        source: value
+        value: "/NewValue"
+      old_value_pointer:
+        source: value
+        value: "/OldValue"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: true
+    expected:
+      azurepolicychange:
+        NewValue: Enabled
+    description: Keeps entries that only provide a new value
+    context: |
+      {
+        "ModifiedProperties": [
+          {"Name": "AzurePolicyChange", "NewValue": "Enabled"}
+        ]
+      }
+
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: AlertThreshold
+            NewValue: 10
+            OldValue: "  "
+      key_pointer:
+        source: value
+        value: "/Name"
+      new_value_pointer:
+        source: value
+        value: "/NewValue"
+      old_value_pointer:
+        source: value
+        value: "/OldValue"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: true
+    expected:
+      alertthreshold:
+        NewValue: 10
+    description: Discards old value when it resolves to blanks
+    context: |
+      {
+        "ModifiedProperties": [
+          {"Name": "AlertThreshold", "NewValue": 10, "OldValue": "  "}
+        ]
+      }
+
+  - arguments:
+      source_array:
+        source: reference
+        value:
+          - Name: RequiredResourceAccess
+            OldValue: old-data
+      key_pointer:
+        source: value
+        value: "/Name"
+      new_value_pointer:
+        source: value
+        value: "/NewValue"
+      old_value_pointer:
+        source: value
+        value: "/OldValue"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: false
+    description: Fails when new value is missing
+    context: |
+      {
+        "ModifiedProperties": [
+          {"Name": "RequiredResourceAccess", "OldValue": "old-data"}
+        ]
+      }
+
+  - arguments:
+      source_array: "$.Missing"
+      key_pointer:
+        source: value
+        value: "/Name"
+      new_value_pointer:
+        source: value
+        value: "/NewValue"
+      old_value_pointer:
+        source: value
+        value: "/OldValue"
+      skip_serializer:
+        source: value
+        value: false
+    should_pass: false
+    description: Fails when array does not exist in the context
+    context: |
+      {}


### PR DESCRIPTION

## Description

This PR introduces two map helpers for building objects from arrays of objects:

- `array_obj_to_mapkv(array_ref, key_pointer, value_pointer, skip_serializer=false)`
 Builds a JSON object from an array by extracting a key and a value via JSON Pointers. Keys can be verbatim or normalized (lowercase, safe _, collapsed/trimming underscores).

- `array_extract_key_obj(array_ref, key_pointer, new_pointer, old_pointer, skip_serializer=false)`
Tailored for change/diff arrays (e.g., `ModifiedProperties`). Produces `{ "<key>": { "NewValue": ..., "OldValue": ... } }.`
If `OldValue` is missing or a blank string (including whitespace-only), it is omitted; NewValue is required per element.

Both helpers provide clear failure tracing and robust argument validation.


## Proposed Changes

- Add array_obj_to_mapkv helper (MapOp) to convert arrays of {Name, Value} objects into a map.
- Arguments:

- **`array_obj_to_mapkv:`**

    - `source_array` (reference)
    - `key` (string JSON Pointer; must start with /)
    - `value` (string JSON Pointer; must start with / OR be / to mean “full element”)
    - `skip_serializer` (optional bool; default false)

- **`array_extract_key_obj:`**

    - `source_array` (reference)
    - `key` (string JSON Pointer; must start with /)
    - `newValue` (string JSON Pointer; must start with /)
    - `oldValue` (string JSON Pointer; must start with /)
    - `skip_serializer` (optional bool; default false)

- Robust validation with descriptive trace messages.
- Unit tests for:

    - Builder argument validation (arity, types, pointer format).
    - Operation behavior across mixed types (string/number/bool/null/array/object).
    - Verbatim vs normalized keys.
    - Alternate value pointers (/NewValue, /).
    - Error paths: ref not found, not an array, empty result.


### Insertion rules

- For each array element:

    - If not an object → skip.
    - If `key_pointer` doesn’t resolve to a non-empty string → skip.
    - If `value_pointer` doesn’t resolve → skip.
    - If `value_pointer` == "/" → use the entire element object as the value.
    - On duplicate keys → last wins.
**Specific to `array_obj_to_map_changes`:**
    - NewValue must resolve; otherwise skip the element.
    - `OldValue`:
        - If missing → omit.
        - If string and blank/whitespace-only → omit.
        - Otherwise → include as-is (supports string/number/bool/null/object/array).


### Normalize rules

- Lowercase everything
- Keep only letters and digits
- Replace spaces, `/`, `.`, `-`, `\`, `:` with `_`
- Drop all other characters
- Collapse consecutive `_` to a single `_`
- Trim leading and trailing `_`

###  Return & traces

- If at least one pair inserted → Success and returns the built object.
- If no pairs inserted → Failure with:  [<opName>] -> Failure: Result map is empty
- If the reference is missing → Failure with TRACE_REFERENCE_NOT_FOUND.
- If the reference exists but is not an array → Failure with TRACE_REFERENCE_TYPE_IS_NOT ... array.
- If schema type check fails during build → throws with a clear message (array/object expectations).


### Testing
**MapBuilderTest**: constructor/validation errors and schema guards.
**MapOperationTest**: success & failure scenarios, including mixed-element arrays, normalization rules,

### Files Changed

Engine / builder wiring:

`src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp/.hpp`
`src/engine/source/builder/src/builders/opmap/register.hpp` (registration)
`src/engine/source/base/src/utils/stringUtils.cpp`
`src/engine/source/builder/CMakeLists.txt` (targets)

Unit tests:

`src/engine/source/test/src/unit/builders/opmap/arrayObj_to_MapKv_test.cpp`
`src/engine/source/test/helper_tests/helpers_description/arrayObj_to_MapKv.yml`
`src/engine/source/base/test/src/unit/stringUtils_test.cpp`

## Results and Evidence

### UnitTest

**For ArrayObjToMapKv**
```console

╭─root@wazuh6x-dev /workspaces/Wazuh_6x/wazuh/src/build/engine/source/builder ‹enhancement/2873-Helper-ArrayObj-To-MapKV-for-6.0.0› 
╰─# ./builder_utest --gtest_filter='*ArrayObjToMapKv*'   
Running main() from /workspaces/Wazuh_6x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *ArrayObjToMapKv*
[==========] Running 22 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 11 tests from ArrayObjToMapKv/MapBuilderTest
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_0
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_0 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_1
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_1 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_2
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_2 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_3
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_3 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_4
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_4 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_5
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_5 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_6
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_6 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_7
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_7 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_8
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_8 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_9
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_9 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_10
[       OK ] ArrayObjToMapKv/MapBuilderTest.Builds/ArrayObjToMapKv_10 (0 ms)
[----------] 11 tests from ArrayObjToMapKv/MapBuilderTest (0 ms total)

[----------] 11 tests from ArrayObjToMapKv/MapOperationTest
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_0
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_0 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_1
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_1 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_2
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_2 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_3
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_3 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_4
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_4 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_5
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_5 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_6
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_6 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_7
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_7 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_8
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_8 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_9
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_9 (0 ms)
[ RUN      ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_10
[       OK ] ArrayObjToMapKv/MapOperationTest.Operates/ArrayObjToMapKv_10 (0 ms)
[----------] 11 tests from ArrayObjToMapKv/MapOperationTest (1 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

```
**For ArrayExtractKeyObj**

```console

╭─root@wazuh6x-dev /workspaces/Wazuh_6x/wazuh/src/build/engine/source/builder ‹enhancement/2873-Helper-ArrayObj-To-MapKV-for-6.0.0› 
╰─# ./builder_utest --gtest_filter='*ArrayExtractKeyObj*'
Running main() from /workspaces/Wazuh_6x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *ArrayExtractKeyObj*
[==========] Running 20 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 11 tests from ArrayExtractKeyObj/MapBuilderTest
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_0
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_0 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_1
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_1 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_2
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_2 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_3
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_3 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_4
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_4 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_5
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_5 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_6
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_6 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_7
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_7 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_8
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_8 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_9
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_9 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_10
[       OK ] ArrayExtractKeyObj/MapBuilderTest.Builds/ArrayExtractKeyObj_10 (0 ms)
[----------] 11 tests from ArrayExtractKeyObj/MapBuilderTest (0 ms total)

[----------] 9 tests from ArrayExtractKeyObj/MapOperationTest
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_0
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_0 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_1
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_1 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_2
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_2 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_3
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_3 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_4
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_4 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_5
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_5 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_6
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_6 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_7
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_7 (0 ms)
[ RUN      ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_8
[       OK ] ArrayExtractKeyObj/MapOperationTest.Operates/ArrayExtractKeyObj_8 (0 ms)
[----------] 9 tests from ArrayExtractKeyObj/MapOperationTest (0 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.


```

### Decoder

**For  `array_obj_to_mapkv`**
```YML

name: decoder/array-obj-to-mapkv-test/0

parse|event.original:
  - <tmp.payload/json>

normalize:
  - check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)
    map:
      - extended.properties: array_obj_to_mapkv($tmp.payload.ExtendedProperties, "/Name", "/Value", true)

  - check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)
    map:
      - parameters: array_obj_to_mapkv($tmp.payload.Parameters, "/Name", "/Value", true)

  - check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)
    map:
      - additional.details: array_obj_to_mapkv($tmp.payload.AdditionalDetails, "/Name", "/Value")

  - map:
      - tmp.payload: delete()

```

**For  `array_obj_to_map_changes`**
```YML

name: decoder/array-obj-to-mapchange-test/0

parse|event.original:
  - <tmp.payload/json>

normalize:
  - check: exists($tmp.payload.ModifiedProperties) AND is_array($tmp.payload.ModifiedProperties)
    map:
      - modified.properties: array_obj_to_map_changes($tmp.payload.ModifiedProperties, "/Name", "/NewValue", "/OldValue")

  - map:
      - tmp.payload: delete()


```


<Details>
<summary> array_obj_to_mapkv</summary>

```console
╰─# engine-test -c /tmp/engine-test.json create-config
(venv) ╭─root@wazuh6x-dev /workspaces/Wazuh_6x/intelligence-data/ruleset/integrations ‹decoders_development●› 
╰─# engine-test -c /tmp/engine-test.json add -i test-wazuh -c single-line -q 1 -o local
(venv) ╭─root@wazuh6x-dev /workspaces/Wazuh_6x/intelligence-data/ruleset/integrations ‹decoders_development●› 
╰─# 
(venv) ╭─root@wazuh6x-dev /workspaces/Wazuh_6x/intelligence-data/ruleset/integrations ‹decoders_development●› 
╰─# cat  /tmp/engine-test.json                                                                                                                                                                            130 ↵
{
  "test-wazuh": {
    "collect_mode": "single-line",
    "template": {
      "event": {
        "queue": "1",
        "location": "local",
        "message": ""
      }
    }
  }
}#      

╰─# engine-test -c /tmp/engine-test.json run-raw test-wazuh -n wazuh -dd 

Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ExtendedProperties":[{"Name":"UserAgent","Value":"Mozilla/5.0"},{"Name":"RequestType","Value":"OAuth2:Authorize"}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Success
  ↳ [extended.properties: array_obj_to_mapkv($tmp.payload.ExtendedProperties, "/Name", "/Value", true)] -> Success
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-10T23:26:33Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ExtendedProperties":[{"Name":"UserAgent","Value":"Mozilla/5.0"},{"Name":"RequestType","Value":"OAuth2:Authorize"}]}'
  extended:
    properties:
      RequestType: OAuth2:Authorize
      UserAgent: Mozilla/5.0
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    ExtendedProperties:
    - Name: UserAgent
      Value: Mozilla/5.0
    - Name: RequestType
      Value: OAuth2:Authorize
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"Parameters":[{"Name":"Force","Value":"True"},{"Name":"Quota","Value":"30 GB"}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Failure
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Success
  ↳ [parameters: array_obj_to_mapkv($tmp.payload.Parameters, "/Name", "/Value", true)] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-10T23:39:55Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"Parameters":[{"Name":"Force","Value":"True"},{"Name":"Quota","Value":"30
      GB"}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  parameters:
    Force: 'True'
    Quota: 30 GB
  tmp: {}
  tmp_json:
    Parameters:
    - Name: Force
      Value: 'True'
    - Name: Quota
      Value: 30 GB
  wazuh:
    location: local
    queue: 49


1:local:{"AdditionalDetails":[{"Name":"Included Updated Properties","Value":"RequiredResourceAccess"},{"Name":"SCL/Reject","Value":"False"},{"Name":"Path:win\\sys32","Value":"ok"},{"Name":"Req.Type","Value":"X"}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Failure
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)] -> Success
  ↳ [additional.details: array_obj_to_mapkv($tmp.payload.AdditionalDetails, "/Name", "/Value")] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-10T23:51:55Z'
  additional:
    details:
      included_updated_properties: RequiredResourceAccess
      path_win_sys32: ok
      req_type: X
      scl_reject: 'False'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"AdditionalDetails":[{"Name":"Included Updated Properties","Value":"RequiredResourceAccess"},{"Name":"SCL/Reject","Value":"False"},{"Name":"Path:win\\sys32","Value":"ok"},{"Name":"Req.Type","Value":"X"}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    AdditionalDetails:
    - Name: Included Updated Properties
      Value: RequiredResourceAccess
    - Name: SCL/Reject
      Value: 'False'
    - Name: Path:win\sys32
      Value: ok
    - Name: Req.Type
      Value: X
  wazuh:
    location: local
    queue: 49


1:local:{"ExtendedProperties":[{"Name":"UserAgent","Value":"Mozilla/5.0"},{"Name":"Age","Value":42},{"Name":"KeepMeSignedIn","Value":true},{"Name":"OptionalField","Value":null},{"Name":"Roles","Value":["admin","user"]},{"Name":"Meta","Value":{"os":"linux","arch":"x64"}}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Success
  ↳ [extended.properties: array_obj_to_mapkv($tmp.payload.ExtendedProperties, "/Name", "/Value", true)] -> Success
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)] -> Failure
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-10T23:56:55Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ExtendedProperties":[{"Name":"UserAgent","Value":"Mozilla/5.0"},{"Name":"Age","Value":42},{"Name":"KeepMeSignedIn","Value":true},{"Name":"OptionalField","Value":null},{"Name":"Roles","Value":["admin","user"]},{"Name":"Meta","Value":{"os":"linux","arch":"x64"}}]}'
  extended:
    properties:
      Age: 42
      KeepMeSignedIn: true
      Meta:
        arch: x64
        os: linux
      OptionalField: null
      Roles:
      - admin
      - user
      UserAgent: Mozilla/5.0
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    ExtendedProperties:
    - Name: UserAgent
      Value: Mozilla/5.0
    - Name: Age
      Value: 42
    - Name: KeepMeSignedIn
      Value: true
    - Name: OptionalField
      Value: null
    - Name: Roles
      Value:
      - admin
      - user
    - Name: Meta
      Value:
        arch: x64
        os: linux
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"AdditionalDetails":[{"Name":"UserAgent","Value":"Mozilla/5.0"},{"Name":"Age","Value":42},{"Name":"KeepMeSignedIn","Value":true},{"Name":"OptionalField","Value":null},{"Name":"Roles","Value":["admin","user"]},{"Name":"Meta","Value":{"os":"linux","arch":"x64"}}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Failure
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)] -> Success
  ↳ [additional.details: array_obj_to_mapkv($tmp.payload.AdditionalDetails, "/Name", "/Value")] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-10T23:57:25Z'
  additional:
    details:
      age: 42
      keepmesignedin: true
      meta:
        arch: x64
        os: linux
      optionalfield: null
      roles:
      - admin
      - user
      useragent: Mozilla/5.0
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"AdditionalDetails":[{"Name":"UserAgent","Value":"Mozilla/5.0"},{"Name":"Age","Value":42},{"Name":"KeepMeSignedIn","Value":true},{"Name":"OptionalField","Value":null},{"Name":"Roles","Value":["admin","user"]},{"Name":"Meta","Value":{"os":"linux","arch":"x64"}}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    AdditionalDetails:
    - Name: UserAgent
      Value: Mozilla/5.0
    - Name: Age
      Value: 42
    - Name: KeepMeSignedIn
      Value: true
    - Name: OptionalField
      Value: null
    - Name: Roles
      Value:
      - admin
      - user
    - Name: Meta
      Value:
        arch: x64
        os: linux
  wazuh:
    location: local
    queue: 49


--SOMES ERROS: 

Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ExtendedProperties":["flag", 123, true]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Success
  ↳ [extended.properties: array_obj_to_mapkv($tmp.payload.ExtendedProperties, "/Name", "/Value", true)] -> Failure: Result map is empty
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)] -> Failure
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T00:04:18Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ExtendedProperties":["flag", 123, true]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    ExtendedProperties:
    - flag
    - 123
    - true
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ExtendedProperties":[{"Name":"UserAgent"},{"Name":"Age"},{"Name":"Roles"}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Success
  ↳ [extended.properties: array_obj_to_mapkv($tmp.payload.ExtendedProperties, "/Name", "/Value", true)] -> Failure: Result map is empty
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)] -> Failure
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T00:05:02Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ExtendedProperties":[{"Name":"UserAgent"},{"Name":"Age"},{"Name":"Roles"}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    ExtendedProperties:
    - Name: UserAgent
    - Name: Age
    - Name: Roles
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ExtendedProperties":[{"Name":"","Value":"x"},{"Value":"y"},{"Other":"z"}]}


---
traces:
[🟢] decoder/array-obj-to-mapkv-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ExtendedProperties) AND is_array($tmp.payload.ExtendedProperties)] -> Success
  ↳ [extended.properties: array_obj_to_mapkv($tmp.payload.ExtendedProperties, "/Name", "/Value", true)] -> Failure: Result map is empty
  ↳ [check: exists($tmp.payload.Parameters) AND is_array($tmp.payload.Parameters)] -> Failure
  ↳ [check: exists($tmp.payload.AdditionalDetails) AND is_array($tmp.payload.AdditionalDetails)] -> Failure
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T00:07:05Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ExtendedProperties":[{"Name":"","Value":"x"},{"Value":"y"},{"Other":"z"}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    ExtendedProperties:
    - Name: ''
      Value: x
    - Value: y
    - Other: z
  wazuh:
    location: local
    queue: 49


```

</Details>

<Details>
<summary> array_obj_to_map_changes</summary>

```console

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/intelligence-data/ruleset/integrations ‹decoders_development●› 
╰─# engine-test -c /tmp/engine-test.json run-raw test-wazuh -n wazuh -dd

Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ModifiedProperties":[{"Name":"RequiredResourceAccess","NewValue":"N1","OldValue":"O1"},{"Name":"Included Updated Properties","NewValue":"RequiredResourceAccess","OldValue":"prev"}]}


---
traces:
[🟢] decoder/array-obj-to-mapchange-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ModifiedProperties) AND is_array($tmp.payload.ModifiedProperties)] -> Success
  ↳ [modified.properties: array_obj_to_map_changes($tmp.payload.ModifiedProperties, "/Name", "/NewValue", "/OldValue")] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T04:31:02Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ModifiedProperties":[{"Name":"RequiredResourceAccess","NewValue":"N1","OldValue":"O1"},{"Name":"Included
      Updated Properties","NewValue":"RequiredResourceAccess","OldValue":"prev"}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  modified:
    properties:
      included_updated_properties:
        NewValue: RequiredResourceAccess
        OldValue: prev
      requiredresourceaccess:
        NewValue: N1
        OldValue: O1
  tmp: {}
  tmp_json:
    ModifiedProperties:
    - Name: RequiredResourceAccess
      NewValue: N1
      OldValue: O1
    - Name: Included Updated Properties
      NewValue: RequiredResourceAccess
      OldValue: prev
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ModifiedProperties":[{"NewValue":"X","OldValue":"Y"},{"Other":"Z"}]}


---
traces:
[🟢] decoder/array-obj-to-mapchange-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ModifiedProperties) AND is_array($tmp.payload.ModifiedProperties)] -> Success
  ↳ [modified.properties: array_obj_to_map_changes($tmp.payload.ModifiedProperties, "/Name", "/NewValue", "/OldValue")] -> Failure: Result map is empty
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T04:31:32Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ModifiedProperties":[{"NewValue":"X","OldValue":"Y"},{"Other":"Z"}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  tmp: {}
  tmp_json:
    ModifiedProperties:
    - NewValue: X
      OldValue: Y
    - Other: Z
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ModifiedProperties":[{"Name":"Quota","NewValue":100}]}


---
traces:
[🟢] decoder/array-obj-to-mapchange-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ModifiedProperties) AND is_array($tmp.payload.ModifiedProperties)] -> Success
  ↳ [modified.properties: array_obj_to_map_changes($tmp.payload.ModifiedProperties, "/Name", "/NewValue", "/OldValue")] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T04:31:45Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ModifiedProperties":[{"Name":"Quota","NewValue":100}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  modified:
    properties:
      quota:
        NewValue: 100
  tmp: {}
  tmp_json:
    ModifiedProperties:
    - Name: Quota
      NewValue: 100
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ModifiedProperties":[{"Name":"FeatureFlag","NewValue":true,"OldValue":""}]}


---
traces:
[🟢] decoder/array-obj-to-mapchange-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ModifiedProperties) AND is_array($tmp.payload.ModifiedProperties)] -> Success
  ↳ [modified.properties: array_obj_to_map_changes($tmp.payload.ModifiedProperties, "/Name", "/NewValue", "/OldValue")] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T04:31:55Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ModifiedProperties":[{"Name":"FeatureFlag","NewValue":true,"OldValue":""}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  modified:
    properties:
      featureflag:
        NewValue: true
  tmp: {}
  tmp_json:
    ModifiedProperties:
    - Name: FeatureFlag
      NewValue: true
      OldValue: ''
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

1:local:{"ModifiedProperties":[{"Name":"FeatureFlag","NewValue":true,"OldValue":"   "}]}


---
traces:
[🟢] decoder/array-obj-to-mapchange-test/0 -> success
  ↳ [/event/original: <tmp.payload/json>] -> Success
  ↳ [check: exists($tmp.payload.ModifiedProperties) AND is_array($tmp.payload.ModifiedProperties)] -> Success
  ↳ [modified.properties: array_obj_to_map_changes($tmp.payload.ModifiedProperties, "/Name", "/NewValue", "/OldValue")] -> Success
  ↳ [tmp.payload: delete] -> Success

output:
  '@timestamp': '2025-10-11T04:32:07Z'
  agent:
    id: '000'
    name: wazuh5x-dev
  event:
    original: '{"ModifiedProperties":[{"Name":"FeatureFlag","NewValue":true,"OldValue":"   "}]}'
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: noble
      kernel: Linux |wazuh5x-dev |6.14.0-33-generic |#33~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Fri Sep 19 17:02:30 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 24.04.3 LTS (Noble Numbat)
  modified:
    properties:
      featureflag:
        NewValue: true
  tmp: {}
  tmp_json:
    ModifiedProperties:
    - Name: FeatureFlag
      NewValue: true
      OldValue: '   '
  wazuh:
    location: local
    queue: 49



Enter any events [ENTER to send event, CTRL+C to finish]:

```

</Details>

## Helper-test

**For array_obj_to_mapkv**

```console

engine-helper-test -e /tmp/clean_env run --input-file /tmp/output/array_obj_to_mapkv.yml --show-failure
Validating parameters...
Parameters validated.

...

Test cases executed.
Generating report...
## Test Report

### General Summary

- Total test cases executed: 68
- Successful test cases: 68
- Failed test cases: 0

Stopping Engine instance...

```

**For array_extract_key_obj**

```console

╰─# engine-helper-test -e /tmp/clean_env run --input-file /tmp/output/array_extract_key_obj.yml --show-failure                                                          
Validating parameters...
Parameters validated.
Starting Engine instance..

...

Test cases executed.
Generating report...
## Test Report

### General Summary

### General Summary

- Total test cases executed: 87
- Successful test cases: 87
- Failed test cases: 0

```

## Doc

<img width="402" height="660" alt="Captura desde 2025-10-15 17-26-30" src="https://github.com/user-attachments/assets/3a7ce1e4-0a88-4a68-bf53-1eb5bbd791f0" />


<img width="840" height="898" alt="Captura desde 2025-10-15 17-28-05" src="https://github.com/user-attachments/assets/5ad13488-4254-4ee6-90ad-65e251f284ff" />


<img width="840" height="898" alt="Captura desde 2025-10-15 17-31-31" src="https://github.com/user-attachments/assets/7987ee52-4c9b-4b91-ac02-b1aede3825c2" />


<img width="648" height="871" alt="Captura desde 2025-10-10 22-56-34" src="https://github.com/user-attachments/assets/77df108b-d9c2-45fc-a9b1-220ee4966c01" />

<img width="648" height="871" alt="Captura desde 2025-10-10 22-56-51" src="https://github.com/user-attachments/assets/43cd8bb9-8f8c-497b-875f-2cc01f56ff22" />


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
