### PR TITLE
Add GET function and its unit tests

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -93,6 +93,23 @@ public:
     nlohmann::json executeSearchQuery(const std::string& index, const nlohmann::json& searchQuery);
 
     /**
+     * @brief Execute a search query with automatic pagination.
+     *
+     * This method performs a search query and automatically handles pagination using
+     * the 'search_after' mechanism of the indexer. It retrieves all results
+     * by making multiple search requests if necessary.
+     *
+     * @param index Index name to search.
+     * @param query JSON object containing the initial search query.
+     *              The query MUST include a "sort" field for pagination to work correctly.
+     * @param onResponse Callback function executed for each page of results.
+     *                   The function receives a JSON object with the response for one page.
+     */
+    void executeSearchQueryWithPagination(const std::string& index,
+                                          const nlohmann::json& query,
+                                          std::function<void(const nlohmann::json&)> onResponse);
+
+    /**
      * @brief Bulk delete.
      *
      * @param id ID.

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
@@ -51,6 +51,13 @@ public:
         return m_impl.executeSearchQuery(index, searchQuery);
     }
 
+    void executeSearchQueryWithPagination(const std::string& index,
+                                          const nlohmann::json& query,
+                                          std::function<void(const nlohmann::json&)> onResponse)
+    {
+        m_impl.executeSearchQueryWithPagination(index, query, onResponse);
+    }
+
     void bulkDelete(std::string_view id, std::string_view index)
     {
         m_impl.bulkDelete(id, index);
@@ -111,6 +118,14 @@ void IndexerConnectorSync::executeUpdateByQuery(const std::vector<std::string>& 
 nlohmann::json IndexerConnectorSync::executeSearchQuery(const std::string& index, const nlohmann::json& searchQuery)
 {
     return m_impl->executeSearchQuery(index, searchQuery);
+}
+
+void IndexerConnectorSync::executeSearchQueryWithPagination(
+    const std::string& index,
+    const nlohmann::json& query,
+    std::function<void(const nlohmann::json&)> onResponse)
+{
+    m_impl->executeSearchQueryWithPagination(index, query, onResponse);
 }
 
 void IndexerConnectorSync::bulkDelete(std::string_view id, std::string_view index)

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp
@@ -232,6 +232,58 @@ namespace InventorySyncQueryBuilder
 
         return updateQuery;
     }
+
+    /// @brief Build GET query for CVE/vulnerability data by package
+    /// @param agentId Agent ID to match
+    /// @param packageName Package name to match
+    /// @param packageVersion Package version to match
+    /// @param size Maximum number of results to return
+    /// @param searchAfter Optional search_after value for pagination [_id]
+    /// @return JSON search query body with bool query and sort
+    inline nlohmann::json buildCveGetQuery(const std::string& agentId,
+                                           const std::string& packageName,
+                                           const std::string& packageVersion,
+                                           std::size_t size,
+                                           const std::string& searchAfter = "")
+    {
+        nlohmann::json query = {{"size", size},
+                                {"query",
+                                 {{"bool",
+                                   {{"must",
+                                     {{{"term", {{"agent.id", agentId}}}},
+                                      {{"term", {{"package.name", packageName}}}},
+                                      {{"term", {{"package.version", packageVersion}}}}}}}}}},
+                                {"sort", {{{"_id", {{"order", "asc"}}}}}}};
+
+        if (!searchAfter.empty())
+        {
+            query["search_after"] = {searchAfter};
+        }
+
+        return query;
+    }
+
+    /// @brief Build GET query for system inventory context data
+    /// @param agentId Agent ID to match
+    /// @param size Maximum number of results to return
+    /// @param searchAfter Optional search_after value for pagination [_id]
+    /// @return JSON search query body with term query and source filtering
+    inline nlohmann::json
+    buildContextGetQuery(const std::string& agentId, std::size_t size, const std::string& searchAfter = "")
+    {
+        nlohmann::json query = {{"_source", {{"excludes", {"wazuh*"}}}},
+                                {"query", {{"term", {{"agent.id", agentId}}}}},
+                                {"size", size},
+                                {"sort", {{{"_id", {{"order", "asc"}}}}}}};
+
+        if (!searchAfter.empty())
+        {
+            query["search_after"] = {searchAfter};
+        }
+
+        return query;
+    }
+
 } // namespace InventorySyncQueryBuilder
 
 #endif // _INVENTORY_SYNC_QUERY_BUILDER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
@@ -1,0 +1,149 @@
+/*
+ * Wazuh Vulnerability scanner - Scan Orchestrator
+ * Copyright (C) 2015, Wazuh Inc.
+ * November 11, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _EVENT_GET_CONTEXT_HPP
+#define _EVENT_GET_CONTEXT_HPP
+
+#include "chainOfResponsability.hpp"
+#include "indexerConnector.hpp"
+#include "scanContext.hpp"
+#include "wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp"
+#include <memory>
+
+/**
+ * @brief EventGetContext class.
+ *
+ * This handler queries the indexer for system inventory context information.
+ * It executes a GET query to retrieve context data from inventory indices.
+ *
+ * @tparam TIndexerConnector indexer connector type.
+ * @tparam TScanContext scan context type.
+ */
+template<typename TIndexerConnector = IndexerConnectorSync, typename TScanContext = ScanContext>
+class TEventGetContext final : public AbstractHandler<std::shared_ptr<TScanContext>>
+{
+private:
+    std::shared_ptr<TIndexerConnector> m_indexerConnector;
+    static constexpr size_t DEFAULT_PAGE_SIZE = 1000;
+    
+    /**
+     * @brief Handles request and passes control to the next step of the chain.
+     *
+     * Executes a GET query to the indexer to retrieve system inventory context data
+     * across multiple indices:
+     * - wazuh-states-inventory-system
+     * - wazuh-states-inventory-packages
+     * - wazuh-states-inventory-hotfixes
+     * - wazuh-states-vulnerabilities
+     *
+     * @param data Scan context.
+     * @return std::shared_ptr<TScanContext> Scan context passed to next handler.
+     */
+    // Helper to safely extract _id from a hit
+    static const std::string* getContextIdPtr(const nlohmann::json& hit)
+    {
+        if (const auto* idPtr = hit.find("_id"); idPtr != hit.end() && idPtr->is_string())
+        {
+            return &idPtr->get_ref<const std::string&>();
+        }
+        return nullptr;
+    }
+
+public:
+    /**
+     * @brief EventGetContext constructor.
+     *
+     * @param indexerConnector Indexer connector.
+     */
+    explicit TEventGetContext(std::shared_ptr<TIndexerConnector> indexerConnector)
+        : m_indexerConnector(std::move(indexerConnector))
+    {
+    }
+
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    {
+        logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetContext - Starting GET context query handler");
+
+        try
+        {
+            // Define the indices to query
+            const std::vector<std::string> indexes = {"wazuh-states-inventory-system",
+                                                      "wazuh-states-inventory-packages",
+                                                      "wazuh-states-inventory-hotfixes",
+                                                      "wazuh-states-vulnerabilities"};
+
+            int totalContextItems = 0;
+
+            logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetContext - Building context query");
+
+            // Build query without search_after - pagination is now automatic
+            auto query = InventorySyncQueryBuilder::buildContextGetQuery(std::string(data->agentId()),
+                                                                         DEFAULT_PAGE_SIZE,
+                                                                         ""); // Empty search_after - first page
+
+            // Execute query for each index separately
+            for (const auto& index : indexes)
+            {
+                m_indexerConnector->executeSearchQueryWithPagination(
+                    index,
+                    query,
+                    [&totalContextItems, data](const nlohmann::json& response) mutable
+                    {
+                        std::size_t pageHits = 0;
+                        std::size_t storedItems = 0;
+                        if (const auto* hitsPtr = response["hits"].find("hits");
+                            hitsPtr != response["hits"].end() && hitsPtr->is_array())
+                        {
+                            const auto& hits = *hitsPtr;
+                            pageHits = hits.size();
+                            // Process each context item hit
+                            for (const auto& hit : hits)
+                            {
+                                const auto* idPtr = getContextIdPtr(hit);
+                                const auto* srcPtr = hit.find("_source");
+                                const auto* idxPtr = hit.find("_index");
+                                if (idPtr && srcPtr != hit.end() && srcPtr->is_object() && idxPtr != hit.end() &&
+                                    idxPtr->is_string())
+                                {
+                                    data->m_elements[*idPtr] = *srcPtr;
+                                    totalContextItems++;
+                                    storedItems++;
+                                    logDebug2(WM_VULNSCAN_LOGTAG,
+                                              "TEventGetContext - Stored context item from index: %s, id: %s",
+                                              idxPtr->get_ref<const std::string&>().c_str(),
+                                              idPtr->c_str());
+                                }
+                            }
+                        }
+                        logDebug2(WM_VULNSCAN_LOGTAG,
+                                  "TEventGetContext - Processing page: %zu hits, %zu context items stored",
+                                  pageHits,
+                                  storedItems);
+                    });
+            }
+
+            logDebug2(
+                WM_VULNSCAN_LOGTAG, "TEventGetContext - Completed. Total context items stored: %d", totalContextItems);
+        }
+        catch (const std::exception& e)
+        {
+            logError(WM_VULNSCAN_LOGTAG, "TEventGetContext - Failed to execute GET context query: %s", e.what());
+            // Continue with the chain even if the query fails
+        }
+
+        logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetContext::handleRequest - Passing to next handler in chain");
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
+    }
+};
+
+using EventGetContext = TEventGetContext<>;
+
+#endif // _EVENT_GET_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp
@@ -1,0 +1,143 @@
+/*
+ * Wazuh Vulnerability scanner - Scan Orchestrator
+ * Copyright (C) 2015, Wazuh Inc.
+ * November 7, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _EVENT_GET_CVE_HPP
+#define _EVENT_GET_CVE_HPP
+
+#include "chainOfResponsability.hpp"
+#include "indexerConnector.hpp"
+#include "scanContext.hpp"
+#include "wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp"
+#include <memory>
+
+/**
+ * @brief EventGetCve class.
+ *
+ * This handler queries the indexer for existing CVEs/vulnerabilities by package information.
+ * It executes a GET query to retrieve vulnerability data from the indexer based on
+ * package name and version.
+ *
+ * @tparam TIndexerConnector indexer connector type.
+ * @tparam TScanContext scan context type.
+ */
+template<typename TIndexerConnector = IndexerConnectorSync, typename TScanContext = ScanContext>
+class TEventGetCve final : public AbstractHandler<std::shared_ptr<TScanContext>>
+{
+private:
+    std::shared_ptr<TIndexerConnector> m_indexerConnector;
+    static constexpr size_t DEFAULT_PAGE_SIZE = 1000;
+
+    /**
+     * @brief Handles request and passes control to the next step of the chain.
+     *
+     * Executes a GET query to the indexer to retrieve existing CVE/vulnerability data
+     * based on package information (agent.id, package.name, package.version).
+     *
+     * @param data Scan context.
+     * @return std::shared_ptr<TScanContext> Scan context passed to next handler.
+     */
+    // Helper to safely extract CVE id from a hit
+    static const std::string* getCveIdPtr(const nlohmann::json& hit)
+    {
+        if (const auto* srcPtr = hit.find("_source"); srcPtr != hit.end() && srcPtr->is_object())
+        {
+            const auto& src = *srcPtr;
+            if (const auto* vulnPtr = src.find("vulnerability"); vulnPtr != src.end() && vulnPtr->is_object())
+            {
+                const auto& vuln = *vulnPtr;
+                if (const auto* idPtr = vuln.find("id"); idPtr != vuln.end() && idPtr->is_string())
+                {
+                    return &idPtr->get_ref<const std::string&>();
+                }
+            }
+        }
+        return nullptr;
+    }
+
+public:
+    /**
+     * @brief EventGetCve constructor.
+     *
+     * @param indexerConnector Indexer connector.
+     */
+    explicit TEventGetCve(std::shared_ptr<TIndexerConnector> indexerConnector)
+        : m_indexerConnector(std::move(indexerConnector))
+    {
+    }
+
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    {
+        logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetCve - Starting GET CVE query handler");
+
+        try
+        {
+            const std::string index = "wazuh-states-vulnerabilities";
+            int totalCves = 0;
+            logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetCve - Building CVE query");
+
+            // Build query without search_after - pagination is now automatic
+            auto query = InventorySyncQueryBuilder::buildCveGetQuery(std::string(data->agentId()),
+                                                                     std::string(data->packageName()),
+                                                                     std::string(data->packageVersion()),
+                                                                     DEFAULT_PAGE_SIZE,
+                                                                     ""); // Empty search_after - first page
+
+            m_indexerConnector->executeSearchQueryWithPagination(
+                index,
+                query,
+                [&totalCves, data](const nlohmann::json& response) mutable
+                {
+                    std::size_t pageHits = 0;
+                    std::size_t storedCves = 0;
+                    if (const auto* hitsPtr = response["hits"].find("hits");
+                        hitsPtr != response["hits"].end() && hitsPtr->is_array())
+                    {
+                        const auto& hits = *hitsPtr;
+                        pageHits = hits.size();
+                        // Process each CVE hit
+                        for (const auto& hit : hits)
+                        {
+                            if (const std::string* cveIdPtr = getCveIdPtr(hit))
+                            {
+                                // Store CVE data in context
+                                const auto* srcPtr = hit.find("_source");
+                                if (srcPtr != hit.end() && srcPtr->is_object())
+                                {
+                                    data->m_elements[*cveIdPtr] = *srcPtr;
+                                    totalCves++;
+                                    storedCves++;
+                                    logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetCve - Stored CVE: %s", cveIdPtr->c_str());
+                                }
+                            }
+                        }
+                    }
+                    logDebug2(WM_VULNSCAN_LOGTAG,
+                              "TEventGetCve - Processing page: %zu hits, %zu CVEs stored",
+                              pageHits,
+                              storedCves);
+                });
+
+            logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetCve - Completed. Total CVEs stored: %d", totalCves);
+        }
+        catch (const std::exception& e)
+        {
+            logError(WM_VULNSCAN_LOGTAG, "TEventGetCve - Failed to execute GET CVE query: %s", e.what());
+            // Continue with the chain even if the query fails
+        }
+
+        logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetCve::handleRequest - Passing to next handler in chain");
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
+    }
+};
+
+using EventGetCve = TEventGetCve<>;
+
+#endif // _EVENT_GET_CVE_HPP


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
This PR implements two GET queries to retrieve information.

There is one methods implemented in `src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp`:

- The `executeSearchQueryWithPagination` method:  
  - To return all CVEs associated with a package on a specific agent, you must provide the agent.id, package.name, and package.version.
  - If what you want is to retrieve all the information for a specific index, you only need to provide the agent.id.
---

### Implementation Details
- **Query Builder**

To create the queries, I have implemented two methods in the following file:

`src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp`

The methods are:

- `buildCveGetQuery`, which creates the query using `agent.id`, `package.name`, and `package.version`.
- `buildContextGetQuery`, which creates the query using `agent.id`.

Both methods also include a fourth parameter called `searchAfter`, which is empty by default but is used for testing and manual pagination.

- **Implementation of the methods that execute the query.**

To execute the queries, one new method has been created: `executeSearchQueryWithPagination`.  
This method is responsible for running the queries against the indexer using automatic pagination until no batches remain.

To retrieve the CVEs for a specific package when the query is executed on the index:

- `wazuh-states-vulnerabilities`

To retrieve all information about the packages, vulnerabilities, OS, and hotfixes of a specific agent the query is executed on the indexes:  

- `wazuh-states-inventory-system`
- `wazuh-states-inventory-packages`
- `wazuh-states-inventory-hotfixes`
- `wazuh-states-vulnerabilities`

The method receives an index and the query to be executed.  
As a third parameter, they take a callback named `onResponse`, which is responsible for processing the paginated results.


- **Handlers**

Two new handlers have been added to the chain of responsibility: `eventGetCVE` to retrieve the vulnerabilities of a package, and `eventGetContext` to retrieve all the information.

These handlers perform the following steps:
1. They define the indexes on which the queries will be executed.
2. They create the queries using the query builder with the required values.
3. They then execute the queries.


- **Pagination Using `search_after`**

Pagination has been implemented using the **search_after** mechanism, which works as follows:

1. **Initial query without `search_after`**  
   The first query is executed without the `search_after` field to retrieve the initial batch of documents.  
   This first batch includes a `sort` field that contains the document `_id` values sorted in ascending order.

2. **Extracting the sort value**  
   After receiving the first batch, the `sort` value of the **last element** in the batch is extracted.  
   This value will be used to fetch the next page of results.

3. **Executing the next query with `search_after`**  
   A second query is then executed, this time including the `search_after` field, which is set to the `sort` value obtained from the previous batch.

4. **Iterating through the index**  
   Each subsequent query returns the next batch of documents.  
   For every batch, the `search_after` value is updated using the `sort` of the last element returned.

5. **Termination condition**  
   The pagination process continues until a query returns an **empty batch**, meaning there are no more results to retrieve from the index.

This mechanism ensures that every batch is retrieved sequentially and efficiently, covering the entire index without overlaps or duplicates.


---

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

### Results and Evidence

To test the queries, I deployed a full environment consisting of a Manager, an Agent, and an Indexer, all running version **5.x**.  
Once the environment was operational, I executed the queries directly against the Indexer.

For testing purposes, I manually added **two packages** to the Indexer:

All queries were executed based on these test packages.

After running the tests, the results obtained from the logs were the following:

 - **Execution logs to GET CVEs**

```
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:454 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: === Testing executeSearchQueryWithPagination for CVEs ===
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:456 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: Agent: 001, Package: curl 7.68.0
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:477 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: Query: {"query":{"bool":{"must":[{"term":{"agent.id":"001"}},{"term":{"package.name":"curl"}},{"term":{"package.version":"7.68.0"}}]}},"size":1,"sort":[{"_id":{"order":"asc"}}]}2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:640 at operator()(): DEBUG: Search query response: {"took":3,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"wazuh-states-inventory-packages","_id":"nh1_3poBVcqDsHGX1L4d","_score":null,"_source":{
    "agent": { "id": "001" },
    "package": {
      "name": "curl",
      "version": "7.68.0",
      "architecture": "amd64",
      "type": "deb",
      "vendor": "Debian"
    }
  },"sort":["nh1_3poBVcqDsHGX1L4d"]}]}}
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:494 at operator()(): DEBUG: [PaginationTest] Query response (page 1, docs 1): {"_shards":{"failed":0,"skipped":0,"successful":1,"total":1},"hits":{"hits":[{"_id":"nh1_3poBVcqDsHGX1L4d","_index":"wazuh-states-inventory-packages","_score":null,"_source":{"agent":{"id":"001"},"pac
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:498 at operator()(): DEBUG:   Page 1: 1 CVE documents
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:514 at operator()(): DEBUG:     CVE: nh1_3poBVcqDsHGX1L4d
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:527 at operator()(): DEBUG:     Last sort value: "nh1_3poBVcqDsHGX1L4d"
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:657 at executeSearchQuery(): DEBUG: Executing search query on: https://192.168.57.23:9200/wazuh-states-inventory-packages/_search
2025/12/02 10:03:15 wazuh-modulesd:sca[23802] wm_sca.c:126 at sca_log_callback(): DEBUG: Command rule evaluation result: modprobe -n -v hfs' pattern 'r:install /bin/false|install /bin/true|Module hfs not found' was not found
2025/12/02 10:03:15 wazuh-modulesd:sca[23802] wm_sca.c:126 at sca_log_callback(): DEBUG: Processing command rule: 'lsmod'
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:640 at operator()(): DEBUG: Search query response: {"took":2,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[]}}
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:494 at operator()(): DEBUG: [PaginationTest] Query response (page 2, docs 0): {"_shards":{"failed":0,"skipped":0,"successful":1,"total":1},"hits":{"hits":[],"max_score":null,"total":{"relation":"eq","value":1}},"timed_out":false,"took":2}
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:692 at executeSearchQueryWithPagination(): DEBUG: No 'hits' array in response or it is empty, breaking pagination loop
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:535 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: CVE test completed: 2 pages, 1 total CVE documents
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:539 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: Total unique CVEs found: 1
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:545 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: First CVE: nh1_3poBVcqDsHGX1L4d
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:548 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: Last CVE: nh1_3poBVcqDsHGX1L4d
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:617 at start(): DEBUG: 
***** PAGINATION TESTS COMPLETED *****

```

 - **Execution logs to GET context**

```
--- Testing index: wazuh-states-inventory-packages ---
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:373 at testExecuteSearchQueryWithPagination(): DEBUG: Query: {"_source":{"excludes":["wazuh*"]},"query":{"term":{"agent.id":"001"}},"size":1,"sort":[{"_id":{"order":"asc"}}]}
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:640 at operator()(): DEBUG: Search query response: {"took":15,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"wazuh-states-inventory-packages","_id":"nh1_3poBVcqDsHGX1L4d","_score":null,"_source":{"agent":{"id":"001"},"package":{"vendor":"Debian","name":"curl","type":"deb","version":"7.68.0","architecture":"amd64"}},"sort":["nh1_3poBVcqDsHGX1L4d"]}]}}
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:391 at operator()(): DEBUG: [PaginationTest] Query response (page 1, docs 1): {"_shards":{"failed":0,"skipped":0,"successful":1,"total":1},"hits":{"hits":[{"_id":"nh1_3poBVcqDsHGX1L4d","_index":"wazuh-states-inventory-packages","_score":null,"_source":{"agent":{"id":"001"},"pac
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:395 at operator()(): DEBUG:   Page 1: 1 documents
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:406 at operator()(): DEBUG:     First doc ID: nh1_3poBVcqDsHGX1L4d
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:420 at operator()(): DEBUG:     Last sort value (search_after): "nh1_3poBVcqDsHGX1L4d"
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:657 at executeSearchQuery(): DEBUG: Executing search query on: https://192.168.57.23:9200/wazuh-states-inventory-packages/_search
2025/12/02 10:03:15 wazuh-modulesd:sca[23802] wm_sca.c:126 at sca_log_callback(): DEBUG: Command rule evaluation result: modprobe -n -v freevxfs' pattern 'r:install /bin/false|install /bin/true|Module freevxfs not found' was not found
2025/12/02 10:03:15 wazuh-modulesd:sca[23802] wm_sca.c:126 at sca_log_callback(): DEBUG: Processing command rule: 'lsmod'
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:640 at operator()(): DEBUG: Search query response: {"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"wazuh-states-inventory-packages","_id":"nx1_3poBVcqDsHGX776a","_score":null,"_source":{"agent":{"id":"001"},"package":{"vendor":"Debian","name":"wget","type":"deb","version":"1.20.3","architecture":"amd64"}},"sort":["nx1_3poBVcqDsHGX776a"]}]}}
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:391 at operator()(): DEBUG: [PaginationTest] Query response (page 2, docs 1): {"_shards":{"failed":0,"skipped":0,"successful":1,"total":1},"hits":{"hits":[{"_id":"nx1_3poBVcqDsHGX776a","_index":"wazuh-states-inventory-packages","_score":null,"_source":{"agent":{"id":"001"},"pac
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:395 at operator()(): DEBUG:   Page 2: 1 documents
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:406 at operator()(): DEBUG:     First doc ID: nx1_3poBVcqDsHGX776a
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:420 at operator()(): DEBUG:     Last sort value (search_after): "nx1_3poBVcqDsHGX776a"
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:657 at executeSearchQuery(): DEBUG: Executing search query on: https://192.168.57.23:9200/wazuh-states-inventory-packages/_search
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:640 at operator()(): DEBUG: Search query response: {"took":2,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[]}}
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:391 at operator()(): DEBUG: [PaginationTest] Query response (page 3, docs 0): {"_shards":{"failed":0,"skipped":0,"successful":1,"total":1},"hits":{"hits":[],"max_score":null,"total":{"relation":"eq","value":2}},"timed_out":false,"took":2}
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:692 at executeSearchQueryWithPagination(): DEBUG: No 'hits' array in response or it is empty, breaking pagination loop
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:428 at testExecuteSearchQueryWithPagination(): DEBUG: Index wazuh-states-inventory-packages completed: 3 pages, 2 total documents
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:435 at testExecuteSearchQueryWithPagination(): DEBUG: === Test completed for agent 001 ===
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:454 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: === Testing executeSearchQueryWithPagination for CVEs ===
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:456 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: Agent: 001, Package: curl 7.68.0
2025/12/02 10:03:15 logger-helper[23802] inventorySyncFacade.hpp:477 at testExecuteSearchQueryWithPaginationCVE(): DEBUG: Query: {"query":{"bool":{"must":[{"term":{"agent.id":"001"}},{"term":{"package.name":"curl"}},{"term":{"package.version":"7.68.0"}}]}},"size":1,"sort":[{"_id":{"order":"asc"}}]}
2025/12/02 10:03:15 IndexerConnector[23802] indexerConnectorSyncImpl.hpp:657 at executeSearchQuery(): DEBUG: Executing search query on: https://192.168.57.23:9200/wazuh-states-inventory-packages/_search

```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

---

### Tests Introduced

A total of **2 tests** have been implemented to validate the `executeSearchQueryWithPagination` method.


1. **ExecuteSearchQueryWithPaginationWithoutCallback**
This test verifies that the method has been executed without a callback. Therefore, there is no pagination.

---

2. **ExecuteSearchQueryWithPaginationWithCallbackTwoPages**
This test verifies pagination over one index, returning two pages.  
It confirms that:
- `postCallCount = 2`   
- `callbackCount = 2` (callback invoked once per page)

---
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
