### PR TITLE
Modified default IP used for the indexer-connector

### DIFF
--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -211,8 +211,8 @@ jobs:
           # Install the package
           sudo dpkg -i "$PACKAGE_FILE" || sudo apt-get -f install -y
 
-          # Replace https://0.0.0.0:9200 with http://0.0.0.0:9200 in /var/ossec/etc/ossec.conf
-          sudo sed -i 's/https:\/\/0\.0\.0\.0:9200/http:\/\/localhost:9200/g' /var/ossec/etc/ossec.conf
+          # Replace https://127.0.0.1:9200 with http://127.0.0.1:9200 in /var/ossec/etc/ossec.conf
+          sudo sed -i 's/https:\/\/127\.0\.0\.1:9200/http:\/\/127.0.0.1:9200/g' /var/ossec/etc/ossec.conf
 
           sudo mkdir -p /var/ossec/etc/certs
           sudo touch /var/ossec/etc/certs/root-ca.pem

--- a/docs/ref/modules/inventory-sync/configuration.md
+++ b/docs/ref/modules/inventory-sync/configuration.md
@@ -16,7 +16,7 @@ Incoming FlatBuffer messages from agents are processed and grouped into **bulk o
 ```xml
   <indexer>
     <hosts>
-      <host>https://0.0.0.0:9200</host>
+      <host>https://127.0.0.1:9200</host>
     </hosts>
     <ssl>
       <certificate_authorities>

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -24,7 +24,7 @@ As mentioned above, the **Vulnerability Scanner** delegates the indexing to the 
 ```xml
   <indexer>
     <hosts>
-      <host>https://0.0.0.0:9200</host>
+      <host>https://127.0.0.1:9200</host>
     </hosts>
     <ssl>
       <certificate_authorities>

--- a/docs/ref/modules/vulnerability-scanner/test-tools.md
+++ b/docs/ref/modules/vulnerability-scanner/test-tools.md
@@ -104,7 +104,7 @@ Expanded configuration options for indexing
   },
   "indexer": {
     "hosts": [
-      "https://0.0.0.0:9200"
+      "https://127.0.0.1:9200"
     ],
     "username": "admin",
     "password": "admin",

--- a/etc/templates/config/generic/wodle-indexer.manager.template
+++ b/etc/templates/config/generic/wodle-indexer.manager.template
@@ -1,6 +1,6 @@
   <indexer>
     <hosts>
-      <host>https://0.0.0.0:9200</host>
+      <host>https://127.0.0.1:9200</host>
     </hosts>
     <ssl>
       <certificate_authorities>


### PR DESCRIPTION
## Description

When reviewing the objective, we considered that, as this was a client, the ideal solution was to change the default IP from `0.0.0.0` to `127.0.0.1` (localhost).

- https://github.com/wazuh/wazuh/actions/runs/20108196249

### Artifacts Affected

- Inventory sync artifact.

### Configuration Changes

- Manager default configuration.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
