### PR TITLE
Fix error downloading http-request in package generation - 5.x 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1446,13 +1446,12 @@ HTTP_REQUEST_URL := https://github.com/wazuh/wazuh-http-request/tarball/$(HTTP_R
 CA_BUNDLE := /etc/ssl/certs/ca-certificates.crt
 CACERT_OPT := $(shell test -f $(CA_BUNDLE) && echo "--cacert $(CA_BUNDLE)" || echo "")
 
-.PHONY: shared_modules/http-request.tar.gz
-
 shared_modules/http-request.tar.gz:
-	test -f $@ || $(CURL) $@ $(CACERT_OPT) -L $(HTTP_REQUEST_URL) &&\
-	($(GUNZIP) -f $@ || (rm -f $@ && echo "Error decompressing $@ maybe wrong branch was supplied!" && false)) && \
-	$(TAR) $(patsubst %.gz,%,$@) --strip-components=1 -C $(patsubst %.tar.gz,%,$@) && \
-	rm $(patsubst %.gz,%,$@)
+	find $(patsubst %.tar.gz,%,$@) -type f -exec false {} + &&\
+	((test -e $(patsubst %.gz,%,$@) || $(CURL) $@ $(CACERT_OPT) -L $(HTTP_REQUEST_URL)) &&\
+	($(GUNZIP) $@ || (rm -f $@ && echo "Error decompressing $@ maybe wrong branch was supplied!" && false)) &&\
+	$(TAR) $(patsubst %.gz,%,$@) --strip-components=1 -C $(patsubst %.tar.gz,%,$@) &&\
+	rm $(patsubst %.gz,%,$@)) || true
 
 # Indexer plugin templates download
 # Get refs from get_git_refs.sh if INDEXER_PLUGINS_REFS is not set


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh-agent-packages/issues/594

This PR fixes a certificate validation failure when downloading the `http-request` submodule in Debian 7 environments, which prevented DEB package generation starting January 6, 2026.

The issue was triggered by GitHub's certificate renewal, where they switched from DigiCert to Sectigo as their Certificate Authority. Debian 7 uses curl 7.26.0 (from 2012) with obsolete CA certificates that cannot verify GitHub's new certificate chain, causing SSL/TLS handshake failures during the download process.

## Proposed Changes

### Bugs fixed

- Updated CA certificates in Debian 7 Docker build containers (amd64 and i386) to support modern HTTPS connections
- Modified `Makefile` to conditionally use updated certificates when available

### Technical details

**Dockerfile changes (packages/debs/amd64/agent/Dockerfile and packages/debs/i386/agent/Dockerfile):**
- Added Mozilla CA certificate bundle (cacert.pem) to `certificates/` directory
- Configured Docker containers to copy the certificate bundle to `/etc/ssl/certs/ca-certificates.crt`
- Set `CURL_CA_BUNDLE` environment variable to point to the updated certificates

**Makefile changes (src/Makefile):**
- Added conditional `CACERT_OPT` variable that includes `--cacert` flag only when the certificate file exists
- This ensures compatibility: Debian 7 containers use the updated certificates, while RPM containers (which don't have certificate issues) continue working without changes

### Root cause
Debian 7 containers have CA certificates from 2012-2013 that cannot verify modern certificate chains. curl 7.26.0 respects the `CURL_CA_BUNDLE` environment variable, allowing us to provide updated Mozilla CA certificates without upgrading the entire system. The conditional approach in the Makefile ensures this fix only applies to environments that need it (Debian 7), without affecting other build targets (RPM packages).

### Results and Evidence

- [Packages - Build Wazuh agent Linux amd - agent packages - deb - amd64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/21031062621)
- [Packages - Build Wazuh agent Linux amd - agent packages - deb - i386](https://github.com/wazuh/wazuh-agent-packages/actions/runs/21031046188)

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- wazuh-agent deb packages

### Configuration Changes

- N/A

### Tests Introduced

- N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues


<!--
Include any additional information relevant to the review process.
-->
