### PR TITLE
Handle version field in data events

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -76,6 +76,16 @@ public:
     void bulkIndex(std::string_view id, std::string_view index, std::string_view data);
 
     /**
+     * @brief Bulk index with version.
+     *
+     * @param id ID.
+     * @param index Index name.
+     * @param data Data.
+     * @param version Document version for external versioning.
+     */
+    void bulkIndex(std::string_view id, std::string_view index, std::string_view data, std::string_view version);
+
+    /**
      * @brief Flush the bulk data.
      */
     void flush();
@@ -152,6 +162,16 @@ public:
      * @param data Data.
      */
     void index(std::string_view id, std::string_view index, std::string_view data);
+
+    /**
+     * @brief Index a document with version.
+     *
+     * @param id ID of the document.
+     * @param index Index name.
+     * @param data Data.
+     * @param version Document version for external versioning.
+     */
+    void index(std::string_view id, std::string_view index, std::string_view data, std::string_view version);
 
     /**
      * @brief Index a document.

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
@@ -34,6 +34,11 @@ public:
         m_impl.bulkIndex(id, index, data);
     }
 
+    void index(std::string_view id, std::string_view index, std::string_view data, std::string_view version)
+    {
+        m_impl.bulkIndex(id, index, data, version);
+    }
+
     void index(std::string_view index, std::string_view data)
     {
         m_impl.bulkIndex(std::string_view(), index, data);
@@ -58,6 +63,11 @@ IndexerConnectorAsync::~IndexerConnectorAsync() = default;
 void IndexerConnectorAsync::index(std::string_view id, std::string_view index, std::string_view data)
 {
     m_impl->index(id, index, data);
+}
+
+void IndexerConnectorAsync::index(std::string_view id, std::string_view index, std::string_view data, std::string_view version)
+{
+    m_impl->index(id, index, data, version);
 }
 
 void IndexerConnectorAsync::index(std::string_view index, std::string_view data)

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
@@ -45,6 +45,16 @@ public:
         m_impl.bulkIndex(id, index, data);
     }
 
+    void bulkIndex(std::string_view id, std::string_view index, std::string_view data, std::string_view version)
+    {
+        m_impl.bulkIndex(id, index, data, version);
+    }
+
+    void flush()
+    {
+        m_impl.flush();
+    }
+
     [[nodiscard]] std::unique_lock<std::mutex> scopeLock()
     {
         return m_impl.scopeLock();
@@ -84,6 +94,16 @@ void IndexerConnectorSync::bulkDelete(std::string_view id, std::string_view inde
 void IndexerConnectorSync::bulkIndex(std::string_view id, std::string_view index, std::string_view data)
 {
     m_impl->bulkIndex(id, index, data);
+}
+
+void IndexerConnectorSync::bulkIndex(std::string_view id, std::string_view index, std::string_view data, std::string_view version)
+{
+    m_impl->bulkIndex(id, index, data, version);
+}
+
+void IndexerConnectorSync::flush()
+{
+    m_impl->flush();
 }
 
 [[nodiscard]] std::unique_lock<std::mutex> IndexerConnectorSync::scopeLock()

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -191,7 +191,7 @@ class IndexerConnectorSyncImpl final
 
                 std::string url;
                 url += m_selector->getNext();
-                url += "/_bulk?refresh=wait_for";
+                url += "/_bulk";
                 logDebug2(IC_NAME, "Sending bulk data to: %s", url.c_str());
                 logDebug2(IC_NAME, "Bulk data: %s", m_bulkData.c_str());
 
@@ -276,7 +276,7 @@ class IndexerConnectorSyncImpl final
     {
         std::string url;
         url += m_selector->getNext();
-        url += "/_bulk?refresh=wait_for";
+        url += "/_bulk";
         bool needToRetry = false;
 
         const auto onSuccess = [](const std::string& response)
@@ -493,15 +493,67 @@ public:
     }
     void bulkIndex(std::string_view id, std::string_view index, std::string_view data)
     {
-        if (constexpr auto FORMATTED_SIZE {FORMATTED_LENGTH};
-            m_bulkData.length() + FORMATTED_SIZE + index.size() + id.size() + data.size() > MaxBulkSize)
+        bulkIndex(id, index, data, std::string_view());
+    }
+
+    void bulkIndex(std::string_view id, std::string_view index, std::string_view data, std::string_view version)
+    {
+        constexpr auto FORMATTED_SIZE {FORMATTED_LENGTH};
+        constexpr auto VERSION_SIZE {32};
+
+        // Validate input parameters
+        if (index.empty())
+        {
+            logError(IC_NAME, "Index name cannot be empty for document: %.*s", static_cast<int>(id.size()), id.data());
+            throw IndexerConnectorException("Index name cannot be empty");
+        }
+
+        if (data.empty())
+        {
+            logWarn(IC_NAME, "Empty data provided for document %.*s in index %.*s",
+                   static_cast<int>(id.size()), id.data(),
+                   static_cast<int>(index.size()), index.data());
+        }
+
+        const auto totalSize = m_bulkData.length() + FORMATTED_SIZE + VERSION_SIZE + index.size() + id.size() + data.size();
+
+        if (totalSize > MaxBulkSize)
         {
             processBulk();
         }
         m_bulkData.append(R"({"index":{"_index":")");
         m_bulkData.append(index);
-        m_bulkData.append(R"(","_id":")");
-        m_bulkData.append(id);
+        if (!version.empty())
+        {
+            // In case the version is provided, the id must be provided too
+            if (!id.empty())
+            {
+                m_bulkData.append(R"(","_id":")");
+                m_bulkData.append(id);
+            }
+            else
+            {
+                logError(IC_NAME, "Id must be provided if version value is provided");
+                throw IndexerConnectorException("Id must be provided if version value is provided");
+            }
+
+            m_bulkData.append(R"(","version":")");
+            m_bulkData.append(version);
+            m_bulkData.append(R"(","version_type":"external_gte)");
+            logDebug2(IC_NAME, "Using external version %.*s for document %.*s",
+                     static_cast<int>(version.size()), version.data(),
+                     static_cast<int>(id.size()), id.data());
+        }
+        else
+        {
+            if (!id.empty())
+            {
+                m_bulkData.append(R"(","_id":")");
+                m_bulkData.append(id);
+            }
+            logDebug2(IC_NAME, "No version specified for document %.*s, using default versioning",
+                     static_cast<int>(id.size()), id.data());
+        }
         m_bulkData.append(R"("}})");
         m_bulkData.append("\n");
         m_bulkData.append(data);

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp
@@ -1415,3 +1415,133 @@ TEST_F(IndexerConnectorAsyncTest, VerifyAsyncDataWithErrorProcessing)
     EXPECT_GT(callCount, 0);
     EXPECT_GT(receivedData.size(), 0);
 }
+
+// Test version handling in bulk index operations
+TEST_F(IndexerConnectorAsyncTest, BulkIndexWithVersionHandling)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::promise<void> processingCompletedPromise;
+    std::future<void> processingCompletedFuture = processingCompletedPromise.get_future();
+    std::string capturedBulkData;
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&capturedBulkData, &processingCompletedPromise](
+                RequestParamsVariant requestParams, auto postParams, const ConfigurationParameters& configParams)
+            {
+                std::visit([&capturedBulkData](auto&& request) {
+                    capturedBulkData = request.data;
+                }, requestParams);
+
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                }
+                processingCompletedPromise.set_value();
+            }));
+
+    IndexerConnectorAsyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    // Test with version
+    connector.bulkIndex("doc1", "index1", R"({"field":"value1"})", "12345");
+    // Test without version
+    connector.bulkIndex("doc2", "index1", R"({"field":"value2"})");
+    
+    // Add more data to force bulk processing in async connector (stay within bulk size limit of 5)
+    for (int i = 0; i < 3; ++i)
+    {
+        std::string id = "doc" + std::to_string(i + 3);
+        std::string data = R"({"field":"value)" + std::to_string(i + 3) + R"("})";
+        connector.bulkIndex(id, "index1", data);
+    }
+
+    // Wait for processing to complete
+    auto status = processingCompletedFuture.wait_for(std::chrono::seconds(5));
+    EXPECT_EQ(status, std::future_status::ready) << "Timeout waiting for version test processing";
+
+    // Verify version is included in the bulk data for doc1
+    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"("version":"12345")"));
+    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"("version_type":"external_gte")"));
+
+    // Verify doc2 does not have version information
+    std::size_t doc2_pos = capturedBulkData.find("doc2");
+    EXPECT_NE(doc2_pos, std::string::npos);
+    std::size_t doc2_end = capturedBulkData.find('\n', doc2_pos);
+    std::string doc2_metadata = capturedBulkData.substr(doc2_pos, doc2_end - doc2_pos);
+    EXPECT_THAT(doc2_metadata, ::testing::Not(::testing::HasSubstr("version")));
+}
+
+// Test error handling for missing version fields
+TEST_F(IndexerConnectorAsyncTest, ErrorHandlingForInvalidInput)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorAsyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    // Test with empty index - should throw exception
+    EXPECT_THROW(connector.bulkIndex("doc1", "", R"({"field":"value"})", "123"), IndexerConnectorException);
+
+    // Test with empty data - should not throw but log warning
+    EXPECT_NO_THROW(connector.bulkIndex("doc2", "index1", "", "456"));
+}
+
+// Test version conflict handling
+TEST_F(IndexerConnectorAsyncTest, VersionConflictHandling)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::promise<void> errorProcessedPromise;
+    std::future<void> errorProcessedFuture = errorProcessedPromise.get_future();
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(2) // Initial request + retry
+        .WillOnce(Invoke([&errorProcessedPromise](RequestParamsVariant requestParams, auto postParams, const ConfigurationParameters& configParams) {
+            // Simulate version conflict (409)
+            if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+            {
+                std::get<TPostRequestParameters<const std::string&>>(postParams).onError("Version conflict", 409);
+            }
+            else
+            {
+                std::get<TPostRequestParameters<std::string&&>>(postParams).onError("Version conflict", 409);
+            }
+        }))
+        .WillOnce(Invoke([&errorProcessedPromise](RequestParamsVariant requestParams, auto postParams, const ConfigurationParameters& configParams) {
+            // Simulate successful retry
+            if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+            {
+                std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+            }
+            else
+            {
+                std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+            }
+            errorProcessedPromise.set_value();
+        }));
+
+    IndexerConnectorAsyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    // Send a document with version that will cause conflict
+    connector.bulkIndex("conflict_doc", "index1", R"({"field":"conflicting_value"})", "999");
+    
+    // Add more data to force bulk processing
+    for (int i = 0; i < 10; ++i)
+    {
+        std::string id = "doc" + std::to_string(i);
+        std::string data = R"({"field":"value)" + std::to_string(i) + R"("})";
+        connector.bulkIndex(id, "index1", data);
+    }
+
+    // Wait for error processing to complete
+    auto status = errorProcessedFuture.wait_for(std::chrono::seconds(5));
+    EXPECT_EQ(status, std::future_status::ready) << "Timeout waiting for version conflict handling";
+}

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -421,7 +421,17 @@ public:
                                 dataString.append(R"("}},)");
                                 dataString.append(
                                     std::string_view((const char*)data->data()->data() + 1, data->data()->size() - 1));
-                                m_indexerConnector->bulkIndex(elementId, data->index()->string_view(), dataString);
+                                const auto version = data->version();
+                                const auto indexName = data->index()->string_view();
+                                if (version && version > 0)
+                                {
+                                    m_indexerConnector->bulkIndex(
+                                        elementId, indexName, dataString, std::to_string(version));
+                                }
+                                else
+                                {
+                                    m_indexerConnector->bulkIndex(elementId, indexName, dataString);
+                                }
                             }
                             else if (data->operation() == Wazuh::SyncSchema::Operation_Delete)
                             {


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/issues/32643|

Hi team, 

This PR ensures the version received in the events from the agents is taken into account when it's indexed in the Indexer using the indexer connector.

### Tests

After document is indexed, the version is properly added

```
root@84305a4dfcf3:/# curl -k -u admin:admin   -X GET "https://172.18.0.3:9200/wazuh-states-inventory-services/_doc/wazuh_001_11aadccc039c2d031e7a103e8372f904880e4e9d?pretty"
{
  "_index" : "wazuh-states-inventory-services",
  "_id" : "wazuh_001_11aadccc039c2d031e7a103e8372f904880e4e9d",
  "_version" : 4605029,
  "_seq_no" : 94,
  "_primary_term" : 1,
  "found" : true,
....
....
}
```

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
