### PR TITLE
Add full import namespaces

### DIFF
--- a/src/engine/source/api/cmcrud/include/api/cmcrud/handlers.hpp
+++ b/src/engine/source/api/cmcrud/include/api/cmcrud/handlers.hpp
@@ -14,6 +14,7 @@ namespace api::cmcrud::handlers
 adapter::RouteHandler namespaceList(std::shared_ptr<cm::crud::ICrudService> crud);
 adapter::RouteHandler namespaceCreate(std::shared_ptr<cm::crud::ICrudService> crud);
 adapter::RouteHandler namespaceDelete(std::shared_ptr<cm::crud::ICrudService> crud);
+adapter::RouteHandler namespaceImport(std::shared_ptr<cm::crud::ICrudService> crud);
 
 /*************** Policy ***************/
 adapter::RouteHandler policyUpsert(std::shared_ptr<cm::crud::ICrudService> crud);
@@ -33,6 +34,7 @@ inline void registerHandlers(std::shared_ptr<cm::crud::ICrudService> crud,
     server->addRoute(httpsrv::Method::POST, "/_internal/content/namespace/list", namespaceList(crud));
     server->addRoute(httpsrv::Method::POST, "/_internal/content/namespace/create", namespaceCreate(crud));
     server->addRoute(httpsrv::Method::POST, "/_internal/content/namespace/delete", namespaceDelete(crud));
+    server->addRoute(httpsrv::Method::POST, "/_internal/content/namespace/import", namespaceImport(crud));
 
     // Policy
     server->addRoute(httpsrv::Method::POST, "/_internal/content/policy/upsert", policyUpsert(crud));

--- a/src/engine/source/api/cmcrud/test/src/unit/handlers_test.cpp
+++ b/src/engine/source/api/cmcrud/test/src/unit/handlers_test.cpp
@@ -268,11 +268,14 @@ INSTANTIATE_TEST_SUITE_P(
             {
                 eContent::resourceGet_Response protoRes;
                 protoRes.set_status(eEngine::ReturnStatus::OK);
-                protoRes.set_ymlcontent("yml: content");
+                protoRes.set_content("yml: content");
                 return userResponse<eContent::resourceGet_Response>(protoRes);
             },
             [](auto& mock)
-            { EXPECT_CALL(mock, getResourceByUUID("draft", "uuid-1")).WillOnce(::testing::Return("yml: content")); }),
+            {
+                EXPECT_CALL(mock, getResourceByUUID("draft", "uuid-1", false))
+                    .WillOnce(::testing::Return("yml: content"));
+            }),
         // Wrong request type
         CmCrudHandlerT(
             []()

--- a/src/engine/source/cmcrud/include/cmcrud/cmcrudservice.hpp
+++ b/src/engine/source/cmcrud/include/cmcrud/cmcrudservice.hpp
@@ -28,6 +28,7 @@ public:
     std::vector<cm::store::NamespaceId> listNamespaces() const override;
     void createNamespace(std::string_view nsName) override;
     void deleteNamespace(std::string_view nsName) override;
+    void importNamespace(std::string_view nsName, std::string_view jsonDocument, bool force) override;
 
     /********************************* Policy *********************************/
     void upsertPolicy(std::string_view nsName, std::string_view policyDocument) override;
@@ -35,7 +36,7 @@ public:
 
     /***************************** Generic resources **************************/
     std::vector<ResourceSummary> listResources(std::string_view nsName, cm::store::ResourceType type) const override;
-    std::string getResourceByUUID(std::string_view nsName, const std::string& uuid) const override;
+    std::string getResourceByUUID(std::string_view nsName, const std::string& uuid, bool asJson = false) const override;
     void upsertResource(std::string_view nsName, cm::store::ResourceType type, std::string_view document) override;
     void deleteResourceByUUID(std::string_view nsName, const std::string& uuid) override;
 

--- a/src/engine/source/cmcrud/interface/cmcrud/icmcrudservice.hpp
+++ b/src/engine/source/cmcrud/interface/cmcrud/icmcrudservice.hpp
@@ -74,6 +74,15 @@ public:
      */
     virtual void deleteNamespace(std::string_view nsName) = 0;
 
+    /*
+     * @brief Import a full namespace from a JSON document.
+     *
+     * @param nsName Namespace name (space).
+     * @param jsonDocument JSON string with policy + resources.
+     * @param force If true, skip all validations.
+     */
+    virtual void importNamespace(std::string_view nsName, std::string_view jsonDocument, bool force) = 0;
+
     /********************************* Policy *********************************/
 
     /**
@@ -133,13 +142,14 @@ public:
      *
      * @param nsName Target namespace name.
      * @param uuid   Resource UUID.
+     * @param asJSon Get with json format
      *
      * @return Document representing the resource.
      *
      * @throws std::runtime_error if the namespace or resource does not exist
      *         or if the serialization fails.
      */
-    virtual std::string getResourceByUUID(std::string_view nsName, const std::string& uuid) const = 0;
+    virtual std::string getResourceByUUID(std::string_view nsName, const std::string& uuid, bool asJson) const = 0;
 
     /**
      * @brief Upsert a resource (asset, integration or KVDB) from a document.

--- a/src/engine/source/cmcrud/test/mocks/cmcrud/mockcmcrud.hpp
+++ b/src/engine/source/cmcrud/test/mocks/cmcrud/mockcmcrud.hpp
@@ -14,6 +14,10 @@ public:
     MOCK_METHOD(std::vector<cm::store::NamespaceId>, listNamespaces, (), (const, override));
     MOCK_METHOD(void, createNamespace, (std::string_view nsName), (override));
     MOCK_METHOD(void, deleteNamespace, (std::string_view nsName), (override));
+    MOCK_METHOD(void,
+                importNamespace,
+                (std::string_view nsName, std::string_view jsonDocument, bool force),
+                (override));
 
     MOCK_METHOD(void, upsertPolicy, (std::string_view nsName, std::string_view document), (override));
     MOCK_METHOD(void, deletePolicy, (std::string_view nsName), (override));
@@ -23,7 +27,10 @@ public:
                 (std::string_view nsName, cm::store::ResourceType type),
                 (const, override));
 
-    MOCK_METHOD(std::string, getResourceByUUID, (std::string_view nsName, const std::string& uuid), (const, override));
+    MOCK_METHOD(std::string,
+                getResourceByUUID,
+                (std::string_view nsName, const std::string& uuid, bool asJson),
+                (const, override));
 
     MOCK_METHOD(void,
                 upsertResource,

--- a/src/engine/source/cmstore/include/cmstore/cmstore.hpp
+++ b/src/engine/source/cmstore/include/cmstore/cmstore.hpp
@@ -57,6 +57,9 @@ public:
     /** @copydoc ICMStore::deleteNamespace */
     void deleteNamespace(const NamespaceId& nsId) override;
 
+    /** @copydoc ICMStore::renameNamespace */
+    void renameNamespace(const NamespaceId& from, const NamespaceId& to) override;
+
     /** @copydoc ICMStore::getNamespaces */
     std::vector<NamespaceId> getNamespaces() const override;
 };

--- a/src/engine/source/cmstore/interface/cmstore/icmstore.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/icmstore.hpp
@@ -331,6 +331,14 @@ public:
     virtual void deleteNamespace(const NamespaceId& nsId) = 0;
 
     /**
+     * @brief Rename an existing namespace
+     * @param from NamespaceId of the namespace to rename
+     * @param to NamespaceId of the new namespace
+     * @throw std::runtime_error if the namespace does not exist or any error occurs
+     */
+    virtual void renameNamespace(const NamespaceId& from, const NamespaceId& to) = 0;
+
+    /**
      * @brief Get all existing namespaces
      * @return std::vector<NamespaceId> Vector of NamespaceId
      */

--- a/src/engine/source/cmstore/interface/cmstore/types.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/types.hpp
@@ -104,6 +104,7 @@ inline ResourceType getResourceTypeFromAssetName(const base::Name& name)
     switch (rType)
     {
         case ResourceType::DECODER:
+        case ResourceType::INTEGRATION:
         case ResourceType::OUTPUT:
         case ResourceType::RULE:
         case ResourceType::FILTER: return rType;

--- a/src/engine/source/cmstore/src/storens.cpp
+++ b/src/engine/source/cmstore/src/storens.cpp
@@ -226,7 +226,7 @@ std::filesystem::path CMStoreNS::getResourcePaths(const std::string& name, Resou
 
     auto fileName = name;
     if (type == ResourceType::DECODER || type == ResourceType::OUTPUT || type == ResourceType::RULE
-        || type == ResourceType::FILTER)
+        || type == ResourceType::FILTER || type == ResourceType::INTEGRATION || type == ResourceType::KVDB)
     {
         // Replace '/' with '_' to avoid directory traversal on assets names
         std::replace(fileName.begin(), fileName.end(), '/', '_');
@@ -322,6 +322,10 @@ bool CMStoreNS::assetExistsByUUID(const std::string& uuid) const
     }
 
     const auto& [name, rType] = opt.value();
+    if (rType == ResourceType::KVDB)
+    {
+        return true;
+    }
     const auto assetType = getResourceTypeFromAssetName(base::Name(name));
     return assetType != ResourceType::UNDEFINED && assetType == rType;
 }

--- a/src/engine/source/cmstore/test/mocks/cmstore/mockcmstore.hpp
+++ b/src/engine/source/cmstore/test/mocks/cmstore/mockcmstore.hpp
@@ -84,6 +84,7 @@ public:
 
     MOCK_METHOD(std::shared_ptr<ICMstoreNS>, createNamespace, (const NamespaceId& nsId), (override));
     MOCK_METHOD(void, deleteNamespace, (const NamespaceId& nsId), (override));
+    MOCK_METHOD(void, renameNamespace, (const NamespaceId& from, const NamespaceId& to), (override));
     MOCK_METHOD(std::vector<NamespaceId>, getNamespaces, (), (const, override));
 };
 

--- a/src/engine/source/proto/include/eMessages/crud.pb.cc
+++ b/src/engine/source/proto/include/eMessages/crud.pb.cc
@@ -153,9 +153,11 @@ struct resourceList_ResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 resourceList_ResponseDefaultTypeInternal _resourceList_Response_default_instance_;
 PROTOBUF_CONSTEXPR resourceGet_Request::resourceGet_Request(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.space_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.space_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.uuid_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_._cached_size_)*/{}} {}
+  , /*decltype(_impl_.asjson_)*/false} {}
 struct resourceGet_RequestDefaultTypeInternal {
   PROTOBUF_CONSTEXPR resourceGet_RequestDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
@@ -170,7 +172,7 @@ PROTOBUF_CONSTEXPR resourceGet_Response::resourceGet_Response(
     /*decltype(_impl_._has_bits_)*/{}
   , /*decltype(_impl_._cached_size_)*/{}
   , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.ymlcontent_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.content_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.status_)*/0} {}
 struct resourceGet_ResponseDefaultTypeInternal {
   PROTOBUF_CONSTEXPR resourceGet_ResponseDefaultTypeInternal()
@@ -210,12 +212,27 @@ struct resourceDelete_RequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 resourceDelete_RequestDefaultTypeInternal _resourceDelete_Request_default_instance_;
+PROTOBUF_CONSTEXPR namespaceImport_Request::namespaceImport_Request(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.space_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.jsoncontent_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.force_)*/false
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct namespaceImport_RequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR namespaceImport_RequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~namespaceImport_RequestDefaultTypeInternal() {}
+  union {
+    namespaceImport_Request _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 namespaceImport_RequestDefaultTypeInternal _namespaceImport_Request_default_instance_;
 }  // namespace content
 }  // namespace engine
 }  // namespace api
 }  // namespace wazuh
 }  // namespace com
-static ::_pb::Metadata file_level_metadata_crud_2eproto[13];
+static ::_pb::Metadata file_level_metadata_crud_2eproto[14];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_crud_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_crud_2eproto = nullptr;
 
@@ -299,7 +316,7 @@ const uint32_t TableStruct_crud_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
   ~0u,
   0,
   ~0u,
-  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Request, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Request, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -307,6 +324,10 @@ const uint32_t TableStruct_crud_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Request, _impl_.space_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Request, _impl_.uuid_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Request, _impl_.asjson_),
+  ~0u,
+  ~0u,
+  0,
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Response, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Response, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -315,7 +336,7 @@ const uint32_t TableStruct_crud_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Response, _impl_.status_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Response, _impl_.error_),
-  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Response, _impl_.ymlcontent_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceGet_Response, _impl_.content_),
   ~0u,
   0,
   1,
@@ -336,6 +357,15 @@ const uint32_t TableStruct_crud_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceDelete_Request, _impl_.space_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::resourceDelete_Request, _impl_.uuid_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::namespaceImport_Request, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::namespaceImport_Request, _impl_.space_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::namespaceImport_Request, _impl_.jsoncontent_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::content::namespaceImport_Request, _impl_.force_),
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, 9, -1, sizeof(::com::wazuh::api::engine::content::ResourceSummary)},
@@ -347,10 +377,11 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 52, -1, -1, sizeof(::com::wazuh::api::engine::content::policyDelete_Request)},
   { 59, -1, -1, sizeof(::com::wazuh::api::engine::content::resourceList_Request)},
   { 67, 76, -1, sizeof(::com::wazuh::api::engine::content::resourceList_Response)},
-  { 79, -1, -1, sizeof(::com::wazuh::api::engine::content::resourceGet_Request)},
-  { 87, 96, -1, sizeof(::com::wazuh::api::engine::content::resourceGet_Response)},
-  { 99, -1, -1, sizeof(::com::wazuh::api::engine::content::resourcePost_Request)},
-  { 108, -1, -1, sizeof(::com::wazuh::api::engine::content::resourceDelete_Request)},
+  { 79, 88, -1, sizeof(::com::wazuh::api::engine::content::resourceGet_Request)},
+  { 91, 100, -1, sizeof(::com::wazuh::api::engine::content::resourceGet_Response)},
+  { 103, -1, -1, sizeof(::com::wazuh::api::engine::content::resourcePost_Request)},
+  { 112, -1, -1, sizeof(::com::wazuh::api::engine::content::resourceDelete_Request)},
+  { 120, -1, -1, sizeof(::com::wazuh::api::engine::content::namespaceImport_Request)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -367,6 +398,7 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::com::wazuh::api::engine::content::_resourceGet_Response_default_instance_._instance,
   &::com::wazuh::api::engine::content::_resourcePost_Request_default_instance_._instance,
   &::com::wazuh::api::engine::content::_resourceDelete_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::content::_namespaceImport_Request_default_instance_._instance,
 };
 
 const char descriptor_table_protodef_crud_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
@@ -387,25 +419,27 @@ const char descriptor_table_protodef_crud_2eproto[] PROTOBUF_SECTION_VARIABLE(pr
   "nse\0222\n\006status\030\001 \001(\0162\".com.wazuh.api.engi"
   "ne.ReturnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022@\n\tr"
   "esources\030\003 \003(\0132-.com.wazuh.api.engine.co"
-  "ntent.ResourceSummaryB\010\n\006_error\"2\n\023resou"
+  "ntent.ResourceSummaryB\010\n\006_error\"R\n\023resou"
   "rceGet_Request\022\r\n\005space\030\001 \001(\t\022\014\n\004uuid\030\002 "
-  "\001(\t\"\220\001\n\024resourceGet_Response\0222\n\006status\030\001"
-  " \001(\0162\".com.wazuh.api.engine.ReturnStatus"
-  "\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\027\n\nymlContent\030\003 \001(\t"
-  "H\001\210\001\001B\010\n\006_errorB\r\n\013_ymlContent\"G\n\024resour"
-  "cePost_Request\022\r\n\005space\030\001 \001(\t\022\014\n\004type\030\002 "
-  "\001(\t\022\022\n\nymlContent\030\003 \001(\t\"5\n\026resourceDelet"
-  "e_Request\022\r\n\005space\030\001 \001(\t\022\014\n\004uuid\030\002 \001(\tb\006"
-  "proto3"
+  "\001(\t\022\023\n\006asJson\030\003 \001(\010H\000\210\001\001B\t\n\007_asJson\"\212\001\n\024"
+  "resourceGet_Response\0222\n\006status\030\001 \001(\0162\".c"
+  "om.wazuh.api.engine.ReturnStatus\022\022\n\005erro"
+  "r\030\002 \001(\tH\000\210\001\001\022\024\n\007content\030\003 \001(\tH\001\210\001\001B\010\n\006_e"
+  "rrorB\n\n\010_content\"G\n\024resourcePost_Request"
+  "\022\r\n\005space\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\022\n\nymlCont"
+  "ent\030\003 \001(\t\"5\n\026resourceDelete_Request\022\r\n\005s"
+  "pace\030\001 \001(\t\022\014\n\004uuid\030\002 \001(\t\"L\n\027namespaceImp"
+  "ort_Request\022\r\n\005space\030\001 \001(\t\022\023\n\013jsonConten"
+  "t\030\002 \001(\t\022\r\n\005force\030\003 \001(\010b\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_crud_2eproto_deps[1] = {
   &::descriptor_table_engine_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_crud_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_crud_2eproto = {
-    false, false, 1046, descriptor_table_protodef_crud_2eproto,
+    false, false, 1150, descriptor_table_protodef_crud_2eproto,
     "crud.proto",
-    &descriptor_table_crud_2eproto_once, descriptor_table_crud_2eproto_deps, 1, 13,
+    &descriptor_table_crud_2eproto_once, descriptor_table_crud_2eproto_deps, 1, 14,
     schemas, file_default_instances, TableStruct_crud_2eproto::offsets,
     file_level_metadata_crud_2eproto, file_level_enum_descriptors_crud_2eproto,
     file_level_service_descriptors_crud_2eproto,
@@ -2482,6 +2516,10 @@ void resourceList_Response::InternalSwap(resourceList_Response* other) {
 
 class resourceGet_Request::_Internal {
  public:
+  using HasBits = decltype(std::declval<resourceGet_Request>()._impl_._has_bits_);
+  static void set_has_asjson(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
 };
 
 resourceGet_Request::resourceGet_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
@@ -2494,9 +2532,11 @@ resourceGet_Request::resourceGet_Request(const resourceGet_Request& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   resourceGet_Request* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.space_){}
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.space_){}
     , decltype(_impl_.uuid_){}
-    , /*decltype(_impl_._cached_size_)*/{}};
+    , decltype(_impl_.asjson_){}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   _impl_.space_.InitDefault();
@@ -2515,6 +2555,7 @@ resourceGet_Request::resourceGet_Request(const resourceGet_Request& from)
     _this->_impl_.uuid_.Set(from._internal_uuid(), 
       _this->GetArenaForAllocation());
   }
+  _this->_impl_.asjson_ = from._impl_.asjson_;
   // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.content.resourceGet_Request)
 }
 
@@ -2523,9 +2564,11 @@ inline void resourceGet_Request::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.space_){}
-    , decltype(_impl_.uuid_){}
+      decltype(_impl_._has_bits_){}
     , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.space_){}
+    , decltype(_impl_.uuid_){}
+    , decltype(_impl_.asjson_){false}
   };
   _impl_.space_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
@@ -2564,11 +2607,14 @@ void resourceGet_Request::Clear() {
 
   _impl_.space_.ClearToEmpty();
   _impl_.uuid_.ClearToEmpty();
+  _impl_.asjson_ = false;
+  _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
 const char* resourceGet_Request::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
@@ -2593,6 +2639,15 @@ const char* resourceGet_Request::_InternalParse(const char* ptr, ::_pbi::ParseCo
         } else
           goto handle_unusual;
         continue;
+      // optional bool asJson = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+          _Internal::set_has_asjson(&has_bits);
+          _impl_.asjson_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
       default:
         goto handle_unusual;
     }  // switch
@@ -2609,6 +2664,7 @@ const char* resourceGet_Request::_InternalParse(const char* ptr, ::_pbi::ParseCo
     CHK_(ptr != nullptr);
   }  // while
 message_done:
+  _impl_._has_bits_.Or(has_bits);
   return ptr;
 failure:
   ptr = nullptr;
@@ -2642,6 +2698,12 @@ uint8_t* resourceGet_Request::_InternalSerialize(
         2, this->_internal_uuid(), target);
   }
 
+  // optional bool asJson = 3;
+  if (_internal_has_asjson()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(3, this->_internal_asjson(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -2672,6 +2734,12 @@ size_t resourceGet_Request::ByteSizeLong() const {
         this->_internal_uuid());
   }
 
+  // optional bool asJson = 3;
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    total_size += 1 + 1;
+  }
+
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
@@ -2696,6 +2764,9 @@ void resourceGet_Request::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, co
   if (!from._internal_uuid().empty()) {
     _this->_internal_set_uuid(from._internal_uuid());
   }
+  if (from._internal_has_asjson()) {
+    _this->_internal_set_asjson(from._internal_asjson());
+  }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
@@ -2715,6 +2786,7 @@ void resourceGet_Request::InternalSwap(resourceGet_Request* other) {
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
       &_impl_.space_, lhs_arena,
       &other->_impl_.space_, rhs_arena
@@ -2723,6 +2795,7 @@ void resourceGet_Request::InternalSwap(resourceGet_Request* other) {
       &_impl_.uuid_, lhs_arena,
       &other->_impl_.uuid_, rhs_arena
   );
+  swap(_impl_.asjson_, other->_impl_.asjson_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata resourceGet_Request::GetMetadata() const {
@@ -2739,7 +2812,7 @@ class resourceGet_Response::_Internal {
   static void set_has_error(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
   }
-  static void set_has_ymlcontent(HasBits* has_bits) {
+  static void set_has_content(HasBits* has_bits) {
     (*has_bits)[0] |= 2u;
   }
 };
@@ -2757,7 +2830,7 @@ resourceGet_Response::resourceGet_Response(const resourceGet_Response& from)
       decltype(_impl_._has_bits_){from._impl_._has_bits_}
     , /*decltype(_impl_._cached_size_)*/{}
     , decltype(_impl_.error_){}
-    , decltype(_impl_.ymlcontent_){}
+    , decltype(_impl_.content_){}
     , decltype(_impl_.status_){}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
@@ -2769,12 +2842,12 @@ resourceGet_Response::resourceGet_Response(const resourceGet_Response& from)
     _this->_impl_.error_.Set(from._internal_error(), 
       _this->GetArenaForAllocation());
   }
-  _impl_.ymlcontent_.InitDefault();
+  _impl_.content_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.ymlcontent_.Set("", GetArenaForAllocation());
+    _impl_.content_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (from._internal_has_ymlcontent()) {
-    _this->_impl_.ymlcontent_.Set(from._internal_ymlcontent(), 
+  if (from._internal_has_content()) {
+    _this->_impl_.content_.Set(from._internal_content(), 
       _this->GetArenaForAllocation());
   }
   _this->_impl_.status_ = from._impl_.status_;
@@ -2789,16 +2862,16 @@ inline void resourceGet_Response::SharedCtor(
       decltype(_impl_._has_bits_){}
     , /*decltype(_impl_._cached_size_)*/{}
     , decltype(_impl_.error_){}
-    , decltype(_impl_.ymlcontent_){}
+    , decltype(_impl_.content_){}
     , decltype(_impl_.status_){0}
   };
   _impl_.error_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
     _impl_.error_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.ymlcontent_.InitDefault();
+  _impl_.content_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.ymlcontent_.Set("", GetArenaForAllocation());
+    _impl_.content_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
@@ -2814,7 +2887,7 @@ resourceGet_Response::~resourceGet_Response() {
 inline void resourceGet_Response::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.error_.Destroy();
-  _impl_.ymlcontent_.Destroy();
+  _impl_.content_.Destroy();
 }
 
 void resourceGet_Response::SetCachedSize(int size) const {
@@ -2833,7 +2906,7 @@ void resourceGet_Response::Clear() {
       _impl_.error_.ClearNonDefaultToEmpty();
     }
     if (cached_has_bits & 0x00000002u) {
-      _impl_.ymlcontent_.ClearNonDefaultToEmpty();
+      _impl_.content_.ClearNonDefaultToEmpty();
     }
   }
   _impl_.status_ = 0;
@@ -2867,13 +2940,13 @@ const char* resourceGet_Response::_InternalParse(const char* ptr, ::_pbi::ParseC
         } else
           goto handle_unusual;
         continue;
-      // optional string ymlContent = 3;
+      // optional string content = 3;
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
-          auto str = _internal_mutable_ymlcontent();
+          auto str = _internal_mutable_content();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.content.resourceGet_Response.ymlContent"));
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.content.resourceGet_Response.content"));
         } else
           goto handle_unusual;
         continue;
@@ -2924,14 +2997,14 @@ uint8_t* resourceGet_Response::_InternalSerialize(
         2, this->_internal_error(), target);
   }
 
-  // optional string ymlContent = 3;
-  if (_internal_has_ymlcontent()) {
+  // optional string content = 3;
+  if (_internal_has_content()) {
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_ymlcontent().data(), static_cast<int>(this->_internal_ymlcontent().length()),
+      this->_internal_content().data(), static_cast<int>(this->_internal_content().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "com.wazuh.api.engine.content.resourceGet_Response.ymlContent");
+      "com.wazuh.api.engine.content.resourceGet_Response.content");
     target = stream->WriteStringMaybeAliased(
-        3, this->_internal_ymlcontent(), target);
+        3, this->_internal_content(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2959,11 +3032,11 @@ size_t resourceGet_Response::ByteSizeLong() const {
           this->_internal_error());
     }
 
-    // optional string ymlContent = 3;
+    // optional string content = 3;
     if (cached_has_bits & 0x00000002u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-          this->_internal_ymlcontent());
+          this->_internal_content());
     }
 
   }
@@ -2997,7 +3070,7 @@ void resourceGet_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, c
       _this->_internal_set_error(from._internal_error());
     }
     if (cached_has_bits & 0x00000002u) {
-      _this->_internal_set_ymlcontent(from._internal_ymlcontent());
+      _this->_internal_set_content(from._internal_content());
     }
   }
   if (from._internal_status() != 0) {
@@ -3028,8 +3101,8 @@ void resourceGet_Response::InternalSwap(resourceGet_Response* other) {
       &other->_impl_.error_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.ymlcontent_, lhs_arena,
-      &other->_impl_.ymlcontent_, rhs_arena
+      &_impl_.content_, lhs_arena,
+      &other->_impl_.content_, rhs_arena
   );
   swap(_impl_.status_, other->_impl_.status_);
 }
@@ -3596,6 +3669,286 @@ void resourceDelete_Request::InternalSwap(resourceDelete_Request* other) {
       file_level_metadata_crud_2eproto[12]);
 }
 
+// ===================================================================
+
+class namespaceImport_Request::_Internal {
+ public:
+};
+
+namespaceImport_Request::namespaceImport_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.content.namespaceImport_Request)
+}
+namespaceImport_Request::namespaceImport_Request(const namespaceImport_Request& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  namespaceImport_Request* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.space_){}
+    , decltype(_impl_.jsoncontent_){}
+    , decltype(_impl_.force_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.space_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.space_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_space().empty()) {
+    _this->_impl_.space_.Set(from._internal_space(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.jsoncontent_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.jsoncontent_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_jsoncontent().empty()) {
+    _this->_impl_.jsoncontent_.Set(from._internal_jsoncontent(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.force_ = from._impl_.force_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.content.namespaceImport_Request)
+}
+
+inline void namespaceImport_Request::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.space_){}
+    , decltype(_impl_.jsoncontent_){}
+    , decltype(_impl_.force_){false}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.space_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.space_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.jsoncontent_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.jsoncontent_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+namespaceImport_Request::~namespaceImport_Request() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.content.namespaceImport_Request)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void namespaceImport_Request::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.space_.Destroy();
+  _impl_.jsoncontent_.Destroy();
+}
+
+void namespaceImport_Request::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void namespaceImport_Request::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.content.namespaceImport_Request)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.space_.ClearToEmpty();
+  _impl_.jsoncontent_.ClearToEmpty();
+  _impl_.force_ = false;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* namespaceImport_Request::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // string space = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_space();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.content.namespaceImport_Request.space"));
+        } else
+          goto handle_unusual;
+        continue;
+      // string jsonContent = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_jsoncontent();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.content.namespaceImport_Request.jsonContent"));
+        } else
+          goto handle_unusual;
+        continue;
+      // bool force = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+          _impl_.force_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* namespaceImport_Request::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.content.namespaceImport_Request)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string space = 1;
+  if (!this->_internal_space().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_space().data(), static_cast<int>(this->_internal_space().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.content.namespaceImport_Request.space");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_space(), target);
+  }
+
+  // string jsonContent = 2;
+  if (!this->_internal_jsoncontent().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_jsoncontent().data(), static_cast<int>(this->_internal_jsoncontent().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.content.namespaceImport_Request.jsonContent");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_jsoncontent(), target);
+  }
+
+  // bool force = 3;
+  if (this->_internal_force() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(3, this->_internal_force(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.content.namespaceImport_Request)
+  return target;
+}
+
+size_t namespaceImport_Request::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.content.namespaceImport_Request)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string space = 1;
+  if (!this->_internal_space().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_space());
+  }
+
+  // string jsonContent = 2;
+  if (!this->_internal_jsoncontent().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_jsoncontent());
+  }
+
+  // bool force = 3;
+  if (this->_internal_force() != 0) {
+    total_size += 1 + 1;
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData namespaceImport_Request::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    namespaceImport_Request::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*namespaceImport_Request::GetClassData() const { return &_class_data_; }
+
+
+void namespaceImport_Request::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<namespaceImport_Request*>(&to_msg);
+  auto& from = static_cast<const namespaceImport_Request&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.content.namespaceImport_Request)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_space().empty()) {
+    _this->_internal_set_space(from._internal_space());
+  }
+  if (!from._internal_jsoncontent().empty()) {
+    _this->_internal_set_jsoncontent(from._internal_jsoncontent());
+  }
+  if (from._internal_force() != 0) {
+    _this->_internal_set_force(from._internal_force());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void namespaceImport_Request::CopyFrom(const namespaceImport_Request& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.content.namespaceImport_Request)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool namespaceImport_Request::IsInitialized() const {
+  return true;
+}
+
+void namespaceImport_Request::InternalSwap(namespaceImport_Request* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.space_, lhs_arena,
+      &other->_impl_.space_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.jsoncontent_, lhs_arena,
+      &other->_impl_.jsoncontent_, rhs_arena
+  );
+  swap(_impl_.force_, other->_impl_.force_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata namespaceImport_Request::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_crud_2eproto_getter, &descriptor_table_crud_2eproto_once,
+      file_level_metadata_crud_2eproto[13]);
+}
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace content
 }  // namespace engine
@@ -3654,6 +4007,10 @@ Arena::CreateMaybeMessage< ::com::wazuh::api::engine::content::resourcePost_Requ
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::content::resourceDelete_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::content::resourceDelete_Request >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::content::resourceDelete_Request >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::content::namespaceImport_Request*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::content::namespaceImport_Request >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::content::namespaceImport_Request >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/src/engine/source/proto/include/eMessages/crud.pb.h
+++ b/src/engine/source/proto/include/eMessages/crud.pb.h
@@ -63,6 +63,9 @@ extern namespaceGet_RequestDefaultTypeInternal _namespaceGet_Request_default_ins
 class namespaceGet_Response;
 struct namespaceGet_ResponseDefaultTypeInternal;
 extern namespaceGet_ResponseDefaultTypeInternal _namespaceGet_Response_default_instance_;
+class namespaceImport_Request;
+struct namespaceImport_RequestDefaultTypeInternal;
+extern namespaceImport_RequestDefaultTypeInternal _namespaceImport_Request_default_instance_;
 class namespacePost_Request;
 struct namespacePost_RequestDefaultTypeInternal;
 extern namespacePost_RequestDefaultTypeInternal _namespacePost_Request_default_instance_;
@@ -100,6 +103,7 @@ template<> ::com::wazuh::api::engine::content::ResourceSummary* Arena::CreateMay
 template<> ::com::wazuh::api::engine::content::namespaceDelete_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::namespaceDelete_Request>(Arena*);
 template<> ::com::wazuh::api::engine::content::namespaceGet_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::namespaceGet_Request>(Arena*);
 template<> ::com::wazuh::api::engine::content::namespaceGet_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::namespaceGet_Response>(Arena*);
+template<> ::com::wazuh::api::engine::content::namespaceImport_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::namespaceImport_Request>(Arena*);
 template<> ::com::wazuh::api::engine::content::namespacePost_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::namespacePost_Request>(Arena*);
 template<> ::com::wazuh::api::engine::content::policyDelete_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::policyDelete_Request>(Arena*);
 template<> ::com::wazuh::api::engine::content::policyPost_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::content::policyPost_Request>(Arena*);
@@ -1738,6 +1742,7 @@ class resourceGet_Request final :
   enum : int {
     kSpaceFieldNumber = 1,
     kUuidFieldNumber = 2,
+    kAsJsonFieldNumber = 3,
   };
   // string space = 1;
   void clear_space();
@@ -1767,6 +1772,19 @@ class resourceGet_Request final :
   std::string* _internal_mutable_uuid();
   public:
 
+  // optional bool asJson = 3;
+  bool has_asjson() const;
+  private:
+  bool _internal_has_asjson() const;
+  public:
+  void clear_asjson();
+  bool asjson() const;
+  void set_asjson(bool value);
+  private:
+  bool _internal_asjson() const;
+  void _internal_set_asjson(bool value);
+  public:
+
   // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.content.resourceGet_Request)
  private:
   class _Internal;
@@ -1775,9 +1793,11 @@ class resourceGet_Request final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr space_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr uuid_;
-    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    bool asjson_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_crud_2eproto;
@@ -1906,7 +1926,7 @@ class resourceGet_Response final :
 
   enum : int {
     kErrorFieldNumber = 2,
-    kYmlContentFieldNumber = 3,
+    kContentFieldNumber = 3,
     kStatusFieldNumber = 1,
   };
   // optional string error = 2;
@@ -1927,22 +1947,22 @@ class resourceGet_Response final :
   std::string* _internal_mutable_error();
   public:
 
-  // optional string ymlContent = 3;
-  bool has_ymlcontent() const;
+  // optional string content = 3;
+  bool has_content() const;
   private:
-  bool _internal_has_ymlcontent() const;
+  bool _internal_has_content() const;
   public:
-  void clear_ymlcontent();
-  const std::string& ymlcontent() const;
+  void clear_content();
+  const std::string& content() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_ymlcontent(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_ymlcontent();
-  PROTOBUF_NODISCARD std::string* release_ymlcontent();
-  void set_allocated_ymlcontent(std::string* ymlcontent);
+  void set_content(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_content();
+  PROTOBUF_NODISCARD std::string* release_content();
+  void set_allocated_content(std::string* content);
   private:
-  const std::string& _internal_ymlcontent() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_ymlcontent(const std::string& value);
-  std::string* _internal_mutable_ymlcontent();
+  const std::string& _internal_content() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_content(const std::string& value);
+  std::string* _internal_mutable_content();
   public:
 
   // .com.wazuh.api.engine.ReturnStatus status = 1;
@@ -1965,7 +1985,7 @@ class resourceGet_Response final :
     ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr ymlcontent_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr content_;
     int status_;
   };
   union { Impl_ _impl_; };
@@ -2320,6 +2340,186 @@ class resourceDelete_Request final :
   struct Impl_ {
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr space_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr uuid_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_crud_2eproto;
+};
+// -------------------------------------------------------------------
+
+class namespaceImport_Request final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.content.namespaceImport_Request) */ {
+ public:
+  inline namespaceImport_Request() : namespaceImport_Request(nullptr) {}
+  ~namespaceImport_Request() override;
+  explicit PROTOBUF_CONSTEXPR namespaceImport_Request(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  namespaceImport_Request(const namespaceImport_Request& from);
+  namespaceImport_Request(namespaceImport_Request&& from) noexcept
+    : namespaceImport_Request() {
+    *this = ::std::move(from);
+  }
+
+  inline namespaceImport_Request& operator=(const namespaceImport_Request& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline namespaceImport_Request& operator=(namespaceImport_Request&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const namespaceImport_Request& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const namespaceImport_Request* internal_default_instance() {
+    return reinterpret_cast<const namespaceImport_Request*>(
+               &_namespaceImport_Request_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    13;
+
+  friend void swap(namespaceImport_Request& a, namespaceImport_Request& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(namespaceImport_Request* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(namespaceImport_Request* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  namespaceImport_Request* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<namespaceImport_Request>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const namespaceImport_Request& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const namespaceImport_Request& from) {
+    namespaceImport_Request::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(namespaceImport_Request* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.content.namespaceImport_Request";
+  }
+  protected:
+  explicit namespaceImport_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kSpaceFieldNumber = 1,
+    kJsonContentFieldNumber = 2,
+    kForceFieldNumber = 3,
+  };
+  // string space = 1;
+  void clear_space();
+  const std::string& space() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_space(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_space();
+  PROTOBUF_NODISCARD std::string* release_space();
+  void set_allocated_space(std::string* space);
+  private:
+  const std::string& _internal_space() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_space(const std::string& value);
+  std::string* _internal_mutable_space();
+  public:
+
+  // string jsonContent = 2;
+  void clear_jsoncontent();
+  const std::string& jsoncontent() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_jsoncontent(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_jsoncontent();
+  PROTOBUF_NODISCARD std::string* release_jsoncontent();
+  void set_allocated_jsoncontent(std::string* jsoncontent);
+  private:
+  const std::string& _internal_jsoncontent() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_jsoncontent(const std::string& value);
+  std::string* _internal_mutable_jsoncontent();
+  public:
+
+  // bool force = 3;
+  void clear_force();
+  bool force() const;
+  void set_force(bool value);
+  private:
+  bool _internal_force() const;
+  void _internal_set_force(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.content.namespaceImport_Request)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr space_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr jsoncontent_;
+    bool force_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -3317,6 +3517,34 @@ inline void resourceGet_Request::set_allocated_uuid(std::string* uuid) {
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.resourceGet_Request.uuid)
 }
 
+// optional bool asJson = 3;
+inline bool resourceGet_Request::_internal_has_asjson() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool resourceGet_Request::has_asjson() const {
+  return _internal_has_asjson();
+}
+inline void resourceGet_Request::clear_asjson() {
+  _impl_.asjson_ = false;
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline bool resourceGet_Request::_internal_asjson() const {
+  return _impl_.asjson_;
+}
+inline bool resourceGet_Request::asjson() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.content.resourceGet_Request.asJson)
+  return _internal_asjson();
+}
+inline void resourceGet_Request::_internal_set_asjson(bool value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.asjson_ = value;
+}
+inline void resourceGet_Request::set_asjson(bool value) {
+  _internal_set_asjson(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.content.resourceGet_Request.asJson)
+}
+
 // -------------------------------------------------------------------
 
 // resourceGet_Response
@@ -3409,72 +3637,72 @@ inline void resourceGet_Response::set_allocated_error(std::string* error) {
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.resourceGet_Response.error)
 }
 
-// optional string ymlContent = 3;
-inline bool resourceGet_Response::_internal_has_ymlcontent() const {
+// optional string content = 3;
+inline bool resourceGet_Response::_internal_has_content() const {
   bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
   return value;
 }
-inline bool resourceGet_Response::has_ymlcontent() const {
-  return _internal_has_ymlcontent();
+inline bool resourceGet_Response::has_content() const {
+  return _internal_has_content();
 }
-inline void resourceGet_Response::clear_ymlcontent() {
-  _impl_.ymlcontent_.ClearToEmpty();
+inline void resourceGet_Response::clear_content() {
+  _impl_.content_.ClearToEmpty();
   _impl_._has_bits_[0] &= ~0x00000002u;
 }
-inline const std::string& resourceGet_Response::ymlcontent() const {
-  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.content.resourceGet_Response.ymlContent)
-  return _internal_ymlcontent();
+inline const std::string& resourceGet_Response::content() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.content.resourceGet_Response.content)
+  return _internal_content();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void resourceGet_Response::set_ymlcontent(ArgT0&& arg0, ArgT... args) {
+void resourceGet_Response::set_content(ArgT0&& arg0, ArgT... args) {
  _impl_._has_bits_[0] |= 0x00000002u;
- _impl_.ymlcontent_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.content.resourceGet_Response.ymlContent)
+ _impl_.content_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.content.resourceGet_Response.content)
 }
-inline std::string* resourceGet_Response::mutable_ymlcontent() {
-  std::string* _s = _internal_mutable_ymlcontent();
-  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.content.resourceGet_Response.ymlContent)
+inline std::string* resourceGet_Response::mutable_content() {
+  std::string* _s = _internal_mutable_content();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.content.resourceGet_Response.content)
   return _s;
 }
-inline const std::string& resourceGet_Response::_internal_ymlcontent() const {
-  return _impl_.ymlcontent_.Get();
+inline const std::string& resourceGet_Response::_internal_content() const {
+  return _impl_.content_.Get();
 }
-inline void resourceGet_Response::_internal_set_ymlcontent(const std::string& value) {
+inline void resourceGet_Response::_internal_set_content(const std::string& value) {
   _impl_._has_bits_[0] |= 0x00000002u;
-  _impl_.ymlcontent_.Set(value, GetArenaForAllocation());
+  _impl_.content_.Set(value, GetArenaForAllocation());
 }
-inline std::string* resourceGet_Response::_internal_mutable_ymlcontent() {
+inline std::string* resourceGet_Response::_internal_mutable_content() {
   _impl_._has_bits_[0] |= 0x00000002u;
-  return _impl_.ymlcontent_.Mutable(GetArenaForAllocation());
+  return _impl_.content_.Mutable(GetArenaForAllocation());
 }
-inline std::string* resourceGet_Response::release_ymlcontent() {
-  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.content.resourceGet_Response.ymlContent)
-  if (!_internal_has_ymlcontent()) {
+inline std::string* resourceGet_Response::release_content() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.content.resourceGet_Response.content)
+  if (!_internal_has_content()) {
     return nullptr;
   }
   _impl_._has_bits_[0] &= ~0x00000002u;
-  auto* p = _impl_.ymlcontent_.Release();
+  auto* p = _impl_.content_.Release();
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.ymlcontent_.IsDefault()) {
-    _impl_.ymlcontent_.Set("", GetArenaForAllocation());
+  if (_impl_.content_.IsDefault()) {
+    _impl_.content_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   return p;
 }
-inline void resourceGet_Response::set_allocated_ymlcontent(std::string* ymlcontent) {
-  if (ymlcontent != nullptr) {
+inline void resourceGet_Response::set_allocated_content(std::string* content) {
+  if (content != nullptr) {
     _impl_._has_bits_[0] |= 0x00000002u;
   } else {
     _impl_._has_bits_[0] &= ~0x00000002u;
   }
-  _impl_.ymlcontent_.SetAllocated(ymlcontent, GetArenaForAllocation());
+  _impl_.content_.SetAllocated(content, GetArenaForAllocation());
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.ymlcontent_.IsDefault()) {
-    _impl_.ymlcontent_.Set("", GetArenaForAllocation());
+  if (_impl_.content_.IsDefault()) {
+    _impl_.content_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.resourceGet_Response.ymlContent)
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.resourceGet_Response.content)
 }
 
 // -------------------------------------------------------------------
@@ -3735,9 +3963,135 @@ inline void resourceDelete_Request::set_allocated_uuid(std::string* uuid) {
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.resourceDelete_Request.uuid)
 }
 
+// -------------------------------------------------------------------
+
+// namespaceImport_Request
+
+// string space = 1;
+inline void namespaceImport_Request::clear_space() {
+  _impl_.space_.ClearToEmpty();
+}
+inline const std::string& namespaceImport_Request::space() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.content.namespaceImport_Request.space)
+  return _internal_space();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void namespaceImport_Request::set_space(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.space_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.content.namespaceImport_Request.space)
+}
+inline std::string* namespaceImport_Request::mutable_space() {
+  std::string* _s = _internal_mutable_space();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.content.namespaceImport_Request.space)
+  return _s;
+}
+inline const std::string& namespaceImport_Request::_internal_space() const {
+  return _impl_.space_.Get();
+}
+inline void namespaceImport_Request::_internal_set_space(const std::string& value) {
+  
+  _impl_.space_.Set(value, GetArenaForAllocation());
+}
+inline std::string* namespaceImport_Request::_internal_mutable_space() {
+  
+  return _impl_.space_.Mutable(GetArenaForAllocation());
+}
+inline std::string* namespaceImport_Request::release_space() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.content.namespaceImport_Request.space)
+  return _impl_.space_.Release();
+}
+inline void namespaceImport_Request::set_allocated_space(std::string* space) {
+  if (space != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.space_.SetAllocated(space, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.space_.IsDefault()) {
+    _impl_.space_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.namespaceImport_Request.space)
+}
+
+// string jsonContent = 2;
+inline void namespaceImport_Request::clear_jsoncontent() {
+  _impl_.jsoncontent_.ClearToEmpty();
+}
+inline const std::string& namespaceImport_Request::jsoncontent() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.content.namespaceImport_Request.jsonContent)
+  return _internal_jsoncontent();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void namespaceImport_Request::set_jsoncontent(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.jsoncontent_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.content.namespaceImport_Request.jsonContent)
+}
+inline std::string* namespaceImport_Request::mutable_jsoncontent() {
+  std::string* _s = _internal_mutable_jsoncontent();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.content.namespaceImport_Request.jsonContent)
+  return _s;
+}
+inline const std::string& namespaceImport_Request::_internal_jsoncontent() const {
+  return _impl_.jsoncontent_.Get();
+}
+inline void namespaceImport_Request::_internal_set_jsoncontent(const std::string& value) {
+  
+  _impl_.jsoncontent_.Set(value, GetArenaForAllocation());
+}
+inline std::string* namespaceImport_Request::_internal_mutable_jsoncontent() {
+  
+  return _impl_.jsoncontent_.Mutable(GetArenaForAllocation());
+}
+inline std::string* namespaceImport_Request::release_jsoncontent() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.content.namespaceImport_Request.jsonContent)
+  return _impl_.jsoncontent_.Release();
+}
+inline void namespaceImport_Request::set_allocated_jsoncontent(std::string* jsoncontent) {
+  if (jsoncontent != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.jsoncontent_.SetAllocated(jsoncontent, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.jsoncontent_.IsDefault()) {
+    _impl_.jsoncontent_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.content.namespaceImport_Request.jsonContent)
+}
+
+// bool force = 3;
+inline void namespaceImport_Request::clear_force() {
+  _impl_.force_ = false;
+}
+inline bool namespaceImport_Request::_internal_force() const {
+  return _impl_.force_;
+}
+inline bool namespaceImport_Request::force() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.content.namespaceImport_Request.force)
+  return _internal_force();
+}
+inline void namespaceImport_Request::_internal_set_force(bool value) {
+  
+  _impl_.force_ = value;
+}
+inline void namespaceImport_Request::set_force(bool value) {
+  _internal_set_force(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.content.namespaceImport_Request.force)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/engine/source/proto/src/crud.proto
+++ b/src/engine/source/proto/src/crud.proto
@@ -52,6 +52,22 @@ message namespaceDelete_Request
 }
 // message namespaceDelete_Response -> Return a GenericStatus_Response
 
+/***************************************************
+ * Import a full namespace from JSON
+ *
+ * endpoint: POST content/namespace/import (<resource>/<action>)
+ * Imports a complete namespace definition provided as a JSON payload.
+ * This operation may create all resources within the target namespace.
+ * When `force` is enabled, validation checks are skipped.
+ **************************************************/
+message namespaceImport_Request
+{
+    string space = 1;       // Namespace name to import into
+    string jsonContent = 2; // Full namespace JSON payload
+    bool force = 3;         // If true, skip validation
+}
+// message namespaceImport_Response -> Return a GenericStatus_Response
+
 /******************** Policy operations ********************/
 /***************************************************
  * Upsert policy for a namespace
@@ -102,15 +118,16 @@ message resourceList_Response
  **************************************************/
 message resourceGet_Request
 {
-    string space = 1; // Namespace name
-    string uuid = 2;  // UUID of the resource to retrieve
+    string space = 1;         // Namespace name
+    string uuid = 2;          // UUID of the resource to retrieve
+    optional bool asJson = 3; // If true, return the resource in JSON format
 }
 
 message resourceGet_Response
 {
-    ReturnStatus status = 1;        // Status of the query
-    optional string error = 2;      // Error message if status is ERROR
-    optional string ymlContent = 3; // YAML representation of the resource (asset/integration/kvdb)
+    ReturnStatus status = 1;     // Status of the query
+    optional string error = 2;   // Error message if status is ERROR
+    optional string content = 3; // YAML or JSON representation of the resource (asset/integration/kvdb)
 }
 
 /***************************************************

--- a/src/engine/source/yml/src/yml.cpp
+++ b/src/engine/source/yml/src/yml.cpp
@@ -105,27 +105,28 @@ rapidjson::Document Converter::loadYMLfromString(const std::string& yamlStr)
 
 YAML::Node Converter::jsonToYaml(const rapidjson::Value& value)
 {
-    YAML::Node node;
     if (value.IsObject())
     {
+        YAML::Node node(YAML::NodeType::Map);
         for (auto& m : value.GetObject())
         {
             node[m.name.GetString()] = jsonToYaml(m.value);
         }
+        return node;
     }
     else if (value.IsArray())
     {
+        YAML::Node node(YAML::NodeType::Sequence);   // key for empty arrays
         for (auto& v : value.GetArray())
         {
             node.push_back(jsonToYaml(v));
         }
+        return node;
     }
     else
     {
-        node = parseScalar(value);
+        return parseScalar(value);
     }
-
-    return node;
 }
 
 rapidjson::Value Converter::yamlToJson(const YAML::Node& root, rapidjson::Document::AllocatorType& allocator)

--- a/src/engine/tools/api-communication/src/api_communication/endpoints.py
+++ b/src/engine/tools/api-communication/src/api_communication/endpoints.py
@@ -37,6 +37,8 @@ def get_endpoint(message: Message) -> Tuple[Optional[str], str]:
         return None, '_internal/content/namespace/delete'
     if isinstance(message, crud.namespaceGet_Request):
         return None, '_internal/content/namespace/list'
+    if isinstance(message, crud.namespaceImport_Request):
+        return None, '_internal/content/namespace/import'
 
     # CRUD CM
     if isinstance(message, crud.resourcePost_Request):

--- a/src/engine/tools/api-communication/src/api_communication/proto/crud_pb2.py
+++ b/src/engine/tools/api-communication/src/api_communication/proto/crud_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 import api_communication.proto.engine_pb2 as _engine_pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\ncrud.proto\x12\x1c\x63om.wazuh.api.engine.content\x1a\x0c\x65ngine.proto\"e\n\x0fResourceSummary\x12\x11\n\x04uuid\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04hash\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\x07\n\x05_uuidB\x07\n\x05_nameB\x07\n\x05_hash\"\x16\n\x14namespaceGet_Request\"y\n\x15namespaceGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0e\n\x06spaces\x18\x03 \x03(\tB\x08\n\x06_error\"&\n\x15namespacePost_Request\x12\r\n\x05space\x18\x01 \x01(\t\"(\n\x17namespaceDelete_Request\x12\r\n\x05space\x18\x01 \x01(\t\"7\n\x12policyPost_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x12\n\nymlContent\x18\x02 \x01(\t\"%\n\x14policyDelete_Request\x12\r\n\x05space\x18\x01 \x01(\t\"3\n\x14resourceList_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\"\xab\x01\n\x15resourceList_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12@\n\tresources\x18\x03 \x03(\x0b\x32-.com.wazuh.api.engine.content.ResourceSummaryB\x08\n\x06_error\"2\n\x13resourceGet_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04uuid\x18\x02 \x01(\t\"\x90\x01\n\x14resourceGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nymlContent\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\r\n\x0b_ymlContent\"G\n\x14resourcePost_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x12\n\nymlContent\x18\x03 \x01(\t\"5\n\x16resourceDelete_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04uuid\x18\x02 \x01(\tb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\ncrud.proto\x12\x1c\x63om.wazuh.api.engine.content\x1a\x0c\x65ngine.proto\"e\n\x0fResourceSummary\x12\x11\n\x04uuid\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x11\n\x04hash\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\x07\n\x05_uuidB\x07\n\x05_nameB\x07\n\x05_hash\"\x16\n\x14namespaceGet_Request\"y\n\x15namespaceGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0e\n\x06spaces\x18\x03 \x03(\tB\x08\n\x06_error\"&\n\x15namespacePost_Request\x12\r\n\x05space\x18\x01 \x01(\t\"(\n\x17namespaceDelete_Request\x12\r\n\x05space\x18\x01 \x01(\t\"7\n\x12policyPost_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x12\n\nymlContent\x18\x02 \x01(\t\"%\n\x14policyDelete_Request\x12\r\n\x05space\x18\x01 \x01(\t\"3\n\x14resourceList_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\"\xab\x01\n\x15resourceList_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12@\n\tresources\x18\x03 \x03(\x0b\x32-.com.wazuh.api.engine.content.ResourceSummaryB\x08\n\x06_error\"R\n\x13resourceGet_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04uuid\x18\x02 \x01(\t\x12\x13\n\x06\x61sJson\x18\x03 \x01(\x08H\x00\x88\x01\x01\x42\t\n\x07_asJson\"\x8a\x01\n\x14resourceGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07\x63ontent\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_content\"G\n\x14resourcePost_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x12\n\nymlContent\x18\x03 \x01(\t\"5\n\x16resourceDelete_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x0c\n\x04uuid\x18\x02 \x01(\t\"L\n\x17namespaceImport_Request\x12\r\n\x05space\x18\x01 \x01(\t\x12\x13\n\x0bjsonContent\x18\x02 \x01(\t\x12\r\n\x05\x66orce\x18\x03 \x01(\x08\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'crud_pb2', globals())
@@ -40,11 +40,13 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _RESOURCELIST_RESPONSE._serialized_start=540
   _RESOURCELIST_RESPONSE._serialized_end=711
   _RESOURCEGET_REQUEST._serialized_start=713
-  _RESOURCEGET_REQUEST._serialized_end=763
-  _RESOURCEGET_RESPONSE._serialized_start=766
-  _RESOURCEGET_RESPONSE._serialized_end=910
-  _RESOURCEPOST_REQUEST._serialized_start=912
-  _RESOURCEPOST_REQUEST._serialized_end=983
-  _RESOURCEDELETE_REQUEST._serialized_start=985
-  _RESOURCEDELETE_REQUEST._serialized_end=1038
+  _RESOURCEGET_REQUEST._serialized_end=795
+  _RESOURCEGET_RESPONSE._serialized_start=798
+  _RESOURCEGET_RESPONSE._serialized_end=936
+  _RESOURCEPOST_REQUEST._serialized_start=938
+  _RESOURCEPOST_REQUEST._serialized_end=1009
+  _RESOURCEDELETE_REQUEST._serialized_start=1011
+  _RESOURCEDELETE_REQUEST._serialized_end=1064
+  _NAMESPACEIMPORT_REQUEST._serialized_start=1066
+  _NAMESPACEIMPORT_REQUEST._serialized_end=1142
 # @@protoc_insertion_point(module_scope)

--- a/src/engine/tools/api-communication/src/api_communication/proto/crud_pb2.pyi
+++ b/src/engine/tools/api-communication/src/api_communication/proto/crud_pb2.pyi
@@ -36,6 +36,16 @@ class namespaceGet_Response(_message.Message):
     status: _engine_pb2.ReturnStatus
     def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., spaces: _Optional[_Iterable[str]] = ...) -> None: ...
 
+class namespaceImport_Request(_message.Message):
+    __slots__ = ["force", "jsonContent", "space"]
+    FORCE_FIELD_NUMBER: _ClassVar[int]
+    JSONCONTENT_FIELD_NUMBER: _ClassVar[int]
+    SPACE_FIELD_NUMBER: _ClassVar[int]
+    force: bool
+    jsonContent: str
+    space: str
+    def __init__(self, space: _Optional[str] = ..., jsonContent: _Optional[str] = ..., force: bool = ...) -> None: ...
+
 class namespacePost_Request(_message.Message):
     __slots__ = ["space"]
     SPACE_FIELD_NUMBER: _ClassVar[int]
@@ -65,22 +75,24 @@ class resourceDelete_Request(_message.Message):
     def __init__(self, space: _Optional[str] = ..., uuid: _Optional[str] = ...) -> None: ...
 
 class resourceGet_Request(_message.Message):
-    __slots__ = ["space", "uuid"]
+    __slots__ = ["asJson", "space", "uuid"]
+    ASJSON_FIELD_NUMBER: _ClassVar[int]
     SPACE_FIELD_NUMBER: _ClassVar[int]
     UUID_FIELD_NUMBER: _ClassVar[int]
+    asJson: bool
     space: str
     uuid: str
-    def __init__(self, space: _Optional[str] = ..., uuid: _Optional[str] = ...) -> None: ...
+    def __init__(self, space: _Optional[str] = ..., uuid: _Optional[str] = ..., asJson: bool = ...) -> None: ...
 
 class resourceGet_Response(_message.Message):
-    __slots__ = ["error", "status", "ymlContent"]
+    __slots__ = ["content", "error", "status"]
+    CONTENT_FIELD_NUMBER: _ClassVar[int]
     ERROR_FIELD_NUMBER: _ClassVar[int]
     STATUS_FIELD_NUMBER: _ClassVar[int]
-    YMLCONTENT_FIELD_NUMBER: _ClassVar[int]
+    content: str
     error: str
     status: _engine_pb2.ReturnStatus
-    ymlContent: str
-    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., ymlContent: _Optional[str] = ...) -> None: ...
+    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., content: _Optional[str] = ...) -> None: ...
 
 class resourceList_Request(_message.Message):
     __slots__ = ["space", "type"]

--- a/src/engine/tools/engine-suite/src/engine_cm/cmds/get.py
+++ b/src/engine/tools/engine-suite/src/engine_cm/cmds/get.py
@@ -11,6 +11,7 @@ def run(args):
     json_request = dict()
     json_request['space'] = args['space']
     json_request['uuid'] = args['uuid']
+    json_request['asJson'] = args['json']
 
     # Create the api request
     try:
@@ -21,7 +22,7 @@ def run(args):
         if error:
             sys.exit(f'Error getting asset or collection: {error}')
 
-        print(response['ymlContent'])
+        print(response['content'])
 
     except Exception as e:
         sys.exit(f'Error getting asset or collection: {e}')
@@ -35,5 +36,7 @@ def configure(subparsers):
 
     parser_get.add_argument('uuid', type=str,
                             help=f'UUID of the resource to get.')
+
+    parser_get.add_argument('--json', action='store_true', help='Json format', default=False)
 
     parser_get.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_ns/__main__.py
+++ b/src/engine/tools/engine-suite/src/engine_ns/__main__.py
@@ -6,6 +6,7 @@ from shared.default_settings import Constants
 from engine_ns.cmds.list import configure as configure_list
 from engine_ns.cmds.create import configure as configure_create
 from engine_ns.cmds.delete import configure as configure_delete
+from engine_ns.cmds.import_ns import configure as configure_import
 
 
 def parse_args():
@@ -25,6 +26,7 @@ def parse_args():
     configure_create(subparsers)
     configure_delete(subparsers)
     configure_list(subparsers)
+    configure_import(subparsers)
 
     return parser.parse_args()
 

--- a/src/engine/tools/engine-suite/src/engine_ns/cmds/import_ns.py
+++ b/src/engine/tools/engine-suite/src/engine_ns/cmds/import_ns.py
@@ -1,0 +1,48 @@
+import sys
+from google.protobuf.json_format import ParseDict
+
+from api_communication.client import APIClient
+import api_communication.proto.engine_pb2 as engine
+import api_communication.proto.crud_pb2 as crud
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    json_request = dict()
+    json_request['space'] = args['space']
+
+    content = args['jsonContent']
+    # Read all content from stdin
+    if not content:
+        content = sys.stdin.read()
+
+    json_request['jsonContent'] = content
+    json_request['force'] = args['force']
+
+    # Create the api request
+    try:
+        client = APIClient(api_socket)
+        error, response = client.jsend(
+            json_request, crud.namespaceImport_Request(), engine.GenericStatus_Response())
+
+        if error:
+            sys.exit(f'Error importing namespace: {error}')
+
+    except Exception as e:
+        sys.exit(f'Error importing namespace: {e}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser = subparsers.add_parser('import', help='Import a namespace')
+    parser.add_argument('space', type=str, help='Name of the namespace')
+    parser.add_argument('-c', '--jsonContent', type=str, help='JSON content for the namespace', default='')
+    parser.add_argument('--force', action='store_true', help='Force import', default=False)
+    parser.set_defaults(func=run)


### PR DESCRIPTION
## Description

Closes #33515

This PR implements **full namespace import support in CM::CRUD**, allowing an entire namespace (policy and all its resources) to be imported from a single JSON document in a **safe and atomic-like way**.

The import logic was designed to ensure consistency even in case of partial failures, avoiding corrupted or half-imported namespaces. To achieve this, the implementation introduces a **staging strategy based on namespace renaming**, rather than copying directories.

Additionally, a **`--force` mode** is supported, allowing namespaces to be imported **without performing any validation**, which is useful for recovery scenarios, migrations, or low-level administrative operations.

This change lays the foundation for upcoming features such as public policy validation APIs and logtest APIs, which rely on isolated, disposable namespaces for testing and validation.

---

## Proposed Changes

### Full Namespace Import in CM::CRUD
- Added `importNamespace(...)` to `CM::CRUD`, enabling the import of:
  - KVDBs
  - Filters
  - Decoders
  - Rules
  - Outputs
  - Integrations
  - Policy (imported last)
- Resources are imported in a **strict order** to satisfy dependency requirements:
  1. KVDBs  
  2. Filters  
  3. Decoders  
  4. Rules  
  5. Outputs  
  6. Integrations  
  7. Policy  

- A `--force` mode is supported to **bypass all validation steps**, allowing the import process to proceed even if resources or policies are not valid.

---

### Atomic-like Import via Namespace Staging (Rename Strategy)
To avoid leaving a namespace in an inconsistent state when an import fails:

- **If the namespace does not exist**:
  - The namespace is created.
  - The import is attempted.
  - On failure, the namespace is deleted.
  - On success, it is left as-is.

- **If the namespace already exists**:
  - The existing namespace is **renamed to a temporary backup namespace**.
  - A new empty namespace with the original name is created.
  - The import is executed on the new namespace.
  - On failure:
    - The partially imported namespace is deleted.
    - The backup namespace is restored via rename.
  - On success:
    - The backup namespace is deleted.

This approach:
- Avoids directory copying.
- Keeps filesystem operations fast and atomic.
- Ensures the CM store never exposes partially imported namespaces.

---

### CMStore Enhancements
- Added `renameNamespace(...)` to `CMStore` to support safe namespace staging.
- The rename operation:
  - Invalidates the cached namespace instance before renaming.
  - Renames the namespace directory on disk.
  - Re-creates a fresh namespace instance under the new name.
- Rollback operations are implemented as **best-effort**, with warnings logged but without masking the original error.

---

### Design Notes
- Namespace backup names are generated using valid namespace characters only (`[A-Za-z0-9_]`).
- The `--force` flag disables all validation logic but preserves the import order.
- No behavior changes were introduced for existing CRUD operations.
- Testing is intentionally deferred to Phase 3, as specified in the issue.

### Results and Evidence

<details>

<summary>namespace.json</summary>

```
{
  "policy": {
    "default_parent": "3fd51b78-4cd1-41d8-95a4-39926d39437e",
    "root_decoder": "e16565ed-82a4-46e5-aea1-7142cc5af4e6",
    "integrations": [
      "5c1df6b6-1458-4b2e-9001-96f67a8b12c8"
    ]
  },
  "resources": {
    "kvdb": [
      {
        "id": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
        "title": "suricata_event_id_to_info",
        "enabled": true,
        "content": {
          "alert": {
            "event": {
              "kind": "alert",
              "category": [
                "network",
                "intrusion_detection"
              ]
            }
          },
          "dns": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "dns"
            }
          },
          "flow": {
            "event": {
              "type": [
                "connection"
              ]
            }
          },
          "ftp": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "ftp"
            }
          },
          "ftp_data": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "ftp"
            }
          },
          "http": {
            "event": {
              "category": [
                "network",
                "web"
              ],
              "type": [
                "protocol",
                "access"
              ]
            },
            "network": {
              "protocol": "http"
            }
          },
          "http2": {
            "event": {
              "category": [
                "network",
                "web"
              ],
              "type": [
                "protocol",
                "access"
              ]
            },
            "network": {
              "protocol": "http"
            }
          },
          "ikev2": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "ikev2"
            }
          },
          "krb5": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "krb5"
            }
          },
          "mqtt": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "mqtt"
            }
          },
          "smb": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "smb"
            }
          },
          "smtp": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "smtp"
            }
          },
          "snmp": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "snmp"
            }
          },
          "ssh": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "ssh"
            }
          },
          "stats": {
            "event": {
              "kind": "metric"
            }
          },
          "tftp": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "tftp"
            }
          },
          "tls": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "tls"
            }
          },
          "rdp": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "rdp"
            }
          },
          "rfb": {
            "event": {
              "type": [
                "protocol"
              ]
            },
            "network": {
              "protocol": "rdp"
            }
          }
        }
      }
    ],
    "filter": [],
    "decoder": [
      {
        "name": "decoder/core-wazuh-message/0",
        "metadata": {
          "module": "wazuh",
          "title": "Wazuh message decoder",
          "description": "Base decoder to process Wazuh message format, parses location part and enriches the events that comes from a Wazuh agent with the host information.",
          "compatibility": "All wazuh events.",
          "versions": [
            "Wazuh 5.*"
          ],
          "author": {
            "name": "Wazuh, Inc.",
            "date": "22/11/2024"
          },
          "references": [
            "https://documentation.wazuh.com/"
          ]
        },
        "normalize": [
          {
            "map": [
              {
                "@timestamp": "get_date()"
              }
            ]
          }
        ],
        "id": "e16565ed-82a4-46e5-aea1-7142cc5af4e6",
        "enabled": true
      },
      {
        "name": "decoder/integrations/0",
        "metadata": {
          "module": "wazuh",
          "title": "Integrations decoder",
          "description": "Example decoder referenced by an integration.",
          "compatibility": "All wazuh events."
        },
        "parents": [
          "decoder/core-wazuh-message/0"
        ],
        "normalize": [
          {
            "map": [
              {
                "tmp_json": "parse_json($event.original)"
              }
            ]
          }
        ],
        "id": "3fd51b78-4cd1-41d8-95a4-39926d39437e",
        "enabled": true
      },
      {
        "name": "decoder/suricata/0",
        "metadata": {
          "module": "suricata",
          "compatibility": "v6.0.0 and higher",
          "versions": [
            "6",
            "7"
          ],
          "author": {
            "name": "Wazuh Inc, info@wazuh.com",
            "date": "May 18 2024"
          },
          "references": [
            "https://suricata.readthedocs.io/en/suricata-6.0.8/output/eve/eve-json-format.html?highlight=eve%20format"
          ],
          "title": "Suricata decoder",
          "description": "Decoder for Suricata open source network analysis and threat detection software."
        },
        "check": "((exists($tmp_json.timestamp) AND exists($tmp_json.event_type) AND exists($tmp_json.flow_id)) OR (exists($tmp_json.timestamp) AND exists($tmp_json.event_type) AND $tmp_json.event_type == \"stats\"))",
        "normalize": [
          {
            "map": [
              {
                "suricata": "rename($tmp_json)"
              },
              {
                "tmp": "delete()"
              },
              {
                "destination.address": "$suricata.dest_ip"
              },
              {
                "destination.bytes": "$suricata.flow.bytes_toclient"
              },
              {
                "destination.domain": "$suricata.http.hostname"
              },
              {
                "destination.ip": "$destination.address"
              },
              {
                "destination.mac": "$suricata.ether.dest_mac"
              },
              {
                "destination.mac": "replace(':' , '-')"
              },
              {
                "destination.packets": "$suricata.flow.pkts_toclient"
              },
              {
                "destination.port": "$suricata.dest_port"
              },
              {
                "event.category": "array_append(network)"
              },
              {
                "event.end": "parse_date($suricata.flow.end, %FT%T%z)"
              },
              {
                "event.kind": "event"
              },
              {
                "event.severity": "$suricata.alert.severity"
              },
              {
                "event.start": "parse_date($suricata.timestamp, %FT%T%z)"
              },
              {
                ".": "kvdb_get_merge_recursive(suricata_event_id_to_info, $suricata.event_type)"
              },
              {
                "file.name": "$suricata.alert.metadata.filename"
              },
              {
                "file.path": "$suricata.fileinfo.filename"
              },
              {
                "file.size": "$suricata.fileinfo.size"
              },
              {
                "http.request.method": "$suricata.http.http_method"
              },
              {
                "http.request.referrer": "$suricata.http.http_refer"
              },
              {
                "http.response.body.bytes": "$suricata.http.length"
              },
              {
                "http.response.status_code": "$suricata.http.status"
              },
              {
                "http.version": "$suricata.http.protocol"
              },
              {
                "suricata.app_proto": "downcase($suricata.app_proto)"
              },
              {
                "network.transport": "downcase($suricata.proto)"
              },
              {
                "message": "$suricata.alert.category"
              },
              {
                "related.hosts": "array_append($suricata.http.hostname)"
              },
              {
                "related.ip": "array_append($suricata.src_ip, $suricata.dest_ip)"
              },
              {
                "related.hash": "array_append($suricata.tls.server.ja3s, $suricata.tls.client.ja3)"
              },
              {
                "source.address": "$suricata.src_ip"
              },
              {
                "source.bytes": "$suricata.flow.bytes_toserver"
              },
              {
                "source.ip": "$suricata.src_ip"
              },
              {
                "source.port": "$suricata.src_port"
              },
              {
                "source.mac": "$suricata.ether.src_mac"
              },
              {
                "source.mac": "replace(':' , '-')"
              },
              {
                "source.packets": "$suricata.flow.pkts_toserver"
              },
              {
                "user_agent.original": "$suricata.http.http_user_agent"
              },
              {
                "url.original": "$suricata.http.url"
              },
              {
                "url.path": "regex_extract($url.original, ([^?]*\\)(?:\\\\?.*\\)?)"
              },
              {
                "url.query": "regex_extract($url.original, ^(?:[^?]*\\\\?(.*\\)\\)?)"
              },
              {
                "wazuh.decoders": "array_append(suricata)"
              }
            ]
          },
          {
            "check": "$suricata.app_proto == ftp-data",
            "map": [
              {
                "network.protocol": "ftp"
              }
            ]
          },
          {
            "check": "$suricata.app_proto != failed AND $suricata.app_proto != template AND $suricata.app_proto != template-rust",
            "map": [
              {
                "network.protocol": "$suricata.app_proto"
              }
            ]
          },
          {
            "check": "$suricata.event_type == http AND $suricata.http.status < 400",
            "map": [
              {
                "event.outcome": "success"
              }
            ]
          },
          {
            "check": "$suricata.event_type == http AND $suricata.http.status > 400",
            "map": [
              {
                "event.outcome": "failure"
              }
            ]
          },
          {
            "check": "$suricata.flow.state == new",
            "map": [
              {
                "event.type": "array_append(start)"
              }
            ]
          },
          {
            "check": "$suricata.flow.state == closed",
            "map": [
              {
                "event.type": "array_append(end)"
              }
            ]
          },
          {
            "check": "$source.bytes >= 0 OR $destination.bytes >= 0",
            "map": [
              {
                "network.bytes": 0
              },
              {
                "network.bytes": "int_calculate(sum, $source.bytes, $destination.bytes)"
              }
            ]
          },
          {
            "check": "$source.packets >= 0 OR $destination.packets >= 0",
            "map": [
              {
                "network.packets": 0
              },
              {
                "network.packets": "int_calculate(sum, $source.packets, $destination.packets)"
              }
            ]
          },
          {
            "check": [
              {
                "suricata.alert.action": "is_not_null()"
              }
            ],
            "map": [
              {
                "event.type": "array_append($suricata.alert.action)"
              }
            ]
          },
          {
            "check": "$network.protocol == http",
            "map": [
              {
                "url.domain": "$destination.domain"
              }
            ]
          },
          {
            "check": "$network.protocol == dns",
            "map": [
              {
                "dns.id": "to_string($suricata.dns.id)"
              },
              {
                "dns.response_code": "$suricata.dns.rcode"
              },
              {
                "dns.type": "$suricata.dns.type"
              }
            ]
          },
          {
            "check": "$dns.type == query OR $suricata.dns.version == 2",
            "map": [
              {
                "dns.question.name": "$suricata.dns.rrname"
              },
              {
                "dns.question.type": "$suricata.dns.rrtype"
              }
            ]
          },
          {
            "check": "$dns.type == answer AND not_exists($suricata.dns.version)",
            "map": [
              {
                "_answer.name": "$suricata.dns.rrname"
              },
              {
                "_answer.data": "$suricata.dns.rdata"
              },
              {
                "_answer.type": "$suricata.dns.rrtype"
              },
              {
                "_answer.ttl": "$suricata.dns.ttl"
              },
              {
                "dns.answers": "array_append($_answer)"
              }
            ]
          },
          {
            "check": "$_answer.type == A OR $_answer.type == AAAA",
            "map": [
              {
                "dns.resolved_ip": "array_append($_answer.data)"
              }
            ]
          },
          {
            "check": "$dns.type == answer AND $suricata.dns.version == 2",
            "map": [
              {
                "dns.answers": "$suricata.dns.answers"
              }
            ]
          },
          {
            "check": "$suricata.dns.rrtype == A OR $suricata.dns.rrtype == AAAA",
            "map": [
              {
                "dns.resolved_ip": "array_append($dns.answers.i.rdata)"
              }
            ]
          },
          {
            "check": "$suricata.dns.aa == true",
            "map": [
              {
                "dns.header_flags": "array_append(AA)"
              }
            ]
          },
          {
            "check": "$suricata.dns.tc == true",
            "map": [
              {
                "dns.header_flags": "array_append(TC)"
              }
            ]
          },
          {
            "check": "$suricata.dns.rd == true",
            "map": [
              {
                "dns.header_flags": "array_append(RD)"
              }
            ]
          },
          {
            "check": "$suricata.dns.ra == true",
            "map": [
              {
                "dns.header_flags": "array_append(RA)"
              }
            ]
          },
          {
            "check": "$network.protocol == tls",
            "map": [
              {
                "_subject": "$suricata.tls.subject"
              },
              {
                "_subject": "replace(', ', ',')"
              },
              {
                "_issuer": "$suricata.tls.issuerdn"
              },
              {
                "_issuer": "replace(', ', ',')"
              },
              {
                "tls.resumed": "$suricata.tls.session_resumed"
              },
              {
                "tls.server.hash.sha1": "upcase($suricata.tls.fingerprint)"
              },
              {
                "tls.server.hash.sha1": "replace(':' , '')"
              },
              {
                "related.hash": "array_append($tls.server.hash.sha1)"
              },
              {
                "tls.client.server_name": "$suricata.tls.sni"
              },
              {
                "destination.domain": "$suricata.tls.sni"
              },
              {
                "related.hosts": "array_append($suricata.tls.sni)"
              },
              {
                "tls.server.ja3s": "$suricata.tls.ja3s.hash"
              },
              {
                "related.hash": "array_append($tls.server.ja3s)"
              },
              {
                "tls.client.ja3": "$suricata.tls.ja3.hash"
              },
              {
                "related.hash": "array_append($tls.client.ja3)"
              },
              {
                "tls.server.certificate": "$suricata.tls.certificate"
              },
              {
                "tls.server.certificate_chain": "$suricata.tls.chain"
              },
              {
                "tls.server.issuer": "$suricata.tls.issuerdn"
              },
              {
                "tls.server.subject": "$suricata.tls.subject"
              },
              {
                "tls.server.x509.serial_number": "$suricata.tls.serial"
              },
              {
                "tls.server.x509.serial_number": "replace(':' , '')"
              },
              {
                "tls.server.x509.not_after": "parse_date($suricata.tls.notafter, %FT%T)"
              },
              {
                "tls.server.x509.not_before": "parse_date($suricata.tls.notbefore, %FT%T)"
              },
              {
                "tls.server.not_after": "parse_date($suricata.tls.notafter, %FT%T)"
              },
              {
                "tls.server.not_before": "parse_date($suricata.tls.notbefore, %FT%T)"
              }
            ]
          },
          {
            "parse|_subject": [
              "<_tmp_subject/kv/=/,/\"/\\\\><?_remainder>"
            ],
            "map": [
              {
                "tls.server.x509.subject.common_name": "array_append($_tmp_subject.CN)"
              },
              {
                "tls.server.x509.subject.country": "array_append($_tmp_subject.C)"
              },
              {
                "tls.server.x509.subject.locality": "array_append($_tmp_subject.L)"
              },
              {
                "tls.server.x509.subject.organization": "array_append($_tmp_subject.O)"
              },
              {
                "tls.server.x509.subject.organizational_unit": "array_append($_tmp_subject.OU)"
              },
              {
                "tls.server.x509.subject.state_or_province": "array_append($_tmp_subject.ST)"
              }
            ]
          },
          {
            "parse|_issuer": [
              "<_tmp_issuer/kv/=/,/\"/\\\\><?_remainder>"
            ],
            "map": [
              {
                "tls.server.x509.issuer.country": "array_append($_tmp_issuer.C)"
              },
              {
                "tls.server.x509.issuer.common_name": "array_append($_tmp_issuer.CN)"
              },
              {
                "tls.server.x509.issuer.locality": "array_append($_tmp_issuer.L)"
              },
              {
                "tls.server.x509.issuer.organization": "array_append($_tmp_issuer.O)"
              },
              {
                "tls.server.x509.issuer.organizational_unit": "array_append($_tmp_issuer.OU)"
              },
              {
                "tls.server.x509.issuer.state_or_province": "array_append($_tmp_issuer.ST)"
              }
            ]
          },
          {
            "check": "$suricata.tls.version != UNDETERMINED",
            "map": [
              {
                "_version": "split($suricata.tls.version, ' ')"
              },
              {
                "tls.version": "$_version.1"
              },
              {
                "tls.version_protocol": "downcase($_version.0)"
              }
            ]
          }
        ],
        "id": "32624ae7-77c7-4759-ba98-ad292bf650b5",
        "enabled": true
      }
    ],
    "rule": [],
    "output": [],
    "integration": [
      {
        "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
        "title": "integration/wazuh-core/0",
        "enabled": true,
        "category": "Security",
        "decoders": [
          "e16565ed-82a4-46e5-aea1-7142cc5af4e6",
          "3fd51b78-4cd1-41d8-95a4-39926d39437e",
          "32624ae7-77c7-4759-ba98-ad292bf650b5"
        ],
        "kvdbs": [
          "82e215c4-988a-4f64-8d15-b98b2fc03a4f"
        ]
      }
    ]
  }
}

```


</details>

```
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# engine-ns list             
- draft
- cti
- custom
- testing

(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# engine-ns import testing_01  < /workspaces/devContainer/namespace.json
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# engine-ns list                                                        
- testing_01
- draft
- cti
- custom
- testing

(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# ls /var/ossec/etc/ruleset/testing_01/
cache_ns.json  decoders  integrations  kvdbs  policy.json
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# ls /var/ossec/etc/ruleset/testing_01/decoders     
decoder_core-wazuh-message_0.yml  decoder_integrations_0.yml  decoder_suricata_0.yml
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# ls /var/ossec/etc/ruleset/testing_01/integrations 
integration_wazuh-core_0.yml
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# ls /var/ossec/etc/ruleset/testing_01/kvdbs       
suricata_event_id_to_info.yml
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# cat /var/ossec/etc/ruleset/testing_01/cache_ns.json| jq   
[
  {
    "uuid": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
    "name": "integration/wazuh-core/0",
    "type": "integration",
    "hash": "4caa7f3ef79f9054015fba4257358775"
  },
  {
    "uuid": "3fd51b78-4cd1-41d8-95a4-39926d39437e",
    "name": "decoder/integrations/0",
    "type": "decoder",
    "hash": "ed24af8eb1720d48bddd26102a1244c0"
  },
  {
    "uuid": "e16565ed-82a4-46e5-aea1-7142cc5af4e6",
    "name": "decoder/core-wazuh-message/0",
    "type": "decoder",
    "hash": "ef2e4ce08e6548fdd13899fa07652df7"
  },
  {
    "uuid": "32624ae7-77c7-4759-ba98-ad292bf650b5",
    "name": "decoder/suricata/0",
    "type": "decoder",
    "hash": "3b25c9934d6f0759f6bf23f0118f42f2"
  },
  {
    "uuid": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
    "name": "suricata_event_id_to_info",
    "type": "kvdb",
    "hash": "f378021fefa6b380e74b7b94ff751273"
  }
]
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/33515-full-ns-import●› 
╰─# engine-test run test -n testing_01 -dd

Enter any events [ENTER to send event, CTRL+C to finish]:

{"timestamp":"2018-10-03T14:42:44.836744+0000","flow_id":2191386088856669,"in_iface":"enp0s3","event_type":"alert","src_ip":"192.168.1.146","src_port":32858,"dest_ip":"89.160.20.112","dest_port":80,"proto":"TCP","tx_id":0,"alert":{"action":"allowed","gid":1,"signature_id":2013028,"rev":4,"signature":"ET POLICY curl User-Agent Outbound","category":"Attempted Information Leak","severity":2},"http":{"hostname":"example.net","url":"\/","http_user_agent":"curl\/7.58.0","http_content_type":"text\/html","http_method":"GET","protocol":"HTTP\/1.1","status":200,"length":1121},"app_proto":"http","flow":{"pkts_toserver":4,"pkts_toclient":3,"bytes_toserver":347,"bytes_toclient":1654,"start":"2018-10-03T14:42:44.613469+0000"}}


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ tmp_json: parse_json($event.original) -> Success
[🟢] decoder/suricata/0 -> success
  ↳ [check: ((exists($tmp_json.timestamp) AND exists($tmp_json.event_type) AND exists($tmp_json.flow_id)) OR (exists($tmp_json.timestamp) AND exists($tmp_json.event_type) AND $tmp_json.event_type == "stats"))] -> Success
  ↳ suricata: rename($tmp_json) -> Success
  ↳ [tmp: delete] -> Failure: Target field 'tmp' could not be erased
  ↳ destination.address: map($suricata.dest_ip) -> Success
  ↳ destination.bytes: map($suricata.flow.bytes_toclient) -> Success
  ↳ destination.domain: map($suricata.http.hostname) -> Success
  ↳ destination.ip: map($destination.address) -> Success
  ↳ destination.mac: map($suricata.ether.dest_mac) -> Reference 'suricata.ether.dest_mac' not found
  ↳ [destination.mac: replace(":", "-")] -> Failure: Target field 'destination.mac' reference not found
  ↳ destination.packets: map($suricata.flow.pkts_toclient) -> Success
  ↳ destination.port: map($suricata.dest_port) -> Success
  ↳ event.category: array_append("network") -> Success
  ↳ event.end: parse_date($suricata.flow.end, "%FT%T%z") -> Reference 'suricata.flow.end' is not a string or it doesn't exist
  ↳ event.kind: map("event") -> Success
  ↳ event.severity: map($suricata.alert.severity) -> Success
  ↳ event.start: parse_date($suricata.timestamp, "%FT%T%z") -> Success
  ↳ .: kvdb_get_merge_recursive("suricata_event_id_to_info", $suricata.event_type) -> Success
  ↳ file.name: map($suricata.alert.metadata.filename) -> Reference 'suricata.alert.metadata.filename' not found
  ↳ file.path: map($suricata.fileinfo.filename) -> Reference 'suricata.fileinfo.filename' not found
  ↳ file.size: map($suricata.fileinfo.size) -> Reference 'suricata.fileinfo.size' not found
  ↳ http.request.method: map($suricata.http.http_method) -> Success
  ↳ http.request.referrer: map($suricata.http.http_refer) -> Reference 'suricata.http.http_refer' not found
  ↳ http.response.body.bytes: map($suricata.http.length) -> Success
  ↳ http.response.status_code: map($suricata.http.status) -> Success
  ↳ http.version: map($suricata.http.protocol) -> Success
  ↳ [suricata.app_proto: downcase($suricata.app_proto)] -> Success
  ↳ [network.transport: downcase($suricata.proto)] -> Success
  ↳ message: map($suricata.alert.category) -> Success
  ↳ related.hosts: array_append($suricata.http.hostname) -> Success
  ↳ related.ip: array_append($suricata.src_ip, $suricata.dest_ip) -> Success
  ↳ related.hash: array_append($suricata.tls.server.ja3s, $suricata.tls.client.ja3) -> Failure: 'suricata.tls.server.ja3s' not found
  ↳ source.address: map($suricata.src_ip) -> Success
  ↳ source.bytes: map($suricata.flow.bytes_toserver) -> Success
  ↳ source.ip: map($suricata.src_ip) -> Success
  ↳ source.port: map($suricata.src_port) -> Success
  ↳ source.mac: map($suricata.ether.src_mac) -> Reference 'suricata.ether.src_mac' not found
  ↳ [source.mac: replace(":", "-")] -> Failure: Target field 'source.mac' reference not found
  ↳ source.packets: map($suricata.flow.pkts_toserver) -> Success
  ↳ user_agent.original: map($suricata.http.http_user_agent) -> Success
  ↳ url.original: map($suricata.http.url) -> Success
  ↳ url.path: regex_extract($url.original, "([^?]*)(?:\\?.*)?") -> Success
  ↳ url.query: regex_extract($url.original, "^(?:[^?]*\\?(.*))?") -> Success
  ↳ wazuh.decoders: array_append("suricata") -> Success
  ↳ [check: $suricata.app_proto == ftp-data] -> Failure
  ↳ [check: $suricata.app_proto != failed AND $suricata.app_proto != template AND $suricata.app_proto != template-rust] -> Success
  ↳ network.protocol: map($suricata.app_proto) -> Success
  ↳ [check: $suricata.event_type == http AND $suricata.http.status < 400] -> Failure
  ↳ [check: $suricata.event_type == http AND $suricata.http.status > 400] -> Failure
  ↳ [check: $suricata.flow.state == new] -> Failure
  ↳ [check: $suricata.flow.state == closed] -> Failure
  ↳ [check: $source.bytes >= 0 OR $destination.bytes >= 0] -> Success
  ↳ network.bytes: map(0) -> Success
  ↳ [network.bytes: int_calculate("sum", $source.bytes, $destination.bytes)] -> Success
  ↳ [check: $source.packets >= 0 OR $destination.packets >= 0] -> Success
  ↳ network.packets: map(0) -> Success
  ↳ [network.packets: int_calculate("sum", $source.packets, $destination.packets)] -> Success
  ↳ [suricata.alert.action: is_not_null] -> Success
  ↳ event.type: array_append($suricata.alert.action) -> Success
  ↳ [check: $network.protocol == http] -> Success
  ↳ url.domain: map($destination.domain) -> Success
  ↳ [check: $network.protocol == dns] -> Failure
  ↳ [check: $dns.type == query OR $suricata.dns.version == 2] -> Failure
  ↳ [check: $dns.type == answer AND not_exists($suricata.dns.version)] -> Failure
  ↳ [check: $_answer.type == A OR $_answer.type == AAAA] -> Failure
  ↳ [check: $dns.type == answer AND $suricata.dns.version == 2] -> Failure
  ↳ [check: $suricata.dns.rrtype == A OR $suricata.dns.rrtype == AAAA] -> Failure
  ↳ [check: $suricata.dns.aa == true] -> Failure
  ↳ [check: $suricata.dns.tc == true] -> Failure
  ↳ [check: $suricata.dns.rd == true] -> Failure
  ↳ [check: $suricata.dns.ra == true] -> Failure
  ↳ [check: $network.protocol == tls] -> Failure
  ↳ [/_subject: <_tmp_subject/kv/=/,/"/\\><?_remainder>] -> Failure: Parameter "/_subject" reference not found
  ↳ [/_issuer: <_tmp_issuer/kv/=/,/"/\\><?_remainder>] -> Failure: Parameter "/_issuer" reference not found
  ↳ [check: $suricata.tls.version != UNDETERMINED] -> Failure

output:
  '@timestamp': '2025-12-15T19:39:24Z'
  agent:
    id: '000'
    name: ca37659e68c4
  destination:
    address: 89.160.20.112
    bytes: 1654
    domain: example.net
    ip: 89.160.20.112
    packets: 3
    port: 80
  event:
    category:
    - network
    - intrusion_detection
    kind: alert
    original: '{"timestamp":"2018-10-03T14:42:44.836744+0000","flow_id":2191386088856669,"in_iface":"enp0s3","event_type":"alert","src_ip":"192.168.1.146","src_port":32858,"dest_ip":"89.160.20.112","dest_port":80,"proto":"TCP","tx_id":0,"alert":{"action":"allowed","gid":1,"signature_id":2013028,"rev":4,"signature":"ET
      POLICY curl User-Agent Outbound","category":"Attempted Information Leak","severity":2},"http":{"hostname":"example.net","url":"\/","http_user_agent":"curl\/7.58.0","http_content_type":"text\/html","http_method":"GET","protocol":"HTTP\/1.1","status":200,"length":1121},"app_proto":"http","flow":{"pkts_toserver":4,"pkts_toclient":3,"bytes_toserver":347,"bytes_toclient":1654,"start":"2018-10-03T14:42:44.613469+0000"}}'
    severity: 2
    start: '2018-10-03T14:42:44.836Z'
    type:
    - allowed
  host:
    architecture: x86_64
    ip:
    - 172.17.0.2
    os:
      full: jammy
      kernel: Linux |ca37659e68c4 |6.8.0-88-generic |#89~22.04.2-Ubuntu SMP PREEMPT_DYNAMIC
        Wed Oct 29 10:45:25 UTC 2 |x86_64
      name: Ubuntu
      platform: ubuntu
      version: 22.04.5 LTS (Jammy Jellyfish)
  http:
    request:
      method: GET
    response:
      body:
        bytes: 1121
      status_code: 200
    version: HTTP/1.1
  message: Attempted Information Leak
  network:
    bytes: 2001
    packets: 7
    protocol: http
    transport: tcp
  related:
    hosts:
    - example.net
    ip:
    - 192.168.1.146
    - 89.160.20.112
  source:
    address: 192.168.1.146
    bytes: 347
    ip: 192.168.1.146
    packets: 4
    port: 32858
  suricata:
    alert:
      action: allowed
      category: Attempted Information Leak
      gid: 1
      rev: 4
      severity: 2
      signature: ET POLICY curl User-Agent Outbound
      signature_id: 2013028
    app_proto: http
    dest_ip: 89.160.20.112
    dest_port: 80
    event_type: alert
    flow:
      bytes_toclient: 1654
      bytes_toserver: 347
      pkts_toclient: 3
      pkts_toserver: 4
      start: 2018-10-03T14:42:44.613469+0000
    flow_id: 2191386088856669
    http:
      hostname: example.net
      http_content_type: text/html
      http_method: GET
      http_user_agent: curl/7.58.0
      length: 1121
      protocol: HTTP/1.1
      status: 200
      url: /
    in_iface: enp0s3
    proto: TCP
    src_ip: 192.168.1.146
    src_port: 32858
    timestamp: 2018-10-03T14:42:44.836744+0000
    tx_id: 0
  url:
    domain: example.net
    original: /
    path: /
    query: ''
  user_agent:
    original: curl/7.58.0
  wazuh:
    decoders:
    - suricata
    integration:
      category: Security
      decoders:
      - core-wazuh-message
      - integrations
      - suricata
      name: integration/wazuh-core/0
    protocol:
      location: some
      queue: 49

```


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
