### PR TITLE
Add socket-based keystore wrapper

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
@@ -15,12 +15,6 @@
 #include "loggerHelper.h"
 #include "serverSelector.hpp"
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-}; // namespace Log
-
 // LCOV_EXCL_START
 // Implementation of the facade IndexerConnectorSync
 class IndexerConnectorSync::Impl

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -25,12 +25,6 @@
 #include <thread>
 #include <utility>
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-}; // namespace Log
-
 // Template.
 static const auto TEMPLATE_FILE_PATH {std::filesystem::temp_directory_path() / "template.json"};
 static const auto TEMPLATE_DATA = R"(

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -20,12 +20,6 @@ constexpr auto SERVER_SELECTOR_HEALTH_CHECK_INTERVAL = 1u;
 constexpr auto SERVER_SELECTOR_HEALTH_CHECK_INTERVAL_ZERO = 0u;
 constexpr auto SERVER_SELECTOR_HEALTH_CHECK_INTERVAL_INFINITE = std::numeric_limits<uint32_t>::max();
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-}; // namespace Log
-
 /**
  * @brief Test instantiation with valid servers.
  */

--- a/src/shared_modules/keystore/src/keyStore.cpp
+++ b/src/shared_modules/keystore/src/keyStore.cpp
@@ -18,6 +18,12 @@ constexpr auto KS_NAME {"keystore"};
 constexpr auto KS_VERSION {"2"};
 constexpr auto KS_VERSION_FIELD {"version"};
 
+namespace Log
+{
+    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
+        GLOBAL_LOG_FUNCTION;
+};
+
 static void upgrade(Utils::RocksDBWrapper& keystoreDB, const std::string& columnFamily)
 {
     std::string versionValue;

--- a/src/shared_modules/keystore/src/main.cpp
+++ b/src/shared_modules/keystore/src/main.cpp
@@ -17,12 +17,6 @@
 #include <fstream>
 #include <functional>
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-}; // namespace Log
-
 int main(int argc, char* argv[])
 {
     std::string family;

--- a/src/shared_modules/keystore/tests/component/main.cpp
+++ b/src/shared_modules/keystore/tests/component/main.cpp
@@ -12,12 +12,6 @@
 #include "loggerHelper.h"
 #include "gtest/gtest.h"
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-}; // namespace Log
-
 int main(int argc, char** argv)
 {
     Log::assignLogFunction(

--- a/src/shared_modules/keystore/testtool/main.cpp
+++ b/src/shared_modules/keystore/testtool/main.cpp
@@ -14,12 +14,6 @@
 #include <functional>
 #include <iostream>
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-}; // namespace Log
-
 int main(int argc, char* argv[])
 {
     try

--- a/src/wazuh_modules/inventory_sync/src/inventorySync.cpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySync.cpp
@@ -13,12 +13,6 @@
 #include "cjsonSmartDeleter.hpp"
 #include "inventorySyncFacade.hpp"
 
-namespace Log
-{
-    std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
-        GLOBAL_LOG_FUNCTION;
-};
-
 void InventorySync::start(
     const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -15,9 +15,11 @@
 #include "agentSession.hpp"
 #include "flatbuffers/include/agentInfo_generated.h"
 #include "flatbuffers/include/inventorySync_generated.h"
+#include "keyStore.hpp"
 #include "loggerHelper.h"
 #include "routerSubscriber.hpp"
 #include "singleton.hpp"
+#include "socketServer.hpp"
 #include "stringHelper.h"
 #include <asyncValueDispatcher.hpp>
 #include <filesystem>
@@ -37,6 +39,7 @@ constexpr int DEFAULT_TIME {60 * 10}; // 10 minutes
 constexpr auto INVENTORY_SYNC_PATH {"inventory_sync"};
 constexpr auto INVENTORY_SYNC_TOPIC {"inventory-states"};
 constexpr auto INVENTORY_SYNC_SUBSCRIBER_ID {"inventory-sync-module"};
+constexpr auto SOCKET_KEYSTORE_PATH {"/var/ossec/queue/sockets/keystore"};
 
 using WorkersQueue = Utils::AsyncValueDispatcher<std::vector<char>, std::function<void(const std::vector<char>&)>>;
 using IndexerQueue = Utils::AsyncValueDispatcher<Response, std::function<void(const Response&)>>;
@@ -197,6 +200,78 @@ class InventorySyncFacadeImpl final
         {
             throw InventorySyncException("Invalid message buffer");
         }
+    }
+
+    void initializeKeystoreSocket()
+    {
+        m_keystoreSocketServer = std::make_unique<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>>(
+            SOCKET_KEYSTORE_PATH);
+
+        m_keystoreSocketServer->listen(
+            [keystoreServer = m_keystoreSocketServer.get()](
+                const int fd, const char* body, const uint32_t bodySize, const char*, const uint32_t)
+            {
+                std::string_view queryView(body, bodySize);
+                nlohmann::json result;
+
+                try
+                {
+                    size_t pos1 = queryView.find('|');
+                    size_t pos2 = queryView.find('|', pos1 + 1);
+                    size_t pos3 = queryView.find('|', pos2 + 1);
+
+                    if (pos1 == std::string_view::npos || pos2 == std::string_view::npos)
+                    {
+                        throw std::runtime_error("Invalid query format");
+                    }
+
+                    auto queryOp = queryView.substr(0, pos1);
+                    auto queryCf = queryView.substr(pos1 + 1, pos2 - pos1 - 1);
+                    auto key = (pos3 == std::string_view::npos) ? queryView.substr(pos2 + 1)
+                                                                : queryView.substr(pos2 + 1, pos3 - pos2 - 1);
+                    auto val = (pos3 == std::string_view::npos) ? std::string_view() : queryView.substr(pos3 + 1);
+
+                    if (queryOp == "GET")
+                    {
+                        std::string value;
+                        Keystore::get(std::string(queryCf), std::string(key), value);
+                        result["status"] = "ok";
+                        result["operation"] = "get";
+                        result["columnFamily"] = queryCf;
+                        result["key"] = key;
+                        result["value"] = value;
+                    }
+                    else if (queryOp == "PUT")
+                    {
+                        Keystore::put(std::string(queryCf), std::string(key), std::string(val));
+                        result["status"] = "ok";
+                        result["operation"] = "put";
+                        result["columnFamily"] = queryCf;
+                        result["key"] = key;
+                    }
+                    else if (queryOp == "DELETE")
+                    {
+                        Keystore::put(std::string(queryCf), std::string(key), "");
+                        result["status"] = "ok";
+                        result["operation"] = "delete";
+                        result["columnFamily"] = queryCf;
+                        result["key"] = key;
+                    }
+                    else
+                    {
+                        result["status"] = "error";
+                        result["message"] = "Unknown operation";
+                    }
+                }
+                catch (const std::exception& e)
+                {
+                    result["status"] = "error";
+                    result["message"] = e.what();
+                }
+
+                auto response = result.dump();
+                keystoreServer->send(fd, response.c_str(), response.size());
+            });
     }
 
 public:
@@ -443,6 +518,9 @@ public:
                 }
             });
 
+        // Init the socket server to attend keystore requests
+        initializeKeystoreSocket();
+
         logInfo(LOGGER_DEFAULT_TAG, "InventorySyncFacade started.");
     }
 
@@ -463,6 +541,7 @@ public:
         m_indexerQueue.reset();
         m_indexerConnector.reset();
         m_dataStore.reset();
+        m_keystoreSocketServer.reset();
     }
 
 private:
@@ -480,6 +559,7 @@ private:
     std::unique_ptr<TRouterSubscriber> m_inventorySubscription;
     std::map<uint64_t, TAgentSession, std::less<>> m_agentSessions;
     std::thread m_sessionTimeoutThread;
+    std::unique_ptr<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>> m_keystoreSocketServer;
 };
 
 using InventorySyncFacade = InventorySyncFacadeImpl<AgentSession,


### PR DESCRIPTION
## Description

This PR introduces a **Keystore socket server** that enables secure, language-agnostic access to the Wazuh Keystore from Python and other external clients via Unix domain sockets.

The implementation integrates directly with the existing `SocketServer` infrastructure (no wrapper class needed), providing:
- A lightweight socket listener that receives queries (e.g., `PUT|credentials|apikey|secret`)
- Direct execution of Keystore operations (encryption/decryption handled by existing Keystore)
- JSON responses with operation results

This design maintains security through file system permissions while enabling flexible, multi-language integration without shared library dependencies or ABI compatibility concerns.

## Changelog

### Added
* **Keystore socket server** - Direct integration with `SocketServer` for Keystore IPC access
* **Socket protocol** - Simple pipe-delimited format for operations
* **JSON response format** - Structured responses with status, operation type, and values

### Testing

On issue