### PR TITLE
Fix SCA scan for debian 13

### DIFF
--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -3090,8 +3090,8 @@ checks:
       - soc_2: ["CC6.2", "CC6.3"]
     condition: any
     rules:
-      - "f:/etc/security/faillock.conf -> r:even_deny_root"
-      - "f:/etc/security/faillock.conf -> n:root_unlock_time=(\\d+), compare >= 60"
+      - 'f:/etc/security/faillock.conf -> r:even_deny_root'
+      - 'f:/etc/security/faillock.conf -> n:root_unlock_time=(\d+) compare >= 60'
 
   # 5.3.3.2.1 Ensure password number of changed characters is configured. (Automated)
   - id: 33193


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes #33109 

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

Before these changes:
```console
2025/11/06 10:02:46 wazuh-modulesd:sca: INFO: SCA scan started.
2025/11/06 10:02:47 wazuh-modulesd:sca: ERROR: Exception 'Invalid operator or expected value in numeric comparison' was caught while evaluating pattern 'n:timestamp_timeout=(\d+) compare <=15'.
2025/11/06 10:02:47 wazuh-modulesd:sca: ERROR: Exception 'Invalid operator or expected value in numeric comparison' was caught while evaluating pattern 'n:timestamp_timeout=(\d+) compare <=15'.
2025/11/06 10:02:47 wazuh-modulesd:sca: ERROR: Exception 'Invalid expression format, 'compare' keyword missing' was caught while evaluating pattern 'n:root_unlock_time >= 60'.
2025/11/06 10:02:47 wazuh-modulesd:sca: INFO: SCA scan ended.
```

After applying changes and creating a package to test (https://github.com/wazuh/wazuh-agent-packages/actions/runs/19343876423):
``` console
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA message queue initialized successfully.
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA initialized.
2025/11/13 17:15:43 wazuh-modulesd:agent-info: INFO: Agent-info sync protocol initialized with database: queue/agent_info/db/agent_info_sync.db
2025/11/13 17:15:43 wazuh-modulesd:agent-info: INFO: AgentInfo module started with interval: 60 seconds, integrity interval: 86400 seconds.
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA sync protocol initialized successfully with database: queue/sca/db/sca_sync.db
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA module initialized successfully.
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA module running.
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA module scan on start.
2025/11/13 17:15:43 wazuh-modulesd:sca: INFO: SCA scan started.
2025/11/13 17:15:44 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2025/11/13 17:16:03 wazuh-modulesd:agent-info: INFO: Successfully set version 5 on sca
2025/11/13 17:16:03 wazuh-modulesd: INFO: Agent is now online. Process unlocked, continuing...
2025/11/13 17:16:09 wazuh-modulesd:sca: INFO: SCA scan ended.
```
### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
- [x] Log syntax and correct language review

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
 - NA
### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
 - NA
### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
- NA
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
