### PR TITLE
Fix checkfiles failure for agent-deb-i386 libsyscollector.so size

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -17,7 +17,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,47248,0.1
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2123404,0.1
-/var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,649684,0.1
+/var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,735224,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,734000,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,466244,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,118632,0.1


### PR DESCRIPTION
## Description

The `agent-deb-i386` package workflow was failing during the file integrity check because the expected size for `libsyscollector.so` did not match the generated i386 DEB package. This pull request updates the expected file size so that the checkfiles test passes for i386 builds.

## Proposed Changes

- Update the expected size of `libsyscollector.so` for DEB i386 agent packages in the checkfiles verification logic.
- Keep the rest of the file integrity expectations unchanged to avoid impacting other platforms or package types.

### Results and Evidence

- `agent-deb-i386` workflow completed successfully:
  - [Workflow run](https://github.com/wazuh/wazuh-agent-packages/actions/runs/20168512785)

### Artifacts Affected

- DEB i386 agent packages:
  - Checkfiles test for `libsyscollector.so`.

### Configuration Changes

- No configuration changes introduced.

### Documentation Updates

- Not applicable.

### Tests Introduced

- No new tests added.
- Existing checkfiles test for DEB i386 now passes with the corrected expected size:
  - Verified by the successful workflow run linked above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues