### PR TITLE
Fix Wine crashes on winagent RTR tests

### DIFF
--- a/src/data_provider/src/extended_sources/browser_extensions/tests/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/browser_extensions/tests/CMakeLists.txt
@@ -39,5 +39,7 @@ target_link_libraries(extended_sources_browser_extensions_unit_test
   gtest_maind
   gmock_maind
   pthread
+  $<$<PLATFORM_ID:Windows>:-static-libgcc>
+  $<$<PLATFORM_ID:Windows>:-static-libstdc++>
 )
 add_test(NAME BrowsersExtensionsTests COMMAND extended_sources_browser_extensions_unit_test)

--- a/src/shared_modules/file_helper/file_io/tests/CMakeLists.txt
+++ b/src/shared_modules/file_helper/file_io/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ target_link_libraries(file_io_unit_test PRIVATE FileIO
     optimized gmock
     optimized gtest_main
     optimized gmock_main
+    $<$<PLATFORM_ID:Windows>:-static-libgcc>
+    $<$<PLATFORM_ID:Windows>:-static-libstdc++>
 )
 add_test(NAME FileIO COMMAND file_io_unit_test)
 set_tests_properties(FileIO PROPERTIES LABELS file_helper_utest)

--- a/src/shared_modules/file_helper/filesystem/tests/CMakeLists.txt
+++ b/src/shared_modules/file_helper/filesystem/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ target_link_libraries(filesystem_unit_test PRIVATE FilesystemWrapper
     optimized gmock
     optimized gtest_main
     optimized gmock_main
+    $<$<PLATFORM_ID:Windows>:-static-libgcc>
+    $<$<PLATFORM_ID:Windows>:-static-libstdc++>
 )
 add_test(NAME Filesystem COMMAND filesystem_unit_test)
 set_tests_properties(Filesystem PROPERTIES LABELS file_helper_utest)

--- a/src/shared_modules/sync_protocol/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/CMakeLists.txt
@@ -115,8 +115,8 @@ target_include_directories(agent_sync_protocol
 
 target_link_libraries(agent_sync_protocol
   PRIVATE
-    flatbuffers
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../external/sqlite/libsqlite3.a
+  flatbuffers
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../external/sqlite/libsqlite3.a
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/src/shared_modules/sync_protocol/tests/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ project(agent_sync_protocol_tests)
 set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
 
 if(FSANITIZE)
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address,leak,undefined")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address,leak,undefined")
 endif(FSANITIZE)
 
 message(STATUS "SRC_FOLDER is: ${SRC_FOLDER}")
@@ -35,7 +35,6 @@ target_include_directories(agent_sync_protocol_tests PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/..
 )
 
-# Link test executable to the main library and GTest
 target_link_libraries(agent_sync_protocol_tests
     PRIVATE
     agent_sync_protocol
@@ -45,5 +44,14 @@ target_link_libraries(agent_sync_protocol_tests
     optimized gmock
     pthread
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_custom_command(TARGET agent_sync_protocol_tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_CURRENT_BINARY_DIR}/../bin/libagent_sync_protocol.dll"
+        "$<TARGET_FILE_DIR:agent_sync_protocol_tests>/libagent_sync_protocol.dll"
+        COMMENT "Copying libagent_sync_protocol.dll to test directory"
+    )
+endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
 add_test(NAME agent_sync_protocol_tests COMMAND agent_sync_protocol_tests)


### PR DESCRIPTION
## Description

Several RTR workflows were failing due to crashes in Wine.

These crashes seemed to be related to missing libraries for the tests, namely libgcc and libstdc++.

This PR links statically to them in some tests, while fixing path resolution in the python scripts.
