### PR TITLE
Move concurrency control to job level for parallel builds

### DIFF
--- a/.github/workflows/5_builderpackage_engine-standalone.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone.yml
@@ -40,10 +40,6 @@ on:
       - 'src/engine/**'
       - '.github/workflows/5_builderpackage_engine-standalone.yml'
 
-# Ensures only one instance of this workflow is running per PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_call' && 'called' || 'trigger' }}
-
 env:
   ENGINE_DIR: ${{github.workspace}}/src/engine
   WAZUH_BRANCH: ${{ inputs.wazuh-branch || 'main' }}
@@ -53,6 +49,9 @@ jobs:
   build:
     name: Build Server (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    # Groups builds by architecture to track concurrent executions
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.arch }}-${{ github.event_name == 'workflow_call' && 'called' || 'trigger' }}
     outputs:
       version: ${{ steps.set_version.outputs.version }}
     strategy:


### PR DESCRIPTION
## Description

This PR fixes a concurrency issue in the Engine Standalone workflow that was preventing parallel builds when called from the Wazuh Indexer build workflow. Previously, the workflow-level concurrency control was causing builds to be cancelled when multiple parallel invocations occurred (for different distributions/architectures), resulting in missing engine artifacts.

Closes [#1300](https://github.com/wazuh/wazuh-indexer/issues/1300)

## Proposed Changes

### Changes Made
- **Moved concurrency control from workflow level to job level** in the `build` job
- **Added architecture to the concurrency group key** to allow parallel builds for different architectures (amd64/arm64)

### Technical Details
The previous workflow-level concurrency configuration:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_call' && 'called' || 'trigger' }}
```

Was causing all parallel invocations from the indexer workflow to share the same concurrency group, resulting in build cancellations.

The new job-level concurrency configuration:
```yaml
jobs:
  build:
    concurrency:
      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.arch }}-${{ github.event_name == 'workflow_call' && 'called' || 'trigger' }}
```

Now allows each architecture to have its own concurrency group, enabling parallel builds without cancellations.

### Results and Evidence

**Before the fix:**
- When the Wazuh Indexer workflow called the engine workflow for multiple distributions (deb, rpm), builds were cancelled
- Only partial engine artifacts were generated
- Build failures occurred with "Cancelled" status

**After the fix:**
- Both amd64 and arm64 engine builds complete successfully in parallel
- All 2 engine artifacts are generated correctly:
  - `wazuh-engine-VERSION-linux-amd64.tar.gz`
  - `wazuh-engine-VERSION-linux-arm64.tar.gz`
- All 4 indexer build jobs (deb-x64, deb-arm64, rpm-x64, rpm-arm64) successfully download their corresponding engine artifacts
- "Display structure of downloaded files" step shows all 4 engine tar.gz files present

Workflow run ID: [21257978716](https://github.com/wazuh/wazuh-indexer/actions/runs/21257978716)

### Artifacts Affected

- GitHub Actions workflow: `.github/workflows/5_builderpackage_engine-standalone.yml`

### Configuration Changes

- N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...