### PR TITLE
Migrate 4.x GitHub Actions workflows from macOS 13 to macOS 14

### DIFF
--- a/.github/workflows/4_testcomponent_build-macos.yml
+++ b/.github/workflows/4_testcomponent_build-macos.yml
@@ -7,15 +7,6 @@ on:
       - ".github/workflows/4_testcomponent_build-macos.yml"
 
 jobs:
-  build-ventura:
-    runs-on: macos-13
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Build wazuh agent for macOS 13
-        run: |
-          make deps -C src TARGET=agent -j4
-          make -C src TARGET=agent -j4
   build-sonoma:
     runs-on: macos-14
     steps:

--- a/.github/workflows/4_testcomponent_sysinfo-macos.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-macos.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -24,13 +24,15 @@ jobs:
       - name: Install dependencies
         run: |
           brew install wget jq
-          pip3 install -r src/data_provider/qa/requirements.txt
+          python3 -m venv src/data_provider/.venv
+          source src/data_provider/.venv/bin/activate
+          pip install -r src/data_provider/qa/requirements.txt
       - name: Install macports package manager
         run: |
           API_URL="https://api.github.com/repos/macports/macports-base/releases/latest"
           last_macport=$(curl -s -H "Accept: application/vnd.github+json" \
                             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                            "$API_URL" | jq -r '.assets[] | select(.name | endswith("Ventura.pkg")).browser_download_url')
+                            "$API_URL" | jq -r '.assets[] | select(.name | endswith("Sonoma.pkg")).browser_download_url')
           wget $last_macport
           sudo installer -pkg $(basename $last_macport) -target /
           rm -rf $(basename $last_macport)
@@ -41,4 +43,5 @@ jobs:
       - name: Run tests
         run: |
           cd src/data_provider
-          sudo python3 -m pytest -vv qa/
+          VENV_PYTHON="$(pwd)/.venv/bin/python"
+          sudo "$VENV_PYTHON" -m pytest -vv qa/

--- a/.github/workflows/4_testunit_macos.yml
+++ b/.github/workflows/4_testunit_macos.yml
@@ -8,37 +8,6 @@ on:
       - ".github/workflows/4_testunit_macos.yml"
 
 jobs:
-  build-ventura:
-    runs-on: macos-13
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Install cmocka 1.1.7 and lcov
-        run: |
-          brew install lcov
-          curl -LO https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz
-          tar -xf cmocka-1.1.7.tar.xz
-          cd cmocka-1.1.7
-          mkdir build && cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
-          make -j$(sysctl -n hw.ncpu)
-          sudo make install
-      - name: Build wazuh agent for macOS 13 with tests flags
-        env:
-          CMAKE_POLICY_VERSION_MINIMUM: 3.5
-        run: |
-          make deps -C src TARGET=agent -j4
-          LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j4 DEBUG=1 TEST=1
-      - name: Run wazuh unit tests for macOS 13
-        run: |
-          cd src/data_provider/build
-          ctest -V
-          cd ../../shared_modules/dbsync/build
-          ctest -V
-          cd ../../rsync/build
-          ctest -V
-          cd ../../../wazuh_modules/syscollector/build
-          ctest -V
   build-sonoma:
     runs-on: macos-14
     steps:

--- a/src/data_provider/qa/requirements.txt
+++ b/src/data_provider/qa/requirements.txt
@@ -1,2 +1,2 @@
-pytest==7.2.2
-jsonschema==4.17.3
+pytest==8.3.4
+jsonschema==4.23.0


### PR DESCRIPTION
# Description

  This pull request addresses the deprecation of macOS 13 (Ventura) runners in GitHub Actions, scheduled for removal on December 4, 2025. As announced in the [GitHub Actions deprecation notice](https://github.com/actions/runner-images/issues/13046), all workflows using macOS 13 runners must be migrated to macOS 14 (Sonoma) to ensure continuous operation of our CI/CD pipelines.

  This PR updates all affected GitHub Actions workflows and documentation to use macOS 14 runners exclusively, removing macOS 13 from our supported platform list for Wazuh 4.X.X.

  Closes #33039

  # Proposed Changes

  ## Features/Changes:
  - **GitHub Actions Workflows:**
    - Removed all `build-ventura` jobs using `macos-13` runners from test workflows
    - Updated `runs-on` directives from `macos-13` to `macos-14` in syscollector test workflows
    - Updated MacPorts package downloads from `Ventura.pkg` to `Sonoma.pkg`

  - **Documentation:**
    - Removed macOS 13 from the supported platforms table in `packages.md`
    - Updated minimum macOS version requirement from "13 or later" to "14 or later" in `compatibility.md`
    
  # Results and Evidence

  ### Workflow Changes:

  #### Removed build-ventura jobs from:
  - .github/workflows/4_testunit_macos.yml
  - .github/workflows/4_testcomponent_build-macos.yml
  
  #### Updated runner and MacPorts references in:
  - .github/workflows/4_testcomponent_sysinfo-macos.yml
    - runs-on: macos-13 → macos-14
    - Ventura.pkg → Sonoma.pkg

 ### Documentation Changes (2 files modified):

  #### docs/ref/getting-started/packages.md
  - Removed macOS 13 from supported platforms table

  #### docs/ref/compatibility.md
  - macOS: 13 or later → macOS: 14 or later

 # Manual tests with their corresponding evidence

- 34 checks have passed.

 # Artifacts Affected

  CI/CD Workflows:
  - 4_testunit_macos.yml - Unit tests for 4.X
  - 4_testcomponent_build-macos.yml - Build compilation tests for 4.X
  - 4_testcomponent_sysinfo-macos.yml - Syscollector tests for 4.X

#  Documentation
  - docs/ref/getting-started/packages.md - Supported platforms documentation
  - docs/ref/compatibility.md - Version compatibility matrix

  Note: No binary artifacts, executables, or packages are directly affected. Changes are limited to CI/CD infrastructure and documentation.

# Configuration Changes

  - No runtime configuration changes introduced.

#  Tests Introduced

 -  No new tests introduced.

#  Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues


