### PR TITLE
Avoid using systemctl when systemd is not PID 1

### DIFF
--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -42,7 +42,7 @@ if [ "$TYPE" = "manager" ]; then
     fi
 fi
 
-if command -v systemctl >/dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ] && [ "$(cat /proc/1/comm 2>/dev/null)" = "systemd" ]; then
     # If reload is requested, wait for service to be fully active first
     if [ "$PARAM_ACTION" = "reload" ]; then
         # Wait up to 60 seconds for service to be active


### PR DESCRIPTION
## Description

In container environments where the `systemctl` binary is present but systemd is not running as PID 1, the restart.sh script incorrectly tries to use `systemctl` to manage the `wazuh-manager` / `wazuh-agent` service. This results in errors like:

```bash
systemctl restart wazuh-manager
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
```

Because the script only checks for the existence of `systemctl`, it never falls back to `${PWD}/bin/wazuh-control` in these environments.

The fix is to use `systemctl` only when systemd is actually the init system (PID 1), for example by checking that system exists and comm is `systemd`. If those conditions are not met, the script should skip `systemctl` and call `${PWD}/bin/wazuh-control $PARAM_ACTION` instead.

### Results and Evidence

Script output before changes (in a container with `systemd` installed):
```sh
# /var/ossec/active-response/bin/restart.sh manager restart
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
```

Script output after changes (in a container with `systemd` installed):
```sh
# /var/ossec/active-response/bin/restart.sh manager restart
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malware-hashes' could not be loaded. Rule '99901' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99902' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99903' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99904' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99905' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7617): Signature ID '99905' was not found and will be ignored in the 'if_sid' option of rule '99906'.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7619): Empty 'if_sid' value. Rule '99906' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99907' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99908' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99909' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99910' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99911' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99912' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99913' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99914' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99915' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99916' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-domains' could not be loaded. Rule '99917' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-domains' could not be loaded. Rule '99918' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99919' will be ignored.
2025/12/19 11:54:47 wazuh-analysisd: WARNING: (7616): List 'etc/lists/malicious-ioc/malicious-ip' could not be loaded. Rule '99920' will be ignored.
2025/12/19 11:54:48 wazuh-modulesd[2964] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/12/19 11:54:48 wazuh-modulesd[2964] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/12/19 11:54:48 wazuh-modulesd[2964] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2025/12/19 11:54:48 wazuh-modulesd[2964] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2025/12/19 11:54:48 wazuh-modulesd:router[2964] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2025/12/19 11:54:48 wazuh-modulesd:content_manager[2964] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2025/12/19 11:54:48 wazuh-modulesd:inventory-harvester[2964] wm_harvester.c:151 at wm_inventory_harvester_read(): INFO: Loaded Inventory harvester module.
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.14.1 Stopped
Starting Wazuh v4.14.1...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2025/12/19 11:54:52 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
Started wazuh-authd...
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2025/12/19 11:54:55 wazuh-modulesd[3284] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/12/19 11:54:55 wazuh-modulesd[3284] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/12/19 11:54:55 wazuh-modulesd[3284] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2025/12/19 11:54:55 wazuh-modulesd[3284] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2025/12/19 11:54:55 wazuh-modulesd:router[3284] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2025/12/19 11:54:55 wazuh-modulesd:content_manager[3284] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2025/12/19 11:54:55 wazuh-modulesd:inventory-harvester[3284] wm_harvester.c:151 at wm_inventory_harvester_read(): INFO: Loaded Inventory harvester module.
Started wazuh-modulesd...
Completed.
```

Script output after changes, on a VM where `systemctl` can be used:
```sh
# /var/ossec/active-response/bin/restart.sh manager restart
Test using systemctl
```

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
