### PR TITLE
Increase timeout for 5.X package generation

### DIFF
--- a/.github/workflows/5_builderpackage_manager.yml
+++ b/.github/workflows/5_builderpackage_manager.yml
@@ -106,7 +106,7 @@ jobs:
       SHOULD_UPLOAD_CHECKSUM: ${{ inputs.checksum && inputs.upload_package }}
 
     runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
-    timeout-minutes: 35
+    timeout-minutes: 45
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
     steps:


### PR DESCRIPTION
## Description

- Closes #33266

It has been observed that in the aforementioned issue, there are occasions where the generation of the manager package for 5.0 on _arm64_ takes longer than the established timeout (`35m`). 
Therefore, since 5.0 still has uncompiled parts, it is possible that this time may increase when they are added. 
Furthermore, as it is possible that downloading a dependency may take longer than normal, it is advisable to allow for a margin of time (+10 minutes) to avoid these failures in a successful package build.

## Proposed Changes

Modify the timeout from 35 minutes to 45 minutes.

### Results and Evidence

- https://github.com/wazuh/wazuh/actions/runs/19633836913


### Artifacts Affected

- https://github.com/wazuh/wazuh/actions/workflows/5_builderpackage_manager.yml

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

