### PR TITLE
Prevent agent termination on DB cleanup failure

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -19,7 +19,7 @@
 #include "commonDefs.h"
 
 using namespace std::chrono_literals;
-auto constexpr MAX_TRIES = 5;
+auto constexpr MAX_TRIES = 10;
 
 SQLiteDBEngine::SQLiteDBEngine(const std::shared_ptr<ISQLiteFactory>& sqliteFactory,
                                const std::string&                     path,
@@ -553,7 +553,9 @@ void SQLiteDBEngine::initialize(const std::string&              path,
     {
         if (!cleanDB(path))
         {
-            throw dbengine_error {DELETE_OLD_DB_ERROR};
+            // Use detailed error message if available, otherwise use default
+            auto errorMsg = m_lastCleanDBError.empty() ? DELETE_OLD_DB_ERROR.second : m_lastCleanDBError;
+            throw dbengine_error {std::make_pair(DELETE_OLD_DB_ERROR.first, errorMsg)};
         }
 
         m_sqliteConnection = m_sqliteFactory->createConnection(path);
@@ -618,22 +620,34 @@ bool SQLiteDBEngine::cleanDB(const std::string& path)
 {
     auto ret { true };
     auto isRemoved {0};
+    auto lastErrno {0};
 
     if (path.compare(":memory") != 0)
     {
         if (std::ifstream(path))
         {
             isRemoved = std::remove(path.c_str());
+            lastErrno = errno;
 
             for (uint8_t amountTries = 0; amountTries < MAX_TRIES && isRemoved; amountTries++)
             {
                 std::this_thread::sleep_for(1s); //< Sleep for 1s
-                std::cerr << "Sleep for 1s and try to delete database again.\n";
+                std::cerr << "Failed to delete database file '" << path
+                          << "' (errno: " << lastErrno << "). Retry attempt "
+                          << static_cast<int>(amountTries + 1) << "/" << MAX_TRIES << ".\n";
                 isRemoved = std::remove(path.c_str());
+                lastErrno = errno;
             }
 
             if (isRemoved)
             {
+                std::cerr << "Failed to delete database file '" << path
+                          << "' after " << MAX_TRIES << " attempts (errno: " << lastErrno << ").\n";
+
+                // Store detailed error message for exception
+                m_lastCleanDBError = "Error deleting old db file '" + path +
+                                     "' after " + std::to_string(MAX_TRIES) +
+                                     " attempts (errno: " + std::to_string(lastErrno) + ")";
                 ret = false;
             }
         }

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -323,6 +323,7 @@ class SQLiteDBEngine final : public DbSync::IDbEngine
         std::unique_ptr<SQLite::ITransaction> m_transaction;
         std::mutex m_maxRowsMutex;
         std::map<std::string, MaxRows> m_maxRows;
+        std::string m_lastCleanDBError;
 };
 
 #endif // _SQLITE_DBENGINE_H

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -46,7 +46,19 @@ static sqlite3* openSQLiteDb(const std::string& path, const int flags = SQLITE_O
     {
         sqlite3_open_v2(path.c_str(), &pDb, flags, nullptr)
     };
-    checkSqliteResult(result, "Unspecified type during initialization of SQLite.");
+
+    if (SQLITE_OK != result)
+    {
+        std::string errorMsg = "Error opening SQLite database '" + path + "' (SQLite error code: " + std::to_string(result) + ")";
+
+        if (pDb)
+        {
+            errorMsg += ": " + std::string(sqlite3_errmsg(pDb));
+        }
+
+        checkSqliteResult(result, errorMsg);
+    }
+
     return pDb;
 }
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -284,7 +284,8 @@ FIMDBErrorCode fim_db_init(int storage,
     catch (const std::exception& ex)
     {
         auto errorMessage { std::string("Error, id: ") + ex.what() };
-        log_callback(LOG_ERROR_EXIT, errorMessage.c_str());
+        log_callback(LOG_ERROR, errorMessage.c_str());
+        retVal = FIMDBErrorCode::FIMDB_ERR;
     }
 
     // LCOV_EXCL_STOP

--- a/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/dbInterface/dbTest.cpp
@@ -223,7 +223,7 @@ TEST(DBTest, TestInvalidFimLimit)
     mockSync = new MockSyncMsg();
 
     EXPECT_CALL(*mockLog,
-                loggingFunction(LOG_ERROR_EXIT,
+                loggingFunction(LOG_ERROR,
                                 "Error, id: dbEngine: Invalid row limit, values below 0 not allowed.")).Times(1);
     auto result
     {

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -286,7 +286,7 @@ int main(int argc, char **argv)
 
     fim_initialize();
 
-    if (start_realtime == 1) {
+    if (!syscheck.disabled && start_realtime == 1) {
         realtime_start();
     }
 

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -110,7 +110,9 @@ void fim_initialize() {
 #endif
 
     if (ret_val != FIMDB_OK) {
-        merror_exit("Unable to initialize database.");
+        merror("Unable to initialize database. FIM module will be disabled.");
+        syscheck.disabled = 1;
+        return;
     }
 
     w_rwlock_init(&syscheck.directories_lock, NULL);


### PR DESCRIPTION
  ## Description

  This PR fixes a critical bug in FIM (File Integrity Monitoring) where the Windows agent terminates completely when the database cleanup process fails during initialization. The issue manifests specifically when FIM Registry monitoring is enabled under stress conditions.

  **Root Cause:**
  When `cleanDB()` fails to delete an old database file (common in Windows due to file locks from antivirus, backup processes, or concurrent threads), the error is treated as `LOG_ERROR_EXIT`, which calls `merror_exit()` and terminates the entire agent process. This results in complete loss of monitoring and metrics collection.

  **Impact:**
  - Agent goes offline without recovery
  - Production environments with FIM Registry enabled are at risk

  Closes #33525

  ## Proposed Changes

  ### 1. Graceful Error Handling in `fim_db_init()`
  - Changed `LOG_ERROR_EXIT` to `LOG_ERROR` to prevent agent termination
  - Added proper error return (`FIMDB_ERR`) instead of process exit
  - **Impact:** Agent continues operating even when database cleanup fails

  ### 2. Increased Retry Attempts
  - Increased `MAX_TRIES` from 5 to 10
  - Provides 10 seconds total retry window instead of 5
  - **Impact:** Better resilience under high load and temporary file locks

  ### 3. Enhanced Diagnostic Logging
  - Added detailed error messages including:
    - Full database file path
    - System error code (`errno`)
    - Current retry attempt number
  - **Impact:** Improved debugging capability for file lock issues


  ## Results and Evidence

  **Before:**
  ```
  2025/12/05 17:31:22 wazuh-agent: CRITICAL: Error, id: dbEngine: Error deleting old db.
  2025/12/05 17:31:22 wazuh-agent: INFO: Received exit signal. Starting exit process.
  2025/12/05 17:31:23 wazuh-agent: INFO: Exit completed successfully.
  ```
  - Agent terminated, no recovery possible

  **After:**
  ```
  Failed to delete database file '/path/to/db.db' (errno: 13). Retry attempt 1/10.
  Failed to delete database file '/path/to/db.db' after 10 attempts (errno: 13).
  2025/12/16 17:31:22 wazuh-agent: ERROR: Error, id: dbEngine: Error deleting old db.
  ```
  - Agent logs error but continues running

## Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [x] Log syntax and correct language review
 
### Additional Manual Testing Required:
  - Verify agent remains operational when database deletion fails
  - Confirm enhanced logging provides sufficient debugging information

## Manual Test

### 1. Normal inicialization

Start Agent - Agent connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

FIM started
```
2025/12/17 11:52:48 wazuh-agent: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/12/17 11:52:48 wazuh-agent: INFO: (6008): File integrity monitoring scan started.
2025/12/17 11:53:33 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2025/12/17 11:53:33 wazuh-agent: INFO: FIM sync module started.
2025/12/17 11:53:35 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
```

### 2. Database locked for reading.

Running the script to lock read the db

``` powershel
PS C:\Program Files (x86)\ossec-agent\queue\fim\db> .\lock-fim-db.ps1
Blocking DB file: C:\Program Files (x86)\ossec-agent\queue\fim\db\fim.db
DB locked. Press any key to release...
```

Start Agent - Agent connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

FIM stops
```
2025/12/17 17:01:38 wazuh-agent: ERROR: Error, id: sqlite: Error opening SQLite database 'queue/fim/db/fim.db' (SQLite error code: 14): unable to open database file
2025/12/17 17:01:38 wazuh-agent: ERROR: Unable to initialize database. FIM module will be disabled.
```

Agent still connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

Release the db

Agent still connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

### 3. Database locked for deleting

Running the script to lock writte or delete the db

```powershel
PS C:\Program Files (x86)\ossec-agent\queue\fim\db> .\lock-fim-db.ps1
Blocking DB file: C:\Program Files (x86)\ossec-agent\queue\fim\db\fim.db
DB locked. Press any key to release...
```

Start Agent - Agent connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

FIM stops
```
2025/12/17 16:36:29 wazuh-agent: ERROR: Error, id: dbEngine: Error deleting old db file 'queue/fim/db/fim.db' after 10 attempts (errno: 13)
2025/12/17 16:36:29 wazuh-agent: ERROR: Unable to initialize database. FIM module will be disabled.
```

Agent still connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

Release the db

Agent still connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```


### 4. Restar agent without blocking the db. 

Start Agent - Agent connected
```console
Wazuh agent_control. List of available agents:
   ID: 015, Name: DESKTOP-VM, IP: any, Active
```

FIM started
```
2025/12/17 12:13:59 wazuh-agent: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/12/17 12:13:59 wazuh-agent: INFO: (6008): File integrity monitoring scan started.
2025/12/17 12:14:44 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2025/12/17 12:14:44 wazuh-agent: INFO: FIM sync module started.
2025/12/17 12:14:46 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
```


## Artifacts Affected

  Executables:
  - wazuh-agent (Windows Server 2019+, Windows 10+)
  - wazuh-agent (Linux - shared dbsync module)

  Components Modified:
  - FIM database initialization (syscheckd)
  - SQLite database engine (shared_modules/dbsync)

## Configuration Changes

  N/A - No configuration changes required. The fix is transparent to end users.

## Tests Introduced

  - Unit Tests Required:
    - Updated existing tests.

  - Integration Tests Required:
    - Windows agent with FIM Registry under load
    - Simulated file lock scenarios
    - Verify footprint metrics collection continues after DB cleanup failure

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

## Related Issues:
  - Issue #18968 (previous similar bug in syscollector - partial fix with retry mechanism)
  - Issue #33441 (footprint metrics stress test failure)
  - Issue #33445 (related footprint test failure)

