### PR TITLE
Add reports to integration tests results 4.x

### DIFF
--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -90,4 +90,12 @@ jobs:
       - name: Run Agentd integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_agentd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_agentd/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentd-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -104,4 +104,12 @@ jobs:
       - name: Run Agentd integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_agentd\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_agentd\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentd-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -91,4 +91,12 @@ jobs:
       - name: Run analysisd integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_analysisd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_analysisd/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysisd-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_analysisd-tier-2.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-2.yml
@@ -80,4 +80,12 @@ jobs:
       - name: Run analysisd integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 2 test_analysisd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 2 test_analysisd/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysisd-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -92,7 +92,15 @@ jobs:
           sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_api/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_api/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -85,7 +85,15 @@ jobs:
           sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python3 -m pytest --tier 2 test_api/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest --tier 2 test_api/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -90,4 +90,12 @@ jobs:
       - name: Run Authd tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_authd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_authd/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: authd-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -149,86 +149,95 @@ jobs:
         if: steps.filter.outputs.parser == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_parser.py
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_parser.py --html=results.html --self-contained-html
 
       - name: Run every test due to base WazuhIntegration class change or manual dispatch
         if: steps.filter.outputs.integration == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/ --html=results.html --self-contained-html
 
       - name: Run Custom Buckets tests
         if: steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k kms test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k macie test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k trusted_advisor test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k kms test_aws/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k macie test_aws/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k trusted_advisor test_aws/ --html=results.html --self-contained-html
 
       - name: Run Config tests
         if: steps.filter.outputs.config == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k config test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k config test_aws/ --html=results.html --self-contained-html
 
       - name: Run GuardDuty tests
         if: steps.filter.outputs.guardduty == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k guardduty test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k guardduty test_aws/ --html=results.html --self-contained-html
 
       - name: Run CloudTrail tests
         if: steps.filter.outputs.cloudtrail == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k cloudtrail test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudtrail test_aws/ --html=results.html --self-contained-html
 
       - name: Run Load Balancers tests
         if: steps.filter.outputs.loadbalancers == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k alb test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k clb test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k nlb test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k alb test_aws/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k clb test_aws/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k nlb test_aws/ --html=results.html --self-contained-html
 
       - name: Run Server Access tests
         if: steps.filter.outputs.serveraccess == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k server_access test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k server_access test_aws/ --html=results.html --self-contained-html
 
       - name: Run Umbrella tests
         if: steps.filter.outputs.umbrella == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k cisco test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cisco test_aws/ --html=results.html --self-contained-html
 
       - name: Run VPC Flow tests
         if: steps.filter.outputs.vpcflow == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/ --html=results.html --self-contained-html
 
       - name: Run WAF tests
         if: steps.filter.outputs.waf == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k waf test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k waf test_aws/ --html=results.html --self-contained-html
 
       - name: Run CloudWatch tests
         if: steps.filter.outputs.cloudwatch == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/ --html=results.html --self-contained-html
 
       - name: Run Inspector tests
         if: steps.filter.outputs.inspector == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/ --html=results.html --self-contained-html
 
       - name: Run Custom Bucket tests
         if: steps.filter.outputs.custom_bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_custom_bucket.py
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_custom_bucket.py --html=results.html --self-contained-html
+
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -91,4 +91,12 @@ jobs:
       - name: Run enrollment integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_enrollment/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_enrollment/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enrollment-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -105,4 +105,12 @@ jobs:
       - name: Run enrollment integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_enrollment\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_enrollment\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enrollment-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run execd integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_execd/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_execd/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: execd-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -103,4 +103,12 @@ jobs:
       - name: Run execd integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest -m win32 --tier 0 --tier 1 test_execd\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest -m win32 --tier 0 --tier 1 test_execd\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: execd-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -94,4 +94,12 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_fim/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
@@ -87,4 +87,12 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_fim/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -103,4 +103,12 @@ jobs:
         run: |
           NET START wazuh
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_fim\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_fim\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-lin.yml
@@ -85,4 +85,12 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 2 test_fim/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 2 test_fim/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -94,4 +94,12 @@ jobs:
         run: |
           NET START wazuh
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 2 test_fim\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 2 test_fim\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fim-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run github integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_github/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_github/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -103,4 +103,12 @@ jobs:
       - name: Run github integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_github\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_github\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run integratord integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_integratord/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_integratord/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integratord-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -51,4 +51,12 @@ jobs:
         run: |
           cd src
           echo "{}" > states_update_mappings.json
-          python -m pytest -vv wazuh_modules/inventory_harvester/qa/ --log-cli-level=DEBUG
+          GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ github.head_ref || github.ref_name }}" python -m pytest -vv wazuh_modules/inventory_harvester/qa/ --log-cli-level=DEBUG --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inventory-harvester-test-results-${{ github.run_id }}
+          path: ./src/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_logcollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcollector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
@@ -87,4 +87,12 @@ jobs:
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_logcollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcollector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -102,4 +102,12 @@ jobs:
       - name: Run logcollector integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_logcollector\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_logcollector\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcollector-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -90,4 +90,12 @@ jobs:
       - name: Run logtest integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_logtest/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logtest/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logtest-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -99,4 +99,12 @@ jobs:
       - name: Run msgraph integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_msgraph/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_msgraph/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: msgraph-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run office365 integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_office365/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_office365/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: office365-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -103,4 +103,12 @@ jobs:
       - name: Run office365 integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_office365\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_office365\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: office365-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -90,7 +90,15 @@ jobs:
           sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest test_api/test_rbac/ --tier 0 --tier 1 --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbac-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -90,4 +90,12 @@ jobs:
       - name: Run remoted integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_remoted/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_remoted/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: remoted-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_remoted-tier-2.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-2.yml
@@ -80,4 +80,12 @@ jobs:
       - name: Run remoted integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 2 test_remoted/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 2 test_remoted/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: remoted-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -93,4 +93,12 @@ jobs:
       - name: Run sca integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_sca/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_sca/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sca-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -104,4 +104,12 @@ jobs:
       - name: Run sca integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest -m win32 --tier 0 --tier 1 test_sca\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest -m win32 --tier 0 --tier 1 test_sca\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sca-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -92,4 +92,12 @@ jobs:
       - name: Run syscollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_syscollector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_syscollector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: syscollector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -102,4 +102,12 @@ jobs:
       - name: Run syscollector integration tests
         run: |
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_syscollector\
+          $env:GITHUB_SHA="${{ github.sha }}"; $env:GITHUB_REF_NAME="$env:BRANCH_NAME"; python -m pytest --tier 0 --tier 1 test_syscollector\ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: syscollector-test-results-${{ github.run_id }}
+          path: C:\wazuh\tests\integration\results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_vulnerability_detector-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_vulnerability_detector-tier-0-1.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run vulnerability detector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_vulnerability_detector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_vulnerability_detector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vulnerability-detector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_vulnerability_detector-tier-2.yml
+++ b/.github/workflows/4_testintegration_vulnerability_detector-tier-2.yml
@@ -80,4 +80,12 @@ jobs:
       - name: Run vulnerability detector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 2 test_vulnerability_detector/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 2 test_vulnerability_detector/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vulnerability-detector-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -89,4 +89,12 @@ jobs:
       - name: Run wazuh_db integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_wazuh_db/
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_wazuh_db/ --html=results.html --self-contained-html
+      # Upload the tests result html as an artifact
+      - name: Upload failed test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wazuh-db-test-results-${{ github.run_id }}
+          path: ./tests/integration/results.html
+          retention-days: 7

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ import pytest
 import sys
 from typing import List
 
+from py.xml import html
 from wazuh_testing import session_parameters
 from wazuh_testing.constants import platforms
 from wazuh_testing.constants.platforms import WINDOWS
@@ -113,6 +114,24 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
 
     config.hook.pytest_deselected(items=deselected_tests)
     items[:] = selected_tests
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_html_results_summary(prefix, summary, postfix):
+    """Add custom information to the HTML report summary section.
+
+    Args:
+        prefix: Content to be added before the summary table
+        summary: The summary table element
+        postfix: Content to be added after the summary table
+    """
+    commit_sha = os.getenv('GITHUB_SHA', os.getenv('GIT_COMMIT', 'unknown'))
+    branch_name = os.getenv('GITHUB_REF_NAME', os.getenv('GIT_BRANCH', 'unknown'))
+
+    prefix.extend([
+        html.p(html.strong("Branch: "), branch_name),
+        html.p(html.strong("Commit SHA: "), commit_sha)
+    ])
 
 
 # - - - - - - - - - - - - - - - - - - - - - - -End of Pytest configuration - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
## Description

  This PR implements HTML report generation for integration test workflows as requested in issue #24080.

## Changes Made

### Enhanced Test Reporting (tests/integration/conftest.py)

  - Added pytest_html_results_summary hook to customize HTML reports
  - Reports now display Branch and Commit SHA prominently in the summary section
  - Metadata is pulled from GITHUB_SHA and GITHUB_REF_NAME environment variables (with fallback
 to GIT_COMMIT and GIT_BRANCH)
  - Uses py.xml.html for proper HTML element rendering

### Updated 38 Integration Test Workflows

  For Linux/macOS workflows:
  - Added environment variables to pytest command: GITHUB_SHA and GITHUB_REF_NAME
  - Added HTML report flags: --html=results.html --self-contained-html
  - Added artifact upload step that triggers on test failure

  For Windows workflows:
  - Added PowerShell environment variables: $env:GITHUB_SHA and $env:GITHUB_REF_NAME
  - Added HTML report flags: --html=results.html --self-contained-html
  - Added artifact upload step with Windows-appropriate paths

The report look like this:
<img width="1829" height="925" alt="image" src="https://github.com/user-attachments/assets/ef3ddfdf-0702-4b9b-bd06-466d400a77d5" />


### Testing

  - ✅ Tested with various failing runs both on linux and windows
  - ✅ Verified HTML report generation includes Branch and Commit SHA metadata
  - ✅ Confirmed artifact upload works on failure

Example test result: https://github.com/wazuh/wazuh/actions/runs/20277586471?pr=33558