### PR TITLE
Azure Log Analytics bookmarks are overwritten for similar configurations - Implementation

### DIFF
--- a/wodles/azure/azure_services/analytics.py
+++ b/wodles/azure/azure_services/analytics.py
@@ -7,7 +7,6 @@
 
 import logging
 import sys
-from hashlib import md5
 from json import dumps
 from os.path import abspath, dirname
 
@@ -68,7 +67,7 @@ def start_log_analytics(args):
     )
 
     # Build the request
-    md5_hash = md5(args.la_query.encode()).hexdigest()
+    md5_hash = orm.create_pk(workspace=args.workspace, query=args.la_query)
     url = f'{URL_ANALYTICS}/v1/workspaces/{args.workspace}/query'
     body = build_log_analytics_query(
         query=args.la_query,
@@ -122,7 +121,7 @@ def build_log_analytics_query(
             )
     except orm.AzureORMError as e:
         logging.error(
-            f'Error trying to obtain row object from "{orm.LogAnalytics.__tablename__}" using md5="{md5}": '
+            f'Error trying to obtain row object from "{orm.LogAnalytics.__tablename__}" using md5="{md5_hash}": '
             f'{e}'
         )
         sys.exit(1)

--- a/wodles/azure/db/orm.py
+++ b/wodles/azure/db/orm.py
@@ -5,12 +5,13 @@
 # This program is free software; you can redistribute
 # it and/or modify it under the terms of GPLv2
 
+from hashlib import md5
 import json
 import logging
 from datetime import datetime, timezone
 from os import remove
 from os.path import abspath, dirname, exists, getsize, join
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from dateutil.parser import ParserError, parse
 from sqlalchemy import Column, String, Text, UniqueConstraint, create_engine, update
@@ -339,3 +340,30 @@ def get_default_min_max_values() -> str:
         Execution date as a string with format %Y-%m-%dT%H:%M:%S.%fZ
     """
     return datetime.utcnow().replace(tzinfo=timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+
+def create_pk(**kwargs: Any) -> str:
+    """Create a deterministic MD5 hash for use as a primary key.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Keyword arguments to include in the hash. Keys are sorted for deterministic output.
+
+    Returns
+    -------
+    str
+        The hexadecimal MD5 hash string.
+
+    Notes
+    -----
+    Intended for uniqueness, not for cryptographic security.
+    """
+    # Sort items for deterministic hashing
+    sorted_items = sorted(kwargs.items())
+
+    # Build a string representation of key-value pairs
+    concatenated = "|".join(f"{k}={v}" for k, v in sorted_items)
+
+    # Compute the MD5 hash
+    return md5(concatenated.encode("utf-8")).hexdigest()

--- a/wodles/azure/tests/azure_services/test_analytics.py
+++ b/wodles/azure/tests/azure_services/test_analytics.py
@@ -7,7 +7,6 @@
 
 import json
 import sys
-from hashlib import md5
 from os.path import abspath, dirname, join, realpath
 from unittest.mock import MagicMock, call, patch
 
@@ -91,7 +90,7 @@ def test_start_log_analytics(
         domain=tenant,
         scope=f'{URL_ANALYTICS}/.default',
     )
-    md5_hash = md5(query.encode()).hexdigest()
+    md5_hash = orm.create_pk(workspace=workspace, query=query)
     mock_build.assert_called_with(query=query, offset=offset, reparse=reparse, md5_hash=md5_hash)
     mock_get_logs.assert_called_with(
         url=f'{URL_ANALYTICS}/v1/workspaces/{workspace}/query',


### PR DESCRIPTION
## Description

Closes #32846

This PR aims to fix #32846 caused by not including the workspace as part of the composed PK of the internal tracking DB at Azure Log Analytics feature

## Proposed Changes

- Change the current PK from the query hash to a composed hash PK that includes the workspace and the query
### Results and Evidence

```console
(venv) root@wazuh-dev:/var/ossec# wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/credentials/log_analytics_credentials --la_tenant_domain wazuh.com --la_tag azure-auditlogs --la_query "AuditLogs" --workspace WORKSPACE --la_time_offset 10d --debug 1
2025/11/06 11:35:14 azure: INFO: Checking database integrity
2025/11/06 11:35:14 azure: INFO: Database integrity check finished
2025/11/06 11:35:14 azure: INFO: Azure Log Analytics starting.
2025/11/06 11:35:14 azure: INFO: Log Analytics: Getting authentication token.
2025/11/06 11:35:15 azure: INFO: 479a2163bc972a80d7b339c9fcfbcd68 was not found in the database for log_analytics. Adding it.
2025/11/06 11:35:15 azure: INFO: Log Analytics: Sending a request to the Log Analytics API.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Log Analytics: Sending event by socket.
2025/11/06 11:35:17 azure: INFO: Azure Log Analytics ending.
(venv) root@wazuh-dev:/var/ossec# wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/credentials/log_analytics_credentials --la_tenant_domain wazuh.com --la_tag azure-auditlogs --la_query "AuditLogs" --workspace WORKSPACE --la_time_offset 10d --debug 1
2025/11/06 11:37:29 azure: INFO: Checking database integrity
2025/11/06 11:37:29 azure: INFO: Database integrity check finished
2025/11/06 11:37:29 azure: INFO: Azure Log Analytics starting.
2025/11/06 11:37:29 azure: INFO: Log Analytics: Getting authentication token.
2025/11/06 11:37:30 azure: INFO: Log Analytics: Sending a request to the Log Analytics API.
2025/11/06 11:37:31 azure: INFO: Log Analytics: There are no new results for wazuh.com
2025/11/06 11:37:31 azure: INFO: Azure Log Analytics ending.
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
