### PR TITLE
Fix Loopback interface inventory incomplete

### DIFF
--- a/src/shared_modules/utils/networkUnixHelper.h
+++ b/src/shared_modules/utils/networkUnixHelper.h
@@ -50,7 +50,7 @@ namespace Utils
 
                     for (auto ifa = ifaddr; ifa; ifa = ifa->ifa_next)
                     {
-                        if (!(ifa->ifa_flags & IFF_LOOPBACK) && ifa->ifa_name)
+                        if (ifa->ifa_name)
                         {
                             networkInterfaces[substrOnFirstOccurrence(ifa->ifa_name, ":")].push_back(ifa);
                         }

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -503,7 +503,7 @@ namespace Utils
                 static const auto MAX_BITS_LENGTH { 128 };
                 std::string netmask;
 
-                if (maskLength < MAX_BITS_LENGTH)
+                if (maskLength <= MAX_BITS_LENGTH)
                 {
                     // For a unicast IPv6 address, any value greater than 128 is an illegal value
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #29860
-->
The Wazuh agent is currently not collecting complete network interface data for loopback interfaces on Windows, MacOS and Linux.

* On **Windows**, the `netmask` field is missing for IPv6 loopback interfaces.
<details>
<summary>Sample output of sysinfo on Windows:</summary>

```
{
    "iface": [
        {
            "IPv4": [
                {
                    "address": "10.0.2.15",
                    "broadcast": "10.0.2.255",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "255.255.255.0"
                }
            ],
            "IPv6": [
                {
                    "address": "fe80::3510:b1c2:6759:3f1c",
                    "broadcast": " ",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "ffff:ffff:ffff:ffff::"
                }
            ],
            "adapter": "Intel(R) PRO/1000 MT Desktop Adapter",
            "gateway": "10.0.2.2",
            "mac": "08:00:27:4e:5b:9b",
            "mtu": 1500,
            "name": "Ethernet",
            "rx_bytes": 22117912,
            "rx_dropped": 0,
            "rx_errors": 0,
            "rx_packets": 217796,
            "state": "up",
            "tx_bytes": 152175059,
            "tx_dropped": 0,
            "tx_errors": 0,
            "tx_packets": 213172,
            "type": "ethernet"
        },
        {
            "IPv4": [
                {
                    "address": "192.168.56.3",
                    "broadcast": "192.168.56.255",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "255.255.255.0"
                }
            ],
            "IPv6": [
                {
                    "address": "fe80::61ed:cb09:77ea:3f51",
                    "broadcast": " ",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "ffff:ffff:ffff:ffff::"
                }
            ],
            "adapter": "Intel(R) PRO/1000 MT Desktop Adapter #2",
            "gateway": " ",
            "mac": "08:00:27:0f:f3:2b",
            "mtu": 1500,
            "name": "Ethernet 2",
            "rx_bytes": 366223,
            "rx_dropped": 0,
            "rx_errors": 0,
            "rx_packets": 1521,
            "state": "up",
            "tx_bytes": 254383,
            "tx_dropped": 0,
            "tx_errors": 0,
            "tx_packets": 2514,
            "type": "ethernet"
        },
        {
            "IPv4": [
                {
                    "address": "127.0.0.1",
                    "broadcast": "127.255.255.255",
                    "dhcp": "disabled",
                    "metric": "75",
                    "netmask": "255.0.0.0"
                }
            ],
            "IPv6": [
                {
                    "address": "::1",
                    "broadcast": " ",
                    "dhcp": "disabled",
                    "metric": "75",
                    "netmask": ""
                }
            ],
            "adapter": "Software Loopback Interface 1",
            "gateway": " ",
            "mac": "00:00:00:00:00:00",
            "mtu": 4294967295,
            "name": "Loopback Pseudo-Interface 1",
            "rx_bytes": 0,
            "rx_dropped": 0,
            "rx_errors": 0,
            "rx_packets": 0,
            "state": "up",
            "tx_bytes": 0,
            "tx_dropped": 0,
            "tx_errors": 0,
            "tx_packets": 0,
            "type": " "
        }
    ]
}
```
</details>

* On **macOS** and **Linux**, loopback interfaces are not being listed at all.
<details>
<summary>Sample output of sysinfo on MacOS and Linux:</summary>

```
{
  "networks": {
    "iface": [
      {
        "host_mac": "c8:53:09:80:7d:13",
        "host_network_egress_bytes": 0,
        "host_network_egress_drops": 0,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 0,
        "host_network_ingress_bytes": 0,
        "host_network_ingress_drops": 0,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 0,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "enp0s31f6",
        "interface_state": "down",
        "interface_type": "ethernet",
        "network_gateway": " "
      },
      {
        "host_mac": "fa:e5:ce:21:1a:97",
        "host_network_egress_bytes": 0,
        "host_network_egress_drops": 0,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 0,
        "host_network_ingress_bytes": 0,
        "host_network_ingress_drops": 0,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 0,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "enxfae5ce211a97",
        "interface_state": "down",
        "interface_type": "ethernet",
        "network_gateway": " "
      },
      {
        "IPv4": [
          {
            "network_broadcast": "192.168.56.255",
            "network_dhcp": 0,
            "network_ip": "192.168.56.1",
            "network_metric": "0",
            "network_netmask": "255.255.255.0"
          }
        ],
        "IPv6": [
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "fe80::800:27ff:fe00:0",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          }
        ],
        "host_mac": "0a:00:27:00:00:00",
        "host_network_egress_bytes": 1809477,
        "host_network_egress_drops": 276,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 13404,
        "host_network_ingress_bytes": 0,
        "host_network_ingress_drops": 0,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 0,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "vboxnet0",
        "interface_state": "up",
        "interface_type": "ethernet",
        "network_gateway": " "
      },
      {
        "IPv4": [
          {
            "network_broadcast": "192.168.0.255",
            "network_dhcp": 0,
            "network_ip": "192.168.0.90",
            "network_metric": "600",
            "network_netmask": "255.255.255.0"
          }
        ],
        "IPv6": [
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "2804:14c:482:93b9::1001",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
          },
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "2804:14c:482:93b9:71:63aa:b1b2:86ec",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          },
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "2804:14c:482:93b9:2a95:29ff:fe31:ba55",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          },
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "fe80::2a95:29ff:fe31:ba55",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          }
        ],
        "host_mac": "28:95:29:31:ba:55",
        "host_network_egress_bytes": 1607876304,
        "host_network_egress_drops": 156,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 4889143,
        "host_network_ingress_bytes": 973846055,
        "host_network_ingress_drops": 9,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 10372198,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "wlp0s20f3",
        "interface_state": "up",
        "interface_type": "ethernet",
        "network_gateway": "192.168.0.1"
      }
    ]
  }
}
```
</details>



Closes #29860

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- On Windows, the function that sets the netmask (ipv6Netmask) allowed up to 127 bits for netmask, set this to allow up to 128 bit.
- On MacOS and Linux, the function that retrieves network interfaces filtered out loopback interfaces, undo this filter.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

<details>
<summary>On Windows, IPv6 loopback interfaces now hold the `netmask` field:</summary>

```
{
    "iface": [
        {
            "IPv4": [
                {
                    "address": "10.0.2.15",
                    "broadcast": "10.0.2.255",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "255.255.255.0"
                }
            ],
            "IPv6": [
                {
                    "address": "fe80::3510:b1c2:6759:3f1c",
                    "broadcast": " ",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "ffff:ffff:ffff:ffff::"
                }
            ],
            "adapter": "Intel(R) PRO/1000 MT Desktop Adapter",
            "gateway": "10.0.2.2",
            "mac": "08:00:27:4e:5b:9b",
            "mtu": 1500,
            "name": "Ethernet",
            "rx_bytes": 21864569,
            "rx_dropped": 0,
            "rx_errors": 0,
            "rx_packets": 215449,
            "state": "up",
            "tx_bytes": 150429311,
            "tx_dropped": 0,
            "tx_errors": 0,
            "tx_packets": 210888,
            "type": "ethernet"
        },
        {
            "IPv4": [
                {
                    "address": "192.168.56.3",
                    "broadcast": "192.168.56.255",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "255.255.255.0"
                }
            ],
            "IPv6": [
                {
                    "address": "fe80::61ed:cb09:77ea:3f51",
                    "broadcast": " ",
                    "dhcp": "enabled",
                    "metric": "25",
                    "netmask": "ffff:ffff:ffff:ffff::"
                }
            ],
            "adapter": "Intel(R) PRO/1000 MT Desktop Adapter #2",
            "gateway": " ",
            "mac": "08:00:27:0f:f3:2b",
            "mtu": 1500,
            "name": "Ethernet 2",
            "rx_bytes": 362937,
            "rx_dropped": 0,
            "rx_errors": 0,
            "rx_packets": 1507,
            "state": "up",
            "tx_bytes": 252917,
            "tx_dropped": 0,
            "tx_errors": 0,
            "tx_packets": 2498,
            "type": "ethernet"
        },
        {
            "IPv4": [
                {
                    "address": "127.0.0.1",
                    "broadcast": "127.255.255.255",
                    "dhcp": "disabled",
                    "metric": "75",
                    "netmask": "255.0.0.0"
                }
            ],
            "IPv6": [
                {
                    "address": "::1",
                    "broadcast": " ",
                    "dhcp": "disabled",
                    "metric": "75",
                    "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
                }
            ],
            "adapter": "Software Loopback Interface 1",
            "gateway": " ",
            "mac": "00:00:00:00:00:00",
            "mtu": 4294967295,
            "name": "Loopback Pseudo-Interface 1",
            "rx_bytes": 0,
            "rx_dropped": 0,
            "rx_errors": 0,
            "rx_packets": 0,
            "state": "up",
            "tx_bytes": 0,
            "tx_dropped": 0,
            "tx_errors": 0,
            "tx_packets": 0,
            "type": " "
        }
    ]
}
```
</details>


<details>
<summary>On MacOS and Linux, loopback interfaces are now listed:</summary>

```
{
  "networks": {
    "iface": [
      {
        "host_mac": "c8:53:09:80:7d:13",
        "host_network_egress_bytes": 0,
        "host_network_egress_drops": 0,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 0,
        "host_network_ingress_bytes": 0,
        "host_network_ingress_drops": 0,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 0,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "enp0s31f6",
        "interface_state": "down",
        "interface_type": "ethernet",
        "network_gateway": " "
      },
      {
        "IPv4": [
          {
            "network_broadcast": "127.0.0.1",
            "network_dhcp": 1,
            "network_ip": "127.0.0.1",
            "network_metric": "",
            "network_netmask": "255.0.0.0"
          }
        ],
        "IPv6": [
          {
            "network_broadcast": "",
            "network_dhcp": 1,
            "network_ip": "::1",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
          }
        ],
        "host_mac": "00:00:00:00:00:00",
        "host_network_egress_bytes": 1298655,
        "host_network_egress_drops": 0,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 16080,
        "host_network_ingress_bytes": 1298655,
        "host_network_ingress_drops": 0,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 16080,
        "interface_alias": "",
        "interface_mtu": 65536,
        "interface_name": "lo",
        "interface_state": "unknown",
        "interface_type": "",
        "network_gateway": " "
      },
      {
        "IPv4": [
          {
            "network_broadcast": "192.168.56.255",
            "network_dhcp": 0,
            "network_ip": "192.168.56.1",
            "network_metric": "0",
            "network_netmask": "255.255.255.0"
          }
        ],
        "IPv6": [
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "fe80::800:27ff:fe00:0",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          }
        ],
        "host_mac": "0a:00:27:00:00:00",
        "host_network_egress_bytes": 1829523,
        "host_network_egress_drops": 276,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 13489,
        "host_network_ingress_bytes": 0,
        "host_network_ingress_drops": 0,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 0,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "vboxnet0",
        "interface_state": "up",
        "interface_type": "ethernet",
        "network_gateway": " "
      },
      {
        "IPv4": [
          {
            "network_broadcast": "192.168.0.255",
            "network_dhcp": 0,
            "network_ip": "192.168.0.90",
            "network_metric": "600",
            "network_netmask": "255.255.255.0"
          }
        ],
        "IPv6": [
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "2804:14c:482:93b9::1001",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
          },
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "2804:14c:482:93b9:71:63aa:b1b2:86ec",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          },
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "2804:14c:482:93b9:2a95:29ff:fe31:ba55",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          },
          {
            "network_broadcast": "",
            "network_dhcp": 0,
            "network_ip": "fe80::2a95:29ff:fe31:ba55",
            "network_metric": "",
            "network_netmask": "ffff:ffff:ffff:ffff::"
          }
        ],
        "host_mac": "28:95:29:31:ba:55",
        "host_network_egress_bytes": 1625122092,
        "host_network_egress_drops": 156,
        "host_network_egress_errors": 0,
        "host_network_egress_packages": 5023713,
        "host_network_ingress_bytes": 1515978727,
        "host_network_ingress_drops": 9,
        "host_network_ingress_errors": 0,
        "host_network_ingress_packages": 10747758,
        "interface_alias": "",
        "interface_mtu": 1500,
        "interface_name": "wlp0s20f3",
        "interface_state": "up",
        "interface_type": "ethernet",
        "network_gateway": "192.168.0.1"
      }
    ]
  }
}
```
</details>

### Manual tests with their corresponding evidence

### Configuration Changes

NA

### Tests Introduced

NA

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
