### PR TITLE
Fix syscollector is adding new hardware entries upon multiple scans

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -151,7 +151,7 @@ static std::string getSerialNumber()
     std::string serial;
     std::fstream file{WM_SYS_HW_DIR, std::ios_base::in};
 
-    if (file.is_open())
+    if (file.is_open() && std::filesystem::file_size(WM_SYS_HW_DIR) > 0)
     {
         file >> serial;
     }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes #32859

It was reported that while running E2E ITHygiene tests, that hardware information was being duplicated instead of updated upon consecutive scans.
It has been observed that when this issue ocurred, the primary key field "board_serial" was not being reported as can be seen in the output of this query:

``` console
root@ip-x.x.x.x:/home/qa# python3 /tmp/wdb-query.py 005 "select * from sys_hwinfo";
[
    {
        "scan_id": 0,
        "scan_time": "2025/10/27 17:08:58",
        "cpu_name": " ",
        "cpu_cores": 2,
        "ram_total": 3928120,
        "ram_free": 3582544,
        "ram_usage": 9,
        "checksum": "9d076070353e8ff3674239f44809d17d23f61d50"
    },
    {
        "scan_id": 0,
        "scan_time": "2025/10/27 17:10:58",
        "cpu_name": " ",
        "cpu_cores": 2,
        "ram_total": 3928120,
        "ram_free": 3579492,
        "ram_usage": 9,
        "checksum": "4c15ccdb780040e24138d9cee534d9ca7b9ecc14"
    }
]
```

Upon closer inspection I realized that this happens because the /sys/class/dmi/id/board_serial file on AWS machines is empty, and this empty string caused the board_serial field to remain NULL.
<img width="1370" height="323" alt="Screenshot From 2025-12-23 14-44-45" src="https://github.com/user-attachments/assets/a090f092-e2b7-406d-b2a3-7979f8c2c9d7" />


## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->
As a fix, the code was modified so that the board_serial file is not read if it is empty.
### Results and Evidence
Before this fix (board_serial field not sent):

``` console
INFO: Module started.
INFO: Starting evaluation.
DEBUG2: Starting hardware scan
diff output payload:
{"data":{"checksum":"e3d8dc73f1e689a6cbdf3914eda12803536c158c","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22175596,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:20:08"},"operation":"INSERTED","type":"dbsync_hwinfo"}
DEBUG2: Delta sent: {"data":{"checksum":"e3d8dc73f1e689a6cbdf3914eda12803536c158c","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22175596,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:20:08"},"operation":"INSERTED","type":"dbsync_hwinfo"}
DEBUG2: Ending hardware scan
INFO: Evaluation finished.

INFO: Starting evaluation.
DEBUG2: Starting hardware scan
diff output payload:
{"data":{"checksum":"3ca4fe8153c71637dd4fdc2a660194a10af382f8","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22240652,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:20:23"},"operation":"MODIFIED","type":"dbsync_hwinfo"}
DEBUG2: Delta sent: {"data":{"checksum":"3ca4fe8153c71637dd4fdc2a660194a10af382f8","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22240652,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:20:23"},"operation":"MODIFIED","type":"dbsync_hwinfo"}
DEBUG2: Ending hardware scan
INFO: Evaluation finished.
```
After this fix (board_serial field sent with the UNKNOWN_VALUE):

``` console
INFO: Module started.
INFO: Starting evaluation.
DEBUG2: Starting hardware scan
diff output payload:
{"data":{"board_serial":" ","checksum":"d37337923fda49666211dbfa12b7d9442fbc3691","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22005908,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:42:38"},"operation":"INSERTED","type":"dbsync_hwinfo"}
DEBUG2: Delta sent: {"data":{"board_serial":" ","checksum":"d37337923fda49666211dbfa12b7d9442fbc3691","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22005908,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:42:38"},"operation":"INSERTED","type":"dbsync_hwinfo"}
DEBUG2: Ending hardware scan
INFO: Evaluation finished.

INFO: Starting evaluation.
DEBUG2: Starting hardware scan
diff output payload:
{"data":{"board_serial":" ","checksum":"dddac675b791572c696df88253145e8113b668c0","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22149268,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:42:53"},"operation":"MODIFIED","type":"dbsync_hwinfo"}
DEBUG2: Delta sent: {"data":{"board_serial":" ","checksum":"dddac675b791572c696df88253145e8113b668c0","cpu_cores":14,"cpu_mhz":401.0,"cpu_name":"Intel(R) Core(TM) Ultra 7 155U","ram_free":22149268,"ram_total":32328068,"ram_usage":32,"scan_time":"2025/12/26 12:42:53"},"operation":"MODIFIED","type":"dbsync_hwinfo"}
DEBUG2: Ending hardware scan
INFO: Evaluation finished.
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
- N/A
### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
- N/A
### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
