### PR TITLE
ThreadSanitizer SEGV Fix: Race Condition

### DIFF
--- a/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp
+++ b/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp
@@ -9,11 +9,21 @@
 #include <gtest/gtest.h>
 
 #include <base/json.hpp>
+#include <base/utils/hash.hpp>
 #include <cmstore/icmstore.hpp>
 #include <cmstore/mockcmstore.hpp>
 #include <cmstore/datakvdb.hpp>
 
 #include <kvdbstore/kvdbManager.hpp>
+
+class KVDB_Component : public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        [[maybe_unused]] volatile auto warmup = base::utils::hash::sha256("openssl_init");
+    }
+};
 
 namespace
 {
@@ -53,7 +63,7 @@ inline std::vector<std::reference_wrapper<const json::Json>> parallelReadRefs(kv
 } // namespace
 
 // Build once and then serve from the cache: no refetch, same pointer.
-TEST(KVDB_Component, BuildOnceThenCache_NoRefetch_SamePointer)
+TEST_F(KVDB_Component, BuildOnceThenCache_NoRefetch_SamePointer)
 {
     kvdbstore::KVDBManager mgr;
     cm::store::NamespaceId nsId {"ns"};
@@ -86,7 +96,7 @@ TEST(KVDB_Component, BuildOnceThenCache_NoRefetch_SamePointer)
 }
 
 // After all handlers are released, a subsequent request rebuilds with new content.
-TEST(KVDB_Component, ExpireAllHandlers_RebuildWithNewContent)
+TEST_F(KVDB_Component, ExpireAllHandlers_RebuildWithNewContent)
 {
     kvdbstore::KVDBManager mgr;
     cm::store::NamespaceId nsId {"ns"};
@@ -118,7 +128,7 @@ TEST(KVDB_Component, ExpireAllHandlers_RebuildWithNewContent)
 }
 
 // Different namespaces and db names are fully isolated (distinct caches).
-TEST(KVDB_Component, CrossNamespaceAndDb_IsolatedCaches)
+TEST_F(KVDB_Component, CrossNamespaceAndDb_IsolatedCaches)
 {
     kvdbstore::KVDBManager mgr;
     cm::store::NamespaceId nsA {"A"}, nsB {"B"};
@@ -163,7 +173,7 @@ TEST(KVDB_Component, CrossNamespaceAndDb_IsolatedCaches)
 }
 
 // Concurrent cold race on the same (ns, db) eventually converges to a stable cache.
-TEST(KVDB_Component, ConcurrentColdRace_EventualConvergence)
+TEST_F(KVDB_Component, ConcurrentColdRace_EventualConvergence)
 {
     kvdbstore::KVDBManager mgr;
     cm::store::NamespaceId nsId {"ns"};
@@ -215,7 +225,7 @@ TEST(KVDB_Component, ConcurrentColdRace_EventualConvergence)
 }
 
 // Non-object payloads are invalid and must throw during build.
-TEST(KVDB_Component, InvalidPayload_Throws)
+TEST_F(KVDB_Component, InvalidPayload_Throws)
 {
     kvdbstore::KVDBManager mgr;
     cm::store::NamespaceId nsId {"ns"};
@@ -239,7 +249,7 @@ TEST(KVDB_Component, InvalidPayload_Throws)
 }
 
 // Mixed value types (object, array, number, boolean, string, null) are supported as values.
-TEST(KVDB_Component, NestedValues_AccessAndEquality)
+TEST_F(KVDB_Component, NestedValues_AccessAndEquality)
 {
     kvdbstore::KVDBManager mgr;
     cm::store::NamespaceId nsId {"ns"};

--- a/src/engine/source/router/include/router/orchestrator.hpp
+++ b/src/engine/source/router/include/router/orchestrator.hpp
@@ -1,6 +1,7 @@
 #ifndef _ROUTER_ORCHESTATOR_HPP
 #define _ROUTER_ORCHESTATOR_HPP
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <shared_mutex>
@@ -43,6 +44,7 @@ protected:
     std::list<std::shared_ptr<IWorker<IRouter>>> m_routerWorkers;
     std::shared_ptr<IWorker<ITester>> m_testerWorker;
     mutable std::shared_mutex m_syncMutex; ///< Mutex for the Workers synchronization (1 query at a time)
+    std::atomic<bool> m_isShutdown{false}; ///< Flag to indicate orchestrator has been shutdown
 
     // Workers configuration
     std::shared_ptr<ProdQueueType> m_eventQueue;      ///< The event queue
@@ -60,6 +62,10 @@ protected:
     using WorkerOp = std::function<base::OptError(const std::shared_ptr<IWorker<T>>&)>;
     base::OptError forEachRouterWorker(const WorkerOp<IRouter>& f);
     base::OptError forTesterWorker(const WorkerOp<ITester>& f);
+
+    void dumpTestersInternal() const;                                        ///< Dump testers (lock must be held)
+    void dumpRoutersInternal() const;                                        ///< Dump routers (lock must be held)
+    void dumpEpsInternal() const;                                            ///< Dump EPS (lock must be held)
 
     void dumpTesters() const;                                                ///< Dump the testers to the store
     void dumpRouters() const;                                                ///< Dump the routers to the store


### PR DESCRIPTION
## Description

[Spike #32387](https://github.com/wazuh/wazuh/issues/32387)  ThreadSanitizer detected multiple critical race conditions in the router orchestrator and logging subsystems that caused segmentation faults and test failures.

 #### Issue 1: Router Orchestrator Race Condition

- **Error Type:** SEGV (Segmentation Fault)
- **Memory Address:** `0x000000000000` (null pointer dereference)
- **Location:** `orchestrator.cpp:449` in `getEntries()`
- **Root Cause:** Time-Of-Check-To-Time-Of-Use (TOCTOU) vulnerability

<details><summary>Tsan_report</summary>
<p>

```bash
==256415==ERROR: ThreadSanitizer: SEGV on unknown address 0x000000000000 (pc 0x559009e7a933 bp 0x7fab2c3e6af0 sp 0x7fab2c3e6aa0 T256727)
==256415==The signal is caused by a READ memory access.
==256415==Hint: address points to the zero page.
    #0 router::Orchestrator::getEntries[abi:cxx11]() const /workspaces/Wazuh_5x/wazuh/src/engine/source/router/src/orchestrator.cpp:449 (wazuh-analysisdTsan+0x124a933) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #1 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/main.cpp:584 (wazuh-analysisdTsan+0xd73338) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #2 __invoke_impl<void, main(int, char**)::<lambda()>&> /usr/include/c++/14/bits/invoke.h:61 (wazuh-analysisdTsan+0xd7e857) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #3 __invoke_r<void, main(int, char**)::<lambda()>&> /usr/include/c++/14/bits/invoke.h:111 (wazuh-analysisdTsan+0xd7d86c) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #4 _M_invoke /usr/include/c++/14/bits/std_function.h:290 (wazuh-analysisdTsan+0xd7c2be) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #5 std::function<void ()>::operator()() const /usr/include/c++/14/bits/std_function.h:591 (wazuh-analysisdTsan+0xdbfbde) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #6 scheduler::Scheduler::executeTask(scheduler::TaskQueue::TaskItem const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/scheduler/src/scheduler.cpp:217 (wazuh-analysisdTsan+0x12f39f4) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #7 scheduler::Scheduler::workerThread() /workspaces/Wazuh_5x/wazuh/src/engine/source/scheduler/src/scheduler.cpp:177 (wazuh-analysisdTsan+0x12f351f) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #8 void std::__invoke_impl<void, void (scheduler::Scheduler::*)(), scheduler::Scheduler*>(std::__invoke_memfun_deref, void (scheduler::Scheduler::*&&)(), scheduler::Scheduler*&&) /usr/include/c++/14/bits/invoke.h:74 (wazuh-analysisdTsan+0x12fc091) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #9 std::__invoke_result<void (scheduler::Scheduler::*)(), scheduler::Scheduler*>::type std::__invoke<void (scheduler::Scheduler::*)(), scheduler::Scheduler*>(void (scheduler::Scheduler::*&&)(), scheduler::Scheduler*&&) /usr/include/c++/14/bits/invoke.h:96 (wazuh-analysisdTsan+0x12fbf5e) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #10 void std::thread::_Invoker<std::tuple<void (scheduler::Scheduler::*)(), scheduler::Scheduler*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/include/c++/14/bits/std_thread.h:301 (wazuh-analysisdTsan+0x12fbe5a) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #11 std::thread::_Invoker<std::tuple<void (scheduler::Scheduler::*)(), scheduler::Scheduler*> >::operator()() /usr/include/c++/14/bits/std_thread.h:308 (wazuh-analysisdTsan+0x12fbd72) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #12 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (scheduler::Scheduler::*)(), scheduler::Scheduler*> > >::_M_run() /usr/include/c++/14/bits/std_thread.h:253 (wazuh-analysisdTsan+0x12fbce8) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #13 execute_native_thread_routine <null> (wazuh-analysisdTsan+0x1944393) (BuildId: dfeb9fcefa84a8cd6cdf7de0e555041b5c1a47e6)
    #14 __tsan_thread_start_func ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1012 (libtsan.so.2+0x4edee) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #15 start_thread nptl/pthread_create.c:447 (libc.so.6+0x9caa3) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #16 clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78 (libc.so.6+0x129c6b) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)

ThreadSanitizer can not provide additional info.
SUMMARY: ThreadSanitizer: SEGV /workspaces/Wazuh_5x/wazuh/src/engine/source/router/src/orchestrator.cpp:449 in router::Orchestrator::getEntries[abi:cxx11]() const
==256415==ABORTING
```
</p>
</details> 

**Race Condition Flow:**

1. Scheduler thread calls `getEntries() `and acquires `shared_lock`
2. Cleanup thread calls `cleanup()` with incorrect `shared_lock` 
3. Cleanup clears `m_routerWorkers` while other threads can still read it
4. Scheduler thread calls `front()` on empty list 


**Root Cause:** Race condition between scheduler threads calling `getEntries()` and cleanup operations. The `cleanup()` method used a `shared_lock `(read lock) instead of `unique_lock `(write lock), allowing concurrent reads while clearing `m_routerWorkers`, resulting in null pointer dereference.


#### Issue 2: Router Orchestrator Deadlock

**Problem:** After fixing the initial race condition, integration tests revealed a deadlock caused by attempting to acquire locks twice in nested function calls. 

TSAN Report Summary:
- **Error Type:** Deadlock / Lock ordering issue
- **Location:** `orchestrator.cpp` - multiple `dump*()` methods
- **Root Cause:** Lock re-acquisition in nested calls

**Deadlock Flow:**

1. Public method acquires unique_lock (e.g., `postEntry()`, `deleteEntry()`)
2. Same method calls `dumpRouters()` or `dumpTesters()`
3. `dump*()` methods attempt to acquire `shared_lock` again
4. **Deadlock:** Thread already holds a lock and tries to acquire another

```cpp
base::OptError Orchestrator::postEntry(const prod::EntryPost& entry) {
    std::unique_lock lock {m_syncMutex};  // ← Lock acquired
    // ... operations ...
    dumpRouters();  // ← Tries to acquire shared_lock AGAIN → DEADLOCK
}
```
**Solution:** Introduced *Internal variants of dump methods that assume lock is already held:
`dumpTestersInternal()` - no lock acquisition
`dumpRoutersInternal()` - no lock acquisition
`dumpEpsInternal()` - no lock acquisition
Public methods (`dumpTesters()`, `dumpRouters()`, `dumpEps()`) acquire locks and call Internal variants.


### Issue 3: Logging Subsystem Data Races

**Problem:**  ChannelHandler tests  failed due to data races in CustomSink. 

**TSAN Report Summary:**

- **Error Type:** Data race (concurrent unsynchronized writes)
- **Memory Address:** 0x720c0000004c (shared mutable state in CustomSink)
- **Locations:**
`logging.cpp:37` in `CustomSink::log()`
`logging.cpp:55` in `CustomSink::flush()`
`spdlog/pattern_formatter-inl.h:970`
- **Root Cause:** CustomSink not thread-safe despite multi-threaded usage


<details><summary>TSAN Report - CustomSink Data Race</summary> 

<p>

```bash
==================
6882: WARNING: ThreadSanitizer: data race (pid=114085)
6882:   Write of size 4 at 0x720c0000004c by thread T5:
6882:     #0 logging::CustomSink::log(spdlog::details::log_msg const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/src/logging.cpp:37 (streamlogger_utest+0x68a664) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #1 spdlog::logger::sink_it_(spdlog::details::log_msg const&) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger-inl.h:138 (streamlogger_utest+0x3c02cf) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #2 spdlog::logger::log_it_(spdlog::details::log_msg const&, bool, bool) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger-inl.h:128 (streamlogger_utest+0x56632e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #3 void spdlog::logger::log_<char const*&, int>(spdlog::source_loc, spdlog::level::level_enum, fmt::v8::basic_string_view<char>, char const*&, int&&) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger.h:332 (streamlogger_utest+0x568449) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #4 void spdlog::logger::log<char const*&, int>(spdlog::source_loc, spdlog::level::level_enum, fmt::v8::basic_format_string<char, fmt::v8::type_identity<char const*&>::type, fmt::v8::type_identity<int>::type>, char const*&, int&&) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger.h:80 (streamlogger_utest+0x567626) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #5 logging::backend_log(logging::Level, char const*, int, char const*, char const*, unsigned long) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/include/base/logging.hpp:274 (streamlogger_utest+0x566cf5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #6 void logging::log_bridge<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(logging::Level, char const*, int, char const*, fmt::v8::basic_format_string<char, fmt::v8::type_identity<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::type>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/include/base/logging.hpp:328 (streamlogger_utest+0x567b30) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #7 streamlog::ChannelHandler::workerThreadFunc() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/src/channel.cpp:282 (streamlogger_utest+0x570e26) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #8 void std::__invoke_impl<void, void (streamlog::ChannelHandler::*)(), streamlog::ChannelHandler*>(std::__invoke_memfun_deref, void (streamlog::ChannelHandler::*&&)(), streamlog::ChannelHandler*&&) /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x5d7d4e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #9 std::__invoke_result<void (streamlog::ChannelHandler::*)(), streamlog::ChannelHandler*>::type std::__invoke<void (streamlog::ChannelHandler::*)(), streamlog::ChannelHandler*>(void (streamlog::ChannelHandler::*&&)(), streamlog::ChannelHandler*&&) /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x5d7b8d) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #10 void std::thread::_Invoker<std::tuple<void (streamlog::ChannelHandler::*)(), streamlog::ChannelHandler*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x5d7a2c) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #11 std::thread::_Invoker<std::tuple<void (streamlog::ChannelHandler::*)(), streamlog::ChannelHandler*> >::operator()() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x5d77b0) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #12 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (streamlog::ChannelHandler::*)(), streamlog::ChannelHandler*> > >::_M_run() /usr/include/c++/14/bits/std_thread.h:253 (streamlogger_utest+0x5d74ac) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #13 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
6882: 
6882:   Previous write of size 4 at 0x720c0000004c by thread T4 (mutexes: write M0):
6882:     #0 logging::CustomSink::log(spdlog::details::log_msg const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/src/logging.cpp:37 (streamlogger_utest+0x68a664) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #1 spdlog::logger::sink_it_(spdlog::details::log_msg const&) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger-inl.h:138 (streamlogger_utest+0x3c02cf) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #2 spdlog::logger::log_it_(spdlog::details::log_msg const&, bool, bool) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger-inl.h:128 (streamlogger_utest+0x56632e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #3 void spdlog::logger::log_<char const*&, int>(spdlog::source_loc, spdlog::level::level_enum, fmt::v8::basic_string_view<char>, char const*&, int&&) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger.h:332 (streamlogger_utest+0x568449) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #4 void spdlog::logger::log<char const*&, int>(spdlog::source_loc, spdlog::level::level_enum, fmt::v8::basic_format_string<char, fmt::v8::type_identity<char const*&>::type, fmt::v8::type_identity<int>::type>, char const*&, int&&) /workspaces/Wazuh_5x/wazuh/src/external/spdlog/include/spdlog/logger.h:80 (streamlogger_utest+0x567626) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #5 logging::backend_log(logging::Level, char const*, int, char const*, char const*, unsigned long) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/include/base/logging.hpp:274 (streamlogger_utest+0x566cf5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #6 void logging::log_bridge<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(logging::Level, char const*, int, char const*, fmt::v8::basic_format_string<char, fmt::v8::type_identity<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>::type>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/include/base/logging.hpp:328 (streamlogger_utest+0x567b30) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #7 streamlog::ChannelHandler::createWriter() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/src/channel.cpp:693 (streamlogger_utest+0x5744c8) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #8 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/test/src/unit/channel_test.cpp:957 (streamlogger_utest+0x4bed51) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #9 __invoke_impl<void, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (streamlogger_utest+0x4db71f) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #10 __invoke<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4db56e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #11 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x4db3d6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #12 operator() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x4db22c) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #13 operator() /usr/include/c++/14/future:1439 (streamlogger_utest+0x4dac27) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #14 __invoke_impl<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>&> /usr/include/c++/14/bits/invoke.h:61 (streamlogger_utest+0x4da5fa) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #15 __invoke_r<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>&> /usr/include/c++/14/bits/invoke.h:114 (streamlogger_utest+0x4d9e49) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #16 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (streamlogger_utest+0x4d95b2) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #17 std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>::operator()() const /usr/include/c++/14/bits/std_function.h:591 (streamlogger_utest+0x4ea6fe) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #18 std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) /usr/include/c++/14/future:596 (streamlogger_utest+0x4e40b4) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #19 void std::__invoke_impl<void, void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::__invoke_memfun_deref, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x4fb9a6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #20 std::__invoke_result<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>::type std::__invoke<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4f3a80) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #21 std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}::operator()() const /usr/include/c++/14/mutex:909 (streamlogger_utest+0x4ea507) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #22 std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::operator()() const /usr/include/c++/14/mutex:845 (streamlogger_utest+0x4f3af6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #23 std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::_FUN() /usr/include/c++/14/mutex:845 (streamlogger_utest+0x4f3b3d) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #24 pthread_once ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1587 (libtsan.so.2+0x57ff5) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #25 __gthread_once /usr/include/x86_64-linux-gnu/c++/14/bits/gthr-default.h:713 (streamlogger_utest+0x4aca10) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #26 void std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/mutex:916 (streamlogger_utest+0x4ea5f1) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #27 std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>, bool) /usr/include/c++/14/future:435 (streamlogger_utest+0x4e3f6e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #28 _M_run /usr/include/c++/14/future:1781 (streamlogger_utest+0x4d85f9) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #29 __invoke_impl<void, void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>*> /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x4e2aa5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #30 __invoke<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>*> /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4e2760) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #31 _M_invoke<0, 1> /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x4e23fc) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #32 operator() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x4e217a) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #33 _M_run /usr/include/c++/14/bits/std_thread.h:253 (streamlogger_utest+0x4e0efa) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #34 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
6882: 
6882:   Location is heap block of size 40 at 0x720c00000030 allocated by main thread:
6882:     #0 operator new(unsigned long) ../../../../src/libsanitizer/tsan/tsan_new_delete.cpp:64 (libtsan.so.2+0xa6fae) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #1 std::__new_allocator<std::_Sp_counted_ptr_inplace<logging::CustomSink, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/include/c++/14/bits/new_allocator.h:151 (streamlogger_utest+0x69bad4) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #2 std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<logging::CustomSink, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<logging::CustomSink, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/include/c++/14/bits/alloc_traits.h:478 (streamlogger_utest+0x699a35) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #3 std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<logging::CustomSink, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<logging::CustomSink, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<logging::CustomSink, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> >&) /usr/include/c++/14/bits/allocated_ptr.h:98 (streamlogger_utest+0x699a35)
6882:     #4 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<logging::CustomSink, std::allocator<void>>(logging::CustomSink*&, std::_Sp_alloc_shared_tag<std::allocator<void> >) /usr/include/c++/14/bits/shared_ptr_base.h:967 (streamlogger_utest+0x697722) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #5 std::__shared_ptr<logging::CustomSink, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>>(std::_Sp_alloc_shared_tag<std::allocator<void> >) /usr/include/c++/14/bits/shared_ptr_base.h:1713 (streamlogger_utest+0x694530) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #6 std::shared_ptr<logging::CustomSink>::shared_ptr<std::allocator<void>>(std::_Sp_alloc_shared_tag<std::allocator<void> >) /usr/include/c++/14/bits/shared_ptr.h:463 (streamlogger_utest+0x691def) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #7 std::shared_ptr<std::enable_if<!std::is_array<logging::CustomSink>::value, logging::CustomSink>::type> std::make_shared<logging::CustomSink>() /usr/include/c++/14/bits/shared_ptr.h:1008 (streamlogger_utest+0x68df21) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #8 logging::start(logging::LoggingConfig const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/src/logging.cpp:129 (streamlogger_utest+0x682660) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #9 logging::testInit(logging::Level) /workspaces/Wazuh_5x/wazuh/src/engine/source/base/src/logging.cpp:156 (streamlogger_utest+0x6829fc) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #10 ChannelHandlerTest::SetUp() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/test/src/unit/channel_test.cpp:100 (streamlogger_utest+0x4e6d59) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #11 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googletest/src/gtest.cc:2607 (streamlogger_utest+0x615d04) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882: 
6882:   Mutex M0 (0x7260000008d8) created at:
6882:     #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1341 (libtsan.so.2+0x59a13) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/14/bits/gthr-default.h:762 (streamlogger_utest+0x3b37f5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #2 std::mutex::lock() /usr/include/c++/14/bits/std_mutex.h:113 (streamlogger_utest+0x3bc8a6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/14/bits/std_mutex.h:250 (streamlogger_utest+0x3cf6ea) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #4 streamlog::ChannelHandler::createWriter() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/src/channel.cpp:681 (streamlogger_utest+0x574370) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #5 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/test/src/unit/channel_test.cpp:957 (streamlogger_utest+0x4bed51) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #6 __invoke_impl<void, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (streamlogger_utest+0x4db71f) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #7 __invoke<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4db56e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #8 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x4db3d6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #9 operator() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x4db22c) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #10 operator() /usr/include/c++/14/future:1439 (streamlogger_utest+0x4dac27) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #11 __invoke_impl<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>&> /usr/include/c++/14/bits/invoke.h:61 (streamlogger_utest+0x4da5fa) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #12 __invoke_r<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>&> /usr/include/c++/14/bits/invoke.h:114 (streamlogger_utest+0x4d9e49) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #13 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (streamlogger_utest+0x4d95b2) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #14 std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>::operator()() const /usr/include/c++/14/bits/std_function.h:591 (streamlogger_utest+0x4ea6fe) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #15 std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) /usr/include/c++/14/future:596 (streamlogger_utest+0x4e40b4) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #16 void std::__invoke_impl<void, void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::__invoke_memfun_deref, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x4fb9a6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #17 std::__invoke_result<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>::type std::__invoke<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4f3a80) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #18 std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}::operator()() const /usr/include/c++/14/mutex:909 (streamlogger_utest+0x4ea507) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #19 std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::operator()() const /usr/include/c++/14/mutex:845 (streamlogger_utest+0x4f3af6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #20 std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::_FUN() /usr/include/c++/14/mutex:845 (streamlogger_utest+0x4f3b3d) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #21 pthread_once ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1587 (libtsan.so.2+0x57ff5) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #22 __gthread_once /usr/include/x86_64-linux-gnu/c++/14/bits/gthr-default.h:713 (streamlogger_utest+0x4aca10) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #23 void std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/mutex:916 (streamlogger_utest+0x4ea5f1) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #24 std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>, bool) /usr/include/c++/14/future:435 (streamlogger_utest+0x4e3f6e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #25 _M_run /usr/include/c++/14/future:1781 (streamlogger_utest+0x4d85f9) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #26 __invoke_impl<void, void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>*> /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x4e2aa5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #27 __invoke<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>*> /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4e2760) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #28 _M_invoke<0, 1> /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x4e23fc) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #29 operator() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x4e217a) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #30 _M_run /usr/include/c++/14/bits/std_thread.h:253 (streamlogger_utest+0x4e0efa) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #31 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
6882: 
6882:   Thread T5 (tid=114091, running) created by thread T2 at:
6882:     #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
6882:     #2 streamlog::ChannelHandler::startWorkerThread() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/src/channel.cpp:344 (streamlogger_utest+0x571399) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #3 streamlog::ChannelHandler::createWriter() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/src/channel.cpp:694 (streamlogger_utest+0x5744db) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #4 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/test/src/unit/channel_test.cpp:957 (streamlogger_utest+0x4bed51) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #5 __invoke_impl<void, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (streamlogger_utest+0x4db71f) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #6 __invoke<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4db56e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #7 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x4db3d6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #8 operator() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x4db22c) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #9 operator() /usr/include/c++/14/future:1439 (streamlogger_utest+0x4dac27) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #10 __invoke_impl<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>&> /usr/include/c++/14/bits/invoke.h:61 (streamlogger_utest+0x4da5fa) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #11 __invoke_r<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>&> /usr/include/c++/14/bits/invoke.h:114 (streamlogger_utest+0x4d9e49) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #12 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (streamlogger_utest+0x4d95b2) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #13 std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>::operator()() const /usr/include/c++/14/bits/std_function.h:591 (streamlogger_utest+0x4ea6fe) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #14 std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) /usr/include/c++/14/future:596 (streamlogger_utest+0x4e40b4) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #15 void std::__invoke_impl<void, void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::__invoke_memfun_deref, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x4fb9a6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #16 std::__invoke_result<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>::type std::__invoke<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4f3a80) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #17 std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}::operator()() const /usr/include/c++/14/mutex:909 (streamlogger_utest+0x4ea507) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #18 std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::operator()() const /usr/include/c++/14/mutex:845 (streamlogger_utest+0x4f3af6) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #19 std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::_FUN() /usr/include/c++/14/mutex:845 (streamlogger_utest+0x4f3b3d) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #20 pthread_once ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1587 (libtsan.so.2+0x57ff5) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #21 __gthread_once /usr/include/x86_64-linux-gnu/c++/14/bits/gthr-default.h:713 (streamlogger_utest+0x4aca10) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #22 void std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) /usr/include/c++/14/mutex:916 (streamlogger_utest+0x4ea5f1) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #23 std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>, bool) /usr/include/c++/14/future:435 (streamlogger_utest+0x4e3f6e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #24 _M_run /usr/include/c++/14/future:1781 (streamlogger_utest+0x4d85f9) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #25 __invoke_impl<void, void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>*> /usr/include/c++/14/bits/invoke.h:74 (streamlogger_utest+0x4e2aa5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #26 __invoke<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>*> /usr/include/c++/14/bits/invoke.h:96 (streamlogger_utest+0x4e2760) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #27 _M_invoke<0, 1> /usr/include/c++/14/bits/std_thread.h:301 (streamlogger_utest+0x4e23fc) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #28 operator() /usr/include/c++/14/bits/std_thread.h:308 (streamlogger_utest+0x4e217a) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #29 _M_run /usr/include/c++/14/bits/std_thread.h:253 (streamlogger_utest+0x4e0efa) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #30 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
6882: 
6882:   Thread T4 (tid=114090, running) created by main thread at:
6882:     #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
6882:     #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
6882:     #2 _Async_state_impl<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/future:1763 (streamlogger_utest+0x4d7d03) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #3 _Construct<std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/stl_construct.h:119 (streamlogger_utest+0x4d723e) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #4 construct<std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/alloc_traits.h:657 (streamlogger_utest+0x4d57ea) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #5 _Sp_counted_ptr_inplace<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/shared_ptr_base.h:607 (streamlogger_utest+0x4d57ea)
6882:     #6 __shared_count<std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>, std::allocator<void>, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/shared_ptr_base.h:969 (streamlogger_utest+0x4d4735) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #7 __shared_ptr<std::allocator<void>, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/shared_ptr_base.h:1713 (streamlogger_utest+0x4d3cbf) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #8 shared_ptr<std::allocator<void>, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/shared_ptr.h:463 (streamlogger_utest+0x4d34d8) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #9 make_shared<std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > >, void>, ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/bits/shared_ptr.h:1008 (streamlogger_utest+0x4d2e7c) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #10 async<ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody()::<lambda()> > /usr/include/c++/14/future:1812 (streamlogger_utest+0x4d26d5) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #11 ChannelHandlerTest_ConcurrentMultipleChannels_Test::TestBody() /workspaces/Wazuh_5x/wazuh/src/engine/source/streamlog/test/src/unit/channel_test.cpp:954 (streamlogger_utest+0x4bf124) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882:     #12 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googletest/src/gtest.cc:2607 (streamlogger_utest+0x615d04) (BuildId: 93aaf8854262f4c48e8821021932957ab2503b7a)
6882: 
6882: SUMMARY: ThreadSanitizer: data race /workspaces/Wazuh_5x/wazuh/src/engine/source/base/src/logging.cpp:37 in logging::CustomSink::log(spdlog::details::log_msg const&)
6882: ==================

```
</p> 
</details> 

<details><summary>List of UnitTest Failed</summary> 
<p>

```bash

The following tests FAILED:
        6494 - KVDB_Manager_Unit.ParallelColdRace_EventualConvergence (Failed)
        6859 - ChannelHandlerTest.BasicCreationAndDestruction (Failed)
        6866 - ChannelHandlerTest.WriterLifecycle (Failed)
        6867 - ChannelHandlerTest.BasicMessageWriting (Failed)
        6869 - ChannelHandlerTest.TimeBasedRotation (Failed)
        6872 - ChannelHandlerTest.WorkerThreadLifecycle (Failed)
        6874 - ChannelHandlerTest.PlaceholderReplacement (Failed)
        6875 - ChannelHandlerTest.CounterPlaceholderWithSizeRotation (Failed)
        6876 - ChannelHandlerTest.WriterNonCopyable (Failed)
        6877 - ChannelHandlerTest.BufferOverflowBehavior (Failed)
        6878 - ChannelHandlerTest.DirectoryCreation (Failed)
        6880 - ChannelHandlerTest.RegexReplacementEdgeCases (Failed)
        6882 - ChannelHandlerTest.ConcurrentMultipleChannels (Failed)
        6884 - ChannelHandlerTest.MaxSizeBoundaryConditions (Failed)
        6885 - ChannelHandlerTest.PatternValidationEdgeCases (Failed)
        6886 - ChannelHandlerTest.ThreadInterruptionAndCleanup (Failed)
        6887 - ChannelHandlerTest.MemoryPressureTest (Failed)
        6888 - ChannelHandlerTest.ExistingFileResumption (Failed)
        6889 - ChannelHandlerTest.ExistingFileWithRotation (Failed)
        6891 - ChannelHandlerTest.EmptyExistingFileResumption (Failed)
        6892 - ChannelHandlerTest.ConcurrentWritesToExistingFile (Failed)
        6893 - ChannelHandlerTest.LargeExistingFileResumption (Failed)
        6894 - ChannelHandlerTest.FileAppendPositioning (Failed)
        6895 - ChannelHandlerTest.LongChannelName (Failed)
        6898 - ChannelHandlerTest.CompressionWithMockScheduler (Failed)
        6901 - ChannelHandlerTest.CompressionWithDifferentLevels (Failed)
        6902 - ChannelHandlerTest.CompressionWithTimeRotation (Failed)
        6906 - ChannelHandlerTest.StorePersistenceSaveDuringRotation (Failed)
        6908 - ChannelHandlerTest.StorePersistenceSaveError (Failed)
        6921 - Patterns/PatternTest.DifferentPatterns/"logs/${YYYY}/${MM}/${name}-${DD}.json" (Failed)
        6926 - BufferSizes/BufferSizeTest.DifferentBufferSizes/1048576 (Failed)
        7065 - WIndexerConnectorTest.ConcurrentIndexingAndShutdown (Failed)
Errors while running CTest

```
</p> 
</details> 

**Race Condition**

1. `CustomSink::log()` - Concurrent writes at 0x720c0000004c
2. `CustomSink::flush()` - Concurrent writes at same address
3. `spdlog::pattern_formatter` - Triggered by unsafe CustomSink usage

**Root cause:** `CustomSink` lacks synchronization despite being called from multiple threads.
**Solution:** Made `CustomSink` thread-safe by inheriting from `spdlog::sinks::base_sink<std::mutex>` and implementing synchronized methods:

- Protected `sink_it_()` for logging
- Protected `flush_()` for flushing
- Mutex automatically managed by base class

## Proposed Changes

#### Issue 1:

1. **Fix lock type:** Change `cleanup()` to use `unique_lock` for exclusive write access
2. **Add empty validation:** Check `m_routerWorkers.empty()` before accessing `front()`
3. **Atomic shutdown flag:** Add `m_isShutdown` for thread-safe early exit
5. **Proper lock scoping:** Move TOCTOU-vulnerable checks inside lock scope

**Affected Methods**

- `Orchestrator::getEntries()` - line 449
- `Orchestrator::getEntry()` - line 408
- `Orchestrator::dumpRouters()` - line 120
- `Orchestrator::cleanup() `- line 343

#### Issue 2:

**Files Modified:**

- `src/engine/source/router/src/orchestrator.cpp`
- `src/engine/source/router/include/router/orchestrator.hpp`

**Key Changes:**

1. Created internal dump methods (no lock acquisition):
    - `dumpTestersInternal()`
    - `dumpRoutersInternal()`
    - `dumpEpsInternal()`
    
2. Modified public dump methods to acquire lock and delegate to internal variants
3. Updated all call sites to use `*Internal()` when lock already held:
    - `postEntry()`→ `dumpRoutersInternal()`
    - `deleteEntry()` → `dumpRoutersInternal()`
    - `changeEntryPriority()` → `dumpRoutersInternal()`
    - `postTestEntry()` → `dumpTestersInternal()`
    - `deleteTestEntry()` → `dumpTestersInternal()`
    -`renameTestEntry()` → `dumpTestersInternal()`
    - `stop()` → `dumpTestersInternal()`
    - `loadEpsCounter()` → `dumpEpsInternal()` (constructor context)

#### Issue 3:

**Files Modified:**

- `src/engine/source/base/src/logging.cpp`
- `src/engine/source/base/include/base/logging.hpp`

**Key Changes:**

1. Changed `CustomSink` to inherit from `spdlog::sinks::base_sink<std::mutex>`
2. Renamed and protected virtual methods:
     - `log()` → `sink_it_()` (protected, synchronized by base class)
     - `flush()` → `flush_()` (protected, synchronized by base class)
3. Removed manual synchronization (handled by base class mutex)
4. Ensured thread-safety for all concurrent logging operations


⚠️ **TSAN note (KVDB / OpenSSL “ColdRace” warning)**

While running the KVDB TSAN tests, we still see a **ThreadSanitizer data-race warning** reported inside **OpenSSL** (`ossl_ht_get` / `ossl_ht_insert`) during the *first* concurrent SHA256 usage. 

<details><summary>KVDB Test Failed</summary> 
<p>

```bash
==================
WARNING: ThreadSanitizer: data race (pid=148453)
  Read of size 8 at 0x721c0001fd68 by thread T9:
    #0 memcmp ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:844 (libtsan.so.2+0x5e1f0) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 memcmp ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:840 (libtsan.so.2+0x5e1f0)
    #2 ossl_ht_get <null> (kvdbstore_ctest+0x74df8a) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #3 cm::store::dataType::KVDB::updateHash() <null> (kvdbstore_ctest+0x3b2154) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #4 cm::store::dataType::KVDB::KVDB(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, json::Json&&, bool) <null> (kvdbstore_ctest+0x3b235f) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #5 cm::store::dataType::KVDB::fromJson(json::Json const&) <null> (kvdbstore_ctest+0x3b2842) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #6 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:181 (kvdbstore_ctest+0x3aa140) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #7 __invoke_impl<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3ae7e3) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #8 __invoke_r<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:116 (kvdbstore_ctest+0x3ae586) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #9 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (kvdbstore_ctest+0x3ae313) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #10 std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ff687) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #11 decltype (((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}))((get<0ul>)((forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2})))) testing::internal::ApplyImpl<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, 0ul>(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, testing::internal::IndexSequence<0ul>) <null> (kvdbstore_ctest+0x3fd097) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #12 decltype (ApplyImpl((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}), (forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2}), (testing::internal::MakeIndexSequenceImpl<std::tuple_size<std::remove_reference<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >::type>::value>::type)())) testing::internal::Apply<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&) <null> (kvdbstore_ctest+0x3f6792) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #13 testing::Action<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::Perform(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>) const <null> (kvdbstore_ctest+0x3ed671) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #14 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::PerformDefaultAction(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ed399) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #15 testing::internal::ActionResultHolder<cm::store::dataType::KVDB>* testing::internal::ActionResultHolder<cm::store::dataType::KVDB>::PerformDefaultAction<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>(testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const*, testing::internal::Function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::ArgumentTuple&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) <null> (kvdbstore_ctest+0x3e57b8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #16 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::UntypedPerformDefaultAction(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3e0910) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #17 testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googlemock/src/gmock-spec-builders.cc:409 (kvdbstore_ctest+0x4070b4) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #18 cm::store::MockICMStoreNSReader::getKVDBByName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3b4ccb) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #19 auto cm::store::ICMStoreNSReader::getResourceByName<cm::store::dataType::KVDB>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x417862) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #20 kvdbstore::KVDBManager::getKVDBHandler(cm::store::ICMStoreNSReader const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/src/kvdbManager.cpp:36 (kvdbstore_ctest+0x416a59) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #21 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:42 (kvdbstore_ctest+0x3a60da) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #22 __invoke_impl<void, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3af600) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #23 __invoke<(anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (kvdbstore_ctest+0x3af577) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #24 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (kvdbstore_ctest+0x3af4d8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #25 operator() /usr/include/c++/14/bits/std_thread.h:308 (kvdbstore_ctest+0x3af47e) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #26 _M_run /usr/include/c++/14/bits/std_thread.h:253 (kvdbstore_ctest+0x3af434) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #27 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Previous write of size 8 at 0x721c0001fd68 by thread T16 (mutexes: write M0):
    #0 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115 (libtsan.so.2+0x8bd30) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:107 (libtsan.so.2+0x8bd30)
    #2 ossl_ht_insert <null> (kvdbstore_ctest+0x74ddd6) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #3 cm::store::dataType::KVDB::updateHash() <null> (kvdbstore_ctest+0x3b2154) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #4 cm::store::dataType::KVDB::KVDB(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, json::Json&&, bool) <null> (kvdbstore_ctest+0x3b235f) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #5 cm::store::dataType::KVDB::fromJson(json::Json const&) <null> (kvdbstore_ctest+0x3b2842) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #6 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:181 (kvdbstore_ctest+0x3aa140) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #7 __invoke_impl<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3ae7e3) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #8 __invoke_r<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:116 (kvdbstore_ctest+0x3ae586) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #9 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (kvdbstore_ctest+0x3ae313) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #10 std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ff687) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #11 decltype (((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}))((get<0ul>)((forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2})))) testing::internal::ApplyImpl<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, 0ul>(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, testing::internal::IndexSequence<0ul>) <null> (kvdbstore_ctest+0x3fd097) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #12 decltype (ApplyImpl((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}), (forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2}), (testing::internal::MakeIndexSequenceImpl<std::tuple_size<std::remove_reference<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >::type>::value>::type)())) testing::internal::Apply<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&) <null> (kvdbstore_ctest+0x3f6792) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #13 testing::Action<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::Perform(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>) const <null> (kvdbstore_ctest+0x3ed671) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #14 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::PerformDefaultAction(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ed399) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #15 testing::internal::ActionResultHolder<cm::store::dataType::KVDB>* testing::internal::ActionResultHolder<cm::store::dataType::KVDB>::PerformDefaultAction<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>(testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const*, testing::internal::Function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::ArgumentTuple&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) <null> (kvdbstore_ctest+0x3e57b8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #16 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::UntypedPerformDefaultAction(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3e0910) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #17 testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googlemock/src/gmock-spec-builders.cc:409 (kvdbstore_ctest+0x4070b4) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #18 cm::store::MockICMStoreNSReader::getKVDBByName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3b4ccb) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #19 auto cm::store::ICMStoreNSReader::getResourceByName<cm::store::dataType::KVDB>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x417862) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #20 kvdbstore::KVDBManager::getKVDBHandler(cm::store::ICMStoreNSReader const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/src/kvdbManager.cpp:36 (kvdbstore_ctest+0x416a59) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #21 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:42 (kvdbstore_ctest+0x3a60da) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #22 __invoke_impl<void, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3af600) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #23 __invoke<(anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (kvdbstore_ctest+0x3af577) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #24 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (kvdbstore_ctest+0x3af4d8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #25 operator() /usr/include/c++/14/bits/std_thread.h:308 (kvdbstore_ctest+0x3af47e) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #26 _M_run /usr/include/c++/14/bits/std_thread.h:253 (kvdbstore_ctest+0x3af434) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #27 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Location is heap block of size 104 at 0x721c0001fd40 allocated by thread T16:
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:665 (libtsan.so.2+0x54b3f) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 CRYPTO_malloc <null> (kvdbstore_ctest+0x5db990) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #2 cm::store::dataType::KVDB::updateHash() <null> (kvdbstore_ctest+0x3b2154) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #3 cm::store::dataType::KVDB::KVDB(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, json::Json&&, bool) <null> (kvdbstore_ctest+0x3b235f) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #4 cm::store::dataType::KVDB::fromJson(json::Json const&) <null> (kvdbstore_ctest+0x3b2842) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #5 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:181 (kvdbstore_ctest+0x3aa140) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #6 __invoke_impl<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3ae7e3) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #7 __invoke_r<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:116 (kvdbstore_ctest+0x3ae586) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #8 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (kvdbstore_ctest+0x3ae313) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #9 std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ff687) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #10 decltype (((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}))((get<0ul>)((forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2})))) testing::internal::ApplyImpl<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, 0ul>(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, testing::internal::IndexSequence<0ul>) <null> (kvdbstore_ctest+0x3fd097) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #11 decltype (ApplyImpl((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}), (forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2}), (testing::internal::MakeIndexSequenceImpl<std::tuple_size<std::remove_reference<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >::type>::value>::type)())) testing::internal::Apply<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&) <null> (kvdbstore_ctest+0x3f6792) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #12 testing::Action<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::Perform(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>) const <null> (kvdbstore_ctest+0x3ed671) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #13 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::PerformDefaultAction(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ed399) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #14 testing::internal::ActionResultHolder<cm::store::dataType::KVDB>* testing::internal::ActionResultHolder<cm::store::dataType::KVDB>::PerformDefaultAction<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>(testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const*, testing::internal::Function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::ArgumentTuple&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) <null> (kvdbstore_ctest+0x3e57b8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #15 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::UntypedPerformDefaultAction(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3e0910) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #16 testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googlemock/src/gmock-spec-builders.cc:409 (kvdbstore_ctest+0x4070b4) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #17 cm::store::MockICMStoreNSReader::getKVDBByName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3b4ccb) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #18 auto cm::store::ICMStoreNSReader::getResourceByName<cm::store::dataType::KVDB>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x417862) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #19 kvdbstore::KVDBManager::getKVDBHandler(cm::store::ICMStoreNSReader const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/src/kvdbManager.cpp:36 (kvdbstore_ctest+0x416a59) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #20 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:42 (kvdbstore_ctest+0x3a60da) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #21 __invoke_impl<void, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3af600) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #22 __invoke<(anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (kvdbstore_ctest+0x3af577) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #23 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (kvdbstore_ctest+0x3af4d8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #24 operator() /usr/include/c++/14/bits/std_thread.h:308 (kvdbstore_ctest+0x3af47e) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #25 _M_run /usr/include/c++/14/bits/std_thread.h:253 (kvdbstore_ctest+0x3af434) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #26 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Mutex M0 (0x72100000e500) created at:
    #0 pthread_rwlock_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1458 (libtsan.so.2+0x5633d) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 CRYPTO_THREAD_lock_new <null> (kvdbstore_ctest+0x5e63f9) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #2 CRYPTO_THREAD_run_once <null> (kvdbstore_ctest+0x5e64c8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #3 CRYPTO_THREAD_run_once <null> (kvdbstore_ctest+0x5e64c8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #4 cm::store::dataType::KVDB::updateHash() <null> (kvdbstore_ctest+0x3b2154) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #5 cm::store::dataType::KVDB::KVDB(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, json::Json&&, bool) <null> (kvdbstore_ctest+0x3b235f) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #6 cm::store::dataType::KVDB::fromJson(json::Json const&) <null> (kvdbstore_ctest+0x3b2842) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #7 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:181 (kvdbstore_ctest+0x3aa140) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #8 __invoke_impl<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3ae7e3) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #9 __invoke_r<cm::store::dataType::KVDB, KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody()::<lambda(const std::string&)>&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/14/bits/invoke.h:116 (kvdbstore_ctest+0x3ae586) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #10 _M_invoke /usr/include/c++/14/bits/std_function.h:291 (kvdbstore_ctest+0x3ae313) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #11 std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ff687) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #12 decltype (((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}))((get<0ul>)((forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2})))) testing::internal::ApplyImpl<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, 0ul>(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, testing::internal::IndexSequence<0ul>) <null> (kvdbstore_ctest+0x3fd097) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #13 decltype (ApplyImpl((forward<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&>)({parm#1}), (forward<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >)({parm#2}), (testing::internal::MakeIndexSequenceImpl<std::tuple_size<std::remove_reference<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >::type>::value>::type)())) testing::internal::Apply<std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&> >(std::function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&) <null> (kvdbstore_ctest+0x3f6792) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #14 testing::Action<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::Perform(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>) const <null> (kvdbstore_ctest+0x3ed671) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #15 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::PerformDefaultAction(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3ed399) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #16 testing::internal::ActionResultHolder<cm::store::dataType::KVDB>* testing::internal::ActionResultHolder<cm::store::dataType::KVDB>::PerformDefaultAction<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>(testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const*, testing::internal::Function<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::ArgumentTuple&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) <null> (kvdbstore_ctest+0x3e57b8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #17 testing::internal::FunctionMocker<cm::store::dataType::KVDB (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::UntypedPerformDefaultAction(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3e0910) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #18 testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith(void*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googlemock/src/gmock-spec-builders.cc:409 (kvdbstore_ctest+0x4070b4) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #19 cm::store::MockICMStoreNSReader::getKVDBByName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x3b4ccb) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #20 auto cm::store::ICMStoreNSReader::getResourceByName<cm::store::dataType::KVDB>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const <null> (kvdbstore_ctest+0x417862) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #21 kvdbstore::KVDBManager::getKVDBHandler(cm::store::ICMStoreNSReader const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/src/kvdbManager.cpp:36 (kvdbstore_ctest+0x416a59) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #22 operator() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:42 (kvdbstore_ctest+0x3a60da) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #23 __invoke_impl<void, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:61 (kvdbstore_ctest+0x3af600) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #24 __invoke<(anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/invoke.h:96 (kvdbstore_ctest+0x3af577) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #25 _M_invoke<0> /usr/include/c++/14/bits/std_thread.h:301 (kvdbstore_ctest+0x3af4d8) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #26 operator() /usr/include/c++/14/bits/std_thread.h:308 (kvdbstore_ctest+0x3af47e) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #27 _M_run /usr/include/c++/14/bits/std_thread.h:253 (kvdbstore_ctest+0x3af434) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #28 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Thread T9 (tid=148463, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #2 construct<std::thread, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/new_allocator.h:191 (kvdbstore_ctest+0x3ad8f5) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #3 construct<std::thread, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/alloc_traits.h:534 (kvdbstore_ctest+0x3ad8f5)
    #4 emplace_back<(anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/vector.tcc:117 (kvdbstore_ctest+0x3ad8f5)
    #5 parallelReadRefs /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:35 (kvdbstore_ctest+0x3a6543) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #6 KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:186 (kvdbstore_ctest+0x3aa4bf) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #7 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googletest/src/gtest.cc:2607 (kvdbstore_ctest+0x461202) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)

  Thread T16 (tid=148470, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
    #2 construct<std::thread, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/new_allocator.h:191 (kvdbstore_ctest+0x3ad8f5) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #3 construct<std::thread, (anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/alloc_traits.h:534 (kvdbstore_ctest+0x3ad8f5)
    #4 emplace_back<(anonymous namespace)::parallelReadRefs(kvdbstore::KVDBManager&, const cm::store::ICMStoreNSReader&, const std::string&, const std::string&, int)::<lambda()> > /usr/include/c++/14/bits/vector.tcc:117 (kvdbstore_ctest+0x3ad8f5)
    #5 parallelReadRefs /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:35 (kvdbstore_ctest+0x3a6543) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #6 KVDB_Component_ConcurrentColdRace_EventualConvergence_Test::TestBody() /workspaces/Wazuh_5x/wazuh/src/engine/source/kvdbstore/test/src/component/kvdb_test.cpp:186 (kvdbstore_ctest+0x3aa4bf) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)
    #7 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/Wazuh_5x/wazuh/src/external/googletest/googletest/src/gtest.cc:2607 (kvdbstore_ctest+0x461202) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789)

SUMMARY: ThreadSanitizer: data race (/workspaces/Wazuh_5x/wazuh/src/build/engine/source/kvdbstore/kvdbstore_ctest+0x74df8a) (BuildId: 83c0fcbe67cdba68ee956f6746ecdc2910fef789) in ossl_ht_get
==================

```
</p> 
</details> 

```bash

99% tests passed, 2 tests failed out of 158

Total Test time (real) =  35.60 sec

The following tests FAILED:
	6494 - KVDB_Manager_Unit.ParallelColdRace_EventualConvergence (Failed)
	6501 - KVDB_Component.ConcurrentColdRace_EventualConvergence (Failed)
Errors while running CTest

```

This is triggered by `KVDB::updateHash()` → `base::utils::hash::sha256()` (each call creates its own `EVP_MD_CTX`, so we’re not sharing hash contexts or KVDB state across threads).

Based on the investigation, this **does not look like a KVDB bug** (no shared Wazuh memory involved). It matches an OpenSSL 3.x **lazy-init / cold-start** behavior where internal registries/caches are initialized when multiple threads call SHA256 at the same time

**Options to handle it:**
1) **Accept & document** it as a benign/upstream TSAN warning (OpenSSL internal init).
2)  **Suppress it in TSAN** (CI/workflow) targeting only these symbols (`ossl_ht_get` / `ossl_ht_insert`), so we don’t hide unrelated races.
3)  **Warm-up** OpenSSL before the parallel section (e.g., a single early SHA256 call during init / test setup) to avoid concurrent first-time initialization.

No KVDB functional failures were observed; this is a TSAN signal coming from OpenSSL internals during cold-start concurrency.

**UPDATE:** We first tried to avoid the OpenSSL “cold-start” TSAN race by serializing the KVDB TSAN tests with `gtest_discover_tests(... PROPERTIES RESOURCE_LOCK ...)` (same idea as `wIndexerConnector_utest`), but it didn’t help—the OpenSSL warning still showed up.

Given that, we went with the warm-up approach instead: we added a one-time SHA256 call during the test suite setup to force OpenSSL initialization before the parallel section.

To apply this with minimal code changes, we updated these test fixtures:


- `KVDB_Component` (in `kvdb_test.cpp`)
- `KVDB_Manager_Unit` (in `kvdb_manager_test.cpp`)

Both now include a static void SetUpTestSuite() that does the warm-up SHA256 call, and the affected tests were switched from TEST(...) to TEST_F(...) so they run under the fixture setup.

### Results and Evidence

Ran TSAN build multiple times - no crashes observed after fix. Previously reproduced consistently within 2-3 runs. 

