### PR TITLE
Fix post-install failure when a shared subfolder exists during agent upgrade

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -107,9 +107,7 @@ case "$1" in
 
     # Restore group files
     if [ -d ${WAZUH_TMP_DIR}/group ]; then
-        for file in ${WAZUH_TMP_DIR}/group/* ; do
-            mv ${file} ${DIR}/etc/shared/
-        done
+        cp -rfp ${WAZUH_TMP_DIR}/group/* ${DIR}/etc/shared
         rm -rf ${WAZUH_TMP_DIR}/group
     fi
 


### PR DESCRIPTION
## Description

This pull request addresses an issue where the Wazuh agent upgrade process fails if a shared directory already exists and contains custom content. The fix ensures that custom data is preserved and the upgrade completes successfully.

## Proposed Changes

- Update post-install scripts to use recursive copy (`cp -rfp`) instead of `mv` when restoring group directories. This approach aligns with manager specs and safely handles pre-existing directories.

### Results and Evidence

Upgrade scenario validated with the following steps:

```
wazuh-uninstall
apt-get install wazuh-agent=4.14.0-1
cp -p /root/{ossec.conf,client.keys} /var/ossec/etc
mkdir -p /var/ossec/etc/shared/default/sca
touch /var/ossec/etc/shared/default/sca/dummy
chown wazuh:wazuh /var/ossec/etc/shared/default{,/sca{,/dummy}}

dpkg -i wazuh-agent_4.14.2-0_amd64_4eef61d.deb
```

Output:

```
(Reading database ... 171982 files and directories currently installed.)
Preparing to unpack wazuh-agent_4.14.2-0_amd64_4eef61d.deb ...
Unpacking wazuh-agent (4.14.2-0) over (4.14.0-1) ...
Setting up wazuh-agent (4.14.2-0) ...
```

The agent installs correctly even when custom data is present in `/var/ossec/etc/shared/default`.

### Artifacts Affected

- DEB installer for Wazuh Agent

### Configuration Changes

- None

### Documentation Updates

- None

### Tests Introduced

- None (functionality not covered by smoke tests)

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues