### PR TITLE
Fix checkfiles test for DEB i386 package by adjusting expected file size

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -1,6 +1,6 @@
 full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_error
 /var/ossec/var/selinux/wazuh.pp,root,wazuh,640,file,-rw-r-----,3219,0.1
-/var/ossec/bin/wazuh-syscheckd,root,root,750,file,-rwxr-x---,1221012,0.1
+/var/ossec/bin/wazuh-syscheckd,root,root,750,file,-rwxr-x---,1097644,0.1
 /var/ossec/bin/wazuh-execd,root,root,750,file,-rwxr-x---,958152,0.1
 /var/ossec/bin/wazuh-logcollector,root,root,750,file,-rwxr-x---,1055440,0.1
 /var/ossec/bin/wazuh-control,root,root,750,file,-rwxr-x---,7146,0.1


### PR DESCRIPTION
## Description

This pull request resolves an issue where the DEB i386 package failed the checkfiles test due to an unexpected file size for `/var/ossec/bin/wazuh-syscheckd`.

## Proposed Changes

- Updated the expected file size for `/var/ossec/bin/wazuh-syscheckd` in the DEB i386 package, aligning it with the size found in the RPM package.

### Results and Evidence

- The issue was fixed by matching the expected file size to the actual one, consistent with the RPM package.

||Workflow|Run|
|--|--|--|
|🟢|Build Wazuh agent Linux amd - agent packages - deb - i386|[#991](https://github.com/wazuh/wazuh-agent-packages/actions/runs/19358035295)|

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

Not applicable.

### Tests Introduced

Not applicable.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues