### PR TITLE
Add version selector for CIS Windows Server 2022 and 2025

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -447,11 +447,11 @@
                             </Component>
                             <Component Id="SCA_WIN2022" DiskId="1" Guid="795CC5E6-C27A-47B5-945A-8026470F1B0D">
                                 <File Id="SCA_WIN2022" Name="cis_win2022.yml" Source="..\..\ruleset\sca\windows\cis_win2022.yml" />
-                                <Condition>BUILDVERSION &gt; 20000 AND MsiNTProductType &gt; 1</Condition>
+                                <Condition>BUILDVERSION = "20348" AND MsiNTProductType &gt; 1</Condition>
                             </Component>
                             <Component Id="SCA_WIN2025" DiskId="1" Guid="0C466900-EB75-46E1-97F3-14DB39E77412">
                                 <File Id="SCA_WIN2025" Name="cis_win2025.yml" Source="..\..\ruleset\sca\windows\cis_win2025.yml" />
-                                <Condition>BUILDVERSION &gt; 20000 AND MsiNTProductType &gt; 1</Condition>
+                                <Condition>BUILDVERSION = "26100" AND MsiNTProductType &gt; 1</Condition>
                             </Component>
                         </Directory>
                     </Directory>


### PR DESCRIPTION
## Description

This pull request adapts the version selector logic to ensure the appropriate CIS benchmark files are installed based on the detected Windows Server build version.

## Proposed Changes

- Updated the installer logic to use the following mapping:
  - `cis_win2022.yml` is installed for Windows Server 2022 (`BUILD = 20348`)
  - `cis_win2025.yml` is installed for Windows Server 2025 (`BUILD = 26100`)

Reference: [List of Microsoft Windows versions (Wikipedia)](https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions)

### Results and Evidence

- [x] `cis_win2022.yml` is installed on Windows Server 2022 and not on Windows Server 2025
- [x] `cis_win2025.yml` is installed on Windows Server 2025 and not on Windows Server 2022

### Artifacts Affected

- `cis_win2022.yml` (not installed on Windows Server 2025)

### Configuration Changes

Not applicable.

### Documentation Updates

Not applicable.

### Tests Introduced

Automated tests do not apply.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues