### PR TITLE
Fill host.os field with current agent OS info in VD

### DIFF
--- a/src/wazuh_modules/inventory_sync/testtool/test_data/INPUT_000.json
+++ b/src/wazuh_modules/inventory_sync/testtool/test_data/INPUT_000.json
@@ -21,7 +21,7 @@
   },
   "data_values": [
     {
-      "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "id": "pkg-zlib1g-001",
       "operation": "upsert",
       "payload": {
         "checksum": {
@@ -39,11 +39,9 @@
           "vendor": "Ubuntu Developers",
           "version": "1:1.2.11.dfsg-2ubuntu1.5",
           "architecture": "amd64",
-          "checksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "description": "zlib1g - compression library - runtime",
           "name": "zlib1g",
           "size": 512,
-          "format": "deb",
           "multiarch": "foreign",
           "groups": "compression"
         },
@@ -54,7 +52,7 @@
       }
     },
     {
-      "id": "ffffffffffffffffffffffffffffffffffffffff",
+      "id": "pkg-zlib1g-002",
       "operation": "upsert",
       "payload": {
         "checksum": {
@@ -72,11 +70,9 @@
           "vendor": "Ubuntu Developers",
           "version": "1.2.11",
           "architecture": "amd64",
-          "checksum": "dddddddddddddddddddddddddddddddddddddddd",
           "description": "zlib1g - compression library runtime",
           "name": "zlib1g",
           "size": 512,
-          "format": "deb",
           "multiarch": "foreign",
           "groups": "compression",
           "cpe": "cpe:2.3:a:zlib:zlib:1.2.11:*:*:*:*:*:*:*"
@@ -88,7 +84,7 @@
       }
     },
     {
-      "id": "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh",
+      "id": "pkg-zlib1g-doc-001",
       "operation": "delete",
       "payload": {
         "checksum": {
@@ -106,11 +102,9 @@
           "vendor": "Ubuntu Developers",
           "version": "1:1.2.11.dfsg-2ubuntu1.5",
           "architecture": "amd64",
-          "checksum": "cccccccccccccccccccccccccccccccccccccccc",
           "description": "zlib1g-doc - compression library - documentation",
           "name": "zlib1g-doc",
           "size": 256,
-          "format": "deb",
           "multiarch": "foreign",
           "groups": "compression"
         },
@@ -123,6 +117,7 @@
   ],
   "data_context": [
     {
+      "id": "ctx-os-ubuntu24-001",
       "payload": {
         "checksum": {
           "hash": {

--- a/src/wazuh_modules/inventory_sync/testtool/test_data/INPUT_001.json
+++ b/src/wazuh_modules/inventory_sync/testtool/test_data/INPUT_001.json
@@ -10,7 +10,7 @@
     "osname": "Windows 11 Pro",
     "osplatform": "windows",
     "ostype": "windows",
-    "osversion": "10.0.22631",
+    "osversion": "11.0.22631",
     "groups": [
       "default"
     ],
@@ -22,18 +22,17 @@
   },
   "data_values": [
     {
-      "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "id": "os-win11-upsert-001",
       "operation": "upsert",
       "payload": {
         "host": {
           "hostname": "win11-host",
           "architecture": "x86_64",
           "os": {
-            "item_id": "os-win11-001",
             "name": "Windows",
             "platform": "windows",
             "type": "windows",
-            "version": "10.0.22631",
+            "version": "11.0.22631",
             "full": "Windows 11 23H2",
             "major": "11",
             "minor": "0"
@@ -46,12 +45,18 @@
       }
     },
     {
-      "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "id": "os-win10-delete-001",
       "operation": "delete",
       "payload": {
         "host": {
           "os": {
-            "item_id": "os-win10-old"
+            "name": "Windows",
+            "platform": "windows",
+            "type": "windows",
+            "version": "10.0.11432",
+            "full": "Windows 10 23H2",
+            "major": "10",
+            "minor": "0"
           }
         },
         "state": {
@@ -74,11 +79,9 @@
           "vendor": "Microsoft Corporation",
           "version": "130.0.0.0",
           "architecture": "amd64",
-          "checksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "description": "Microsoft Edge browser",
           "name": "microsoft-edge",
           "size": 250000000,
-          "format": "win",
           "multiarch": "no",
           "groups": "browser"
         },
@@ -102,11 +105,9 @@
           "vendor": "Microsoft Corporation",
           "version": "16.0.18000.20100",
           "architecture": "amd64",
-          "checksum": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
           "description": "Microsoft Office suite",
           "name": "microsoft-office",
           "size": 1200000000,
-          "format": "win",
           "multiarch": "no",
           "groups": "office"
         },
@@ -119,14 +120,14 @@
   ],
   "data_context": [
     {
+      "id": "ctx-os-win11-001",
       "payload": {
         "host": {
           "os": {
-            "item_id": "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk",
             "name": "Windows",
             "platform": "windows",
             "type": "windows",
-            "version": "10.0.22631",
+            "version": "11.0.22631",
             "full": "Windows 11 23H2",
             "major": "11",
             "minor": "0"
@@ -139,6 +140,7 @@
       }
     },
     {
+      "id": "ctx-hotfix-kb5068865",
       "payload": {
         "package": {
           "hotfix": {
@@ -152,6 +154,7 @@
       }
     },
     {
+      "id": "ctx-hotfix-kb5068909",
       "payload": {
         "package": {
           "hotfix": {
@@ -165,6 +168,7 @@
       }
     },
     {
+      "id": "ctx-hotfix-kb4532951",
       "payload": {
         "package": {
           "hotfix": {

--- a/src/wazuh_modules/inventory_sync/testtool/test_data/INPUT_002.json
+++ b/src/wazuh_modules/inventory_sync/testtool/test_data/INPUT_002.json
@@ -1,0 +1,226 @@
+{
+  "Start": {
+    "agentid": "020",
+    "mode": "full",
+    "option": "VDSync",
+    "agentname": "ubuntu24",
+    "agentversion": "v5.0.0",
+    "architecture": "x86_64",
+    "hostname": "ubuntu24",
+    "osname": "Ubuntu",
+    "osplatform": "ubuntu",
+    "ostype": "linux",
+    "osversion": "24.04.2 LTS (Noble Numbat)",
+    "groups": [
+      "default"
+    ],
+    "indices": [
+      "wazuh-states-inventory-system",
+      "wazuh-states-inventory-packages"
+    ],
+    "size": 7
+  },
+  "data_values": [
+    {
+      "id": "os-upsert-ubuntu24-24042",
+      "operation": "upsert",
+      "payload": {
+        "host": {
+          "hostname": "ubuntu24",
+          "architecture": "x86_64",
+          "os": {
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "24.04.2 LTS (Noble Numbat)",
+            "full": "Ubuntu 24.04.2 LTS",
+            "major": "24",
+            "minor": "04",
+            "patch": "2"
+          }
+        },
+        "state": {
+          "document_version": 3,
+          "modified_at": "2025-11-27T14:10:00.000Z"
+        }
+      }
+    },
+    {
+      "id": "os-delete-ubuntu24-old",
+      "operation": "delete",
+      "payload": {
+        "host": {
+          "os": {
+            "name": "Ubuntu",
+            "platform": "ubuntu",
+            "type": "linux",
+            "version": "24.04.2 LTS (Noble Numbat)",
+            "full": "Ubuntu 24.04.2 LTS",
+            "major": "24",
+            "minor": "04",
+            "patch": "2"
+          }
+        },
+        "state": {
+          "document_version": 4,
+          "modified_at": "2025-11-27T14:12:00.000Z"
+        }
+      }
+    },
+    {
+      "id": "kernel-old-6-8-0-36",
+      "operation": "delete",
+      "payload": {
+        "checksum": {
+          "hash": {
+            "sha1": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          }
+        },
+        "package": {
+          "category": "kernel",
+          "installed": null,
+          "path": "/boot/vmlinuz-6.8.0-36-generic",
+          "priority": "required",
+          "source": "linux-image-generic",
+          "type": "deb",
+          "vendor": "Ubuntu",
+          "version": "6.8.0-36.36~22.04.1",
+          "architecture": "amd64",
+          "description": "Linux kernel image for version 6.8.0-36-generic",
+          "name": "linux-image-6.8.0-36-generic",
+          "size": 65000000,
+          "multiarch": "no",
+          "groups": "kernel"
+        },
+        "state": {
+          "document_version": 2,
+          "modified_at": "2025-11-27T14:15:00.000Z"
+        }
+      }
+    },
+    {
+      "id": "kernel-new-6-8-0-41",
+      "operation": "upsert",
+      "payload": {
+        "checksum": {
+          "hash": {
+            "sha1": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        },
+        "package": {
+          "category": "kernel",
+          "installed": null,
+          "path": "/boot/vmlinuz-6.8.0-41-generic",
+          "priority": "required",
+          "source": "linux-image-generic",
+          "type": "deb",
+          "vendor": "Ubuntu",
+          "version": "6.8.0-41.41~24.04.1",
+          "architecture": "amd64",
+          "description": "Linux kernel image for version 6.8.0-41-generic",
+          "name": "linux-image-6.8.0-41-generic",
+          "size": 66000000,
+          "multiarch": "no",
+          "groups": "kernel"
+        },
+        "state": {
+          "document_version": 3,
+          "modified_at": "2025-11-27T14:16:00.000Z"
+        }
+      }
+    }
+  ],
+  "data_context": [
+    {
+      "id": "ctx-zlib1g-001",
+      "payload": {
+        "checksum": {
+          "hash": {
+            "sha1": "4444444444444444444444444444444444444444"
+          }
+        },
+        "package": {
+          "category": "libs",
+          "installed": null,
+          "path": null,
+          "priority": "required",
+          "source": "zlib",
+          "type": "deb",
+          "vendor": "Ubuntu Developers",
+          "version": "1:1.2.11.dfsg-2ubuntu1.5",
+          "architecture": "amd64",
+          "description": "zlib1g - compression library - runtime",
+          "name": "zlib1g",
+          "size": 512,
+          "multiarch": "foreign",
+          "groups": "compression"
+        },
+        "state": {
+          "document_version": 1,
+          "modified_at": "2025-11-27T12:31:07.733Z"
+        }
+      }
+    },
+    {
+      "id": "ctx-zlib1g-002",
+      "payload": {
+        "checksum": {
+          "hash": {
+            "sha1": "5555555555555555555555555555555555555555"
+          }
+        },
+        "package": {
+          "category": "libs",
+          "installed": null,
+          "path": null,
+          "priority": "required",
+          "source": "zlib",
+          "type": "deb",
+          "vendor": "Ubuntu Developers",
+          "version": "1.2.11",
+          "architecture": "amd64",
+          "description": "zlib1g - compression library runtime",
+          "name": "zlib1g",
+          "size": 512,
+          "multiarch": "foreign",
+          "groups": "compression",
+          "cpe": "cpe:2.3:a:zlib:zlib:1.2.11:*:*:*:*:*:*:*"
+        },
+        "state": {
+          "document_version": 1,
+          "modified_at": "2025-11-27T12:31:07.733Z"
+        }
+      }
+    },
+    {
+      "id": "ctx-zlib1g-doc-001",
+      "payload": {
+        "checksum": {
+          "hash": {
+            "sha1": "6666666666666666666666666666666666666666"
+          }
+        },
+        "package": {
+          "category": "doc",
+          "installed": null,
+          "path": "/usr/share/doc/zlib1g-doc",
+          "priority": "optional",
+          "source": "zlib",
+          "type": "deb",
+          "vendor": "Ubuntu Developers",
+          "version": "1:1.2.11.dfsg-2ubuntu1.5",
+          "architecture": "amd64",
+          "description": "zlib1g-doc - compression library - documentation",
+          "name": "zlib1g-doc",
+          "size": 256,
+          "multiarch": "foreign",
+          "groups": "compression"
+        },
+        "state": {
+          "document_version": 2,
+          "modified_at": "2025-11-27T13:05:00.000Z"
+        }
+      }
+    }
+  ]
+}

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
@@ -265,8 +265,8 @@ private:
         // ---------------------------------------------------------------------
         // package.*
         //
-        // Only for package vulnerabilities (AffectedComponentType::Package).
-        // For OS vulnerabilities we DO NOT populate package.* at all.
+        // For package vulnerabilities we use the package context.
+        // For OS vulnerabilities we also fill package.* with OS data as the affected component.
         // ---------------------------------------------------------------------
         if (detection.componentType == AffectedComponentType::Package && packageCtx)
         {
@@ -308,39 +308,56 @@ private:
                 }
             }
         }
-
-        // ---------------------------------------------------------------------
-        // host.os.*
-        //
-        // Only populate for OS detections. For package detections we leave
-        // host.os empty to avoid mixing OS context into package events.
-        // ---------------------------------------------------------------------
-        if (detection.componentType == AffectedComponentType::Os)
+        else if (detection.componentType == AffectedComponentType::Os)
         {
-            if (!osFullName.empty())
-            {
-                json["host"]["os"]["full"] = osFullName;
-            }
-            if (!context->osKernelRelease().empty())
-            {
-                json["host"]["os"]["kernel"] = context->osKernelRelease();
-            }
             if (!context->osName().empty())
             {
-                json["host"]["os"]["name"] = context->osName();
+                json["package"]["name"] = context->osName();
+            }
+            if (!context->osVersion().empty())
+            {
+                json["package"]["version"] = context->osVersion();
+            }
+            if (!context->osArchitecture().empty())
+            {
+                json["package"]["architecture"] = context->osArchitecture();
             }
             if (!context->osPlatform().empty())
             {
-                json["host"]["os"]["platform"] = Utils::toLowerCase(std::string(context->osPlatform()));
+                json["package"]["type"] = context->osPlatform();
             }
-            if (!osType.empty())
+            if (!context->osCodeName().empty())
             {
-                json["host"]["os"]["type"] = osType;
+                json["package"]["description"] = context->osCodeName();
             }
-            if (!osVersion.empty())
-            {
-                json["host"]["os"]["version"] = osVersion;
-            }
+        }
+
+        // ---------------------------------------------------------------------
+        // host.os.*
+        // ---------------------------------------------------------------------
+        if (!osFullName.empty())
+        {
+            json["host"]["os"]["full"] = osFullName;
+        }
+        if (!context->osKernelRelease().empty())
+        {
+            json["host"]["os"]["kernel"] = context->osKernelRelease();
+        }
+        if (!context->osName().empty())
+        {
+            json["host"]["os"]["name"] = context->osName();
+        }
+        if (!context->osPlatform().empty())
+        {
+            json["host"]["os"]["platform"] = Utils::toLowerCase(std::string(context->osPlatform()));
+        }
+        if (!osType.empty())
+        {
+            json["host"]["os"]["type"] = osType;
+        }
+        if (!osVersion.empty())
+        {
+            json["host"]["os"]["version"] = osVersion;
         }
 
         // ---------------------------------------------------------------------

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
@@ -210,6 +210,8 @@ public:
                         const std::string cveId       = *cveIdPtr;
                         const std::string detectionIdBase =
                             TScanContext::detectionIdBaseFromDetection(detectionId);
+                        const auto pkg = parsePackage(hit);
+                        const bool hasPackageContext = !pkg.name.empty();
 
                         ++totalExistingInIndexer;
                         // Preload as DELETE. Scanners will remove entries that remain present.
@@ -217,12 +219,13 @@ public:
                         det.operation        = ElementOperation::Delete;
                         det.vulnerability.id = cveId;
                         det.detectionIdBase  = detectionIdBase;
+                        det.componentType    =
+                            hasPackageContext ? AffectedComponentType::Package : AffectedComponentType::Os;
 
                         data->addDetectedCVE(detectionId, std::move(det));
                         ++scheduledDeletes;
 
                         // Also preload package context if not already present
-                        const auto pkg = parsePackage(hit);
                         if (!pkg.name.empty())
                         {
                             if (!data->findPackageByDetectionBase(detectionIdBase))

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -213,6 +213,12 @@ private:
         {
             auto osData = extractOSFromHostDocument(doc);
 
+            // Use the inventory document id as OS item_id.
+            if (!documentId.empty())
+            {
+                osData.item_id = documentId;
+            }
+
             if (operation == ElementOperation::Delete)
             {
                 // For OS delete operations we only track the deleted OS item_id


### PR DESCRIPTION
## Description

- Populate host.os in all vulnerability events (not only OS detections) using the installed OS data cached in ScanContext (Start + OS upserts). This makes the host context always present.
- For OS detections, mirror the OS as the affected component in package.* (name, version, architecture, platform, codename) so the event clearly points to the OS even when no package is involved.

### Results and Evidence

- Example of indexed alert for a package vulnerability:


<details>
  <summary> Event: </summary>

```

{
    "agent": {
        "groups": [
            "default"
        ],
        "host": {
            "architecture": "aarch64",
            "hostname": "ubuntu22",
            "os": {
                "name": "Ubuntu",
                "platform": "ubuntu",
                "type": "linux",
                "version": "22.04.5 LTS (Jammy Jellyfish)"
            }
        },
        "id": "001",
        "name": "ubuntu22",
        "type": "Wazuh",
        "version": "v5.0.0"
    },
    "host": {
        "os": {
            "full": "Ubuntu 24.04.2 LTS (Noble Numbat)",
            "kernel": "6.8.0-71-generic",
            "name": "Ubuntu",
            "platform": "ubuntu",
            "type": "ubuntu",
            "version": "24.04.2"
        }
    },
    "package": {
        "architecture": "amd64",
        "description": "zlib1g - compression library - runtime",
        "name": "zlib1g",
        "size": 512,
        "type": "deb",
        "version": "1:1.2.11.dfsg-2ubuntu1.5"
    },
    "vulnerability": {
        "category": "Packages",
        "classification": "-",
        "description": "zlib before 1.2.12 allows memory corruption when deflating (i.e., whencompressing) if the input has many distant matches.",
        "detected_at": "2025-12-16T11:20:25.968Z",
        "enumeration": "CVE",
        "id": "CVE-2018-25032",
        "published_at": "2022-03-25T09:15:08Z",
        "reference": "https://ubuntu.com/security/CVE-2018-25032, https://ubuntu.com/security/notices/USN-5355-1, https://ubuntu.com/security/notices/USN-5355-2, https://ubuntu.com/security/notices/USN-5359-1, https://ubuntu.com/security/notices/USN-5359-2, https://ubuntu.com/security/notices/USN-5739-1, https://ubuntu.com/security/notices/USN-6736-1, https://ubuntu.com/security/notices/USN-6736-2, https://www.cve.org/CVERecord?id=CVE-2018-25032",
        "scanner": {
            "condition": "Package less than 1:1.2.11.dfsg-2ubuntu9",
            "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2018-25032",
            "source": "Canonical Security Tracker",
            "vendor": "Wazuh"
        },
        "score": {
            "base": 7.5,
            "version": "3.1"
        },
        "severity": "High",
        "under_evaluation": false
    },
    "wazuh": {
        "cluster": {
            "name": "cluster01",
            "node": " "
        },
        "schema": {
            "version": "1.0.0"
        }
    }
}

```

</details>

- Full testtool output for base case:
[testtool.txt](https://github.com/user-attachments/files/24189821/testtool.txt)

- Dashboard overview for specific vulnerable package Django, showing OS info:
<img width="1717" height="915" alt="image" src="https://github.com/user-attachments/assets/473d5ef5-4a1b-4a57-a41a-5843aa421eba" />


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->


<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
- [x] Log syntax and correct language review


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
