### PR TITLE
Windows Server 2016 SCA policy not configured correctly

### DIFF
--- a/ruleset/sca/windows/cis_win2016.yml
+++ b/ruleset/sca/windows/cis_win2016.yml
@@ -786,7 +786,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa'
       - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> TurnOffAnonymousBlock'
-      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> TurnOffAnonymousBlock -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> TurnOffAnonymousBlock -> 1'
 
   # 2.3.10.2 (L1) Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled' (MS only). (Automated)
   - id: 16035
@@ -2211,7 +2211,7 @@ checks:
       - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:auditpol /get /subcategory:"PNP Activity" -> r:Success'
+      - 'c:auditpol /get /subcategory:"Plug and Play Events" -> r:Success'
 
   # 17.3.2 (L1) Ensure 'Audit Process Creation' is set to include 'Success'. (Automated)
   - id: 16105
@@ -2465,7 +2465,7 @@ checks:
       - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:auditpol /get /subcategory:"Audit Other Object Access Events" -> r:Success and Failure'
+      - 'c:auditpol /get /subcategory:"Other Object Access Events" -> r:Success and Failure'
 
   # 17.6.4 (L1) Ensure 'Audit Removable Storage' is set to 'Success and Failure'. (Automated)
   - id: 16117
@@ -3381,7 +3381,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 0'
 
   # 18.6.5.1 (L2) Ensure 'Enable Font Providers' is set to 'Disabled'. (Automated)
   - id: 16161
@@ -3533,7 +3533,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> NC_ShowSharedAccessUI'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> NC_ShowSharedAccessUI -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections -> NC_ShowSharedAccessUI -> 0'
 
   # 18.6.11.4 (L1) Ensure 'Require domain users to elevate when setting a network's location' is set to 'Enabled'. (Automated)
   - id: 16168
@@ -3687,7 +3687,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers'
       - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers -> RegisterSpoolerRemoteRpcEndPoint'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers -> RegisterSpoolerRemoteRpcEndPoint -> 0'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers -> RegisterSpoolerRemoteRpcEndPoint -> 2'
 
   # 18.7.2 (L1) Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirection Guard Enabled'. (Automated)
   - id: 16176
@@ -3841,7 +3841,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
       - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> NoWarningNoElevationOnInstall -> 0'
 
   # 18.7.11 (L1) Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'. (Automated)
   - id: 16185
@@ -3863,7 +3863,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
       - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> UpdatePromptSettings'
-      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> UpdatePromptSettings -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint -> UpdatePromptSettings -> 0'
 
   # 18.8.1.1 (L2) Ensure 'Turn off notifications network usage' is set to 'Enabled'. (Automated)
   - id: 16186
@@ -3927,7 +3927,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters -> AllowEncryptionOracle'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters -> AllowEncryptionOracle -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters -> AllowEncryptionOracle -> 0'
 
   # 18.9.4.2 (L1) Ensure 'Remote host allows delegation of non- exportable credentials' is set to 'Enabled'. (Automated)
   - id: 16189


### PR DESCRIPTION
# Description 

Hi team,
This is a continuation of issue #6511 . The customer also reported the following policies, which are misconfigured:

- ID 16034 → CIS 2.3.10.1 Variable TurnOffAnonymousBlock must be value 1

- ID 16160 → CIS 18.6.4.2 Variable EnableMulticast must be value 0 

- ID 16167 → CIS 18.6.11.3 Variable  NC_ShowSharedAccessUI must be value  0

- ID 16175 → CIS 18.7.1 The variable must be 2, not 0

- ID 16184 → CIS 18.7.10 The variable must be 0

- ID 16185 → CIS 18.7.11 The variable must be 0

- ID 16188 → CIS 18.9.4.1 The variable must be 0

This is according to CIS 4.0:  [CIS_Microsoft_Windows_Server_2016_Benchmark_v4.0.0.pdf](https://github.com/user-attachments/files/22915033/CIS_Microsoft_Windows_Server_2016_Benchmark_v4.0.0.pdf)

They also created this report with their findings (some parts are in spanish): [ObservacionesWazuh.pdf](https://github.com/user-attachments/files/22915091/ObservacionesWazuh.pdf)

The customer requests that these fixes be added to the next version.

I'll be waiting for your comments.

# Approved by

DRI name: @gascoj 
