### PR TITLE
enhancement: add read/write shared lock to ContentManager

### DIFF
--- a/src/engine/source/ctistore/include/ctistore/cm.hpp
+++ b/src/engine/source/ctistore/include/ctistore/cm.hpp
@@ -45,6 +45,12 @@ public:
      * ICMReader interface implementation
      ************************************************************************************/
 
+    /** @copydoc ICMReader::acquireReadGuard */
+    ReadGuard acquireReadGuard() const override;
+
+    /** @copydoc ICMReader::acquireWriteGuard */
+    WriteGuard acquireWriteGuard() override;
+
     /** @copydoc ICMReader::getAssetList */
     std::vector<base::Name> getAssetList(cti::store::AssetType type) const override;
 

--- a/src/engine/source/ctistore/test/mocks/ctistore/mockcm.hpp
+++ b/src/engine/source/ctistore/test/mocks/ctistore/mockcm.hpp
@@ -10,11 +10,15 @@ namespace cti::store
 class MockCMReader : public ICMReader
 {
 public:
+    // Synchronization
+    MOCK_METHOD(ReadGuard, acquireReadGuard, (), (const, override));
+    MOCK_METHOD(WriteGuard, acquireWriteGuard, (), (override));
+
     // Asset operations
     MOCK_METHOD(std::vector<base::Name>, getAssetList, (cti::store::AssetType type), (const, override));
     MOCK_METHOD(json::Json, getAsset, (const base::Name& name), (const, override));
     MOCK_METHOD(bool, assetExists, (const base::Name& name), (const, override));
-    MOCK_METHOD(std::string, resolvNameFromUUID, (const std::string& uuid), (const, override));
+    MOCK_METHOD(std::string, resolveNameFromUUID, (const std::string& uuid), (const, override));
 
     // KVDB operations
     MOCK_METHOD(std::vector<std::string>, listKVDB, (), (const, override));

--- a/src/engine/source/ctistore/test/src/unit/cm_test.cpp
+++ b/src/engine/source/ctistore/test/src/unit/cm_test.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -94,6 +95,241 @@ TEST(ContentManagerTest, processSkipsUnclassifiedLines)
 
     EXPECT_EQ(std::get<0>(result), 11); // last offset from second line
     EXPECT_TRUE(std::get<2>(result));
+
+    std::filesystem::remove_all(base);
+}
+
+TEST(ContentManagerConcurrencyTest, MultipleReadGuardsAllowConcurrentAccess)
+{
+    cti::store::ContentManagerConfig cfg;
+    auto base = makeIsolatedConfig(cfg, "cm_concurrent_read");
+
+    auto cm = std::make_shared<cti::store::ContentManager>(cfg);
+
+    // Tracks when readers are active
+    std::atomic<int> activeReaders{0};
+    std::atomic<int> maxConcurrentReaders{0};
+
+    const int numReaders = 5;
+    std::vector<std::thread> readers;
+
+    for (int i = 0; i < numReaders; ++i)
+    {
+        readers.emplace_back([&cm, &activeReaders, &maxConcurrentReaders]()
+        {
+            // Acquire read guard
+            auto readGuard = cm->acquireReadGuard();
+
+            // Track concurrent readers
+            int current = ++activeReaders;
+            maxConcurrentReaders.store(std::max(maxConcurrentReaders.load(), current), 
+                                       std::memory_order_relaxed);
+
+
+            // Simulate some read work
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+            --activeReaders;
+        });
+    }
+
+    // Wait for all readers to complete
+    for (auto& t : readers)
+    {
+        t.join();
+    }
+
+    // Verify that multiple readers were active simultaneously
+    EXPECT_GT(maxConcurrentReaders.load(), 1) << "Multiple readers should be able to access concurrently";
+
+    std::filesystem::remove_all(base);
+}
+
+TEST(ContentManagerConcurrencyTest, WriteGuardBlocksReaders)
+{
+    cti::store::ContentManagerConfig cfg;
+    auto base = makeIsolatedConfig(cfg, "cm_write_blocks_read");
+    cfg.deleteDownloadedContent = false;
+
+    auto cm = std::make_shared<cti::store::ContentManager>(cfg);
+
+    std::atomic<bool> writerHasLock{false};
+    std::atomic<bool> readerBlocked{true};
+    std::atomic<bool> readerAcquiredLock{false};
+
+    // Create a file for writing
+    std::filesystem::create_directories(cfg.outputFolder);
+    const std::string filePath = cfg.outputFolder + "/write_test.json";
+    std::ofstream f(filePath);
+    f << R"({"name":"d1","offset":1,"payload":{"document":{"metadata":{"module":"m"}},"type":"decoder"}})" << '\n';
+    f.close();
+
+    std::string message = std::string("{\"paths\":[\"") + filePath + "\"],\"type\":\"raw\",\"offset\":0}";
+
+    // Writer thread - acquires write lock
+    std::thread writer([&cm, &writerHasLock, &readerBlocked]()
+    {
+        // Acquire write guard
+        auto writeGuard = cm->acquireWriteGuard();
+
+        writerHasLock = true;
+
+        // Hold the write lock for a bit
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // Check if reader is still blocked
+        EXPECT_TRUE(readerBlocked.load()) << "Reader should still be blocked while writer holds lock";
+    });
+
+    // Wait for writer to acquire lock
+    while (!writerHasLock)
+    {
+        std::this_thread::yield();
+    }
+
+    // Reader thread - tries to acquire read lock while writer holds it
+    std::thread reader([&cm, &readerBlocked, &readerAcquiredLock]()
+    {
+        // Try to acquire read guard - should block until writer releases
+        auto readGuard = cm->acquireReadGuard();
+
+        readerBlocked = false;
+        readerAcquiredLock = true;
+    });
+
+    // Give reader a chance to try acquiring the lock
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // At this point, reader should still be blocked
+    EXPECT_TRUE(readerBlocked) << "Reader should be blocked while writer holds lock";
+
+    writer.join();
+    reader.join();
+
+    // Verify reader eventually acquired the lock after writer released it
+    EXPECT_TRUE(readerAcquiredLock) << "Reader should acquire lock after writer releases it";
+
+    std::filesystem::remove_all(base);
+}
+
+TEST(ContentManagerConcurrencyTest, ReadGuardBlocksWriter)
+{
+    cti::store::ContentManagerConfig cfg;
+    auto base = makeIsolatedConfig(cfg, "cm_read_blocks_write");
+
+    auto cm = std::make_shared<cti::store::ContentManager>(cfg);
+
+    std::atomic<bool> readerHasLock{false};
+    std::atomic<bool> writerBlocked{true};
+    std::atomic<bool> writerAcquiredLock{false};
+
+    // Reader thread - holds read lock
+    std::thread reader([&cm, &readerHasLock, &writerBlocked]()
+    {
+        auto readGuard = cm->acquireReadGuard();
+        readerHasLock = true;
+
+        // Hold the read lock for a bit
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // Check if writer is still blocked
+        EXPECT_TRUE(writerBlocked.load()) << "Writer should still be blocked while reader holds lock";
+    });
+
+    // Wait for reader to acquire lock
+    while (!readerHasLock)
+    {
+        std::this_thread::yield();
+    }
+
+    // Writer thread - tries to acquire write lock while reader holds read lock
+    std::thread writer([&cm, &writerBlocked, &writerAcquiredLock]()
+    {
+        // Try to acquire write guard - should block until reader releases
+        auto writeGuard = cm->acquireWriteGuard();
+
+        writerBlocked = false;
+        writerAcquiredLock = true;
+    });
+
+    // Give writer a chance to try acquiring the lock
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // At this point, writer should still be blocked
+    EXPECT_TRUE(writerBlocked) << "Writer should be blocked while reader holds lock";
+
+    reader.join();
+    writer.join();
+
+    // Verify writer eventually acquired the lock after reader released it
+    EXPECT_TRUE(writerAcquiredLock) << "Writer should acquire lock after reader releases it";
+
+    std::filesystem::remove_all(base);
+}
+
+TEST(ContentManagerConcurrencyTest, WriteGuardBlocksMultipleReaders)
+{
+    cti::store::ContentManagerConfig cfg;
+    auto base = makeIsolatedConfig(cfg, "cm_write_blocks_multiple_reads");
+
+    auto cm = std::make_shared<cti::store::ContentManager>(cfg);
+
+    std::atomic<bool> writerHasLock{false};
+    std::atomic<int> readersAcquiredLock{0};
+    std::atomic<bool> writeLockReleased{false};
+
+    // Writer thread - holds write lock
+    std::thread writer([&cm, &writerHasLock, &writeLockReleased, &readersAcquiredLock]()
+    {
+        auto writeGuard = cm->acquireWriteGuard();
+
+        writerHasLock = true;
+
+        // Hold the write lock for a bit
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        writeLockReleased = true;
+        EXPECT_EQ(readersAcquiredLock.load(), 0) << "No readers should acquire locks while writer holds lock";
+    });
+
+    // Wait for writer to acquire lock
+    while (!writerHasLock)
+    {
+        std::this_thread::yield();
+    }
+
+    // Multiple reader threads - all try to acquire read locks
+    const int numReaders = 3;
+    std::vector<std::thread> readers;
+
+    for (int i = 0; i < numReaders; ++i)
+    {
+        readers.emplace_back([&cm, &readersAcquiredLock]()
+        {
+            auto readGuard = cm->acquireReadGuard();
+            ++readersAcquiredLock;
+
+            // Hold lock briefly
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        });
+    }
+
+    // Give readers a chance to try acquiring locks
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // No readers should have acquired locks yet
+    EXPECT_EQ(readersAcquiredLock.load(), 0) << "No readers should acquire locks while writer holds lock";
+
+    writer.join();
+
+    // Wait for all readers to complete
+    for (auto& t : readers)
+    {
+        t.join();
+    }
+
+    // All readers should have acquired locks after writer released
+    EXPECT_EQ(readersAcquiredLock.load(), numReaders) << "All readers should acquire locks after writer releases";
 
     std::filesystem::remove_all(base);
 }


### PR DESCRIPTION
|Related issue|
|---|
|#33017|


## Description


This pull request adds ReadGuard and WriteGuard objects that use a shared_lock and unique_lock approach for the following:

- Write operations block all access.
- Read operations block write access. Other reads are allowed.

A given function requiring consistency among multiple individual calls to DB operations (CTIStorageDB class) should acquire the respective guard, which will then unlock when it goes out of scope. In this case, I am adding guards to the following functions:
1. `ContentManager::processDownloadedContent()`: A write guard is added, preventing reads or writes while the content is downloaded and stored in the RocksDB database.
2 `CMSync::deploy()`: A read guard is added, preventing writes (but not reads) while the current RocksDB content is fetched and pushed to the engine.


### Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
