### PR TITLE
Update CURL dependency to 8.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Here you can find all the automation tools maintained by the Wazuh team.
 |[cJSON](https://github.com/DaveGamble/cJSON)|1.7.18|Dave Gamble|MIT License|
 |[cpp-httplib](https://github.com/yhirose/cpp-httplib)|0.25.0|yhirose|MIT License|
 |[cPython](https://github.com/python/cpython)|3.10.19|Guido van Rossum|Python Software Foundation License version 2|
-|[cURL](https://github.com/curl/curl)|8.11.1|Daniel Stenberg|MIT License|
+|[cURL](https://github.com/curl/curl)|8.12.1|Daniel Stenberg|MIT License|
 |[dbus](https://gitlab.freedesktop.org/dbus/dbus)|1.14.10|freedesktop.org|GNU Public License version 2|
 |[Flatbuffers](https://github.com/google/flatbuffers/)|23.5.26|Google Inc.|Apache 2.0 License|
 |[Google Benchmark](https://github.com/google/benchmark)|1.6.1|Google Inc.|Apache 2.0 License||


### PR DESCRIPTION
|Dependency|Current version|Proposed version|
|---|---|---|
|CURL|`8.11.1`|`8.12.1`|

## Description

Due to the segfault found in the following issue, we have updated the CURL dependency to fix the problem:
- #32820 

## Testing
- [Packages - Build Wazuh agent Linux arm - rpm - arm64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18966529774) - 🟢
- [Packages - Build Wazuh agent Linux arm - deb - arm64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18966524935) - 🟢
- [Packages - Build Wazuh agent Linux amd - legacy packages - rpm - x86_64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18958363586) - 🟢
- [Packages - Build Wazuh agent Linux amd - agent packages - rpm - x86_64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18957845753) - 🟢
- [Packages - Build Wazuh agent Linux amd - agent packages - deb - amd64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18957834934) - 🟢
- [Packages - Build Wazuh agent Linux amd - agent packages - rpm - i386](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18957827878) - 🟢
- [Packages - Build Wazuh agent Linux amd - agent packages - deb - i386](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18957822814) - 🟢
- [Packages - Build Wazuh agent macOS packages - arm64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18958372120) - 🟢
- [Packages - Build Wazuh agent macOS packages - intel64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18958369258) - 🟢
- [Packages - Build Wazuh agent Windows](https://github.com/wazuh/wazuh-agent-packages/actions/runs/18958377820) - 🟢
