### PR TITLE
Fix race condition causing syscollector shutdown deadlock

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -276,6 +276,7 @@ void* wm_sys_main(wm_sys_t *sys) {
 
     mtinfo(WM_SYS_LOGTAG, "Module finished.");
     w_mutex_lock(&sys_stop_mutex);
+    need_shutdown_wait = false;
     w_cond_signal(&sys_stop_condition);
     w_mutex_unlock(&sys_stop_mutex);
     return 0;
@@ -304,7 +305,7 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t *data) {
         syscollector_stop_ptr();
     }
     w_mutex_lock(&sys_stop_mutex);
-    if (need_shutdown_wait) {
+    while (need_shutdown_wait) {
         w_cond_wait(&sys_stop_condition, &sys_stop_mutex);
     }
     w_mutex_unlock(&sys_stop_mutex);


### PR DESCRIPTION
## Description

Closes: #34068 

This pull request fixes a deadlock in `wazuh-modulesd` that occurs during shutdown of the syscollector module. The deadlock happens when the main thread attempts to stop the syscollector module, but the module's worker thread has already finished and sent a condition variable signal that was lost due to a race condition.

The issue manifests when `SIGTERM`/`SIGINT` is received after the syscollector thread completes its execution but before the signal handler enters the wait state. This causes the main thread to wait indefinitely for a signal that has already been sent and lost, preventing graceful shutdown of `wazuh-modulesd`.

**Impact:** The process becomes unresponsive to `stop` commands and must be forcefully terminated with `SIGKILL`.

## Proposed Changes

Two changes are required to properly implement the condition variable pattern:

**Change 1: Update state before signaling (wm_syscollector.c:279)**
```c
// Before:
w_mutex_lock(&sys_stop_mutex);
w_cond_signal(&sys_stop_condition);
w_mutex_unlock(&sys_stop_mutex);

// After:
w_mutex_lock(&sys_stop_mutex);
need_shutdown_wait = false;  // Mark condition as met before signaling
w_cond_signal(&sys_stop_condition);
w_mutex_unlock(&sys_stop_mutex);
```

**Change 2: Use while loop instead of if (wm_syscollector.c:308)**
```c
// Before:
w_mutex_lock(&sys_stop_mutex);
if (need_shutdown_wait) {
    w_cond_wait(&sys_stop_condition, &sys_stop_mutex);
}
w_mutex_unlock(&sys_stop_mutex);

// After:
w_mutex_lock(&sys_stop_mutex);
while (need_shutdown_wait) {  // Re-verify condition after wakeup
    w_cond_wait(&sys_stop_condition, &sys_stop_mutex);
}
w_mutex_unlock(&sys_stop_mutex);
```

### How the Fix Works

**Scenario A: Signal arrives before wait (race condition - previously caused deadlock)**
- Syscollector thread sets `need_shutdown_wait = false` and signals
- Main thread arrives late, sees `need_shutdown_wait == false`
- Main thread **does not enter** the wait → No deadlock ✅

**Scenario B: Wait arrives before signal (normal order)**
- Main thread enters wait with `need_shutdown_wait == true`
- Syscollector thread sets `need_shutdown_wait = false` and signals
- Main thread wakes up, re-evaluates `while(need_shutdown_wait)` → now false
- Main thread exits the loop → No deadlock ✅

### Results and Evidence

For testing purposes, I created a script that starts the agent, waits for a configurable interval, then stops and waits to see if the string `“Process wazuh-modulesd couldn't be terminated. It will be killed.”` is obtained. If it is obtained, it logs Fail; otherwise, it logs OK.

<details><summary>script</summary>

```
#!/usr/bin/env bash

DEBUG=false

usage() {
    echo "Usage: $0 [-d] [ITERATIONS] [START_DELAY_MS]"
    echo
    echo "  -d    Debug mode (print start/stop output)"
    echo
    exit 1
}

# Parse flags
while getopts ":d" opt; do
    case $opt in
        d)
            DEBUG=true
            ;;
        *)
            usage
            ;;
    esac
done
shift $((OPTIND -1))

ITERATIONS=${1:-30}
START_DELAY_MS=${2:-400}

WAZUH_CONTROL="/var/ossec/bin/wazuh-control"
FAIL_PATTERN="Process wazuh-modulesd couldn't be terminated. It will be killed."

TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
CSV_FILE="wazuh_start_stop_results_${TIMESTAMP}.csv"

success=0
fail=0
times=()

echo "========================================"
echo "Wazuh Service Start/Stop Test (Linux)"
echo "========================================"
echo "Iterations: $ITERATIONS"
echo "Start delay: ${START_DELAY_MS} ms"
echo "Debug mode: $DEBUG"
echo

echo "iteration,status,stop_duration_seconds,error" > "$CSV_FILE"

for ((i=1; i<=ITERATIONS; i++)); do
    echo -n "[$i/$ITERATIONS] Starting test cycle... "

    # START
    start_output=$($WAZUH_CONTROL start 2>&1)

    if $DEBUG; then
        echo
        echo "--- START output ---"
        echo "$start_output"
        echo "--------------------"
    fi

    sleep $(awk "BEGIN {print $START_DELAY_MS / 1000}")

    # STOP (measure only stop time)
    start_time=$(date +%s.%N)
    stop_output=$($WAZUH_CONTROL stop 2>&1)
    end_time=$(date +%s.%N)

    duration=$(awk "BEGIN {print $end_time - $start_time}")

    if $DEBUG; then
        echo "--- STOP output ---"
        echo "$stop_output"
        echo "-------------------"
    fi

    if echo "$stop_output" | grep -Fq "$FAIL_PATTERN"; then
        echo "FAIL (${duration}s)"
        ((fail++))
        echo "$i,FAIL,$duration,\"$FAIL_PATTERN\"" >> "$CSV_FILE"
    else
        echo "OK (${duration}s)"
        ((success++))
        times+=("$duration")
        echo "$i,OK,$duration," >> "$CSV_FILE"
    fi
done

echo
echo "========================================"
echo "Test Results Summary"
echo "========================================"
echo
echo "Total Iterations: $ITERATIONS"
echo "Successful Stops: $success ($((success*100/ITERATIONS))%)"
echo "Failed Stops:     $fail ($((fail*100/ITERATIONS))%)"

if [ ${#times[@]} -gt 0 ]; then
    min=$(printf "%s\n" "${times[@]}" | sort -n | head -1)
    max=$(printf "%s\n" "${times[@]}" | sort -n | tail -1)
    avg=$(printf "%s\n" "${times[@]}" | awk '{sum+=$1} END {print sum/NR}')

    echo
    echo "Stop Time Statistics (successful stops only):"
    printf "  Average: %.3fs\n" "$avg"
    printf "  Minimum: %.3fs\n" "$min"
    printf "  Maximum: %.3fs\n" "$max"
fi

echo
echo "Detailed results exported to: $(pwd)/$CSV_FILE"
echo
echo "Test completed!"
```

</details>

Note: I tested the previous version on 4.14.2, but it is also reproducible on 4.14.3.
<details><summary>4.14.2 before fix:</summary>

```
root@debian13:/home/vagrant# sudo ./test_wazuh_start_stop.sh -d 30 25000
========================================
Wazuh Service Start/Stop Test (Linux)
========================================
Iterations: 30
Start delay: 25000 ms
Debug mode: true

[1/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
wazuh-execd already running...
wazuh-agentd already running...
wazuh-syscheckd already running...
wazuh-logcollector already running...
wazuh-modulesd already running...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8694s)
[2/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.9044s)
[3/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8812s)
[4/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.777s)
[5/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8217s)
[6/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8636s)
[7/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8431s)
[8/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.9053s)
[9/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8286s)
[10/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.9024s)
[11/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.8992s)
[12/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (29.855s)
[13/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.2266s)
[14/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.5763s)
[15/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.1489s)
[16/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.4292s)
[17/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.1604s)
[18/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.2 Stopped
-------------------
OK (6.1828s)
[19/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.7044s)
[20/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.2 Stopped
-------------------
OK (6.12479s)
[21/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.4994s)
[22/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.3754s)
[23/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.1756s)
[24/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.0213s)
[25/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.4979s)
[26/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.4304s)
[27/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.5833s)
[28/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.5237s)
[29/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.5976s)
[30/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.2...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Process wazuh-modulesd couldn't be terminated. It will be killed.
Wazuh v4.14.2 Stopped
-------------------
FAIL (30.6993s)

========================================
Test Results Summary
========================================

Total Iterations: 30
Successful Stops: 2 (6%)
Failed Stops:     28 (93%)

Stop Time Statistics (successful stops only):
  Average: 6.154s
  Minimum: 6.125s
  Maximum: 6.183s

Detailed results exported to: /home/vagrant/wazuh_start_stop_results_20260121_161337.csv

Test completed!
```

</details>

<details><summary>4.14.4 after fix:</summary>

```
root@debian13:/home/vagrant# apt-get install ./wazuh-agent_4.14.4-0_amd64_ced6f50.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_4.14.4-0_amd64_ced6f50.deb'
The following packages will be upgraded:
  wazuh-agent
1 upgraded, 0 newly installed, 0 to remove and 26 not upgraded.
Need to get 0 B/13.2 MB of archives.
After this operation, 468 kB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_4.14.4-0_amd64_ced6f50.deb wazuh-agent amd64 4.14.4-0 [13.2 MB]
Reading changelogs... Done
Preconfiguring packages ...
(Reading database ... 65129 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.14.4-0_amd64_ced6f50.deb ...
Unpacking wazuh-agent (4.14.4-0) over (4.14.2-1) ...
Setting up wazuh-agent (4.14.4-0) ...
N: Download is performed unsandboxed as root as file '/home/vagrant/wazuh-agent_4.14.4-0_amd64_ced6f50.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
root@debian13:/home/vagrant# sudo ./test_wazuh_start_stop.sh -d 30 25000
========================================
Wazuh Service Start/Stop Test (Linux)
========================================
Iterations: 30
Start delay: 25000 ms
Debug mode: true

[1/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
wazuh-execd already running...
wazuh-agentd already running...
wazuh-syscheckd already running...
wazuh-logcollector already running...
wazuh-modulesd already running...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (1.73055s)
[2/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.12946s)
[3/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.15578s)
[4/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.10301s)
[5/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.03618s)
[6/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.10569s)
[7/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.84245s)
[8/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.97007s)
[9/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.1436s)
[10/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.94457s)
[11/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.65316s)
[12/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (7.19492s)
[13/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.01244s)
[14/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.22831s)
[15/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.92163s)
[16/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.11314s)
[17/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.89916s)
[18/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.12733s)
[19/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.9542s)
[20/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.00201s)
[21/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.18351s)
[22/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.09433s)
[23/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.00242s)
[24/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.84239s)
[25/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.36988s)
[26/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.06845s)
[27/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (5.99077s)
[28/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.00551s)
[29/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.04356s)
[30/30] Starting test cycle...
--- START output ---
Starting Wazuh v4.14.4...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
--------------------
--- STOP output ---
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v4.14.4 Stopped
-------------------
OK (6.10433s)

========================================
Test Results Summary
========================================

Total Iterations: 30
Successful Stops: 30 (100%)
Failed Stops:     0 (0%)

Stop Time Statistics (successful stops only):
  Average: 5.932s
  Minimum: 1.731s
  Maximum: 7.195s

Detailed results exported to: /home/vagrant/wazuh_start_stop_results_20260121_164711.csv

Test completed!
```

</details>

### Artifacts Affected

- **Executables**: `wazuh-modulesd` (all platforms)

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->