### PR TITLE
Fix checkfiles manifest paths for SLES 16 SCA files

### DIFF
--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -61,8 +61,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-5.*-*-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1
 /var/ossec/tmp/sca-5.*-*-tmp/sles/15/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-5.*-*-tmp/sles/15/cis_sles15_linux.yml,root,wazuh,640,file,-rw-r-----,290194,0.1
-/var/ossec/tmp/sca-4.*-*-tmp/sles/16/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
-/var/ossec/tmp/sca-4.*-*-tmp/sles/16/cis_sles16_linux.yml,root,wazuh,640,file,-rw-r-----,290281,0.1
+/var/ossec/tmp/sca-5.*-*-tmp/sles/16/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
+/var/ossec/tmp/sca-5.*-*-tmp/sles/16/cis_sles16_linux.yml,root,wazuh,640,file,-rw-r-----,290281,0.1
 /var/ossec/var/selinux/wazuh.pp,root,wazuh,640,file,-rw-r-----,3199,0.1
 /var/ossec/bin/wazuh-syscheckd,root,root,750,file,-rwxr-x---,749136,0.1
 /var/ossec/bin/wazuh-execd,root,root,750,file,-rwxr-x---,591616,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -61,8 +61,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-5.*-*-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1
 /var/ossec/tmp/sca-5.*-*-tmp/sles/15/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-5.*-*-tmp/sles/15/cis_sles15_linux.yml,root,wazuh,640,file,-rw-r-----,290194,0.1
-/var/ossec/tmp/sca-4.*-*-tmp/sles/16/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
-/var/ossec/tmp/sca-4.*-*-tmp/sles/16/cis_sles16_linux.yml,root,wazuh,640,file,-rw-r-----,290281,0.1
+/var/ossec/tmp/sca-5.*-*-tmp/sles/16/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
+/var/ossec/tmp/sca-5.*-*-tmp/sles/16/cis_sles16_linux.yml,root,wazuh,640,file,-rw-r-----,290281,0.1
 /var/ossec/var/selinux/wazuh.pp,root,wazuh,640,file,-rw-r-----,3199,0.1
 /var/ossec/bin/wazuh-syscheckd,root,root,750,file,-rwxr-x---,947696,0.1
 /var/ossec/bin/wazuh-execd,root,root,750,file,-rwxr-x---,745284,0.1


### PR DESCRIPTION
## Description

After merging `4.14.3` into `main` via wazuh/wazuh#33954, the RPM package generation workflows started failing the **checkfiles** validation.  
Root cause: the new SCA content for **SLES 16** is installed under `tmp/5.0.0`, while the checkfiles manifest still expects `tmp/4.*.*` paths inherited from the `4.14.3` branch.

This PR aligns the expected checkfiles entries with the actual installation paths so RPM builds for `i386` and `x86_64` pass again.

## Proposed Changes

- Update the checkfiles manifest to reference the correct SCA base directory for SLES 16 (`tmp/5.0.0` instead of `tmp/4.*.*`).
- Ensure the expected paths match the installed files:
  - `cis_sles16_linux.yml`
  - `sca.files`

### Results and Evidence

Workflows re-run successfully after applying the fix:

||Platform|Job|
|--|--|--|
|🟢|RPM i386|[#1384](https://github.com/wazuh/wazuh-agent-packages/actions/runs/21064227093)
|🟢|RPM x86_64|[#1385](https://github.com/wazuh/wazuh-agent-packages/actions/runs/21064233360)

### Artifacts Affected

- Checkfiles output for **Wazuh agent RPM packages**:
  - `i386`
  - `x86_64`

### Configuration Changes

None.

### Documentation Updates

Not applicable.

### Tests Introduced

None. Existing **check_files** test was executed as validation.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues