### PR TITLE
The timestamps of the /agents/upgrade_result endpoint of the Wazuh server API are in an unknown time zone - Implementation

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1492,7 +1492,7 @@ def core_upgrade_agents(agents_chunk: list, command: str = 'upgrade_result', wpk
     data = loads(s.receive().decode())
     s.close()
 
-    [agent_info.update((k, get_utc_strptime(v, "%Y/%m/%d %H:%M:%S").strftime(DATE_FORMAT))
+    [agent_info.update((k, get_utc_strptime(v, "%Y/%m/%d %H:%M:%S", date_is_at_utc=False).strftime(DATE_FORMAT))
                        for k, v in agent_info.items() if k in {'create_time', 'update_time'})
      for agent_info in data['data']]
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -227,6 +227,7 @@ STATS_PATH = os.path.join(WAZUH_PATH, 'stats')
 BACKUP_PATH = os.path.join(WAZUH_PATH, 'backup')
 MULTI_GROUPS_PATH = os.path.join(WAZUH_PATH, 'var', 'multigroups')
 DEFAULT_RBAC_RESOURCES = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'rbac', 'default')
+WAZUH_LOCALTIME_PATH = os.path.join(WAZUH_PATH, 'etc', 'localtime')
 
 
 # ================================================ Wazuh path - Sockets ================================================

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -10,9 +10,9 @@ from io import StringIO
 from requests import exceptions
 from shutil import copyfile, Error
 from tempfile import TemporaryDirectory, NamedTemporaryFile
-from unittest.mock import call, MagicMock, Mock, mock_open, patch, ANY
+from unittest.mock import call, MagicMock, Mock, mock_open, patch, ANY, sentinel
 from xml.etree.ElementTree import Element
-from wazuh.core.common import OSSEC_TMP_PATH
+from wazuh.core.common import OSSEC_TMP_PATH, WAZUH_LOCALTIME_PATH
 
 import pytest
 from defusedxml.ElementTree import parse
@@ -2051,17 +2051,52 @@ def test_get_utc_now():
     date = utils.get_utc_now()
     assert date == datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
 
-
-@freeze_time('1970-01-01')
-def test_get_utc_strptime():
+@pytest.mark.parametrize('is_at_utc', [True, False])
+@patch('wazuh.core.utils.get_localtime')
+def test_get_utc_strptime(mock_get_localtime, is_at_utc):
     """Test if the result is the expected date."""
-    mock_date = '1970-01-01'
-    default_format = '%Y-%M-%d'
 
-    date = utils.get_utc_strptime(mock_date, default_format)
+    mock_date = '2026/01/28 03:30:15'
+    mock_tz =  datetime.timezone.utc if is_at_utc else datetime.timezone(datetime.timedelta(hours=-3))
+    mock_get_localtime.return_value = mock_tz
+    date_str_format = "%Y/%m/%d %H:%M:%S"
+
+    date = utils.get_utc_strptime(mock_date, date_str_format, is_at_utc)
     assert isinstance(date, datetime.datetime)
-    assert date == datetime.datetime(1970, 1, 1, 0, 1, tzinfo=datetime.timezone.utc)
 
+    if is_at_utc:
+        assert date == datetime.datetime(2026, 1, 28, 3, 30, 15, tzinfo=datetime.timezone.utc)
+    else:
+        assert date == datetime.datetime(2026, 1, 28, 6, 30, 15, tzinfo=datetime.timezone.utc)
+
+@pytest.mark.parametrize(
+    'wazuh_localtime, system_localtime',
+    [
+        pytest.param(None, sentinel.system_tz, id='system_fallback'),
+        pytest.param(sentinel.wazuh_tz, sentinel.system_tz, id='wazuh'),
+        pytest.param(None, None, id='utc_fallback'),
+    ]
+)
+@patch('wazuh.core.utils.gettz')
+def test_get_localtime(mock_gettz, wazuh_localtime, system_localtime):
+    """Test if the result is the expected timezone."""
+
+    mock_gettz.side_effect = [wazuh_localtime, system_localtime]
+
+    timezone = utils.get_localtime()
+
+    calls = [call(WAZUH_LOCALTIME_PATH)]
+
+    if wazuh_localtime is None:
+        calls.append(call())
+
+    mock_gettz.assert_has_calls(calls)
+
+    assert timezone is (
+        wazuh_localtime
+        if wazuh_localtime is not None
+        else system_localtime or timezone.utc
+    )
 
 @pytest.mark.parametrize(
     "new_conf, original_conf, unchanged_limits_conf",

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -13,7 +13,8 @@ import sys
 import tempfile
 import typing
 from copy import deepcopy
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
+from dateutil.tz import gettz
 from functools import wraps
 from itertools import groupby, chain
 from os import chmod, chown, listdir, mkdir, curdir, rename, utime, remove, path
@@ -2377,6 +2378,22 @@ def get_date_from_timestamp(timestamp: float) -> datetime:
     return datetime.utcfromtimestamp(timestamp).replace(tzinfo=timezone.utc)
 
 
+def get_localtime() -> tzinfo:
+    """Function to return the localtime timezone.
+
+    Returns
+    -------
+    timezone : tzinfo
+        The localtime timezone. Wazuh custom localtime has precedence over the
+        system one. If none is found, UTC is returned.   """
+    if (tz := gettz(common.WAZUH_LOCALTIME_PATH)) is not None:
+        return tz
+    if (tz := gettz()) is not None:
+        return tz
+
+    return timezone.utc
+
+
 def get_utc_now() -> datetime:
     """Function to return the current date.
 
@@ -2388,7 +2405,7 @@ def get_utc_now() -> datetime:
     return datetime.utcnow().replace(tzinfo=timezone.utc)
 
 
-def get_utc_strptime(date: str, datetime_format: str) -> datetime:
+def get_utc_strptime(date: str, datetime_format: str, date_is_at_utc: bool = True) -> datetime:
     """Function to transform str to date.
 
     Parameters
@@ -2397,13 +2414,24 @@ def get_utc_strptime(date: str, datetime_format: str) -> datetime:
         String to be transformed.
     datetime_format: str
         Datetime pattern.
+    date_is_at_utc: bool
+        Whether the input date string is in UTC or not.
 
     Returns
     -------
     date: datetime
         The current date.
     """
-    return datetime.strptime(date, datetime_format).replace(tzinfo=timezone.utc)
+
+    dt = datetime.strptime(date, datetime_format)
+
+    if date_is_at_utc:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.replace(tzinfo=get_localtime()).astimezone(timezone.utc)
+
+    return dt
+
 
 def check_if_wazuh_agent_version(version_str: str) -> bool:
     """Check if the string has the expected wazuh agent version format.


### PR DESCRIPTION
## Description

Closes #34131 

This issue aims to provide accurate time information at UTC from the`/agents/upgrade_result endpoint

## Proposed Changes

- Add `get_localtime` function that attempts to provide Wazuh server custom localzone (`/var/ossec/etc/localtime`). If this information is not available, will use system localtime as a fallback, or UTC otherwise
- `get_localtime` uses `dateutil.gettz` that caches the information, avoiding continuous openingof the  localtime file
- Add an optional parameter to `get_utc_strptime` to allow parsing datetimes that were not provided at UTC and need to be adjusted based on localtime

### Results and Evidence

**NOTE**: Python static code analysis check is failing due to creating the PR pointing to the wrong branch (main), which leads to using that branch as the baseline

<details><summary>Set Wazuh localtime (UTC-3) different than System localtime (UTC-8)</summary>

```console
(venv) root@wazuh-dev:~/repos/wazuh# zdump  /var/ossec/etc/localtime
/var/ossec/etc/localtime  Thu Jan 29 07:16:03 2026 -03
(venv) root@wazuh-dev:~/repos/wazuh# ll /etc/localtime 
lrwxrwxrwx 1 root root 45 May 29  2025 /etc/localtime -> /usr/share/zoneinfo/America/Argentina/Cordoba
(venv) root@wazuh-dev:~/repos/wazuh# zdump /etc/localtime 
/etc/localtime  Thu Jan 29 07:21:24 2026 -03
(venv) root@wazuh-dev:~/repos/wazuh# ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime 
(venv) root@wazuh-dev:~/repos/wazuh# zdump /etc/localtime 
/etc/localtime  Thu Jan 29 02:22:30 2026 PST
```

</details>

<details><summary>Get agents</summary>

```console
(venv) root@wazuh-dev:~/repos/wazuh# curl -k -X GET "https://localhost:55000/agents?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "os": {
               "arch": "x86_64",
               "codename": "Noble Numbat",
               "major": "24",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "uname": "Linux |wazuh-dev |6.8.0-90-generic |#91-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 18 14:14:30 UTC 2025 |x86_64",
               "version": "24.04.3 LTS"
            },
            "dateAdd": "2026-01-29T10:11:27+00:00",
            "lastKeepAlive": "9999-12-31T23:59:59+00:00",
            "id": "000",
            "node_name": "node01",
            "version": "Wazuh v4.14.4",
            "name": "wazuh-dev",
            "group_config_status": "synced",
            "status": "active",
            "status_code": 0,
            "ip": "127.0.0.1",
            "registerIP": "127.0.0.1",
            "manager": "wazuh-dev"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Jammy Jellyfish",
               "major": "22",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "uname": "Linux |08d9eb115ba0 |6.12.63-1-MANJARO |#1 SMP PREEMPT_DYNAMIC Thu, 18 Dec 2025 13:46:28 +0000 |x86_64",
               "version": "22.04.5 LTS"
            },
            "dateAdd": "2026-01-29T15:35:29+00:00",
            "lastKeepAlive": "2026-01-29T10:36:33+00:00",
            "id": "001",
            "node_name": "node01",
            "version": "Wazuh v4.13.1",
            "mergedSum": "e15cd0c9f7dec03be7b82012b99d73bf",
            "name": "08d9eb115ba0",
            "group": [
               "default"
            ],
            "group_config_status": "synced",
            "status": "active",
            "status_code": 0,
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "ip": "172.17.0.2",
            "registerIP": "any",
            "manager": "wazuh-dev"
         }
      ],
      "total_affected_items": 2,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected agents information was returned",
   "error": 0
}
```
</details>

<details><summary>Attempt to upgrade</summary>

```console
(venv) root@wazuh-dev:~/repos/wazuh# curl -k -X PUT   "https://localhost:55000/agents/upgrade?agents_list=all&pretty=true" -H "Authorization: Bearer $
TOKEN"
{
   "data": {
      "affected_items": [
         {
            "agent": "001",
            "task_id": 1
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were created",
   "error": 0
}
(venv) root@wazuh-dev:~/repos/wazuh# curl -k -X GET "https://localhost:55000/agents/upgrade_result?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "message": "Success",
            "agent": "001",
            "task_id": 1,
            "node": "node01",
            "module": "upgrade_module",
            "command": "upgrade",
            "status": "Error",
            "error_msg": "The version of the WPK does not exist in the repository",
            "create_time": "2026-01-29T10:41:35Z",
            "update_time": "2026-01-29T10:41:35Z"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were returned",
   "error": 0
}
```
:green_circle: Despite the WPK error, dates are accurate at UTC

</details>

<details><summary>Remove Wazuh localtime, keeping system localtime (UTC-8)</summary>

```console
root@wazuh-dev:~/repos/wazuh# mv /var/ossec/etc/localtime /var/ossec/etc/localtime.bak
root@wazuh-dev:~/repos/wazuh# /var/ossec/bin/wazuh-control restart
```

</details>

<details><summary>Attempt to upgrade</summary>

```console
root@wazuh-dev:~/repos/wazuh# curl -k -X PUT   "https://localhost:55000/agents/upgrade?agents_list=all&pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "agent": "001",
            "task_id": 2
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were created",
   "error": 0
}root@wazuh-dev:~/repos/wazuh# curl -k -XGET "https://localhost:55000/agents/upgrade_result?&pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "message": "Success",
            "agent": "001",
            "task_id": 2,
            "node": "node01",
            "module": "upgrade_module",
            "command": "upgrade",
            "status": "Error",
            "error_msg": "The version of the WPK does not exist in the repository",
            "create_time": "2026-01-29T10:52:02Z",
            "update_time": "2026-01-29T10:52:02Z"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were returned",
   "error": 0
}
```
:green_circle: Despite the WPK error, dates are accurate at UTC

</details>


<details><summary>Successfull attempt to upgrade</summary>

```console
root@wazuh-dev:~/repos/wazuh# curl -k -X PUT   "https://localhost:55000/agents/upgrade?agents_list=all&upgrade_version=4.14.2&pretty=true" -H "Authori
zation: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "agent": "001",
            "task_id": 3
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were created",
   "error": 0
}

root@wazuh-dev:~/repos/wazuh#  url -k -X GET "https://localhost:55000/agents/upgrade_result?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "message": "Success",
            "agent": "001",
            "task_id": 3,
            "node": "node01",
            "module": "upgrade_module",
            "command": "upgrade",
            "status": "Updated",
            "create_time": "2026-01-29T10:59:43Z",
            "update_time": "2026-01-29T11:00:47Z"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were returned",
   "error": 0
}

root@wazuh-dev:~/repos/wazuh# curl -k -X GET "https://localhost:55000/agents?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "os": {
               "arch": "x86_64",
               "codename": "Noble Numbat",
               "major": "24",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "uname": "Linux |wazuh-dev |6.8.0-90-generic |#91-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 18 14:14:30 UTC 2025 |x86_64",
               "version": "24.04.3 LTS"
            },
            "registerIP": "127.0.0.1",
            "status_code": 0,
            "name": "wazuh-dev",
            "id": "000",
            "group_config_status": "synced",
            "node_name": "node01",
            "version": "Wazuh v4.14.4",
            "status": "active",
            "ip": "127.0.0.1",
            "manager": "wazuh-dev",
            "lastKeepAlive": "9999-12-31T23:59:59+00:00",
            "dateAdd": "2026-01-29T10:11:27+00:00"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Jammy Jellyfish",
               "major": "22",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "uname": "Linux |08d9eb115ba0 |6.12.63-1-MANJARO |#1 SMP PREEMPT_DYNAMIC Thu, 18 Dec 2025 13:46:28 +0000 |x86_64",
               "version": "22.04.5 LTS"
            },
            "mergedSum": "e15cd0c9f7dec03be7b82012b99d73bf",
            "registerIP": "any",
            "status_code": 0,
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "08d9eb115ba0",
            "id": "001",
            "group_config_status": "synced",
            "node_name": "node01",
            "version": "Wazuh v4.14.2",
            "status": "active",
            "ip": "172.17.0.2",
            "group": [
               "default"
            ],
            "manager": "wazuh-dev",
            "lastKeepAlive": "2026-01-29T11:01:34+00:00",
            "dateAdd": "2026-01-29T15:35:29+00:00"
         }
      ],
      "total_affected_items": 2,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected agents information was returned",
   "error": 0
}
```
:green_circle: Dates are accurate at UTC

</details>

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform NA
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux NA
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows NA
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS NA
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_ NA
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_ NA
  - [ ] Test run in parallel 
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [x] Run API Integration Tests https://jenkins-staging.qa.wazuh.info/job/4.14.4/job/Test_integration_endpoints/2/

### Artifacts Affected

NA

### Configuration Changes

NA

### Tests Introduced

NA


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
