### PR TITLE
Fix error downloading http-request submodule from Debian 7 - 5.x

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1435,12 +1435,13 @@ endif
 # Shared tools
 HTTP_REQUEST_URL := https://github.com/wazuh/wazuh-http-request/tarball/$(HTTP_REQUEST_BRANCH)
 
+.PHONY: shared_modules/http-request.tar.gz
+
 shared_modules/http-request.tar.gz:
-	find $(patsubst %.tar.gz,%,$@) -type f -exec false {} + &&\
-	((test -e $(patsubst %.gz,%,$@) || $(CURL) $@ -L $(HTTP_REQUEST_URL)) &&\
-	($(GUNZIP) $@ || (rm -f $@ && echo "Error decompressing $@ maybe wrong branch was supplied!" && false)) &&\
-	$(TAR) $(patsubst %.gz,%,$@) --strip-components=1 -C $(patsubst %.tar.gz,%,$@) &&\
-	rm $(patsubst %.gz,%,$@)) || true
+	test -f $@ || $(CURL) $@ -L $(HTTP_REQUEST_URL) &&\
+	($(GUNZIP) -f $@ || (rm -f $@ && echo "Error decompressing $@ maybe wrong branch was supplied!" && false)) && \
+	$(TAR) $(patsubst %.gz,%,$@) --strip-components=1 -C $(patsubst %.tar.gz,%,$@) && \
+	rm $(patsubst %.gz,%,$@)
 
 # Indexer plugin templates download
 # Get refs from get_git_refs.sh if INDEXER_PLUGINS_REFS is not set


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh-agent-packages/issues/594

This PR fixes a certificate validation failure when downloading the `http-request` submodule in Debian 7 environments, which prevented DEB package generation.

The issue was triggered by GitHub's certificate renewal on January 6, 2026, where they switched from DigiCert to Sectigo as their Certificate Authority. Debian 7 uses OpenSSL 1.0.1e (from 2013), which cannot correctly build modern certificate chains when intermediate certificates are not bundled, causing SSL/TLS handshake failures during the download process.

## Proposed Changes

### Bugs fixed

- Modified `Makefile` target `shared_modules/http-request.tar.gz` to preserve pre-downloaded tarballs
- Simplified download logic to work with pre-downloaded dependencies from GitHub Actions runners

### Technical details

- Made the target `.PHONY` to ensure proper dependency handling
- Changed from `find ... -exec` false logic that would always trigger re-download
- Replaced with `test -f` check that preserves existing tarballs downloaded by CI/CD runners
- The workflow now supports pre-downloading in modern environments (GitHub Actions runners with up-to-date OpenSSL) and using those tarballs in older environments (Debian 7 container with OpenSSL 1.0.1e)

### Root cause
OpenSSL 1.0.1e in Debian 7 container cannot handle GitHub's new certificate chain (Sectigo CA with intermediate certificates not in the bundle), while GitHub Actions runners have modern OpenSSL that can establish the connection successfully.

### Related PR

- https://github.com/wazuh/wazuh-agent-packages/pull/600

### Results and Evidence

- [Packages - Build Wazuh agent Linux amd - agent packages - deb - i386](https://github.com/wazuh/wazuh-agent-packages/actions/runs/20830278888) :green_circle: 
- [Packages - Build Wazuh agent Linux amd - agent packages - deb - amd64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/20832179942) :green_circle: 

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Wazuh Agent Linux deb packages

### Configuration Changes

- N/A

### Tests Introduced

- N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues


<!--
Include any additional information relevant to the review process.
-->
