### PR TITLE
Fix error in test_disconnected_agents_sync.py

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_disconnected_agents_sync.py
+++ b/framework/wazuh/core/cluster/tests/test_disconnected_agents_sync.py
@@ -10,16 +10,7 @@ import pytest
 
 with patch("wazuh.core.common.wazuh_uid"):
     with patch("wazuh.core.common.wazuh_gid"):
-        sys.modules["wazuh.rbac.orm"] = MagicMock()
-        sys.modules["api"] = MagicMock()
-        sys.modules["api.configuration"] = MagicMock()
-        sys.modules["api.validator"] = MagicMock()
         import wazuh.rbac.decorators
-
-        del sys.modules["wazuh.rbac.orm"]
-        del sys.modules["api"]
-        del sys.modules["api.configuration"]
-        del sys.modules["api.validator"]
         from wazuh.tests.util import RBAC_bypasser
 
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser

--- a/framework/wazuh/rbac/tests/test_auth_context.py
+++ b/framework/wazuh/rbac/tests/test_auth_context.py
@@ -20,6 +20,7 @@ def db_setup():
     with patch('wazuh.core.common.wazuh_uid'), patch('wazuh.core.common.wazuh_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
+                with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     from wazuh.rbac.auth_context import RBAChecker
     init_db('schema_security_test.sql', test_data_path)
 

--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -24,6 +24,7 @@ def db_setup():
     with patch('wazuh.core.common.wazuh_uid'), patch('wazuh.core.common.wazuh_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
+                with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.decorators as decorator
 
     init_db('schema_security_test.sql', test_data_path)

--- a/framework/wazuh/rbac/tests/test_default_configuration.py
+++ b/framework/wazuh/rbac/tests/test_default_configuration.py
@@ -20,6 +20,7 @@ def db_setup():
     with patch('wazuh.core.common.wazuh_uid'), patch('wazuh.core.common.wazuh_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
+                with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as rbac
                     import wazuh.rbac.decorators
                     wazuh.rbac.decorators.rbac.set({'rbac_mode': 'white'})

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -29,6 +29,7 @@ def db_setup():
     with patch('wazuh.core.common.wazuh_uid'), patch('wazuh.core.common.wazuh_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
+                with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as rbac
                     # Clear mappers
                     sqlalchemy_orm.clear_mappers()

--- a/framework/wazuh/rbac/tests/test_preprocessor.py
+++ b/framework/wazuh/rbac/tests/test_preprocessor.py
@@ -20,6 +20,7 @@ def db_setup():
     with patch('wazuh.core.common.wazuh_uid'), patch('wazuh.core.common.wazuh_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
+                with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     from wazuh.rbac.preprocessor import PreProcessor
     init_db('schema_security_test.sql', test_data_path)
 

--- a/framework/wazuh/rbac/tests/utils.py
+++ b/framework/wazuh/rbac/tests/utils.py
@@ -25,6 +25,7 @@ def init_db(schema, test_data_path):
     with patch('wazuh.core.common.wazuh_uid'), patch('wazuh.core.common.wazuh_gid'):
         with patch('sqlalchemy.create_engine', return_value=create_engine("sqlite://")):
             with patch('shutil.chown'), patch('os.chmod'):
+                with patch('api.constants.SECURITY_PATH', new=test_data_path):
                     import wazuh.rbac.orm as orm
 
                     # Clear mappers


### PR DESCRIPTION
## Description

This pull request addresses an issue in `test_disconnected_agents_sync.py` that was causing test failures in subsequent RBAC tests. The mocking strategy used in this test was too broad, leading to unintended side effects and making the test suite fragile.

## Proposed Changes

- The primary change is the removal of the `sys.modules` manipulation in `wazuh/core/cluster/tests/test_disconnected_agents_sync.py`. This test was previously mocking and deleting modules, which caused dependency issues for other tests running in the same suite.

- To ensure the RBAC tests have the correct `SECURITY_PATH` and are properly isolated, `patch('api.constants.SECURITY_PATH', new=test_data_path)` has been added to the setup of the following RBAC tests:
  - `test_auth_context.py`
  - `test_decorators.py`
  - `test_default_configuration.py`
  - `test_orm.py`
  - `test_preprocessor.py`
  - `utils.py`

These changes correct the test's behavior and prevent it from affecting other tests.

### Results and Evidence

The evidence of this fix is the successful execution of the test suite without the previously observed errors.
```
> PYTHONPATH=$WAZUH_REPO/framework:$WAZUH_REPO/api ~/wazuh/wazuh_unit_testing/bin/python3.10 -m pytest --disable-warnings framework/wazuh/


================================================================================= test session starts ==================================================================================
platform linux -- Python 3.10.19, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/franco-rivero/wazuh/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, html-2.1.1, tavern-1.23.5, metadata-3.1.1
asyncio: mode=auto
collected 1907 items                                                                                                                                                                   

framework/wazuh/core/cluster/dapi/tests/test_dapi.py .................................                                                                                           [  1%]
framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py .......................................................                                                         [  4%]
framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py ........................................................................................................             [ 10%]
framework/wazuh/core/cluster/hap_helper/tests/test_wazuh.py ..........                                                                                                           [ 10%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                               [ 11%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                           [ 13%]
framework/wazuh/core/cluster/tests/test_common.py ........................................................................................                                       [ 17%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                        [ 18%]
framework/wazuh/core/cluster/tests/test_disconnected_agents_sync.py ....................                                                                                         [ 19%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                                           [ 19%]
framework/wazuh/core/cluster/tests/test_local_server.py .................                                                                                                        [ 20%]
framework/wazuh/core/cluster/tests/test_master.py ....................................................                                                                           [ 23%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                  [ 25%]
framework/wazuh/core/cluster/tests/test_utils.py ...........................                                                                                                     [ 26%]
framework/wazuh/core/cluster/tests/test_worker.py ...................................                                                                                            [ 28%]
framework/wazuh/core/tests/test_active_response.py ...................                                                                                                           [ 29%]
framework/wazuh/core/tests/test_agent.py ....................................................................................................................................... [ 36%]
............                                                                                                                                                                     [ 37%]
framework/wazuh/core/tests/test_common.py ...........                                                                                                                            [ 37%]
framework/wazuh/core/tests/test_configuration.py ....................................................................................                                            [ 42%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                                          [ 42%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                           [ 42%]
framework/wazuh/core/tests/test_manager.py ...............................                                                                                                       [ 44%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                          [ 44%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                              [ 46%]
framework/wazuh/core/tests/test_security.py .............                                                                                                                        [ 47%]
framework/wazuh/core/tests/test_stats.py ........................................                                                                                                [ 49%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                 [ 49%]
framework/wazuh/core/tests/test_utils.py ....................................................................................................................................... [ 57%]
..........................................................................................................................................................................       [ 65%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                                           [ 67%]
framework/wazuh/core/tests/test_wazuh_socket.py ......................................                                                                                           [ 69%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                           [ 70%]
framework/wazuh/core/tests/test_wdb_http.py ...........                                                                                                                          [ 71%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                                         [ 71%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                               [ 72%]
framework/wazuh/rbac/tests/test_decorators.py ................................................................................................................                   [ 77%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................                                                                                 [ 79%]
framework/wazuh/rbac/tests/test_orm.py ................................................................                                                                          [ 83%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                      [ 83%]
framework/wazuh/tests/test_active_response.py ..........                                                                                                                         [ 84%]
framework/wazuh/tests/test_agent.py ...................................................................................................................................          [ 91%]
framework/wazuh/tests/test_cluster.py .......                                                                                                                                    [ 91%]
framework/wazuh/tests/test_event.py ....                                                                                                                                         [ 91%]
framework/wazuh/tests/test_manager.py ...................................                                                                                                        [ 93%]
framework/wazuh/tests/test_rootcheck.py ...                                                                                                                                      [ 93%]
framework/wazuh/tests/test_security.py .......................................................................                                                                   [ 97%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                              [ 98%]
framework/wazuh/tests/test_syscheck.py ...                                                                                                                                       [ 98%]
framework/wazuh/tests/test_task.py ............................                                                                                                                  [100%]

===================================================================== 1907 passed, 9 warnings in 190.01s (0:03:10) =====================================================================
```


### Manual tests with their corresponding evidence

- [ ] Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Wazuh server API/Framework
  - [X] Run API Integration Tests

### Artifacts Affected

- None.

### Configuration Changes

- None.

### Tests Introduced

- No new tests were added. This pull request modifies existing tests to improve their reliability and isolation.

## Review Checklist

- [X] Code changes reviewed
- [X] Relevant evidence provided
- [X] Tests cover the new functionality
- [X] Configuration changes documented
- [X] Developer documentation reflects the changes
- [X] Meets requirements and/or definition of done
- [X] No unresolved dependencies with other issues

Closes #33945 