### PR TITLE
Scape document id if necessary before sending document to indexer

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -13,6 +13,7 @@
 #include "HTTPRequest.hpp"
 #include "keyStore.hpp"
 #include "loggerHelper.h"
+#include "reflectiveJson.hpp"
 #include "secureCommunication.hpp"
 #include "serverSelector.hpp"
 #include <chrono>
@@ -194,7 +195,19 @@ static void builderBulkIndex(std::string& bulkData, std::string_view id, std::st
     bulkData.append(R"({"index":{"_index":")");
     bulkData.append(index);
     bulkData.append(R"(","_id":")");
-    bulkData.append(id);
+
+    // Escape special characters in ID to prevent JSON parsing errors
+    if (needEscape(id))
+    {
+        std::string escapedId;
+        escapeJSONString(id, escapedId);
+        bulkData.append(escapedId);
+    }
+    else
+    {
+        bulkData.append(id);
+    }
+
     bulkData.append(R"("}})");
     bulkData.append("\n");
     bulkData.append(data);


### PR DESCRIPTION
## Description

This PR fixes an issue where the document ID sent to the indexer was not being escaped/scaled when necessary. Some IDs require the same “scaping” (character escaping / transformation for safe indexing) already applied to the data field. Without this, certain IDs could cause indexing errors or mismatches.

## Proposed Changes

- Apply the same scaping/escaping logic used for data to the document ID before sending it to the indexer.
- Ensure the ID is transformed only when required (i.e., when scaling/escaping is needed).
- Keep the original ID untouched when no scaping is necessary.

### Results and Evidence

```
curl -s -k -u admin:admin 'https://192.168.64.17:9200/wazuh-states-inventory-groups-*/_search?pretty' -H 'Content-Type: application/json' -d '{"query": {"wildcard": {"group.name": "*dum*"}},"size": 5}'

{
  "took" : 278,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "wazuh-states-inventory-groups-tomas",
        "_id" : "001_dum\\amy",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "id" : "001",
            "name" : "tomas2",
            "version" : "v4.14.1"
          },
          "group" : {
            "id" : 112,
            "id_signed" : 112,
            "is_hidden" : false,
            "name" : "dum\\amy"
          },
          "wazuh" : {
            "cluster" : {
              "name" : "tomas"
            },
            "schema" : {
              "version" : "1.0"
            }
          }
        }
      }
    ]
  }
}
```

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
