### PR TITLE
Change wazuh.cluster.name to "wazuh"

### DIFF
--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -676,7 +676,7 @@ int main(int argc, char* argv[])
                     archiver->archive(msg.data());
                     auto event = base::eventParsers::parseLegacyEvent(msg, hostInfo);
                     // TODO: momentary change
-                    event->setString("temp-cluster-name", "/wazuh/cluster/name");
+                    event->setString("wazuh", "/wazuh/cluster/name");
                     orchestrator->postEvent(std::move(event));
                 },
                 confManager.get<std::string>(conf::key::SERVER_EVENT_SOCKET));
@@ -701,7 +701,7 @@ int main(int argc, char* argv[])
                     std::queue<base::Event> modifiedEvents;
                     while (!batchEvents.empty())
                     {
-                        batchEvents.front()->setString("temp-cluster-name", "/wazuh/cluster/name");
+                        batchEvents.front()->setString("wazuh", "/wazuh/cluster/name");
                         modifiedEvents.push(std::move(batchEvents.front()));
                         batchEvents.pop();
                     }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Close  #33587

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

Modify default value forced on engine main to "wazuh"

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

```console
╰─# cat /workspaces/wazuh-5.x-v1/intelligence-data/ruleset/integrations/aws/test/s3access/aws-s3access_input.txt >> /var/ossec/logs/active-responses.log
```

```json
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"cluster":{"name":"wazuh"},"integration":{"category":"security","name":"wazuh-core","decoders":["core-wazuh-message","integrations"]}},"agent":{"name":"09c2e042038b","id":"000"},"host":{"os":{"name":"Ubuntu","version":"22.04.5 LTS (Jammy Jellyfish)","full":"jammy","platform":"ubuntu","kernel":"Linux |09c2e042038b |5.15.0-144-generic |#157-Ubuntu SMP Mon Jun 16 07:33:10 UTC 2025 |x86_64"},"ip":["172.17.0.3"],"architecture":"x86_64"},"event":{"original":"ossec: output: 'df -P': /dev/mapper/ubuntu--vg-ubuntu--lv   253706580 132856308 110191764      55% /usr/sbin/docker-init"},"@timestamp":"2025-12-18T15:58:59Z"}
{"wazuh":{"protocol":{"queue":49,"location":"netstat listening ports"},"cluster":{"name":"wazuh"},"integration":{"category":"security","name":"wazuh-core","decoders":["core-wazuh-message","integrations"]}},"agent":{"name":"09c2e042038b","id":"000"},"host":{"os":{"name":"Ubuntu","version":"22.04.5 LTS (Jammy Jellyfish)","full":"jammy","platform":"ubuntu","kernel":"Linux |09c2e042038b |5.15.0-144-generic |#157-Ubuntu SMP Mon Jun 16 07:33:10 UTC 2025 |x86_64"},"ip":["172.17.0.3"],"architecture":"x86_64"},"event":{"original":"ossec: output: 'netstat listening ports':\ntcp 0.0.0.0:443 0.0.0.0:* 871538/node\ntcp 0.0.0.0:1514 0.0.0.0:* 870087/wazuh-remote\ntcp 0.0.0.0:1515 0.0.0.0:* 869777/wazuh-authd\ntcp 127.0.0.1:1516 0.0.0.0:* 870368/python3\ntcp 0.0.0.0:2222 0.0.0.0:* /usr\ntcp6 :::2222 :::* /usr\ntcp6 :::9200 :::* 869470/java\ntcp6 :::9300 :::* 869470/java\ntcp 127.0.0.1:42169 0.0.0.0:* 586/node\ntcp 0.0.0.0:55000 0.0.0.0:* 869763/python3\ntcp6 :::55000 :::* 869763/python3"},"@timestamp":"2025-12-18T15:58:59Z"}
```

<img width="1920" height="930" alt="image" src="https://github.com/user-attachments/assets/b81a7d75-baf2-4320-a405-2290526966df" />

<img width="1920" height="930" alt="image" src="https://github.com/user-attachments/assets/bec722bd-52ea-46d0-b8d9-69e702da6a99" />

Events from agent 5.0 

```json
╰─# tail  /var/ossec/logs/alerts/alerts.json | grep "pm-ubuntu24-server"                                                                                                                  1 ↵
{"wazuh":{"protocol":{"queue":49,"location":"journald"},"cluster":{"name":"wazuh"},"integration":{"category":"system-activity","name":"syslog","decoders":["core-wazuh-message","integrations","syslog"]}},"agent":{"name":"pm-ubuntu24-server","version":"Wazuh v5.0.0","id":"001"},"host":{"os":{"name":"Ubuntu","version":"24.04.1 LTS","full":"Noble Numbat","platform":"ubuntu","kernel":"Linux |pm-ubuntu24-server |6.8.0-57-generic |#59-Ubuntu SMP PREEMPT_DYNAMIC Sat Mar 15 17:40:59 UTC 2025 |x86_64"},"ip":["192.168.0.141"],"architecture":"x86_64","hostname":"pm-ubuntu24-server"},"event":{"original":"Dec 18 18:30:23 pm-ubuntu24-server systemd[1]: Starting sysstat-collect.service - system activity accounting tool...","start":"2025-12-18T18:30:23.000Z","kind":"event"},"@timestamp":"2025-12-18T18:30:25Z","process":{"pid":1,"name":"systemd"},"message":"Starting sysstat-collect.service - system activity accounting tool...","related":{"hosts":["pm-ubuntu24-server"]}}
{"wazuh":{"protocol":{"queue":49,"location":"journald"},"cluster":{"name":"wazuh"},"integration":{"category":"system-activity","name":"syslog","decoders":["core-wazuh-message","integrations","syslog"]}},"agent":{"name":"pm-ubuntu24-server","version":"Wazuh v5.0.0","id":"001"},"host":{"os":{"name":"Ubuntu","version":"24.04.1 LTS","full":"Noble Numbat","platform":"ubuntu","kernel":"Linux |pm-ubuntu24-server |6.8.0-57-generic |#59-Ubuntu SMP PREEMPT_DYNAMIC Sat Mar 15 17:40:59 UTC 2025 |x86_64"},"ip":["192.168.0.141"],"architecture":"x86_64","hostname":"pm-ubuntu24-server"},"event":{"original":"Dec 18 18:30:23 pm-ubuntu24-server systemd[1]: sysstat-collect.service: Deactivated successfully.","start":"2025-12-18T18:30:23.000Z","kind":"event"},"@timestamp":"2025-12-18T18:30:25Z","process":{"pid":1,"name":"systemd"},"message":"sysstat-collect.service: Deactivated successfully.","related":{"hosts":["pm-ubuntu24-server"]}}
{"wazuh":{"protocol":{"queue":49,"location":"journald"},"cluster":{"name":"wazuh"},"integration":{"category":"system-activity","name":"syslog","decoders":["core-wazuh-message","integrations","syslog"]}},"agent":{"name":"pm-ubuntu24-server","version":"Wazuh v5.0.0","id":"001"},"host":{"os":{"name":"Ubuntu","version":"24.04.1 LTS","full":"Noble Numbat","platform":"ubuntu","kernel":"Linux |pm-ubuntu24-server |6.8.0-57-generic |#59-Ubuntu SMP PREEMPT_DYNAMIC Sat Mar 15 17:40:59 UTC 2025 |x86_64"},"ip":["192.168.0.141"],"architecture":"x86_64","hostname":"pm-ubuntu24-server"},"event":{"original":"Dec 18 18:30:23 pm-ubuntu24-server systemd[1]: Finished sysstat-collect.service - system activity accounting tool.","start":"2025-12-18T18:30:23.000Z","kind":"event"},"@timestamp":"2025-12-18T18:30:25Z","process":{"pid":1,"name":"systemd"},"message":"Finished sysstat-collect.service - system activity accounting tool.","related":{"hosts":["pm-ubuntu24-server"]}}
```
<img width="1920" height="930" alt="image (3)" src="https://github.com/user-attachments/assets/9635bd64-532b-4f3c-a791-ee8c9f0039a8" />
<img width="1920" height="930" alt="image (2)" src="https://github.com/user-attachments/assets/ee13aa41-21fb-417f-9e4b-9ede663028bf" />
<img width="1920" height="930" alt="image (1)" src="https://github.com/user-attachments/assets/e23da1f2-8904-42bd-a24f-b61233102e3a" />



<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
