### PR TITLE
Add ARM64 support to Engine Standalone workflow

### DIFF
--- a/.github/workflows/5_builderpackage_engine-standalone.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone.yml
@@ -24,6 +24,7 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
+      - '.github/workflows/5_builderpackage_engine-standalone.yml'
 
 # Ensures only one instance of this workflow is running per PR
 concurrency:
@@ -31,25 +32,37 @@ concurrency:
 
 env:
   ENGINE_DIR: ${{github.workspace}}/src/engine
-  ENGINE_STANDALONE_DIR: wazuh-engine-standalone
-  ENGINE_STANDALONE_SOCKET: wazuh-engine-standalone/sockets/engine-api.sock
   WAZUH_BRANCH: ${{ github.event.inputs.wazuh-branch || 'main' }}
   BUILD_TYPE: ${{ github.event.inputs.build-type || 'release' }}
 
 jobs:
   build:
-    name: Build Server
-    runs-on: ubuntu-latest
+    name: Build Server (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      version: ${{ steps.set_version.outputs.version }}
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            container_name: pkg_rpm_manager_builder_amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            container_name: pkg_rpm_manager_builder_arm64
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || env.WAZUH_BRANCH }}
 
       - name: Set tag and container name
+        id: set_version
         run: |
           VERSION="$(grep '"version"' $GITHUB_WORKSPACE/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
           echo "TAG=$VERSION" >> $GITHUB_ENV;
-          echo "CONTAINER_NAME=pkg_rpm_manager_builder_amd64" >> $GITHUB_ENV;
+          echo "version=$VERSION" >> $GITHUB_OUTPUT;
+          echo "CONTAINER_NAME=${{ matrix.container_name }}" >> $GITHUB_ENV;
 
       - name: Download docker image for package building
         run: |
@@ -61,140 +74,79 @@ jobs:
           docker run --entrypoint /workspace/wazuh/src/engine/standalone/docker-entrypoint.sh \
             -e BUILD_TYPE="${BUILD_TYPE}" \
             -t -v ${{github.workspace}}:/workspace/wazuh:Z \
-            -v ${{github.workspace}}/packages/output:/var/local/wazuh:Z \
             ${CONTAINER_NAME}:${TAG}
 
-      - name: Upload engine binary
+      - name: Create standalone package
+        run: |
+          mkdir auxiliar_dir
+          cd auxiliar_dir
+          install -d -m 770 \
+            wazuh-engine-standalone/bin/lib \
+            wazuh-engine-standalone/default-security-policy \
+            wazuh-engine-standalone/data/store/schema \
+            wazuh-engine-standalone/data/store/schema/engine-schema \
+            wazuh-engine-standalone/data/store/schema/wazuh-logpar-overrides \
+            wazuh-engine-standalone/data/store/schema/allowed-fields \
+            wazuh-engine-standalone/data/kvdb \
+            wazuh-engine-standalone/data/tzdb \
+            wazuh-engine-standalone/data/cti \
+            wazuh-engine-standalone/schemas \
+            wazuh-engine-standalone/logs \
+            wazuh-engine-standalone/sockets
+          touch wazuh-engine-standalone/bin/lib/.keep
+          touch wazuh-engine-standalone/default-security-policy/.keep
+          touch wazuh-engine-standalone/data/kvdb/.keep
+          touch wazuh-engine-standalone/data/tzdb/.keep
+          touch wazuh-engine-standalone/data/cti/.keep
+          touch wazuh-engine-standalone/logs/.keep
+          touch wazuh-engine-standalone/sockets/.keep
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/engine-schema.json wazuh-engine-standalone/data/store/schema/engine-schema/0
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-logpar-overrides.json  wazuh-engine-standalone/data/store/schema/wazuh-logpar-overrides/0
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/allowed-fields.json  wazuh-engine-standalone/data/store/schema/allowed-fields/0
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/fields_decoder.json wazuh-engine-standalone/schemas/
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/fields_rule.json  wazuh-engine-standalone/schemas/
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-decoders.json  wazuh-engine-standalone/schemas/
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-rules.json  wazuh-engine-standalone/schemas/
+          cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-filters.json  wazuh-engine-standalone/schemas/
+          cp -r ${{ env.ENGINE_DIR }}/standalone/run_engine.sh wazuh-engine-standalone/
+          chmod +x wazuh-engine-standalone/run_engine.sh
+          cp ${{ env.ENGINE_DIR }}/standalone/README.md wazuh-engine-standalone/
+          cp ${{github.workspace}}/src/external/rocksdb/build/librocksdb.so.8 wazuh-engine-standalone/bin/lib
+          cp ${{github.workspace}}/src/libwazuhext.so wazuh-engine-standalone/bin/lib
+          cp ${{github.workspace}}/src/build/shared_modules/indexer_connector/libindexer_connector.so wazuh-engine-standalone/bin/lib
+          cp ${{github.workspace}}/src/build/shared_modules/content_manager/libcontent_manager.so wazuh-engine-standalone/bin/lib
+          cp ${{github.workspace}}/gcc-libs/libstdc++.so.6* wazuh-engine-standalone/bin/lib/
+          cp ${{github.workspace}}/src/build/engine/wazuh-engine wazuh-engine-standalone/bin/
+          chmod +x wazuh-engine-standalone/bin/wazuh-engine
+          cd ..
+
+      - name: Upload standalone package
         uses: actions/upload-artifact@v4
         with:
-          name: wazuh-engine
-          path: src/build/engine/wazuh-engine
-
-      - name: Upload wazuh shared libraries
-        uses: actions/upload-artifact@v4
-        with:
-          name: wazuh-shared-libraries
-          path: |
-            src/libwazuhext.so
-            src/libwazuhshared.so
-            src/build/shared_modules/indexer_connector/libindexer_connector.so
-            src/build/shared_modules/content_manager/libcontent_manager.so
-
-      - name: Upload rocksdb shared libraries
-        uses: actions/upload-artifact@v4
-        with:
-          name: rocksdb-shared-library
-          path: |
-            src/external/rocksdb/build/librocksdb.so
-            src/external/rocksdb/build/librocksdb.so.8
-            src/external/rocksdb/build/librocksdb.so.8.3.2
-
-  create_standalone_zip:
-    name: Create standalone compressed engine
-
-    # Only runs if the PR status is different to Draft
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-
-    - name: Download engine binary
-      uses: actions/download-artifact@v4
-      with:
-        name: wazuh-engine
-        path: src/build/engine/
-
-    - name: Download rocksdb shared libraries
-      uses: actions/download-artifact@v4
-      with:
-        name: rocksdb-shared-library
-        path: src/external/rocksdb/build/
-
-    - name: Download wazuh shared libraries
-      uses: actions/download-artifact@v4
-      with:
-        name: wazuh-shared-libraries
-        path: src/
-
-    - name: Create tar scaffolding and copy files
-      run: |
-        mkdir auxiliar_dir
-        cd auxiliar_dir
-        install -d -m 770 \
-          wazuh-engine-standalone/bin/lib \
-          wazuh-engine-standalone/default-security-policy \
-          wazuh-engine-standalone/data/store/schema \
-          wazuh-engine-standalone/data/store/schema/engine-schema \
-          wazuh-engine-standalone/data/store/schema/wazuh-logpar-overrides \
-          wazuh-engine-standalone/data/store/schema/allowed-fields \
-          wazuh-engine-standalone/data/kvdb \
-          wazuh-engine-standalone/data/tzdb \
-          wazuh-engine-standalone/data/cti \
-          wazuh-engine-standalone/schemas \
-          wazuh-engine-standalone/logs \
-          wazuh-engine-standalone/sockets
-        touch wazuh-engine-standalone/bin/lib/.keep
-        touch wazuh-engine-standalone/default-security-policy/.keep
-        touch wazuh-engine-standalone/data/kvdb/.keep
-        touch wazuh-engine-standalone/data/tzdb/.keep
-        touch wazuh-engine-standalone/data/cti/.keep
-        touch wazuh-engine-standalone/logs/.keep
-        touch wazuh-engine-standalone/sockets/.keep
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/engine-schema.json wazuh-engine-standalone/data/store/schema/engine-schema/0
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-logpar-overrides.json  wazuh-engine-standalone/data/store/schema/wazuh-logpar-overrides/0
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/allowed-fields.json  wazuh-engine-standalone/data/store/schema/allowed-fields/0
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/fields_decoder.json wazuh-engine-standalone/schemas/
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/fields_rule.json  wazuh-engine-standalone/schemas/
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-decoders.json  wazuh-engine-standalone/schemas/
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-rules.json  wazuh-engine-standalone/schemas/
-        cp -r ${{ env.ENGINE_DIR }}/ruleset/schemas/wazuh-filters.json  wazuh-engine-standalone/schemas/
-        cp -r ${{ env.ENGINE_DIR }}/standalone/run_engine.sh wazuh-engine-standalone/
-        chmod +x wazuh-engine-standalone/run_engine.sh
-        cp ${{ env.ENGINE_DIR }}/standalone/README.md wazuh-engine-standalone/
-        cp ${{github.workspace}}/src/external/rocksdb/build/librocksdb.so.8 wazuh-engine-standalone/bin/lib
-        cp ${{github.workspace}}/src/libwazuhext.so wazuh-engine-standalone/bin/lib
-        cp ${{github.workspace}}/src/build/shared_modules/indexer_connector/libindexer_connector.so wazuh-engine-standalone/bin/lib
-        cp ${{github.workspace}}/src/build/shared_modules/content_manager/libcontent_manager.so wazuh-engine-standalone/bin/lib
-        cp ${{github.workspace}}/src/build/engine/wazuh-engine wazuh-engine-standalone/bin/
-        chmod +x wazuh-engine-standalone/bin/wazuh-engine
-        cd ..
-
-    - name: Set version
-      run: |
-        VERSION="$(grep '"version"' $GITHUB_WORKSPACE/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
-        echo "TAG=$VERSION" >> $GITHUB_ENV;
-
-    - name: Upload compressed tar file
-      uses: actions/upload-artifact@v4
-      with:
-        name: wazuh-engine-${{ env.TAG }}-standalone
-        path: auxiliar_dir
-        include-hidden-files: true
+          name: wazuh-engine-${{ env.TAG }}-linux-${{ matrix.arch }}
+          path: auxiliar_dir
+          include-hidden-files: true
 
   check_standalone_engine:
-    name: Test standalone engine
+    name: Test standalone engine (${{ matrix.arch }})
 
-    runs-on: ubuntu-latest
-    needs: create_standalone_zip
+    runs-on: ${{ matrix.runner }}
+    needs: build
     timeout-minutes: 60
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-
-    - name: Set version
-      run: |
-        VERSION="$(grep '"version"' $GITHUB_WORKSPACE/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
-        echo "TAG=$VERSION" >> $GITHUB_ENV;
-
     - name: Download compressed zip file
       uses: actions/download-artifact@v4
       with:
-        name: wazuh-engine-${{ env.TAG }}-standalone
+        name: wazuh-engine-${{ needs.build.outputs.version }}-linux-${{ matrix.arch }}
         path: /tmp/standalone-test
 
     - name: Verify artifact structure

--- a/src/engine/standalone/docker-entrypoint.sh
+++ b/src/engine/standalone/docker-entrypoint.sh
@@ -18,8 +18,13 @@ build_dir="/build_wazuh"
 
 make -C /workspace/wazuh/src deps TARGET=server
 
-if [${BUILD_TYPE} == "debug" ]; then
+if [ "${BUILD_TYPE}" = "debug" ]; then
     make -j2 -C /workspace/wazuh/src TARGET=server DEBUG="yes"
 else
     make -j2 -C /workspace/wazuh/src TARGET=server
+fi
+
+if [ -d "/opt/gcc-14/lib64" ]; then
+    mkdir -p /workspace/wazuh/gcc-libs
+    cp /opt/gcc-14/lib64/libstdc++.so.6* /workspace/wazuh/gcc-libs/
 fi


### PR DESCRIPTION
## Description

Extended `.github/workflows/5_builderpackage_engine-standalone.yml `to build and upload standalone artifacts for amd64 and arm64, while keeping an x86_64 smoke validation to prevent regressions. 


## Proposed Changes

- Added build matrix for `amd64` and `arm64` architectures with their respective runners and builder images.

- Made artifact names architecture-aware to generate separate standalone packages for each architecture (e.g., `wazuh-engine-5.0.0-linux-amd64` and `wazuh-engine-5.0.0-linux-arm64`).

- Added `libstdc++.so.6` from GCC 14 to fix compatibility on RedHat 9/10. The library is copied from the build container during compilation and included in `bin/lib/`.

- Fixed bash syntax in `docker-entrypoint.sh` for `BUILD_TYPE=debug`:
  - **Before**: `if [${BUILD_TYPE} == "debug" ]; then`
  - **After**: `if [ "${BUILD_TYPE}" = "debug" ]; then`

- Unified build and packaging stages to avoid multiple Docker runs and redundant artifact uploads.

- Added ARM64 validation to `check_standalone_engine` job.

- Removed unused environment variables and unnecessary volume mounts.



## Results and Evidence

#### Before
<img width="1827" height="648" alt="Captura desde 2026-01-06 13-30-15" src="https://github.com/user-attachments/assets/0798be24-d9dd-42a6-aeeb-6419861fbc7e" />

#### After

<img width="1794" height="814" alt="Captura desde 2026-01-08 22-43-48" src="https://github.com/user-attachments/assets/23db14cc-84c6-4d85-9831-f08ec723581e" />


### amd64 

<details><summary>Amazon Linux 2023</summary>
<p>

```console

docker exec -it aa9658623d16 bash

bash-5.2# cat /etc/os-release
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"
VERSION_ID="2023"
PLATFORM_ID="platform:al2023"
PRETTY_NAME="Amazon Linux 2023.9.20251208"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
VENDOR_NAME="AWS"
VENDOR_URL="https://aws.amazon.com/"
SUPPORT_END="2029-06-30"

bash-5.2# uname -a
Linux aa9658623d16 6.14.0-37-generic #37~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov 20 10:25:38 UTC 2 x86_64 x86_64 x86_64 GNU/Linux


bash-5.2# file /test/wazuh-engine-standalone/bin/wazuh-engine
/test/wazuh-engine-standalone/bin/wazuh-engine: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, with debug_info, not stripped


bash-5.2# ls -la /test/wazuh-engine-standalone/sockets/
total 8
drwxrwxr-x 2 1000 1000 4096 Jan  7 18:56 .
drwxrwxr-x 9 1000 1000 4096 Jan  7 18:34 ..
-rw-r--r-- 1 1000 1000    0 Jan  7  2026 .keep
srw-rw---- 1 root root    0 Jan  7 18:56 engine-api.sock
srw-rw---- 1 root root    0 Jan  7 18:56 engine-prod-event.sock
srw-rw---- 1 root root    0 Jan  7 18:56 queue-http.sock
bash-5.2#


bash-5.2# cd /test/wazuh-engine-standalone
bash-5.2# ./run_engine.sh
2026-01-07 18:56:33.186 31:31 info: Logging initialized.
2026-01-07 18:56:33.186 31:31 info: Store initialized.
2026-01-07 18:56:33.186 31:31 info: Initializing CTI Store ContentManager
2026-01-07 18:56:33.637 31:31 info: ContentManager: CTIStorageDB opened at '/test/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-07 18:56:33.637 31:31 info: CTI Store initialized
2026-01-07 18:56:33.637 31:31 info: Starting CTI Store content synchronization
2026-01-07 18:56:33.637 31:31 info: Starting CTI Store ContentDownloader
2026-01-07 18:56:33.637 31:31 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-07 18:56:34.201 31:31 info: CTI Store ContentDownloader started successfully
2026-01-07 18:56:34.201 31:31 info: Content Manager initialized.
2026-01-07 18:56:34.201 31:31 info: KVDB initialized.
2026-01-07 18:56:34.201 31:31 info: Geo initialized.
2026-01-07 18:56:34.248 31:31 info: Schema initialized.
2026-01-07 18:56:34.535 31:31 info: Loaded timezone database version: '2025c'
2026-01-07 18:56:34.535 31:31 info: HLP initialized.
2026-01-07 18:56:36.110 31:31 info: Indexer Connector initialized.
2026-01-07 18:56:36.110 31:31 info: Scheduler initialized and started.
2026-01-07 18:56:36.110 31:31 info: Stream logger initialized.
2026-01-07 18:56:36.122 31:31 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:56:36.130 31:31 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:56:36.131 31:31 info: Builder initialized.
2026-01-07 18:56:36.131 31:31 info: Content Manager CRUD Service initialized.
2026-01-07 18:56:36.132 31:31 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:56:36.136 31:31 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:56:36.136 31:31 warning: Router: router/tester/0 table is empty
2026-01-07 18:56:36.136 31:31 info: No thread count provided. Using 20 worker threads based on system hardware.
2026-01-07 18:56:54.835 31:31 info: Router initialized.
2026-01-07 18:56:54.835 31:31 info: Archiver initialized.
2026-01-07 18:56:54.845 31:31 info: Server API_SRV started in thread 129364104554048 at /test/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-07 18:56:54.845 31:31 info: Local engine's server initialized and started.
2026-01-07 18:56:54.856 31:31 info: Server ENRICHED_EVENTS_SRV started in thread 129363500574272 at /test/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-07 18:56:54.856 31:31 info: Remote engine's server initialized and started.
2026-01-07 18:56:54.856 31:31 info: Engine started in standalone mode.

```


</p>
</details> 


<details><summary>RedHat 9.7</summary>
<p>

```console

[root@fe4960492c3b /]# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="9.7 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.7"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux 9.7 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://issues.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.7
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.7"

[root@fe4960492c3b /]# uname -a
Linux fe4960492c3b 6.14.0-37-generic #37~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov 20 10:25:38 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

[root@fe4960492c3b /]# file /test/wazuh-engine-standalone/bin/wazuh-engine
/test/wazuh-engine-standalone/bin/wazuh-engine: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, with debug_info, not stripped


[root@fe4960492c3b wazuh-engine-standalone]# cd /test/wazuh-engine-standalone
[root@fe4960492c3b wazuh-engine-standalone]# ./run_engine.sh
2026-01-07 18:34:43.177 98:98 info: Logging initialized.
2026-01-07 18:34:43.177 98:98 info: Store initialized.
2026-01-07 18:34:43.177 98:98 info: Initializing CTI Store ContentManager
2026-01-07 18:34:45.226 98:98 info: ContentManager: CTIStorageDB opened at '/test/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-07 18:34:45.227 98:98 info: CTI Store initialized
2026-01-07 18:34:45.227 98:98 info: Starting CTI Store content synchronization
2026-01-07 18:34:45.227 98:98 info: Starting CTI Store ContentDownloader
2026-01-07 18:34:45.227 98:98 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-07 18:34:46.426 98:98 info: CTI Store ContentDownloader started successfully
2026-01-07 18:34:46.426 98:98 info: Content Manager initialized.
2026-01-07 18:34:46.426 98:98 info: KVDB initialized.
2026-01-07 18:34:46.426 98:98 info: Geo initialized.
2026-01-07 18:34:46.477 98:98 info: Schema initialized.
2026-01-07 18:34:46.693 98:98 warning: Failed to load timezone database: 'Timezone database not found at "/test/wazuh-engine-standalone/data/tzdb/iana"', try to download it
2026-01-07 18:34:46.978 98:98 info: Timezone database updated to version: '2025c'
2026-01-07 18:34:46.978 98:98 info: HLP initialized.
2026-01-07 18:34:53.115 98:98 info: Indexer Connector initialized.
2026-01-07 18:34:53.115 98:98 info: Scheduler initialized and started.
2026-01-07 18:34:53.115 98:98 info: Stream logger initialized.
2026-01-07 18:34:53.132 98:98 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:34:53.141 98:98 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:34:53.142 98:98 info: Builder initialized.
2026-01-07 18:34:53.142 98:98 info: Content Manager CRUD Service initialized.
2026-01-07 18:34:53.142 98:98 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:34:53.146 98:98 info: No flooding file provided, the queue will not be flooded.
2026-01-07 18:34:53.146 98:98 info: Router: router/router/0 table not found in store. Creating new table: File '/test/wazuh-engine-standalone/data/store/router/router/0' does not exist
2026-01-07 18:34:53.146 98:98 info: Router: router/tester/0 table not found in store. Creating new table: File '/test/wazuh-engine-standalone/data/store/router/tester/0' does not exist
2026-01-07 18:34:53.146 98:98 info: No thread count provided. Using 20 worker threads based on system hardware.
2026-01-07 18:34:53.146 98:98 warning: Router: EPS settings could not be loaded from the store due to 'File '/test/wazuh-engine-standalone/data/store/router/eps/0' does not exist'. Using default settings
2026-01-07 18:34:53.146 98:98 info: Router: EPS settings dumped to the store
2026-01-07 18:34:53.147 98:98 info: Router initialized.
2026-01-07 18:34:53.147 98:98 info: Archiver initialized.
2026-01-07 18:34:53.157 98:98 info: Server API_SRV started in thread 133223820543552 at /test/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-07 18:34:53.157 98:98 info: Local engine's server initialized and started.
2026-01-07 18:34:53.167 98:98 info: Server ENRICHED_EVENTS_SRV started in thread 133222151181888 at /test/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-07 18:34:53.167 98:98 info: Remote engine's server initialized and started.
2026-01-07 18:34:53.167 98:98 info: Engine started in standalone mode.
2026-01-07 18:34:58.155 98:230 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-07 18:34:59.752 98:134 info: CTI snapshot: processing consolidated file /test/wazuh-engine-standalone/data/cti/content/contents/decoders_development_0.0.1_decoders_development_0.0.1_1591_1767627276.json
2026-01-07 18:34:59.777 98:134 info: CTI processed up to offset 1591 (type='raw')
2026-01-07 18:35:12.078 98:134 info: Successfully updated asset type='integration' resource_id='5c1df6b6-1458-4b2e-9001-96f67a8b12c8' with 1 operations
2026-01-07 18:35:12.078 98:134 info: Successfully updated asset type='policy' resource_id='policy' with 2 operations
2026-01-07 18:35:12.078 98:134 info: CTI processed up to offset 1593 (type='offsets')
2026-01-07 18:35:21.990 98:230 info: CTI 'default' route created.


❯ docker exec -it fe4960492c3b bash
[root@31aaa5910206 wazuh-engine-standalone]# ls -la ./sockets
ss -xl | grep -E "engine-api|queue-http" || true
total 8
drwxrwxr-x 2 1000 1000 4096 Jan  9 04:31 .
drwxrwxr-x 9 1000 1000 4096 Jan  9 04:31 ..
-rw-r--r-- 1 1000 1000    0 Jan  9  2026 .keep
srw-rw---- 1 root root    0 Jan  9 04:31 engine-api.sock
srw-rw---- 1 root root    0 Jan  9 04:31 engine-prod-event.sock
srw-rw---- 1 root root    0 Jan  9 04:31 queue-http.sock
u_str LISTEN 0      5             /test/wazuh-engine-standalone/sockets/engine-api.sock 2333002            * 0
u_str LISTEN 0      5             /test/wazuh-engine-standalone/sockets/queue-http.sock 2652485            * 0

[root@31aaa5910206 wazuh-engine-standalone]# ps -ef | grep -i wazuh-engine | grep -v grep
root          52      43 17 04:31 pts/0    00:00:51 /test/wazuh-engine-standalone/bin/wazuh-engine -f

```

</p>
</details> 

<details><summary>Ubuntu  22.04</summary>
<p>

```console

root@1308e90899aa:/# cd /test
root@1308e90899aa:/test# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
root@1308e90899aa:/test#

root@1308e90899aa:/test# uname -a
Linux 1308e90899aa 6.14.0-37-generic #37~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov 20 10:25:38 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

root@1308e90899aa:/test# file /test/wazuh-engine-standalone/bin/wazuh-engine
/test/wazuh-engine-standalone/bin/wazuh-engine: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, with debug_info, not stripped

root@1308e90899aa:/# ls -la /test/wazuh-engine-standalone/sockets/
total 8
drwxrwxr-x 2 1000 1000 4096 Jan  7 19:18 .
drwxrwxr-x 9 1000 1000 4096 Jan  7 18:34 ..
-rw-r--r-- 1 1000 1000    0 Jan  7  2026 .keep
srw-rw---- 1 root root    0 Jan  7 19:18 engine-api.sock
srw-rw---- 1 root root    0 Jan  7 19:18 engine-prod-event.sock
srw-rw---- 1 root root    0 Jan  7 19:18 queue-http.sock
root@1308e90899aa:/#

root@1308e90899aa:/test# cd /test/wazuh-engine-standalone
./run_engine.sh
2026-01-07 19:18:16.565 2982:2982 info: Logging initialized.
2026-01-07 19:18:16.565 2982:2982 info: Store initialized.
2026-01-07 19:18:16.565 2982:2982 info: Initializing CTI Store ContentManager
2026-01-07 19:18:16.882 2982:2982 info: ContentManager: CTIStorageDB opened at '/test/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-07 19:18:16.882 2982:2982 info: CTI Store initialized
2026-01-07 19:18:16.882 2982:2982 info: Starting CTI Store content synchronization
2026-01-07 19:18:16.882 2982:2982 info: Starting CTI Store ContentDownloader
2026-01-07 19:18:16.882 2982:2982 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-07 19:18:17.324 2982:2982 info: CTI Store ContentDownloader started successfully
2026-01-07 19:18:17.324 2982:2982 info: Content Manager initialized.
2026-01-07 19:18:17.324 2982:2982 info: KVDB initialized.
2026-01-07 19:18:17.324 2982:2982 info: Geo initialized.
2026-01-07 19:18:17.376 2982:2982 info: Schema initialized.
2026-01-07 19:18:17.652 2982:2982 info: Loaded timezone database version: '2025c'
2026-01-07 19:18:17.652 2982:2982 info: HLP initialized.
2026-01-07 19:18:18.994 2982:2982 info: Indexer Connector initialized.
2026-01-07 19:18:18.994 2982:2982 info: Scheduler initialized and started.
2026-01-07 19:18:18.994 2982:2982 info: Stream logger initialized.
2026-01-07 19:18:19.006 2982:2982 info: No flooding file provided, the queue will not be flooded.
2026-01-07 19:18:19.014 2982:2982 info: No flooding file provided, the queue will not be flooded.
2026-01-07 19:18:19.015 2982:2982 info: Builder initialized.
2026-01-07 19:18:19.015 2982:2982 info: Content Manager CRUD Service initialized.
2026-01-07 19:18:19.016 2982:2982 info: No flooding file provided, the queue will not be flooded.
2026-01-07 19:18:19.020 2982:2982 info: No flooding file provided, the queue will not be flooded.
2026-01-07 19:18:19.020 2982:2982 warning: Router: router/tester/0 table is empty
2026-01-07 19:18:19.020 2982:2982 info: No thread count provided. Using 20 worker threads based on system hardware.
2026-01-07 19:18:38.602 2982:2982 info: Router initialized.
2026-01-07 19:18:38.602 2982:2982 info: Archiver initialized.
2026-01-07 19:18:38.612 2982:2982 info: Server API_SRV started in thread 134883498251840 at /test/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-07 19:18:38.613 2982:2982 info: Local engine's server initialized and started.
2026-01-07 19:18:38.623 2982:2982 info: Server ENRICHED_EVENTS_SRV started in thread 134883095598656 at /test/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-07 19:18:38.623 2982:2982 info: Remote engine's server initialized and started.
2026-01-07 19:18:38.623 2982:2982 info: Engine started in standalone mode.

```

</p>
</details> 


### arm64 

<details><summary>Ubuntu 24.04</summary>
<p>

```console

ubuntu@ip-172-31-36-232:~$ uname -m
aarch64

ubuntu@ip-172-31-36-232:~$ cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo

ubuntu@ip-172-31-36-232:~/engine-standalone/wazuh-engine-standalone$ file ./bin/wazuh-engine
./bin/wazuh-engine: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped


ubuntu@ip-172-31-36-232:~$ ls -la ~/engine-standalone/wazuh-engine-standalone/sockets/
total 8
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 16:26 .
drwxrwxr-x 9 ubuntu ubuntu 4096 Jan  8 16:26 ..
-rw-r--r-- 1 ubuntu ubuntu    0 Jan  7 19:57 .keep
srw-rw---- 1 ubuntu ubuntu    0 Jan  8 16:26 engine-api.sock
srw-rw---- 1 ubuntu ubuntu    0 Jan  8 16:26 engine-prod-event.sock
srw-rw---- 1 ubuntu ubuntu    0 Jan  8 16:26 queue-http.sock


ubuntu@ip-172-31-36-232:~/engine-standalone/wazuh-engine-standalone$ ls -la
total 40
drwxrwxr-x 8 ubuntu ubuntu 4096 Jan  8 16:24 .
drwxrwxr-x 3 ubuntu ubuntu 4096 Jan  8 16:24 ..
-rw-r--r-- 1 ubuntu ubuntu 3538 Jan  7 19:57 README.md
drwxrwxr-x 3 ubuntu ubuntu 4096 Jan  8 16:24 bin
drwxrwxr-x 6 ubuntu ubuntu 4096 Jan  8 16:24 data
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 16:24 default-security-policy
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 16:24 logs
-rwxr-xr-x 1 ubuntu ubuntu 1427 Jan  7 19:57 run_engine.sh
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 16:24 schemas
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 16:24 sockets


ubuntu@ip-172-31-36-232:~/engine-standalone/wazuh-engine-standalone$ ./run_engine.sh
2026-01-08 16:26:31.459 2171:2171 info: Logging initialized.
2026-01-08 16:26:31.459 2171:2171 info: Store initialized.
2026-01-08 16:26:31.459 2171:2171 info: Initializing CTI Store ContentManager
2026-01-08 16:26:31.510 2171:2171 info: ContentManager: CTIStorageDB opened at '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-08 16:26:31.510 2171:2171 info: CTI Store initialized
2026-01-08 16:26:31.510 2171:2171 info: Starting CTI Store content synchronization
2026-01-08 16:26:31.510 2171:2171 info: Starting CTI Store ContentDownloader
2026-01-08 16:26:31.510 2171:2171 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-08 16:26:31.552 2171:2171 info: CTI Store ContentDownloader started successfully
2026-01-08 16:26:31.552 2171:2171 info: Content Manager initialized.
2026-01-08 16:26:31.552 2171:2171 info: KVDB initialized.
2026-01-08 16:26:31.552 2171:2171 info: Geo initialized.
2026-01-08 16:26:31.661 2171:2171 info: Schema initialized.
2026-01-08 16:26:31.738 2171:2171 warning: Failed to load timezone database: 'Timezone database not found at "/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/tzdb/iana"', try to download it
2026-01-08 16:26:31.920 2171:2171 info: Timezone database updated to version: '2025c'
2026-01-08 16:26:31.921 2171:2171 info: HLP initialized.
2026-01-08 16:26:32.034 2171:2171 info: Indexer Connector initialized.
2026-01-08 16:26:32.034 2171:2171 info: Scheduler initialized and started.
2026-01-08 16:26:32.034 2171:2171 info: Stream logger initialized.
2026-01-08 16:26:32.045 2171:2171 info: No flooding file provided, the queue will not be flooded.
2026-01-08 16:26:32.056 2171:2171 info: No flooding file provided, the queue will not be flooded.
2026-01-08 16:26:32.057 2171:2171 info: Builder initialized.
2026-01-08 16:26:32.057 2171:2171 info: Content Manager CRUD Service initialized.
2026-01-08 16:26:32.058 2171:2171 info: No flooding file provided, the queue will not be flooded.
2026-01-08 16:26:32.063 2171:2171 info: No flooding file provided, the queue will not be flooded.
2026-01-08 16:26:32.064 2171:2171 info: Router: router/router/0 table not found in store. Creating new table: File '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/store/router/router/0' does not exist
2026-01-08 16:26:32.064 2171:2171 info: Router: router/tester/0 table not found in store. Creating new table: File '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/store/router/tester/0' does not exist
2026-01-08 16:26:32.064 2171:2171 info: No thread count provided. Using 4 worker threads based on system hardware.
2026-01-08 16:26:32.064 2171:2171 warning: Router: EPS settings could not be loaded from the store due to 'File '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/store/router/eps/0' does not exist'. Using default settings
2026-01-08 16:26:32.064 2171:2171 info: Router: EPS settings dumped to the store
2026-01-08 16:26:32.064 2171:2171 info: Router initialized.
2026-01-08 16:26:32.064 2171:2171 info: Archiver initialized.
2026-01-08 16:26:32.074 2171:2171 info: Server API_SRV started in thread 246742001949440 at /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-08 16:26:32.076 2171:2171 info: Local engine's server initialized and started.
2026-01-08 16:26:32.086 2171:2171 info: Server ENRICHED_EVENTS_SRV started in thread 246741238586112 at /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-08 16:26:32.086 2171:2171 info: Remote engine's server initialized and started.
2026-01-08 16:26:32.086 2171:2171 info: Engine started in standalone mode.
2026-01-08 16:26:37.067 2171:2291 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 16:26:42.070 2171:2291 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 16:26:44.518 2171:2207 info: CTI snapshot: processing consolidated file /home/ubuntu/engine-standalone/wazuh-engine-standalone/data/cti/content/contents/decoders_development_0.0.1_decoders_development_0.0.1_1591_1767627276.json
2026-01-08 16:26:44.575 2171:2207 info: CTI processed up to offset 1591 (type='raw')
2026-01-08 16:26:53.891 2171:2291 info: CTI 'default' route created.
2026-01-08 16:26:56.789 2171:2207 info: Successfully updated asset type='integration' resource_id='5c1df6b6-1458-4b2e-9001-96f67a8b12c8' with 1 operations
2026-01-08 16:26:56.789 2171:2207 info: Successfully updated asset type='policy' resource_id='policy' with 2 operations
2026-01-08 16:26:56.789 2171:2207 info: CTI processed up to offset 1593 (type='offsets')


ubuntu@ip-172-31-36-232:~$ ps -ef | grep -i wazuh-engine | grep -v grep
ubuntu      2171    2162  8 16:26 pts/0    00:00:22 /home/ubuntu/engine-standalone/wazuh-engine-standalone/bin/wazuh-engine -f


ubuntu@ip-172-31-36-232:~$ ls -la ./sockets
ss -xl | grep -E "engine-api|queue-http" || true

u_str LISTEN 0      5             /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock 15029            * 0
u_str LISTEN 0      5             /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock 15032            * 0

```


</p>
</details> 

<details><summary>Amazon Linux 2023</summary>
<p>

```console

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ uname -m
aarch64

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ cat /etc/os-release
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"
VERSION_ID="2023"
PLATFORM_ID="platform:al2023"
PRETTY_NAME="Amazon Linux 2023.9.20251014"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
VENDOR_NAME="AWS"
VENDOR_URL="https://aws.amazon.com/"
SUPPORT_END="2029-06-30"

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ file ./bin/wazuh-engine
./bin/wazuh-engine: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ ls -la
total 8
drwxr-xr-x. 8 ec2-user ec2-user  140 Jan  8 17:30 .
drwxr-xr-x. 3 ec2-user ec2-user   79 Jan  8 17:30 ..
-rw-r--r--. 1 ec2-user ec2-user 3538 Jan  7 19:57 README.md
drwxr-xr-x. 3 ec2-user ec2-user   37 Jan  8 17:30 bin
drwxr-xr-x. 6 ec2-user ec2-user   54 Jan  8 17:30 data
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  8 17:30 default-security-policy
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  8 17:30 logs
-rwxr-xr-x. 1 ec2-user ec2-user 1427 Jan  7 19:57 run_engine.sh
drwxr-xr-x. 2 ec2-user ec2-user  134 Jan  8 17:30 schemas
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  8 17:30 sockets

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ ./run_engine.sh
2026-01-08 17:38:50.403 33759:33759 info: Logging initialized.
2026-01-08 17:38:50.403 33759:33759 info: Store initialized.
2026-01-08 17:38:50.403 33759:33759 info: Initializing CTI Store ContentManager
2026-01-08 17:38:50.468 33759:33759 info: ContentManager: CTIStorageDB opened at '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-08 17:38:50.468 33759:33759 info: CTI Store initialized
2026-01-08 17:38:50.468 33759:33759 info: Starting CTI Store content synchronization
2026-01-08 17:38:50.468 33759:33759 info: Starting CTI Store ContentDownloader
2026-01-08 17:38:50.468 33759:33759 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-08 17:38:50.501 33759:33759 info: CTI Store ContentDownloader started successfully
2026-01-08 17:38:50.501 33759:33759 info: Content Manager initialized.
2026-01-08 17:38:50.501 33759:33759 info: KVDB initialized.
2026-01-08 17:38:50.501 33759:33759 info: Geo initialized.
2026-01-08 17:38:50.609 33759:33759 info: Schema initialized.
2026-01-08 17:38:50.742 33759:33759 warning: Failed to load timezone database: 'Timezone database not found at "/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/tzdb/iana"', try to download it
2026-01-08 17:38:50.832 33759:33759 info: Timezone database updated to version: '2025c'
2026-01-08 17:38:50.833 33759:33759 info: HLP initialized.
2026-01-08 17:38:50.909 33759:33759 info: Indexer Connector initialized.
2026-01-08 17:38:50.909 33759:33759 info: Scheduler initialized and started.
2026-01-08 17:38:50.909 33759:33759 info: Stream logger initialized.
2026-01-08 17:38:50.917 33759:33759 info: No flooding file provided, the queue will not be flooded.
2026-01-08 17:38:50.926 33759:33759 info: No flooding file provided, the queue will not be flooded.
2026-01-08 17:38:50.928 33759:33759 info: Builder initialized.
2026-01-08 17:38:50.928 33759:33759 info: Content Manager CRUD Service initialized.
2026-01-08 17:38:50.928 33759:33759 info: No flooding file provided, the queue will not be flooded.
2026-01-08 17:38:50.932 33759:33759 info: No flooding file provided, the queue will not be flooded.
2026-01-08 17:38:50.932 33759:33759 info: Router: router/router/0 table not found in store. Creating new table: File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/router/0' does not exist
2026-01-08 17:38:50.933 33759:33759 info: Router: router/tester/0 table not found in store. Creating new table: File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/tester/0' does not exist
2026-01-08 17:38:50.933 33759:33759 info: No thread count provided. Using 4 worker threads based on system hardware.
2026-01-08 17:38:50.933 33759:33759 warning: Router: EPS settings could not be loaded from the store due to 'File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/eps/0' does not exist'. Using default settings
2026-01-08 17:38:50.933 33759:33759 info: Router: EPS settings dumped to the store
2026-01-08 17:38:50.933 33759:33759 info: Router initialized.
2026-01-08 17:38:50.933 33759:33759 info: Archiver initialized.
2026-01-08 17:38:50.943 33759:33759 info: Server API_SRV started in thread 281472331586176 at /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-08 17:38:50.946 33759:33759 info: Local engine's server initialized and started.
2026-01-08 17:38:50.956 33759:33759 info: Server ENRICHED_EVENTS_SRV started in thread 281471409363584 at /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-08 17:38:50.956 33759:33759 info: Remote engine's server initialized and started.
2026-01-08 17:38:50.956 33759:33759 info: Engine started in standalone mode.
2026-01-08 17:38:55.936 33759:33874 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 17:39:00.939 33759:33874 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 17:39:03.290 33759:33795 info: CTI snapshot: processing consolidated file /home/ec2-user/engine-standalone/wazuh-engine-standalone/data/cti/content/contents/decoders_development_0.0.1_decoders_development_0.0.1_1591_1767627276.json
2026-01-08 17:39:03.344 33759:33795 info: CTI processed up to offset 1591 (type='raw')
2026-01-08 17:39:12.643 33759:33874 info: CTI 'default' route created.
2026-01-08 17:39:15.619 33759:33795 info: Successfully updated asset type='integration' resource_id='5c1df6b6-1458-4b2e-9001-96f67a8b12c8' with 1 operations
2026-01-08 17:39:15.620 33759:33795 info: Successfully updated asset type='policy' resource_id='policy' with 2 operations
2026-01-08 17:39:15.620 33759:33795 info: CTI processed up to offset 1593 (type='offsets')

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ ls -la ./sockets
ss -xl | grep -E "engine-api|queue-http" || true
total 0
drwxr-xr-x. 2 ec2-user ec2-user  95 Jan  8 17:38 .
drwxr-xr-x. 9 ec2-user ec2-user 153 Jan  8 17:38 ..
-rw-r--r--. 1 ec2-user ec2-user   0 Jan  7 19:57 .keep
srw-rw----. 1 ec2-user ec2-user   0 Jan  8 17:38 engine-api.sock
srw-rw----. 1 ec2-user ec2-user   0 Jan  8 17:38 engine-prod-event.sock
srw-rw----. 1 ec2-user ec2-user   0 Jan  8 17:38 queue-http.sock
u_str LISTEN 0      5             /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock 63626            * 0
u_str LISTEN 0      5             /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock 62091            * 0

[ec2-user@ip-172-31-45-209 wazuh-engine-standalone]$ ps -ef | grep -i wazuh-engine | grep -v grep
ec2-user   33759   33750 11 17:38 pts/1    00:00:21 /home/ec2-user/engine-standalone/wazuh-engine-standalone/bin/wazuh-engine -f

```


</p>
</details> 


<details><summary>RedHat 9.7</summary>
<p>

```console

[ec2-user@ip-172-31-44-30 engine-standalone]$ uname -m
aarch64

[ec2-user@ip-172-31-44-30 engine-standalone]$ cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="9.7 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.7"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux 9.7 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://issues.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.7
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.7"

[ec2-user@ip-172-31-44-30 wazuh-engine-standalone]$ file ./bin/wazuh-engine
./bin/wazuh-engine: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped

[ec2-user@ip-172-31-44-30 wazuh-engine-standalone]$ ls -la
total 8
drwxr-xr-x. 8 ec2-user ec2-user  140 Jan  8 20:54 .
drwxr-xr-x. 3 ec2-user ec2-user   79 Jan  8 20:54 ..
drwxr-xr-x. 3 ec2-user ec2-user   37 Jan  8 20:54 bin
drwxr-xr-x. 6 ec2-user ec2-user   54 Jan  8 20:54 data
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  8 20:54 default-security-policy
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  8 20:54 logs
-rw-r--r--. 1 ec2-user ec2-user 3538 Jan  7 19:57 README.md
-rwxr-xr-x. 1 ec2-user ec2-user 1427 Jan  7 19:57 run_engine.sh
drwxr-xr-x. 2 ec2-user ec2-user  134 Jan  8 20:54 schemas
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  8 20:54 sockets

[ec2-user@ip-172-31-44-30 wazuh-engine-standalone]$ ./run_engine.sh
2026-01-08 20:56:07.559 17313:17313 info: Logging initialized.
2026-01-08 20:56:07.559 17313:17313 info: Store initialized.
2026-01-08 20:56:07.559 17313:17313 info: Initializing CTI Store ContentManager
2026-01-08 20:56:07.618 17313:17313 info: ContentManager: CTIStorageDB opened at '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-08 20:56:07.618 17313:17313 info: CTI Store initialized
2026-01-08 20:56:07.618 17313:17313 info: Starting CTI Store content synchronization
2026-01-08 20:56:07.618 17313:17313 info: Starting CTI Store ContentDownloader
2026-01-08 20:56:07.618 17313:17313 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-08 20:56:07.650 17313:17313 info: CTI Store ContentDownloader started successfully
2026-01-08 20:56:07.650 17313:17313 info: Content Manager initialized.
2026-01-08 20:56:07.650 17313:17313 info: KVDB initialized.
2026-01-08 20:56:07.650 17313:17313 info: Geo initialized.
2026-01-08 20:56:07.759 17313:17313 info: Schema initialized.
2026-01-08 20:56:07.894 17313:17313 warning: Failed to load timezone database: 'Timezone database not found at "/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/tzdb/iana"', try to download it
2026-01-08 20:56:07.993 17313:17313 info: Timezone database updated to version: '2025c'
2026-01-08 20:56:07.993 17313:17313 info: HLP initialized.
2026-01-08 20:56:08.065 17313:17313 info: Indexer Connector initialized.
2026-01-08 20:56:08.066 17313:17313 info: Scheduler initialized and started.
2026-01-08 20:56:08.066 17313:17313 info: Stream logger initialized.
2026-01-08 20:56:08.076 17313:17313 info: No flooding file provided, the queue will not be flooded.
2026-01-08 20:56:08.086 17313:17313 info: No flooding file provided, the queue will not be flooded.
2026-01-08 20:56:08.088 17313:17313 info: Builder initialized.
2026-01-08 20:56:08.088 17313:17313 info: Content Manager CRUD Service initialized.
2026-01-08 20:56:08.088 17313:17313 info: No flooding file provided, the queue will not be flooded.
2026-01-08 20:56:08.093 17313:17313 info: No flooding file provided, the queue will not be flooded.
2026-01-08 20:56:08.093 17313:17313 info: Router: router/router/0 table not found in store. Creating new table: File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/router/0' does not exist
2026-01-08 20:56:08.093 17313:17313 info: Router: router/tester/0 table not found in store. Creating new table: File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/tester/0' does not exist
2026-01-08 20:56:08.093 17313:17313 info: No thread count provided. Using 4 worker threads based on system hardware.
2026-01-08 20:56:08.093 17313:17313 warning: Router: EPS settings could not be loaded from the store due to 'File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/eps/0' does not exist'. Using default settings
2026-01-08 20:56:08.094 17313:17313 info: Router: EPS settings dumped to the store
2026-01-08 20:56:08.094 17313:17313 info: Router initialized.
2026-01-08 20:56:08.094 17313:17313 info: Archiver initialized.
2026-01-08 20:56:08.104 17313:17313 info: Server API_SRV started in thread 281472627874432 at /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-08 20:56:08.105 17313:17313 info: Local engine's server initialized and started.
2026-01-08 20:56:08.116 17313:17313 info: Server ENRICHED_EVENTS_SRV started in thread 281472174496384 at /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-08 20:56:08.116 17313:17313 info: Remote engine's server initialized and started.
2026-01-08 20:56:08.116 17313:17313 info: Engine started in standalone mode.
2026-01-08 20:56:13.097 17313:17428 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 20:56:18.100 17313:17428 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 20:56:20.682 17313:17349 info: CTI snapshot: processing consolidated file /home/ec2-user/engine-standalone/wazuh-engine-standalone/data/cti/content/contents/decoders_development_0.0.1_decoders_development_0.0.1_1591_1767627276.json
2026-01-08 20:56:20.737 17313:17349 info: CTI processed up to offset 1591 (type='raw')
2026-01-08 20:56:29.923 17313:17428 info: CTI 'default' route created.
2026-01-08 20:56:32.969 17313:17349 info: Successfully updated asset type='integration' resource_id='5c1df6b6-1458-4b2e-9001-96f67a8b12c8' with 1 operations
2026-01-08 20:56:32.970 17313:17349 info: Successfully updated asset type='policy' resource_id='policy' with 2 operations
2026-01-08 20:56:32.970 17313:17349 info: CTI processed up to offset 1593 (type='offsets')

[ec2-user@ip-172-31-44-30 wazuh-engine-standalone]$  ls -la ./sockets
ss -xl | grep -E "engine-api|queue-http" || true
total 0
drwxr-xr-x. 2 ec2-user ec2-user  95 Jan  9 04:57 .
drwxr-xr-x. 9 ec2-user ec2-user 153 Jan  9 04:57 ..
srw-rw----. 1 ec2-user ec2-user   0 Jan  9 04:57 engine-api.sock
srw-rw----. 1 ec2-user ec2-user   0 Jan  9 04:57 engine-prod-event.sock
-rw-r--r--. 1 ec2-user ec2-user   0 Jan  9 04:07 .keep
srw-rw----. 1 ec2-user ec2-user   0 Jan  9 04:57 queue-http.sock
u_str LISTEN 0      5             /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock 55187            * 0
u_str LISTEN 0      5             /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock 57443            * 0

[ec2-user@ip-172-31-44-30 wazuh-engine-standalone]$ ps -ef | grep -i wazuh-engine | grep -v grep
ec2-user   18728   18719  9 04:57 pts/0    00:00:21 /home/ec2-user/engine-standalone/wazuh-engine-standalone/bin/wazuh-engine -f

```

</p>
</details> 

<details><summary>RedHat 10.1</summary>
<p>

```console

[ec2-user@ip-172-31-41-119 ~]$ uname -m
aarch64

[ec2-user@ip-172-31-41-119 ~]$ cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="10.1 (Coughlan)"
ID="rhel"
ID_LIKE="centos fedora"
VERSION_ID="10.1"
PLATFORM_ID="platform:el10"
PRETTY_NAME="Red Hat Enterprise Linux 10.1 (Coughlan)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:10.1"
HOME_URL="https://www.redhat.com/"
VENDOR_NAME="Red Hat"
VENDOR_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/10"
BUG_REPORT_URL="https://issues.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 10"
REDHAT_BUGZILLA_PRODUCT_VERSION=10.1
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="10.1"

[ec2-user@ip-172-31-41-119 wazuh-engine-standalone]$ ls -la
total 8
drwxr-xr-x. 8 ec2-user ec2-user  140 Jan  9 14:42 .
drwxr-xr-x. 3 ec2-user ec2-user   79 Jan  9 14:42 ..
-rw-r--r--. 1 ec2-user ec2-user 3538 Jan  9 14:07 README.md
drwxr-xr-x. 3 ec2-user ec2-user   37 Jan  9 14:42 bin
drwxr-xr-x. 6 ec2-user ec2-user   54 Jan  9 14:42 data
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  9 14:42 default-security-policy
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  9 14:42 logs
-rwxr-xr-x. 1 ec2-user ec2-user 1360 Jan  9 14:07 run_engine.sh
drwxr-xr-x. 2 ec2-user ec2-user  134 Jan  9 14:42 schemas
drwxr-xr-x. 2 ec2-user ec2-user   19 Jan  9 14:42 sockets

[ec2-user@ip-172-31-41-119 wazuh-engine-standalone]$ file ./bin/wazuh-engine
./bin/wazuh-engine: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped

[ec2-user@ip-172-31-41-119 wazuh-engine-standalone]$ ./run_engine.sh
2026-01-09 14:43:57.546 6059:6059 info: Logging initialized.
2026-01-09 14:43:57.546 6059:6059 info: Store initialized.
2026-01-09 14:43:57.546 6059:6059 info: Initializing CTI Store ContentManager
2026-01-09 14:43:57.584 6059:6059 info: ContentManager: CTIStorageDB opened at '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-09 14:43:57.584 6059:6059 info: CTI Store initialized
2026-01-09 14:43:57.584 6059:6059 info: Starting CTI Store content synchronization
2026-01-09 14:43:57.584 6059:6059 info: Starting CTI Store ContentDownloader
2026-01-09 14:43:57.584 6059:6059 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-09 14:43:57.603 6059:6059 info: CTI Store ContentDownloader started successfully
2026-01-09 14:43:57.603 6059:6059 info: Content Manager initialized.
2026-01-09 14:43:57.603 6059:6059 info: KVDB initialized.
2026-01-09 14:43:57.603 6059:6059 info: Geo initialized.
2026-01-09 14:43:57.712 6059:6059 info: Schema initialized.
2026-01-09 14:43:57.848 6059:6059 warning: Failed to load timezone database: 'Timezone database not found at "/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/tzdb/iana"', try to download it
2026-01-09 14:43:58.030 6059:6059 info: Timezone database updated to version: '2025c'
2026-01-09 14:43:58.030 6059:6059 info: HLP initialized.
2026-01-09 14:43:58.074 6059:6059 info: Indexer Connector initialized.
2026-01-09 14:43:58.074 6059:6059 info: Scheduler initialized and started.
2026-01-09 14:43:58.074 6059:6059 info: Stream logger initialized.
2026-01-09 14:43:58.085 6059:6059 info: No flooding file provided, the queue will not be flooded.
2026-01-09 14:43:58.096 6059:6059 info: No flooding file provided, the queue will not be flooded.
2026-01-09 14:43:58.097 6059:6059 info: Builder initialized.
2026-01-09 14:43:58.097 6059:6059 info: Content Manager CRUD Service initialized.
2026-01-09 14:43:58.098 6059:6059 info: No flooding file provided, the queue will not be flooded.
2026-01-09 14:43:58.103 6059:6059 info: No flooding file provided, the queue will not be flooded.
2026-01-09 14:43:58.103 6059:6059 info: Router: router/router/0 table not found in store. Creating new table: File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/router/0' does not exist
2026-01-09 14:43:58.104 6059:6059 info: Router: router/tester/0 table not found in store. Creating new table: File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/tester/0' does not exist
2026-01-09 14:43:58.104 6059:6059 info: No thread count provided. Using 4 worker threads based on system hardware.
2026-01-09 14:43:58.104 6059:6059 warning: Router: EPS settings could not be loaded from the store due to 'File '/home/ec2-user/engine-standalone/wazuh-engine-standalone/data/store/router/eps/0' does not exist'. Using default settings
2026-01-09 14:43:58.104 6059:6059 info: Router: EPS settings dumped to the store
2026-01-09 14:43:58.104 6059:6059 info: Router initialized.
2026-01-09 14:43:58.104 6059:6059 info: Archiver initialized.
2026-01-09 14:43:58.114 6059:6059 info: Server API_SRV started in thread 281472719821568 at /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-09 14:43:58.116 6059:6059 info: Local engine's server initialized and started.
2026-01-09 14:43:58.126 6059:6059 info: Server ENRICHED_EVENTS_SRV started in thread 281472132750080 at /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-09 14:43:58.126 6059:6059 info: Remote engine's server initialized and started.
2026-01-09 14:43:58.126 6059:6059 info: Engine started in standalone mode.
2026-01-09 14:44:03.107 6059:6174 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-09 14:44:08.110 6059:6174 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-09 14:44:10.142 6059:6095 info: CTI snapshot: processing consolidated file /home/ec2-user/engine-standalone/wazuh-engine-standalone/data/cti/content/contents/decoders_development_0.0.1_decoders_development_0.0.1_1591_1767627276.json
2026-01-09 14:44:10.198 6059:6095 info: CTI processed up to offset 1591 (type='raw')

[ec2-user@ip-172-31-41-119 wazuh-engine-standalone]$  ls -la ./sockets
ss -xl | grep -E "engine-api|queue-http" || true
total 0
drwxr-xr-x. 2 ec2-user ec2-user  95 Jan  9 14:43 .
drwxr-xr-x. 9 ec2-user ec2-user 153 Jan  9 14:43 ..
-rw-r--r--. 1 ec2-user ec2-user   0 Jan  9 14:07 .keep
srw-rw----. 1 ec2-user ec2-user   0 Jan  9 14:43 engine-api.sock
srw-rw----. 1 ec2-user ec2-user   0 Jan  9 14:43 engine-prod-event.sock
srw-rw----. 1 ec2-user ec2-user   0 Jan  9 14:43 queue-http.sock
u_str LISTEN 0      5             /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock 21959            * 0
u_str LISTEN 0      5             /home/ec2-user/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock 21961            * 0

[ec2-user@ip-172-31-41-119 wazuh-engine-standalone]$  ps -ef | grep -i wazuh-engine | grep -v grep
ec2-user    6059    6050 17 14:43 pts/0    00:00:21 /home/ec2-user/engine-standalone/wazuh-engine-standalone/bin/wazuh-engine -f

```

</p>
</details> 


<details><summary>Ubuntu  22.04</summary>
<p>

```console

ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ uname -m
aarch64


ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy

ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ file ./bin/wazuh-engine
./bin/wazuh-engine: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped

ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ ls -la
total 40
drwxrwxr-x 8 ubuntu ubuntu 4096 Jan  8 19:41 .
drwxrwxr-x 3 ubuntu ubuntu 4096 Jan  8 19:41 ..
-rw-r--r-- 1 ubuntu ubuntu 3538 Jan  7 19:57 README.md
drwxrwxr-x 3 ubuntu ubuntu 4096 Jan  8 19:41 bin
drwxrwxr-x 6 ubuntu ubuntu 4096 Jan  8 19:41 data
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 19:41 default-security-policy
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 19:41 logs
-rwxr-xr-x 1 ubuntu ubuntu 1427 Jan  7 19:57 run_engine.sh
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 19:41 schemas
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 19:41 sockets


ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ ./run_engine.sh
2026-01-08 19:48:03.864 2045:2045 info: Logging initialized.
2026-01-08 19:48:03.864 2045:2045 info: Store initialized.
2026-01-08 19:48:03.864 2045:2045 info: Initializing CTI Store ContentManager
2026-01-08 19:48:03.910 2045:2045 info: ContentManager: CTIStorageDB opened at '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/cti/assets_database' (open=true)
2026-01-08 19:48:03.910 2045:2045 info: CTI Store initialized
2026-01-08 19:48:03.910 2045:2045 info: Starting CTI Store content synchronization
2026-01-08 19:48:03.910 2045:2045 info: Starting CTI Store ContentDownloader
2026-01-08 19:48:03.910 2045:2045 info: OAuth authentication enabled for CTI Store (productType: catalog:consumer:decoders)
2026-01-08 19:48:03.933 2045:2045 info: CTI Store ContentDownloader started successfully
2026-01-08 19:48:03.933 2045:2045 info: Content Manager initialized.
2026-01-08 19:48:03.933 2045:2045 info: KVDB initialized.
2026-01-08 19:48:03.933 2045:2045 info: Geo initialized.
2026-01-08 19:48:04.042 2045:2045 info: Schema initialized.
2026-01-08 19:48:04.123 2045:2045 warning: Failed to load timezone database: 'Timezone database not found at "/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/tzdb/iana"', try to download it
2026-01-08 19:48:04.214 2045:2045 info: Timezone database updated to version: '2025c'
2026-01-08 19:48:04.214 2045:2045 info: HLP initialized.
2026-01-08 19:48:04.269 2045:2045 info: Indexer Connector initialized.
2026-01-08 19:48:04.269 2045:2045 info: Scheduler initialized and started.
2026-01-08 19:48:04.269 2045:2045 info: Stream logger initialized.
2026-01-08 19:48:04.278 2045:2045 info: No flooding file provided, the queue will not be flooded.
2026-01-08 19:48:04.288 2045:2045 info: No flooding file provided, the queue will not be flooded.
2026-01-08 19:48:04.290 2045:2045 info: Builder initialized.
2026-01-08 19:48:04.290 2045:2045 info: Content Manager CRUD Service initialized.
2026-01-08 19:48:04.290 2045:2045 info: No flooding file provided, the queue will not be flooded.
2026-01-08 19:48:04.295 2045:2045 info: No flooding file provided, the queue will not be flooded.
2026-01-08 19:48:04.295 2045:2045 info: Router: router/router/0 table not found in store. Creating new table: File '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/store/router/router/0' does not exist
2026-01-08 19:48:04.295 2045:2045 info: Router: router/tester/0 table not found in store. Creating new table: File '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/store/router/tester/0' does not exist
2026-01-08 19:48:04.295 2045:2045 info: No thread count provided. Using 4 worker threads based on system hardware.
2026-01-08 19:48:04.295 2045:2045 warning: Router: EPS settings could not be loaded from the store due to 'File '/home/ubuntu/engine-standalone/wazuh-engine-standalone/data/store/router/eps/0' does not exist'. Using default settings
2026-01-08 19:48:04.295 2045:2045 info: Router: EPS settings dumped to the store
2026-01-08 19:48:04.296 2045:2045 info: Router initialized.
2026-01-08 19:48:04.296 2045:2045 info: Archiver initialized.
2026-01-08 19:48:04.306 2045:2045 info: Server API_SRV started in thread 281472485202560 at /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock
2026-01-08 19:48:04.308 2045:2045 info: Local engine's server initialized and started.
2026-01-08 19:48:04.318 2045:2045 info: Server ENRICHED_EVENTS_SRV started in thread 281472065641088 at /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock
2026-01-08 19:48:04.318 2045:2045 info: Remote engine's server initialized and started.
2026-01-08 19:48:04.318 2045:2045 info: Engine started in standalone mode.
2026-01-08 19:48:09.299 2045:2165 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 19:48:14.302 2045:2165 error: Failed to create CTI default route: Failed to create the route: Failed to create environment with policy 'cti' and filter 'filter/allow-all/0': No policy found in CTI Store
2026-01-08 19:48:16.506 2045:2081 info: CTI snapshot: processing consolidated file /home/ubuntu/engine-standalone/wazuh-engine-standalone/data/cti/content/contents/decoders_development_0.0.1_decoders_development_0.0.1_1591_1767627276.json
2026-01-08 19:48:16.564 2045:2081 info: CTI processed up to offset 1591 (type='raw')
2026-01-08 19:48:26.037 2045:2165 info: CTI 'default' route created.

ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ ls -la ./sockets
ss -xl | grep -E "engine-api|queue-http" || true
total 8
drwxrwxr-x 2 ubuntu ubuntu 4096 Jan  8 19:48 .
drwxrwxr-x 9 ubuntu ubuntu 4096 Jan  8 19:48 ..
-rw-r--r-- 1 ubuntu ubuntu    0 Jan  7 19:57 .keep
srw-rw---- 1 ubuntu ubuntu    0 Jan  8 19:48 engine-api.sock
srw-rw---- 1 ubuntu ubuntu    0 Jan  8 19:48 engine-prod-event.sock
srw-rw---- 1 ubuntu ubuntu    0 Jan  8 19:48 queue-http.sock
u_str LISTEN 0      5             /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/engine-api.sock 21495            * 0
u_str LISTEN 0      5             /home/ubuntu/engine-standalone/wazuh-engine-standalone/sockets/queue-http.sock 22029            * 0

ubuntu@ip-172-31-47-164:~/engine-standalone/wazuh-engine-standalone$ ps -ef | grep -i wazuh-engine | grep -v grep
ubuntu      2045    2036 15 19:48 pts/0    00:00:21 /home/ubuntu/engine-standalone/wazuh-engine-standalone/bin/wazuh-engine -f

```

</p>
</details> 