### PR TITLE
Поддержка МСВ Сфера ОС в Wazuh

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -689,6 +689,9 @@ os_info *get_unix_version()
             }
             regfree(&regexCompiled);
             fclose(version_release);
+        // MSVSphere
+        } else if (info->os_platform && strcmp(info->os_platform, "msvsphere") == 0) {
+            info->os_name = strdup("MSVSphere");
         } else {
             char *uname_path = NULL;
 

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -53,6 +53,7 @@ static const char* rpm_platforms[] = {
     "suse",
     "rocky",
     "almalinux",
+    "msvsphere",
 };
 
 int wm_agent_upgrade_validate_id(int agent_id) {


### PR DESCRIPTION
# Поддержка МСВ Сфера ОС в Wazuh

Данный форк добавляет официальную поддержку **МСВ Сфера ОС 9.6** в Wazuh.

##  Что сделано

- Добавлена детекция ОС через стандартный механизм парсинга `/etc/os-release`.
- Поддержка включена для:
  - агента (`wazuh-agent`)
  - менеджера (`wazuh-manager`)
  - модуля обновления (`agent_upgrade`)
- Проверено на **ветке `main`**.

##  Как определяется МСВ Сфера

На основе `/etc/os-release`:
```ini
NAME="MSVSphere"
ID="msvsphere"
VERSION_ID="9.6"
PRETTY_NAME="MSVSphere 9.6 Server Certified"