### PR TITLE
Dynamic Categories Retrieval

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -34,6 +34,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-monitord,root,root,750,file,-rwxr-x---,,
 /var/ossec/bin/wazuh-remoted,root,root,750,file,-rwxr-x---,,
 /var/ossec/bin/wazuh-syscheckd,root,root,750,file,-rwxr-x---,,
+/var/ossec/engine/categories.json,root,root,644,file,-rw-r--r--,,
 /var/ossec/engine/store/schema/allowed-fields/0,wazuh,wazuh,640,file,-rw-r-----,,
 /var/ossec/engine/store/schema/engine-schema/0,wazuh,wazuh,640,file,-rw-r-----,,
 /var/ossec/engine/store/schema/wazuh-logpar-overrides/0,wazuh,wazuh,640,file,-rw-r-----,,

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -699,6 +699,7 @@ rm -fr %{buildroot}
 %attr(640, wazuh, wazuh) %{_localstatedir}/engine/store/schema/wazuh-logpar-overrides/0
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/outputs
 %attr(640, wazuh, wazuh) %{_localstatedir}/engine/outputs/*.yml
+%attr(644, root, root) %{_localstatedir}/engine/categories.json
 %dir %attr(750, root, wazuh) %{_localstatedir}/framework
 %dir %attr(750, root, wazuh) %{_localstatedir}/framework/python
 %{_localstatedir}/framework/python/*

--- a/src/Makefile
+++ b/src/Makefile
@@ -1361,7 +1361,7 @@ INDEXER_TEMPLATES_SERVER_STREAMS := \
 WCS_FLAT_DIR := external/wcs-flat-files
 WCS_FLAT_STATELESS_PATH := ecs/stateless
 
-# TODO: can I avoid the list and just bring everything in that dir?
+# List can be avoided and bring everything in that directory
 WCS_FLAT_YAML_FILES := \
 	access-management-ecs-flat.yml \
 	applications-ecs-flat.yml \
@@ -1369,6 +1369,13 @@ WCS_FLAT_YAML_FILES := \
 	other-ecs-flat.yml \
 	security-ecs-flat.yml \
 	system-activity-ecs-flat.yml
+
+# Categories are fetched from a different repository
+INDEXER_SECURITY_BASE_URL := https://raw.githubusercontent.com/wazuh/wazuh-indexer-security-analytics
+CATEGORIES_URL_PATH := src/main/resources/OSMapping
+CATEGORIES_RESOURCE_FILE := logtypes.json
+CATEGORIES_DIR := external/categories
+CATEGORIES_FILE := $(CATEGORIES_DIR)/$(CATEGORIES_RESOURCE_FILE)
 
 # Create WCS flat file paths
 WCS_FLAT_FILES := $(WCS_FLAT_YAML_FILES:%=$(WCS_FLAT_DIR)/%)
@@ -1385,7 +1392,7 @@ endif
 INDEXER_TEMPLATE_FILES := $(INDEXER_TEMPLATES_STATES:%=$(INDEXER_PLUGINS_DIR)/%) $(INDEXER_TEMPLATES_STREAMS:%=$(INDEXER_PLUGINS_DIR)/%)
 
 .PHONY: deps
-deps: $(EXTERNAL_TAR) $(SHARED_TAR) $(INDEXER_TEMPLATE_FILES) $(WCS_FLAT_FILES)
+deps: $(EXTERNAL_TAR) $(SHARED_TAR) $(INDEXER_TEMPLATE_FILES) $(WCS_FLAT_FILES) $(CATEGORIES_FILE)
 
 external/$(CPYTHON).tar.gz:
 # Python interpreter
@@ -1508,6 +1515,26 @@ $(WCS_FLAT_DIR)/%-ecs-flat.yml: | $(WCS_FLAT_DIR)
 	done; \
 	if [ $$success -eq 0 ]; then \
 		echo "ERROR: Failed to download $(notdir $@) from any reference" >&2; \
+		exit 1; \
+	fi
+
+# Categories directory
+$(CATEGORIES_DIR):
+	mkdir -p $(CATEGORIES_DIR)
+
+# Rule for categories files
+$(CATEGORIES_DIR)/$(CATEGORIES_RESOURCE_FILE): | $(CATEGORIES_DIR)
+	@success=0; \
+	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
+		url="$(INDEXER_SECURITY_BASE_URL)/$$ref/$(CATEGORIES_URL_PATH)/$(CATEGORIES_RESOURCE_FILE)"; \
+		echo "curl -f -s -o $@ $$url"; \
+		if curl -f -s -o $@ "$$url" 2>/dev/null; then \
+			success=1; \
+			break; \
+		fi; \
+	done; \
+	if [ $$success -eq 0 ]; then \
+		echo "ERROR: Failed to download $(CATEGORIES_RESOURCE_FILE) from any reference" >&2; \
 		exit 1; \
 	fi
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1010,7 +1010,6 @@ InstallCommon()
 
 }
 
-
 generateSchemaFiles()
 {
     echo "Generating schema files..."
@@ -1144,6 +1143,10 @@ InstallLocal()
             chcon -t textrel_shlib_t ${INSTALLDIR}/lib/librouter.so
         fi
     fi
+
+    ### Categories JSON
+    cp "external/categories/logtypes.json" ${INSTALLDIR}/engine/categories.json
+    echo "Categories JSON moved to: ${INSTALLDIR}/engine/categories.json"
 }
 
 TransferShared()


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Closes #33247 

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

* Dowload logtypes.json from indexer-security repo
* Modify that file to leave only unique categories.
* Moved that file to an specific directory at install time.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

* make deps

```console
cd external && gunzip concurrentqueue.tar.gz && tar -xf concurrentqueue.tar && rm concurrentqueue.tar)
curl -f -s -o external/wcs-flat-files/system-activity-ecs-flat.yml https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/refs/heads/main/ecs/stateless/system-activity/docs/ecs_flat.yml
curl -f -s -o external/categories/logtypes.json https://raw.githubusercontent.com/wazuh/wazuh-indexer-security-analytics/refs/heads/main/src/main/resources/OSMapping/logtypes.json
cd external && [ -f cpython.tar.gz ] && gunzip cpython.tar.gz || true
test -e external/cpython.tar ||\
(curl -so external/cpython.tar.gz https://packages.wazuh.com/deps/99-29585/libraries/sources/cpython_x86_64.tar.gz &&\
cd external && gunzip cpython.tar.gz && tar -xf cpython.tar && rm cpython.tar)
test -d external/cpython || (cd external && gzip cpython.tar)
╰─# ls -l src/external/categories/logtypes.json 
-rw-r--r-- 1 root root 4307 Nov 20 20:57 src/external/categories/logtypes.json
```

* install

```console

General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:cd50797cfe03c27f3759bdc243fecca6f7535d35
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Wl,--start-group -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/sync_protocol/include -Iwazuh_modules/syscollector/include -Iwazuh_modules/sca/include -Iwazuh_modules/agent_info/include -Idata_provider/include -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include -Ishared_modules/router/include -Ishared_modules/content_manager/include -Ishared_modules/file_helper/file_io/include -Ishared_modules/file_helper/filesystem/include -Iwazuh_modules/vulnerability_scanner/include -I./shared_modules/ 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/sync_protocol/build/lib -Lshared_modules/file_helper/build/lib  -Lwazuh_modules/syscollector/build/lib -Lwazuh_modules/sca/build/lib -Lwazuh_modules/agent_info/build/lib -Ldata_provider/build/lib -Lsyscheckd/build/lib
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/wazuh-5.x-v1/wazuh/src'

Done building server

Wait for success...
success
Makefile:927: warning: overriding recipe for target 'external/simdjson/build/libsimdjson.a'
Makefile:898: warning: ignoring old recipe for target 'external/simdjson/build/libsimdjson.a'
Makefile:2422: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2365: warning: ignoring old recipe for target 'win32/ui_resource.o'
mkdir -p /var/ossec/framework/python
cp external/cpython.tar.gz /var/ossec/framework/python/cpython.tar.gz && tar -xf /var/ossec/framework/python/cpython.tar.gz -C /var/ossec/framework/python && rm -rf /var/ossec/framework/python/cpython.tar.gz
find /var/ossec/framework/python -name "*libpython3.10.so.1.0" -exec ln -f {} /var/ossec/lib/libpython3.10.so.1.0 \;
cd ../framework && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /workspaces/wazuh-5.x-v1/wazuh/framework
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-5.0.0-py3-none-any.whl size=305040 sha256=52fa2e2f555e0163d7c945e6f04094634dc5201f52099c90a908807cf487fdc7
  Stored in directory: /tmp/pip-ephem-wheel-cache-jq7ngqg8/wheels/4d/02/17/3d166d40b1fe4e9716dffb3ec7f332f2cfdbea9c6e1af216c7
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.3.2 -> 25.3
[notice] To update, run: /var/ossec/framework/python/bin/python3 -m pip install --upgrade pip
chown -R root:wazuh /var/ossec/framework/python
chmod -R o=- /var/ossec/framework/python
cd ../api && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /workspaces/wazuh-5.x-v1/wazuh/api
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-5.0.0-py3-none-any.whl size=139920 sha256=f5c00203145b3691ee964996a835e0331db35d2516f2682e0ee6e25c569ea0f3
  Stored in directory: /tmp/pip-ephem-wheel-cache-sg6owwmo/wheels/bd/95/a9/30937339a19727bbd24a28690efa0ebac097f7d0a4f02c4ceb
Successfully built api
Installing collected packages: api
Successfully installed api-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.3.2 -> 25.3
[notice] To update, run: /var/ossec/framework/python/bin/python3 -m pip install --upgrade pip
Generating schema files...
Loading resources...
Loading WCS files from directory external/wcs-flat-files/...
Found 6 YAML files to merge: ['applications-ecs-flat.yml', 'system-activity-ecs-flat.yml', 'security-ecs-flat.yml', 'access-management-ecs-flat.yml', 'other-ecs-flat.yml', 'network-activity-ecs-flat.yml']
Loading access-management-ecs-flat.yml...
Loading applications-ecs-flat.yml...
Loading network-activity-ecs-flat.yml...
Loading other-ecs-flat.yml...
Loading security-ecs-flat.yml...
Loading system-activity-ecs-flat.yml...
Successfully merged 6 files into temporary file: /tmp/merged_wcs_6aejw_hq.yml
Loading schema template...
Loading mappings template...
Loading logpar overrides template...
Building field tree from WCS definition...
Success.
Generating engine schema...
Generating fields schema properties...
Success.
Generating indexer mappings...
Success.
Generating logpar configuration...
Success.
Cleaned up temporary file: /tmp/merged_wcs_6aejw_hq.yml
Saving files to "engine/ruleset/schemas/"...
Success.
Schema files generated successfully.
Copying store files...
Engine store installed successfully.
Engine output configuration files installed successfully.
Removing old SCA policies...
Installing SCA policies...
Installing additional SCA policies...
Categories JSON moved to: /var/ossec/engine/categories.json
Generating self-signed certificate for wazuh-authd...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
server
2025/12/01 20:10:44 wazuh-modulesd: ERROR: File '/var/ossec/etc/certs/root-ca.pem' not found for 'indexer.ssl.certificate_authorities' in module 'indexer'. Check configuration
2025/12/01 20:10:44 wazuh-modulesd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-modulesd: Configuration error. Exiting

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


 - In order to connect agent and server, you need to add each agent to the server.

   More information at: 
   https://documentation.wazuh.com/
╭─root@3bfac2abd2c6 /workspaces/wazuh-5.x-v1/wazuh ‹enhancement/33247-dynamic-categories-retrieval●› 
╰─# ls -l src/external/categories/logtypes.json        
-rw-r--r-- 1 root root 4307 Nov 20 20:57 src/external/categories/logtypes.json
╭─root@3bfac2abd2c6 /workspaces/wazuh-5.x-v1/wazuh ‹enhancement/33247-dynamic-categories-retrieval●› 
╰─# ls -l /var/ossec/engine                                                                                                                                                                                                    130 ↵
total 20
-rw-r--r-- 1 root  root  4307 Dec  1 20:10 categories.json
drwxr-x--- 2 wazuh wazuh 4096 Dec  1 20:10 kvdb
drwxr-x--- 2 wazuh wazuh 4096 Dec  1 20:10 outputs
drwxr-x--- 3 wazuh wazuh 4096 Dec  1 20:10 store
╭─root@3bfac2abd2c6 /workspaces/wazuh-5.x-v1/wazuh ‹enhancement/33247-dynamic-categories-retrieval●› 
╰─# head  /var/ossec/engine/categories.json 
{
  "others_application": {
    "name": "others_application",
    "description": "Application logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 0
    }
  },
```

categories.json
```json
{
  "others_application": {
    "name": "others_application",
    "description": "Application logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 0
    }
  },
  "others_apt": {
    "name": "others_apt",
    "description": "Apt logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 1
    }
  },
  "others_cloud": {
    "name": "others_cloud",
    "description": "Cloud logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 2
    }
  },
  "others_compliance": {
    "name": "others_compliance",
    "description": "Compliance logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 4
    }
  },
  "linux": {
    "name": "linux",
    "description": "Sys logs",
    "category": "System Activity",
    "source": "Sigma",
    "tags": {
      "correlation_id": 5
    }
  },
  "others_macos": {
    "name": "others_macos",
    "description": "MacOS logs",
    "category": "System Activity",
    "source": "Sigma",
    "tags": {
      "correlation_id": 6
    }
  },
  "network": {
    "name": "network",
    "description": "Network logs",
    "category": "Network Activity",
    "source": "Sigma",
    "tags": {
      "correlation_id": 7
    }
  },
  "others_proxy": {
    "name": "others_proxy",
    "description": "Proxy logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 8
    }
  },
  "others_web": {
    "name": "others_web",
    "description": "Web logs",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 9
    }
  },
  "windows": {
    "name": "windows",
    "description": "Windows logs",
    "category": "System Activity",
    "source": "Sigma",
    "tags": {
      "correlation_id": 10
    }
  },
  "ad_ldap": {
    "name": "ad_ldap",
    "description": "Ad/ldap logs",
    "category": "Access Management",
    "source": "Sigma",
    "tags": {
      "correlation_id": 11
    }
  },
  "apache_access": {
    "name": "apache_access",
    "description": "Apache Access logs",
    "category": "Access Management",
    "source": "Sigma",
    "tags": {
      "correlation_id": 12
    }
  },
  "cloudtrail": {
    "name": "cloudtrail",
    "description": "Cloudtrail Raw or OCSF based logs",
    "category": "Cloud Services",
    "source": "Sigma",
    "tags": {
      "correlation_id": 14
    }
  },
  "dns": {
    "name": "dns",
    "description": "DNS Raw or Route53 OCSF based logs",
    "category": "Network Activity",
    "source": "Sigma",
    "tags": {
      "correlation_id": 15
    }
  },
  "github": {
    "name": "github",
    "description": "Github logs",
    "category": "Applications",
    "source": "Sigma",
    "tags": {
      "correlation_id": 16
    }
  },
  "m365": {
    "name": "m365",
    "description": "M365 logs",
    "category": "Applications",
    "source": "Sigma",
    "tags": {
      "correlation_id": 17
    }
  },
  "gworkspace": {
    "name": "gworkspace",
    "description": "GWorkspace logs",
    "category": "Applications",
    "source": "Sigma",
    "tags": {
      "correlation_id": 18
    }
  },
  "okta": {
    "name": "okta",
    "description": "Okta logs",
    "category": "Access Management",
    "source": "Sigma",
    "tags": {
      "correlation_id": 19
    }
  },
  "azure": {
    "name": "azure",
    "description": "Azure logs",
    "category": "Cloud Services",
    "source": "Sigma",
    "tags": {
      "correlation_id": 20
    }
  },
  "s3": {
    "name": "s3",
    "description": "S3 logs",
    "category": "Cloud Services",
    "source": "Sigma",
    "tags": {
      "correlation_id": 21
    }
  },
  "test_windows": {
    "name": "test_windows",
    "description": "Test Windows Log Type for integ tests. Please do not use.",
    "category": "Other",
    "source": "Sigma",
    "tags": {
      "correlation_id": 22
    }
  },
  "vpcflow": {
    "name": "vpcflow",
    "description": "VPC Flow Raw or OCSF based logs",
    "category": "Network Activity",
    "source": "Sigma",
    "tags": {
      "correlation_id": 23
    }
  },
  "waf": {
    "name": "waf",
    "description": "Web Application Firewall based logs",
    "category": "Security",
    "source": "Sigma",
    "tags": {
      "correlation_id": 24
    }
  }
}
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
