### PR TITLE
Fixed sca decoder print

### DIFF
--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -1574,9 +1574,9 @@ static void FillCheckEventInfo(Eventinfo *lf, cJSON *scan_id, cJSON *id, cJSON *
         char value[OS_SIZE_128];
 
         if(scan_id->valueint >= 0){
-            sprintf(value, "%d", scan_id->valueint);
+            snprintf(value, sizeof(value), "%d", scan_id->valueint);
         } else if (scan_id->valuedouble) {
-             sprintf(value, "%lf", scan_id->valuedouble);
+            snprintf(value, sizeof(value), "%lf", scan_id->valuedouble);
         }
         fillData(lf, "sca.scan_id", value);
     }
@@ -1740,9 +1740,9 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         char value[OS_SIZE_128];
 
         if(pass->valueint >= 0){
-            sprintf(value, "%d", pass->valueint);
+            snprintf(value, sizeof(value), "%d", pass->valueint);
         } else if (pass->valuedouble >= 0) {
-            sprintf(value, "%lf", pass->valuedouble);
+            snprintf(value, sizeof(value), "%lf", pass->valuedouble);
         } else {
             mdebug1("Unexpected 'sca.passed' type: %d", pass->type);
             return;
@@ -1755,9 +1755,9 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         char value[OS_SIZE_128];
 
         if(failed->valueint >= 0){
-            sprintf(value, "%d", failed->valueint);
+            snprintf(value, sizeof(value), "%d", failed->valueint);
         } else if (failed->valuedouble >= 0) {
-            sprintf(value, "%lf", failed->valuedouble);
+            snprintf(value, sizeof(value), "%lf", failed->valuedouble);
         } else {
             mdebug1("Unexpected 'sca.failed' type: %d", failed->type);
             return;
@@ -1770,9 +1770,9 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         char value[OS_SIZE_128];
 
         if(invalid->valueint >= 0){
-            sprintf(value, "%d", invalid->valueint);
+            snprintf(value, sizeof(value), "%d", invalid->valueint);
         } else if (invalid->valuedouble >= 0) {
-            sprintf(value, "%lf", invalid->valuedouble);
+            snprintf(value, sizeof(value), "%lf", invalid->valuedouble);
         } else {
             mdebug1("Unexpected 'sca.invalid' type: %d", invalid->type);
             return;
@@ -1785,9 +1785,9 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         char value[OS_SIZE_128];
 
         if(total_checks->valueint >= 0){
-            sprintf(value, "%d", total_checks->valueint);
+            snprintf(value, sizeof(value), "%d", total_checks->valueint);
         } else if (total_checks->valuedouble >= 0) {
-            sprintf(value, "%lf", total_checks->valuedouble);
+            snprintf(value, sizeof(value), "%lf", total_checks->valuedouble);
         } else {
             mdebug1("Unexpected 'sca.total_checks' type: %d", total_checks->type);
             return;
@@ -1800,9 +1800,9 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         char value[OS_SIZE_128];
 
         if(score->valueint >= 0){
-            sprintf(value, "%d", score->valueint);
+            snprintf(value, sizeof(value), "%d", score->valueint);
         } else if (score->valuedouble >= 0) {
-            sprintf(value, "%lf", score->valuedouble);
+            snprintf(value, sizeof(value), "%lf", score->valuedouble);
         } else {
             mdebug1("Unexpected 'sca.score' type: %d", score->type);
             return;


### PR DESCRIPTION
## Description
Multiple bugs exist in the prints of Security Configuration Assessment (SCA) decoder (wazuh-analysisd). The use of sprintf with a floating-point (%lf) format specifier on a fixed-size 128-byte buffer.

Reported by @skraft9 through our responsible disclosure process.

## Proposed Changes

**File:** `src/analysisd/decoders/security_configuration_assessment.c`

**Changes:**
- Line 1579: Replace `sprintf` with `snprintf` for `scan_id` field
- Line 1745: Replace `sprintf` with `snprintf` for `pass` field  
- Line 1760: Replace `sprintf` with `snprintf` for `failed` field
- Line 1775: Replace `sprintf` with `snprintf` for `invalid` field
- Line 1790: Replace `sprintf` with `snprintf` for `total_checks` field
- Line 1805: Replace `sprintf` with `snprintf` for `score` field


## Results and Evidence

### Before the Fix


**poc_overflow.c:**

```c
#include <stdio.h>
#include <string.h>

#define OS_SIZE_128 128

void test(double bad_double)
{
    char value[OS_SIZE_128];
    sprintf(value, "%lf", bad_double);
}

int main()
{
    double overflow_payload = 1.0e150;
    test(overflow_payload);
    return 0;
}

```

**Compile and Execute**

```bash
─root@Wazuh4x_dev /workspaces/Wazuh_4x/poc_overflow 
╰─# gcc -fsanitize=address -g poc_overflow.c -o poc_overflow
╭─root@Wazuh4x_dev /workspaces/Wazuh_4x/poc_overflow 
╰─# ./poc_overflow
```

### ASan Logs

```bash
=================================================================
==270188==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffcae34fbd0 at pc 0x7f5e144d804f bp 0x7ffcae34fa20 sp 0x7ffcae34f1b0
WRITE of size 158 at 0x7ffcae34fbd0 thread T0
    #0 0x7f5e144d804e in __interceptor_vsprintf ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1687
    #1 0x7f5e144d827e in __interceptor_sprintf ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1730
    #2 0x564d5bbf42c8 in test /workspaces/Wazuh_4x/poc_overflow/poc_overflow.c:8
    #3 0x564d5bbf4378 in main /workspaces/Wazuh_4x/poc_overflow/poc_overflow.c:13
    #4 0x7f5e14279d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #5 0x7f5e14279e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #6 0x564d5bbf4144 in _start (/workspaces/Wazuh_4x/poc_overflow/poc_overflow+0x1144)

Address 0x7ffcae34fbd0 is located in stack of thread T0 at offset 160 in frame
    #0 0x564d5bbf4218 in test /workspaces/Wazuh_4x/poc_overflow/poc_overflow.c:6

  This frame has 1 object(s):
    [32, 160) 'value' (line 7) <== Memory access at offset 160 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1687 in __interceptor_vsprintf
Shadow bytes around the buggy address:
  0x100015c61f20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61f30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61f40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61f50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61f60: 00 00 00 00 00 00 f1 f1 f1 f1 00 00 00 00 00 00
=>0x100015c61f70: 00 00 00 00 00 00 00 00 00 00[f3]f3 f3 f3 00 00
  0x100015c61f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61f90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61fa0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100015c61fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==270188==ABORTING
```

### After the Fix


**poc_fixed.c:**

```c
#include <stdio.h>
#include <string.h>

#define OS_SIZE_128 128

void fixed_function(double bad_double)
{
    char value[OS_SIZE_128];
    snprintf(value, sizeof(value), "%lf", bad_double);
}

int main()
{
    double overflow_payload = 1.0e150;
    fixed_function(overflow_payload);
    return 0;
}

```

**Compile and Execute**

```bash

╭─root@Wazuh4x_dev /workspaces/Wazuh_4x/poc_overflow 
╰─# gcc -fsanitize=address -g poc_fixed.c -o poc_fixed
╭─root@Wazuh4x_dev /workspaces/Wazuh_4x/poc_overflow 
╰─# ./poc_fixed

```
#### NO TSAN report was found

<details><summary>Unit Test</summary>
<p>


```bash
[100%] Built target test_create_db
Test project /workspaces/Wazuh_4x/wazuh/src/unit_tests/build
        Start   1: test_analysisd_syscheck
  1/181 Test   #1: test_analysisd_syscheck .................................   Passed    1.54 sec
        Start   2: test_cleanevent
  2/181 Test   #2: test_cleanevent .........................................   Passed    0.04 sec
        Start   3: test_dbsync
  3/181 Test   #3: test_dbsync .............................................   Passed    0.04 sec
        Start   4: test_exec
  4/181 Test   #4: test_exec ...............................................   Passed    0.04 sec
        Start   5: test_log
  5/181 Test   #5: test_log ................................................   Passed    0.04 sec
        Start   6: test_labels
  6/181 Test   #6: test_labels .............................................   Passed    0.25 sec
        Start   7: test_mitre
  7/181 Test   #7: test_mitre ..............................................   Passed    0.01 sec
        Start   8: test_rules
  8/181 Test   #8: test_rules ..............................................   Passed    0.04 sec
        Start   9: test_same_different_loop
  9/181 Test   #9: test_same_different_loop ................................   Passed    0.04 sec
        Start  10: test_logtest
 10/181 Test  #10: test_logtest ............................................   Passed    0.10 sec
        Start  11: test_logtest-config
 11/181 Test  #11: test_logtest-config .....................................   Passed    0.02 sec
        Start  12: test_analysisd_hotreload
 12/181 Test  #12: test_analysisd_hotreload ................................   Passed    0.04 sec
        Start  13: test_decoder_list
 13/181 Test  #13: test_decoder_list .......................................   Passed    0.02 sec
        Start  14: test_decode-xml
 14/181 Test  #14: test_decode-xml .........................................   Passed    0.04 sec
        Start  15: test_lists_list
 15/181 Test  #15: test_lists_list .........................................   Passed    0.01 sec
        Start  16: test_rule_list
 16/181 Test  #16: test_rule_list ..........................................   Passed    0.02 sec
        Start  17: test_eventinfo_list
 17/181 Test  #17: test_eventinfo_list .....................................   Passed    0.01 sec
        Start  18: test_logmsg
 18/181 Test  #18: test_logmsg .............................................   Passed    0.02 sec
        Start  19: test_decoder_rootcheck
 19/181 Test  #19: test_decoder_rootcheck ..................................   Passed    0.04 sec
        Start  20: test_decoder_syscollector
 20/181 Test  #20: test_decoder_syscollector ...............................   Passed    1.14 sec
        Start  21: test_decoder_winevtchannel
 21/181 Test  #21: test_decoder_winevtchannel ..............................   Passed    0.03 sec
        Start  22: test_decoder_winevtchannel_input
 22/181 Test  #22: test_decoder_winevtchannel_input ........................   Passed    0.04 sec
        Start  23: test_analysis-state
 23/181 Test  #23: test_analysis-state .....................................   Passed    0.04 sec
        Start  24: test_asyscom
 24/181 Test  #24: test_asyscom ............................................   Passed    0.04 sec
        Start  25: test_limits
 25/181 Test  #25: test_limits .............................................   Passed    0.01 sec
        Start  26: test_manager
 26/181 Test  #26: test_manager ............................................   Passed    0.21 sec
        Start  27: test_secure
 27/181 Test  #27: test_secure .............................................   Passed    0.03 sec
        Start  28: test_save_ctrlmsg_thread
 28/181 Test  #28: test_save_ctrlmsg_thread ................................   Passed    0.03 sec
        Start  29: test_netbuffer
 29/181 Test  #29: test_netbuffer ..........................................   Passed    0.03 sec
        Start  30: test_sendmsg
 30/181 Test  #30: test_sendmsg ............................................   Passed    0.03 sec
        Start  31: test_remote-config
 31/181 Test  #31: test_remote-config ......................................   Passed    0.02 sec
        Start  32: test_syslogtcp
 32/181 Test  #32: test_syslogtcp ..........................................   Passed    0.04 sec
        Start  33: test_remote-state
 33/181 Test  #33: test_remote-state .......................................   Passed    0.03 sec
        Start  34: test_remcom
 34/181 Test  #34: test_remcom .............................................   Passed    0.04 sec
        Start  35: test_wdb_integrity
 35/181 Test  #35: test_wdb_integrity ......................................   Passed    0.03 sec
        Start  36: test_wdb_fim
 36/181 Test  #36: test_wdb_fim ............................................   Passed    0.04 sec
        Start  37: test_wdb_parser
 37/181 Test  #37: test_wdb_parser .........................................   Passed    0.03 sec
        Start  38: test_wdb_global_parser
 38/181 Test  #38: test_wdb_global_parser ..................................   Passed    0.04 sec
        Start  39: test_wdb_global
 39/181 Test  #39: test_wdb_global .........................................   Passed    0.06 sec
        Start  40: test_wdb_agents
 40/181 Test  #40: test_wdb_agents .........................................   Passed    0.02 sec
        Start  41: test_wdb_global_helpers
 41/181 Test  #41: test_wdb_global_helpers .................................   Passed    0.03 sec
        Start  42: test_wdb_agents_helpers
 42/181 Test  #42: test_wdb_agents_helpers .................................   Passed    0.02 sec
        Start  43: test_wdb
 43/181 Test  #43: test_wdb ................................................   Passed    0.03 sec
        Start  44: test_wdb_upgrade
 44/181 Test  #44: test_wdb_upgrade ........................................   Passed    0.02 sec
        Start  45: test_wdb_metadata
 45/181 Test  #45: test_wdb_metadata .......................................   Passed    0.02 sec
        Start  46: test_wdb_task_parser
 46/181 Test  #46: test_wdb_task_parser ....................................   Passed    0.02 sec
        Start  47: test_wdb_rootcheck
 47/181 Test  #47: test_wdb_rootcheck ......................................   Passed    0.02 sec
        Start  48: test_wdb_syscollector
 48/181 Test  #48: test_wdb_syscollector ...................................   Passed    0.03 sec
        Start  49: test_wdb_task
 49/181 Test  #49: test_wdb_task ...........................................   Passed    0.02 sec
        Start  50: test_wdb_delta_event
 50/181 Test  #50: test_wdb_delta_event ....................................   Passed    0.03 sec
        Start  51: test_wazuh_db-config
 51/181 Test  #51: test_wazuh_db-config ....................................   Passed    0.03 sec
        Start  52: test_wazuh_db_state
 52/181 Test  #52: test_wazuh_db_state .....................................   Passed    0.02 sec
        Start  53: test_wdb_com
 53/181 Test  #53: test_wdb_com ............................................   Passed    0.02 sec
        Start  54: test_wdb_pool
 54/181 Test  #54: test_wdb_pool ...........................................   Passed    0.02 sec
        Start  55: test_create_agent_db
 55/181 Test  #55: test_create_agent_db ....................................   Passed    0.02 sec
        Start  56: test_auth_parse
 56/181 Test  #56: test_auth_parse .........................................   Passed    0.02 sec
        Start  57: test_auth_validate
 57/181 Test  #57: test_auth_validate ......................................   Passed    0.02 sec
        Start  58: test_auth_add
 58/181 Test  #58: test_auth_add ...........................................   Passed    0.02 sec
        Start  59: test_ssl
 59/181 Test  #59: test_ssl ................................................   Passed    0.02 sec
        Start  60: test_auth_key_request
 60/181 Test  #60: test_auth_key_request ...................................   Passed    0.03 sec
        Start  61: test_auth
 61/181 Test  #61: test_auth ...............................................   Passed    0.02 sec
        Start  62: test_generate_cert
 62/181 Test  #62: test_generate_cert ......................................   Passed    0.40 sec
        Start  63: test_authd-config
 63/181 Test  #63: test_authd-config .......................................   Passed    0.01 sec
        Start  64: test_aes_op
 64/181 Test  #64: test_aes_op .............................................   Passed    0.02 sec
        Start  65: test_hmac_op
 65/181 Test  #65: test_hmac_op ............................................   Passed    0.02 sec
        Start  66: test_msgs
 66/181 Test  #66: test_msgs ...............................................   Passed    0.03 sec
        Start  67: test_keys
 67/181 Test  #67: test_keys ...............................................   Passed    0.02 sec
        Start  68: test_sha1_op
 68/181 Test  #68: test_sha1_op ............................................   Passed    0.02 sec
        Start  69: test_blowfish_op
 69/181 Test  #69: test_blowfish_op ........................................   Passed    0.01 sec
        Start  70: test_md5_op
 70/181 Test  #70: test_md5_op .............................................   Passed    0.02 sec
        Start  71: test_md5_sha1_op
 71/181 Test  #71: test_md5_sha1_op ........................................   Passed    0.02 sec
        Start  72: test_md5_sha1_sha256_op
 72/181 Test  #72: test_md5_sha1_sha256_op .................................   Passed    0.02 sec
        Start  73: test_sha256_op
 73/181 Test  #73: test_sha256_op ..........................................   Passed    0.02 sec
        Start  74: test_sha512_op
 74/181 Test  #74: test_sha512_op ..........................................   Passed    0.02 sec
        Start  75: test_wm_aws
 75/181 Test  #75: test_wm_aws .............................................   Passed    0.04 sec
        Start  76: test_wm_azure
 76/181 Test  #76: test_wm_azure ...........................................   Passed    0.08 sec
        Start  77: test_wm_ciscat
 77/181 Test  #77: test_wm_ciscat ..........................................   Passed    0.03 sec
        Start  78: test_wm_command
 78/181 Test  #78: test_wm_command .........................................   Passed    0.03 sec
        Start  79: test_wm_database
 79/181 Test  #79: test_wm_database ........................................   Passed    0.03 sec
        Start  80: test_wm_docker
 80/181 Test  #80: test_wm_docker ..........................................   Passed    0.04 sec
        Start  81: test_wm_gcp
 81/181 Test  #81: test_wm_gcp .............................................   Passed    0.20 sec
        Start  82: test_wmodules_gcp
 82/181 Test  #82: test_wmodules_gcp .......................................   Passed    0.05 sec
        Start  83: test_wm_oscap
 83/181 Test  #83: test_wm_oscap ...........................................   Passed    0.03 sec
        Start  84: test_wm_sca
 84/181 Test  #84: test_wm_sca .............................................   Passed    0.03 sec
        Start  85: test_wmodules_scheduling
 85/181 Test  #85: test_wmodules_scheduling ................................   Passed    0.01 sec
        Start  86: test_wm_vulnerability_detection
 86/181 Test  #86: test_wm_vulnerability_detection .........................   Passed    0.05 sec
        Start  87: test_wm_task_manager
 87/181 Test  #87: test_wm_task_manager ....................................   Passed    0.03 sec
        Start  88: test_wm_task_manager_parsing
 88/181 Test  #88: test_wm_task_manager_parsing ............................   Passed    0.02 sec
        Start  89: test_wm_task_manager_commands
 89/181 Test  #89: test_wm_task_manager_commands ...........................   Passed    0.02 sec
        Start  90: test_wm_agent_upgrade
 90/181 Test  #90: test_wm_agent_upgrade ...................................   Passed    0.02 sec
        Start  91: test_wm_agent_upgrade_manager
 91/181 Test  #91: test_wm_agent_upgrade_manager ...........................   Passed    0.03 sec
        Start  92: test_wm_agent_upgrade_parsing
 92/181 Test  #92: test_wm_agent_upgrade_parsing ...........................   Passed    0.04 sec
        Start  93: test_wm_agent_upgrade_validate
 93/181 Test  #93: test_wm_agent_upgrade_validate ..........................   Passed    0.02 sec
        Start  94: test_wm_agent_upgrade_tasks
 94/181 Test  #94: test_wm_agent_upgrade_tasks .............................   Passed    0.02 sec
        Start  95: test_wm_agent_upgrade_tasks_callbacks
 95/181 Test  #95: test_wm_agent_upgrade_tasks_callbacks ...................   Passed    0.03 sec
        Start  96: test_wm_agent_upgrade_commands
 96/181 Test  #96: test_wm_agent_upgrade_commands ..........................   Passed    0.04 sec
        Start  97: test_wm_agent_upgrade_upgrades
 97/181 Test  #97: test_wm_agent_upgrade_upgrades ..........................   Passed    0.04 sec
        Start  98: test_wmodules
 98/181 Test  #98: test_wmodules ...........................................   Passed    0.02 sec
        Start  99: test_wm_control
 99/181 Test  #99: test_wm_control .........................................   Passed    0.03 sec
        Start 100: test_wm_github
100/181 Test #100: test_wm_github ..........................................   Passed    0.04 sec
        Start 101: test_wm_office365
101/181 Test #101: test_wm_office365 .......................................   Passed    0.07 sec
        Start 102: test_wm_ms_graph
102/181 Test #102: test_wm_ms_graph ........................................   Passed    0.06 sec
        Start 103: test_wm_osquery_already_running
103/181 Test #103: test_wm_osquery_already_running .........................   Passed    0.03 sec
        Start 104: test_wm_exec
104/181 Test #104: test_wm_exec ............................................   Passed    0.03 sec
        Start 105: test_monitord
105/181 Test #105: test_monitord ...........................................   Passed    0.02 sec
        Start 106: test_monitor_actions
106/181 Test #106: test_monitor_actions ....................................   Passed    0.03 sec
        Start 107: test_logcollector
107/181 Test #107: test_logcollector .......................................   Passed    0.04 sec
        Start 108: test_read_multiline_regex
108/181 Test #108: test_read_multiline_regex ...............................   Passed    0.03 sec
        Start 109: test_localfile-config
109/181 Test #109: test_localfile-config ...................................   Passed    0.04 sec
        Start 110: test_state
110/181 Test #110: test_state ..............................................   Passed    0.02 sec
        Start 111: test_lccom
111/181 Test #111: test_lccom ..............................................   Passed    0.06 sec
        Start 112: test_macos_log
112/181 Test #112: test_macos_log ..........................................   Passed    0.02 sec
        Start 113: test_read_macos
113/181 Test #113: test_read_macos .........................................   Passed    0.05 sec
        Start 114: test_read_multiline
114/181 Test #114: test_read_multiline .....................................   Passed    0.03 sec
        Start 115: test_read_journal
115/181 Test #115: test_read_journal .......................................   Passed    0.04 sec
        Start 116: test_journal_log
116/181 Test #116: test_journal_log ........................................   Passed    0.05 sec
        Start 117: test_read_syslog
117/181 Test #117: test_read_syslog ........................................   Passed    0.04 sec
        Start 118: test_execd
118/181 Test #118: test_execd ..............................................   Passed    0.02 sec
        Start 119: test_get_command_by_name
119/181 Test #119: test_get_command_by_name ................................   Passed    0.01 sec
        Start 120: test_integrator
120/181 Test #120: test_integrator .........................................   Passed    0.02 sec
        Start 121: test_manage_keys
121/181 Test #121: test_manage_keys ........................................   Passed    0.02 sec
        Start 122: test_printtable
122/181 Test #122: test_printtable .........................................   Passed    0.02 sec
        Start 123: test_csyslogd
123/181 Test #123: test_csyslogd ...........................................   Passed    0.02 sec
        Start 124: test_syscom
124/181 Test #124: test_syscom .............................................   Passed    0.02 sec
        Start 125: test_fim_diff_changes
125/181 Test #125: test_fim_diff_changes ...................................   Passed    0.04 sec
        Start 126: test_run_realtime
126/181 Test #126: test_run_realtime .......................................   Passed    0.05 sec
        Start 127: test_config
127/181 Test #127: test_config .............................................   Passed    0.06 sec
        Start 128: test_syscheck
128/181 Test #128: test_syscheck ...........................................   Passed    0.03 sec
        Start 129: test_run_check
129/181 Test #129: test_run_check ..........................................   Passed    0.04 sec
        Start 130: test_create_db
130/181 Test #130: test_create_db ..........................................   Passed    0.06 sec
        Start 131: test_audit_healthcheck
131/181 Test #131: test_audit_healthcheck ..................................   Passed    0.04 sec
        Start 132: test_audit_rule_handling
132/181 Test #132: test_audit_rule_handling ................................   Passed    0.03 sec
        Start 133: test_syscheck_audit
133/181 Test #133: test_syscheck_audit .....................................   Passed    0.04 sec
        Start 134: test_audit_parse
134/181 Test #134: test_audit_parse ........................................   Passed    0.05 sec
        Start 135: test_syscheck_ebpf
135/181 Test #135: test_syscheck_ebpf ......................................   Passed    0.08 sec
        Start 136: test_list_op
136/181 Test #136: test_list_op ............................................   Passed    0.02 sec
        Start 137: test_file_op
137/181 Test #137: test_file_op ............................................   Passed    0.01 sec
        Start 138: test_integrity_op
138/181 Test #138: test_integrity_op .......................................   Passed    0.01 sec
        Start 139: test_rbtree_op
139/181 Test #139: test_rbtree_op ..........................................   Passed    0.01 sec
        Start 140: test_validate_op
140/181 Test #140: test_validate_op ........................................   Passed    0.02 sec
        Start 141: test_string_op
141/181 Test #141: test_string_op ..........................................   Passed    0.02 sec
        Start 142: test_expression
142/181 Test #142: test_expression .........................................   Passed    0.02 sec
        Start 143: test_version_op
143/181 Test #143: test_version_op .........................................   Passed    0.04 sec
        Start 144: test_queue_op
144/181 Test #144: test_queue_op ...........................................   Passed    0.02 sec
        Start 145: test_queue_linked_op
145/181 Test #145: test_queue_linked_op ....................................   Passed    0.02 sec
        Start 146: test_indexed_queue_op
146/181 Test #146: test_indexed_queue_op ...................................   Passed    0.02 sec
        Start 147: test_agent_op
147/181 Test #147: test_agent_op ...........................................   Passed    0.02 sec
        Start 148: test_enrollment_op
148/181 Test #148: test_enrollment_op ......................................   Passed    0.04 sec
        Start 149: test_time_op
149/181 Test #149: test_time_op ............................................   Passed    0.01 sec
        Start 150: test_buffer_op
150/181 Test #150: test_buffer_op ..........................................   Passed    0.02 sec
        Start 151: test_utf8_op
151/181 Test #151: test_utf8_op ............................................   Passed    0.02 sec
        Start 152: test_log_builder
152/181 Test #152: test_log_builder ........................................   Passed    0.02 sec
        Start 153: test_custom_output_search_replace
153/181 Test #153: test_custom_output_search_replace .......................   Passed    0.02 sec
        Start 154: test_binaries_op
154/181 Test #154: test_binaries_op ........................................   Passed    0.02 sec
        Start 155: test_bzip2_op
155/181 Test #155: test_bzip2_op ...........................................   Passed    0.01 sec
        Start 156: test_schedule_scan
156/181 Test #156: test_schedule_scan ......................................   Passed    0.02 sec
        Start 157: test_rootcheck_op
157/181 Test #157: test_rootcheck_op .......................................   Passed    0.02 sec
        Start 158: test_fs_op
158/181 Test #158: test_fs_op ..............................................   Passed    0.01 sec
        Start 159: test_wazuhdb_op
159/181 Test #159: test_wazuhdb_op .........................................   Passed    0.01 sec
        Start 160: test_syscheck_op
160/181 Test #160: test_syscheck_op ........................................   Passed    0.05 sec
        Start 161: test_json_op
161/181 Test #161: test_json_op ............................................   Passed    0.02 sec
        Start 162: test_audit_op
162/181 Test #162: test_audit_op ...........................................   Passed    0.03 sec
        Start 163: test_privsep_op
163/181 Test #163: test_privsep_op .........................................   Passed    0.01 sec
        Start 164: test_mq_op
164/181 Test #164: test_mq_op ..............................................   Passed    0.02 sec
        Start 165: test_remoted_op
165/181 Test #165: test_remoted_op .........................................   Passed    0.02 sec
        Start 166: test_json-queue
166/181 Test #166: test_json-queue .........................................   Passed    0.02 sec
        Start 167: test_bqueue
167/181 Test #167: test_bqueue .............................................   Passed    0.02 sec
        Start 168: test_atomic
168/181 Test #168: test_atomic .............................................   Passed    0.02 sec
        Start 169: test_url
169/181 Test #169: test_url ................................................   Passed    0.02 sec
        Start 170: test_sysinfo_utils
170/181 Test #170: test_sysinfo_utils ......................................   Passed    0.02 sec
        Start 171: test_rwlock_op
171/181 Test #171: test_rwlock_op ..........................................   Passed    0.04 sec
        Start 172: test_os_xml
172/181 Test #172: test_os_xml .............................................   Passed    0.06 sec
        Start 173: test_os_regex
173/181 Test #173: test_os_regex ...........................................   Passed    0.02 sec
        Start 174: test_os_regex_match
174/181 Test #174: test_os_regex_match .....................................   Passed    0.01 sec
        Start 175: test_os_regex_execute
175/181 Test #175: test_os_regex_execute ...................................   Passed    0.25 sec
        Start 176: test_os_zlib
176/181 Test #176: test_os_zlib ............................................   Passed    0.01 sec
        Start 177: test_client-config_validate_ipv6_link_local_interface
177/181 Test #177: test_client-config_validate_ipv6_link_local_interface ...   Passed    0.02 sec
        Start 178: test_indexer
178/181 Test #178: test_indexer ............................................   Passed    0.02 sec
        Start 179: test_os_net
179/181 Test #179: test_os_net .............................................   Passed    0.02 sec
        Start 180: test_fluentd_forwarder
180/181 Test #180: test_fluentd_forwarder ..................................   Passed    0.03 sec
        Start 181: test_active-response
181/181 Test #181: test_active-response ....................................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 181

Total Test time (real) =   9.32 sec
 *  Terminal will be reused by tasks, press any key to close it. 
```

</p>
</details> 
