### PR TITLE
Fix AWS integration test 

### DIFF
--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_inspector_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_inspector_with_only_logs_after.yaml
@@ -7,4 +7,8 @@
     service_type: inspector
     aws_profile: inspector_tests
     only_logs_after: 2025-SEP-15
-    expected_results: 106
+    # Validate V1 and V2 separately:
+    # - V1 must execute successfully (can return 0+ events)
+    # - V2 must execute successfully (returns 106-155 events for this dataset)
+    # - Total must be at least 106 events
+    expected_results_min: 106

--- a/tests/integration/test_aws/data/test_cases/regions_test_module/cases_inspector_regions.yaml
+++ b/tests/integration/test_aws/data/test_cases/regions_test_module/cases_inspector_regions.yaml
@@ -8,7 +8,11 @@
     aws_profile: inspector_tests
     only_logs_after: 2025-SEP-15
     regions: us-east-2
-    expected_results: 106
+    # Validate V1 and V2 separately:
+    # - V1 must execute successfully (can return 0+ events)
+    # - V2 must execute successfully (returns 106-155 events for this dataset)
+    # - Total must be at least 106 events
+    expected_results_min: 106
 
 - name: inspector_inexistent_region
   description: Inspector regions configurations


### PR DESCRIPTION
## Description

  AWS Inspector integration tests were failing intermittently with the error:
  AssertionError: The AWS module did not process the expected number of events

  **Root Cause:**
  When AWS Inspector V2 support was added, the module processes findings from **both Inspector V1 and V2 APIs** in regions that support both versions (like `us-east-2`). The APIs use
  different filtering mechanisms:

  - **Inspector V1**: Filters by `creationTimeRange` (when findings were created) - consistent
  - **Inspector V2**: Filters by `updatedAt` (when findings were updated) - variable

  For the test dataset:
  - V1 returns: 0 events (no findings created after test date)
  - V2 returns: 106-155 events (findings updated after test date)
    - Base: 106 events (always available)
    - Variable: +49 events (when findings have recent metadata updates)

  Tests expected exactly 155 events but sometimes received only 106, causing random failures.

  Closes #33476

  ## Proposed Changes

  ### Features Added
  - **Separate event tracking for V1 and V2**: Added `sent_events_v1` and `sent_events_v2` counters to independently track events from each API
  - **Enhanced logging**: Log messages now clearly indicate events from each API separately:
    +++ [InspectorV1] 0 events collected and processed
    +++ [InspectorV2] 106 events collected and processed
    +++ Total: 106 events collected and processed in us-east-2

  ### Bugs Fixed
  - **Intermittent test failures**: Changed validation strategy from expecting exact count (155) to:
  1. Validate V1 API executes successfully (returns 0+ events)
  2. Validate V2 API executes successfully (returns 0+ events)
  3. Validate total events ≥ 106 (minimum guaranteed by test dataset)
  4. Fail if either API throws an exception

  ### Technical Details
  - Removed try-except wrapper around V2 calls to allow real API errors to propagate to tests
  - Updated test configuration files to use `expected_results_min: 106` instead of `expected_results: 155`
  - Modified test validation logic to check for separate V1/V2 log patterns and minimum total threshold

### Results and Evidence

  - Run action test 8 times:
    - https://github.com/wazuh/wazuh/actions/runs/20176405802?pr=33487 

### Log Output Example:
  
  ```
  DEBUG: +++ Listing findings from 2025-09-15 00:00:00
  DEBUG: +++ Attempting to fetch Inspector V2 findings from 2025-09-15 00:00:00
  DEBUG: +++ [InspectorV1] 0 events collected and processed
  DEBUG: +++ [InspectorV2] 106 events collected and processed
  DEBUG: +++ Total: 106 events collected and processed in us-east-2
  ```
### Artifacts Affected
  Python modules:
  - wodles/aws/services/inspector.py

### Test files:
  - tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_inspector_with_only_logs_after.yaml
  - tests/integration/test_aws/data/test_cases/regions_test_module/cases_inspector_regions.yaml
  - tests/integration/test_aws/test_only_logs_after.py
  - tests/integration/test_aws/test_regions.py

###  Configuration Changes

  N/A - No user-facing configuration changes. This PR only affects internal event tracking and test validation logic.

###  Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
