### PR TITLE
Update README screenshot URLs to use main

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,31 +77,31 @@ The Wazuh WUI provides a powerful user interface for data visualization and anal
 
 **Modules overview**
 
-![Modules overview](https://github.com/wazuh/wazuh-dashboard-plugins/raw/master/screenshots/app.png)
+![Modules overview](https://github.com/wazuh/wazuh-dashboard-plugins/raw/main/screenshots/app.png)
 
 **Security events**
 
-![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/screenshots/app2.png)
+![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/screenshots/app2.png)
 
 **Integrity monitoring**
 
-![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/screenshots/app3.png)
+![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/screenshots/app3.png)
 
 **Vulnerability detection**
 
-![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/screenshots/app4.png)
+![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/screenshots/app4.png)
 
 **Regulatory compliance**
 
-![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/screenshots/app5.png)
+![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/screenshots/app5.png)
 
 **Agents overview**
 
-![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/screenshots/app6.png)
+![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/screenshots/app6.png)
 
 **Agent summary**
 
-![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/screenshots/app7.png)
+![Overview](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/screenshots/app7.png)
 
 ## Orchestration
 

--- a/architecture/centralized_configuration/001-sequence.puml
+++ b/architecture/centralized_configuration/001-sequence.puml
@@ -30,14 +30,14 @@ end
 
 loop
     wclusterd -> mclusterd: sync
-    rnote over wclusterd, mclusterd: [[https://github.com/wazuh/wazuh/blob/master/framework/wazuh/core/cluster/cluster.json sync file list]]
+    rnote over wclusterd, mclusterd: [[https://github.com/wazuh/wazuh/blob/main/framework/wazuh/core/cluster/cluster.json sync file list]]
     mclusterd --> wclusterd: delta
 end
 
 loop every <client> notify_time
     opt merged.mg hash not cached
         agent -> agent: hash current merged.mg and\nsave it into cache value
-    end 
+    end
     workerremote <- agent: send agent status\n(uname, labels, ip, merged.mg hash, labels ip)
     workerremote -> workerremote: update agent status
     opt agent's and worker's merged.mg differ\n(based on their hashes)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Updates README (and any related documentation references, if present) to replace screenshot URLs that still point to the deprecated master branch of wazuh-dashboard-plugins with the correct main branch, restoring broken images.

Closes #32588 

## Proposed Changes

- Replaced all occurrences of [https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/…](https://github.com/wazuh/wazuh-dashboard-plugins/blob/master/) with [https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/…](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/) in the README.

### Results and Evidence

<img width="881" height="811" alt="image" src="https://github.com/user-attachments/assets/db10399e-2ad9-4d9f-b91c-c1fd9fde99e7" />

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided

