### PR TITLE
Identify db actions and determine Data Context inclusion

### DIFF
--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -45,7 +45,8 @@ class AgentSyncProtocol : public IAgentSyncProtocol
                                Operation operation,
                                const std::string& index,
                                const std::string& data,
-                               uint64_t version) override;
+                               uint64_t version,
+                               bool isDataContext = false) override;
 
         /// @copydoc IAgentSyncProtocol::persistDifferenceInMemory
         void persistDifferenceInMemory(const std::string& id,
@@ -73,6 +74,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @copydoc IAgentSyncProtocol::sendDataContextMessages
         bool sendDataContextMessages(uint64_t session,
                                      const std::vector<PersistedData>& data) override;
+
+        /// @copydoc IAgentSyncProtocol::fetchPendingItems
+        std::vector<PersistedData> fetchPendingItems(bool onlyDataValues = true) override;
+
+        /// @copydoc IAgentSyncProtocol::clearAllDataContext
+        void clearAllDataContext() override;
 
         /// @copydoc IAgentSyncProtocol::deleteDatabase
         void deleteDatabase() override;

--- a/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
@@ -25,11 +25,13 @@ class IAgentSyncProtocol
         /// @param index Index where to send the difference
         /// @param data Difference data
         /// @param version Version of the data.
+        /// @param isDataContext Flag to mark data as DataContext (true) or DataValue (false).
         virtual void persistDifference(const std::string& id,
                                        Operation operation,
                                        const std::string& index,
                                        const std::string& data,
-                                       uint64_t version) = 0;
+                                       uint64_t version,
+                                       bool isDataContext = false) = 0;
 
         /// @brief Persist a difference to in-memory vector instead of database.
         /// This method is used for recovery scenarios where data should be kept in memory.
@@ -91,6 +93,15 @@ class IAgentSyncProtocol
         /// @return true if all messages were sent successfully, false otherwise
         virtual bool sendDataContextMessages(uint64_t session,
                                              const std::vector<PersistedData>& data) = 0;
+
+        /// @brief Fetches pending DataValue items from the persistent queue without marking them.
+        /// @param onlyDataValues If true, only returns items with is_data_context=false
+        /// @return Vector of pending items
+        virtual std::vector<PersistedData> fetchPendingItems(bool onlyDataValues = true) = 0;
+
+        /// @brief Clears all DataContext items from the persistent queue.
+        /// This should be called before adding new DataContext to prevent inconsistencies.
+        virtual void clearAllDataContext() = 0;
 
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.

--- a/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
@@ -105,6 +105,11 @@ class IPersistentQueue
         /// @return A vector of messages now marked as SYNCING.
         virtual std::vector<PersistedData> fetchAndMarkForSync() = 0;
 
+        /// @brief Fetches pending DataValue items without marking them for sync.
+        /// @param onlyDataValues If true, only returns items with is_data_context=false
+        /// @return A vector of pending DataValue messages.
+        virtual std::vector<PersistedData> fetchPendingItems(bool onlyDataValues = true) = 0;
+
         /// @brief Clears items that were successfully synchronized.
         virtual void clearSyncedItems() = 0;
 
@@ -114,6 +119,9 @@ class IPersistentQueue
         /// @brief Clears all items belonging to a specific index.
         /// @param index The index for which all items should be cleared.
         virtual void clearItemsByIndex(const std::string& index) = 0;
+
+        /// @brief Clears all DataContext items (where is_data_context = true).
+        virtual void clearAllDataContext() = 0;
 
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.

--- a/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
@@ -33,6 +33,11 @@ class IPersistentQueueStorage
         /// @return A vector of messages now marked as SYNCING.
         virtual std::vector<PersistedData> fetchAndMarkForSync() = 0;
 
+        /// @brief Fetches pending items without marking them for sync.
+        /// @param onlyDataValues If true, only returns items with is_data_context=false
+        /// @return A vector of pending messages.
+        virtual std::vector<PersistedData> fetchPending(bool onlyDataValues = true) = 0;
+
         /// @brief Deletes all messages for a module currently marked as SYNCING.
         virtual void removeAllSynced() = 0;
 
@@ -42,6 +47,9 @@ class IPersistentQueueStorage
         /// @brief Deletes all messages belonging to a specific index.
         /// @param index The index for which all messages should be removed.
         virtual void removeByIndex(const std::string& index) = 0;
+
+        /// @brief Deletes all DataContext messages (where is_data_context = 1).
+        virtual void removeAllDataContext() = 0;
 
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -69,6 +69,20 @@ std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync()
     }
 }
 
+std::vector<PersistedData> PersistentQueue::fetchPendingItems(bool onlyDataValues)
+{
+    try
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_storage->fetchPending(onlyDataValues);
+    }
+    catch (const std::exception& ex)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error fetching pending items: ") + ex.what());
+        throw;
+    }
+}
+
 void PersistentQueue::clearSyncedItems()
 {
     try
@@ -107,6 +121,20 @@ void PersistentQueue::clearItemsByIndex(const std::string& index)
     catch (const std::exception& ex)
     {
         m_logger(LOG_ERROR, std::string("PersistentQueue: Error clearing items by index: ") + ex.what());
+        throw;
+    }
+}
+
+void PersistentQueue::clearAllDataContext()
+{
+    try
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_storage->removeAllDataContext();
+    }
+    catch (const std::exception& ex)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error clearing DataContext items: ") + ex.what());
         throw;
     }
 }

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -58,6 +58,11 @@ class PersistentQueue : public IPersistentQueue
         /// @return A vector of messages now marked as SYNCING.
         std::vector<PersistedData> fetchAndMarkForSync() override;
 
+        /// @brief Fetches pending items without marking them for sync.
+        /// @param onlyDataValues If true, only returns items with is_data_context=false
+        /// @return A vector of pending messages.
+        std::vector<PersistedData> fetchPendingItems(bool onlyDataValues = true) override;
+
         /// @brief Clears items that were successfully synchronized.
         void clearSyncedItems() override;
 
@@ -67,6 +72,9 @@ class PersistentQueue : public IPersistentQueue
         /// @brief Clears all items belonging to a specific index.
         /// @param index The index for which all items should be cleared.
         void clearItemsByIndex(const std::string& index) override;
+
+        /// @brief Clears all DataContext items (where is_data_context = true).
+        void clearAllDataContext() override;
 
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -269,6 +269,55 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync()
     return result;
 }
 
+std::vector<PersistedData> PersistentQueueStorage::fetchPending(bool onlyDataValues)
+{
+    std::vector<PersistedData> result;
+
+    try
+    {
+        std::string selectQuery =
+            "SELECT rowid, id, idx, data, operation, is_data_context "
+            "FROM persistent_queue "
+            "WHERE sync_status = ?";
+
+        if (onlyDataValues)
+        {
+            selectQuery += " AND is_data_context = 0";
+        }
+
+        selectQuery += " ORDER BY rowid ASC;";
+
+        SQLite3Wrapper::Statement selectStmt(m_connection, selectQuery);
+        selectStmt.bind(1, static_cast<int>(SyncStatus::PENDING));
+
+        while (selectStmt.step() == SQLITE_ROW)
+        {
+            PersistedData data;
+            data.seq = selectStmt.value<uint64_t>(0);
+            data.id = selectStmt.value<std::string>(1);
+            data.index = selectStmt.value<std::string>(2);
+            data.data = selectStmt.value<std::string>(3);
+            data.operation = static_cast<Operation>(selectStmt.value<int>(4));
+            data.is_data_context = selectStmt.value<int>(5) != 0;
+
+            result.emplace_back(std::move(data));
+        }
+
+        if (m_logger)
+        {
+            m_logger(LOG_DEBUG, "PersistentQueueStorage: Fetched " + std::to_string(result.size()) +
+                     " pending items (onlyDataValues=" + std::to_string(onlyDataValues) + ")");
+        }
+    }
+    catch (const std::exception& e)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueueStorage: Failed to fetch pending items: ") + e.what());
+        throw;
+    }
+
+    return result;
+}
+
 void PersistentQueueStorage::removeAllSynced()
 {
     m_connection.execute("BEGIN IMMEDIATE TRANSACTION;");
@@ -355,6 +404,34 @@ void PersistentQueueStorage::removeByIndex(const std::string& index)
     catch (const std::exception& ex)
     {
         m_logger(LOG_ERROR, std::string("PersistentQueueStorage: SQLite error in removeByIndex: ") + ex.what());
+        m_connection.execute("ROLLBACK;");
+        throw;
+    }
+
+    // LCOV_EXCL_STOP
+}
+
+void PersistentQueueStorage::removeAllDataContext()
+{
+    m_connection.execute("BEGIN IMMEDIATE TRANSACTION;");
+
+    try
+    {
+        const std::string query = "DELETE FROM persistent_queue WHERE is_data_context = 1;";
+        SQLite3Wrapper::Statement stmt(m_connection, query);
+        stmt.step();
+
+        m_connection.execute("COMMIT;");
+
+        if (m_logger)
+        {
+            m_logger(LOG_DEBUG, "PersistentQueueStorage: Removed all DataContext items");
+        }
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& ex)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueueStorage: SQLite error in removeAllDataContext: ") + ex.what());
         m_connection.execute("ROLLBACK;");
         throw;
     }

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -58,6 +58,11 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @return A vector of messages now marked as SYNCING.
         std::vector<PersistedData> fetchAndMarkForSync() override;
 
+        /// @brief Fetches pending items without marking them for sync.
+        /// @param onlyDataValues If true, only returns items with is_data_context=false
+        /// @return A vector of pending messages.
+        std::vector<PersistedData> fetchPending(bool onlyDataValues = true) override;
+
         /// @brief Deletes all messages for a module currently marked as SYNCING.
         void removeAllSynced() override;
 
@@ -67,6 +72,9 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @brief Deletes all messages belonging to a specific index.
         /// @param index The index for which all messages should be removed.
         void removeByIndex(const std::string& index) override;
+
+        /// @brief Deletes all DataContext messages (where is_data_context = 1).
+        void removeAllDataContext() override;
 
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -34,9 +34,11 @@ class MockPersistentQueue : public IPersistentQueue
                                    uint64_t version,
                                    bool isDataContext), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchPendingItems, (bool onlyDataValues), (override));
         MOCK_METHOD(void, clearSyncedItems, (), (override));
         MOCK_METHOD(void, resetSyncingItems, (), (override));
         MOCK_METHOD(void, clearItemsByIndex, (const std::string& index), (override));
+        MOCK_METHOD(void, clearAllDataContext, (), (override));
         MOCK_METHOD(void, deleteDatabase, (), (override));
 
 };
@@ -4266,9 +4268,13 @@ TEST(InterfaceDestructorTest, IAgentSyncProtocolDeletingDestructor)
     auto mockQueue = std::make_shared<MockPersistentQueue>();
 
     // Create mock MQ functions
-    MQ_Functions mockMq{
+    MQ_Functions mockMq
+    {
         [](const char*, short, short) { return 1; },
-        [](int, const void*, size_t, const char*, char) { return 0; }
+        [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
     };
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -43,9 +43,11 @@ class MockPersistentQueue : public IPersistentQueue
                                    uint64_t version,
                                    bool isDataContext), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchPendingItems, (bool onlyDataValues), (override));
         MOCK_METHOD(void, clearSyncedItems, (), (override));
         MOCK_METHOD(void, resetSyncingItems, (), (override));
         MOCK_METHOD(void, clearItemsByIndex, (const std::string& index), (override));
+        MOCK_METHOD(void, clearAllDataContext, (), (override));
         MOCK_METHOD(void, deleteDatabase, (), (override));
 };
 

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_router.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_router.cpp
@@ -31,9 +31,11 @@ class MockPersistentQueue : public IPersistentQueue
                                    uint64_t version,
                                    bool isDataContext), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchPendingItems, (bool onlyDataValues), (override));
         MOCK_METHOD(void, clearSyncedItems, (), (override));
         MOCK_METHOD(void, resetSyncingItems, (), (override));
         MOCK_METHOD(void, clearItemsByIndex, (const std::string& index), (override));
+        MOCK_METHOD(void, clearAllDataContext, (), (override));
         MOCK_METHOD(void, deleteDatabase, (), (override));
 };
 

--- a/src/shared_modules/sync_protocol/tests/test_mqueue_transport.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_mqueue_transport.cpp
@@ -355,9 +355,13 @@ TEST(InterfaceDestructorTest, ISyncMessageTransportDeletingDestructor)
     // Create concrete implementation through base interface pointer
     ISyncMessageTransport* transport = nullptr;
 
-    MQ_Functions mockMq{
+    MQ_Functions mockMq
+    {
         [](const char*, short, short) { return 1; },
-        [](int, const void*, size_t, const char*, char) { return 0; }
+        [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
     };
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -22,9 +22,11 @@ class MockPersistentQueueStorage : public IPersistentQueueStorage
     public:
         MOCK_METHOD(void, submitOrCoalesce, (const PersistedData& data), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchPending, (bool onlyDataValues), (override));
         MOCK_METHOD(void, removeAllSynced, (), (override));
         MOCK_METHOD(void, resetAllSyncing, (), (override));
         MOCK_METHOD(void, removeByIndex, (const std::string& index), (override));
+        MOCK_METHOD(void, removeAllDataContext, (), (override));
         MOCK_METHOD(void, deleteDatabase, (), (override));
 };
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <fstream>
 #include <stack>
+#include <set>
 #include <chrono>
 #include <thread>
 
@@ -112,6 +113,10 @@ static const std::map<std::string, std::string> INDEX_MAP
     {BROWSER_EXTENSIONS_TABLE, SYSCOLLECTOR_SYNC_INDEX_BROWSER_EXTENSIONS},
     // LCOV_EXCL_STOP
 };
+
+// VD (Vulnerability Detection) flag file path
+// This file is created after the first successful VD sync to distinguish VDFIRST from VDSYNC
+static constexpr auto VD_FIRST_SYNC_FLAG_FILE = "queue/syscollector/db/.vd_first_sync_done";
 
 static void sanitizeJsonValue(nlohmann::json& input)
 {
@@ -1322,6 +1327,14 @@ void Syscollector::scan()
     TRY_CATCH_TASK(scanUsers);
     TRY_CATCH_TASK(scanServices);
     TRY_CATCH_TASK(scanBrowserExtensions);
+
+    // Process VD DataContext after scan completes
+    // This adds context data (e.g., all packages when OS changes) based on platform-specific rules
+    if (m_vdSyncEnabled)
+    {
+        TRY_CATCH_TASK(processVDDataContext);
+    }
+
     m_notify = true;
     m_logFunction(LOG_INFO, "Evaluation finished.");
 }
@@ -1708,8 +1721,7 @@ bool Syscollector::syncModule(Mode mode)
     if (m_spSyncProtocolVD)
     {
         Option vdOption;
-        const std::string vdFlagFile = "queue/syscollector/db/.vd_first_sync_done";
-        bool firstSyncDone = false;
+        bool firstSyncDone = isVDFirstSyncDone();
 
         if (!m_vdSyncEnabled)
         {
@@ -1719,11 +1731,6 @@ bool Syscollector::syncModule(Mode mode)
         }
         else
         {
-            // Check if first VD scan has been completed
-            std::ifstream flagCheck(vdFlagFile);
-            firstSyncDone = flagCheck.good();
-            flagCheck.close();
-
             // Use VDFIRST for first scan, VDSYNC for subsequent syncs
             vdOption = firstSyncDone ? Option::VDSYNC : Option::VDFIRST;
         }
@@ -1733,8 +1740,8 @@ bool Syscollector::syncModule(Mode mode)
         // Create flag file after successful first sync
         if (vdSuccess && !firstSyncDone)
         {
-            m_logFunction(LOG_DEBUG, "VD first sync successful, attempting to create flag file: " + vdFlagFile);
-            std::ofstream flagFile(vdFlagFile);
+            m_logFunction(LOG_DEBUG, "VD first sync successful, attempting to create flag file: " + std::string(VD_FIRST_SYNC_FLAG_FILE));
+            std::ofstream flagFile(VD_FIRST_SYNC_FLAG_FILE);
 
             if (flagFile.is_open())
             {
@@ -1744,7 +1751,7 @@ bool Syscollector::syncModule(Mode mode)
             }
             else
             {
-                m_logFunction(LOG_ERROR, "Failed to create VD flag file: " + vdFlagFile);
+                m_logFunction(LOG_ERROR, "Failed to create VD flag file: " + std::string(VD_FIRST_SYNC_FLAG_FILE));
             }
         }
         else if (!vdSuccess)
@@ -1767,7 +1774,7 @@ bool Syscollector::syncModule(Mode mode)
     return success;
 }
 
-void Syscollector::persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version)
+void Syscollector::persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext)
 {
     // VD tables: system (os), packages, hotfixes
     bool isVDTable = (index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM ||
@@ -1776,11 +1783,11 @@ void Syscollector::persistDifference(const std::string& id, Operation operation,
 
     if (isVDTable && m_spSyncProtocolVD)
     {
-        m_spSyncProtocolVD->persistDifference(id, operation, index, data, version);
+        m_spSyncProtocolVD->persistDifference(id, operation, index, data, version, isDataContext);
     }
     else if (m_spSyncProtocol)
     {
-        m_spSyncProtocol->persistDifference(id, operation, index, data, version);
+        m_spSyncProtocol->persistDifference(id, operation, index, data, version, isDataContext);
     }
 }
 
@@ -1877,6 +1884,279 @@ std::vector<std::string> Syscollector::getDisabledVDIndices() const
 #endif
 
     return indices;
+}
+
+std::vector<nlohmann::json> Syscollector::fetchAllFromTable(const std::string& tableName, const std::set<std::string>& excludeIds)
+{
+    std::vector<nlohmann::json> results;
+
+    if (!m_spDBSync)
+    {
+        if (m_logFunction)
+        {
+            m_logFunction(LOG_WARNING, "Cannot fetch from table " + tableName + ": DBSync not initialized");
+        }
+
+        return results;
+    }
+
+    try
+    {
+        // Build SELECT query to fetch all rows from the table
+        auto selectQuery = SelectQuery::builder()
+                           .table(tableName)
+                           .columnList({"*"})
+                           .build();
+
+        // Callback to collect selected rows, filtering out excluded IDs in-memory
+        // Note: We filter in the callback because excluded IDs are hash values (SHA1),
+        // not primary keys, so we cannot use SQL WHERE clause directly
+        const auto selectCallback = [&](ReturnTypeCallback returnType, const nlohmann::json & resultData)
+        {
+            if (returnType == SELECTED)
+            {
+                // Calculate the hash ID for this row
+                std::string rowId = calculateHashId(resultData, tableName);
+
+                // Only include if not in the exclude list
+                if (excludeIds.find(rowId) == excludeIds.end())
+                {
+                    results.push_back(resultData);
+                }
+            }
+        };
+
+        m_spDBSync->selectRows(selectQuery.query(), selectCallback);
+
+        if (m_logFunction)
+        {
+            m_logFunction(LOG_DEBUG, "Fetched " + std::to_string(results.size()) + " rows from table " + tableName +
+                          " (excluded " + std::to_string(excludeIds.size()) + " DataValue items)");
+        }
+    }
+    catch (const std::exception& e)
+    {
+        if (m_logFunction)
+        {
+            m_logFunction(LOG_ERROR, "Failed to fetch from table " + tableName + ": " + std::string(e.what()));
+        }
+    }
+
+    return results;
+}
+
+std::vector<std::string> Syscollector::getDataContextTables(Operation operation, const std::string& index)
+{
+    std::vector<std::string> tables;
+
+    // Apply platform-specific DataContext inclusion rules
+    if (index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM)
+    {
+        // OS changes → include packages as DataContext
+        if (operation == Operation::CREATE || operation == Operation::MODIFY)
+        {
+            tables.push_back(PACKAGES_TABLE);
+
+#ifdef _WIN32
+            // Windows: also include hotfixes
+            tables.push_back(HOTFIXES_TABLE);
+#endif
+        }
+    }
+    else if (index == SYSCOLLECTOR_SYNC_INDEX_PACKAGES)
+    {
+        // Package changes
+        if (operation == Operation::DELETE_)
+        {
+            // Package DELETE → NO DataContext
+            // (no tables added)
+        }
+        else  // CREATE or MODIFY
+        {
+            // Linux/macOS: include OS
+            // Windows: include hotfixes (and OS implicitly needed but not in spec)
+            tables.push_back(OS_TABLE);
+
+#ifdef _WIN32
+            // Windows: also include hotfixes (except on delete, handled above)
+            tables.push_back(HOTFIXES_TABLE);
+#endif
+        }
+    }
+
+#ifdef _WIN32
+    else if (index == SYSCOLLECTOR_SYNC_INDEX_HOTFIXES)
+    {
+        // Hotfix changes (Windows only)
+        if (operation == Operation::CREATE)
+        {
+            // Hotfix INSERT → include packages
+            tables.push_back(PACKAGES_TABLE);
+        }
+        else  // MODIFY or DELETE
+        {
+            // Hotfix UPDATE/DELETE → include packages + hotfixes
+            tables.push_back(PACKAGES_TABLE);
+            tables.push_back(HOTFIXES_TABLE);
+        }
+    }
+
+#endif
+
+    if (m_logFunction && !tables.empty())
+    {
+        std::string tablesStr;
+
+        for (const auto& table : tables)
+        {
+            if (!tablesStr.empty()) tablesStr += ", ";
+
+            tablesStr += table;
+        }
+
+        m_logFunction(LOG_DEBUG, "DataContext tables for index=" + index +
+                      " operation=" + std::to_string(static_cast<int>(operation)) +
+                      ": [" + tablesStr + "]");
+    }
+
+    return tables;
+}
+
+bool Syscollector::isVDFirstSyncDone() const
+{
+    std::ifstream flagCheck(VD_FIRST_SYNC_FLAG_FILE);
+    bool firstSyncDone = flagCheck.good();
+    flagCheck.close();
+    return firstSyncDone;
+}
+
+void Syscollector::processVDDataContext()
+{
+    // Skip DataContext processing on first VD scan or if protocol not initialized
+    if (!m_spSyncProtocolVD || !isVDFirstSyncDone())
+    {
+        return;
+    }
+
+    if (m_logFunction)
+    {
+        m_logFunction(LOG_DEBUG, "Processing VD DataContext after scan");
+    }
+
+    try
+    {
+        // Step 0: Clear any existing DataContext from previous scans
+        // This prevents inconsistencies if a scan happens before the previous sync completes
+        m_spSyncProtocolVD->clearAllDataContext();
+
+        // Step 1: Fetch pending DataValue items from syscollector_vd_sync.db
+        std::vector<PersistedData> pendingDataValues = m_spSyncProtocolVD->fetchPendingItems(true);
+
+        if (pendingDataValues.empty())
+        {
+            return;
+        }
+
+        // Step 2: Build exclusion sets - IDs of items already submitted as DataValue
+        // These IDs are calculated from local.db data, so they match what we'll calculate later
+        std::map<std::string, std::set<std::string>> dataValueIdsByIndex;
+
+        for (const auto& dataValue : pendingDataValues)
+        {
+            dataValueIdsByIndex[dataValue.index].insert(dataValue.id);
+        }
+
+        // Step 3: Determine what DataContext tables are needed based on platform rules
+        std::set<std::string> dataContextTablesToFetch;
+
+        for (const auto& dataValue : pendingDataValues)
+        {
+            std::vector<std::string> contextTables = getDataContextTables(dataValue.operation, dataValue.index);
+
+            for (const auto& table : contextTables)
+            {
+                dataContextTablesToFetch.insert(table);
+            }
+        }
+
+        if (dataContextTablesToFetch.empty())
+        {
+            return;
+        }
+
+        // Step 4: Fetch and submit DataContext for each required table
+        size_t totalDataContextItems = 0;
+
+        for (const auto& tableName : dataContextTablesToFetch)
+        {
+            std::string contextIndex;
+            std::set<std::string> excludeIds;
+
+            if (tableName == OS_TABLE)
+            {
+                contextIndex = SYSCOLLECTOR_SYNC_INDEX_SYSTEM;
+                excludeIds = dataValueIdsByIndex[SYSCOLLECTOR_SYNC_INDEX_SYSTEM];
+            }
+            else if (tableName == PACKAGES_TABLE)
+            {
+                contextIndex = SYSCOLLECTOR_SYNC_INDEX_PACKAGES;
+                excludeIds = dataValueIdsByIndex[SYSCOLLECTOR_SYNC_INDEX_PACKAGES];
+            }
+            else if (tableName == HOTFIXES_TABLE)
+            {
+                contextIndex = SYSCOLLECTOR_SYNC_INDEX_HOTFIXES;
+                excludeIds = dataValueIdsByIndex[SYSCOLLECTOR_SYNC_INDEX_HOTFIXES];
+            }
+
+            if (contextIndex.empty())
+            {
+                continue;
+            }
+
+            // Fetch all items from local.db, excluding those already in DataValue
+            // Since local.db is stable during scan, the calculated IDs will match
+            std::vector<nlohmann::json> contextItems = fetchAllFromTable(tableName, excludeIds);
+
+            for (const auto& item : contextItems)
+            {
+                try
+                {
+                    // Calculate ID the same way as done during scan for DataValue
+                    std::string itemId = calculateHashId(item, tableName);
+
+                    // Submit as DataContext (isDataContext=true)
+                    // Note: operation and version parameters are not used for DataContext
+                    m_spSyncProtocolVD->persistDifference(itemId, Operation::MODIFY, contextIndex, item.dump(), 0, true);
+                    totalDataContextItems++;
+                }
+                catch (const std::exception& e)
+                {
+                    if (m_logFunction)
+                    {
+                        m_logFunction(LOG_ERROR, "Failed to persist DataContext from " + tableName + ": " + std::string(e.what()));
+                    }
+                }
+            }
+
+            if (m_logFunction && !contextItems.empty())
+            {
+                m_logFunction(LOG_INFO, "Added " + std::to_string(contextItems.size()) + " DataContext items from " + tableName);
+            }
+        }
+
+        if (m_logFunction)
+        {
+            m_logFunction(LOG_INFO, "VD DataContext complete: " + std::to_string(totalDataContextItems) +
+                          " items for " + std::to_string(pendingDataValues.size()) + " DataValues");
+        }
+    }
+    catch (const std::exception& e)
+    {
+        if (m_logFunction)
+        {
+            m_logFunction(LOG_ERROR, "Error processing VD DataContext: " + std::string(e.what()));
+        }
+    }
 }
 
 bool Syscollector::notifyDataClean(const std::vector<std::string>& indices)


### PR DESCRIPTION
## Description

  This PR fixes compilation errors in the sync_protocol unit tests caused by 
  missing mock implementations for recently added pure virtual functions in the 
  `IPersistentQueue` and `IPersistentQueueStorage` interfaces.

  Related to issue #33014 - DataContext implementation enhancements.

  ## Proposed Changes

  ### Bug Fixes
  - Added missing mock method implementations in test files:
    - `MockPersistentQueueStorage::fetchPending(bool onlyDataValues)` - Fetches 
  pending items without marking them for sync
    - `MockPersistentQueueStorage::removeAllDataContext()` - Removes all 
  DataContext items from storage
    - `MockPersistentQueue::fetchPendingItems(bool onlyDataValues)` - Fetches 
  pending items for the queue interface
    - `MockPersistentQueue::clearAllDataContext()` - Clears all DataContext items 
  from the queue

  ### Files Modified
  - `src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp`
  - `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp`
  - `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.c
  pp`
  - `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_router.cpp`

  ### Technical Details
  The pure virtual functions `fetchPending()`, `removeAllDataContext()`,
  `fetchPendingItems()`, and `clearAllDataContext()` were added to the interfaces
  as part of the DataContext implementation. The mock classes used in unit tests
  were not updated to implement these methods, causing abstract class
  instantiation errors during compilation.

  ### Results and Evidence

  <details><summary>  Package Installation </summary>

  **Objective:** Install a package and verify DataValue + DataContext generation

  **Results:**
  - ✅ DataValues detected: 1
  - ✅ DataContext items: 1
  - ✅ Total items in queue: 2

  ```bash
  2025/12/05 15:28:05 wazuh-modulesd:syscollector[2068] DEBUG: Processing VD
  DataContext after scan
  2025/12/05 15:28:05 wazuh-modulesd:syscollector[2068] DEBUG:
  PersistentQueueStorage: Removed all DataContext items
  2025/12/05 15:28:05 wazuh-modulesd:syscollector[2068] DEBUG:
  PersistentQueueStorage: Fetched 1 pending items (onlyDataValues=1)
  2025/12/05 15:28:05 wazuh-modulesd:syscollector[2068] DEBUG: DataContext tables
  for index=wazuh-states-inventory-packages operation=0: [dbsync_osinfo]
  2025/12/05 15:28:05 wazuh-modulesd:syscollector[2068] INFO: Added 1 DataContext
  items from dbsync_osinfo
  2025/12/05 15:28:05 wazuh-modulesd:syscollector[2068] INFO: VD DataContext
  complete: 1 items for 1 DataValues
```

  </details>

  <details><summary> OS Information Update </summary>

  Objective: Modify OS information and verify package DataContext generation

  Results:
  - ✅ OS DataValue detected: 1
  - ✅ Package DataContext items: 239
  - ✅ Platform rule applied correctly: OS change → packages as DataContext

```bash
  2025/12/05 15:29:38 wazuh-modulesd:syscollector[2846] DEBUG: DataContext tables
  for index=wazuh-states-inventory-system operation=1: [dbsync_packages]
  2025/12/05 15:29:38 wazuh-modulesd:syscollector[2846] DEBUG: Fetched 239 rows
  from table dbsync_packages (excluded 0 DataValue items)
  2025/12/05 15:29:38 wazuh-modulesd:syscollector[2846] INFO: Added 239
  DataContext items from dbsync_packages
  2025/12/05 15:29:38 wazuh-modulesd:syscollector[2846] INFO: VD DataContext
  complete: 239 items for 1 DataValues
```

  </details>

  <details><summary>   DataContext Exclusion Logic  </summary>

  Objective: Verify items in DataValue are excluded from DataContext

  Results:
  - ✅ Package 'base-passwd' found in DataValue: 2
  - ✅ Package 'base-passwd' NOT found in DataContext: 0
  - ✅ Exclusion logic working correctly

  base-passwd in DataValue: 2
  base-passwd in DataContext: 0

  </details>

  <details><summary>  Multiple Scans Before Sync  </summary> 

  Objective: Verify DataContext cleanup between scans

  Results:
- Item counts:
- Total: 242
- DataValues: 5
- DataContext: 237


```bash
2025/12/05 15:29:55 wazuh-agentd[2803] notify.c:116 at run_notify(): DEBUG: Sending agent notification.
2025/12/05 15:29:55 wazuh-agentd[2803] notify.c:189 at run_notify(): DEBUG: Sending keep alive: #!-Linux |wazuh-agent-1 |6.8.0-87-generic |#88~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Oct 14 14:03:14 UTC 2 |x86_64 [Ubuntu|ubuntu: 22.04.5 LTS (Jammy Jellyfish)] - Wazuh v5.0.0 / ab73af41699f13fdd81903b5f23d8d00
ca35f9148a3273413eccb79f149f4757 merged.mg
--
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: Processing VD DataContext after scan
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: PersistentQueueStorage: Removed all DataContext items
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: PersistentQueueStorage: Fetched 5 pending items (onlyDataValues=1)
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: DataContext tables for index=wazuh-states-inventory-system operation=1: [dbsync_packages]
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: DataContext tables for index=wazuh-states-inventory-packages operation=0: [dbsync_osinfo]
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: DataContext tables for index=wazuh-states-inventory-packages operation=0: [dbsync_osinfo]
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: Fetched 0 rows from table dbsync_osinfo (excluded 1 DataValue items)
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:37 at taggedLogFunction(): DEBUG: Fetched 237 rows from table dbsync_packages (excluded 4 DataValue items)
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:31 at taggedLogFunction(): INFO: Added 237 DataContext items from dbsync_packages
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:31 at taggedLogFunction(): INFO: VD DataContext complete: 237 items for 5 DataValues
2025/12/05 15:30:09 wazuh-modulesd:syscollector[3111] logging_helper.c:31 at taggedLogFunction(): INFO: Evaluation finished.
2025/12/05 15:30:10 wazuh-agentd[3068] state.c:78 at write_state(): DEBUG: Updating state file.
2025/12/05 15:30:15 wazuh-agentd[3068] state.c:78 at write_state(): DEBUG: Updating state file.
2025/12/05 15:30:20 wazuh-agentd[3068] state.c:78 at write_state(): DEBUG: Updating state file.
2025/12/05 15:30:25 wazuh-agentd[3068] state.c:78 at write_state(): DEBUG: Updating state file.
2025/12/05 15:30:25 wazuh-agentd[3068] notify.c:116 at run_notify(): DEBUG: Sending agent notification.

```
  
 </details>


###  Manual tests with their corresponding evidence

  - Compilation without warnings on every supported platform
    - Linux
  - Log syntax and correct language review
  - Memory tests for Linux
    - Coverity (pending, will be fixed on the parent)
     
  Artifacts Affected

  - Unit test executables:
    - agent_sync_protocol_tests (Linux)

  Configuration Changes

  N/A - No configuration changes introduced by this PR.

  Tests Introduced

  Modified Existing Tests:
  - Updated mock classes in 4 test files to include new interface methods
  - All existing tests continue to pass with updated mocks

</details>


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
