### PR TITLE
Unit tests for os_trimcrlf function

### DIFF
--- a/src/unit_tests/shared/test_string_op.c
+++ b/src/unit_tests/shared/test_string_op.c
@@ -15,8 +15,8 @@
 
 #include "../headers/shared.h"
 
-#define OS_TRIMCRLF_ARRAY_SIZE 8
-#define OS_TRIMCRLF_MAX_STR_SIZE 11
+#define OS_TRIMCRLF_ARRAY_SIZE 11
+#define OS_TRIMCRLF_MAX_STR_SIZE 8
 
 char * w_tolower_str(const char *string);
 
@@ -1128,7 +1128,7 @@ void test_os_trimcrlf(void **state) {
         "TEST\n\n",
         "TEST\r\r"
     };
-    
+
     char result_value_array[OS_TRIMCRLF_ARRAY_SIZE][OS_TRIMCRLF_MAX_STR_SIZE] = {
         "",
         "TEST",
@@ -1276,7 +1276,7 @@ int main(void) {
         cmocka_unit_test(test_print_hex_string_equal_dest_ok),
         cmocka_unit_test(test_print_hex_string_miss_last_dest_ok),
         cmocka_unit_test(test_print_hex_string_null_src_err),
-        cmocka_unit_test(test_print_hex_string_null_dst_err),        
+        cmocka_unit_test(test_print_hex_string_null_dst_err),
         // Test os_trimcrlf
         cmocka_unit_test(test_os_trimcrlf),
         cmocka_unit_test(test_os_trimcrlf_NULL)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
This pull request is the outcome of the Task 11 of the onboarding issue numbered 3791. In this task I developed the corresponding Unit Tests in the `test_string_op.c` file for `os_trimcrlf` function, in `string_op.c` file.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

Changes made in this pull request were:
- Developing all Unit Tests for `os_trimcrlf` function.
- Adding a comma after the last test so cmocka framework recognises the next Unit Tests.
- Adding calls to the developed tests.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->


<details>
<summary>Defined constants</summary>

```
#define OS_TRIMCRLF_ARRAY_SIZE 11
#define OS_TRIMCRLF_MAX_STR_SIZE 8
```

</details>

<details>
<summary>Developed tests</summary>

```
void test_os_trimcrlf(void **state) {
    char initial_value_array[OS_TRIMCRLF_ARRAY_SIZE][OS_TRIMCRLF_MAX_STR_SIZE] = {
        "",
        "TEST",
        "\n",
        "\r",
        "TEST\n",
        "TEST\r",
        "TEST\n\r",
        "TE\nST",
        "TE\rST",
        "TEST\n\n",
        "TEST\r\r"
    };
    
    char result_value_array[OS_TRIMCRLF_ARRAY_SIZE][OS_TRIMCRLF_MAX_STR_SIZE] = {
        "",
        "TEST",
        "",
        "",
        "TEST",
        "TEST",
        "TEST",
        "TE\nST",
        "TE\rST",
        "TEST",
        "TEST"
    };

    for (int idx = 0; idx < OS_TRIMCRLF_ARRAY_SIZE; ++idx) {
        os_trimcrlf(initial_value_array[idx]);
        assert_string_equal(initial_value_array[idx], result_value_array[idx]);
    }

}

void test_os_trimcrlf_NULL(void **state) {
    char *str = NULL;
    os_trimcrlf(str);
    assert_null(str);
}
```

<br>
<img width="314" height="39" alt="image" src="https://github.com/user-attachments/assets/7e1b3946-ec79-4064-8bf0-2f5322d1b671" />


<img width="315" height="44" alt="image" src="https://github.com/user-attachments/assets/c4ace20e-df89-417f-8d04-92622d4d097c" />

</details>

<details>
<summary>Coverage tests</summary>

After succesfully running coverage tests I got this general information:

<img width="335" height="70" alt="image" src="https://github.com/user-attachments/assets/169048fc-8e81-46d8-8545-a3fed0e23da8" />


However, I visited the `index.html` file the tool generated and I got these results regarding the tested function:

<img width="869" height="460" alt="image" src="https://github.com/user-attachments/assets/b9902636-c564-40e1-a7c7-9d1187b20586" />

</details>

### Tests Introduced

- `test_os_trimcrlf`
- `test_os_trimcrlf_NULL`

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
