### PR TITLE
Solves pip and setuptools packages listed twice.

### DIFF
--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -221,7 +221,7 @@ class BerkeleyRpmDBReader final
                         {
                             std::string name(ucp);
 
-                            if (name.rfind("python", 0) == 0)
+                            if (name.rfind("python", 0) == 0 || name.rfind("platform-python", 0) == 0)
                             {
                                 isPython = true;
                             }

--- a/src/data_provider/src/packages/packageLinuxParserRpm.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserRpm.cpp
@@ -119,7 +119,7 @@ void getRpmPythonPackages(std::unordered_set<std::string>& pythonPackages)
         }
     };
 
-    const auto filterPyhtonFiles
+    const auto filterPythonFiles
     {
         [&pythonPackages](const std::vector<std::string>& pFiles)
         {
@@ -197,6 +197,6 @@ void getRpmPythonPackages(std::unordered_set<std::string>& pythonPackages)
 
     if (!pythonFiles.empty())
     {
-        filterPyhtonFiles(pythonFiles);
+        filterPythonFiles(pythonFiles);
     }
 }

--- a/src/data_provider/tests/sysInfoPackagesBerkeleyDB/sysInfoPackagesBerkeleyDB_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesBerkeleyDB/sysInfoPackagesBerkeleyDB_test.cpp
@@ -588,3 +588,140 @@ TEST_F(SysInfoPackagesBerkeleyDBTest, PythonPackageNoFilesGetNextPythonFiles)
     ASSERT_TRUE(reader.getNextPythonFiles(pythonFiles));
     ASSERT_TRUE(pythonFiles.empty());
 }
+
+TEST_F(SysInfoPackagesBerkeleyDBTest, PlatformPythonPackageWithFilesGetNextPythonFiles)
+{
+    DBT data, key;
+    memset(&key, 0, sizeof(key));
+    memset(&data, 0, sizeof(data));
+    char bytes[FIRST_ENTRY_OFFSET + ENTRY_SIZE * 4 + 27 + 4 + 4 + 9 + 9 + 10 + 1];
+    memset(bytes, 0, sizeof(bytes));
+    char* cp;
+    int* ip;
+
+    data.data = bytes;
+    data.size = sizeof(bytes);
+
+    cp = (char*) bytes;
+
+    // index lenght
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(4);
+    cp += 4;
+
+    // Data lenght
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(63);
+    cp += 4;
+
+    // Name tag
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(TAG_NAME);
+    cp += 4;
+
+    // type
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(STRING_TYPE);
+    cp += 4;
+
+    //offset
+    ip = (int32_t*)cp;
+    *ip = 0;
+    cp += 4;
+
+    // unused data
+    cp += 4;
+
+    // dir indexes tag
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(TAG_DIRINDEXES);
+    cp += 4;
+
+    // type
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(INT32_TYPE);
+    cp += 4;
+
+    //offset
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(27);
+    cp += 4;
+
+    // count
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(2);
+    cp += 4;
+
+    // basenames tag
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(TAG_BASENAMES);
+    cp += 4;
+
+    // type
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(STRING_VECTOR_TYPE);
+    cp += 4;
+
+    // offset
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(35);
+    cp += 4;
+
+    // count
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(2);
+    cp += 4;
+
+    // dirnames tag
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(TAG_DIRNAMES);
+    cp += 4;
+
+    // type
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(STRING_VECTOR_TYPE);
+    cp += 4;
+
+    // offset
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(53);
+    cp += 4;
+
+    // count
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(1);
+    cp += 4;
+
+    strcpy(cp, "platform-python-sample-pkg");
+    cp += 27;
+
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(0);
+    cp += 4;
+
+    ip = (int32_t*)cp;
+    *ip = __builtin_bswap32(0);
+    cp += 4;
+
+    strcpy(cp, "file1.py");
+    cp += 9;
+
+    strcpy(cp, "file2.py");
+    cp += 9;
+
+    strcpy(cp, "/usr/lib/");
+    cp += 10;
+
+    const auto& dbWrapper { std::make_shared<BerkeleyDbWrapperMock>() };
+    EXPECT_CALL(*dbWrapper, getRow(_, _))
+    .Times(2)
+    .WillOnce(DoAll(SetArgReferee<0>(key), SetArgReferee<1>(data), Return(0)))
+    .WillOnce(DoAll(SetArgReferee<0>(key), SetArgReferee<1>(data), Return(0)));
+
+    BerkeleyRpmDBReader reader(dbWrapper);
+    std::vector<std::string> pythonFiles;
+    ASSERT_TRUE(reader.getNextPythonFiles(pythonFiles));
+    ASSERT_EQ(2u, pythonFiles.size());
+    ASSERT_EQ("/usr/lib/file1.py", pythonFiles[0]);
+    ASSERT_EQ("/usr/lib/file2.py", pythonFiles[1]);
+}

--- a/src/data_provider/tests/sysInfoPackagesBerkeleyDB/sysInfoPackagesBerkeleyDB_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesBerkeleyDB/sysInfoPackagesBerkeleyDB_test.cpp
@@ -438,7 +438,7 @@ TEST_F(SysInfoPackagesBerkeleyDBTest, PythonPackageWithFilesGetNextPythonFiles)
     // unused data
     cp += 4;
 
-    // dirindexes tag
+    // dir indexes tag
     ip = (int32_t*)cp;
     *ip = __builtin_bswap32(TAG_DIRINDEXES);
     cp += 4;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes #33169

The syscollector module searches for RPM packages using librpm for RPM versions 4.16 and higher, but falls back to reading the rpm berkeley database for older RPM versions.

Since Oracle 8 comes with RPM version 4.14, the collector relied on the fallback database reading method which encountered a corner case when detecting Python packages installed via RPM, the pip and setuptools RPM packages were being detected as PyPi packages.

By properly detecting pip and setuptools as RPM packages rather than PyPi packages, the Oracle vendor CVEs should be applied which will not throw the false positive vulnerabilities in the Vulnerability Detector module.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->
Fix the corner case in the filter code that prevented pip and setuptools from being detected as RPM packages.

### Results and Evidence
Before applying this fix, pip and setup tools were not detected as RPM packages and thus were reported as PyPi packages:
``` console
excluded path: /usr/lib64/python3.6/site-packages/perf-0.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/slip.dbus-0.6.4-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/rhnlib-2.8.6-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/gpg-1.13.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/configshell_fb-1.1.28-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pyOpenSSL-19.0.0-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pyudev-0.21.0-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/rpm-4.14.3-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/cryptography-3.2.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pciutils-2.3.6-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/slip-0.6.4-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/python_dmidecode-3.12.2-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/setools-4.3.0-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/netifaces-0.10.6-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/dbus_python-1.2.4-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/nftables-0.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/pycparser-2.14-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/sepolicy-1.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/isc-2.0-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/python_linux_procfs-0.7.3-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pyparsing-2.1.10.dist-info/METADATA
excluded path: /usr/lib64/python3.6/site-packages/systemd_python-234-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/six-1.11.0.dist-info/METADATA
excluded path: /usr/lib64/python3.6/site-packages/selinux-2.9-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/urwid-1.3.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/ply-3.9-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/decorator-4.2.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/cffi-1.11.5-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/pygobject-3.28.3-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/python_dateutil-2.6.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/kmod-0.1-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/libcomps-0.1.18-py3.6.egg-info/PKG-INFO
```
After this fix:

``` console
excluded path: /usr/lib64/python3.6/site-packages/perf-0.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/slip.dbus-0.6.4-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/rhnlib-2.8.6-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/gpg-1.13.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/setuptools-39.2.0.dist-info/METADATA
excluded path: /usr/lib/python3.6/site-packages/pip-9.0.3.dist-info/METADATA
excluded path: /usr/lib/python3.6/site-packages/configshell_fb-1.1.28-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pyOpenSSL-19.0.0-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pyudev-0.21.0-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/rpm-4.14.3-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/cryptography-3.2.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pciutils-2.3.6-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/slip-0.6.4-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/python_dmidecode-3.12.2-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/setools-4.3.0-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/netifaces-0.10.6-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/dbus_python-1.2.4-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/nftables-0.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/pycparser-2.14-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/sepolicy-1.1-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/isc-2.0-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/python_linux_procfs-0.7.3-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/pyparsing-2.1.10.dist-info/METADATA
excluded path: /usr/lib64/python3.6/site-packages/systemd_python-234-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/six-1.11.0.dist-info/METADATA
excluded path: /usr/lib64/python3.6/site-packages/selinux-2.9-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/urwid-1.3.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/ply-3.9-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib/python3.6/site-packages/decorator-4.2.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/cffi-1.11.5-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/pygobject-3.28.3-py3.6.egg-info
excluded path: /usr/lib/python3.6/site-packages/python_dateutil-2.6.1-py3.6.egg-info/PKG-INFO
excluded path: /usr/lib64/python3.6/site-packages/kmod-0.1-py3.6.egg-info
excluded path: /usr/lib64/python3.6/site-packages/libcomps-0.1.18-py3.6.egg-info/PKG-INFO
```

Before this fix, pip and setuptools were listes as Open Source packages (PyPi packages):
<img width="1900" height="873" alt="Screenshot From 2025-12-09 21-05-58" src="https://github.com/user-attachments/assets/d5836e40-7f13-44c2-a046-d13ab1708826" />


After this fix, there are no more Open Source Vulnerabilities detected:
<img width="1881" height="710" alt="Screenshot From 2025-12-12 15-51-35" src="https://github.com/user-attachments/assets/d80c8795-e285-4191-87f9-d3e2bb45ddaf" />

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
Wazuh Agent RPM packages, when rpm version <= 4.16

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
- NA
### Tests Introduced
- NA
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
