### PR TITLE
Harden Logcollector multiline backup to use full-buffer copies

### DIFF
--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -489,21 +489,17 @@ STATIC void multiline_ctxt_backup(char * buffer, int readed_lines, w_multiline_c
 
     size_t current_bsize = strlen(buffer);
 
-    if (*ctxt && (strlen((*ctxt)->buffer) == current_bsize)) {
-        return;
-    }
-
-    if (*ctxt) {
-        size_t old_size = strlen((*ctxt)->buffer);
-        os_realloc((*ctxt)->buffer, sizeof(char) * (current_bsize + 1), (*ctxt)->buffer);
-        strcpy((*ctxt)->buffer + old_size, buffer + old_size);
-
-    } else {
+    if (!*ctxt) {
         os_calloc(1, sizeof(w_multiline_ctxt_t), *ctxt);
         os_calloc(current_bsize + 1, sizeof(char), (*ctxt)->buffer);
-        strcpy((*ctxt)->buffer, buffer);
+    } else if (strlen((*ctxt)->buffer) == current_bsize) {
+        /* Size unchanged, nothing to do */
+        return;
+    } else {
+        os_realloc((*ctxt)->buffer, sizeof(char) * (current_bsize + 1), (*ctxt)->buffer);
     }
 
+    strcpy((*ctxt)->buffer, buffer);
     (*ctxt)->lines_count = readed_lines;
     (*ctxt)->timestamp = time(NULL);
 }


### PR DESCRIPTION
## Description

This pull request hardens the multiline logcollector implementation for regex-based multiline files by simplifying how the accumulator buffer is updated. Instead of performing incremental, offset-based updates on an existing buffer, the code now performs clean copies of the new buffer when the context changes.

The goal is to make the logic more robust and defensive without impacting existing behavior or configuration. The change is limited to the multiline reader based on regex and only affects the `wazuh-logcollector` binary.

This defensive programming enhancement was suggested by @skraft9.

## Proposed Changes

### Summary

Update the multiline regex reader accumulator (`multiline_ctxt_backup` in `/src/logcollector/read_multiline_regex.c`) to:
- Copy the entire new buffer from the beginning of the destination buffer.
- Avoid partial updates using offsets derived from previous buffer sizes.
- Skip copying when the existing context buffer length matches the new buffer size and content, avoiding unnecessary work.

### Details

Previously, the accumulator logic reused an existing buffer and updated it incrementally, using offsets based on the previous buffer length. This made the behavior more complex and depended on assumptions about how buffer sizes evolved over time.

The new approach:

- Always treats the new multiline content as the single source of truth.
- Ensures that when reusing an existing context buffer, the copy operation starts at the beginning of the buffer instead of using any offset derived from prior sizes.
- Checks whether the new buffer size is identical to the existing one; if so, and if the content is already up to date, the function performs no copy to avoid unnecessary work.

The trade-off is minimal: the expected impact is an extra copy of a small to moderate-sized string in the multiline accumulator path, which is negligible compared to I/O and parsing cost.

### Results and Evidence

A manual test was executed using a regex-based multiline configuration to validate that multiline grouping and accumulation behavior remain correct.

Configuration used:

```xml
<localfile>
  <log_format>multi-line-regex</log_format>
  <location>/root/test.log</location>
  <multiline_regex>---</multiline_regex>
</localfile>
```

Procedure:

```shell
echo -e "---Hello 1\nHello 2\nBye" >> /root/test.log
```

Observed archive entry:

```
2026 Jan 13 17:36:52 ubuntu->/root/test.log ---Hello 1
Hello 2
Bye
```

This confirms that:

- The multiline accumulator still groups records as expected for `multi-line-regex`.
- There is no change in visible behavior for typical multiline inputs.
- The new accumulator logic is compatible with existing configurations.

### Artifacts Affected

- `wazuh-logcollector`

### Configuration Changes

No configuration changes are required.
Existing `<localfile>` entries using `multi-line-regex` continue to function as before.

### Documentation Updates

No documentation changes are required.
The behavior for regex-based multiline processing remains the same from a user perspective.

### Tests Introduced

- Existing unit tests for the multiline regex accumulator are preserved and still pass.
- Manual testing has been executed using the configuration and procedure described above to verify end-to-end behavior of `wazuh-logcollector` with `multi-line-regex` inputs.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues