### PR TITLE
Fixed deserialization in cluster

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1849,7 +1849,7 @@ def as_wazuh_object(dct: Dict):
                 wazuh = Wazuh()
                 return getattr(wazuh, funcname)
             else:
-                # Encoded function or static method (restricted to allowlisted internal modules).
+                # Encoded function or static method.
                 qualname = encoded_callable['__qualname__'].split('.')
                 classname = qualname[0] if len(qualname) > 1 else None
                 module_path = encoded_callable['__module__']

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1783,13 +1783,16 @@ def test_as_wazuh_object_ok(mock_chmod, mock_chown, mock_gid, mock_uid):
     # Test the first condition and nested if
     assert cluster_common.as_wazuh_object({"__callable__": {"__name__": "type", "__wazuh__": "version"}}) == "server"
 
-    # Test the first condition and nested else
-    assert isinstance(
+    # Test the first condition - non-internal callable must be blocked
+    with pytest.raises(exception.WazuhInternalError) as err:
         cluster_common.as_wazuh_object({"__callable__": {"__name__": "path", "__qualname__": "__loader__.value",
-                                                         "__module__": "os"}}), str)
+                                                        "__module__": "os"}})
+    assert "Decoding callable from module" in str(err.value)
 
-    assert cluster_common.as_wazuh_object({"__callable__": {"__name__": "__name__", "__qualname__": "value",
-                                                            "__module__": "itertools"}}) == "itertools"
+    with pytest.raises(exception.WazuhInternalError) as err:
+        cluster_common.as_wazuh_object({"__callable__": {"__name__": "__name__", "__qualname__": "value",
+                                                        "__module__": "itertools"}})
+    assert "Decoding callable from module" in str(err.value)
 
     # Test the second condition
     assert isinstance(cluster_common.as_wazuh_object(


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR closes a cluster deserialization.

Thanks to @skraft9 for responsibly reporting this issue.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/core/cluster/tests/test_common.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 89 items                                                                                                                                                                                                

framework/wazuh/core/cluster/tests/test_common.py .........................................................................................                                                                 [100%]
```

## Test report
[archive.zip](https://github.com/user-attachments/files/24613606/archive.zip)
https://jenkins-production.qa.wazuh.info/job/4.14.3/job/Test_integration_endpoints/7/artifact/

## Test results

---
| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Issues Ref.** | **Status** |
|--|--|--|--|--|--|--|--|
| test_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_DELETE_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_GET_endpoints.tavern.yaml | 96 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_POST_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_PUT_endpoints.tavern.yaml | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cluster_endpoints.tavern.yaml | 49 | 0 | 0 | 0 | 1 | https://github.com/wazuh/wazuh/issues/30623 | :yellow_circle: |
| test_decoder_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_default_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_event_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_manager_endpoints.tavern.yaml | 35 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_agent_endpoints.tavern.yaml | 43 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cluster_endpoints.tavern.yaml | 20 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_manager_endpoints.tavern.yaml | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscollector_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_agent_endpoints.tavern.yaml | 43 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_all_endpoints.tavern.yaml | 165 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cluster_endpoints.tavern.yaml | 19 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_manager_endpoints.tavern.yaml | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscollector_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rule_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_sca_endpoints.tavern.yaml | 45 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_DELETE_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_GET_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_POST_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_PUT_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscheck_endpoints.tavern.yaml | 34 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscollector_endpoints.tavern.yaml | 161 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_task_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |



<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
