### PR TITLE
Scape document id if necessary before sending document to indexer - 5.0

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -14,6 +14,7 @@
 #include "indexerConnector.hpp"
 #include "keyStore.hpp"
 #include "loggerHelper.h"
+#include "reflectiveJson.hpp"
 #include "secureCommunication.hpp"
 #include "shared_modules/utils/certHelper.hpp"
 #include <atomic>
@@ -55,6 +56,25 @@ constexpr auto FORMATTED_LENGTH {INDEX_OPERATION_PREFIX + ID_FIELD_PREFIX + CLOS
 // {"delete":{"_index":"<index>","_id":"<id>"}}
 constexpr auto DELETE_FORMATTED_LENGTH {DELETE_OPERATION_PREFIX + DELETE_ID_FIELD_PREFIX + CLOSING_BRACES +
                                         NEWLINE_CHAR};
+
+/**
+ * @brief Appends an ID to bulkData, escaping special characters if necessary
+ * @param bulkData The string to append the ID to
+ * @param id The ID to append (will be escaped if needed)
+ */
+inline void appendEscapedId(std::string& bulkData, std::string_view id)
+{
+    if (needEscape(id))
+    {
+        std::string escapedId;
+        escapeJSONString(id, escapedId);
+        bulkData.append(escapedId);
+    }
+    else
+    {
+        bulkData.append(id);
+    }
+}
 
 template<typename TSelector,
          typename THttpRequest,
@@ -674,7 +694,7 @@ public:
         m_bulkData.append(R"({"delete":{"_index":")");
         m_bulkData.append(index);
         m_bulkData.append(R"(","_id":")");
-        m_bulkData.append(id);
+        appendEscapedId(m_bulkData, id);
         m_bulkData.append(R"("}})");
         m_bulkData.append("\n");
         m_boundaries.push_back(m_bulkData.size());
@@ -721,7 +741,7 @@ public:
             if (!id.empty())
             {
                 m_bulkData.append(R"(","_id":")");
-                m_bulkData.append(id);
+                appendEscapedId(m_bulkData, id);
             }
             else
             {
@@ -744,7 +764,7 @@ public:
             if (!id.empty())
             {
                 m_bulkData.append(R"(","_id":")");
-                m_bulkData.append(id);
+                appendEscapedId(m_bulkData, id);
             }
             logDebug2(IC_NAME,
                       "No version specified for document %.*s, using default versioning",

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -858,42 +858,28 @@ public:
                                 if (data->operation() == Wazuh::SyncSchema::Operation_Upsert)
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Upserting data...");
+
+                                    // Build metadata using nlohmann::json for automatic escaping
+                                    nlohmann::json metadata;
+                                    metadata["agent"]["id"] = res.context->agentId;
+                                    metadata["agent"]["name"] = res.context->agentName;
+                                    metadata["agent"]["version"] = res.context->agentVersion;
+                                    metadata["agent"]["groups"] = res.context->groups;
+                                    metadata["agent"]["host"]["architecture"] = res.context->architecture;
+                                    metadata["agent"]["host"]["hostname"] = res.context->hostname;
+                                    metadata["agent"]["host"]["os"]["name"] = res.context->osname;
+                                    metadata["agent"]["host"]["os"]["platform"] = res.context->osplatform;
+                                    metadata["agent"]["host"]["os"]["type"] = res.context->ostype;
+                                    metadata["agent"]["host"]["os"]["version"] = res.context->osversion;
+                                    metadata["wazuh"]["cluster"]["name"] = m_clusterName;
+
+                                    // Serialize metadata to string and append FlatBuffer inventory data
                                     thread_local std::string dataString;
-                                    dataString.clear();
-                                    dataString.append(R"({"agent":{"id":")");
-                                    dataString.append(res.context->agentId);
-                                    dataString.append(R"(","name":")");
-                                    dataString.append(res.context->agentName);
-                                    dataString.append(R"(","version":")");
-                                    dataString.append(res.context->agentVersion);
-                                    dataString.append(R"(","groups":[)");
-                                    bool firstGroup = true;
-                                    for (const auto& group : res.context->groups)
-                                    {
-                                        if (!firstGroup)
-                                        {
-                                            dataString.append(",");
-                                        }
-                                        dataString.append(R"(")");
-                                        dataString.append(group);
-                                        dataString.append(R"(")");
-                                        firstGroup = false;
-                                    }
-                                    dataString.append(R"(],"host":{"architecture":")");
-                                    dataString.append(res.context->architecture);
-                                    dataString.append(R"(","hostname":")");
-                                    dataString.append(res.context->hostname);
-                                    dataString.append(R"(","os":{"name":")");
-                                    dataString.append(res.context->osname);
-                                    dataString.append(R"(","platform":")");
-                                    dataString.append(res.context->osplatform);
-                                    dataString.append(R"(","type":")");
-                                    dataString.append(res.context->ostype);
-                                    dataString.append(R"(","version":")");
-                                    dataString.append(res.context->osversion);
-                                    dataString.append(R"("}}},"wazuh":{"cluster":{"name":")");
-                                    dataString.append(m_clusterName);
-                                    dataString.append(R"("}},)");
+                                    dataString = metadata.dump();
+                                    // Remove closing brace to append inventory data
+                                    dataString.pop_back();
+                                    dataString.append(",");
+                                    // Append inventory data (skip opening brace from FlatBuffer data)
                                     dataString.append(std::string_view((const char*)data->data()->data() + 1,
                                                                        data->data()->size() - 1));
                                     const auto version = data->version();


### PR DESCRIPTION
## Description

This PR fixes an issue where the document ID sent to the indexer was not being escaped/scaled when necessary. Some IDs require the same “scaping” (character escaping / transformation for safe indexing) already applied to the data field. Without this, certain IDs could cause indexing errors or mismatches.

## Proposed Changes

- Apply the same scaping/escaping logic used for data to the document ID before sending it to the indexer.
- Ensure the ID is transformed only when required (i.e., when scaling/escaping is needed).
- Keep the original ID untouched when no scaping is necessary.

### Results and Evidence

```
curl -s -k -u admin:admin 'https://192.168.64.17:9200/wazuh-states-inventory-groups-*/_search?pretty' -H 'Content-Type: application/json' -d '{"query": {"wildcard": {"group.name": "*dum*"}},"size": 5}'

{
  "took" : 278,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "wazuh-states-inventory-groups-tomas",
        "_id" : "001_dum\\amy",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "id" : "001",
            "name" : "tomas2",
            "version" : "v4.14.1"
          },
          "group" : {
            "id" : 112,
            "id_signed" : 112,
            "is_hidden" : false,
            "name" : "dum\\amy"
          },
          "wazuh" : {
            "cluster" : {
              "name" : "tomas"
            },
            "schema" : {
              "version" : "1.0"
            }
          }
        }
      }
    ]
  }
}
```

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
