### PR TITLE
fix download http-request submodule

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1584,7 +1584,7 @@ HTTP_REQUEST_URL := https://github.com/wazuh/wazuh-http-request/tarball/$(HTTP_R
 
 shared_modules/http-request.tar.gz:
 	find $(patsubst %.tar.gz,%,$@) -type f -exec false {} + &&\
-	((test -e $(patsubst %.gz,%,$@) || $(CURL) $@ -L $(HTTP_REQUEST_URL)) &&\
+	((test -e $(patsubst %.gz,%,$@) || curl -fsSLko $@ $(HTTP_REQUEST_URL)) &&\
 	($(GUNZIP) $@ || (rm -f $@ && echo "Error decompressing $@ maybe wrong branch was supplied!" && false)) &&\
 	$(TAR) $(patsubst %.gz,%,$@) --strip-components=1 -C $(patsubst %.tar.gz,%,$@) &&\
 	rm $(patsubst %.gz,%,$@)) || true


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh-agent-packages/issues/594
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR fixes issue #594 where some Debian packages were not being generated due to a CMake download error during the build process. The root cause was identified in the Makefile where the curl command was missing the -k (insecure) option, causing certificate validation failures when downloading the wazuh-http-request submodule.

## Proposed Changes

Fixed Makefile curl command: Modified [Makefile](vscode-file://vscode-app/snap/code/217/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use curl -fsLk instead of the $(CURL) variable when downloading the `http-request` submodule tarball

- Added -k flag to bypass SSL certificate verification issues

This ensures the DEB package build process can successfully download dependencies even in environments with certificate validation issues, allowing all packages to be generated correctly.

### Results and Evidence

- https://github.com/wazuh/wazuh-agent-packages/actions/runs/20824386137/job/59821603463

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review


### Artifacts Affected

- Makefile

### Configuration Changes

- N/A

### Tests Introduced

 - N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues


<!--
Include any additional information relevant to the review process.
-->
