### PR TITLE
Add reports to integration tests results 5.x

### DIFF
--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -73,8 +73,18 @@ jobs:
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
+
       # Run syscollector integration tests.
       - name: Run syscollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_syscollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_syscollector/ --html=results.html --self-contained-html
+
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: syscollector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_agentd-tier-0-1-lin.yml
@@ -90,4 +90,13 @@ jobs:
       - name: Run Agentd integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_agentd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_agentd/ --html=results.html --self-contained-html
+
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentd-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_agentd-tier-0-1-win.yml
@@ -109,4 +109,13 @@ jobs:
       - name: Run Agentd integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_agentd\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_agentd\ --html=results.html --self-contained-html
+
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentd-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_api-tier-0-1.yml
@@ -100,7 +100,7 @@ jobs:
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/cluster.log >> /tmp/wazuh-logs/cluster.log 2>/dev/null &
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_api/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_api/ --html=results.html --self-contained-html
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
@@ -114,3 +114,11 @@ jobs:
         with:
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-tier-0-1-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_api-tier-2.yml
+++ b/.github/workflows/5_testintegration_api-tier-2.yml
@@ -91,7 +91,7 @@ jobs:
           sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python3 -m pytest --tier 2 test_api/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest --tier 2 test_api/ --html=results.html --self-contained-html
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
@@ -105,3 +105,11 @@ jobs:
         with:
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-tier-2-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_enrollment-tier-0-1-lin.yml
@@ -91,4 +91,12 @@ jobs:
       - name: Run enrollment integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_enrollment/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_enrollment/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enrollment-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_enrollment-tier-0-1-win.yml
@@ -110,4 +110,12 @@ jobs:
       - name: Run enrollment integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_enrollment\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_enrollment\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enrollment-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_execd-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run execd integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_execd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_execd/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: execd-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_execd-tier-0-1-win.yml
@@ -108,4 +108,12 @@ jobs:
       - name: Run execd integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest -m win32 --tier 0 --tier 1 test_execd\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest -m win32 --tier 0 --tier 1 test_execd\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: execd-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-lin.yml
@@ -94,4 +94,12 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_fim/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-macos.yml
@@ -87,4 +87,12 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_fim/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-tier-0-1-macos-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-win.yml
@@ -108,4 +108,12 @@ jobs:
         run: |
           NET START wazuh
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_fim\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_fim\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/5_testintegration_fim-tier-2-lin.yml
@@ -85,4 +85,12 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 2 test_fim/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 2 test_fim/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-tier-2-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/5_testintegration_fim-tier-2-win.yml
@@ -99,4 +99,12 @@ jobs:
         run: |
           NET START wazuh
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 2 test_fim\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 2 test_fim\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-tier-2-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_github-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run github integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_github/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_github/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_github-tier-0-1-win.yml
@@ -108,4 +108,12 @@ jobs:
       - name: Run github integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_github\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_github\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_logcollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcollector-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-macos.yml
@@ -87,4 +87,12 @@ jobs:
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_logcollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcollector-tier-0-1-macos-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-win.yml
@@ -107,4 +107,12 @@ jobs:
       - name: Run logcollector integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_logcollector\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_logcollector\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcollector-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -99,4 +99,12 @@ jobs:
       - name: Run msgraph integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_msgraph/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_msgraph/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: msgraph-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_office365-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run office365 integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_office365/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_office365/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: office365-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_office365-tier-0-1-win.yml
@@ -108,4 +108,12 @@ jobs:
       - name: Run office365 integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_office365\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_office365\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: office365-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_rbac-tier-0-1.yml
@@ -96,7 +96,7 @@ jobs:
           sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest test_api/test_rbac/ --tier 0 --tier 1 --html=results.html --self-contained-html
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
@@ -110,3 +110,11 @@ jobs:
         with:
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbac-tier-0-1-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_sca-tier-0-1-lin.yml
@@ -93,4 +93,12 @@ jobs:
       - name: Run sca integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_sca/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_sca/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sca-tier-0-1-lin-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_sca-tier-0-1-win.yml
@@ -109,4 +109,12 @@ jobs:
       - name: Run sca integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest -m win32 --tier 0 --tier 1 test_sca\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest -m win32 --tier 0 --tier 1 test_sca\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sca-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_syscollector-tier-0-1-lin.yml
@@ -88,8 +88,18 @@ jobs:
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
+
       # Run syscollector integration tests.
       - name: Run syscollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_syscollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_syscollector/ --html=results.html --self-contained-html
+
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: syscollector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/5_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/5_testintegration_syscollector-tier-0-1-win.yml
@@ -107,4 +107,12 @@ jobs:
       - name: Run syscollector integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_syscollector\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_syscollector\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: syscollector-tier-0-1-win-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ import pytest
 import sys
 from typing import List
 
+from py.xml import html
 from wazuh_testing import session_parameters
 from wazuh_testing.constants import platforms
 from wazuh_testing.constants.platforms import WINDOWS
@@ -112,6 +113,24 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
 
     config.hook.pytest_deselected(items=deselected_tests)
     items[:] = selected_tests
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_html_results_summary(prefix, summary, postfix):
+    """Add custom information to the HTML report summary section.
+
+    Args:
+        prefix: Content to be added before the summary table
+        summary: The summary table element
+        postfix: Content to be added after the summary table
+    """
+    commit_sha = os.getenv('GITHUB_SHA', os.getenv('GIT_COMMIT', 'unknown'))
+    branch_name = os.getenv('GITHUB_REF_NAME', os.getenv('GIT_BRANCH', 'unknown'))
+
+    prefix.extend([
+        html.p(html.strong("Branch: "), branch_name),
+        html.p(html.strong("Commit SHA: "), commit_sha)
+    ])
 
 
 # - - - - - - - - - - - - - - - - - - - - - - -End of Pytest configuration - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
## Description

  This PR implements HTML report generation for integration test workflows as requested in issue #24080.

## Changes Made

### Enhanced Test Reporting (tests/integration/conftest.py)

  - Added pytest_html_results_summary hook to customize HTML reports
  - Reports now display Branch and Commit SHA prominently in the summary section
  - Metadata is pulled from GITHUB_SHA and GITHUB_REF_NAME environment variables (with fallback
 to GIT_COMMIT and GIT_BRANCH)
  - Uses py.xml.html for proper HTML element rendering

### Updated 25 Integration Test Workflows

  For Linux/macOS workflows:
  - Added environment variables to pytest command: GITHUB_SHA and GITHUB_REF_NAME
  - Added HTML report flags: --html=results.html --self-contained-html
  - Added artifact upload step that triggers on test failure

  For Windows workflows:
  - Added PowerShell environment variables: $env:GITHUB_SHA and $env:GITHUB_REF_NAME
  - Added HTML report flags: --html=results.html --self-contained-html
  - Added artifact upload step with Windows-appropriate paths

  Workflows updated:
  - 5_testintegration_agentd-tier-0-1-{lin,win}.yml
  - 5_testintegration_api-tier-{0-1,2}.yml
  - 5_testintegration_enrollment-tier-0-1-{lin,win}.yml
  - 5_testintegration_execd-tier-0-1-{lin,win}.yml
  - 5_testintegration_fim-tier-{0-1,2}-{lin,win,macos}.yml
  - 5_testintegration_github-tier-0-1-{lin,win}.yml
  - 5_testintegration_logcollector-tier-0-1-{lin,win,macos}.yml
  - 5_testintegration_msgraph-tier-0-1-lin.yml
  - 5_testintegration_office365-tier-0-1-{lin,win}.yml
  - 5_testintegration_rbac-tier-0-1.yml
  - 5_testintegration_sca-tier-0-1-{lin,win}.yml
  - 5_testintegration_syscollector-tier-0-1-{lin,win}.yml

The report look like this:
<img width="1829" height="925" alt="image" src="https://github.com/user-attachments/assets/ef3ddfdf-0702-4b9b-bd06-466d400a77d5" />


### Testing

  - ✅ Tested with various failing runs both on linux and windows
  - ✅ Verified HTML report generation includes Branch and Commit SHA metadata
  - ✅ Confirmed artifact upload works on failure

Example failing run: https://github.com/wazuh/wazuh/actions/runs/20275960451/job/58225356873?pr=33553