### PR TITLE
Fix #33796 Take format into account

### DIFF
--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -781,7 +781,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L "%n %a %u %U %g %G" /boot/grub/grub.cfg -> r:0 root 0 root && r:600'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /boot/grub/grub.cfg -> r:0 root 0 root && r:600'
 
   # 1.5.1 Ensure address space layout randomization is enabled. (Automated) - Not Implemented
   # 1.5.2 Ensure ptrace_scope is restricted. (Automated) - Not Implemented
@@ -853,7 +853,7 @@ checks:
     condition: any
     rules:
       - "not f:/etc/motd"
-      - 'c:stat -L "%n %a %u %U %g %G" /etc/motd -> r:0 root 0 root && r:644|640|600|400'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/motd -> r:0 root 0 root && r:644|640|600|400'
 
   # 1.6.5 Ensure access to /etc/issue is configured. (Automated)
   - id: 33052
@@ -877,7 +877,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L "%n %a %u %U %g %G" /etc/issue -> r:0 root 0 root && r:644|640|600|400'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/issue -> r:0 root 0 root && r:644|640|600|400'
 
   # 1.6.6 Ensure access to /etc/issue.net is configured. (Automated)
   - id: 33053
@@ -901,7 +901,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L "%n %a %u %U %g %G" /etc/issue.net -> r:0 root 0 root && r:644|640|600|400'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/issue.net -> r:0 root 0 root && r:644|640|600|400'
 
   # 1.7.1 Ensure GDM is removed. (Automated)
   - id: 33054


### PR DESCRIPTION
## Description

This pull request attempts to fix the problem described in Issue #33796.
Take format into account for the check 33044 33051 33052 33053

## Proposed Changes

Just add a lower case "**c**" after the "**-L**" option to take into account the format seqence of the command output

## Results and Evidence
Output Before:
    
    $ stat -L "%n %a %u %U %g %G" /etc/issue.net
    stat: cannot statx '%n %a %u %U %g %G': No such file or directory
    File: /etc/issue.net
    Size: 426       	Blocks: 8          IO Block: 4096   regular file
    Device: 8,1	Inode: 578         Links: 1
    Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
    Access: 2026-01-07 07:30:06.052215969 +0000
    Modify: 2024-12-13 14:25:51.120393421 +0000
    Change: 2024-12-13 14:25:51.120393421 +0000
    Birth: 2024-10-04 04:32:31.382166904 +0000


Output after:
        
    $ stat -Lc "%n %a %u %U %g %G" /etc/issue.net
    /etc/issue.net 644 0 root 0 root