### PR TITLE
Maintain unified vendor name, remove email filter in IT Hygiene

### DIFF
--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -70,7 +70,6 @@ namespace PackageLinuxHelper
             std::string source {UNKNOWN_VALUE};
             std::string version {UNKNOWN_VALUE};
             std::string vendor {UNKNOWN_VALUE};
-            std::string email {UNKNOWN_VALUE};
             std::string description {UNKNOWN_VALUE};
             int64_t size { 0 };
 
@@ -127,7 +126,7 @@ namespace PackageLinuxHelper
 
             if (it != info.end())
             {
-                Utils::splitMaintainerField(it->second, vendor, email);
+                vendor = it->second;
             }
 
             it = info.find("Description");
@@ -162,7 +161,6 @@ namespace PackageLinuxHelper
         std::string name;
         std::string version;
         std::string vendor       { UNKNOWN_VALUE };
-        std::string email        { UNKNOWN_VALUE };
         std::string install_time { UNKNOWN_VALUE };
         std::string description  { UNKNOWN_VALUE };
         int64_t     size         { 0 };
@@ -201,7 +199,7 @@ namespace PackageLinuxHelper
 
             if (publisher.contains("display-name"))
             {
-                Utils::splitMaintainerField(publisher.at("display-name"), vendor, email);
+                vendor = publisher.at("display-name");
             }
         }
 

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
@@ -26,8 +26,6 @@ namespace PackageLinuxHelper
     {
         nlohmann::json ret;
         auto version { package.version };
-        std::string vendor       { UNKNOWN_VALUE };
-        std::string email        { UNKNOWN_VALUE };
 
         if (package.epoch)
         {
@@ -41,10 +39,6 @@ namespace PackageLinuxHelper
 
         if (package.name.compare("gpg-pubkey") != 0 && !package.name.empty())
         {
-            if (!package.vendor.empty())
-            {
-                Utils::splitMaintainerField(package.vendor, vendor, email);
-            }
 
             ret["name"]         = package.name;
             ret["size"]         = package.size;
@@ -56,7 +50,7 @@ namespace PackageLinuxHelper
             ret["architecture"] = package.architecture;
             ret["source"]       = UNKNOWN_VALUE;
             ret["format"]       = "rpm";
-            ret["vendor"]       = vendor;
+            ret["vendor"]       = package.vendor.empty() ? UNKNOWN_VALUE : package.vendor;
             ret["description"]  = package.description;
         }
 

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
@@ -28,8 +28,6 @@ namespace PackageLinuxHelper
         nlohmann::json ret;
         const auto fields { Utils::split(packageInfo, '\t') };
         constexpr auto DEFAULT_VALUE { "(none)" };
-        std::string vendor       { UNKNOWN_VALUE };
-        std::string email        { UNKNOWN_VALUE };
 
         if (RPMFields::RPM_FIELDS_SIZE <= fields.size())
         {
@@ -42,7 +40,7 @@ namespace PackageLinuxHelper
                 std::string groups       { fields.at(RPMFields::RPM_FIELDS_GROUPS) };
                 std::string version      { fields.at(RPMFields::RPM_FIELDS_VERSION) };
                 std::string architecture { fields.at(RPMFields::RPM_FIELDS_ARCHITECTURE) };
-                std::string publisher    { fields.at(RPMFields::RPM_FIELDS_VENDOR) };
+                std::string vendor       { fields.at(RPMFields::RPM_FIELDS_VENDOR) };
                 std::string description  { fields.at(RPMFields::RPM_FIELDS_SUMMARY) };
 
                 std::string release      { fields.at(RPMFields::RPM_FIELDS_RELEASE) };
@@ -58,11 +56,6 @@ namespace PackageLinuxHelper
                     version += "-" + release;
                 }
 
-                if (!publisher.empty() && publisher.compare(DEFAULT_VALUE) != 0)
-                {
-                    Utils::splitMaintainerField(publisher, vendor, email);
-                }
-
                 ret["name"]         = name;
                 ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoll(size);
                 ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : install_time;
@@ -73,7 +66,7 @@ namespace PackageLinuxHelper
                 ret["architecture"] = architecture.empty() || architecture.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : architecture;
                 ret["source"]       = UNKNOWN_VALUE;
                 ret["format"]       = "rpm";
-                ret["vendor"]       = vendor;
+                ret["vendor"]       = vendor.empty() || vendor.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : vendor;
                 ret["description"]  = description.empty() || description.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : description;
                 // The multiarch field won't have a default value
             }

--- a/src/data_provider/src/sysInfoFreeBSD.cpp
+++ b/src/data_provider/src/sysInfoFreeBSD.cpp
@@ -236,13 +236,9 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
         {
             const auto data{Utils::split(line, '|')};
             nlohmann::json package;
-            std::string vendor       { UNKNOWN_VALUE };
-            std::string email        { UNKNOWN_VALUE };
-
-            Utils::splitMaintainerField(data[1], vendor, email);
 
             package["name"] = data[0];
-            package["vendor"] = vendor;
+            package["vendor"] = data[1];
             package["version"] = data[2];
             package["install_time"] = UNKNOWN_VALUE;
             package["location"] = UNKNOWN_VALUE;

--- a/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -324,7 +324,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)
     EXPECT_EQ("1:1.2.11.dfsg-2ubuntu1.2", jsPackageInfo["version"]);
     EXPECT_EQ("amd64", jsPackageInfo["architecture"]);
     EXPECT_EQ("deb", jsPackageInfo["format"]);
-    EXPECT_EQ("Ubuntu Developers", jsPackageInfo["vendor"]);
+    EXPECT_EQ("Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>", jsPackageInfo["vendor"]);
     EXPECT_EQ("compression library - development", jsPackageInfo["description"]);
     EXPECT_EQ("zlib", jsPackageInfo["source"]);
 }

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -546,30 +546,6 @@ namespace Utils
 
         return tokens;
     }
-    /**
-     * @brief Split a maintainer field into name and email.
-     *
-     * @param input Input string containing the maintainer field.
-     * @param name Output parameter for the name.
-     * @param email Output parameter for the email.
-     */
-    static void splitMaintainerField(const std::string& input, std::string& name, std::string& email)
-    {
-        const auto start = input.find('<');
-        const auto end = input.find('>');
-
-        if (start != std::string::npos && end != std::string::npos && start < end)
-        {
-            name  = Utils::trim(input.substr(0, start));
-            email = input.substr(start + 1, end - start - 1);
-        }
-        else
-        {
-            name = input;
-            email.clear();
-        }
-    }
-
 #if __cplusplus >= 201703L
 
     static bool startsWith(std::string_view str, std::string_view start)

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -685,28 +685,6 @@ TEST_F(StringUtilsTest, splitToNumbers)
     EXPECT_ANY_THROW({ ret = Utils::splitToNumbers("1.1.1", ' '); });
 }
 
-TEST_F(StringUtilsTest, splitMaintainerField)
-{
-    std::string name;
-    std::string email;
-
-    Utils::splitMaintainerField("Test name <test@example.com>", name, email);
-    EXPECT_EQ(name,  "Test name");
-    EXPECT_EQ(email, "test@example.com");
-
-    Utils::splitMaintainerField("<test@example.com>", name, email);
-    EXPECT_EQ(name,  "");
-    EXPECT_EQ(email, "test@example.com");
-
-    Utils::splitMaintainerField("Test name", name, email);
-    EXPECT_EQ(name,  "Test name");
-    EXPECT_EQ(email, "");
-
-    Utils::splitMaintainerField("", name, email);
-    EXPECT_EQ(name,  "");
-    EXPECT_EQ(email, "");
-}
-
 #if __cplusplus >= 201703L
 
 TEST_F(StringUtilsTest, SplitEmptyStringSV)


### PR DESCRIPTION
## Description

This PR maintains the unified vendor name ("Wazuh" instead of "Wazuh, Inc") across packages, but now allows the package manager to decide whether to include the email address in the vendor field. The filter that removed the email from the vendor field has been reverted. If the package manager includes the email, it will appear in the metadata.

## Proposed Changes

- Reverted logic that filtered out the email from the vendor field.
- Vendor field will now reflect the output provided by each package manager.
- Provided a wazuh-agent package with the changes applied for testing.

### Results and Evidence

#### Testing package

📦 [wazuh-agent_4.14.1-0_amd64_5b897d0.zip](https://github.com/user-attachments/files/23121542/wazuh-agent_4.14.1-0_amd64_5b897d0.zip)

#### Package metadata

Package metadata for versions 4.14.0 and 4.14.1 (proposed) show no change in vendor, still including the email.

```shell
dpkg -s wazuh-agent
```

<details><summary>4.14.0</summary>

```
Package: wazuh-agent
Status: install ok installed
Priority: extra
Section: admin
Installed-Size: 46814
Maintainer: Wazuh <info@wazuh.com>
Architecture: amd64
Version: 4.14.0-1
Depends: libc6 (>= 2.7), lsb-release, debconf, adduser, procps
Breaks: ossec-hids, ossec-hids-agent, wazuh-manager
Conflicts: ossec-hids, ossec-hids-agent, wazuh-api, wazuh-manager
Conffiles:
 /etc/systemd/system/wazuh-agent.service daebdc25d7e200621a15b1b2f2d14720
 /etc/init.d/wazuh-agent c345ae4ebe96bdfac36a7979acd3905a
Description: Wazuh agent
 Wazuh helps you to gain security visibility into your infrastructure by
 monitoring hosts at an operating system and application level. It provides
 the following capabilities: log analysis, file integrity monitoring,
 intrusions detection and policy and compliance monitoring.
Homepage: https://www.wazuh.com
```

</details>

<details><summary>4.14.1 (proposed)</summary>

```
Package: wazuh-agent
Status: install ok installed
Priority: extra
Section: admin
Installed-Size: 47196
Maintainer: Wazuh <info@wazuh.com>
Architecture: amd64
Version: 4.14.1-0
Depends: libc6 (>= 2.7), lsb-release, debconf, adduser, procps
Breaks: ossec-hids, ossec-hids-agent, wazuh-manager
Conflicts: ossec-hids, ossec-hids-agent, wazuh-api, wazuh-manager
Conffiles:
 /etc/systemd/system/wazuh-agent.service daebdc25d7e200621a15b1b2f2d14720
 /etc/init.d/wazuh-agent c345ae4ebe96bdfac36a7979acd3905a
Description: Wazuh agent
 Wazuh helps you to gain security visibility into your infrastructure by
 monitoring hosts at an operating system and application level. It provides
 the following capabilities: log analysis, file integrity monitoring,
 intrusions detection and policy and compliance monitoring.
Homepage: https://www.wazuh.com
```

</details>

#### IT Hyiene Dashboard

IT Hygiene dashboard displays the email in the vendor field for DEB packages.

|4.14.0|4.14.1 (proposed)|
|--|--|
| <img width="1679" height="1135" alt="Screenshot 2025-10-24 120847" src="https://github.com/user-attachments/assets/85b97350-8963-4b75-98a0-094b9619c0a2" /> | <img width="1676" height="1088" alt="Screenshot 2025-10-24 120823" src="https://github.com/user-attachments/assets/9c37560b-89be-42cd-b647-a9946d6eda25" /> |

#### Capture of wazuh-agent Package

<details><summary>4.14.0</summary>

```json
{
  "_index": "wazuh-states-inventory-packages-wazuh.manager",
  "_id": "002_a80f14b651e862b7784dee115be1ad99d9595c3b",
  "_score": null,
  "_source": {
    "agent": {
      "id": "002",
      "name": "Rocket-old",
      "version": "v4.14.0"
    },
    "package": {
      "architecture": "amd64",
      "description": "Wazuh agent",
      "name": "wazuh-agent",
      "size": 47937536,
      "type": "deb",
      "vendor": "Wazuh",
      "version": "4.14.0-1"
    },
    "wazuh": {
      "cluster": {
        "name": "wazuh.manager"
      },
      "schema": {
        "version": "1.0"
      }
    }
  },
  "sort": [
    "wazuh-agent"
  ]
}
```

</details>

<details><summary>4.14.1 (proposed)</summary>

```json
{
  "_index": "wazuh-states-inventory-packages-wazuh.manager",
  "_id": "001_b79cc0cbba7e2f804472ad843e749d9f1e22cb87",
  "_score": null,
  "_source": {
    "agent": {
      "id": "001",
      "name": "Rocket",
      "version": "v4.14.1"
    },
    "package": {
      "architecture": "amd64",
      "description": "Wazuh agent",
      "name": "wazuh-agent",
      "size": 48328704,
      "type": "deb",
      "vendor": "Wazuh <info@wazuh.com>",
      "version": "4.14.1-0"
    },
    "wazuh": {
      "cluster": {
        "name": "wazuh.manager"
      },
      "schema": {
        "version": "1.0"
      }
    }
  },
  "sort": [
    "wazuh-agent"
  ]
}
```

</details>

#### Vulnerability Detector Dashboard Screenshot

388 vulnerabilities detected in both versions:

|Filter|4.14.0|4.14.1 (proposed)|
|--|--|--|
| All vulnerabilities | <img width="1677" height="949" alt="image" src="https://github.com/user-attachments/assets/a348a2c4-b150-453d-a90c-e0096a8aa00d" /> | <img width="1675" height="947" alt="Screenshot 2025-10-24 120519" src="https://github.com/user-attachments/assets/9ef42b89-af2d-42c2-ab10-ae131cd1231c" /> |
| Canonical only | <img width="1676" height="953" alt="Screenshot 2025-10-24 115938" src="https://github.com/user-attachments/assets/3443dac7-6b83-4799-81be-8278b032f597" /> | <img width="1677" height="955" alt="Screenshot 2025-10-24 120623" src="https://github.com/user-attachments/assets/c81a83ab-fcfd-4c72-94fd-8c0d4bb1f726" /> |

#### Vulnerability Example

`source` field is "Canonical" in both versions:

<details><summary>4.14.0</summary>

```json
{
  "_index": "wazuh-states-inventory-packages-wazuh.manager",
  "_id": "002_a80f14b651e862b7784dee115be1ad99d9595c3b",
  "_score": null,
  "_source": {
    "agent": {
      "id": "002",
      "name": "Rocket-old",
      "version": "v4.14.0"
    },
    "package": {
      "architecture": "amd64",
      "description": "Wazuh agent",
      "name": "wazuh-agent",
      "size": 47937536,
      "type": "deb",
      "vendor": "Wazuh",
      "version": "4.14.0-1"
    },
    "wazuh": {
      "cluster": {
        "name": "wazuh.manager"
      },
      "schema": {
        "version": "1.0"
      }
    }
  },
  "sort": [
    "wazuh-agent"
  ]
}
```

</details>

<details><summary>4.14.1 (proposed)</summary>

```json
{
  "_index": "wazuh-states-vulnerabilities-wazuh.manager",
  "_id": "001_59189d9bcc80a5e664a5313f8c664f3fed40b5c3_CVE-2022-27943_2689703",
  "_score": 0,
  "_source": {
    "agent": {
      "id": "001",
      "name": "Rocket",
      "type": "Wazuh",
      "version": "v4.14.1"
    },
    "host": {
      "os": {
        "full": "Ubuntu 24.04.2 LTS (Noble Numbat)",
        "kernel": "6.6.87.2-microsoft-standard-WSL2",
        "name": "Ubuntu",
        "platform": "ubuntu",
        "type": "ubuntu",
        "version": "24.04.2"
      }
    },
    "package": {
      "architecture": "amd64",
      "description": "GNU C compiler",
      "name": "gcc-11",
      "size": 54589440,
      "type": "deb",
      "version": "11.4.0-9ubuntu1"
    },
    "vulnerability": {
      "category": "Packages",
      "classification": "-",
      "description": "libiberty/rust-demangle.c in GNU GCC 11.2 allows stack consumption indemangle_const, as demonstrated by nm-new.",
      "detected_at": "2025-10-24T09:44:29.093Z",
      "enumeration": "CVE",
      "id": "CVE-2022-27943",
      "published_at": "2022-03-26T13:15:07Z",
      "reference": "https://ubuntu.com/security/CVE-2022-27943, https://www.cve.org/CVERecord?id=CVE-2022-27943",
      "scanner": {
        "condition": "Package default status",
        "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2022-27943",
        "source": "Canonical Security Tracker",
        "vendor": "Wazuh"
      },
      "score": {
        "base": 5.5,
        "version": "3.1"
      },
      "severity": "Medium",
      "under_evaluation": false
    },
    "wazuh": {
      "cluster": {
        "name": "wazuh.manager"
      },
      "schema": {
        "version": "1.0.0"
      }
    }
  },
  "fields": {
    "vulnerability.detected_at": [
      "2025-10-24T09:44:29.093Z"
    ],
    "vulnerability.published_at": [
      "2022-03-26T13:15:07.000Z"
    ]
  }
}
```

</details>

> [!IMPORTANT]
> The issue reports that **version 4.14.0 generates a large number of vulnerabilities based on the NVD**. I have not observed this effect, or could not reproduce it reliably. **Please double-check this point during review.**

### Artifacts Affected

- wazuh-modulesd (agent and manager)

### Configuration Changes

- None required.

### Documentation Updates

- Not applicable.

### Tests Introduced

- DataProvider tests have been updated accordingly.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided ⚠️
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

