### PR TITLE
SCA regexp bug for Multiple CIS Apple macOS check 'Enable FileVault'

### DIFF
--- a/ruleset/sca/darwin/16/cis_apple_macOS_10.12.yml
+++ b/ruleset/sca/darwin/16/cis_apple_macOS_10.12.yml
@@ -168,7 +168,7 @@ checks:
       - cis: ["2.6.1.1"]
     condition: all
     rules:
-      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+      - "c:fdesetup status -> r:^FileVault is On"
 
   # 2.6.2 Enable Gatekeeper (Scored)
   - id: 9012

--- a/ruleset/sca/darwin/17/cis_apple_macOS_10.13.yml
+++ b/ruleset/sca/darwin/17/cis_apple_macOS_10.13.yml
@@ -168,7 +168,7 @@ checks:
       - cis: ["2.6.1.1"]
     condition: all
     rules:
-      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+      - "c:fdesetup status -> r:^FileVault is On"
 
   # 2.6.2 Enable Gatekeeper (Scored)
   - id: 9512

--- a/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
+++ b/ruleset/sca/darwin/18/cis_apple_macOS_10.14.yml
@@ -297,7 +297,7 @@ checks:
       - cis: ["2.5.1.1"]
     condition: all
     rules:
-      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+      - "c:fdesetup status -> r:^FileVault is On"
 
   # 2.5.2 Enable Gatekeeper (Automated)
   - id: 17023

--- a/ruleset/sca/darwin/19/cis_apple_macOS_10.15.yml
+++ b/ruleset/sca/darwin/19/cis_apple_macOS_10.15.yml
@@ -317,7 +317,7 @@ checks:
       - https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-encrypted-boot-drive-from-the-command-line-on-macos-mojave/
     condition: all
     rules:
-      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+      - "c:fdesetup status -> r:^FileVault is On"
 
   # not implemented - SCA Limit -> 2.5.1.2 Ensure all user storage APFS volumes are encrypted (Manual)
   # not implemented - SCA Limit -> 2.5.1.3 Ensure all user storage CoreStorage volumes are encrypted (Manual)

--- a/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
+++ b/ruleset/sca/darwin/20/cis_apple_macOS_11.1.yml
@@ -387,7 +387,7 @@ checks:
       - https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-encrypted-boot-drive-from-the-command-line-on-macos-mojave/
     condition: all
     rules:
-      - 'c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$'
+      - "c:fdesetup status -> r:^FileVault is On"
 
   # not implemented - SCA Limit -> 2.5.1.2 Ensure all user storage APFS volumes are encrypted (Manual)
   # not implemented - SCA Limit -> 2.5.1.3 Ensure all user storage CoreStorage volumes are encrypted (Manual)


### PR DESCRIPTION
|Wazuh version| Component | Action type |
|---| --- | --- |
| 4.3.x| SCA | Bug |

from cschultz@chadis.com:

macOS Agent on 11.7.1 (Big Sur) says that FileVault is not enabled when it is. The problem is that the regexp for this check is wrong.

This is what the SCA says:
c:fdesetup status -> r:^FileVault\s*\t*is\s*\t*On$

This is what [fdesetup status] returns:
FileVault is On.

The regular expression should be ^FileVault\s*is\s*On[.]?$

Note that \s includes \t, so \s*\t* is redundant. I have added an optional period at the end of the line (which is why this check is failing for me). This check probably ought to be case-insensitive; I'm not sure how to express that in the regexp syntax used for Wazuh.
