### PR TITLE
Fix OpenSearch image pull failure in GitHub Actions

### DIFF
--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -33,8 +33,7 @@ jobs:
         image: opensearchproject/opensearch:latest
         env:
           discovery.type: single-node
-          plugins.security.disabled: true
-          OPENSEARCH_INITIAL_ADMIN_PASSWORD: WazuhTest99$
+          DISABLE_SECURITY_PLUGIN: true
           action.auto_create_index: "true"
           cluster.routing.allocation.disk.threshold_enabled: "false"
         ports:

--- a/src/wazuh_modules/inventory_sync/qa/test_inventory_sync_integration.py
+++ b/src/wazuh_modules/inventory_sync/qa/test_inventory_sync_integration.py
@@ -50,8 +50,7 @@ def init_opensearch(low_resources=False):
     # If not available, prepare to start local container
     env_vars = {
         'discovery.type': 'single-node',
-        'plugins.security.disabled': 'true',
-        'OPENSEARCH_INITIAL_ADMIN_PASSWORD': 'WazuhTest99$'
+        'DISABLE_SECURITY_PLUGIN': 'true'
     }
 
     if low_resources:


### PR DESCRIPTION
Resolves: #33651

<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
This pull request fixes recurring failures in the **inventory sync integration tests** caused by Docker Hub rate limits when pulling the OpenSearch image during CI execution.

The solution moves OpenSearch provisioning to a GitHub Actions service container, ensuring a deterministic and reliable test environment and removing runtime image pulls from the test code.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

 - Define OpenSearch as a service container in the GitHub Actions workflow, including health checks.

- Apply CI-specific OpenSearch settings to avoid read-only cluster states:

  -  Enable automatic index creation.

  -  Disable disk allocation threshold checks.

- Update the Python test setup to detect an existing OpenSearch instance before starting a local container.

- Keep an explicit image pull and container startup only as a fallback for local development.
- Add a safe cleanup step after checkout to free disk space by removing unused SDKs, helping prevent disk space issues that could interfere with log generation.
<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->
**Why service containers?**

Service containers are the recommended approach in GitHub Actions to provide external dependencies because they avoid Docker Hub rate limits, ensure services are ready before tests run via built-in health checks, keep test code CI-agnostic, and provide isolated, reproducible environments for each job.

**Additional Notes**

The current CI failure is caused by the `nodata_flow `test. This issue is unrelated to the OpenSearch setup.

A warning related to missing Wazuh logs (ossec.log) was already present before these changes.

<img width="623" height="169" alt="image" src="https://github.com/user-attachments/assets/827eb74d-47dc-4d8c-90b2-709da8b87aaf" />

<img width="327" height="50" alt="image" src="https://github.com/user-attachments/assets/99553f25-d414-4869-93ef-676f4d86f3de" />

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->
**Local Execution**

<img width="1445" height="621" alt="image" src="https://github.com/user-attachments/assets/bac81b70-225a-41ac-8c2d-d2a5f0c1d54c" />

**GitHub Actions Workflow**
<img width="596" height="97" alt="image" src="https://github.com/user-attachments/assets/84039cda-bc44-4986-b15d-183c4273c419" />

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
