### PR TITLE
Allow "destination" agent as active response target

### DIFF
--- a/src/active-response/active_responses.c
+++ b/src/active-response/active_responses.c
@@ -261,6 +261,47 @@ const char* get_srcip_from_json(const cJSON *input) {
     return NULL;
 }
 
+
+const char* get_dest_ip_from_json(const cJSON *input) {
+    cJSON *parameters_json = NULL;
+    cJSON *alert_json = NULL;
+    cJSON *data_json = NULL;
+    cJSON *srcip_json = NULL;
+
+    // Detect parameters
+    parameters_json = cJSON_GetObjectItem(input, "parameters");
+    if (!cJSON_IsObject(parameters_json)) {
+        return NULL;
+    }
+
+    // Detect alert
+    alert_json = cJSON_GetObjectItem(parameters_json, "alert");
+    if (!cJSON_IsObject(alert_json)) {
+        return NULL;
+    }
+
+    // Detect data
+    data_json = cJSON_GetObjectItem(alert_json, "data");
+    if (!cJSON_IsObject(data_json)) {
+        return NULL;
+    }
+
+    // Detect srcip from win.eventdata
+    // TODO: rewrite to parse dest_ip from win_eventdata
+    // srcip_json = get_srcip_from_win_eventdata(data_json); 
+    // if (cJSON_IsString(srcip_json)) {
+    //     return srcip_json->valuestring;
+    // }
+    
+    // Detect srcip from data
+    srcip_json = cJSON_GetObjectItem(data_json, "dest_ip");
+    if (cJSON_IsString(srcip_json)) {
+        return srcip_json->valuestring;
+    }
+
+    return NULL;
+}
+
 static cJSON* get_srcip_from_win_eventdata(const cJSON *data) {
     cJSON *win_json = NULL;
     cJSON *eventdata_json = NULL;

--- a/src/active-response/active_responses.h
+++ b/src/active-response/active_responses.h
@@ -84,6 +84,13 @@ const cJSON* get_alert_from_json(const cJSON *input);
 const char* get_srcip_from_json(const cJSON *input);
 
 /**
+ * Get dest_ip from input
+ * @param input Input
+ * @return char * with the dest_ip or NULL on fail
+ * */
+const char* get_dest_ip_from_json(const cJSON *input);
+
+/**
  * Get username from input
  * @param input Input
  * @return char * with the username or NULL on fail

--- a/src/headers/ar.h
+++ b/src/headers/ar.h
@@ -19,6 +19,7 @@
 #define SPECIFIC_AGENT  0000004
 #define AS_ONLY         0000010
 #define SPECIFIC_AGENT_SIZED 0000040
+#define DESTINATION_AGENT 0000060 // TODO which number?
 
 /* We now also support non Active Response messages in here */
 #define NO_AR_MSG       0000020
@@ -27,6 +28,7 @@
 #define REMOTE_AGENT_C          'R'
 #define SPECIFIC_AGENT_C        'S'
 #define SPECIFIC_AGENT_SIZED_C  's'
+#define DESTINATION_AGENT_C     'D'
 #define NONE_C                  'N'
 #define NO_AR_C                 '!'
 

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -80,6 +80,19 @@ void *AR_Forward(__attribute__((unused)) void *arg)
             } else if (*tmp_str == SPECIFIC_AGENT_SIZED_C) {
                 ar_location |= SPECIFIC_AGENT_SIZED;
             }
+            tmp_str++;
+            if (*tmp_str == DESTINATION_AGENT_C) {
+                ar_location |= DESTINATION_AGENT;
+                
+                // TODO: get agent IP from JSON parsed "dest_ip"
+                // active-responses.h should have get_dest_ip_from_json()
+                // besides get_srcip_from_json()
+                //
+                // then find the correct agent_id for this IP
+                // read-agents.c->get_agent_info
+                ar_agent_id = tmp_str; // CHANGE THIS
+
+            }
             tmp_str += 2;
 
             /* Extract the agent id */
@@ -189,9 +202,8 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 
                 key_unlock();
             }
-
-            /* Send to the remote agent that generated the event or to a pre-defined agent */
-            else if (ar_location & (REMOTE_AGENT | SPECIFIC_AGENT)) {
+            /* Send to the remote agent that generated the event or to a pre-defined agent or to the dest_ip agent */
+            else if (ar_location & (REMOTE_AGENT | SPECIFIC_AGENT | DESTINATION_AGENT)) {
                 if (send_msg(ar_agent_id, msg_to_send, -1) >= 0) {
                     rem_inc_send_ar(ar_agent_id);
                 }


### PR DESCRIPTION
I have the situation, that I need active response on a "specific" agent, which is not statically configurable. 

Example scenario:

I have 4 HOSTS

- WAZUH_SERVER
- HOST_A (Attacker)
- HOST_B (Wazuh Agent with Suricata as NIDS on switch mirror port)
- HOST_C (Wazuh Agent installed)


now if HOST_A attacks or port scans HOST_C it is detected by HOST_B through Suricata because it is reading the whole network traffic. But I only have active response `<location>` options like "local" "server" "defined-agent" "all" which are not what I need. In this case I need HOST_B to detect the attacker (srcip) and the victim (dest_ip) and then tells the WAZUH_SERVER that HOST_C (dest_ip) should `firewall-drop` HOST_A (srcip)

I solved it for now that I use custom active_response scripts and SSH from HOST_B to HOST_C and execute iptables command to block HOST_A but that should be configurable directly in `<active-response>`

configuration on the WAZUH_SERVER could look like this

```
<ossec_config>
  <active-response>
    <disabled>no</disabled>
    <command>firewall-drop</command>
    <!-- or "dest_ip" or whatever -->
    <location>destination_agent</location>
    <rules_id>5763</rules_id>
    <timeout>180</timeout>
  </active-response>
</ossec_config>
```

_**The provided commits are more like "example code" where I think the changes should be made!**_