### PR TITLE
Added stream bulk support to indexer connector module

### DIFF
--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -105,7 +105,7 @@ void WIndexerConnector::index(std::string_view index, std::string_view data)
     if (m_indexerConnectorAsync)
     {
         try {
-            m_indexerConnectorAsync->index(index, data);
+            m_indexerConnectorAsync->indexDataStream(index, data);
         }
         catch (const IndexerConnectorException& e) {
             LOG_WARNING("Error indexing data: %s", e.what());

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -216,6 +216,14 @@ public:
     void index(std::string_view index, std::string_view data);
 
     /**
+     * @brief Index a document to a data stream.
+     *
+     * @param index Data stream name.
+     * @param data Data.
+     */
+    void indexDataStream(std::string_view index, std::string_view data);
+
+    /**
      * @brief Check have a server available.
      *
      * @return true if have a server available, false otherwise.

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
@@ -44,6 +44,11 @@ public:
         m_impl.bulkIndex(std::string_view(), index, data);
     }
 
+    void indexDataStream(std::string_view index, std::string_view data)
+    {
+        m_impl.bulkIndexDataStream(index, data);
+    }
+
     bool isAvailable() const
     {
         return m_impl.isAvailable();
@@ -73,6 +78,11 @@ void IndexerConnectorAsync::index(std::string_view id, std::string_view index, s
 void IndexerConnectorAsync::index(std::string_view index, std::string_view data)
 {
     m_impl->index(std::string_view(), index, data);
+}
+
+void IndexerConnectorAsync::indexDataStream(std::string_view index, std::string_view data)
+{
+    m_impl->indexDataStream(index, data);
 }
 
 bool IndexerConnectorAsync::isAvailable() const

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -472,6 +472,33 @@ public:
         m_dispatcher->push(bulkData);
     }
 
+    void bulkIndexDataStream(std::string_view index, std::string_view data)
+    {
+        constexpr auto FORMATTED_SIZE {24}; // {"create":{"_index":""}} + newlines"
+
+        // Validate input parameters
+        if (index.empty())
+        {
+            throw IndexerConnectorException("Data stream name cannot be empty");
+        }
+
+        if (data.empty())
+        {
+            throw IndexerConnectorException("Data cannot be empty for data stream: " + std::string(index));
+        }
+
+        std::string bulkData;
+        bulkData.reserve(data.size() + index.size() + FORMATTED_SIZE);
+
+        bulkData.append(R"({"create":{"_index":")");
+        bulkData.append(index);
+        bulkData.append(R"("}})");
+        bulkData.append("\n");
+        bulkData.append(data);
+        bulkData.append("\n");
+        m_dispatcher->push(bulkData);
+    }
+
     bool isAvailable() const
     {
         return m_selector->isAvailable();


### PR DESCRIPTION
Closes #33388

## Description

This PR adds a new type of operation to the indexer-connector, creating the indexDataStream method in the module facade.
[According to the documentation](https://docs.opensearch.org/latest/api-reference/document-apis/bulk/
), we can combine operations into a single bulk, so we should only add the new action to the bulk.

## Proposed Changes

- Add a new metodos to indexer-connector to index document in a datastream
- Change the indexer output to index in a datastream.

### Results and Evidence

**Raw sended event**

```bash
╭─root@92c3c1c3a786 /workspaces/wazuh-5.x 
╰─# go run ./scripts/event_sock_v2.go -m '1:[002] (testAgentDavid) 192.168.0.1->/tmp/file.log:Dec 04 18:16:23 drag0n sudo[4377]: pam_unix(sudo:session): session opened for user root(uid=0) by drag0n(uid=1000)' -r  
Sended: 1:[002] (testAgentDavid) 192.168.0.1->/tmp/file.log:Dec 04 18:16:23 drag0n sudo[4377]: pam_unix(sudo:session): session opened for user root(uid=0) by drag0n(uid=1000)
```

**Generated alert in the alert.json**

```bash
{"wazuh":{"protocol":{"queue":49,"location":"/tmp/file.log"},"decoders":["syslog","system-auth"]},"agent":{"id":"002","name":"testAgentDavid"},"event":{"original":"Dec 04 18:16:23 drag0n sudo[4377]: pam_unix(sudo:session): session opened for user root(uid=0) by drag0n(uid=1000)","start":"2025-12-04T18:16:23.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"logged-on","category":["session"]},"@timestamp":"2025-12-06T23:14:59Z","process":{"pid":4377,"name":"sudo"},"message":"pam_unix(sudo:session): session opened for user root(uid=0) by drag0n(uid=1000)","host":{"hostname":"drag0n"},"related":{"hosts":["drag0n"],"user":["drag0n","root(uid=0)"]},"user":{"id":"1000","name":"drag0n","effective":{"name":"root(uid=0)"}}}
```

**Indexer fetch**

```bash
╭─root@92c3c1c3a786 /workspaces/wazuh-5.x 
╰─# curl -k -u admin:admin -X GET "https://localhost:9200/.ds-wazuh-events-v5-system-activity-*/_search?pretty" -H 'Content-Type: application/json' -d '{"size": 10, "sort": [{"@timestamp": {"order": "desc"}}]}'
{
  "took" : 33,
  "timed_out" : false,
  "_shards" : {
    "total" : 3,
    "successful" : 3,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 5,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [
      {
        "_index" : ".ds-wazuh-events-v5-system-activity-000001",
        "_id" : "gRMI9poBF7VIObNpVMSL",
        "_score" : null,
        "_source" : {
          "wazuh" : {
            "protocol" : {
              "queue" : 49,
              "location" : "/tmp/file.log"
            },
            "decoders" : [
              "syslog",
              "system-auth"
            ]
          },
          "agent" : {
            "id" : "002",
            "name" : "testAgentDavid"
          },
          "event" : {
            "original" : "Dec 04 18:16:23 drag0n sudo[4377]: pam_unix(sudo:session): session opened for user root(uid=0) by drag0n(uid=1000)",
            "start" : "2025-12-04T18:16:23.000Z",
            "kind" : "event",
            "dataset" : "system-auth",
            "outcome" : "success",
            "action" : "logged-on",
            "category" : [
              "session"
            ]
          },
          "@timestamp" : "2025-12-06T23:33:54Z",
          "process" : {
            "pid" : 4377,
            "name" : "sudo"
          },
          "message" : "pam_unix(sudo:session): session opened for user root(uid=0) by drag0n(uid=1000)",
          "host" : {
            "hostname" : "drag0n"
          },
          "related" : {
            "hosts" : [
              "drag0n"
            ],
            "user" : [
              "drag0n",
              "root(uid=0)"
            ]
          },
          "user" : {
            "id" : "1000",
            "name" : "drag0n",
            "effective" : {
              "name" : "root(uid=0)"
            }
          }
        },
        "sort" : [
          1765064034000
        ]
      }
    ]
  }
}
```


### Manual tests with their corresponding evidence

<img width="4231" height="1589" alt="image" src="https://github.com/user-attachments/assets/d6c9e8a4-8d35-4f03-829b-d68139f78842" />
<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Indexer connector
- Engine outputs

### Configuration Changes

None

### Tests Introduced

- 

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
