### PR TITLE
Remove deprecated rootcheck options from SLES 16 templates

### DIFF
--- a/etc/templates/config/sles/16/rootcheck.agent.template
+++ b/etc/templates/config/sles/16/rootcheck.agent.template
@@ -1,8 +1,6 @@
   <!-- Policy monitoring -->
   <rootcheck>
     <disabled>no</disabled>
-    <check_files>yes</check_files>
-    <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>
     <check_sys>yes</check_sys>
     <check_pids>yes</check_pids>
@@ -11,9 +9,6 @@
 
     <!-- Frequency that rootcheck is executed - every 12 hours -->
     <frequency>43200</frequency>
-
-    <rootkit_files>etc/shared/rootkit_files.txt</rootkit_files>
-    <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
 

--- a/etc/templates/config/sles/16/rootcheck.manager.template
+++ b/etc/templates/config/sles/16/rootcheck.manager.template
@@ -1,8 +1,6 @@
   <!-- Policy monitoring -->
   <rootcheck>
     <disabled>no</disabled>
-    <check_files>yes</check_files>
-    <check_trojans>yes</check_trojans>
     <check_dev>yes</check_dev>
     <check_sys>yes</check_sys>
     <check_pids>yes</check_pids>
@@ -11,9 +9,6 @@
 
     <!-- Frequency that rootcheck is executed - every 12 hours -->
     <frequency>43200</frequency>
-
-    <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
-    <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
 

--- a/src/engine/test/acceptance_test/analysisd/config/ossec.conf
+++ b/src/engine/test/acceptance_test/analysisd/config/ossec.conf
@@ -28,13 +28,6 @@
     <!-- Frequency that rootcheck is executed - every 12 hours -->
     <frequency>43200</frequency>
 
-    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
-    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
-
-    <system_audit>/var/ossec/etc/shared/system_audit_rcl.txt</system_audit>
-    <system_audit>/var/ossec/etc/shared/system_audit_ssh.txt</system_audit>
-    <system_audit>/var/ossec/etc/shared/cis_debian_linux_rcl.txt</system_audit>
-
     <skip_nfs>yes</skip_nfs>
   </rootcheck>
 


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                   
                                                                                                                                                                                                                   
  This PR completes the rootcheck cleanup initiative by removing deprecated configuration options from SLES 16 templates and test configurations. These options were previously deprecated as part of the rootcheck
   simplification effort.                                                                                                                                                                                          
                                                                                                                                                                                                                   
  Related to #33650 (Rootcheck simplification) and #34056 (Add rootcheck module documentation).               

Closes #34071                                                                                                     
                                                                                                                                                                                                                   
  ## Proposed Changes                                                                                                                                                                                              
                                                                                                                                                                                                                   
  - Remove deprecated `check_files` and `check_trojans` configuration options from SLES 16 agent and manager rootcheck templates                                                                                   
  - Remove deprecated `rootkit_files` and `rootkit_trojans` file references from SLES 16 templates                                                                                                                 
  - Clean up obsolete rootcheck configuration in acceptance test files (`rootkit_files`, `rootkit_trojans`, and `system_audit` references)                                                                         
                                                                                                                                                                                                                   
  ### Results and Evidence                                                                                                                                                                                         
                                                                                                                                                                                                                   
  The following deprecated options have been removed:                                                                                                                                                              
  - `check_files`: Previously used to enable/disable file integrity checks (now handled by other modules)                                                                                                          
  - `check_trojans`: Previously used to enable/disable trojan detection (now handled by other modules)                                                                                                             
  - `rootkit_files`: Reference to rootkit database file                                                                                                                                                            
  - `rootkit_trojans`: Reference to trojan database file                                                                                                                                                           
  - `system_audit`: References to system audit configuration files (in test configurations)                                                                                                                        
                                                                                                                                                                                                                   
  ### Manual tests with their corresponding evidence                                                                                                                                                               
                                                                                                                                                                                                                   
  - Compilation without warnings on every supported platform                                                                                                                                                       
    - [ ] Linux                                                                                                                                                                                                    
    - [ ] Windows                                                                                                                                                                                                  
    - [ ] MAC OS X                                                                                                                                                                                                 
  - [ ] Log syntax and correct language review                                                                                                                                                                     
                                                                                                                                                                                                                   
  ### Artifacts Affected                                                                                                                                                                                           
                                                                                                                                                                                                                   
  **Configuration Templates:**                                                                                                                                                                                     
  - `etc/templates/config/sles/16/rootcheck.agent.template`                                                                                                                                                        
  - `etc/templates/config/sles/16/rootcheck.manager.template`                                                                                                                                                      
                                                                                                                                                                                                                   
  **Test Configurations:**                                                                                                                                                                                         
  - `src/engine/test/acceptance_test/analysisd/config/ossec.conf`                                                                                                                                                  
                                                                                                                                                                                                                   
  ### Configuration Changes                                                                                                                                                                                        
                                                                                                                                                                                                                   
  **Removed deprecated options:**                                                                                                                                                                                  
  - `check_files`                                                                                                                                                                                                  
  - `check_trojans`                                                                                                                                                                                                
  - `rootkit_files`                                                                                                                                                                                                
  - `rootkit_trojans`                                                                                                                                                                                              
  - `system_audit` (from test configurations)                                                                                                                                                                      
                                                                                                                                                                                                                   
  **Backward compatibility:** These options have been deprecated and their removal aligns with the rootcheck simplification effort. SLES 16 configurations will continue to function with the remaining rootcheck  
  options.                                                                                                                                                                                                         
                                                                                                                                                                                                                   
  ### Tests Introduced                                                                                                                                                                                             
                                                                                                                                                                                                                   
  N/A - This PR removes deprecated configuration options only.                                                                                                                                                     
                                                                                                                                                                                                                   
  ## Review Checklist                                                                                                                                                                                              
                                                                                                                                                                                                                   
  - [ ] Code changes reviewed                                                                                                                                                                                      
  - [ ] Relevant evidence provided                                                                                                                                                                                 
  - [ ] Tests cover the new functionality                                                                                                                                                                          
  - [ ] Configuration changes documented                                                                                                                                                                           
  - [ ] Developer documentation reflects the changes                                                                                                                                                               
  - [ ] Meets requirements and/or definition of done                                                                                                                                                               
  - [ ] No unresolved dependencies with other issues      