### PR TITLE
Fix checkfiles failure for rpm5 agent packages

### DIFF
--- a/.github/actions/check_files/rpm5_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_amd64.csv
@@ -66,6 +66,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/15/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/15/cis_sles15_linux.yml,root,wazuh,640,file,-rw-r-----,290194,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/sles/16/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/sles/16/cis_sles16_linux.yml,root,wazuh,640,file,-rw-r-----,290281,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/11/sca.files,root,wazuh,640,file,-rw-r-----,28,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/11/cis_sles11_linux.yml,root,wazuh,640,file,-rw-r-----,60607,0.1
 /var/ossec/agentless/register_host.sh,root,wazuh,750,file,-rwxr-x---,2406,0.1

--- a/.github/actions/check_files/rpm5_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_i386.csv
@@ -66,6 +66,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/15/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/15/cis_sles15_linux.yml,root,wazuh,640,file,-rw-r-----,290194,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/sles/16/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/sles/16/cis_sles16_linux.yml,root,wazuh,640,file,-rw-r-----,290281,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/11/sca.files,root,wazuh,640,file,-rw-r-----,28,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/11/cis_sles11_linux.yml,root,wazuh,640,file,-rw-r-----,60607,0.1
 /var/ossec/agentless/register_host.sh,root,wazuh,750,file,-rwxr-x---,2406,0.1


### PR DESCRIPTION
## Description

The `RPM5 agent` package workflow was failing during the file integrity check because the unexpected files `sca.files` and `cis_sles16_linux.yml`. This pull request updates the expected files so that the checkfiles test passes for RPM5 builds.

## Proposed Changes

- Update the check-files adding the new files `sca.files` and `cis_sles16_linux.yml` for RPM5 agent packages.
- Keep the rest of the file integrity expectations unchanged to avoid impacting other platforms or package types.

### Results and Evidence

[Packages - Build Wazuh agent Linux amd - legacy packages - rpm - i386](https://github.com/wazuh/wazuh-agent-packages/actions/runs/21039589677)
[Packages - Build Wazuh agent Linux amd - legacy packages - rpm - x86_64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/21039660722)


### Artifacts Affected

- RPM5 agent packages:
  - Checkfiles test for `sca.files`.
  - Checkfiles test for `cis_sles16_linux.yml`.

### Configuration Changes

- No configuration changes introduced.

### Documentation Updates

- Not applicable.

### Tests Introduced

- No new tests added.
- Existing checkfiles test for RPM5 now passes with the corrected expected size:
  - Verified by the successful workflow run linked above.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues