### PR TITLE
Prevent race condition during syscollector shutdown

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -242,7 +242,6 @@ Syscollector::Syscollector()
     , m_processes { false }
     , m_hotfixes { false }
     , m_stopping { true }
-    , m_syncLoopFinished { false }
     , m_notify { false }
     , m_groups { false }
     , m_users { false }
@@ -458,7 +457,6 @@ void Syscollector::init(const std::shared_ptr<ISysInfo>& spInfo,
 
     std::unique_lock<std::mutex> lock{m_mutex};
     m_stopping = false;
-    m_syncLoopFinished = false;
 
     m_spDBSync      = std::move(dbSync);
     m_spRsync       = std::move(remoteSync);
@@ -474,11 +472,6 @@ void Syscollector::destroy()
     m_stopping = true;
     m_cv.notify_all();
 
-    // Wait for syncLoop to finish completely, including cleanup of resources
-    m_cv.wait(lock, [this]()
-    {
-        return m_syncLoopFinished;
-    });
     lock.unlock();
 }
 
@@ -1081,7 +1074,6 @@ void Syscollector::syncLoop(std::unique_lock<std::mutex>& lock)
     }
     m_spRsync.reset(nullptr);
     m_spDBSync.reset(nullptr);
-    m_syncLoopFinished = true;
     m_cv.notify_all();
 }
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR addresses an issue where the Wazuh agent fails to shut down cleanly on Windows systems, often leading to a forced termination by the OS. The root cause was identified in the synchronization loops of Syscollector and FIM, which did not check for the global stop signal frequently enough, and in blocking synchronous API calls that saturated the processing threads.


Closes #33761


## Proposed Changes

This PR reverts commit [78c69f189b8fa1ed9bcf6f196a3639adf0f3dc97](https://github.com/wazuh/wazuh/pull/33488/commits/78c69f189b8fa1ed9bcf6f196a3639adf0f3dc97), as the issue it originally addressed was resolved in PR #33677. Consequently, those specific changes are no longer required

### Results and Evidence

We used the following script for testing:

[test-issue-33761.zip](https://github.com/user-attachments/files/24461900/test-issue-33761.zip)

**Note**: This script reproduces the TCP/UDP configuration switch scenario and tracks NET STOP failures.

<details><summary>Result</summary>
<img width="491" height="486" alt="image" src="https://github.com/user-attachments/assets/557b2649-b2de-40c7-a33a-83eb7ec440a1" />
</details>


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [x] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
