### PR TITLE
Implement Static KVDB

### DIFF
--- a/src/engine/source/cmstore/interface/cmstore/types.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/types.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -138,5 +139,17 @@ public:
 };
 
 } // namespace cm::store
+
+namespace std
+{
+template<>
+struct hash<cm::store::NamespaceId>
+{
+    size_t operator()(const cm::store::NamespaceId& ns) const noexcept
+    {
+        return std::hash<std::string_view> {}(static_cast<std::string_view>(ns));
+    }
+};
+} // namespace std
 
 #endif // _CMSTORE_ITYPES

--- a/src/engine/source/cmstore/test/mocks/cmstore/mockcmstore.hpp
+++ b/src/engine/source/cmstore/test/mocks/cmstore/mockcmstore.hpp
@@ -15,46 +15,67 @@ public:
     MOCK_METHOD(const NamespaceId&, getNamespaceId, (), (const, override));
     MOCK_METHOD(dataType::Integration, getIntegrationByName, (const std::string& name), (const, override));
     MOCK_METHOD(dataType::Integration, getIntegrationByUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD(bool, integrationExistsByName, (const std::string& name), (const, override));
+    MOCK_METHOD(bool, integrationExistsByUUID, (const std::string& uuid), (const, override));
     MOCK_METHOD(json::Json, getKVDBByName, (const std::string& name), (const, override));
     MOCK_METHOD(json::Json, getKVDBByUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD(bool, kvdbExistsByName, (const base::Name& name), (const, override));
+    MOCK_METHOD(bool, kvdbExistsByUUID, (const std::string& uuid), (const, override));
     MOCK_METHOD(json::Json, getAssetByName, (const base::Name& name), (const, override));
     MOCK_METHOD(json::Json, getAssetByUUID, (const std::string& uuid), (const, override));
-    MOCK_METHOD(std::vector<std::tuple<std::string, std::string>>,
+    MOCK_METHOD(bool, assetExistsByName, (const base::Name& name), (const, override));
+    MOCK_METHOD(bool, assetExistsByUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD((std::vector<std::tuple<std::string, std::string>>),
                 getCollection,
                 (ResourceType type),
                 (const, override));
-    MOCK_METHOD(std::tuple<std::string, ResourceType>,
+    MOCK_METHOD((std::tuple<std::string, ResourceType>),
                 resolveNameFromUUID,
                 (const std::string& uuid),
                 (const, override));
     MOCK_METHOD(std::string, resolveUUIDFromName, (const std::string& name, ResourceType type), (const, override));
-    MOCK_METHOD(bool, isCustomResource, (const std::string& uuid), (const, override));
-    MOCK_METHOD(bool, isCustomResource, (const std::string& name, ResourceType type), (const, override));
 };
 
 class MockICMstoreNS : public ICMstoreNS
-
 {
 public:
     MOCK_METHOD(dataType::Policy, getPolicy, (), (const, override));
     MOCK_METHOD(const NamespaceId&, getNamespaceId, (), (const, override));
     MOCK_METHOD(dataType::Integration, getIntegrationByName, (const std::string& name), (const, override));
     MOCK_METHOD(dataType::Integration, getIntegrationByUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD(bool, integrationExistsByName, (const std::string& name), (const, override));
+    MOCK_METHOD(bool, integrationExistsByUUID, (const std::string& uuid), (const, override));
     MOCK_METHOD(json::Json, getKVDBByName, (const std::string& name), (const, override));
     MOCK_METHOD(json::Json, getKVDBByUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD(bool, kvdbExistsByName, (const base::Name& name), (const, override));
+    MOCK_METHOD(bool, kvdbExistsByUUID, (const std::string& uuid), (const, override));
     MOCK_METHOD(json::Json, getAssetByName, (const base::Name& name), (const, override));
     MOCK_METHOD(json::Json, getAssetByUUID, (const std::string& uuid), (const, override));
-    MOCK_METHOD(std::vector<std::tuple<std::string, std::string>>,
+    MOCK_METHOD(bool, assetExistsByName, (const base::Name& name), (const, override));
+    MOCK_METHOD(bool, assetExistsByUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD((std::vector<std::tuple<std::string, std::string>>),
                 getCollection,
                 (ResourceType type),
                 (const, override));
-    MOCK_METHOD(std::tuple<std::string, ResourceType>,
+    MOCK_METHOD((std::tuple<std::string, ResourceType>),
                 resolveNameFromUUID,
                 (const std::string& uuid),
                 (const, override));
     MOCK_METHOD(std::string, resolveUUIDFromName, (const std::string& name, ResourceType type), (const, override));
-    MOCK_METHOD(bool, isCustomResource, (const std::string& uuid), (const, override));
-    MOCK_METHOD(bool, isCustomResource, (const std::string& name, ResourceType type), (const, override));
+    MOCK_METHOD(void, upsertPolicy, (const dataType::Policy& policy), (override));
+    MOCK_METHOD(void, deletePolicy, (), (override));
+    MOCK_METHOD(std::string, createIntegration, (const dataType::Integration&), (override));
+    MOCK_METHOD(void, updateIntegration, (const dataType::Integration&), (override));
+    MOCK_METHOD(void, deleteIntegrationByName, (const std::string&), (override));
+    MOCK_METHOD(void, deleteIntegrationByUUID, (const std::string&), (override));
+    MOCK_METHOD(std::string, createKVDB, (const dataType::KVDB&), (override));
+    MOCK_METHOD(void, updateKVDB, (const dataType::KVDB&), (override));
+    MOCK_METHOD(void, deleteKVDBByName, (const std::string&), (override));
+    MOCK_METHOD(void, deleteKVDBByUUID, (const std::string&), (override));
+    MOCK_METHOD(std::string, createAsset, (const json::Json&), (override));
+    MOCK_METHOD(void, updateAsset, (const json::Json&), (override));
+    MOCK_METHOD(void, deleteAssetByName, (const base::Name&), (override));
+    MOCK_METHOD(void, deleteAssetByUUID, (const std::string&), (override));
 };
 
 class MockICMstore : public ICMstore
@@ -63,7 +84,9 @@ public:
     MOCK_METHOD(std::shared_ptr<ICMStoreNSReader>, getNSReader, (const NamespaceId& nsId), (const, override));
     MOCK_METHOD(std::shared_ptr<ICMstoreNS>, getNS, (const NamespaceId& nsId), (override));
     MOCK_METHOD(void, createNamespace, (const NamespaceId& nsId), (override));
+    MOCK_METHOD(void, cloneNamespace, (const NamespaceId& sourceNsId, const NamespaceId& targetNsId), (override));
     MOCK_METHOD(void, deleteNamespace, (const NamespaceId& nsId), (override));
+    MOCK_METHOD(std::vector<NamespaceId>, getNamespaces, (), (const, override));
 };
 
 } // namespace cm::store

--- a/src/engine/source/kvdbstore/CMakeLists.txt
+++ b/src/engine/source/kvdbstore/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(kvdbstore_kvdb
     ${INC_DIR}
     PRIVATE
     ${SRC_DIR}
-    ${INC_DIR}/kvdb
 )
 target_link_libraries(kvdbstore_kvdb
     PUBLIC
@@ -52,6 +51,7 @@ target_link_libraries(kvdbstore_utest
         GTest::gmock
         kvdbstore::kvdb
         kvdbstore::mocks
+        cmstore::mocks
 )
 target_include_directories(kvdbstore_utest PRIVATE ${SRC_DIR})
 gtest_discover_tests(kvdbstore_utest)
@@ -63,7 +63,9 @@ add_executable(kvdbstore_ctest
 target_link_libraries(kvdbstore_ctest
     PRIVATE
         GTest::gtest_main
+        GTest::gmock
         kvdbstore::kvdb
+        cmstore::mocks
 )
 gtest_discover_tests(kvdbstore_ctest)
 

--- a/src/engine/source/kvdbstore/include/kvdb/kvdbHandler.hpp
+++ b/src/engine/source/kvdbstore/include/kvdb/kvdbHandler.hpp
@@ -1,16 +1,37 @@
 #ifndef _KVDB_HANDLER_H
 #define _KVDB_HANDLER_H
 
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
 #include <kvdb/ikvdbhandler.hpp>
 
 namespace kvdbStore
 {
 
+using KVMap = std::unordered_map<std::string, json::Json>;
+
 class KVDBHandler final : public IKVDBHandler
 {
 public:
-    KVDBHandler() = default;
-    ~KVDBHandler() = default;
+    explicit KVDBHandler(std::shared_ptr<const KVMap> map) noexcept;
+    ~KVDBHandler() override = default;
+
+    // Non-copyable / non-movable
+    KVDBHandler(const KVDBHandler&) = delete;
+    KVDBHandler& operator=(const KVDBHandler&) = delete;
+    KVDBHandler(KVDBHandler&&) = delete;
+    KVDBHandler& operator=(KVDBHandler&&) = delete;
+
+    // IKVDBHandler
+    const json::Json& get(const std::string& key) const override;
+    bool contains(const std::string& key) const noexcept override;
+
+private:
+    std::shared_ptr<const KVMap> m_map;
 };
 
 } // namespace kvdbStore

--- a/src/engine/source/kvdbstore/include/kvdb/kvdbManager.hpp
+++ b/src/engine/source/kvdbstore/include/kvdb/kvdbManager.hpp
@@ -2,17 +2,42 @@
 #ifndef _KVDB_STORE_MANAGER_H
 #define _KVDB_STORE_MANAGER_H
 
+#include <memory>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+
+#include <cmstore/icmstore.hpp>
+#include <cmstore/types.hpp>
+
 #include <kvdb/ikvdbhandler.hpp>
 #include <kvdb/ikvdbmanager.hpp>
+#include <kvdb/kvdbHandler.hpp>
 
 namespace kvdbStore
 {
+
+using DBMap = std::unordered_map<std::string /*dbName*/, std::weak_ptr<const KVMap>>;
+using Registry = std::unordered_map<cm::store::NamespaceId, DBMap>;
 
 class KVDBManager final : public IKVDBManager
 {
 public:
     KVDBManager() = default;
     ~KVDBManager() = default;
+
+    // Non-copyable / non-movable
+    KVDBManager(const KVDBManager&) = delete;
+    KVDBManager& operator=(const KVDBManager&) = delete;
+    KVDBManager(KVDBManager&&) = delete;
+    KVDBManager& operator=(KVDBManager&&) = delete;
+
+    std::shared_ptr<IKVDBHandler> getKVDBHandler(const cm::store::ICMStoreNSReader& nsReader,
+                                                 const std::string& dbName) override;
+
+private:
+    std::shared_mutex m_mutex;
+    Registry m_registry;
 };
 
 } // namespace kvdbStore

--- a/src/engine/source/kvdbstore/interface/kvdb/ikvdbhandler.hpp
+++ b/src/engine/source/kvdbstore/interface/kvdb/ikvdbhandler.hpp
@@ -3,7 +3,8 @@
 
 #include <optional>
 #include <string>
-#include <string_view>
+
+#include <base/json.hpp>
 
 namespace kvdbStore
 {
@@ -12,7 +13,7 @@ namespace kvdbStore
  *
  * A handler is bound to exactly one logical database (namespace, dbName).
  * Keys are plain strings (field names in the original JSON), and values are
- * exposed as JSON-serialized string views into stable storage owned by the map.
+ * exposed as json::Json object.
  */
 class IKVDBHandler
 {
@@ -20,17 +21,16 @@ public:
     virtual ~IKVDBHandler() = default;
 
     /**
-     * @brief Lookup @p key and return a view of its JSON-serialized value.
+     * @brief Lookup @p key and return a const reference to the stored JSON value.
      *
-     * If present, the view refers to the exact serialized JSON stored in the KV map
+     * If present, the reference aliases the exact JSON node stored in the KV map
      * (object, array, number, boolean, string or null).
      *
      * @param key Entry name inside the KVDB.
-     * @return std::nullopt if the key does not exist; otherwise a std::string_view
-     *         pointing to stable storage owned by the KV map. The view becomes invalid
-     *         if the underlying map is destroyed or replaced.
+     * @return const reference to the JSON value.
+     * @throws std::out_of_range if the key is not found, or the underlying map is not available.
      */
-    virtual std::optional<std::string_view> get(const std::string& key) const noexcept = 0;
+    virtual const json::Json& get(const std::string& key) const = 0;
 
     /**
      * @brief Check whether @p key exists in this KVDB.

--- a/src/engine/source/kvdbstore/interface/kvdb/ikvdbmanager.hpp
+++ b/src/engine/source/kvdbstore/interface/kvdb/ikvdbmanager.hpp
@@ -40,7 +40,7 @@ public:
      * @return Shared handler on success; nullptr if not found.
      */
     virtual std::shared_ptr<IKVDBHandler> getKVDBHandler(const cm::store::ICMStoreNSReader& nsReader,
-                                                         const std::string& dbName) noexcept = 0;
+                                                         const std::string& dbName) = 0;
 };
 
 } // namespace kvdbStore

--- a/src/engine/source/kvdbstore/src/kvdbHandler.cpp
+++ b/src/engine/source/kvdbstore/src/kvdbHandler.cpp
@@ -3,4 +3,30 @@
 namespace kvdbStore
 {
 
+KVDBHandler::KVDBHandler(std::shared_ptr<const KVMap> map) noexcept
+    : m_map(std::move(map))
+{
+}
+
+const json::Json& KVDBHandler::get(const std::string& key) const
+{
+    if (!m_map)
+    {
+        throw std::out_of_range("KVDBHandler has no backing map (null).");
+    }
+
+    const auto it = m_map->find(key);
+    if (it == m_map->end())
+    {
+        throw std::out_of_range("Key not found in KVDB: '" + key + "'.");
+    }
+
+    return it->second;
+}
+
+bool KVDBHandler::contains(const std::string& key) const noexcept
+{
+    return m_map && (m_map->find(key) != m_map->end());
+}
+
 } // namespace kvdbStore

--- a/src/engine/source/kvdbstore/src/kvdbManager.cpp
+++ b/src/engine/source/kvdbstore/src/kvdbManager.cpp
@@ -1,6 +1,90 @@
 #include <kvdb/kvdbManager.hpp>
 
+#include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <base/json.hpp>
+
+#include <kvdb/kvdbHandler.hpp>
+
 namespace kvdbStore
 {
+
+std::shared_ptr<IKVDBHandler> KVDBManager::getKVDBHandler(const cm::store::ICMStoreNSReader& nsReader,
+                                                          const std::string& dbName)
+{
+    const auto& nsId = nsReader.getNamespaceId();
+
+    {
+        // Fast path: read lock + cache hit
+        std::shared_lock<std::shared_mutex> rlk(m_mutex);
+        if (auto nsIt = m_registry.find(nsId); nsIt != m_registry.end())
+        {
+            if (auto dbIt = nsIt->second.find(dbName); dbIt != nsIt->second.end())
+            {
+                if (auto alive = dbIt->second.lock())
+                {
+                    return std::make_shared<KVDBHandler>(std::move(alive));
+                }
+            }
+        }
+    }
+
+    const json::Json j = nsReader.getKVDBByName(dbName);
+    auto keysOpt = j.getFields("");
+    if (!keysOpt.has_value())
+    {
+        const auto nsStr = nsId.toStr();
+        throw std::runtime_error("KVDB payload must be a JSON object (ns='" + nsStr + "', db='" + dbName + "').");
+    }
+
+    auto wmap = std::make_shared<KVMap>();
+    wmap->reserve(keysOpt->size());
+
+    for (const auto& key : *keysOpt)
+    {
+        const std::string ptrPath = json::Json::formatJsonPath(key, true);
+        auto valOpt = j.getJson(ptrPath);
+        if (!valOpt.has_value())
+        {
+            const auto nsStr = nsId.toStr();
+            throw std::runtime_error("KVDB value for key '" + key + "' is not addressable via JSON Pointer '" + ptrPath
+                                     + "' (ns='" + nsStr + "', db='" + dbName + "').");
+        }
+        wmap->try_emplace(key, std::move(*valOpt));
+    }
+
+    std::shared_ptr<const KVMap> cmap = std::move(wmap);
+
+    {
+        // Publish to cache (write lock)
+        std::unique_lock<std::shared_mutex> wlk(m_mutex);
+        auto& dbMap = m_registry[nsId];
+        auto it = dbMap.find(dbName);
+        if (it != dbMap.end())
+        {
+            // Another thread won: reuse theirs
+            if (auto alive = it->second.lock())
+            {
+                cmap = std::move(alive);
+            }
+            else
+            {
+                // Refresh expired entry
+                it->second = cmap;
+            }
+        }
+        else
+        {
+            // First insertion
+            dbMap.try_emplace(dbName, cmap);
+        }
+    }
+
+    return std::make_shared<KVDBHandler>(std::move(cmap));
+}
 
 } // namespace kvdbStore

--- a/src/engine/source/kvdbstore/test/mocks/kvdb/mockKvdbHandler.hpp
+++ b/src/engine/source/kvdbstore/test/mocks/kvdb/mockKvdbHandler.hpp
@@ -1,12 +1,11 @@
-#ifndef _KVDBSTORE_MOCK_KVDB_HANDLER_HPP
-#define _KVDBSTORE_MOCK_KVDB_HANDLER_HPP
+#ifndef _MOCKS_KVDBSTORE_KVDB_HANDLER_HPP
+#define _MOCKS_KVDBSTORE_KVDB_HANDLER_HPP
 
-#include <optional>
 #include <string>
-#include <string_view>
 
 #include <gmock/gmock.h>
 
+#include <base/json.hpp>
 #include <kvdb/ikvdbhandler.hpp>
 
 namespace kvdbStore::mocks
@@ -15,10 +14,10 @@ namespace kvdbStore::mocks
 class MockKVDBHandler : public kvdbStore::IKVDBHandler
 {
 public:
-    MOCK_METHOD((std::optional<std::string_view>), get, (const std::string& key), (const, noexcept, override));
+    MOCK_METHOD(const json::Json&, get, (const std::string& key), (const, override));
     MOCK_METHOD(bool, contains, (const std::string& key), (const, noexcept, override));
 };
 
 } // namespace kvdbStore::mocks
 
-#endif // _KVDBSTORE_MOCK_KVDB_HANDLER_HPP
+#endif // _MOCKS_KVDBSTORE_KVDB_HANDLER_HPP

--- a/src/engine/source/kvdbstore/test/mocks/kvdb/mockKvdbManager.hpp
+++ b/src/engine/source/kvdbstore/test/mocks/kvdb/mockKvdbManager.hpp
@@ -1,5 +1,5 @@
-#ifndef _KVDB_MOCK_KVDB_MANAGER_HPP
-#define _KVDB_MOCK_KVDB_MANAGER_HPP
+#ifndef _MOCKS_KVDBSTORE_KVDB_MANAGER_HPP
+#define _MOCKS_KVDBSTORE_KVDB_MANAGER_HPP
 
 #include <memory>
 #include <string>
@@ -20,9 +20,9 @@ public:
     MOCK_METHOD(std::shared_ptr<IKVDBHandler>,
                 getKVDBHandler,
                 (const cm::store::ICMStoreNSReader& nsReader, const std::string& dbName),
-                (noexcept, override));
+                (override));
 };
 
 } // namespace kvdbStore::mocks
 
-#endif // _KVDB_MOCK_KVDB_MANAGER_HPP
+#endif // _MOCKS_KVDBSTORE_KVDB_MANAGER_HPP

--- a/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp
+++ b/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp
@@ -1,7 +1,251 @@
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
 #include <gtest/gtest.h>
 
-TEST(KVDBManagerTest, init)
+#include <base/json.hpp>
+#include <cmstore/icmstore.hpp>
+#include <cmstore/mockcmstore.hpp>
+
+#include <kvdb/kvdbManager.hpp>
+
+namespace
 {
-    // Dummy test to verify that KVDBManager can be instantiated.
-    GTEST_SKIP() << "Not implemented yet.";
+// Helper: run N parallel reads to the same (ns, db, key) and collect pointers.
+inline std::vector<std::reference_wrapper<const json::Json>> parallelReadRefs(kvdbStore::KVDBManager& mgr,
+                                                                              const cm::store::ICMStoreNSReader& ns,
+                                                                              const std::string& db,
+                                                                              const std::string& key,
+                                                                              int threads)
+{
+    std::atomic<bool> start {false};
+    static const json::Json kDummy {"null"};
+    std::vector<std::reference_wrapper<const json::Json>> refs(threads, std::cref(kDummy));
+    std::vector<std::thread> ths;
+    ths.reserve(threads);
+
+    for (int i = 0; i < threads; ++i)
+    {
+        ths.emplace_back(
+            [&, i]
+            {
+                // Spin barrier to align thread start
+                while (!start.load(std::memory_order_acquire))
+                { /* spin */
+                }
+                auto h = mgr.getKVDBHandler(ns, db);
+                ASSERT_NE(h, nullptr);
+                const json::Json& v = h->get(key);
+                refs[i] = std::cref(v);
+            });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& t : ths) t.join();
+    return refs;
+}
+} // namespace
+
+// Build once and then serve from the cache: no refetch, same pointer.
+TEST(KVDB_Component, BuildOnceThenCache_NoRefetch_SamePointer)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> seed, again;
+
+    ON_CALL(seed, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(again, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(seed, getKVDBByName("kv")).Times(1).WillOnce(::testing::Return(json::Json {R"({"k":"v1"})"}));
+
+    // First build
+    auto h1 = mgr.getKVDBHandler(seed, "kv");
+    ASSERT_NE(h1, nullptr);
+    const json::Json& v1 = h1->get("k");
+    EXPECT_EQ(v1, json::Json {"\"v1\""});
+
+    // No refetch on cache hit
+    ::testing::Mock::VerifyAndClearExpectations(&seed);
+    EXPECT_CALL(again, getKVDBByName("kv")).Times(0);
+
+    auto h2 = mgr.getKVDBHandler(again, "kv");
+    ASSERT_NE(h2, nullptr);
+    const json::Json& v2 = h2->get("k");
+
+    EXPECT_EQ(v2, json::Json {"\"v1\""});
+    EXPECT_EQ(std::addressof(v1), std::addressof(v2)); // same underlying pointer (same cached map)
+}
+
+// After all handlers are released, a subsequent request rebuilds with new content.
+TEST(KVDB_Component, ExpireAllHandlers_RebuildWithNewContent)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> r1, r2;
+
+    ON_CALL(r1, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(r2, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(r1, getKVDBByName("kv")).Times(1).WillOnce(::testing::Return(json::Json {R"({"k":"v1"})"}));
+
+    // Build and drop
+    auto h1 = mgr.getKVDBHandler(r1, "kv");
+    ASSERT_NE(h1, nullptr);
+    h1.reset(); // all handlers gone → cache can expire
+
+    // Next call must refetch with new payload
+    EXPECT_CALL(r2, getKVDBByName("kv")).Times(1).WillOnce(::testing::Return(json::Json {R"({"k":"v2"})"}));
+
+    auto h2 = mgr.getKVDBHandler(r2, "kv");
+    ASSERT_NE(h2, nullptr);
+    const json::Json& v2 = h2->get("k");
+    EXPECT_EQ(v2, json::Json {"\"v2\""});
+}
+
+// Different namespaces and db names are fully isolated (distinct caches).
+TEST(KVDB_Component, CrossNamespaceAndDb_IsolatedCaches)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsA {"A"}, nsB {"B"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> a1, a2, b1;
+
+    ON_CALL(a1, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsA));
+    ON_CALL(a2, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsA));
+    ON_CALL(b1, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsB));
+
+    EXPECT_CALL(a1, getKVDBByName("db1")).Times(1).WillOnce(::testing::Return(json::Json {R"({"k":"A1"})"}));
+    EXPECT_CALL(a2, getKVDBByName("db2")).Times(1).WillOnce(::testing::Return(json::Json {R"({"k":"A2"})"}));
+    EXPECT_CALL(b1, getKVDBByName("db1")).Times(1).WillOnce(::testing::Return(json::Json {R"({"k":"B1"})"}));
+
+    auto hA1 = mgr.getKVDBHandler(a1, "db1");
+    auto hA2 = mgr.getKVDBHandler(a2, "db2");
+    auto hB1 = mgr.getKVDBHandler(b1, "db1");
+    ASSERT_NE(hA1, nullptr);
+    ASSERT_NE(hA2, nullptr);
+    ASSERT_NE(hB1, nullptr);
+
+    const json::Json& vA1 = hA1->get("k");
+    const json::Json& vA2 = hA2->get("k");
+    const json::Json& vB1 = hB1->get("k");
+
+    EXPECT_EQ(vA1, json::Json {"\"A1\""});
+    EXPECT_EQ(vA2, json::Json {"\"A2\""});
+    EXPECT_EQ(vB1, json::Json {"\"B1\""});
+
+    // Distinct caches → distinct pointers across {ns,db}
+    EXPECT_NE(std::addressof(vA1), std::addressof(vA2));
+    EXPECT_NE(std::addressof(vA1), std::addressof(vB1));
+    EXPECT_NE(std::addressof(vA2), std::addressof(vB1));
+}
+
+// Concurrent cold race on the same (ns, db) eventually converges to a stable cache.
+TEST(KVDB_Component, ConcurrentColdRace_EventualConvergence)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> ns;
+
+    ON_CALL(ns, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    std::atomic<int> fetches {0};
+    ON_CALL(ns, getKVDBByName("kv"))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string&)
+            {
+                fetches.fetch_add(1, std::memory_order_relaxed);
+                return json::Json {R"({"k":"v"})"};
+            }));
+
+    // Parallel cold start (no pre-warm)
+    constexpr int kThreads = 16;
+    auto refs = parallelReadRefs(mgr, ns, "kv", "k", kThreads);
+
+    // Multiple builds may happen before publish; we only require convergence afterwards.
+    std::unordered_set<const json::Json*> uniq;
+    uniq.reserve(refs.size());
+    for (const auto& r : refs) uniq.insert(std::addressof(r.get()));
+    EXPECT_GE(uniq.size(), 1u);
+    EXPECT_LE(uniq.size(), static_cast<size_t>(kThreads));
+    EXPECT_GE(fetches.load(), 1);
+
+    // A follow-up call must either hit the existing cache (pointer in uniq)
+    // or rebuild once if everything already expired.
+    const auto before = fetches.load();
+
+    auto h = mgr.getKVDBHandler(ns, "kv");
+    ASSERT_NE(h, nullptr);
+    const json::Json& v = h->get("k");
+    EXPECT_EQ(v, json::Json {"\"v\""});
+
+    const auto p = std::addressof(v);
+    const auto after = fetches.load();
+    if (after == before)
+    {
+        EXPECT_EQ(uniq.count(p), 1u);
+    }
+    else
+    {
+        EXPECT_GT(after, before);
+    }
+}
+
+// Non-object payloads are invalid and must throw during build.
+TEST(KVDB_Component, InvalidPayload_Throws)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> badStr, badArr;
+
+    ON_CALL(badStr, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(badArr, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(badStr, getKVDBByName("kv")).Times(1).WillOnce(::testing::Return(json::Json {"\"not-an-object\""}));
+    EXPECT_CALL(badArr, getKVDBByName("kv")).Times(1).WillOnce(::testing::Return(json::Json {"[1,2,3]"}));
+
+    // Manager expects a JSON object to enumerate top-level keys.
+    EXPECT_THROW({ (void)mgr.getKVDBHandler(badStr, "kv"); }, std::runtime_error);
+    EXPECT_THROW({ (void)mgr.getKVDBHandler(badArr, "kv"); }, std::runtime_error);
+}
+
+// Mixed value types (object, array, number, boolean, string, null) are supported as values.
+TEST(KVDB_Component, NestedValues_AccessAndEquality)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> ns;
+
+    ON_CALL(ns, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    EXPECT_CALL(ns, getKVDBByName("kv"))
+        .Times(1)
+        .WillOnce(::testing::Return(json::Json {
+            R"({
+                "obj": {"a":1, "b":[2,3]},
+                "arr": [10, 20, 30],
+                "num": 42,
+                "boo": true,
+                "str": "text",
+                "nil": null
+            })"}));
+
+    auto h = mgr.getKVDBHandler(ns, "kv");
+    ASSERT_NE(h, nullptr);
+
+    const json::Json& obj = h->get("obj");
+    const json::Json& arr = h->get("arr");
+    const json::Json& num = h->get("num");
+    const json::Json& boo = h->get("boo");
+    const json::Json& str = h->get("str");
+    const json::Json& nil = h->get("nil");
+
+    EXPECT_EQ(obj, json::Json {R"({"a":1,"b":[2,3]})"});
+    EXPECT_EQ(arr, json::Json {"[10,20,30]"});
+    EXPECT_EQ(num, json::Json {"42"});
+    EXPECT_EQ(boo, json::Json {"true"});
+    EXPECT_EQ(str, json::Json {"\"text\""});
+    EXPECT_EQ(nil, json::Json {"null"});
 }

--- a/src/engine/source/kvdbstore/test/src/unit/kvdb_handler_test.cpp
+++ b/src/engine/source/kvdbstore/test/src/unit/kvdb_handler_test.cpp
@@ -1,7 +1,126 @@
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
 #include <gtest/gtest.h>
 
-TEST(KVDBHandlerTest, init)
+#include <base/json.hpp>
+#include <kvdb/kvdbHandler.hpp>
+
+// Basic get() and contains() functionality
+TEST(KVDB_Handler_Unit, GetAndContainsBasic)
 {
-    // Dummy test to verify that KVDBHandler can be instantiated.
-    GTEST_SKIP() << "Not implemented yet.";
+    auto map = std::make_shared<kvdbStore::KVMap>();
+    map->emplace("s", json::Json {"\"str\""});
+    map->emplace("n", json::Json {"123"});
+    map->emplace("o", json::Json {R"({"a":1})"});
+
+    kvdbStore::KVDBHandler h(map);
+
+    EXPECT_TRUE(h.contains("s"));
+    EXPECT_TRUE(h.contains("n"));
+    EXPECT_TRUE(h.contains("o"));
+    EXPECT_FALSE(h.contains("missing"));
+
+    const json::Json& v1 = h.get("s");
+    EXPECT_EQ(std::addressof(v1), &map->at("s")); // no copy, direct reference to stored Json
+
+    const json::Json& v2 = h.get("n");
+    EXPECT_EQ(std::addressof(v2), &map->at("n"));
+
+    const json::Json& v3 = h.get("o");
+    EXPECT_EQ(std::addressof(v3), &map->at("o"));
+
+    EXPECT_THROW((void)h.get("missing"), std::out_of_range);
+}
+
+// Views returned by different handlers over the same map point to the same data
+TEST(KVDB_Handler_Unit, ViewsAreStableWhileMapLives)
+{
+    auto map = std::make_shared<kvdbStore::KVMap>();
+    map->emplace("k", json::Json {"\"v\""});
+
+    kvdbStore::KVDBHandler h1(map);
+    kvdbStore::KVDBHandler h2(map);
+
+    const json::Json& r1 = h1.get("k");
+    const json::Json& r2 = h2.get("k");
+
+    EXPECT_EQ(std::addressof(r1), std::addressof(r2));
+    EXPECT_EQ(std::addressof(r1), &map->at("k"));
+}
+
+// Safe behavior with a null map
+TEST(KVDB_Handler_Unit, NullMapIsSafe)
+{
+    std::shared_ptr<kvdbStore::KVMap> nullMap; // nullptr
+    kvdbStore::KVDBHandler h(nullMap);
+
+    EXPECT_FALSE(h.contains("k"));
+    EXPECT_THROW((void)h.get("k"), std::logic_error);
+}
+
+// Empty key and empty value are handled as regular entries
+TEST(KVDB_Handler_Unit, SupportsEmptyKeyAndEmptyValue)
+{
+    auto map = std::make_shared<kvdbStore::KVMap>();
+    map->emplace("", json::Json {"\"\""});
+
+    kvdbStore::KVDBHandler h(map);
+
+    EXPECT_TRUE(h.contains(""));
+    const json::Json& v = h.get("");
+    EXPECT_EQ(std::addressof(v), &map->at(""));
+}
+
+// Many concurrent readers on the same handler/key are safe
+TEST(KVDB_Handler_Unit, ConcurrentReadersAreSafe)
+{
+    auto map = std::make_shared<kvdbStore::KVMap>();
+    map->emplace("k", json::Json {"\"value\""});
+    kvdbStore::KVDBHandler h(map);
+
+    constexpr int kThreads = 8;
+    constexpr int kItersPerThread = 2000;
+
+    const json::Json* expected = &map->at("k");
+
+    std::atomic<int> okCount {0};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t)
+    {
+        threads.emplace_back(
+            [&]
+            {
+                for (int i = 0; i < kItersPerThread; ++i)
+                {
+                    const json::Json& r = h.get("k");
+                    if (std::addressof(r) == expected)
+                    {
+                        ++okCount;
+                    }
+                }
+            });
+    }
+    for (auto& th : threads) th.join();
+
+    EXPECT_EQ(okCount.load(), kThreads * kItersPerThread);
+}
+
+// Large values are returned verbatim (pointer to the stored Json)
+TEST(KVDB_Handler_Unit, LargeValueIsReturnedVerbatim)
+{
+    auto map = std::make_shared<kvdbStore::KVMap>();
+    std::string big(20000, 'x');
+    const std::string json_text = "\"" + big + "\"";
+    map->emplace("big", json::Json {json_text.c_str()});
+    kvdbStore::KVDBHandler h(map);
+
+    const json::Json& r = h.get("big");
+    EXPECT_EQ(std::addressof(r), &map->at("big")); // same instance, no copy
 }

--- a/src/engine/source/kvdbstore/test/src/unit/kvdb_manager_test.cpp
+++ b/src/engine/source/kvdbstore/test/src/unit/kvdb_manager_test.cpp
@@ -1,7 +1,369 @@
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
 #include <gtest/gtest.h>
 
-TEST(KVDBManagerTest, init)
+#include <base/json.hpp>
+#include <cmstore/icmstore.hpp>
+#include <cmstore/mockcmstore.hpp>
+
+#include <kvdb/kvdbManager.hpp>
+
+namespace
 {
-    // Dummy test to verify that KVDBManager can be instantiated.
-    GTEST_SKIP() << "Not implemented yet.";
+// Helper: run N parallel reads to the same (ns, db, key) and collect references.
+inline std::vector<std::reference_wrapper<const json::Json>> parallelReadRefs(kvdbStore::KVDBManager& mgr,
+                                                                              const cm::store::ICMStoreNSReader& ns,
+                                                                              const std::string& db,
+                                                                              const std::string& key,
+                                                                              int threads)
+{
+    std::atomic<bool> start {false};
+    static const json::Json kDummy {"null"};
+    std::vector<std::reference_wrapper<const json::Json>> refs(threads, std::cref(kDummy));
+    std::vector<std::thread> ths;
+    ths.reserve(threads);
+
+    for (int i = 0; i < threads; ++i)
+    {
+        ths.emplace_back(
+            [&, i]
+            {
+                while (!start.load(std::memory_order_acquire))
+                { /* spin */
+                }
+                auto h = mgr.getKVDBHandler(ns, db);
+                ASSERT_NE(h, nullptr);
+                const json::Json& v = h->get(key);
+                refs[i] = std::cref(v);
+            });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto& t : ths) t.join();
+    return refs;
+}
+} // namespace
+
+TEST(KVDB_Manager_Unit, CacheHitDoesNotFetchAgain)
+{
+    kvdbStore::KVDBManager mgr;
+
+    cm::store::NamespaceId nsId {"ns"};
+    cm::store::MockICMStoreNSReader seed, again;
+
+    ON_CALL(seed, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(again, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(seed, getKVDBByName("db"))
+        .Times(::testing::Exactly(1))
+        .WillOnce(::testing::Return(json::Json {R"({"k":"v1"})"}));
+
+    auto h1 = mgr.getKVDBHandler(seed, "db");
+    ASSERT_NE(h1, nullptr);
+    const json::Json& r1 = h1->get("k");
+    EXPECT_EQ(r1, json::Json {"\"v1\""});
+
+    EXPECT_CALL(again, getKVDBByName("db")).Times(0); // cache hit
+
+    auto h2 = mgr.getKVDBHandler(again, "db");
+    ASSERT_NE(h2, nullptr);
+    const json::Json& r2 = h2->get("k");
+    EXPECT_EQ(r2, json::Json {"\"v1\""});
+    EXPECT_EQ(std::addressof(r1), std::addressof(r2));
+}
+
+// Cache hit reuses the existing map (same underlying buffer) and does not rebuild.
+TEST(KVDB_Manager_Unit, CacheHitReusesExistingMap)
+{
+    kvdbStore::KVDBManager mgr;
+
+    cm::store::NamespaceId nsId {"ns"};
+    cm::store::MockICMStoreNSReader r1, r2;
+
+    ON_CALL(r1, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(r2, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(r1, getKVDBByName("db"))
+        .Times(::testing::Exactly(1))
+        .WillOnce(::testing::Return(json::Json {R"({"k":"v1"})"}));
+    EXPECT_CALL(r2, getKVDBByName("db")).Times(0); // cache hit → no fetch
+
+    auto hA = mgr.getKVDBHandler(r1, "db");
+    ASSERT_NE(hA, nullptr);
+    const json::Json& a = hA->get("k");
+
+    auto hB = mgr.getKVDBHandler(r2, "db");
+    ASSERT_NE(hB, nullptr);
+    const json::Json& b = hB->get("k");
+
+    EXPECT_EQ(std::addressof(a), std::addressof(b));
+}
+
+// After all handlers expire, the manager rebuilds with the new content.
+TEST(KVDB_Manager_Unit, RebuildsAfterAllHandlersExpire)
+{
+    kvdbStore::KVDBManager mgr;
+
+    cm::store::NamespaceId nsId {"ns"};
+    cm::store::MockICMStoreNSReader r1, r2;
+
+    ON_CALL(r1, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(r2, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(r1, getKVDBByName("db"))
+        .Times(::testing::Exactly(1))
+        .WillOnce(::testing::Return(json::Json {R"({"k":"v1"})"}));
+
+    auto h1 = mgr.getKVDBHandler(r1, "db");
+    ASSERT_NE(h1, nullptr);
+    h1.reset(); // drop the only handler to allow cache eviction
+
+    EXPECT_CALL(r2, getKVDBByName("db"))
+        .Times(::testing::Exactly(1))
+        .WillOnce(::testing::Return(json::Json {R"({"k":"v2"})"}));
+
+    auto h2 = mgr.getKVDBHandler(r2, "db");
+    ASSERT_NE(h2, nullptr);
+    const json::Json& v2 = h2->get("k");
+    EXPECT_EQ(v2, json::Json {"\"v2\""});
+}
+
+// Same namespace but different dbName entries must use different cached maps.
+TEST(KVDB_Manager_Unit, DifferentDbNamesUseDifferentCachedMaps)
+{
+    kvdbStore::KVDBManager mgr;
+
+    cm::store::NamespaceId nsId {"ns"};
+    cm::store::MockICMStoreNSReader r;
+
+    ON_CALL(r, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    EXPECT_CALL(r, getKVDBByName("countries"))
+        .Times(::testing::Exactly(1))
+        .WillOnce(::testing::Return(json::Json {R"({"k":"v"})"}));
+    EXPECT_CALL(r, getKVDBByName("cities"))
+        .Times(::testing::Exactly(1))
+        .WillOnce(::testing::Return(json::Json {R"({"k":"v"})"}));
+
+    auto hA = mgr.getKVDBHandler(r, "countries");
+    auto hB = mgr.getKVDBHandler(r, "cities");
+    ASSERT_NE(hA, nullptr);
+    ASSERT_NE(hB, nullptr);
+
+    const json::Json& a = hA->get("k");
+    const json::Json& b = hB->get("k");
+
+    EXPECT_EQ(a, json::Json {"\"v\""});
+    EXPECT_EQ(b, json::Json {"\"v\""});
+    EXPECT_NE(std::addressof(a), std::addressof(b)); // different maps → different addresses
+}
+
+// Parallel requests for the same namespace and dbName must return the same pointer.
+TEST(KVDB_Manager_Unit, ParallelWarm_NoRefetch_SamePointer)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> ns;
+
+    // Same namespace for all calls
+    ON_CALL(ns, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    // Provide a single payload; only the warm-up should fetch
+    ON_CALL(ns, getKVDBByName("db"))
+        .WillByDefault(::testing::Invoke([&](const std::string&) { return json::Json {R"({"k":"v"})"}; }));
+
+    // Warm the cache so concurrent calls hit the same cached map
+    auto warm = mgr.getKVDBHandler(ns, "db");
+    ASSERT_NE(warm, nullptr);
+    const json::Json& winner = warm->get("k");
+
+    // No further fetches are expected after warm-up
+    ::testing::Mock::VerifyAndClearExpectations(&ns);
+    EXPECT_CALL(ns, getKVDBByName("db")).Times(0);
+
+    // Fan-out many threads reading the same entry at the same time
+    constexpr int kThreads = 12;
+    auto refs = parallelReadRefs(mgr, ns, "db", "k", kThreads);
+
+    // Every reference must match the pre-warmed one
+    for (int i = 0; i < kThreads; ++i) EXPECT_EQ(std::addressof(refs[i].get()), std::addressof(winner));
+}
+
+// Cold race where multiple threads request the same namespace and dbName
+TEST(KVDB_Manager_Unit, ParallelColdRace_EventualConvergence)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> ns;
+
+    // All calls refer to the same namespace
+    ON_CALL(ns, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    // Cold start: allow fetch during the race; we count how many happened
+    std::atomic<int> fetches {0};
+    ON_CALL(ns, getKVDBByName("db"))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string&)
+            {
+                fetches.fetch_add(1, std::memory_order_relaxed);
+                return json::Json {R"({"k":"v"})"};
+            }));
+
+    // Launch threads without pre-warming (true cold race)
+    constexpr int kThreads = 12;
+    auto refs = parallelReadRefs(mgr, ns, "db", "k", kThreads);
+
+    // There may be multiple underlying buffers if multiple threads built before publishing
+    std::unordered_set<const json::Json*> uniq;
+    uniq.reserve(kThreads);
+    for (const auto& rr : refs) uniq.insert(std::addressof(rr.get()));
+    EXPECT_GE(uniq.size(), 1u);
+    EXPECT_LE(uniq.size(), static_cast<size_t>(kThreads));
+    EXPECT_GE(fetches.load(), 1);
+
+    // After the dust settles, querying again should either reuse the last map
+    // or, if everything expired, rebuild once. Both paths are valid.
+    const auto before = fetches.load();
+
+    auto after = mgr.getKVDBHandler(ns, "db");
+    ASSERT_NE(after, nullptr);
+    const json::Json& asv = after->get("k");
+    EXPECT_EQ(asv, json::Json {"\"v\""});
+
+    const auto after_fetches = fetches.load();
+    if (after_fetches == before)
+    {
+        // Cache still alive: the address must belong to the set seen by the threads.
+        EXPECT_EQ(uniq.count(std::addressof(asv)), 1u);
+    }
+    else
+    {
+        // Cache expired: a refetch/rebuild occurred, address can differ.
+        EXPECT_GT(after_fetches, before);
+    }
+}
+
+// Parallel requests for the same namespace and dbName must share the cached map.
+TEST(KVDB_Manager_Unit, ParallelSameNsSameDb_SharedCachedMap)
+{
+    kvdbStore::KVDBManager mgr;
+
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> ns;
+
+    // All threads use identical namespace
+    ON_CALL(ns, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+
+    // Allow a single fetch during warm-up; block any later fetches
+    std::atomic<int> fetches {0};
+    ON_CALL(ns, getKVDBByName("db"))
+        .WillByDefault(::testing::Invoke(
+            [&](const std::string&)
+            {
+                fetches.fetch_add(1, std::memory_order_relaxed);
+                return json::Json {R"({"k":"v"})"};
+            }));
+
+    // Warm the cache once and capture the “winner” buffer
+    auto warm = mgr.getKVDBHandler(ns, "db");
+    ASSERT_NE(warm, nullptr);
+    const json::Json& winner = warm->get("k");
+
+    ::testing::Mock::VerifyAndClearExpectations(&ns);
+    EXPECT_CALL(ns, getKVDBByName("db")).Times(0);
+
+    // Many parallel reads, all should point to the same buffer
+    constexpr int kThreads = 12;
+    auto refs = parallelReadRefs(mgr, ns, "db", "k", kThreads);
+
+    // Unblock and ensure everyone sees the same address
+    for (int i = 0; i < kThreads; ++i)
+    {
+        EXPECT_EQ(std::addressof(refs[i].get()), std::addressof(winner));
+    }
+
+    EXPECT_GE(fetches.load(), 1);
+}
+
+// Parallel requests for different namespaces must be isolated.
+TEST(KVDB_Manager_Unit, ParallelTwoNamespaces_Isolated)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsA {"A"}, nsB {"B"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> rA, rB;
+
+    // Distinct namespaces to distinct cache buckets
+    ON_CALL(rA, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsA));
+    ON_CALL(rB, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsB));
+    ON_CALL(rA, getKVDBByName("db"))
+        .WillByDefault(::testing::Invoke([&](const std::string&) { return json::Json {R"({"k":"a"})"}; }));
+    ON_CALL(rB, getKVDBByName("db"))
+        .WillByDefault(::testing::Invoke([&](const std::string&) { return json::Json {R"({"k":"b"})"}; }));
+
+    // Seed both caches and record their buffer pointers
+    auto hA0 = mgr.getKVDBHandler(rA, "db");
+    auto hB0 = mgr.getKVDBHandler(rB, "db");
+    ASSERT_NE(hA0, nullptr);
+    ASSERT_NE(hB0, nullptr);
+    const json::Json& a = hA0->get("k");
+    const json::Json& b = hB0->get("k");
+
+    // Freeze fetches; subsequent reads must be cache-only
+    ::testing::Mock::VerifyAndClearExpectations(&rA);
+    ::testing::Mock::VerifyAndClearExpectations(&rB);
+    EXPECT_CALL(rA, getKVDBByName("db")).Times(0);
+    EXPECT_CALL(rB, getKVDBByName("db")).Times(0);
+
+    // Blast parallel reads into each namespace independently
+    constexpr int kThreads = 8;
+    auto refsA = parallelReadRefs(mgr, rA, "db", "k", kThreads);
+    auto refsB = parallelReadRefs(mgr, rB, "db", "k", kThreads);
+
+    // Verify independence: all A addresses equal &a, all B addresses equal &b, and &a != &b
+    for (int i = 0; i < kThreads; ++i) EXPECT_EQ(std::addressof(refsA[i].get()), std::addressof(a));
+    for (int i = 0; i < kThreads; ++i) EXPECT_EQ(std::addressof(refsB[i].get()), std::addressof(b));
+    EXPECT_NE(std::addressof(a), std::addressof(b));
+}
+
+// Same namespace but different dbName entries must be isolated.
+TEST(KVDB_Manager_Unit, ParallelSameNs_DifferentDb_Isolated)
+{
+    kvdbStore::KVDBManager mgr;
+    cm::store::NamespaceId nsId {"ns"};
+    ::testing::NiceMock<cm::store::MockICMStoreNSReader> r;
+
+    // One namespace, two logical DBs → two independent cached maps
+    ON_CALL(r, getNamespaceId()).WillByDefault(::testing::ReturnRef(nsId));
+    ON_CALL(r, getKVDBByName("countries"))
+        .WillByDefault(::testing::Invoke([&](const std::string&) { return json::Json {R"({"k":"v"})"}; }));
+    ON_CALL(r, getKVDBByName("cities"))
+        .WillByDefault(::testing::Invoke([&](const std::string&) { return json::Json {R"({"k":"v"})"}; }));
+
+    // Seed both DBs and capture distinct buffer pointers
+    auto hC = mgr.getKVDBHandler(r, "countries");
+    auto hT = mgr.getKVDBHandler(r, "cities");
+    ASSERT_NE(hC, nullptr);
+    ASSERT_NE(hT, nullptr);
+    const json::Json& c = hC->get("k");
+    const json::Json& t = hT->get("k");
+
+    // Further fetches are disallowed; reads must hit the cache
+    ::testing::Mock::VerifyAndClearExpectations(&r);
+    EXPECT_CALL(r, getKVDBByName("countries")).Times(0);
+    EXPECT_CALL(r, getKVDBByName("cities")).Times(0);
+
+    // Parallel reads for each DB name
+    constexpr int kThreads = 8;
+    auto refsC = parallelReadRefs(mgr, r, "countries", "k", kThreads);
+    auto refsT = parallelReadRefs(mgr, r, "cities", "k", kThreads);
+
+    // Verify isolation: each group matches its own address, and both groups differ
+    for (int i = 0; i < kThreads; ++i) EXPECT_EQ(std::addressof(refsC[i].get()), std::addressof(c));
+    for (int i = 0; i < kThreads; ++i) EXPECT_EQ(std::addressof(refsT[i].get()), std::addressof(t));
+    EXPECT_NE(std::addressof(c), std::addressof(t));
 }


### PR DESCRIPTION
## Description

This PR introduces a lightweight, read‑only KV database (KVDB) access layer for the engine, backed by CM Store namespace data. It adds a new `kvdbstore` module with a cacheable `KVDBManager` and a `KVDBHandler` that exposes JSON‑serialized values via `std::string_view`. The manager caches per `(namespace, dbName)` using `std::weak_ptr` and a `std::shared_mutex` for thread‑safe reads/writes.

Closes #32909 

## Proposed Changes

- **New module:** `src/engine/source/kvdbstore`
  - **Interfaces:** `ikvdbhandler.hpp`, `ikvdbmanager.hpp`.
  - **Implementation:** `KVDBManager` (per‑NS/db cache with weak refs; shared mutex), `KVDBHandler` (read‑only `get/contains` over stable `std::string` storage).
- **Behavioral semantics:**
  - Fast‑path cache hit under shared lock; otherwise fetch JSON via `ICMStoreNSReader::getKVDBByName`, enumerate keys with `Json::getFields("")`, serialize each value via `Json::str(pointer)` using `formatJsonPath` for pointer escaping, then publish to cache under unique lock.

### Results and Evidence

**Unit Tests with ASAN and TSAN (Separately):**

- Component Tests:
```console
./kvdbstore_ctest                                              
Running main() from /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from KVDB_Component
[ RUN      ] KVDB_Component.BuildOnceThenCache_NoRefetch_SamePointer
[       OK ] KVDB_Component.BuildOnceThenCache_NoRefetch_SamePointer (0 ms)
[ RUN      ] KVDB_Component.ExpireAllHandlers_RebuildWithNewContent
[       OK ] KVDB_Component.ExpireAllHandlers_RebuildWithNewContent (0 ms)
[ RUN      ] KVDB_Component.CrossNamespaceAndDb_IsolatedCaches
[       OK ] KVDB_Component.CrossNamespaceAndDb_IsolatedCaches (0 ms)
[ RUN      ] KVDB_Component.ConcurrentColdRace_EventualConvergence
[       OK ] KVDB_Component.ConcurrentColdRace_EventualConvergence (4 ms)
[ RUN      ] KVDB_Component.InvalidPayload_Throws
[       OK ] KVDB_Component.InvalidPayload_Throws (1 ms)
[ RUN      ] KVDB_Component.NestedValues_AccessAndEquality
[       OK ] KVDB_Component.NestedValues_AccessAndEquality (0 ms)
[----------] 6 tests from KVDB_Component (9 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (9 ms total)
[  PASSED  ] 6 tests.
```

- Unit Tests:
```console
Running main() from /workspaces/wazuh-5.x/wazuh/src/external/googletest/googletest/src/gtest_main.cc
[==========] Running 15 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from KVDB_Handler_Unit
[ RUN      ] KVDB_Handler_Unit.GetAndContainsBasic
[       OK ] KVDB_Handler_Unit.GetAndContainsBasic (0 ms)
[ RUN      ] KVDB_Handler_Unit.ViewsAreStableWhileMapLives
[       OK ] KVDB_Handler_Unit.ViewsAreStableWhileMapLives (0 ms)
...
[       OK ] KVDB_Manager_Unit.DifferentDbNamesUseDifferentCachedMaps (0 ms)
[ RUN      ] KVDB_Manager_Unit.ParallelWarm_NoRefetch_SamePointer
[       OK ] KVDB_Manager_Unit.ParallelWarm_NoRefetch_SamePointer (2 ms)
[ RUN      ] KVDB_Manager_Unit.ParallelColdRace_EventualConvergence
[       OK ] KVDB_Manager_Unit.ParallelColdRace_EventualConvergence (2 ms)
[ RUN      ] KVDB_Manager_Unit.ParallelSameNsSameDb_SharedCachedMap
[       OK ] KVDB_Manager_Unit.ParallelSameNsSameDb_SharedCachedMap (4 ms)
[ RUN      ] KVDB_Manager_Unit.ParallelTwoNamespaces_Isolated
[       OK ] KVDB_Manager_Unit.ParallelTwoNamespaces_Isolated (2 ms)
[ RUN      ] KVDB_Manager_Unit.ParallelSameNs_DifferentDb_Isolated
[       OK ] KVDB_Manager_Unit.ParallelSameNs_DifferentDb_Isolated (2 ms)
[----------] 9 tests from KVDB_Manager_Unit (17 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 2 test suites ran. (25 ms total)
[  PASSED  ] 15 tests.
```

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [X] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer


- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [X] ASAN for test (utest/ctest)
  - [X] TSAN for test and wazuh-engine.

### Artifacts Affected

- New static library: `kvdbstore_kvdb` (alias `kvdbstore::kvdb`).
- New interface library: `kvdbstore_ikvdb` (alias `kvdbstore::ikvdb`).
- Test binaries: `kvdbstore_utest`, `kvdbstore_ctest`.
- Build system: engine adds `kvdbstore` subdirectory; `cmstore_icmstore` drops `ctistore` link.

### Configuration Changes

- N/A

### Tests Introduced

- **Unit tests**
  - `kvdb_handler_test.cpp`: basic get/contains, null map safety, empty key/value, concurrent readers, large values.
  - `kvdb_manager_test.cpp`: cache reuse without rebuild, rebuild after expiration, no refetch on cache hit, per‑db isolation.
- **Component tests**
  - `kvdb_test.cpp`: end‑to‑end validation; special keys (`~0`, `~1`, `a/b`, `dot.name`, `mix/~slash`); namespace and db independence; empty object.
- **Mocks**
  - `mockKvdbHandler.hpp`, `mockKvdbManager.hpp` (updated signature without `noexcept`).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...


