### PR TITLE
Vulnerability scanner - Snapshot offset is set despite processing fails

### DIFF
--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -301,6 +301,7 @@ private:
             catch (const std::exception& e)
             {
                 logWarn(WM_CONTENTUPDATER, "Couldn't run full content download: %s.", e.what());
+                throw;
             }
 
             // Restore original data.

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -365,3 +365,24 @@ TEST_F(ActionOrchestratorTest, FileHashUpdateDataInvalidHashThrows)
 {
     EXPECT_THROW(ActionOrchestrator::UpdateData::createHashUpdateData(""), std::invalid_argument);
 }
+
+/**
+ * @brief Tests that exceptions from runFullContentDownload are properly re-thrown during content update.
+ *
+ */
+TEST_F(ActionOrchestratorTest, ContentUpdateStdExceptionRethrown)
+{
+    m_parameters["configData"]["contentSource"] = "cti-offset";
+    m_parameters["configData"]["url"] = "http://localhost:4444/invalid_endpoint"; // This will cause download failure
+
+    auto actionOrchestrator {std::make_shared<ActionOrchestrator>(m_parameters,
+                                                                  m_spStopActionCondition,
+                                                                  [](const std::string& msg) -> FileProcessingResult {
+                                                                      return {0, "", false};
+                                                                  })};
+
+    // Test that when runFullContentDownload throws a std::exception (not SnapshotProcessingException),
+    // it is properly re-thrown instead of being swallowed.
+    EXPECT_THROW(actionOrchestrator->run(ActionOrchestrator::UpdateData::createContentUpdateData(0)),
+                 std::runtime_error);
+}


### PR DESCRIPTION
## Description

Closes #32687 

The changes introduced by this PR prevent offset updates when the snapshot download (vulnerability feed) fails. 
The issue is located in `actionOrchestrator.hpp` in the `runContentUpdate()` method, specifically in the exception handling for snapshot downloads:

https://github.com/wazuh/wazuh/blob/719e9f6e304c018e0ac4b455caa624cd85a3c590/src/shared_modules/content_manager/src/actionOrchestrator.hpp#L292-L305

1. Snapshot download fails with network error: `"Error -1 from server: Transferred a partial file"`
2. Exception is caught but NOT re-thrown in the second catch block
3. Execution continues to the normal offset update chain:
3.1 `CtiOffsetDownloader` processes successfully
3.2 `UpdateCtiApiOffset` updates the database with the new offset
3.3 `CleanUp` completes normally
4. Result: Offset is updated in database despite snapshot never being processed 

## Proposed Changes

Added missing `throw;` statement in the second catch block:

```c++
catch (const std::exception& e)
{
    logWarn(WM_CONTENTUPDATER, "Couldn't run full content download: %s.", e.what());
    throw; // ← Added this line
}
```

#### Expected Behavior

1. Snapshot download fails → Exception is thrown
2. Exception propagates up to the `run()` method
3. Caught as `std::exception`
4. Cleans context
5. Offset is NOT updated until snapshot is successfully processed

### Results and Evidence

### Manual tests with their corresponding evidence

#### Test conditions

- Set `"feed-update-interval": "30"`
- Simulate snapshot download failure adding this line:

```diff
diff --git a/src/shared_modules/content_manager/src/components/CtiSnapshotDownloader.hpp b/src/shared_modules/content_manager/src/components/CtiSnapshotDownloader.hpp
index 4f086e2927..816b26d4ab 100644
--- a/src/shared_modules/content_manager/src/components/CtiSnapshotDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiSnapshotDownloader.hpp
@@ -60,6 +60,9 @@ private:
 
         logDebug2(WM_CONTENTUPDATER, "Downloading snapshot from '%s'", lastSnapshotURL.string().c_str());
 
+        // TEMPORARY: Force failure to test fix
+        throw std::runtime_error("Simulated download failure for testing");
+
         // Download the content.
         performQueryWithRetry(lastSnapshotURL, onSuccess, "", outputFilepath);
     }
```

<details><summary>Output logs</summary>

```console
$ build/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_scanner_testtool -c wazuh_modules/vulnerability_scanner/testtool/scanner/config.json -d -t wazuh_modules/vulnerability_scanner/indexer/template/index-template.json 
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Only download content flag: 1
Failed to set socket options
Failed to set socket options
keystore:keyStore.cpp:67 upgrade : Keystore upgrade failed, re-run the tool again for all keys to save them. Error: Private key file not found.
wazuh-modulesd:vulnerability-scanner:vulnerabilityScannerFacade.cpp:440 handlePolicyChanges : No policy has changed or no action is needed for the agents.
wazuh-modulesd:vulnerability-scanner:vulnerabilityScannerFacade.cpp:466 handlePolicyChanges : No policy has changed or no action is needed for the manager.
Failed to set socket options
Failed to set socket options
wazuh-modulesd:content-updater:actionOrchestrator.hpp:125 ActionOrchestrator : Creating 'vulnerability_feed_manager' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:218 handleRequest : ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:129 createRocksDB : Column 'current_offset' doesn't exist so it will be created
wazuh-modulesd:content-updater:executionContext.hpp:129 createRocksDB : Column 'downloaded_file_hash' doesn't exist so it will be created
wazuh-modulesd:content-updater:executionContext.hpp:185 createOutputFolder : Creating output folders at 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'cti-offset' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'raw' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:42 create : Creating 'cti-api' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:actionOrchestrator.hpp:139 ActionOrchestrator : Content updater orchestration created
wazuh-modulesd:content-updater:action.hpp:119 runActionScheduled : Starting scheduled action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:210 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:263 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:actionOrchestrator.hpp:282 runContentUpdate : Current offset: '0'. Current hash: ''. ContentSource: 'cti-offset'
wazuh-modulesd:content-updater:actionOrchestrator.hpp:292 runContentUpdate : Triggering full content download
wazuh-modulesd:content-updater:actionOrchestrator.hpp:333 runFullContentDownload : Performing full-content download
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'cti-snapshot' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'zip' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:42 create : Creating 'cti-api' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:CtiDownloader.hpp:314 handleRequest : CtiSnapshotDownloader - Starting process
wazuh-modulesd:vulnerability-scanner:vulnerabilityScannerFacade.cpp:608 start : Vulnerability scanner module started.
wazuh-modulesd:content-updater:CtiDownloader.hpp:121 operator() : CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2025-10-24T14:21:35.257510Z","paths_reject":null,"paths_filter":null,"last_offset":2870973,"changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_snapshot_at":"2025-10-20T12:03:54.974741Z","last_snapshot_link":"https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/2862080_1760961834.zip","last_snapshot_offset":2862080}}'
wazuh-modulesd:content-updater:CtiSnapshotDownloader.hpp:61 download : Downloading snapshot from 'https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/2862080_1760961834.zip'
wazuh-modulesd:content-updater:actionOrchestrator.hpp:307 runContentUpdate : Couldn't run full content download: Simulated download failure for testing.
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' failed: Orchestration run failed: Simulated download failure for testing.
wazuh-modulesd:content-updater:action.hpp:221 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:content-updater:action.hpp:119 runActionScheduled : Starting scheduled action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:210 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:263 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:actionOrchestrator.hpp:282 runContentUpdate : Current offset: '0'. Current hash: ''. ContentSource: 'cti-offset'
wazuh-modulesd:content-updater:actionOrchestrator.hpp:292 runContentUpdate : Triggering full content download
wazuh-modulesd:content-updater:actionOrchestrator.hpp:333 runFullContentDownload : Performing full-content download
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'cti-snapshot' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'zip' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:42 create : Creating 'cti-api' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:CtiDownloader.hpp:314 handleRequest : CtiSnapshotDownloader - Starting process
wazuh-modulesd:content-updater:CtiDownloader.hpp:121 operator() : CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2025-10-24T14:21:35.257510Z","paths_reject":null,"paths_filter":null,"last_offset":2870973,"changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_snapshot_at":"2025-10-20T12:03:54.974741Z","last_snapshot_link":"https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/2862080_1760961834.zip","last_snapshot_offset":2862080}}'
wazuh-modulesd:content-updater:CtiSnapshotDownloader.hpp:61 download : Downloading snapshot from 'https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/2862080_1760961834.zip'
wazuh-modulesd:content-updater:actionOrchestrator.hpp:307 runContentUpdate : Couldn't run full content download: Simulated download failure for testing.
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' failed: Orchestration run failed: Simulated download failure for testing.
wazuh-modulesd:content-updater:action.hpp:221 runAction : Action for 'vulnerability_feed_manager' finished
```

</details> 

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [x] Log syntax and correct language review

### Artifacts Affected

- Content Manager module
- Vulnerability scanner module

### Configuration Changes

- N/A

### Tests Introduced

- Unit test: `ActionOrchestratorTest.ContentUpdateStdExceptionRethrown`

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
