### PR TITLE
Fix SCA syntax error in CentOS 9 check 31978

### DIFF
--- a/ruleset/sca/centos/9/cis_centos9_linux.yml
+++ b/ruleset/sca/centos/9/cis_centos9_linux.yml
@@ -3857,8 +3857,8 @@ checks:
       - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare <= 900'
       - 'c:sshd -T -> r:clientalivecountmax\s*\t*0'
       - 'not f:/etc/ssh/sshd_config -> r:^ClientAliveInterval\s*\t*0'
-      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) > 900'
-      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) > 0'
+      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) compare > 900'
+      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) compare > 0'
 
   # 5.3.1 Ensure sudo is installed. (Automated)
   - id: 39179


### PR DESCRIPTION
## Description

This pull request fixes a syntax error in the SCA policy for CentOS 9 that affects check `31978`.  
The current rules are missing the `compare` keyword in some expressions, causing the 5.x agent to fail the check evaluation with an “Invalid expression format, 'compare' keyword missing” error, while 4.x agents silently accept the invalid syntax.

## Proposed Changes

Add the missing `compare` keyword to the affected SCA rules in check `31978` for the CentOS 9 CIS policy:

- Update `ClientAliveInterval` checks to include `compare` before comparison operators.
- Update `clientalivecountmax` checks to include `compare` where a numeric comparison is performed.
- Keep existing logic and thresholds unchanged; only fix expression syntax so it is valid for 5.x agents.

### Results and Evidence

#### Logs

```
2025/12/24 08:52:05 sca: INFO: Starting Security Configuration Assessment scan.
2025/12/24 08:52:05 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_centos9_linux.yml'
2025/12/24 08:52:26 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_centos9_linux.yml'
2025/12/24 08:52:26 sca: INFO: Security Configuration Assessment scan finished. Duration: 21 seconds.
```

#### Screenshot

<img width="1392" height="932" alt="image" src="https://github.com/user-attachments/assets/387c4ad8-5629-48de-8b99-eb835079cb49" />

### Artifacts Affected

- SCA policy: CIS for CentOS 9.

### Configuration Changes

- No configuration changes required.
- Existing SCA configuration continues to work without modification.

### Documentation Updates

- No documentation changes required.

### Tests Introduced

- No automated tests added.
- Manual verification performed:
  - Ran SCA on a 5.x agent with the updated CentOS 9 policy.
  - Confirmed that the previous syntax error is no longer present.
  - Confirmed that check `31978` evaluates successfully and reports expected results.

## Review Checklist

- [ ] Code changes reviewed  
- [ ] Relevant evidence provided  
- [ ] Tests cover the new functionality  
- [ ] Configuration changes documented  
- [ ] Developer documentation reflects the changes  
- [ ] Meets requirements and/or definition of done  
- [ ] No unresolved dependencies with other issues  