### PR TITLE
Allow unknown leaves under ECS

### DIFF
--- a/src/engine/source/schemf/src/validator.cpp
+++ b/src/engine/source/schemf/src/validator.cpp
@@ -167,6 +167,8 @@ base::RespOrError<ValidationResult> Schema::Validator::validate(const DotPath& n
     // If not a schema field, allways return success with no runtime validator
     if (!m_schema.hasField(name))
     {
+        // TODO: When custom fields are merged into the schema (ECS + custom),
+        // any unknown field should become a hard error instead of being allowed.
         return ValidationResult();
     }
 


### PR DESCRIPTION
## Description

This PR fixes a validation issue in the schema/validator path resolution. When a decoder maps a field that is **not an ECS leaf** but is **under an ECS container** (e.g., `dns.resolved_data` under `dns`), the engine should **not** fail during build-time validation. Today, such mappings incorrectly raise an error in some code paths. This PR updates the behavior to treat those leaves as permissible (untyped) while keeping strict validation for ECS-declared fields.

Closes **2971**.

## Proposed Changes

- **Schema** (`Schema::hasField`)  
  - Return `false` when a child segment is missing under a known parent (instead of throwing).  

- **Validator** (`Schema::Validator::validate`)  
  - If a field is **not present** in the schema (i.e., non-ECS or custom leaf), return a **successful `ValidationResult` with no runtime validator**.  
  - ECS-declared fields remain strictly validated (including runtime validators when applicable).

- **Unit tests (schemf)**  
  - Add tests covering:
    - Unknown leaf under known container → `hasField(...)` returns **false** (no throw).
    - Known leaf declared in schema → `hasField(...)` returns **true**.
    - Unknown top-level path → `hasField(...)` returns **false`**.
    - Unknown child under scalar → `hasField(...)` returns **false**.
    - Unknown child under array item (e.g., `dns.answers.0.foo`) → `hasField(...)` returns **false**.

### Results and Evidence

**Decoder smoke test (before/after):**

Decoder used:
```yaml
name: decoder/test-validate/0

normalize:
  - map:
      - dns.resolved_data: $event.original
```

Before fix:
```bash
engine-catalog -n wazuh create decoder < decoders/testValidate.yml
# -> Error creating asset: An error occurred while trying to validate 'decoder/test-validate/0':
#    In stage 'normalize' builder for block 'map' failed with error:
#    Failed to build operation 'dns.resolved_data: map($event.original)':
#    Field 'resolved_data' does not exist in 'dns.resolved_data'
```

After fix:
```bash
engine-catalog -n wazuh create decoder < decoders/testValidate.yml
$ echo $?
0
```

**Integration tests:**
```bash
engine-helper-test -e /tmp/environment run --input-dir /tmp/helper_tests --show-failure

# Summary
# Total test cases executed: 10788
# Successful test cases:     10788
# Failed test cases:         0
```

**Unit tests (schemf):**
```bash
./schemf_ctest
Running main() from /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
[==========] Running 170 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from SchemaTest
[ RUN      ] SchemaTest.ArrayItem
[       OK ] SchemaTest.ArrayItem (0 ms)
[ RUN      ] SchemaTest.HasField_UnknownLeafUnderKnownContainer_ReturnsFalse
[       OK ] SchemaTest.HasField_UnknownLeafUnderKnownContainer_ReturnsFalse (0 ms)
[ RUN      ] SchemaTest.HasField_KnownECSLeaf_ReturnsTrue
[       OK ] SchemaTest.HasField_KnownECSLeaf_ReturnsTrue (0 ms)
[ RUN      ] SchemaTest.HasField_UnknownTopLevel_ReturnsFalse
[       OK ] SchemaTest.HasField_UnknownTopLevel_ReturnsFalse (0 ms)
[ RUN      ] SchemaTest.HasField_UnknownUnderScalar_ReturnsFalse
[       OK ] SchemaTest.HasField_UnknownUnderScalar_ReturnsFalse (0 ms)
[ RUN      ] SchemaTest.HasField_UnknownChildUnderArrayItem_ReturnsFalse
[       OK ] SchemaTest.HasField_UnknownChildUnderArrayItem_ReturnsFalse (0 ms)
[----------] 6 tests from SchemaTest (0 ms total)
...
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/keyword (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/text
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/text (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/wildcard
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/wildcard (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/date
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/date (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/date_nanos
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/date_nanos (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/ip
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/ip (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/binary
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/binary (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/object
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/object (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/nested
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/nested (0 ms)
[ RUN      ] SchemvalTest/BuildValidation.JValueCompatible/geo_point
[       OK ] SchemvalTest/BuildValidation.JValueCompatible/geo_point (0 ms)
[----------] 95 tests from SchemvalTest/BuildValidation (20 ms total)

[----------] Global test environment tear-down
[==========] 170 tests from 4 test suites ran. (25 ms total)
[  PASSED  ] 170 tests.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

- Engine (schemf):
  - Schema Validate
  - Unit tests: `src/engine/source/schemf/test/src/component/schema_test.cpp`

### Configuration Changes

- N/A

### Tests Introduced

- **New unit tests** in `schema_test.cpp` to cover the updated `hasField(...)` semantics and array-item behavior.  
- Tests ensure strict validation still applies to ECS-declared fields while unknown leaves are allowed without runtime validation.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
