### PR TITLE
BACKPORT: Fix tests compilation in macos-13 and macos-14

### DIFF
--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -55,6 +55,8 @@ jobs:
           make -j$(sysctl -n hw.ncpu)
           sudo make install
       - name: Build wazuh agent for macOS 14 with tests flags
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
         run: |
           make deps -C src TARGET=agent -j3
           C_INCLUDE_PATH=$C_INCLUDE_PATH:/opt/homebrew/include LIBRARY_PATH=/usr/local/lib:/opt/homebrew/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/issues/31904|

## Description

Hi team, 

This PR aims to backport https://github.com/wazuh/wazuh/pull/32020 and https://github.com/wazuh/wazuh/pull/31988

## Tests

:green_circle: Checks https://github.com/wazuh/wazuh/actions/runs/18788074228