### PR TITLE
Update expected file sizes for agent libraries in checkfiles test

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -19,8 +19,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2123404,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,649684,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,582184,0.1
-/var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,416056,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,643992,0.1
+/var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,466244,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,118632,0.1
 /var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,12008,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1


### PR DESCRIPTION
## Description

This pull request updates the expected sizes for the `/var/ossec/lib/libagent_info.so` and `/var/ossec/lib/libsca.so` files in the checkfiles test to align with the actual output in the latest agent DEB i386 builds.

## Proposed Changes

- Updated expected values for the two affected library files in the test.
- No changes to the test logic or additional files.

### Results and Evidence

- [x] The updated checkfiles test now passes with the revised expectations.

||Workflow|
|--|--|
|🟢|[#1010](https://github.com/wazuh/wazuh-agent-packages/actions/runs/19493867061)|

### Artifacts Affected

- No build or release artifacts were impacted. Only the test assertion was updated.

### Configuration Changes

- No configuration changes were required.

### Documentation Updates

- No updates necessary.

### Tests Introduced

- Only the existing test was modified; no new tests were introduced.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues