### PR TITLE
Removed mutual exclusion and create a single tester thread

### DIFF
--- a/src/engine/source/builder/src/policy/factory.cpp
+++ b/src/engine/source/builder/src/policy/factory.cpp
@@ -62,14 +62,7 @@ BuiltAssets buildAssets(const cm::store::dataType::Policy& policy,
                     defaultParentName = policy.getDefaultParent();
                 }
 
-                if (defaultParentName != asset.name().toStr())
-                {
-                    asset.parents().emplace_back(std::move(defaultParentName));
-                }
-                else
-                {
-                    asset.parents().emplace_back(policy.getRootDecoder().toStr());
-                }
+                asset.parents().emplace_back(std::move(defaultParentName));
             }
 
             auto& decodersData = builtAssets[cm::store::ResourceType::DECODER];

--- a/src/engine/source/cmstore/interface/cmstore/datapolicy.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/datapolicy.hpp
@@ -47,7 +47,7 @@ constexpr std::string_view PATH_KEY_ROOT_PARENT = "/root_decoder";
 
 namespace
 {
-const auto DEFAULT_ROOT_DECODER {"decoder/wazuh-core-message/0"};
+const auto DEFAULT_ROOT_DECODER {"decoder/core-wazuh-message/0"};
 const base::Name ROOT_DECODER_NAME {DEFAULT_ROOT_DECODER};
 } // namespace
 

--- a/src/engine/source/router/src/iworker.hpp
+++ b/src/engine/source/router/src/iworker.hpp
@@ -2,18 +2,18 @@
 #define ROUTER_IWORKER_HPP
 
 #include <memory>
-
-#include "irouter.hpp"
-#include "itester.hpp"
+#include <type_traits>
+#include <stdexcept>
 
 namespace router
 {
 
+using EpsLimit = std::function<bool()>;
+
+template<typename T>
 class IWorker
 {
 public:
-    using EpsLimit = std::function<bool()>;
-
     virtual ~IWorker() = default;
 
     /**
@@ -21,24 +21,18 @@ public:
      *
      * @param epsCounter The counter to measure the events per second
      */
-    virtual void start(const EpsLimit& epsLimit) = 0;
+    virtual void start() = 0;
 
     /**
      * @brief Stop the worker
      */
-    virtual void stop() = 0;
+    virtual void stop()  = 0;
 
     /**
-     * @brief Get the router associated with the worker.
+     * @brief Get the router or tester associated with the worker.
      * @return A constant reference to the shared pointer of the router.
      */
-    virtual const std::shared_ptr<IRouter>& getRouter() const = 0;
-
-    /**
-     * @brief Get the tester associated with the worker.
-     * @return A constant reference to the shared pointer of the tester.
-     */
-    virtual const std::shared_ptr<ITester>& getTester() const = 0;
+    virtual std::shared_ptr<T> get() const = 0;
 };
 
 } // namespace router

--- a/src/engine/source/router/src/router.cpp
+++ b/src/engine/source/router/src/router.cpp
@@ -169,20 +169,22 @@ base::RespOrError<prod::Entry> Router::getEntry(const std::string& name) const
 void Router::ingest(base::Event&& event)
 {
     std::shared_lock lock {m_mutex};
+    base::Event shared_event {std::move(event)};
+    bool processed {false};
 
     for (const auto& entry : m_table)
     {
-        if (entry.status() == env::State::ENABLED && entry.environment()->isAccepted(event))
+        if (entry.status() == env::State::ENABLED && entry.environment()->isAccepted(shared_event))
         {
-            entry.environment()->ingest(std::move(event));
-            event = nullptr;
-            break;
+            base::Event ev_copy = shared_event;
+            entry.environment()->ingest(std::move(ev_copy));
+            processed = true;
         }
     }
 
-    if (event)
+    if (!processed && shared_event)
     {
-        LOG_WARNING("Event not processed: {}", event->str());
+        LOG_WARNING("Event not processed: {}", shared_event->str());
     }
 }
 

--- a/src/engine/source/router/src/worker.hpp
+++ b/src/engine/source/router/src/worker.hpp
@@ -20,15 +20,61 @@ namespace router
 constexpr auto WAIT_DEQUEUE_TIMEOUT_USEC = 1 * 100000;
 constexpr auto WAIT_EPS_TIMEOUT_MSEC = 1;
 
-class Worker : public IWorker
+class RouterWorker : public IWorker<IRouter>
 {
 private:
     std::shared_ptr<IRouter> m_router; ///< The router instance
+    std::atomic_bool m_isRunning;      ///< Flag to know if the worker is running
+    std::thread m_thread;              ///< The thread for the worker
+    std::shared_ptr<base::queue::iQueue<base::Event>> m_rQueue;     ///< The router queue
+    EpsLimit m_epsLimit;
+
+public:
+    /**
+     * @brief Construct a new Worker object
+     *
+     */
+    RouterWorker(std::shared_ptr<EnvironmentBuilder> envBuilder,
+           std::shared_ptr<base::queue::iQueue<base::Event>> rQueue, const EpsLimit& epsLimit)
+        : m_router(std::make_shared<Router>(envBuilder))
+        , m_isRunning(false)
+        , m_rQueue(rQueue)
+        , m_epsLimit(epsLimit)
+    {
+        if (!m_rQueue)
+        {
+            throw std::logic_error("Invalid queue for the router worker");
+        }
+    }
+
+    ~RouterWorker() { stop(); }
+
+    /**
+     * @copydoc IWorker::start
+     */
+    void start() override;
+
+    /**
+     * @copydoc IWorker::stop
+     */
+    void stop() override;
+
+     /**
+     * @brief Get the router associated with the worker.
+     * @return A constant reference to the shared pointer of the tester.
+     */
+    std::shared_ptr<IRouter> get() const override
+    {
+        return m_router;
+    }
+};
+
+class TesterWorker : public IWorker<ITester>
+{
+private:
     std::shared_ptr<ITester> m_tester; ///< The tester instance
     std::atomic_bool m_isRunning;      ///< Flag to know if the worker is running
     std::thread m_thread;              ///< The thread for the worker
-
-    std::shared_ptr<base::queue::iQueue<base::Event>> m_rQueue;     ///< The router queue
     std::shared_ptr<base::queue::iQueue<test::QueueType>> m_tQueue; ///< The tester queue
 
 public:
@@ -36,36 +82,39 @@ public:
      * @brief Construct a new Worker object
      *
      */
-    Worker(std::shared_ptr<EnvironmentBuilder> envBuilder,
-           std::shared_ptr<base::queue::iQueue<base::Event>> rQueue,
+    TesterWorker(std::shared_ptr<EnvironmentBuilder> envBuilder,
            std::shared_ptr<base::queue::iQueue<test::QueueType>> tQueue)
-        : m_router(std::make_shared<Router>(envBuilder))
-        , m_tester(std::make_shared<Tester>(envBuilder))
+        : m_tester(std::make_shared<Tester>(envBuilder))
         , m_isRunning(false)
         , m_thread()
-        , m_rQueue(rQueue)
         , m_tQueue(tQueue)
     {
-        if (!m_rQueue || !m_tQueue)
+        if (!m_tQueue)
         {
-            throw std::logic_error("Invalid queues for the worker");
+            throw std::logic_error("Invalid queue for the tester worker");
         }
     }
 
-    ~Worker() { stop(); }
+    ~TesterWorker() { stop(); }
 
     /**
      * @copydoc IWorker::start
      */
-    void start(const EpsLimit& epsLimit) override;
+    void start() override;
 
     /**
      * @copydoc IWorker::stop
      */
     void stop() override;
 
-    const std::shared_ptr<IRouter>& getRouter() const { return m_router; }
-    const std::shared_ptr<ITester>& getTester() const { return m_tester; }
+    /**
+     * @brief Get the tester associated with the worker.
+     * @return A constant reference to the shared pointer of the tester.
+     */
+    std::shared_ptr<ITester> get() const override
+    {
+        return m_tester;
+    }
 };
 
 } // namespace router


### PR DESCRIPTION
## Description

This pull request aims to eliminate mutual exclusion when consuming events in routes, allowing all routes that accept the event by passing the filter to consume the same event. Additionally, the creation of multiple tester threads was eliminated; the worker interface was split to allow the construction of a single tester thread.

Closes #32993 


## Proposed Changes


### Results and Evidence

```
╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/32993-builder-stage2●› 
╰─# WAZUH_STANDALONE_LOG_LEVEL=info WAZUH_ENGINE_STANDALONE=true WAZUH_CTI_ENABLED=false WAZUH_SKIP_GROUP_CHANGE=true build/engine/wazuh-engine -f
2025-11-18 23:04:34.548 62900:62900 info: Logging initialized.
2025-11-18 23:04:34.549 62900:62900 info: Store initialized.
2025-11-18 23:04:34.551 62900:62900 info: Content Manager initialized.
2025-11-18 23:04:34.579 62900:62900 info: KVDB initialized.
2025-11-18 23:04:34.579 62900:62900 info: Geo initialized.
2025-11-18 23:04:34.844 62900:62900 info: Schema initialized.
2025-11-18 23:04:36.016 62900:62900 info: Loaded timezone database version: '2025b'
2025-11-18 23:04:36.017 62900:62900 info: HLP initialized.
2025-11-18 23:04:36.136 62900:62900 info: Indexer Connector initialized.
2025-11-18 23:04:36.136 62900:62900 info: Scheduler initialized and started.
2025-11-18 23:04:36.136 62900:62900 info: Stream logger initialized.
2025-11-18 23:04:36.160 62900:62900 info: No flooding file provided, the queue will not be flooded.
2025-11-18 23:04:36.209 62900:62900 info: No flooding file provided, the queue will not be flooded.
2025-11-18 23:04:36.223 62900:62900 info: Builder initialized.
2025-11-18 23:04:36.224 62900:62900 info: No flooding file provided, the queue will not be flooded.
2025-11-18 23:04:36.252 62900:62900 info: No flooding file provided, the queue will not be flooded.
2025-11-18 23:04:36.253 62900:62900 warning: Router: router/router/0 table is empty
2025-11-18 23:04:36.253 62900:62900 info: No thread count provided. Using 4 worker threads based on system hardware.
2025-11-18 23:04:39.673 62900:62900 info: Router initialized.
2025-11-18 23:04:39.673 62900:62900 info: Archiver initialized.
2025-11-18 23:04:39.686 62900:62900 info: Server API_SRV started in thread 128762230330944 at /var/ossec/queue/sockets/analysis
2025-11-18 23:04:39.686 62900:62900 info: Local engine's server initialized and started.
2025-11-18 23:04:39.696 62900:62900 info: Server ENRICHED_EVENTS_SRV started in thread 128761995433536 at /var/ossec/queue/sockets/queue-http.sock
2025-11-18 23:04:39.697 62900:62900 info: Remote engine's server initialized and started.
2025-11-18 23:04:39.697 62900:62900 info: Engine started in standalone mode.
```

```
Enter any events [ENTER to send event, CTRL+C to finish]:

hello


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ event.original: exists -> Success
  ↳ tmp_json: parse_json($event.original) -> Parser parser failed at: hello
[🔴] decoder/syslog/0 -> failed
  ↳ [/event/original: <event.start/Jun 14 15:16:01> <tmp.hostname/fqdn> <TAG/alphanumeric/->[<process.pid>]:<~/ignore/ ><message>] -> Failure: Parse operation failed: Parser <event.start/Jun 14 15:16:01> failed at: hello
  ↳ [/event/original: <event.start/Jun 14 15:16:01> <tmp.hostname/fqdn> <TAG/alphanumeric/->:<~/ignore/ ><message>] -> Failure: Parse operation failed: Parser <event.start/Jun 14 15:16:01> failed at: hello
  ↳ [/event/original: <event.start/2018-08-14T14:30:02.203151+02:00> <tmp.hostname/fqdn> <TAG/alphanumeric/->[<process.pid>]: <message>] -> Failure: Parse operation failed: Parser <event.start/2018-08-14T14:30:02.203151+02:00> failed at: hello
  ↳ [/event/original: <event.start/2018-08-14T14:30:02.203151+02:00> <tmp.hostname/fqdn> <TAG/alphanumeric/->: <message>] -> Failure: Parse operation failed: Parser <event.start/2018-08-14T14:30:02.203151+02:00> failed at: hello
  ↳ [/event/original: <event.start/ISO8601Z> <tmp.hostname/fqdn> <TAG/alphanumeric/->: <message>] -> Failure: Parse operation failed: Parser <event.start/ISO8601Z> failed at: hello
  ↳ [/event/original: <event.start/SYSLOG> <tmp.hostname/fqdn><?~/ignore/ >(?: )<message>] -> Failure: Parse operation failed: Parser <event.start/SYSLOG> failed at: hello
  ↳ [/event/original: <event.start/%Y %b %d %T> <timezone> <tmp.hostname/fqdn> <tmp.host_ip> <TAG/alphanumeric/->[<process.pid>]:<~/ignore/ ><message>] -> Failure: Parse operation failed: Parser <event.start/%Y %b %d %T> failed at: hello
  ↳ [/event/original: <event.start/%Y %b %d %T> <tmp.hostname/fqdn> <tmp.host_ip> <TAG/alphanumeric/->[<process.pid>]:<~/ignore/ ><message>] -> Failure: Parse operation failed: Parser <event.start/%Y %b %d %T> failed at: hello
  ↳ [/event/original: <?tmp.syslog.priority/between/</\>><event.start/%b %d %T>?<event.start/%b %d %Y %T>(? <tmp.hostname/alphanumeric/.-_>)<?~/ignore/ ><?TAG/alphanumeric/->(?[<process.pid>])<?~/ignore/ >: <message>] -> Failure: Parse operation failed: Parser choice: both failed failed at: hello
  ↳ [/event/original: <?tmp.syslog.priority/between/</\>><event.start/ISO8601Z>(? <tmp.hostname/alphanumeric/.-_>)<?~/ignore/ ><?TAG/alphanumeric/->(?[<process.pid>])<?~/ignore/ >: <message>] -> Failure: Parse operation failed: Parser choice: both failed failed at: hello
  ↳ [/event/original: <?tmp.syslog.priority/between/</\>><event.start/%Y:%m:%d-%H:%M:%S> <tmp.hostname/alphanumeric/.-_> <TAG/alphanumeric/->(?[<process.pid>]): <message>] -> Failure: Parse operation failed: Parser <event.start/%Y:%m:%d-%H:%M:%S> failed at: hello
  ↳ [/event/original: \<<log.syslog.priority>><event.start/SYSLOG> <tmp.hostname/fqdn> <TAG/alphanumeric/->(?[<process.pid>]): <message>] -> Failure: Parse operation failed: Parser < failed at: hello
  ↳ [/event/original: \<<log.syslog.priority>><event.start/ISO8601Z> <tmp.hostname/fqdn> <TAG/alphanumeric/->(?[<process.pid>]): <message>] -> Failure: Parse operation failed: Parser < failed at: hello
[🔴] decoder/akamai-siem/0 -> failed
  ↳ [check: $tmp_json.type == 'akamai_siem'] -> Failure

output:
  '@timestamp': '2025-11-18T23:04:43Z'
  agent:
    id: '000'
    name: ca37659e68c4
  event:
    original: hello
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: jammy
      kernel: Linux |ca37659e68c4 |6.8.0-87-generic |#88~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC
        Tue Oct 14 14:03:14 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 22.04.5 LTS (Jammy Jellyfish)
  wazuh:
    integration:
      category: test00000
      decoders:
      - decoder/core-wazuh-message/0
      - decoder/integrations/0
      name: wazuh-core
    location: some
    queue: 49

```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
