### PR TITLE
Silence INFO log when Active Response is disabled; switch to debug-1

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -242,7 +242,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         /* Connect to the execd queue */
         if (agt->execdq <= 0) {
             if ((agt->execdq = StartMQ(EXECQUEUE, WRITE, 1)) < 0) {
-                minfo("Unable to connect to the active response queue (disabled).");
+                mdebug1("Unable to connect to the active response queue (disabled).");
                 agt->execdq = -1;
             }
         }


### PR DESCRIPTION
## Description

This pull request addresses excessive INFO level logging from the agent when Active Response is disabled via configuration. Previously, the agent printed the following message every time remote configuration was received:

```
2025/12/02 13:02:59 wazuh-agentd: INFO: Unable to connect to the active response queue (disabled).
```

## Proposed Changes

- The log message "Unable to connect to the active response queue (disabled)" is now logged at `debug-1` level instead of INFO when Active Response is disabled (`<active-response><disabled>yes</disabled></active-response>`).

### Results and Evidence

- When disabling Active Response, the INFO log is no longer printed by default.
- If debug mode is enabled, the following message is shown:
  ```
  2025/12/02 13:09:01 wazuh-agentd[96518] agentd.c:245 at AgentdStart(): DEBUG: Unable to connect to the active response queue (disabled).
  ```
- Manual testing confirms the new behavior.

### Artifacts Affected

- `wazuh-agentd` (UNIX)

### Configuration Changes

- No configuration changes introduced.

### Documentation Updates

- Not applicable.

### Tests Introduced

- No new unit tests, as there are no existing tests for this scenario. Manual testing has been performed.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues