### PR TITLE
Add necessary changes to run dev environment in docker

### DIFF
--- a/api/tools/env/README.md
+++ b/api/tools/env/README.md
@@ -10,3 +10,32 @@ This folder contains the development environment for the Wazuh 4.x versions. It 
 - **wazuh-worker2**: Worker node #2.
 - **nginx-lb**: NGINX load balancer to distribute agent connections among nodes.
 - **wazuh-agent**: Agent.
+
+### Working with docker environment
+The following commands runs a cluster:
+1. Run `docker compose build`
+2. Run `docker compose up`
+
+If a single docker is needed, it is possible to run:
+1. Move to the dockefile location for instance:
+ `cd wazuh-manager`
+2. Run `docker build -t dev-wazuh-manager --target server ./wazuh-manager`
+3. Define .env with the necessary environment variables
+4. Run docker:
+```
+docker run -d \
+--name wazuh-master \
+--hostname wazuh-master \
+-p 55000:55000 \
+-v ${WAZUH_LOCAL_PATH}/framework/scripts:/var/ossec/framework/scripts \
+-v ${WAZUH_LOCAL_PATH}/api/scripts:/var/ossec/api/scripts \
+-v ${WAZUH_LOCAL_PATH}/framework/wazuh:/var/ossec/framework/python/lib/python${WAZUH_PYTHON_VERSION}/site-packages/wazuh \
+-v ${WAZUH_LOCAL_PATH}/api/api:/var/ossec/framework/python/lib/python${WAZUH_PYTHON_VERSION}/site-packages/api \
+dev-wazuh-manager \
+/scripts/entrypoint.sh wazuh-master master-node master
+```
+
+### Troubleshooting
+- Use option **-no-cache** when you have building issues.
+
+`docker compose build --no-cache`

--- a/api/tools/env/wazuh-manager/Dockerfile
+++ b/api/tools/env/wazuh-manager/Dockerfile
@@ -14,6 +14,10 @@ COPY --from=builder /var/ossec /var/ossec
 # Soft link for the embedded python
 RUN ln -s /var/ossec/framework/python/bin/python3 /bin/wpy
 RUN ln -s /var/ossec/framework/python/bin/pip3 /bin/wpip
+RUN mkdir -p /var/ossec/etc/certs
+RUN touch /var/ossec/etc/certs/root-ca.pem
+RUN touch /var/ossec/etc/certs/server.pem
+RUN touch /var/ossec/etc/certs/server-key.pem
 
 ADD xml/xml_parser.py /scripts/xml_parser.py
 ADD xml/master_ossec_conf.xml /scripts/master_ossec_conf.xml

--- a/api/tools/env/wazuh-manager/xml/master_ossec_conf.xml
+++ b/api/tools/env/wazuh-manager/xml/master_ossec_conf.xml
@@ -11,7 +11,6 @@
             <node>wazuh-master</node>
         </nodes>
         <hidden>no</hidden>
-        <disabled>no</disabled>
      </cluster>
 
      <use_source_ip>no</use_source_ip>

--- a/api/tools/env/wazuh-manager/xml/worker_ossec_conf.xml
+++ b/api/tools/env/wazuh-manager/xml/worker_ossec_conf.xml
@@ -11,7 +11,6 @@
             <node>wazuh-master</node>
         </nodes>
         <hidden>no</hidden>
-        <disabled>no</disabled>
     </cluster>
 
      <use_source_ip>no</use_source_ip>


### PR DESCRIPTION
## Description
 This pull request introduces the necessary changes to allow the development environment to be executed within Docker. These modifications adapt the existing setup to ensure it runs  
  correctly in a containerised environment.                                                                                                                                             
## Proposed Changes

   - Updated the Dockerfile for the wazuh-manager development environment.                                                                                                              
   - Added a README.md file with instructions on how to set up and run the Dockerized development environment.                                                                          
   - Adjusted the master_ossec_conf.xml and worker_ossec_conf.xml configuration files to better suit the Docker environment. 
   
### Results and Evidence
```
~/wazuh/wazuh/api/tools/env$ docker-compose up --build
[+] Building 3.7s (49/49) FINISHED                                                                                          docker:default
 => [wazuh-base internal] load build definition from Dockerfile                                                                       0.0s
 => => transferring dockerfile: 515B                                                                                                  0.0s
 => [wazuh-base internal] load metadata for docker.io/library/ubuntu:24.04                                                            1.7s
 => [wazuh-base internal] load .dockerignore                                                                                          0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => [wazuh-base 1/4] FROM docker.io/library/ubuntu:24.04@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54      0.0s
 => CACHED [wazuh-base 2/4] RUN apt update &&     apt install -y wget python3 python3-pip git gnupg2 gcc g++ cmake make vim libc6-de  0.0s
 => CACHED [wazuh-base 3/4] RUN mkdir wazuh && curl -sL https://github.com/wazuh/wazuh/tarball/main | tar zx --strip-components=1 -C  0.0s
 => CACHED [wazuh-base 4/4] RUN make -C /wazuh/src deps                                                                               0.0s
 => [wazuh-base] exporting to image                                                                                                   0.0s
 => => exporting layers                                                                                                               0.0s
 => => writing image sha256:2138fbbd4976243e752e9fe2a0ba01c7f8716bf46dd9a86c0fe270e7d646adea                                          0.0s
 => => naming to docker.io/library/dev-wazuh-base                                                                                     0.0s
 => [wazuh-base] resolving provenance for metadata file                                                                               0.0s
 => [wazuh-master internal] load build definition from Dockerfile                                                                     0.0s
 => => transferring dockerfile: 1.04kB                                                                                                0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 10)                                                       0.0s
 => [wazuh-agent internal] load metadata for docker.io/library/dev-wazuh-base:latest                                                  0.0s
 => [wazuh-master internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => [wazuh-agent 1/4] FROM docker.io/library/dev-wazuh-base:latest                                                                    0.0s
 => [wazuh-master internal] load build context                                                                                        0.0s
 => => transferring context: 258B                                                                                                     0.0s
 => CACHED [wazuh-master builder 2/4] COPY preloaded-vars.conf /wazuh/etc/preloaded-vars.conf                                         0.0s
 => CACHED [wazuh-master builder 3/4] RUN /wazuh/install.sh                                                                           0.0s
 => CACHED [wazuh-master builder 4/4] RUN /var/ossec/framework/python/bin/pip3 install pydevd-pycharm freezegun ipdb                  0.0s
 => CACHED [wazuh-master server  1/13] COPY --from=builder /var/ossec /var/ossec                                                      0.0s
 => CACHED [wazuh-master server  2/13] RUN ln -s /var/ossec/framework/python/bin/python3 /bin/wpy                                     0.0s
 => CACHED [wazuh-master server  3/13] RUN ln -s /var/ossec/framework/python/bin/pip3 /bin/wpip                                       0.0s
 => CACHED [wazuh-master server  4/13] RUN mkdir -p /var/ossec/etc/certs                                                              0.0s
 => CACHED [wazuh-master server  5/13] RUN touch /var/ossec/etc/certs/root-ca.pem                                                     0.0s
 => CACHED [wazuh-master server  6/13] RUN touch /var/ossec/etc/certs/server.pem                                                      0.0s
 => CACHED [wazuh-master server  7/13] RUN touch /var/ossec/etc/certs/server-key.pem                                                  0.0s
 => CACHED [wazuh-master server  8/13] ADD xml/xml_parser.py /scripts/xml_parser.py                                                   0.0s
 => CACHED [wazuh-master server  9/13] ADD xml/master_ossec_conf.xml /scripts/master_ossec_conf.xml                                   0.0s
 => CACHED [wazuh-master server 10/13] ADD xml/worker_ossec_conf.xml /scripts/worker_ossec_conf.xml                                   0.0s
 => CACHED [wazuh-master server 11/13] ADD entrypoint.sh /scripts/entrypoint.sh                                                       0.0s
 => CACHED [wazuh-master server 12/13] ADD healthcheck.sh /scripts/healthcheck.sh                                                     0.0s
 => CACHED [wazuh-master server 13/13] RUN chmod +x /scripts/healthcheck.sh                                                           0.0s
 => [wazuh-master] exporting to image                                                                                                 0.0s
 => => exporting layers                                                                                                               0.0s
 => => writing image sha256:43161a8bc36461070eb29fe25e8436e7cf94f316994e026d6321871e7c8ced65                                          0.0s
 => => naming to docker.io/library/dev-wazuh-manager                                                                                  0.0s
 => [wazuh-master] resolving provenance for metadata file                                                                             0.0s
 => [nginx-lb internal] load build definition from Dockerfile                                                                         0.0s
 => => transferring dockerfile: 129B                                                                                                  0.0s
 => [nginx-lb internal] load metadata for docker.io/library/nginx:latest                                                              1.6s
 => [nginx-lb internal] load .dockerignore                                                                                            0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => [nginx-lb 1/3] FROM docker.io/library/nginx:latest@sha256:553f64aecdc31b5bf944521731cd70e35da4faed96b2b7548a3d8e2598c52a42        0.0s
 => [nginx-lb internal] load build context                                                                                            0.0s
 => => transferring context: 64B                                                                                                      0.0s
 => CACHED [nginx-lb 2/3] COPY nginx.conf /etc/nginx/nginx.conf                                                                       0.0s
 => CACHED [nginx-lb 3/3] ADD entrypoint.sh /scripts/entrypoint.sh                                                                    0.0s
 => [nginx-lb] exporting to image                                                                                                     0.0s
 => => exporting layers                                                                                                               0.0s
 => => writing image sha256:97107029bfccc6592c1aa9fdb41a20aaf480b9976f302ba222bc972f9d531c2d                                          0.0s
 => => naming to docker.io/library/dev-nginx-lb                                                                                       0.0s
 => [nginx-lb] resolving provenance for metadata file                                                                                 0.0s
 => [wazuh-agent internal] load build definition from Dockerfile                                                                      0.0s
 => => transferring dockerfile: 337B                                                                                                  0.0s
 => [wazuh-agent internal] load .dockerignore                                                                                         0.0s
 => => transferring context: 2B                                                                                                       0.0s
 => [wazuh-agent internal] load build context                                                                                         0.0s
 => => transferring context: 74B                                                                                                      0.0s
 => CACHED [wazuh-agent 2/4] COPY preloaded-vars.conf /wazuh/etc/preloaded-vars.conf                                                  0.0s
 => CACHED [wazuh-agent 3/4] RUN /wazuh/install.sh                                                                                    0.0s
 => CACHED [wazuh-agent 4/4] ADD entrypoint.sh /scripts/entrypoint.sh                                                                 0.0s
 => [wazuh-agent] exporting to image                                                                                                  0.0s
 => => exporting layers                                                                                                               0.0s
 => => writing image sha256:1b2a3ff899cef0b9825645540ba2b5e532a920e4ab49c63a63f7d9202333ed32                                          0.0s
 => => naming to docker.io/library/dev-wazuh-agent                                                                                    0.0s
 => [wazuh-agent] resolving provenance for metadata file                                                                              0.0s
[+] Running 6/4
 ✔ Container env-wazuh-base-1     Created                                                                                             0.0s 
 ✔ Container env-wazuh-master-1   Created                                                                                             0.0s 
 ✔ Container env-wazuh-worker1-1  Created                                                                                             0.0s 
 ✔ Container env-wazuh-worker2-1  Created                                                                                             0.0s 
 ✔ Container env-nginx-lb-1       Created                                                                                             0.0s 
 ✔ Container env-wazuh-agent-1    Created                                                                                             0.0s 
Attaching to nginx-lb-1, wazuh-agent-1, wazuh-base-1, wazuh-master-1, wazuh-worker1-1, wazuh-worker2-1
wazuh-base-1 exited with code 0
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-db[31] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-db[31] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-remoted[35] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-remoted[35] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-db[29] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-db[29] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-remoted[35] main.c:149 at main(): DEBUG: This is not a worker
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-modulesd:router: INFO: Loaded router module.
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-master-1   | 2025/11/28 01:02:44 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-remoted[33] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-remoted[33] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-remoted[33] main.c:153 at main(): DEBUG: Cluster worker node: Disabling the merged.mg creation
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-modulesd:router: INFO: Loaded router module.
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-db[29] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-db[29] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-remoted[33] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-remoted[33] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-remoted[33] main.c:153 at main(): DEBUG: Cluster worker node: Disabling the merged.mg creation
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-modulesd:router: INFO: Loaded router module.
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
wazuh-worker1-1  | Starting Wazuh v5.0.0...
wazuh-agent-1    | 2025/11/28 01:02:44 wazuh-agentd[18] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-agent-1    | 2025/11/28 01:02:44 wazuh-agentd[18] main.c:187 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-agent-1    | 2025/11/28 01:02:44 wazuh-agentd[18] main.c:189 at main(): DEBUG: Started (pid: 18).
wazuh-master-1   | Starting Wazuh v5.0.0...
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-authd[64] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-authd[64] config.c:24 at authd_read_config(): DEBUG: Reading configuration 'etc/ossec.conf'
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-authd[64] authd-config.c:276 at Read_Authd(): DEBUG: The tag <force><after_registration_time> is not defined. Applied default value: '3600'
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-authd[64] authd-config.c:278 at Read_Authd(): DEBUG: The tag <force><key_mismatch> is not defined. Applied default value: 'true'
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-authd[64] main-server.c:454 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker1-1  | Started wazuh-authd...
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-db[70] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker1-1  | 2025/11/28 01:02:44 wazuh-db[70] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker1-1  | Started wazuh-db...
wazuh-worker1-1  | Started wazuh-execd...
wazuh-agent-1    | Starting Wazuh v5.0.0...
wazuh-worker2-1  | Starting Wazuh v5.0.0...
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-authd[64] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-authd[64] config.c:24 at authd_read_config(): DEBUG: Reading configuration 'etc/ossec.conf'
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-authd[64] authd-config.c:276 at Read_Authd(): DEBUG: The tag <force><after_registration_time> is not defined. Applied default value: '3600'
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-authd[64] authd-config.c:278 at Read_Authd(): DEBUG: The tag <force><key_mismatch> is not defined. Applied default value: 'true'
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-authd[64] main-server.c:454 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker2-1  | Started wazuh-authd...
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-db[70] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker2-1  | 2025/11/28 01:02:44 wazuh-db[70] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker2-1  | Started wazuh-db...
wazuh-worker2-1  | Started wazuh-execd...
wazuh-agent-1    | Started wazuh-execd...
wazuh-agent-1    | 2025/11/28 01:02:45 wazuh-agentd[41] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-agent-1    | 2025/11/28 01:02:45 wazuh-agentd[41] main.c:187 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-agent-1    | 2025/11/28 01:02:45 wazuh-agentd[41] main.c:189 at main(): DEBUG: Started (pid: 41).
wazuh-master-1   | Started wazuh-apid...
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-authd[80] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-authd[80] config.c:24 at authd_read_config(): DEBUG: Reading configuration 'etc/ossec.conf'
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-authd[80] authd-config.c:276 at Read_Authd(): DEBUG: The tag <force><after_registration_time> is not defined. Applied default value: '3600'
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-authd[80] authd-config.c:278 at Read_Authd(): DEBUG: The tag <force><key_mismatch> is not defined. Applied default value: 'true'
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-authd[80] main-server.c:454 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-master-1   | Started wazuh-authd...
nginx-lb-1       | 2025/11/28 01:02:45 [error] 7#7: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 172.18.0.6, server: 0.0.0.0:1515, upstream: "172.18.0.3:1515", bytes from/to client:0/0, bytes from/to upstream:0/0
nginx-lb-1       | 2025/11/28 01:02:45 [warn] 7#7: *1 upstream server temporarily disabled while connecting to upstream, client: 172.18.0.6, server: 0.0.0.0:1515, upstream: "172.18.0.3:1515", bytes from/to client:0/0, bytes from/to upstream:0/0
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-db[86] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-master-1   | 2025/11/28 01:02:45 wazuh-db[86] main.c:127 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-master-1   | Started wazuh-db...
wazuh-master-1   | Started wazuh-execd...
wazuh-agent-1    | Started wazuh-agentd...
wazuh-agent-1    | Started wazuh-syscheckd...
wazuh-agent-1    | Started wazuh-logcollector...
wazuh-worker2-1  | Started wazuh-analysisd...
wazuh-worker2-1  | Started wazuh-syscheckd...
wazuh-worker2-1  | 2025/11/28 01:02:47 wazuh-remoted[314] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-worker2-1  | 2025/11/28 01:02:47 wazuh-remoted[314] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-worker2-1  | 2025/11/28 01:02:47 wazuh-remoted[314] main.c:153 at main(): DEBUG: Cluster worker node: Disabling the merged.mg creation
wazuh-worker2-1  | Started wazuh-remoted...
wazuh-worker2-1  | Started wazuh-logcollector...
wazuh-worker2-1  | Started wazuh-monitord...
wazuh-worker2-1  | 2025/11/28 01:02:47 wazuh-modulesd:router: INFO: Loaded router module.
wazuh-worker2-1  | 2025/11/28 01:02:47 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-worker2-1  | 2025/11/28 01:02:47 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
wazuh-worker2-1  | Started wazuh-modulesd...
wazuh-agent-1    | Started wazuh-modulesd...
wazuh-worker2-1  | Started wazuh-clusterd...
wazuh-master-1   | Started wazuh-analysisd...
wazuh-master-1   | Started wazuh-syscheckd...
wazuh-master-1   | 2025/11/28 01:02:48 wazuh-remoted[341] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
wazuh-master-1   | 2025/11/28 01:02:48 wazuh-remoted[341] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
wazuh-master-1   | 2025/11/28 01:02:48 wazuh-remoted[341] main.c:149 at main(): DEBUG: This is not a worker
wazuh-master-1   | Started wazuh-remoted...
wazuh-master-1   | Started wazuh-logcollector...
wazuh-master-1   | Started wazuh-monitord...
wazuh-master-1   | 2025/11/28 01:02:48 wazuh-modulesd:router: INFO: Loaded router module.
wazuh-master-1   | 2025/11/28 01:02:48 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-master-1   | 2025/11/28 01:02:48 wazuh-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
wazuh-master-1   | Started wazuh-modulesd...
wazuh-master-1   | Started wazuh-clusterd...
wazuh-agent-1    | Completed.
wazuh-worker2-1  | Completed.
wazuh-master-1   | Completed.
```
### Manual tests with their corresponding evidence
   - Successfully built the Docker container for the development environment.                     
   - Started the container and verified that all services came online correctly.
   - Verified that the API is accessible and functional from the host machine. 
   - Followed the new instructions in api/tools/env/README.md to ensure they are clear and correct.
### Artifacts Affected
   - api/tools/env/wazuh-manager/Dockerfile                                                                                                                                             
   - api/tools/env/wazuh-manager/xml/master_ossec_conf.xml                                                                                                                              
   - api/tools/env/wazuh-manager/xml/worker_ossec_conf.xml
  
### Configuration Changes
   - Minor adjustments were made to the ossec.conf files for the master and worker nodes in the development environment to ensure compatibility with Docker.
   
### Tests Introduced
- N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
 
Closes #33297 