### PR TITLE
Add data stream support

### DIFF
--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -78,6 +78,7 @@ WIndexerConnector::WIndexerConnector(std::string_view jsonOssecConfig)
 
     const auto logFunction = logging::createStandaloneLogFunction();
     m_indexerConnectorAsync = std::make_unique<IndexerConnectorAsync>(jsonParsed, logFunction);
+    m_indexerConnectorAsync->enableDataStreamBulkMode();
 }
 
 WIndexerConnector::WIndexerConnector(const Config& config, const LogFunctionType& logFunction)
@@ -89,6 +90,7 @@ WIndexerConnector::WIndexerConnector(const Config& config, const LogFunctionType
     }
 
     m_indexerConnectorAsync = std::make_unique<IndexerConnectorAsync>(jsonConfig, logFunction);
+    m_indexerConnectorAsync->enableDataStreamBulkMode();
 }
 
 WIndexerConnector::~WIndexerConnector() = default;

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -221,6 +221,12 @@ public:
      * @return true if have a server available, false otherwise.
      */
     bool isAvailable() const;
+
+    /**
+     * @brief Enable data stream bulk mode.
+     *
+     */
+    void enableDataStreamBulkMode();
 };
 
 class IndexerConnectorException : public std::exception

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
@@ -48,6 +48,11 @@ public:
     {
         return m_impl.isAvailable();
     }
+
+    void enableDataStreamBulkMode()
+    {
+        m_impl.enableDataStreamBulkMode();
+    }
 };
 
 IndexerConnectorAsync::IndexerConnectorAsync(
@@ -78,6 +83,11 @@ void IndexerConnectorAsync::index(std::string_view index, std::string_view data)
 bool IndexerConnectorAsync::isAvailable() const
 {
     return m_impl->isAvailable();
+}
+
+void IndexerConnectorAsync::enableDataStreamBulkMode()
+{
+    m_impl->enableDataStreamBulkMode();
 }
 
 // LCOV_EXCL_STOP


### PR DESCRIPTION
## Description
Wazuh Engine no longer writes events to OpenSearch indices using index bulk operations. Instead, all events are now sent to OpenSearch Data Streams, which require a different bulk format:

Bulk operations must use create instead of index.

Data Streams do not accept _id or _version metadata; OpenSearch assigns IDs automatically.

Only create-only operations are permitted.

This PR updates the connector so that events generated by the Engine are always sent using the correct Data Stream-compliant format, ensuring successful ingestion and aligning the connector .

Closes #33388


## Proposed Changes

I've added the ability to set the data stream bulk mode during engine instantiation. By default, it's set to index mode to avoid affecting other modules. This option was preferred because modifying the configuration file would have required declaring several optional parameters during instantiation (parameters that would precede the bulk parameter if added). Furthermore, this avoids adding a configuration option to ossec.conf.

### Results and Evidence

```bash
╭─root@ca37659e68c4 /workspaces/devContainer 
╰─# go run write_log.go -f intelligence-data/ruleset/integrations/snort/test/plaintext-syslog/snort-plaintext-syslog_input.txt        1 ↵
Sended: 1:[1000] (hostname1000) any->/var/cosas:Oct 30 14:01:52 ubuntu2204.localdomain snort[32191]: [1:366:11] "PROTOCOL-ICMP PING Unix" [Classification: Misc activity] [Priority: 3] {ICMP} 192.168.56.151 -> 192.168.56.152
Sended: 1:[1001] (hostname1001) any->/var/cosas:Oct 30 14:01:52 ubuntu2204.localdomain snort[32191]: [1:29456:3] "PROTOCOL-ICMP Unusual PING detected" [Classification: Information Leak] [Priority: 2] {ICMP} 192.168.56.151 -> 192.168.56.152
Sended: 1:[1002] (hostname1002) any->/var/cosas:Oct 30 14:01:52 ubuntu2204.localdomain snort[32191]: [1:384:8] "PROTOCOL-ICMP PING" [Classification: Misc activity] [Priority: 3] {ICMP} 192.168.56.151 -> 192.168.56.152
Sended: 1:[1003] (hostname1003) any->/var/cosas:Oct 30 14:01:52 ubuntu2204.localdomain snort[32191]: [1:408:8] "PROTOCOL-ICMP Echo Reply" [Classification: Misc activity] [Priority: 3] {ICMP} 192.168.56.152 -> 192.168.56.151
Sended: 1:[1004] (hostname1004) any->/var/cosas:Oct 30 14:41:45 ubuntu2204.localdomain snort[32846]: [116:423:1] "(tcp) TCP has no SYN, ACK, or RST" [Priority: 3] {TCP} 192.168.56.151:34366 -> 192.168.56.152:22
Sended: 1:[1005] (hostname1005) any->/var/cosas:Oct 30 14:41:45 ubuntu2204.localdomain snort[32846]: [116:401:1] "(tcp) Nmap XMAS attack detected" [Priority: 3] {TCP} 192.168.56.151:34367 -> 192.168.56.152:22
Sended: 1:[1006] (hostname1006) any->/var/cosas:Oct 30 14:41:45 ubuntu2204.localdomain snort[32846]: [116:420:1] "(tcp) TCP SYN with FIN" [Priority: 3] {TCP} 192.168.56.151:34367 -> 192.168.56.152:22
Sended: 1:[1007] (hostname1007) any->/var/cosas:Oct 30 14:48:36 ubuntu2204.localdomain snort[33037]: [1:1390:17] "INDICATOR-SHELLCODE x86 inc ebx NOOP" [Classification: Executable code was detected] [Priority: 1] {UDP} 192.168.56.151:64027 -> 192.168.56.152:38286
╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33177-integrateCM-component●› 
╰─# curl -k -u admin:admin \
  "https://127.0.0.1:9200/.ds-wazuh-events-v5-security-*/_search?size=1&pretty" 
{
  "took" : 19,
  "timed_out" : false,
  "_shards" : {
    "total" : 9,
    "successful" : 9,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 8,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : ".ds-wazuh-events-v5-security-000003",
        "_id" : "gENP9JoB2HZ7UcbJUN2Q",
        "_score" : 1.0,
        "_source" : {
          "wazuh" : {
            "protocol" : {
              "queue" : 49,
              "location" : "/var/cosas"
            },
            "integration" : {
              "category" : "Security",
              "name" : "snort",
              "decoders" : [
                "core-wazuh-message",
                "integrations",
                "syslog",
                "snort-plaintext-syslog"
              ]
            },
            "decoders" : [
              "syslog",
              "snort-plaintext-syslog"
            ]
          },
          "agent" : {
            "id" : "1002",
            "name" : "hostname1002"
          },
          "event" : {
            "original" : "Oct 30 14:01:52 ubuntu2204.localdomain snort[32191]: [1:384:8] \"PROTOCOL-ICMP PING\" [Classification: Misc activity] [Priority: 3] {ICMP} 192.168.56.151 -> 192.168.56.152",
            "start" : "2025-10-30T14:01:52.000Z",
            "kind" : "alert",
            "severity" : 3,
            "category" : [
              "network"
            ]
          },
          "@timestamp" : "2025-12-06T15:36:51Z",
          "process" : {
            "pid" : 32191,
            "name" : "snort"
          },
          "related" : {
            "hosts" : [
              "ubuntu2204.localdomain"
            ],
            "ip" : [
              "192.168.56.151",
              "192.168.56.152"
            ]
          },
          "snort" : {
            "gid" : 1,
            "sid" : "384",
            "rev" : "8",
            "msg" : "PROTOCOL-ICMP PING",
            "class" : "Misc activity"
          },
          "network" : {
            "transport" : "icmp",
            "iana_number" : "1",
            "type" : "IPv4"
          },
          "source" : {
            "address" : "192.168.56.151",
            "ip" : "192.168.56.151"
          },
          "destination" : {
            "address" : "192.168.56.152",
            "ip" : "192.168.56.152"
          },
          "observer" : {
            "name" : "ubuntu2204.localdomain",
            "vendor" : "snort",
            "product" : "ids",
            "type" : "ids"
          }
        }
      }
    ]
  }
}
```

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
