### PR TITLE
Eliminate duplicate package reporting on macOS

### DIFF
--- a/src/data_provider/src/packages/packagesPYPI.hpp
+++ b/src/data_provider/src/packages/packagesPYPI.hpp
@@ -132,12 +132,14 @@ class PYPI final
                 try
                 {
 #ifdef __APPLE__
+
                     // Skip symlinked Python versions (Versions/Current is typically a symlink)
                     // to avoid reporting duplicate packages on macOS
                     if (expandedPath.find("/Versions/Current/") != std::string::npos)
                     {
                         continue;
                     }
+
 #endif
 
                     // Exist and is a directory

--- a/src/data_provider/src/sharedDefs.h
+++ b/src/data_provider/src/sharedDefs.h
@@ -113,7 +113,6 @@ static const std::set<std::string> UNIX_PYPI_DEFAULT_BASE_DIRS
     "/home/*/.local/lib/python*/*-packages",
     "/root/.local/lib/python*/*-packages",
     "/opt/homebrew/lib",
-    "/Library/Python",
     "/Library/Frameworks/Python.framework/Versions/*/lib/python*/*-packages",
     "/root/.pyenv/versions/*/lib/python*/*-packages",
     "/home/*/.pyenv/versions/*/lib/python*/*-packages"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

  This PR fixes duplicate package reporting in syscollector on macOS systems by addressing two root causes identified in issue #30513. 
 1. Symlinked Python versions: The path Versions/Current is a symbolic link pointing to an actual version (e.g., 3.9), causing packages to appear twice with different paths
  2. Overlapping path patterns: Multiple path patterns were scanning the same physical directories, resulting in duplicate entries

Closes #30513

##  Changes Made

1. Skip Symlinked Python Versions (packagesPYPI.hpp)

  - Added logic to skip paths containing /Versions/Current/ to prevent scanning packages through symlinks
  - Made the check macOS-specific using #ifdef __APPLE__ to avoid affecting other platforms
  - Prevents duplicates like:
  /Library/Developer/CommandLineTools/.../Versions/Current/lib/python3.9/site-packages/future-0.18.2.dist-info/METADATA
  /Library/Developer/CommandLineTools/.../Versions/3.9/lib/python3.9/site-packages/future-0.18.2.dist-info/METADATA

  2. Remove Overlapping Path Patterns (sharedDefs.h)

  - Removed /Library/Python from UNIX_PYPI_DEFAULT_BASE_DIRS
  - This path was redundant as sysInfoMac.cpp already includes the more specific pattern /Library/Python/*/*-packages
  - Prevents scanning the same directory twice through different patterns

## Files Modified

  1. src/data_provider/src/packages/packagesPYPI.hpp - Add symlink filtering
  2. src/data_provider/src/sharedDefs.h - Remove duplicate path pattern


>[!Note]
>  Not a Duplicate: Packages installed in both system-wide (/Library/Python/) and user-specific (/Users/*/Library/Python/) directories are correctly reported as separate entries. These are genuinely
> different installations:
>  - System-wide: Installed with sudo pip install (owned by root)
>  - User-specific: Installed with pip install --user (owned by the user)


### Results and Evidence

<details><summary>Current Release 4.x</summary>

```bash

sh-3.2# sudo /Library/Ossec/bin/wazuh-control info
WAZUH_VERSION="v4.14.0"
WAZUH_REVISION="rc2"
WAZUH_TYPE="agent"

sh-3.2# sqlite3 /Library/Ossec/queue/syscollector/db/local.db "SELECT name, version, format FROM dbsync_packages WHERE format != 'pkg' AND name IN (SELECT name FROM dbsync_packages WHERE format != 'pkg' GROUP BY name HAVING COUNT(name) > 1);"
altgraph|0.17.2|pypi
altgraph|0.17.2|pypi
exceptiongroup|1.1.2|pypi
exceptiongroup|1.1.2|pypi
future|0.18.2|pypi
future|0.18.2|pypi
iniconfig|2.0.0|pypi
iniconfig|2.0.0|pypi
macholib|1.15.2|pypi
macholib|1.15.2|pypi
packaging|23.1|pypi
packaging|23.1|pypi
pip|21.2.4|pypi
pip|21.2.4|pypi
pluggy|1.2.0|pypi
pluggy|1.2.0|pypi
pytest|7.4.0|pypi
pytest|7.4.0|pypi
setuptools|58.0.4|pypi
setuptools|58.0.4|pypi
six|1.15.0|pypi
six|1.15.0|pypi
tomli|2.0.1|pypi
tomli|2.0.1|pypi
wheel|0.37.0|pypi
wheel|0.37.0|pypi
```

</details>

<details><summary>Tested the current changes on (4.x)</summary>

```bash
sh-3.2# sudo /Library/Ossec/bin/wazuh-control info
WAZUH_VERSION="v4.14.1"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="agent"

sh-3.2# sqlite3 /Library/Ossec/queue/syscollector/db/local.db "SELECT name, version, format FROM dbsync_packages WHERE format != 'pkg' AND name IN (SELECT name FROM dbsync_packages WHERE format != 'pkg' GROUP BY name HAVING COUNT(name) > 1);"
exceptiongroup|1.1.2|pypi
exceptiongroup|1.1.2|pypi
iniconfig|2.0.0|pypi
iniconfig|2.0.0|pypi
packaging|23.1|pypi
packaging|23.1|pypi
pluggy|1.2.0|pypi
pluggy|1.2.0|pypi
pytest|7.4.0|pypi
pytest|7.4.0|pypi
tomli|2.0.1|pypi
tomli|2.0.1|pypi
```
</details>


<details><summary>Current main (5.0)</summary>


```bash
sh-3.2#  /Library/Ossec/bin/wazuh-control info
WAZUH_VERSION="v5.0.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="agent"

sh-3.2# sudo sqlite3 /Library/Ossec/queue/syscollector/db/local.db "SELECT name,version,type FROM dbsync_packages"
altgraph|0.17.2|pypi
altgraph|0.17.2|pypi
future|0.18.2|pypi
future|0.18.2|pypi
macholib|1.15.2|pypi
macholib|1.15.2|pypi
pip|21.2.4|pypi
pip|21.2.4|pypi
setuptools|58.0.4|pypi
setuptools|58.0.4|pypi
six|1.15.0|pypi
six|1.15.0|pypi
wheel|0.37.0|pypi
wheel|0.37.0|pypi
```
</details>

<details><summary>Tested the current changes on (5.0)</summary>

```bash

vagrant@idr-3324-ventura-13-11 ~ % sudo installer -pkg wazuh-agent_5.0.0-0_intel64_9678725.pkg -target /                                                  
installer: Package name is wazuh-agent_5.0.0-0_intel64_9678725
installer: Upgrading at base path /
installer: The upgrade was successful.

sh-3.2#  /Library/Ossec/bin/wazuh-control info
WAZUH_VERSION="v5.0.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="agent"

# To avoid the noted error, I had to remove the syscollector DBs
sh-3.2# rm /Library/Ossec/queue/syscollector/db/*.db

sh-3.2#  sqlite3 /Library/Ossec/queue/syscollector/db/local.db "SELECT name,version,type FROM dbsync_packages"
altgraph|1|pypi
future|1|pypi
macholib|1|pypi
pip|1|pypi
setuptools|1|pypi
six|1|pypi
wheel|1|pypi
```
</details>

>[!note] 
> To make this work, I had to remove the syscollector DB after upgrading the wazuh-agent to avoid the following issue:

<details><summary>syscollector: ERROR:</summary>

```bash
2025/11/04 16:00:46 wazuh-modulesd:syscollector: INFO: Module started.
2025/11/04 16:00:46 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"a103cf764c1dba70f5d7f3ac79c40d02085566ba","description":" ","installed":" ","name":"future","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/future-0.18.2.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"0.18.2"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"2e97849c0712f8209159aa462e85635bc347fa47","description":" ","installed":" ","name":"six","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/six-1.15.0.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"1.15.0"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"5017874784baa9398e11749c2e579ccd2ad9899d","description":" ","installed":" ","name":"wheel","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/wheel-0.37.0.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"0.37.0"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"77ca4d271c5ed9909833ab66d0e71ac7d3f1e0eb","description":" ","installed":" ","name":"altgraph","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/altgraph-0.17.2.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"0.17.2"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"a02f250512b760463af86bc9b630aab0e1c7f0c5","description":" ","installed":" ","name":"pip","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/pip-21.2.4.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"21.2.4"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"e254e80655ac11223aed8468795ca910fa56ca22","description":" ","installed":" ","name":"macholib","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/macholib-1.15.2.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"1.15.2"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
2025/11/04 16:00:46 wazuh-modulesd:syscollector: ERROR: {"data":[{"architecture":" ","category":" ","checksum":"59cc32bee04874fdfa9753f16e3bf96488f93d1d","description":" ","installed":" ","name":"setuptools","path":"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/setuptools-58.0.4.dist-info/METADATA","priority":" ","size":0,"source":" ","type":"pypi","vendor":" ","version_":"58.0.4"}],"exception":"[json.exception.out_of_range.403] key 'version' not found","options":{"return_old_data":true},"table":"dbsync_packages"}
```
</details>


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
