### PR TITLE
Missing `integrity_interval` configs for syscollector

### DIFF
--- a/docs/ref/modules/syscollector/configuration.md
+++ b/docs/ref/modules/syscollector/configuration.md
@@ -288,6 +288,7 @@ For environments with frequent inventory changes:
         <interval>120</interval>         <!-- Sync every 2 minutes -->
         <response_timeout>60</response_timeout>
         <max_eps>25</max_eps>           <!-- Higher sync throughput -->
+        <integrity_interval>1h</integrity_interval>  <!-- Check integrity every hour -->
     </synchronization>
 </wodle>
 ```

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -42,6 +42,7 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_eps>10</max_eps>
+      <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>
 

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -39,6 +39,7 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_eps>10</max_eps>
+      <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -51,6 +51,7 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_eps>10</max_eps>
+      <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>
 

--- a/etc/templates/config/bsd/wodle-syscollector.template
+++ b/etc/templates/config/bsd/wodle-syscollector.template
@@ -19,5 +19,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_eps>10</max_eps>
+      <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>

--- a/etc/templates/config/darwin/wodle-syscollector.template
+++ b/etc/templates/config/darwin/wodle-syscollector.template
@@ -19,5 +19,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_eps>10</max_eps>
+      <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>

--- a/etc/templates/config/generic/wodle-syscollector.template
+++ b/etc/templates/config/generic/wodle-syscollector.template
@@ -19,5 +19,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <max_eps>10</max_eps>
+      <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>


### PR DESCRIPTION
## Description
Closes https://github.com/wazuh/wazuh/issues/33531 . Updates some configuration files that are missing the `integrity_interval` parameter.

