### PR TITLE
Assign workflow-created issues to trigger user and add to Agent project backlog

### DIFF
--- a/.github/actions/4_operational_prerelease_agent_integration_tests_issue/action.yml
+++ b/.github/actions/4_operational_prerelease_agent_integration_tests_issue/action.yml
@@ -19,6 +19,10 @@ inputs:
   github_token:
     description: 'GitHub token'
     required: true
+  project_token:
+    description: 'GitHub token with project permissions (optional, for project configuration)'
+    required: false
+    default: ''
 outputs:
   issue_url:
     description: 'URL of the created issue'
@@ -38,6 +42,7 @@ runs:
         PREV_ISSUE="${{ inputs.prev_issue }}"
 
         REPO="wazuh/wazuh"
+        PROJECT="XDR+SIEM/Agent team"
         LABEL="level/task,type/test"
         TITLE="Release $RELEASE - $STAGE - Agent integration tests"
         TAG="v$RELEASE-$(echo ${STAGE// /} | tr '[:upper:]' '[:lower:]')"
@@ -116,11 +121,33 @@ runs:
         EOF
         )
 
-        ISSUE_URL=$(gh issue create \
+        if OUTPUT=$(gh issue create \
           --repo "$REPO" \
           --title "$TITLE" \
           --label "$LABEL" \
-          --assignee "${{ inputs.assignee }}" \
-          --body "$BODY")
+          --body "$BODY" \
+          --assignee "${{ inputs.assignee }}" 2>&1); then
 
-        echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+          ISSUE_URL="$OUTPUT"
+          echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+
+          # Extract issue number from URL
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+
+          # Configure project fields if project_token is provided
+          if [[ -n "${{ inputs.project_token }}" ]]; then
+            echo "Configuring project fields..."
+            export GITHUB_TOKEN="${{ inputs.project_token }}"
+
+            # Add issue to project first
+            gh project item-add 86 --owner wazuh --url "$ISSUE_URL"
+
+            # Configure project fields
+            bash .github/scripts/configure-project-fields.sh "$ISSUE_NUMBER" "$RELEASE" "$STAGE"
+          else
+            echo "No project token provided, skipping project configuration"
+          fi
+        else
+          echo "Error creating issue: $OUTPUT"
+          exit 1
+        fi

--- a/.github/actions/4_operational_prerelease_coverity_issue/action.yml
+++ b/.github/actions/4_operational_prerelease_coverity_issue/action.yml
@@ -19,6 +19,10 @@ inputs:
   github_token:
     description: 'GitHub token'
     required: true
+  project_token:
+    description: 'GitHub token with project permissions (optional, for project configuration)'
+    required: false
+    default: ''
 outputs:
   issue_url:
     description: 'URL of the created issue'
@@ -38,6 +42,7 @@ runs:
         PREV_ISSUE="${{ inputs.prev_issue }}"
 
         REPO="wazuh/wazuh"
+        PROJECT="XDR+SIEM/Agent team"
         LABEL="level/task,type/test,type/test/coverity"
         TITLE="Release $RELEASE - $STAGE - Coverity scan"
         TAG="v$RELEASE-$(echo ${STAGE// /} | tr '[:upper:]' '[:lower:]')"
@@ -56,11 +61,33 @@ runs:
         EOF
         )
 
-        ISSUE_URL=$(gh issue create \
+        if OUTPUT=$(gh issue create \
           --repo "$REPO" \
           --title "$TITLE" \
           --label "$LABEL" \
-          --assignee "${{ inputs.assignee }}" \
-          --body "$BODY")
+          --body "$BODY" \
+          --assignee "${{ inputs.assignee }}" 2>&1); then
 
-        echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+          ISSUE_URL="$OUTPUT"
+          echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+
+          # Extract issue number from URL
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+
+          # Configure project fields if project_token is provided
+          if [[ -n "${{ inputs.project_token }}" ]]; then
+            echo "Configuring project fields..."
+            export GITHUB_TOKEN="${{ inputs.project_token }}"
+
+            # Add issue to project first
+            gh project item-add 86 --owner wazuh --url "$ISSUE_URL"
+
+            # Configure project fields
+            bash .github/scripts/configure-project-fields.sh "$ISSUE_NUMBER" "$RELEASE" "$STAGE"
+          else
+            echo "No project token provided, skipping project configuration"
+          fi
+        else
+          echo "Error creating issue: $OUTPUT"
+          exit 1
+        fi

--- a/.github/actions/4_operational_prerelease_unit_tests_issue/action.yml
+++ b/.github/actions/4_operational_prerelease_unit_tests_issue/action.yml
@@ -19,6 +19,10 @@ inputs:
   github_token:
     description: 'GitHub token'
     required: true
+  project_token:
+    description: 'GitHub token with project permissions (optional, for project configuration)'
+    required: false
+    default: ''
 outputs:
   issue_url:
     description: 'URL of the created issue'
@@ -38,6 +42,7 @@ runs:
         PREV_ISSUE="${{ inputs.prev_issue }}"
 
         REPO="wazuh/wazuh"
+        PROJECT="XDR+SIEM/Agent team"
         LABEL="level/task,type/test"
         TITLE="Release $RELEASE - $STAGE - C Unit tests and RTR"
         TAG="v$RELEASE-$(echo ${STAGE// /} | tr '[:upper:]' '[:lower:]')"
@@ -61,11 +66,33 @@ runs:
         EOF
         )
 
-        ISSUE_URL=$(gh issue create \
+        if OUTPUT=$(gh issue create \
           --repo "$REPO" \
           --title "$TITLE" \
           --label "$LABEL" \
-          --assignee "${{ inputs.assignee }}" \
-          --body "$BODY")
+          --body "$BODY" \
+          --assignee "${{ inputs.assignee }}" 2>&1); then
 
-        echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+          ISSUE_URL="$OUTPUT"
+          echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+
+          # Extract issue number from URL
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+
+          # Configure project fields if project_token is provided
+          if [[ -n "${{ inputs.project_token }}" ]]; then
+            echo "Configuring project fields..."
+            export GITHUB_TOKEN="${{ inputs.project_token }}"
+
+            # Add issue to project first
+            gh project item-add 86 --owner wazuh --url "$ISSUE_URL"
+
+            # Configure project fields
+            bash .github/scripts/configure-project-fields.sh "$ISSUE_NUMBER" "$RELEASE" "$STAGE"
+          else
+            echo "No project token provided, skipping project configuration"
+          fi
+        else
+          echo "Error creating issue: $OUTPUT"
+          exit 1
+        fi

--- a/.github/actions/4_operational_prerelease_wpk_tests_issue/action.yml
+++ b/.github/actions/4_operational_prerelease_wpk_tests_issue/action.yml
@@ -19,6 +19,10 @@ inputs:
   github_token:
     description: 'GitHub token'
     required: true
+  project_token:
+    description: 'GitHub token with project permissions (optional, for project configuration)'
+    required: false
+    default: ''
 outputs:
   issue_url:
     description: 'URL of the created issue'
@@ -38,6 +42,7 @@ runs:
         PREV_ISSUE="${{ inputs.prev_issue }}"
 
         REPO="wazuh/wazuh"
+        PROJECT="XDR+SIEM/Agent team"
         LABEL="level/task,type/test"
         TITLE="Release $RELEASE - $STAGE - WPK Upgrade Tests"
         TAG="v$RELEASE-$(echo ${STAGE// /} | tr '[:upper:]' '[:lower:]')"
@@ -149,11 +154,33 @@ runs:
         EOF
         )
 
-        ISSUE_URL=$(gh issue create \
+        if OUTPUT=$(gh issue create \
           --repo "$REPO" \
           --title "$TITLE" \
           --label "$LABEL" \
-          --assignee "${{ inputs.assignee }}" \
-          --body "$BODY")
+          --body "$BODY" \
+          --assignee "${{ inputs.assignee }}" 2>&1); then
 
-        echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+          ISSUE_URL="$OUTPUT"
+          echo "issue_url=$ISSUE_URL" >> $GITHUB_OUTPUT
+
+          # Extract issue number from URL
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oP '\d+$')
+
+          # Configure project fields if project_token is provided
+          if [[ -n "${{ inputs.project_token }}" ]]; then
+            echo "Configuring project fields..."
+            export GITHUB_TOKEN="${{ inputs.project_token }}"
+
+            # Add issue to project first
+            gh project item-add 86 --owner wazuh --url "$ISSUE_URL"
+
+            # Configure project fields
+            bash .github/scripts/configure-project-fields.sh "$ISSUE_NUMBER" "$RELEASE" "$STAGE"
+          else
+            echo "No project token provided, skipping project configuration"
+          fi
+        else
+          echo "Error creating issue: $OUTPUT"
+          exit 1
+        fi

--- a/.github/scripts/configure-project-fields.sh
+++ b/.github/scripts/configure-project-fields.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# Script to configure GitHub Project fields for an issue
+# Usage: configure-project-fields.sh <issue_number> <release> <stage>
+
+set -e
+
+ISSUE_NUMBER=$1
+RELEASE=$2
+STAGE=$3
+
+if [[ -z "$ISSUE_NUMBER" || -z "$RELEASE" || -z "$STAGE" ]]; then
+  echo "Usage: $0 <issue_number> <release> <stage>"
+  exit 1
+fi
+
+REPO="wazuh/wazuh"
+PROJECT_NUMBER=86  # XDR+SIEM/Agent team project number
+
+echo "Configuring fields for issue #$ISSUE_NUMBER in project..."
+
+# Determine release type based on version
+if [[ "$RELEASE" =~ \.0\.0$ ]]; then
+  RELEASE_TYPE="Major"
+elif [[ "$RELEASE" =~ \.0$ ]]; then
+  RELEASE_TYPE="Minor"
+else
+  RELEASE_TYPE="Patch"
+fi
+
+echo "Release: $RELEASE"
+echo "Stage: $STAGE"
+echo "Release Type: $RELEASE_TYPE"
+
+# Get issue node ID and project item ID
+echo ""
+echo "Fetching issue and project data..."
+ISSUE_DATA=$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        id
+        projectItems(first: 10) {
+          nodes {
+            id
+            project {
+              ... on ProjectV2 {
+                id
+                number
+                title
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner='wazuh' -f repo='wazuh' -F number=$ISSUE_NUMBER)
+
+# Find the project item that matches our project number
+PROJECT_ID=$(echo "$ISSUE_DATA" | jq -r ".data.repository.issue.projectItems.nodes[] | select(.project.number==$PROJECT_NUMBER) | .project.id")
+ITEM_ID=$(echo "$ISSUE_DATA" | jq -r ".data.repository.issue.projectItems.nodes[] | select(.project.number==$PROJECT_NUMBER) | .id")
+
+if [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]]; then
+  echo "Error: Issue #$ISSUE_NUMBER not found in project #$PROJECT_NUMBER"
+  echo "Make sure the issue was created with --project flag"
+  exit 1
+fi
+
+echo "✓ Issue found in project"
+echo "Project ID: $PROJECT_ID"
+echo "Item ID: $ITEM_ID"
+
+# Get field IDs from the project
+FIELDS_DATA=$(gh api graphql -f query='
+  query($org: String!, $number: Int!) {
+    organization(login: $org) {
+      projectV2(number: $number) {
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2Field {
+              id
+              name
+            }
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -f org='wazuh' -F number=$PROJECT_NUMBER)
+
+# Extract field IDs
+STATUS_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Status") | .id')
+OBJECTIVE_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Objective") | .id')
+PRIORITY_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Priority") | .id')
+SIZE_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Size") | .id')
+RELEASE_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Release") | .id')
+STAGE_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Stage") | .id')
+RELEASE_TYPE_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Release type") | .id')
+CHANGELOG_FIELD_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Changelog") | .id')
+
+# Extract option IDs for single-select fields
+STATUS_BACKLOG_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Status") | .options[] | select(.name=="Backlog") | .id')
+PRIORITY_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Priority") | .options[] | select(.name=="Urgent") | .id')
+SIZE_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Size") | .options[] | select(.name=="Small") | .id')
+CHANGELOG_DONE_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Changelog") | .options[] | select(.name=="Done") | .id')
+
+# Find Stage option ID based on the provided stage value
+STAGE_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r --arg stage "$STAGE" '.data.organization.projectV2.fields.nodes[] | select(.name=="Stage") | .options[] | select(.name==$stage) | .id')
+
+# Find Release Type option ID based on version
+if [[ "$RELEASE_TYPE" == "Major" ]]; then
+  RELEASE_TYPE_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Release type") | .options[] | select(.name=="Major") | .id')
+elif [[ "$RELEASE_TYPE" == "Minor" ]]; then
+  RELEASE_TYPE_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Release type") | .options[] | select(.name=="Minor") | .id')
+else
+  RELEASE_TYPE_OPTION_ID=$(echo "$FIELDS_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name=="Release type") | .options[] | select(.name=="Patch") | .id')
+fi
+
+# Function to update a single-select field
+update_field() {
+  local field_id=$1
+  local option_id=$2
+  local field_name=$3
+
+  if [[ -z "$field_id" || -z "$option_id" ]]; then
+    echo "Warning: Could not find field or option for $field_name"
+    return 1
+  fi
+
+  gh api graphql -f query='
+    mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $project
+          itemId: $item
+          fieldId: $field
+          value: {
+            singleSelectOptionId: $value
+          }
+        }
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f value="$option_id" > /dev/null
+
+  echo "✓ Set $field_name"
+}
+
+# Function to update text field
+update_text_field() {
+  local field_id=$1
+  local text_value=$2
+  local field_name=$3
+
+  if [[ -z "$field_id" ]]; then
+    echo "Warning: Could not find field for $field_name"
+    return 1
+  fi
+
+  gh api graphql -f query='
+    mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $project
+          itemId: $item
+          fieldId: $field
+          value: {
+            text: $value
+          }
+        }
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f field="$field_id" -f value="$text_value" > /dev/null
+
+  echo "✓ Set $field_name = $text_value"
+}
+
+# Update all fields
+echo ""
+echo "Updating project fields..."
+update_field "$STATUS_FIELD_ID" "$STATUS_BACKLOG_OPTION_ID" "Status"
+update_text_field "$OBJECTIVE_FIELD_ID" "Release testing" "Objective"
+update_field "$PRIORITY_FIELD_ID" "$PRIORITY_OPTION_ID" "Priority"
+update_field "$SIZE_FIELD_ID" "$SIZE_OPTION_ID" "Size"
+update_text_field "$RELEASE_FIELD_ID" "$RELEASE" "Release"
+update_field "$STAGE_FIELD_ID" "$STAGE_OPTION_ID" "Stage"
+update_field "$RELEASE_TYPE_FIELD_ID" "$RELEASE_TYPE_OPTION_ID" "Release type"
+update_field "$CHANGELOG_FIELD_ID" "$CHANGELOG_DONE_OPTION_ID" "Changelog"
+
+echo ""
+echo "✅ Issue #$ISSUE_NUMBER successfully configured in project"

--- a/.github/workflows/4_operational_prerelease_issues.yml
+++ b/.github/workflows/4_operational_prerelease_issues.yml
@@ -86,6 +86,7 @@ jobs:
           prev_issue: ${{ inputs.prev_ut }}
           assignee: ${{ github.actor }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          project_token: ${{ secrets.GH_PAT_WRITE_PROJECT }}
 
   create-coverity-issue:
     name: "Create Coverity Analysis Issue"
@@ -108,6 +109,7 @@ jobs:
           prev_issue: ${{ inputs.prev_cov }}
           assignee: ${{ github.actor }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          project_token: ${{ secrets.GH_PAT_WRITE_PROJECT }}
 
   create-integration-tests-issue:
     name: "Create Integration Tests Issue"
@@ -130,6 +132,7 @@ jobs:
           prev_issue: ${{ inputs.prev_it }}
           assignee: ${{ github.actor }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          project_token: ${{ secrets.GH_PAT_WRITE_PROJECT }}
 
   create-wpk-tests-issue:
     name: "Create WPK Tests Issue"
@@ -152,6 +155,7 @@ jobs:
           prev_issue: ${{ inputs.prev_wpk }}
           assignee: ${{ github.actor }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          project_token: ${{ secrets.GH_PAT_WRITE_PROJECT }}
 
   summary:
     name: "Workflow Result"


### PR DESCRIPTION
## Description

This pull request updates the pre-release issue creation workflow to improve automation and project tracking.

## Proposed Changes

- Issues created by the workflow are assigned to the user who triggers the workflow.
- Issues are automatically added to the backlog of the Agent project, with relevant project fields populated.
- The issue type (Task) is not set, as this feature is not yet supported by the GitHub API.

### Results and Evidence

Issues are now assigned to the correct user and appear in the Agent project backlog with populated fields:

<img width="1284" height="1026" alt="image" src="https://github.com/user-attachments/assets/e9dd301c-c738-44d8-8204-a2e9355abc21" />

### Artifacts Affected

- Pre-release issue creation workflow
- Secret: `GH_PAT_WRITE_PROJECT`

### Configuration Changes

- No configuration changes outside the workflow and secret usage.

### Documentation Updates

- Not applicable.

### Tests Introduced

- Not applicable.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues