### PR TITLE
Fix inventory package.installed field format incompatible with Indexer

### DIFF
--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -204,12 +204,16 @@ namespace PackageLinuxHelper
 
         if (info.contains("install-date"))
         {
-            struct std::tm tm;
+            struct std::tm tm = {};
             std::istringstream iss(info.at("install-date").get<std::string>());
             iss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
-            std::ostringstream oss;
-            oss << std::put_time(&tm, "%Y/%m/%d %H:%M:%S");
-            install_time = oss.str();
+
+            if (!iss.fail())
+            {
+                // timegm converts tm to UTC epoch (not affected by local timezone)
+                time_t epoch = timegm(&tm);
+                install_time = std::to_string(static_cast<uint32_t>(epoch));
+            }
         }
 
         if (info.contains("summary"))
@@ -247,7 +251,7 @@ namespace PackageLinuxHelper
         ret["path"]             = "/snap/" + name;
         ret["version_"]         = version;
         ret["vendor"]           = vendor;
-        ret["installed"]        = install_time == UNKNOWN_VALUE ? UNKNOWN_VALUE : Utils::timestampToISO8601(install_time);
+        ret["installed"]        = install_time == UNKNOWN_VALUE ? UNKNOWN_VALUE : Utils::rawTimestampToISO8601(static_cast<uint32_t>(std::stoll(install_time)));
         ret["description"]      = description;
         ret["size"]             = size;
         ret["source"]           = "snapcraft";

--- a/src/data_provider/src/packages/packageLinuxParserHelperExtra.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelperExtra.h
@@ -43,7 +43,7 @@ namespace PackageLinuxHelper
 
         packageInfo["name"]         = alpmWrapper(alpm_pkg_get_name(pArchPkg));
         packageInfo["size"]         = alpm_pkg_get_isize(pArchPkg);
-        packageInfo["installed"]    = Utils::timestampToISO8601(Utils::getTimestamp(static_cast<time_t>(alpm_pkg_get_installdate(pArchPkg))));
+        packageInfo["installed"]    = Utils::rawTimestampToISO8601(static_cast<uint32_t>(alpm_pkg_get_installdate(pArchPkg)));
 
         for (auto group{alpm_pkg_get_groups(pArchPkg)}; group; group = alpm_list_next(group))
         {

--- a/src/data_provider/src/packages/packageLinuxParserRpm.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserRpm.cpp
@@ -27,7 +27,7 @@ void getRpmInfo(std::function<void(nlohmann::json&)> callback)
     {
         [](std::function<void(nlohmann::json&)> cb)
         {
-            const auto rawRpmPackagesInfo{ UtilsWrapperLinux::exec("rpm -qa --qf '%{name}\t%{arch}\t%{summary}\t%{size}\t%{epoch}\t%{release}\t%{version}\t%{vendor}\t%{installtime:date}\t%{group}\t\n'") };
+            const auto rawRpmPackagesInfo{ UtilsWrapperLinux::exec("rpm -qa --qf '%{name}\t%{arch}\t%{summary}\t%{size}\t%{epoch}\t%{release}\t%{version}\t%{vendor}\t%{installtime}\t%{group}\t\n'") };
 
             if (!rawRpmPackagesInfo.empty())
             {

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
@@ -15,6 +15,7 @@
 #include "json.hpp"
 #include "rpmPackageManager.h"
 #include "sharedDefs.h"
+#include "timeHelper.h"
 
 #include "stringHelper.h"
 
@@ -44,7 +45,7 @@ namespace PackageLinuxHelper
 
             ret["name"]         = package.name;
             ret["size"]         = package.size;
-            ret["installed"]    = package.installTime;
+            ret["installed"]    = package.installTime.empty() ? UNKNOWN_VALUE : Utils::rawTimestampToISO8601(static_cast<uint32_t>(std::stoll(package.installTime)));
             ret["path"]         = UNKNOWN_VALUE;
             ret["category"]     = package.group;
             ret["version_"]     = version;

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
@@ -15,6 +15,7 @@
 #include "sharedDefs.h"
 #include "stringHelper.h"
 #include "json.hpp"
+#include "timeHelper.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -58,7 +59,7 @@ namespace PackageLinuxHelper
 
                 ret["name"]         = name;
                 ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoll(size);
-                ret["installed"]    = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : install_time;
+                ret["installed"]    = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : Utils::rawTimestampToISO8601(static_cast<uint32_t>(stoll(install_time)));
                 ret["path"]         = UNKNOWN_VALUE;
                 ret["category"]     = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : groups;
                 ret["version_"]     = version.empty() || version.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : version;

--- a/src/data_provider/tests/sysInfoPackageLinuxParserRpm/sysInfoPackageLinuxParserRPM_test.cpp
+++ b/src/data_provider/tests/sysInfoPackageLinuxParserRpm/sysInfoPackageLinuxParserRPM_test.cpp
@@ -212,7 +212,7 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFromBerkleyDB)
     CallbackMock wrapper;
 
     auto expectedPackage1 =
-        R"({"architecture":"amd64","description":"The Open Source Security Platform","type":"rpm","category":"test","installed":"5","name":"Wazuh","size":321,"vendor":"The Wazuh Team","version_":"123:4.4-1","path":" ","priority":" ","source":" "})"_json;
+        R"({"architecture":"amd64","description":"The Open Source Security Platform","type":"rpm","category":"test","installed":"1970-01-01T00:00:05.000Z","name":"Wazuh","size":321,"vendor":"The Wazuh Team","version_":"123:4.4-1","path":" ","priority":" ","source":" "})"_json;
 
     auto utils_mock { std::make_unique<UtilsMock>() };
     auto libdb_mock { std::make_unique<LibDBMock>() };
@@ -370,7 +370,7 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFromLibRPM)
     CallbackMock wrapper;
 
     auto expectedPackage1 =
-        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"9","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"1970-01-01T00:00:09.000Z","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
 
     auto utils_mock { std::make_unique<UtilsMock>() };
     auto rpm_mock { std::make_unique<RpmLibMock>() };
@@ -428,9 +428,9 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFallbackFromLibRPM)
     CallbackMock wrapper;
 
     auto expectedPackage1 =
-        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"9","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"1970-01-01T00:00:09.000Z","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
     auto expectedPackage2 =
-        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"19","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"1970-01-01T00:00:19.000Z","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
 
     auto utils_mock { std::make_unique<UtilsMock>() };
     auto rpm_mock { std::make_unique<RpmLibMock>() };
@@ -456,9 +456,9 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFallbackFromBerkleyDBConfigError)
     CallbackMock wrapper;
 
     auto expectedPackage1 =
-        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"9","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"1970-01-01T00:00:09.000Z","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
     auto expectedPackage2 =
-        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"19","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"1970-01-01T00:00:19.000Z","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
 
     auto utils_mock { std::make_unique<UtilsMock>() };
     auto libdb_mock { std::make_unique<LibDBMock>() };
@@ -485,9 +485,9 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFallbackFromBerkleyDBOpenError)
     CallbackMock wrapper;
 
     auto expectedPackage1 =
-        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"9","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"1970-01-01T00:00:09.000Z","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
     auto expectedPackage2 =
-        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"19","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"1970-01-01T00:00:19.000Z","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
 
     auto utils_mock { std::make_unique<UtilsMock>() };
     auto libdb_mock { std::make_unique<LibDBMock>() };
@@ -523,9 +523,9 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFallbackFromBerkleyDBCursorError)
     CallbackMock wrapper;
 
     auto expectedPackage1 =
-        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"9","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"1","architecture":"2","description":"3","size":4,"version_":"5:7-6","vendor":"8","installed":"1970-01-01T00:00:09.000Z","category":"10","type":"rpm","path":" ","priority":" ","source":" "})"_json;
     auto expectedPackage2 =
-        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"19","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
+        R"({"name":"11","architecture":"12","description":"13","size":14,"version_":"15:17-16","vendor":"18","installed":"1970-01-01T00:00:19.000Z","category":"20","type":"rpm","path":" ","priority":" ","source":" "})"_json;
 
     auto utils_mock { std::make_unique<UtilsMock>() };
     auto libdb_mock { std::make_unique<LibDBMock>() };

--- a/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -38,7 +38,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformation)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -64,7 +64,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationLibRpm)
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -125,7 +125,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpoch)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("1.5-24.el5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -149,7 +149,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochNoReleaseLibRpm)
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("4.16", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -174,7 +174,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochLibRpm)
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("1:4.16", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -194,7 +194,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonRelease)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("1.5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -214,7 +214,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonRelease)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("3:1.5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -234,7 +234,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochWithNone)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("1.5-24.el5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -254,7 +254,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonReleaseWithNone)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("3:1.5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);
@@ -274,7 +274,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonReleaseWith
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
     EXPECT_EQ(4111222333, jsPackageInfo["size"]);
-    EXPECT_EQ("1425472738", jsPackageInfo["installed"]);
+    EXPECT_EQ("2015-03-04T12:38:58.000Z", jsPackageInfo["installed"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["category"]);
     EXPECT_EQ("1.5", jsPackageInfo["version_"]);
     EXPECT_EQ("x86_64", jsPackageInfo["architecture"]);


### PR DESCRIPTION
## Description

Closes #33676 

This PR solves the incompatibility between the `package.installed` field format and the Indexer in CentOS 9 agents. The Indexer expects dates in `ISO8601|epoch_millis` format, but the RPM fallback parser was returning human-readable dates like `"Tue 23 Dec 2025 02:28:56 PM UTC"`, causing `mapper_parsing_exception` errors.

## Proposed Changes

### Bugs Fixed

- RPM Parser: Changed RPM query format from `%{installtime:date}` to `%{installtime}` to obtain raw epoch timestamps instead of human-readable dates
- Timezone Issues: Fixed timezone handling bugs in Snap and Pacman parsers that were using `mktime()` (local time) instead of proper UTC conversion

### Features Added

- Unified date format across all Linux package parsers (RPM, DEB, Snap, Pacman)
- All parsers now consistently return ISO 8601 format with UTC timezone: `"YYYY-MM-DDTHH:MM:SS.000Z"`

### Results and Evidence

#### Syscollector events

<details><summary>Before fix</summary>

```json
{
    "checksum":
    {
        "hash":
        {
            "sha1": "9ecadfc20a13c3467fcac20bfaa91bc47b303749"
        }
    },
    "package":
    {
        "architecture": "noarch",
        "category": "Unspecified",
        "description": "System-wide crypto policies",
        "installed": "Mon 01 Jan 2024 10:51:43 AM UTC",
        "multiarch": null,
        "name": "crypto-policies",
        "path": null,
        "priority": null,
        "size": 86176,
        "source": null,
        "type": "rpm",
        "vendor": "CentOS",
        "version": "20231113-1.gite9247c2.el9"
    },
    "state":
    {
        "document_version": 1,
        "modified_at": "2025-12-23T19:43:53.762Z"
    }
}
```

</details> 

<details><summary>After fix</summary>

```json
{
    "checksum":
    {
        "hash":
        {
            "sha1": "957e3ebe1adb36fe1f3b56c8a0ddb484c47aa4a5"
        }
    },
    "package":
    {
        "architecture": "noarch",
        "category": "Unspecified",
        "description": "System-wide crypto policies",
        "installed": "2024-01-01T10:51:43.000Z",
        "multiarch": null,
        "name": "crypto-policies",
        "path": null,
        "priority": null,
        "size": 86176,
        "source": null,
        "type": "rpm",
        "vendor": "CentOS",
        "version": "20231113-1.gite9247c2.el9"
    },
    "state":
    {
        "document_version": 1,
        "modified_at": "2025-12-23T21:12:43.523Z"
    }
}
```

</details> 

<img width="1913" height="974" alt="image" src="https://github.com/user-attachments/assets/12caa533-1e96-4d9e-b4f1-97167c9d2223" />

<img width="1913" height="974" alt="image" src="https://github.com/user-attachments/assets/fb9ae420-0598-48ce-ac35-3312da5b5c8a" />

#### Indexer Connector prints no related logs

```console
root@vm-ubuntu2204-server:/home/vagrant# grep "mapper_parsing_exception" /var/ossec/logs/ossec.log | grep "package.installed"
root@vm-ubuntu2204-server:/home/vagrant#
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `libsysinfo.so` - Data provider library

### Configuration Changes

- N/A

### Tests Introduced

- N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

