### PR TITLE
fix[ruleset/decoder]: Fix regex for dovecot decoders (#33178)

### DIFF
--- a/ruleset/decoders/0085-dovecot_decoders.xml
+++ b/ruleset/decoders/0085-dovecot_decoders.xml
@@ -39,46 +39,16 @@
 
 <decoder name="dovecot-success">
   <parent>dovecot</parent>
-  <prematch offset="after_parent">^\w\w\w\w-login: Login: </prematch>
-  <regex offset="after_prematch">^user=\p(\S+)\p, method=\S+, rip=(\S+), lip=(\S+), mpid=\S+, (\S*)$</regex>
-  <order>user, srcip, dstip, protocol</order>
+  <prematch offset="after_parent">^\S+-login: Login: </prematch>
+  <regex offset="after_prematch">^user=\p(\S+)\p, method=\S+, rip=(\S+), lip=(\S+), mpid=\S+, (\S+), (\.+), session=\p(\S+)\p</regex>
+  <order>user, srcip, dstip, protocol, extra_data, session</order>
 </decoder>
 
 <decoder name="dovecot-aborted">
   <parent>dovecot</parent>
-  <prematch offset="after_parent">^\w\w\w\w-login: Aborted login</prematch>
-  <regex offset="after_prematch">: user=\p(\S+)\p, method=\S+, rip=(\S+), </regex>
-  <order>user, srcip, dstip</order>
-</decoder>
-
-<decoder name="dovecot-aborted">
-  <parent>dovecot</parent>
-  <regex offset="after_regex">lip=(\S+),</regex>
-  <order>dstip</order>
-</decoder>
-
-<decoder name="dovecot-aborted">
-  <parent>dovecot</parent>
-  <regex offset="after_regex">lip=(\S+)</regex>
-  <order>dstip</order>
-</decoder>
-
-<decoder name="dovecot-aborted">
-  <parent>dovecot</parent>
-  <regex offset="after_regex"> session=\p(\S+\S)>,</regex>
-  <order>session</order>
-</decoder>
-
-<decoder name="dovecot-aborted">
-  <parent>dovecot</parent>
-  <regex offset="after_regex"> session=\p(\S+\S)></regex>
-  <order>session</order>
-</decoder>
-
-<decoder name="dovecot-aborted">
-  <parent>dovecot</parent>
-  <regex offset="after_regex"> (\S*)$</regex>
-  <order>protocol</order>
+  <prematch offset="after_parent">^\S+-login: Disconnected: Aborted login</prematch>
+  <regex offset="after_prematch">: user=\p(\S*)\p, rip=(\S+), lip=(\S+), session=\p(\S+)\p</regex>
+  <order>user, srcip, dstip, session</order>
 </decoder>
 
 <decoder name="dovecot-fail">
@@ -88,18 +58,11 @@
   <order>user, srcip</order>
 </decoder>
 
- <decoder name="dovecot-disconnect-user">
-   <parent>dovecot</parent>
-   <prematch offset="after_parent">^\w\w\w\w-login: Disconnected\.+user=</prematch>
-   <regex offset="after_parent">user=(\S+), method=\S+, rip=(\S+), lip=(\S+),</regex>
-   <order>srcuser, srcip, dstip</order>
- </decoder>
-
-<decoder name="dovecot-disconnect">
+<decoder name="dovecot-disconnect-user">
   <parent>dovecot</parent>
-  <prematch offset="after_parent">^\w\w\w\w-login: Disconnected</prematch>
-  <regex offset="after_prematch">rip=(\S+), lip=(\S+),|rip=(\S+), lip=(\S+)$</regex>
-  <order>srcip, dstip</order>
+  <prematch offset="after_parent">^\S+\p\S+\p\.+: Disconnected: </prematch>
+  <regex offset="after_parent">^\S+\p(\S+)\p\p\S+\p\p(\S+)\p</regex>
+  <order>user, session</order>
 </decoder>
 
 <decoder name="dovecot-info">
@@ -117,4 +80,18 @@
   <parent>dovecot-info</parent>
   <regex offset="after_parent">auth\(\.+\): \S+\((\S+),(\S+)\):</regex>
   <order>user, srcip</order>
+</decoder>
+
+<decoder name="dovecot-disconnected-too-many-bad-commands">
+  <parent>dovecot</parent>
+  <prematch offset="after_parent">^\S+-login: Disconnected: Disconnected: Too many bad commands \.+:</prematch>
+  <regex offset="after_prematch">user=\p(\S*)\p, rip=(\S+), lip=(\S+), \.+, session=\p(\S+)\p</regex>
+  <order>user, srcip, dstip, session</order>
+</decoder>
+
+<decoder name="dovecot-disconnected-too-many-invalid-commands">
+  <parent>dovecot</parent>
+  <prematch offset="after_parent">^\S+-login: Disconnected: Too many invalid commands \.+:</prematch>
+  <regex offset="after_prematch">user=\p(\S*)\p, rip=(\S+), lip=(\S+), \.+, session=\p(\S+)\p</regex>
+  <order>user, srcip, dstip, session</order>
 </decoder>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
Fix the regex used to extract fields from the logs in the dovecot decoders
Closes #33178 
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes
Fixed regex in the decoders found at the `ruleset/decoders/0085-dovecot_decoders.xml`
<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

After applying the new regex, the following messages are now successfully decoded, using the `wazuh-logtest` tool:

```
Starting wazuh-logtest v4.13.1
Type one log per line

Nov 16 13:19:44 mail dovecot[798]: imap-login: Login: user=<email@company.com>, method=LOGIN, rip=1.2.3.4, lip=5.6.7.8, mpid=0123456, TLS, TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits), session=<zasfbgtrgh/S2hl>

**Phase 1: Completed pre-decoding.
	full event: 'Nov 16 13:19:44 mail dovecot[798]: imap-login: Login: user=<email@company.com>, method=LOGIN, rip=1.2.3.4, lip=5.6.7.8, mpid=0123456, TLS, TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits), session=<zasfbgtrgh/S2hl>'
	timestamp: 'Nov 16 13:19:44'
	hostname: 'mail'
	program_name: 'dovecot'

**Phase 2: Completed decoding.
	name: 'dovecot'
	parent: 'dovecot'
	dstip: '5.6.7.8'
	dstuser: 'email@company.com'
	extra_data: 'TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)'
	protocol: 'TLS'
	session: 'zasfbgtrgh/S2hl'
	srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
	id: '9701'
	level: '3'
	description: 'Dovecot Authentication Success.'
	groups: '['dovecot', 'authentication_success']'
	firedtimes: '1'
	gdpr: '['IV_32.2']'
	gpg13: '['7.1', '7.2']'
	hipaa: '['164.312.b']'
	mail: 'False'
	mitre.id: '['T1078']'
	mitre.tactic: '['Defense Evasion', 'Persistence', 'Privilege Escalation', 'Initial Access']'
	mitre.technique: '['Valid Accounts']'
	nist_800_53: '['AU.14', 'AC.7']'
	pci_dss: '['10.2.5']'
	tsc: '['CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

Nov 17 01:23:44 mail dovecot[798]: imap-login: Disconnected: Aborted login by logging out (no auth attempts in 0 secs): user=<>, rip=1.2.3.4, lip=5.6.7.8, session=<qPW7MsBDDKWPa28M>

**Phase 1: Completed pre-decoding.
	full event: 'Nov 17 01:23:44 mail dovecot[798]: imap-login: Disconnected: Aborted login by logging out (no auth attempts in 0 secs): user=<>, rip=1.2.3.4, lip=5.6.7.8, session=<qPW7MsBDDKWPa28M>'
	timestamp: 'Nov 17 01:23:44'
	hostname: 'mail'
	program_name: 'dovecot'

**Phase 2: Completed decoding.
	name: 'dovecot'
	parent: 'dovecot'
	dstip: '5.6.7.8'
	dstuser: ''
	session: 'qPW7MsBDDKWPa28M'
	srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
	id: '9707'
	level: '5'
	description: 'Dovecot Aborted Login.'
	groups: '['dovecot', 'invalid_login']'
	firedtimes: '1'
	gdpr: '['IV_35.7.d', 'IV_32.2']'
	gpg13: '['7.1']'
	hipaa: '['164.312.b']'
	mail: 'False'
	nist_800_53: '['AU.14', 'AC.7']'
	pci_dss: '['10.2.4', '10.2.5']'
	tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.

Nov 17 01:24:06 mail dovecot[798]: imap(email@company.com)<2611167><iZSAyL9DHPItoBkr>: Disconnected: Inactivity - no input for 1801 secs in=56 out=5399 deleted=0 expunged=0 trashed=0 hdr_count=0 hdr_bytes=0 body_count=0 body_bytes=0

**Phase 1: Completed pre-decoding.
	full event: 'Nov 17 01:24:06 mail dovecot[798]: imap(email@company.com)<2611167><iZSAyL9DHPItoBkr>: Disconnected: Inactivity - no input for 1801 secs in=56 out=5399 deleted=0 expunged=0 trashed=0 hdr_count=0 hdr_bytes=0 body_count=0 body_bytes=0'
	timestamp: 'Nov 17 01:24:06'
	hostname: 'mail'
	program_name: 'dovecot'

**Phase 2: Completed decoding.
	name: 'dovecot'
	parent: 'dovecot'
	dstuser: 'email@company.com'
	session: 'iZSAyL9DHPItoBkr'

**Phase 3: Completed filtering (rules).
	id: '9706'
	level: '3'
	description: 'Dovecot Session Disconnected.'
	groups: '['dovecot']'
	firedtimes: '1'
	gdpr: '['IV_35.7.d', 'IV_32.2']'
	gpg13: '['7.1']'
	hipaa: '['164.312.b', '164.312.a.1', '164.312.a.2.III']'
	mail: 'False'
	nist_800_53: '['AU.14', 'AC.7', 'AC.2', 'AC.12']'
	pci_dss: '['10.2.5', '8.1.5', '8.1.8']'
	tsc: '['CC6.8', 'CC7.2', 'CC7.3', 'CC6.1']'
**Alert to be generated.

Nov 16 01:11:00 mail dovecot[798]: pop3-login: Disconnected: Disconnected: Too many bad commands (no auth attempts in 0 secs): user=<>, rip=1.2.3.4, lip=5.6.7.8, TLS, TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits), session=<uLdj789DyL2SvuN/>

**Phase 1: Completed pre-decoding.
	full event: 'Nov 16 01:11:00 mail dovecot[798]: pop3-login: Disconnected: Disconnected: Too many bad commands (no auth attempts in 0 secs): user=<>, rip=1.2.3.4, lip=5.6.7.8, TLS, TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits), session=<uLdj789DyL2SvuN/>'
	timestamp: 'Nov 16 01:11:00'
	hostname: 'mail'
	program_name: 'dovecot'

**Phase 2: Completed decoding.
	name: 'dovecot'
	parent: 'dovecot'
	dstip: '5.6.7.8'
	dstuser: ''
	session: 'uLdj789DyL2SvuN/'
	srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
	id: '9706'
	level: '3'
	description: 'Dovecot Session Disconnected.'
	groups: '['dovecot']'
	firedtimes: '2'
	gdpr: '['IV_35.7.d', 'IV_32.2']'
	gpg13: '['7.1']'
	hipaa: '['164.312.b', '164.312.a.1', '164.312.a.2.III']'
	mail: 'False'
	nist_800_53: '['AU.14', 'AC.7', 'AC.2', 'AC.12']'
	pci_dss: '['10.2.5', '8.1.5', '8.1.8']'
	tsc: '['CC6.8', 'CC7.2', 'CC7.3', 'CC6.1']'
**Alert to be generated.

Nov 15 06:55:46 mail dovecot[798]: imap-login: Disconnected: Too many invalid commands (no auth attempts in 0 secs): user=<>, rip=1.2.3.4, lip=5.6.7.8, TLS, TLSv1.2 with cipher ECDHE-ECDSA-AES128-GCM-SHA256 (128/128 bits), session=<o26SADxDWroDjyE/>

**Phase 1: Completed pre-decoding.
	full event: 'Nov 15 06:55:46 mail dovecot[798]: imap-login: Disconnected: Too many invalid commands (no auth attempts in 0 secs): user=<>, rip=1.2.3.4, lip=5.6.7.8, TLS, TLSv1.2 with cipher ECDHE-ECDSA-AES128-GCM-SHA256 (128/128 bits), session=<o26SADxDWroDjyE/>'
	timestamp: 'Nov 15 06:55:46'
	hostname: 'mail'
	program_name: 'dovecot'

**Phase 2: Completed decoding.
	name: 'dovecot'
	parent: 'dovecot'
	dstip: '5.6.7.8'
	dstuser: ''
	session: 'o26SADxDWroDjyE/'
	srcip: '1.2.3.4'

**Phase 3: Completed filtering (rules).
	id: '9706'
	level: '3'
	description: 'Dovecot Session Disconnected.'
	groups: '['dovecot']'
	firedtimes: '3'
	gdpr: '['IV_35.7.d', 'IV_32.2']'
	gpg13: '['7.1']'
	hipaa: '['164.312.b', '164.312.a.1', '164.312.a.2.III']'
	mail: 'False'
	nist_800_53: '['AU.14', 'AC.7', 'AC.2', 'AC.12']'
	pci_dss: '['10.2.5', '8.1.5', '8.1.8']'
	tsc: '['CC6.8', 'CC7.2', 'CC7.3', 'CC6.1']'
**Alert to be generated.
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [X] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [X] Code changes reviewed
- [X] Relevant evidence provided
- [X] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [X] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
