### PR TITLE
Add decorator `authd.pass`

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -15,7 +15,7 @@ from wazuh.core.manager import status, get_api_conf, get_update_information_temp
     get_logs_summary, validate_ossec_conf, OSSEC_LOG_FIELDS
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.utils import process_array, safe_move, validate_wazuh_xml, full_copy
-from wazuh.rbac.decorators import expose_resources
+from wazuh.rbac.decorators import expose_resources, mask_sensitive_config
 
 cluster_enabled = not read_cluster_config(from_import=True)['disabled']
 node_id = get_node().get('node') if cluster_enabled else 'manager'
@@ -241,6 +241,7 @@ def validation() -> AffectedItemsWazuhResult:
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
+@mask_sensitive_config()
 def get_config(component: str = None, config: str = None) -> AffectedItemsWazuhResult:
     """Wrapper for get_active_configuration.
 
@@ -276,6 +277,7 @@ def get_config(component: str = None, config: str = None) -> AffectedItemsWazuhR
 
 @expose_resources(actions=[f"{'cluster' if cluster_enabled else 'manager'}:read"],
                   resources=[f'node:id:{node_id}' if cluster_enabled else '*:*:*'])
+@mask_sensitive_config()
 def read_ossec_conf(section: str = None, field: str = None, raw: bool = False,
                     distinct: bool = False) -> AffectedItemsWazuhResult:
     """Wrapper for get_ossec_conf.

--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -128,3 +128,65 @@ def test_expose_resourcesless(db_setup, decorator_params, rbac, allowed, mode):
         except WazuhError as e:
             assert (not allowed)
             assert (e.code == 4000)
+
+
+def _conf_payload():
+    return {
+        "auth": {
+            "use_password": "yes",
+            "ssl_manager_key": "etc/sslmanager.key",
+            "key_request": {"enabled": "no"}
+        },
+        "integration": {
+            "secret": "topsecret",
+            "token": "abcd-1234"
+        },
+        "authd.pass": "P4ssW0rd!"
+    }
+
+
+def _conf_result_payload():
+    r = AffectedItemsWazuhResult(all_msg="ok", some_msg="ok", none_msg="ok")
+    r.affected_items.append({
+        "auth": {"use_password": "no", "ssl_manager_key": "etc/sslmanager.key"},
+        "integration": {"secret": "topsecret"},
+        "authd.pass": "P4ssW0rd!"
+    })
+    r.total_affected_items = 1
+    return r
+
+
+def test_mask_sensitive_config_without_permissions(db_setup):
+    db_setup.rbac.set({'rbac_mode': 'white'})
+
+    @db_setup.mask_sensitive_config()
+    def get_conf():
+        return _conf_payload()
+
+    result = get_conf()
+    assert result["authd.pass"] == "*****"
+    assert result["integration"]["secret"] == "topsecret"
+
+
+def test_mask_sensitive_config_with_permissions(db_setup):
+    db_setup.rbac.set({'rbac_mode': 'white', 'manager:update_config': {'*:*': 'allow'}})
+
+    @db_setup.mask_sensitive_config()
+    def get_conf():
+        return _conf_payload()
+
+    result = get_conf()
+    assert result["authd.pass"] == "P4ssW0rd!"
+
+
+def test_mask_sensitive_config_on_affected_items_result(db_setup):
+    db_setup.rbac.set({'rbac_mode': 'white'})
+
+    @db_setup.mask_sensitive_config()
+    def get_conf_result():
+        return _conf_result_payload()
+
+    res = get_conf_result()
+    item = res.affected_items[0]
+    assert item["authd.pass"] == "*****"
+    assert item["integration"]["secret"] == "topsecret"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR closes https://github.com/wazuh/internal-devel-requests/issues/3976, where the changes related to https://github.com/wazuh/wazuh/pull/31315 have been added.

### Unit_test

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/rbac/tests/test_decorators.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 112 items                                                                                                                                                                                               

framework/wazuh/rbac/tests/test_decorators.py ................................................................................................................                                              [100%]

=================================================================================== 112 passed, 8 warnings in 72.34s (0:01:12) ====================================================================================
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/tests/
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 635 items                                                                                                                                                                                               

framework/wazuh/tests/test_active_response.py ............                                                                                                                                                  [  1%]
framework/wazuh/tests/test_agent.py ..................................................................................................................................                                      [ 22%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                                [ 30%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                      [ 35%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                            [ 37%]
framework/wazuh/tests/test_decoder.py ..........................................................                                                                                                            [ 46%]
framework/wazuh/tests/test_event.py ....                                                                                                                                                                    [ 47%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                                [ 48%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                                  [ 53%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                                 [ 54%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                                  [ 62%]
framework/wazuh/tests/test_rule.py ..........................................................................                                                                                               [ 74%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                               [ 76%]
framework/wazuh/tests/test_security.py .......................................................................                                                                                              [ 87%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                         [ 89%]
framework/wazuh/tests/test_syscheck.py .........................                                                                                                                                            [ 93%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                     [ 95%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                             [100%]

======================================================================================== 635 passed, 8 warnings in 54.82s =========================================================================================
```

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
