### PR TITLE
Fix Logcollector file modification date retrieval on Windows

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -959,9 +959,6 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
                     fclose((*logf)[i].fp);
                 }
             #ifdef WIN32
-                if ((*logf)[i].h && (*logf)[i].h != INVALID_HANDLE_VALUE) {
-                    CloseHandle((*logf)[i].h);
-                }
                 pthread_mutex_destroy(&(*logf)[i].mutex);
             #endif
             }

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -201,7 +201,6 @@ typedef struct _logreader {
     dev_t dev;
 
 #ifdef WIN32
-    HANDLE h;
     DWORD fd;
 #else
     ino_t fd;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1131,10 +1131,6 @@ void close_file(logreader * lf) {
     fgetpos(lf->fp, &lf->position);
     fclose(lf->fp);
     lf->fp = NULL;
-
-#ifdef WIN32
-    lf->h = NULL;
-#endif
 }
 
 #ifdef WIN32
@@ -2176,7 +2172,6 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                         mdebug1("Ignoring file '%s' due to modification time",current->file);
                         fclose(current->fp);
                         current->fp = NULL;
-                        current->h = NULL;
                         w_mutex_unlock(&current->mutex);
                         rwlock_unlock(&files_update_rwlock);
                         continue;


### PR DESCRIPTION
## Description

This pull request addresses a regression introduced in PR #21791, which caused the Wazuh agent on Windows to incorrectly determine file modification dates when collecting logs. As a result, log files were sometimes considered "infinitely old" and ignored during log collection.

This PR closes https://github.com/wazuh/wazuh/issues/32689.

Thanks to @awest-zehntek for reporting this bug.

## Proposed Changes

- Retrieve the file modification date using the file pointer instead of the file handle.  
- This change is applied for both Windows and UNIX environments to maintain consistency.

### Results and Evidence

#### Configuration

```xml
<localfile>
  <location>D:\Test\%d.log</location>
  <log_format>syslog</log_format>
  <age>1d</age>
</localfile>
```

#### Logs before this change

> 2025/10/20 09:10:12 wazuh-agent: DEBUG: Trace: File 'D:\Test\20.log' has no modification time. Skipping age check.
> 2025/10/20 09:10:12 wazuh-agent: DEBUG: Ignoring file 'D:\Test\20.log' due to modification time
> 2025/10/20 09:10:12 wazuh-agent: DEBUG: Trace: Current time: 1760944212 - Age: 86400 >= File time: -11644473600

#### Logs after this change

> 2025/10/20 10:56:44 wazuh-agent: INFO: (1950): Analyzing file: 'D:\Test\20.log'.

#### Archives
 
> 2025 Oct 20 10:57:20 (Rocky) any->D:\Test\20.log Hello World!

### Artifacts Affected

- wazuh-agent.exe (Windows)

### Configuration Changes

None.

### Documentation Updates

Not applicable.

### Tests Introduced

Manual testing performed.

No automated tests affected or introduced.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues