### PR TITLE
SCA scan results delay

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -501,12 +501,6 @@ void * wm_sca_sync_module(__attribute__((unused)) void * args) {
 
     while (sca_sync_module_running)
     {
-        // Wait for sync_interval before next cycle
-        for (uint32_t i = 0; i < sca_sync_interval && sca_sync_module_running; i++)
-        {
-            sleep(1);
-        }
-
         if (!sca_sync_module_running)
         {
             break;
@@ -570,6 +564,12 @@ void * wm_sca_sync_module(__attribute__((unused)) void * args) {
         }
 
         mdebug1("SCA synchronization cycle finished, waiting for %d seconds before next run.", sca_sync_interval);
+
+        // Wait for sync_interval before next cycle
+        for (uint32_t i = 0; i < sca_sync_interval && sca_sync_module_running; i++)
+        {
+            sleep(1);
+        }
     }
 
 #ifdef WIN32


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
When the synchronization module starts, there is an initial 5m delay (`sca_sync_interval` value) until it successfully initializes. Subsequently, upon entering the synchronization loop, there is an additional 5m delay (`sca_sync_interval` value) before the first synchronization occurs. This causes the initial scan to last more than 10 minutes from scan execution to reporting (sync) phase.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #33552 
-->

## Proposed Changes
- Moved the `sca_sync_interval` delay to the end of the synchronization loop in function `wm_sca_sync_module` of `src/wazuh_modules/wm_sca.c`.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

Important note -> `sca_sync_interval` = 5m

```
2025/12/16 14:18:43 wazuh-modulesd:sca[16570] wm_sca.c:133 at sca_log_callback(): INFO: SCA scan started.
...
2025/12/16 14:18:43 wazuh-modulesd:sca[16570] wm_sca.c:133 at sca_log_callback(): INFO: SCA scan ended.
...
2025/12/16 14:23:44 wazuh-modulesd:sca[16570] wm_sca.c:524 at wm_sca_sync_module(): DEBUG: Running SCA synchronization.
2025/12/16 14:23:44 wazuh-modulesd:sca[16570] wm_sca.c:127 at sca_log_callback(): DEBUG: SCA synchronization started.
...
2025/12/16 14:23:44 wazuh-modulesd:sca[16570] wm_sca.c:133 at sca_log_callback(): INFO: SCA synchronization finished successfully.
2025/12/16 14:23:44 wazuh-modulesd:sca[16570] wm_sca.c:529 at wm_sca_sync_module(): DEBUG: SCA synchronization succeeded.
...
2025/12/16 14:28:45 wazuh-modulesd:sca[16570] wm_sca.c:524 at wm_sca_sync_module(): DEBUG: Running SCA synchronization.
2025/12/16 14:28:45 wazuh-modulesd:sca[16570] wm_sca.c:127 at sca_log_callback(): DEBUG: SCA synchronization started.
```
Total time approximately 5 minutes, and next synchronization starts approximately 5 minutes later as expected.

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [x] Log syntax and correct language review

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
