### PR TITLE
Adjust Vulnerability Detector agent warning message

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -503,9 +503,9 @@ void Syscollector::start()
     if (!m_vdSyncEnabled)
     {
 #ifdef _WIN32
-        m_logFunction(LOG_WARNING, "Vulnerability Detector synchronization is disabled. No packages, OS, or hotfixes scanning is enabled in the configuration.");
+        m_logFunction(LOG_WARNING, "Vulnerability Detector synchronization is disabled. OS, packages, and hotfixes are required to be enabled.");
 #else
-        m_logFunction(LOG_WARNING, "Vulnerability Detector synchronization is disabled. No packages or OS scanning is enabled in the configuration.");
+        m_logFunction(LOG_WARNING, "Vulnerability Detector synchronization is disabled. OS and packages are required to be enabled.");
 #endif
     }
 


### PR DESCRIPTION
  ## Description                                                                                                                                                                                                   
                                                                                                                                                                                                                   
  This pull request adjusts the Vulnerability Detector warning message in the agent to provide platform-specific information when synchronization is disabled. On Windows systems, the message now correctly       
  mentions hotfixes scanning in addition to packages and OS scanning, while on Linux/Unix systems it only mentions packages and OS scanning.                                                                       
                                                                                                                                                                                                                   
  Closes #34088                                                                                                                                                                                                    
                                                                                                                                                                                                                   
  ## Proposed Changes                                                                                                                                                                                              
                                                                                                                                                                                                                   
  - Updated the warning message in `syscollectorImp.c` to differentiate between Windows and non-Windows platforms                                                                                                  
                                                                                                                                                                                                                   
  This ensures users receive accurate information about which scanning capabilities are disabled based on their operating system.                                                                                  
                                                                                                                                                                                                                   
  ## Results and Evidence                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                     
 ### Manual tests with their corresponding evidence                                                                                                                                                                   
 
<details><summary>Windows results with OS scanning disabled</summary>

```bash
2026/01/21 13:25:20 wazuh-modulesd:syscollector: WARNING: Vulnerability Detector synchronization is disabled. OS, packages, and hotfixes are required to be enabled.
```
</details>                                                                                                                                                                               

<details><summary>Linux results with OS scanning disabled</summary>

```bash
2026/01/21 14:14:58 wazuh-modulesd:syscollector: WARNING: Vulnerability Detector synchronization is disabled. OS and packages are required to be enabled.
```
</details>
                                                                                                                                                                                                                   
 ### Artifacts Affected                                                                                                                                                                                               
                                                                                                                                                                                                                   
  - Agent executable on all platforms (Linux, Windows, macOS)                                                                                                                                                      
  - File modified: syscollectorImp.c                                                                                                                                                                               
                                                                                                                                                                                                                   
## Configuration Changes                                                                                                                                                                                            
                                                                                                                                                                                                                   
  N/A - This change only affects a log message and does not introduce any configuration parameter changes.                                                                                                         
                                                                                                                                                                                                                   ### Tests Introduced                                                                                                                                                                                                 
                                                                                                                                                                                                                   
  N/A - This is a cosmetic change to improve log message clarity. The existing test suite covers the logging functionality.                                                                                        
                                                                                                                                                                                                                   
 
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
