### PR TITLE
Unified synchronization logs across modules

### DIFF
--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -837,7 +837,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             // Acknowledge pause (atomic write, no mutex needed)
             atomic_int_set(&syscheck.fim_pausing_is_allowed, 1);
 
-            minfo("Running FIM synchronization requested by agent-info.");
+            minfo("Starting FIM synchronization requested by agent-info.");
 
             bool sync_result = asp_sync_module(syscheck.sync_handle,
                                                MODE_DELTA);
@@ -869,12 +869,12 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             #ifdef WIN32
             w_mutex_lock(&syscheck.fim_registry_scan_mutex);
             #endif
-            mdebug1("Running FIM synchronization.");
+            minfo("Starting FIM synchronization.");
 
             bool sync_result = asp_sync_module(syscheck.sync_handle,
                                                MODE_DELTA);
             if (sync_result) {
-                mdebug1("Synchronization succeeded");
+                minfo("FIM synchronization finished successfully.");
 
                 for (int i = 0; i < table_count; i++) {
                     if (fim_recovery_integrity_interval_has_elapsed(table_names[i], syscheck.integrity_interval)) {
@@ -892,7 +892,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                     }
                 }
             } else {
-                mdebug1("Synchronization failed");
+                mwarn("FIM synchronization failed.");
             }
 
             // Clean up the directories snapshot

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -352,7 +352,7 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
     if (m_spSyncProtocol)
     {
         // Log
-        LoggingHelper::getInstance().log(LOG_DEBUG, "SCA synchronization started.");
+        LoggingHelper::getInstance().log(LOG_INFO, "Starting SCA synchronization.");
 
         // Mark sync as in progress
         m_syncInProgress.store(true);
@@ -552,11 +552,11 @@ void SecurityConfigurationAssessment::pause()
 
     if (!m_keepRunning)
     {
-        LoggingHelper::getInstance().log(LOG_WARNING, "SCA module pause interrupted by shutdown");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module pause interrupted by shutdown");
     }
     else
     {
-        LoggingHelper::getInstance().log(LOG_INFO, "SCA module paused - all operations completed");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module paused successfully");
     }
 }
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1803,7 +1803,7 @@ bool Syscollector::syncModule(Mode mode)
         return false;
     }
 
-    m_logFunction(LOG_DEBUG, "Syscollector synchronization started.");
+    m_logFunction(LOG_INFO, "Starting inventory synchronization.");
 
     // RAII guard ensures m_syncing is set to false even if function exits early
     ScanGuard syncGuard(m_syncing, m_pauseCv);
@@ -2230,11 +2230,11 @@ bool Syscollector::pause()
     {
         if (m_stopping)
         {
-            m_logFunction(LOG_WARNING, "Syscollector module pause interrupted by shutdown");
+            m_logFunction(LOG_DEBUG, "Syscollector module pause interrupted by shutdown");
         }
         else
         {
-            m_logFunction(LOG_INFO, "Syscollector module paused successfully");
+            m_logFunction(LOG_DEBUG, "Syscollector module paused successfully");
         }
     }
 

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -521,7 +521,6 @@ void * wm_sca_sync_module(__attribute__((unused)) void * args) {
         bool sync_result = false;
         if (sca_sync_module_ptr)
         {
-            mdebug1("Running SCA synchronization.");
             sync_result = sca_sync_module_ptr(MODE_DELTA);
         }
         else

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -640,7 +640,6 @@ void* wm_sync_module(__attribute__((unused)) void* args)
     while (sync_module_running) {
         if (syscollector_sync_module_ptr) {
             syscollector_lock_scan_mutex_ptr();
-            mtinfo(WM_SYS_LOGTAG, "Starting inventory synchronization.");
 
             bool sync_result = syscollector_sync_module_ptr(MODE_DELTA);
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This pull request addresses inconsistent logging levels for synchronization messages across FIM, Syscollector, and SCA modules.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #33744 
-->

## Proposed Changes

**Log level standardization for synchronization start/end messages:**
- FIM: Changed "Running FIM synchronization" and "Synchronization succeeded" from `mdebug1` to `minfo`
- FIM: Changed "Synchronization failed" from `mdebug1` to `mwarn`
- Syscollector: Changed "Syscollector synchronization started" from `LOG_DEBUG` to `LOG_INFO`
- SCA: Changed "SCA synchronization started" from `LOG_DEBUG` to `LOG_INFO`

**Log level standardization for module pause messages:**
- Syscollector: Changed "Syscollector module paused successfully" from `LOG_INFO` to `LOG_DEBUG`
- SCA: Changed "SCA module paused - all operations completed" from `LOG_INFO` to `LOG_DEBUG`

**Removed duplicate log messages:**
- Removed redundant "Running SCA synchronization" from `wm_sca.c` (already logged in `sca_impl.cpp`)
- Removed redundant "Starting inventory synchronization" from `wm_syscollector.c` (already logged in `syscollectorImp.cpp`)

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

```
2025/12/30 16:22:33 wazuh-modulesd:syscollector[25649] logging_helper.c:31 at taggedLogFunction(): INFO: Starting inventory synchronization.
2025/12/30 16:22:33 wazuh-modulesd:syscollector[25649] logging_helper.c:34 at taggedLogFunction(): WARNING: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
2025/12/30 16:22:33 wazuh-modulesd:syscollector[25649] logging_helper.c:34 at taggedLogFunction(): WARNING: syscollector_vd: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
2025/12/30 16:22:33 wazuh-modulesd:syscollector[25649] logging_helper.c:34 at taggedLogFunction(): WARNING: Syscollector synchronization process failed.
```

```
2025/12/30 16:27:34 wazuh-syscheckd: INFO: Starting FIM synchronization.
2025/12/30 16:27:34 wazuh-syscheckd: WARNING: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
2025/12/30 16:27:34 wazuh-syscheckd: WARNING: FIM synchronization failed.
```

```
2025/12/30 22:57:35 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2025/12/30 22:57:35 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2025/12/30 22:57:35 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2025/12/30 22:58:16 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [x] Log syntax and correct language review

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
