### PR TITLE
support optional "per" field in auditd decoder

### DIFF
--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -24,8 +24,8 @@
 <!-- SYSCALL -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm="(\S+)" exe="(\S+)"</regex>
-  <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
+  <regex type="pcre2" offset="after_regex">^arch=(\S+) syscall=(\d+)(?: per=(\d+))? success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm="(\S+)" exe="(\S+)"</regex>
+  <order>audit.arch,audit.syscall,audit.per,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
 </decoder>
 
 <!-- SYSCALL - command -->


### PR DESCRIPTION
This PR fixes the issue [Auditd decoder incorrectly parses events with per field. #33802](https://github.com/wazuh/wazuh/issues/33802).

I wasn't sure which branch to choose for the PR becuase `main` branch doesn't have the decoder file, so I decided to go with `4.14.3`. If it's incorrect, please let me know how to improve the PR.