### PR TITLE
Fix #33796 Take format sequences into account for check 33051 and 33052

### DIFF
--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -853,7 +853,7 @@ checks:
     condition: any
     rules:
       - "not f:/etc/motd"
-      - 'c:stat -L "%n %a %u %U %g %G" /etc/motd -> r:0 root 0 root && r:644|640|600|400'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/motd -> r:0 root 0 root && r:644|640|600|400'
 
   # 1.6.5 Ensure access to /etc/issue is configured. (Automated)
   - id: 33052
@@ -877,7 +877,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L "%n %a %u %U %g %G" /etc/issue -> r:0 root 0 root && r:644|640|600|400'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/issue -> r:0 root 0 root && r:644|640|600|400'
 
   # 1.6.6 Ensure access to /etc/issue.net is configured. (Automated)
   - id: 33053


### PR DESCRIPTION
<markdown-accessiblity-table data-catalyst="">
Wazuh version | Component | Install type | Install method | Platform
-- | -- | -- | -- | --
14.14.1-1 | SCA check | Agent | Packages | Debian 13

</markdown-accessiblity-table>
<p dir="auto">Hello, believe I have a mismatch on x4 SCA entries that 
use "stat" to query owner/permissions on files. The file 
cis_debian13.yml files in both current MASTER and also published 
14.4.1-1 .deb packages have this issue.</p>
<p dir="auto">The checks that fail even though configuration shown to be correct are:<br>
33044 Ensure access to bootloader config is configured.<br>
33051 Ensure access to /etc/motd is configured.<br>
33052 Ensure access to /etc/issue is configured.<br>
33053 Ensure access to /etc/issue.net is configured.</p>
<p dir="auto">I believe the offending rulesets are all missing a "<strong>-c</strong>" option ie</p>
<p dir="auto">incorrect check</p>
<div class="snippet-clipboard-content notranslate position-relative overflow-auto"><pre class="notranslate"><code class="notranslate">      - 'c:stat -L "%n %a %u %U %g %G" /boot/grub/grub.cfg -&gt; r:0 root 0 root &amp;&amp; r:600'
      - 'c:stat -L "%n %a %u %U %g %G" /etc/motd -&gt; r:0 root 0 root &amp;&amp; r:644|640|600|400'
      - 'c:stat -L "%n %a %u %U %g %G" /etc/issue -&gt; r:0 root 0 root &amp;&amp; r:644|640|600|400'
      - 'c:stat -L "%n %a %u %U %g %G" /etc/issue.net -&gt; r:0 root 0 root &amp;&amp; r:644|640|600|400'

</code></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
     
  </div></div>
<p dir="auto">correct check:</p>
<div class="snippet-clipboard-content notranslate position-relative overflow-auto"><pre class="notranslate"><code class="notranslate">      - 'c:stat -Lc "%n %a %u %U %g %G" /boot/grub/grub.cfg -&gt; r:0 root 0 root &amp;&amp; r:600'
      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/motd -&gt; r:0 root 0 root &amp;&amp; r:644|640|600|400'
      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/issue -&gt; r:0 root 0 root &amp;&amp; r:644|640|600|400'
      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/issue.net -&gt; r:0 root 0 root &amp;&amp; r:644|640|600|400'
</code></pre></div>