### PR TITLE
Align Wazuh Manager DEB and RPM packages to /var/wazuh-manager

### DIFF
--- a/.github/actions/test-install-components/install_component.sh
+++ b/.github/actions/test-install-components/install_component.sh
@@ -41,8 +41,13 @@ WAZUH_MANAGER="10.0.0.2" $linux $install "/packages/$package_name"| tee /package
 grep -i " installed.*wazuh-$target" $installed_log| tee -a /packages/status.log
 
 # Retrieve wazuh gid and uid
-wazuh_gid=$(getent group wazuh | cut -d: -f3)
-wazuh_uid=$(getent passwd wazuh | cut -d: -f3)
+if [ "$target" = "manager" ]; then
+    wazuh_gid=$(getent group wazuh-manager | cut -d: -f3)
+    wazuh_uid=$(getent passwd wazuh-manager | cut -d: -f3)
+else
+    wazuh_gid=$(getent group wazuh | cut -d: -f3)
+    wazuh_uid=$(getent passwd wazuh | cut -d: -f3)
+fi
 
 echo $wazuh_gid > /tests/wazuh_gid
 echo $wazuh_uid > /tests/wazuh_uid

--- a/.github/workflows/5_builderpackage_manager-multiples.yml
+++ b/.github/workflows/5_builderpackage_manager-multiples.yml
@@ -35,6 +35,9 @@ on:
       - "framework/**"
       - "src/**"
       - ".github/workflows/5_builderpackage_manager-multiples.yml"
+      - "packages/*/SPECS/wazuh-manager/**"
+      - "packages/*"
+      - "packages/*/utils/*"
 
 jobs:
   select-targets:

--- a/packages/README.md
+++ b/packages/README.md
@@ -33,7 +33,7 @@ wazuh# cd packages
 | -j, --jobs           | Number of parallel jobs (optional)                                  | 2                       |
 | -r, --revision       | Package revision (optional)                                         | 0                       |
 | -s, --store          | Destination path for the package (optional)                         | (output folder created) |
-| -p, --path           | Installation path for the package (optional)                        | /var/ossec              |
+| -p, --path           | Installation path for the package (optional)                        | /var/wazuh-manager (manager) or /var/ossec (agent) |
 | -d, --debug          | Build binaries with debug symbols (optional)                        | no                      |
 | -c, --checksum       | Generate checksum on the same directory (optional)                  | no                      |
 | --dont-build-docker  | Use a locally built Docker image (optional)                         | no                      |
@@ -42,11 +42,18 @@ wazuh# cd packages
 | **--is_stage         | Use release name in package (optional)                              | no                      |
 | --src                | Generate the source package (optional)                              | no                      |
 | --system             | Package format to build (optional): rpm, deb (default)              | deb                     |
+| --force              | Force building manager package with /var/ossec path (not recommended) | no                    |
 | -h, --help           | Show this help message                                              | -                       |
 
 ***Note1:** If we don't use this flag, will the script use the current directory where *generate_package.sh* is located.
 
 ****Note 2:** If the package is not a release package, a short hash commit based on the git command `git rev-parse --short HEAD` will be appended to the end of the name. The default length of the short hash is determined by the Git command [git rev-parse --short[=length]](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength:~:text=interpreted%20as%20usual.-,%2D%2Dshort%5B%3Dlength%5D,-Same%20as%20%2D%2Dverify).
+
+**Manager Package Notes:**
+
+- **Default installation path:** Manager packages install to `/var/wazuh-manager` by default.
+- **Soft block:** Building a manager package with `-p /var/ossec` requires the `--force` flag.
+- **Hard block:** Installing a 5.x manager package will fail if a 4.x manager is already installed. Direct upgrades from 4.x to 5.x are not supported.
 
 
 **Example Usage:**

--- a/packages/debs/SPECS/wazuh-manager/debian/postinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/postinst
@@ -16,9 +16,9 @@ case "$1" in
         OS="linux"
         VER="0"
     fi
-    DIR="/var/ossec"
-    USER="wazuh"
-    GROUP="wazuh"
+    DIR="/var/wazuh-manager"
+    USER="wazuh-manager"
+    GROUP="wazuh-manager"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
     OSMYSHELL="/sbin/nologin"
@@ -177,7 +177,7 @@ case "$1" in
     find ${DIR}/etc/shared/ -type f -name 'merged.mg' -exec chmod 644 {} \;
 
     if [ -f ${DIR}/etc/shared/ar.conf ]; then
-        chown root:wazuh ${DIR}/etc/shared/ar.conf
+        chown root:${GROUP} ${DIR}/etc/shared/ar.conf
     fi
 
     # Check if SELinux is installed and enabled
@@ -211,7 +211,7 @@ case "$1" in
     # Remove old ossec user and group if exists and change ownwership of files
 
     if getent group ossec > /dev/null 2>&1; then
-        find ${DIR}/ -group ossec -user root -print0 | xargs -0 chown root:wazuh > /dev/null 2>&1 || true
+        find ${DIR}/ -group ossec -user root -print0 | xargs -0 chown root:${GROUP} > /dev/null 2>&1 || true
         if getent passwd ossec > /dev/null 2>&1; then
             find ${DIR}/ -group ossec -user ossec -print0 | xargs -0 chown ${USER}:${GROUP} > /dev/null 2>&1 || true
             deluser ossec > /dev/null 2>&1

--- a/packages/debs/SPECS/wazuh-manager/debian/postrm
+++ b/packages/debs/SPECS/wazuh-manager/debian/postrm
@@ -2,7 +2,7 @@
 # postrm script for Wazuh
 # Wazuh, Inc 2015
 set -e
-DIR="/var/ossec"
+DIR="/var/wazuh-manager"
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 
 case "$1" in
@@ -51,20 +51,23 @@ case "$1" in
 
         # Delete old .save
         find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
-        find ${DIR}/api/ -type f  -name "*save" -exec rm -f {} \;
 
         # Rename the files
         find ${DIR}/etc/ -type f ! -name *shared* -exec mv {} {}.save \;
-        find ${DIR}/api/ -type f -exec mv {} {}.save \;
+
+        if [ -d "${DIR}/api" ]; then
+            find "${DIR}/api/" -type f -name "*save" -exec rm -f {} \;
+            find "${DIR}/api/" -type f -exec mv {} {}.save \;
+        fi
 
     ;;
 
     purge)
-        if getent passwd wazuh > /dev/null 2>&1 ; then
-            deluser wazuh  > /dev/null 2>&1
+        if getent passwd wazuh-manager > /dev/null 2>&1 ; then
+            deluser wazuh-manager  > /dev/null 2>&1
         fi
-        if getent group wazuh > /dev/null 2>&1; then
-            delgroup wazuh  > /dev/null 2>&1
+        if getent group wazuh-manager > /dev/null 2>&1; then
+            delgroup wazuh-manager  > /dev/null 2>&1
         fi
         rm -rf ${DIR}
     ;;

--- a/packages/debs/SPECS/wazuh-manager/debian/preinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/preinst
@@ -1,10 +1,9 @@
 #!/bin/sh
 # preinst script for Wazuh
-
 set -e
 
 # configuration variables
-DIR="/var/ossec"
+DIR="/var/wazuh-manager"
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 VERSION="$2"
 MAJOR=$(echo "$VERSION" | cut -dv -f2 | cut -d. -f1)
@@ -19,6 +18,24 @@ fi
 
 case "$1" in
     install|upgrade)
+
+        # HARD BLOCK: Prevent upgrade from 4.X to 5.X
+        if [ "$1" = "upgrade" ] && [ -n "$2" ]; then
+            # $2 contains the old version in upgrade scenarios
+            OLD_VERSION="$2"
+            OLD_MAJOR=$(echo "$OLD_VERSION" | cut -d. -f1)
+
+            if [ "$OLD_MAJOR" = "4" ]; then
+                cat <<EOF
+==============================================================
+ERROR: Direct upgrade from Wazuh Manager 4.X to 5.X is not supported.
+
+Detected installed version: $OLD_VERSION
+==============================================================
+EOF
+                exit 1
+            fi
+        fi
 
         if [ "$1" = "upgrade" ]; then
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-manager > /dev/null 2>&1; then

--- a/packages/debs/SPECS/wazuh-manager/debian/prerm
+++ b/packages/debs/SPECS/wazuh-manager/debian/prerm
@@ -2,7 +2,7 @@
 # prerm script for wazuh-manager
 
 set -e
-DIR="/var/ossec"
+DIR="/var/wazuh-manager"
 
 case "$1" in
     upgrade|deconfigure)

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -20,7 +20,7 @@ export PKG_DIR=debian/wazuh-manager
 export TARGET_DIR=${CURDIR}/${PKG_DIR}
 
 # Package build options
-export INSTALLATION_DIR="/var/ossec"
+export INSTALLATION_DIR="/var/wazuh-manager"
 export INSTALLATION_SCRIPTS_DIR="${INSTALLATION_DIR}/packages_files/manager_installation_scripts"
 export JOBS="5"
 export DEBUG_ENABLED="no"

--- a/packages/debs/utils/helper_function.sh
+++ b/packages/debs/utils/helper_function.sh
@@ -33,7 +33,7 @@ setup_build(){
     sed -i "s#export CC.*#export CC=${CC}#g" ${sources_dir}/debian/rules
     sed -i "s#export CXX.*#export CXX=${CXX}#g" ${sources_dir}/debian/rules
     sed -i "s:export INSTALLATION_DIR=.*:export INSTALLATION_DIR=${INSTALLATION_PATH}:g" ${sources_dir}/debian/rules
-    sed -i "s:DIR=\"/var/ossec\":DIR=\"${INSTALLATION_PATH}\":g" ${sources_dir}/debian/{preinst,postinst,prerm,postrm}
+    sed -i "s:DIR=\"/var/wazuh-manager\":DIR=\"${INSTALLATION_PATH}\":g" ${sources_dir}/debian/{preinst,postinst,prerm,postrm}
 }
 
 set_debug(){

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -205,16 +205,46 @@ exit 0
 
 %pre
 
-# Create the wazuh group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group wazuh > /dev/null 2>&1; then
-  groupadd -r wazuh
-elif ! getent group wazuh > /dev/null 2>&1; then
-  groupadd -r wazuh
+# ============================================================
+# HARD BLOCK: Prevent upgrade from 4.X to 5.X
+# ============================================================
+if [ $1 = 2 ]; then
+  # Check if this is an upgrade from 4.X
+  # Note: 4.X was installed in /var/ossec, so we check there (not %{_localstatedir})
+  if [ -f %{_sysconfdir}/ossec-init.conf ]; then
+    . %{_sysconfdir}/ossec-init.conf
+    OLD_VERSION="${VERSION}"
+  elif [ -x /var/ossec/bin/wazuh-control ]; then
+    OLD_VERSION=$(/var/ossec/bin/wazuh-control info -v 2>/dev/null || echo "")
+  elif [ -x %{_localstatedir}/bin/wazuh-control ]; then
+    OLD_VERSION=$(%{_localstatedir}/bin/wazuh-control info -v 2>/dev/null || echo "")
+  fi
+
+  if [ -n "${OLD_VERSION}" ]; then
+    OLD_MAJOR=$(echo "${OLD_VERSION}" | sed 's/^v//' | cut -d. -f1)
+    if [ "${OLD_MAJOR}" = "4" ]; then
+      cat <<EOF
+==============================================================
+ERROR: Direct upgrade from Wazuh Manager 4.X to 5.X is not supported.
+
+Detected installed version: ${OLD_VERSION}
+==============================================================
+EOF
+      exit 1
+    fi
+  fi
 fi
 
-# Create the wazuh user if it doesn't exists
-if ! getent passwd wazuh > /dev/null 2>&1; then
-  useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
+# Create the wazuh-manager group if it doesn't exists
+if command -v getent > /dev/null 2>&1 && ! getent group wazuh-manager > /dev/null 2>&1; then
+  groupadd -r wazuh-manager
+elif ! getent group wazuh-manager > /dev/null 2>&1; then
+  groupadd -r wazuh-manager
+fi
+
+# Create the wazuh-manager user if it doesn't exists
+if ! getent passwd wazuh-manager > /dev/null 2>&1; then
+  useradd -g wazuh-manager -G wazuh-manager -d %{_localstatedir} -r -s /sbin/nologin wazuh-manager
 fi
 
 # Stop the services to upgrade the package
@@ -252,7 +282,7 @@ fi
 
 if [ -f %{_localstatedir}/queue/db/global.db ]; then
   chmod 640 %{_localstatedir}/queue/db/global.db*
-  chown wazuh:wazuh %{_localstatedir}/queue/db/global.db*
+  chown wazuh-manager:wazuh-manager %{_localstatedir}/queue/db/global.db*
 fi
 
 # Remove Vuln-detector database
@@ -328,18 +358,18 @@ if [ $1 = 1 ]; then
 
   # Generating ossec.conf file
   %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh conf manager ${DIST_NAME} ${DIST_VER}.${DIST_SUBVER} %{_localstatedir} > %{_localstatedir}/etc/ossec.conf
-  chown root:wazuh %{_localstatedir}/etc/ossec.conf
+  chown root:wazuh-manager %{_localstatedir}/etc/ossec.conf
 
   touch %{_localstatedir}/logs/active-responses.log
-  chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
+  chown wazuh-manager:wazuh-manager %{_localstatedir}/logs/active-responses.log
   chmod 0660 %{_localstatedir}/logs/active-responses.log
 
   touch %{_localstatedir}/logs/ossec.log
-  chown wazuh:wazuh %{_localstatedir}/logs/ossec.log
+  chown wazuh-manager:wazuh-manager %{_localstatedir}/logs/ossec.log
   chmod 0660 %{_localstatedir}/logs/ossec.log
 
   touch %{_localstatedir}/logs/ossec.json
-  chown wazuh:wazuh %{_localstatedir}/logs/ossec.json
+  chown wazuh-manager:wazuh-manager %{_localstatedir}/logs/ossec.json
   chmod 0660 %{_localstatedir}/logs/ossec.json
 
   # Add default local_files to ossec.conf
@@ -454,17 +484,17 @@ rm -f %{_localstatedir}/etc/shared/default/*.rpmnew
 # Remove old ossec user and group if exists and change ownwership of files
 
 if getent group ossec > /dev/null 2>&1; then
-  find %{_localstatedir}/ -group ossec -user root -print0 | xargs -0 chown root:wazuh > /dev/null 2>&1 || true
+  find %{_localstatedir}/ -group ossec -user root -print0 | xargs -0 chown root:wazuh-manager > /dev/null 2>&1 || true
   if getent passwd ossec > /dev/null 2>&1; then
-    find %{_localstatedir}/ -group ossec -user ossec -print0 | xargs -0 chown wazuh:wazuh > /dev/null 2>&1 || true
+    find %{_localstatedir}/ -group ossec -user ossec -print0 | xargs -0 chown wazuh-manager:wazuh-manager > /dev/null 2>&1 || true
     userdel ossec > /dev/null 2>&1
   fi
   if getent passwd ossecm > /dev/null 2>&1; then
-    find %{_localstatedir}/ -group ossec -user ossecm -print0 | xargs -0 chown wazuh:wazuh > /dev/null 2>&1 || true
+    find %{_localstatedir}/ -group ossec -user ossecm -print0 | xargs -0 chown wazuh-manager:wazuh-manager > /dev/null 2>&1 || true
     userdel ossecm > /dev/null 2>&1
   fi
   if getent passwd ossecr > /dev/null 2>&1; then
-    find %{_localstatedir}/ -group ossec -user ossecr -print0 | xargs -0 chown wazuh:wazuh > /dev/null 2>&1 || true
+    find %{_localstatedir}/ -group ossec -user ossecr -print0 | xargs -0 chown wazuh-manager:wazuh-manager > /dev/null 2>&1 || true
     userdel ossecr > /dev/null 2>&1
   fi
   if getent group ossec > /dev/null 2>&1; then
@@ -503,15 +533,15 @@ fi
 
 # If the package is been uninstalled
 if [ $1 = 0 ];then
-  # Remove the wazuh user if it exists
-  if getent passwd wazuh > /dev/null 2>&1; then
-    userdel wazuh >/dev/null 2>&1
+  # Remove the wazuh-manager user if it exists
+  if getent passwd wazuh-manager > /dev/null 2>&1; then
+    userdel wazuh-manager >/dev/null 2>&1
   fi
-  # Remove the wazuh group if it exists
-  if command -v getent > /dev/null 2>&1 && getent group wazuh > /dev/null 2>&1; then
-    groupdel wazuh >/dev/null 2>&1
-  elif getent group wazuh > /dev/null 2>&1; then
-    groupdel wazuh >/dev/null 2>&1
+  # Remove the wazuh-manager group if it exists
+  if command -v getent > /dev/null 2>&1 && getent group wazuh-manager > /dev/null 2>&1; then
+    groupdel wazuh-manager >/dev/null 2>&1
+  elif getent group wazuh-manager > /dev/null 2>&1; then
+    groupdel wazuh-manager >/dev/null 2>&1
   fi
 
   # Backup agents centralized configuration (etc/shared)
@@ -581,128 +611,128 @@ rm -rf %{_localstatedir}/backup/groups
 
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/etc
- chown root:wazuh %{_localstatedir}/etc/localtime
+ chown root:wazuh-manager %{_localstatedir}/etc/localtime
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %clean
 rm -fr %{buildroot}
 
 %files
-%defattr(-,root,wazuh)
+%defattr(-,root,wazuh-manager)
 %config(missingok) %{_initrddir}/wazuh-manager
 /usr/lib/systemd/system/wazuh-manager.service
-%dir %attr(750, root, wazuh) %{_localstatedir}
-%attr(440, wazuh, wazuh) %{_localstatedir}/VERSION.json
-%dir %attr(750, root, wazuh) %{_localstatedir}/active-response
-%dir %attr(750, root, wazuh) %{_localstatedir}/active-response/bin
-%attr(750, root, wazuh) %{_localstatedir}/active-response/bin/*
-%dir %attr(750, root, wazuh) %{_localstatedir}/api
-%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration
-%attr(660, root, wazuh) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
-%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration/security
-%dir %attr(770, root, wazuh) %{_localstatedir}/api/configuration/ssl
-%dir %attr(750, root, wazuh) %{_localstatedir}/api/scripts
-%attr(640, root, wazuh) %{_localstatedir}/api/scripts/*.py
-%dir %attr(750, root, wazuh) %{_localstatedir}/backup
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/db
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/backup/agents
-%dir %attr(750, root, wazuh) %{_localstatedir}/backup/shared
-%dir %attr(750, root, wazuh) %{_localstatedir}/bin
-%attr(750, root, wazuh) %{_localstatedir}/bin/agent_groups
-%attr(750, root, wazuh) %{_localstatedir}/bin/agent_upgrade
-%attr(750, root, wazuh) %{_localstatedir}/bin/cluster_control
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}
+%attr(440, wazuh-manager, wazuh-manager) %{_localstatedir}/VERSION.json
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/active-response
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/active-response/bin
+%attr(750, root, wazuh-manager) %{_localstatedir}/active-response/bin/*
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/api
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/api/configuration
+%attr(660, root, wazuh-manager) %config(noreplace) %{_localstatedir}/api/configuration/api.yaml
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/api/configuration/security
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/api/configuration/ssl
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/api/scripts
+%attr(640, root, wazuh-manager) %{_localstatedir}/api/scripts/*.py
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/backup
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/backup/db
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/backup/agents
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/backup/shared
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/bin
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/agent_groups
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/agent_upgrade
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/cluster_control
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-analysisd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-authd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-control
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-execd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-monitord
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-remoted
-%attr(750, root, wazuh) %{_localstatedir}/bin/verify-agent-conf
-%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-manager-apid
-%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-manager-clusterd
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/verify-agent-conf
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/wazuh-manager-apid
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/wazuh-manager-clusterd
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-db
 %attr(750, root, root) %{_localstatedir}/bin/wazuh-manager-modulesd
-%attr(750, root, wazuh) %{_localstatedir}/bin/rbac_control
-%attr(750, root, wazuh) %{_localstatedir}/bin/wazuh-keystore
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
-%attr(660, root, wazuh) %ghost %{_localstatedir}/etc/ossec.conf
-%attr(640, root, wazuh) %ghost %{_localstatedir}/etc/sslmanager.cert
-%attr(640, root, wazuh) %ghost %{_localstatedir}/etc/sslmanager.key
-%attr(640, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
-%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
-%attr(640, root, wazuh) %{_localstatedir}/etc/localtime
-%dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc/shared/default
-%attr(660, wazuh, wazuh) %{_localstatedir}/etc/shared/agent-template.conf
-%attr(660, wazuh, wazuh) %config(noreplace) %{_localstatedir}/etc/shared/default/*
-%dir %attr(770, root, wazuh) %{_localstatedir}/engine
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/kvdb
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/store
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/store/schema
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/store/schema/allowed-fields
-%attr(640, wazuh, wazuh) %{_localstatedir}/engine/store/schema/allowed-fields/0
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/store/schema/engine-schema
-%attr(640, wazuh, wazuh) %{_localstatedir}/engine/store/schema/engine-schema/0
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/store/schema/wazuh-logpar-overrides
-%attr(640, wazuh, wazuh) %{_localstatedir}/engine/store/schema/wazuh-logpar-overrides/0
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/engine/outputs
-%attr(640, wazuh, wazuh) %{_localstatedir}/engine/outputs/*.yml
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework/python
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/rbac_control
+%attr(750, root, wazuh-manager) %{_localstatedir}/bin/wazuh-keystore
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/etc
+%attr(660, root, wazuh-manager) %ghost %{_localstatedir}/etc/ossec.conf
+%attr(640, root, wazuh-manager) %ghost %{_localstatedir}/etc/sslmanager.cert
+%attr(640, root, wazuh-manager) %ghost %{_localstatedir}/etc/sslmanager.key
+%attr(640, wazuh-manager, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh-manager) %{_localstatedir}/etc/internal_options*
+%attr(640, root, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(640, root, wazuh-manager) %{_localstatedir}/etc/localtime
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/etc/shared
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/default
+%attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/agent-template.conf
+%attr(660, wazuh-manager, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/shared/default/*
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/engine
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/kvdb
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema/allowed-fields
+%attr(640, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema/allowed-fields/0
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema/engine-schema
+%attr(640, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema/engine-schema/0
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema/wazuh-logpar-overrides
+%attr(640, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/store/schema/wazuh-logpar-overrides/0
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/outputs
+%attr(640, wazuh-manager, wazuh-manager) %{_localstatedir}/engine/outputs/*.yml
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework/python
 %{_localstatedir}/framework/python/*
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework/scripts
-%attr(640, root, wazuh) %{_localstatedir}/framework/scripts/*.py
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh
-%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/*.py
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster
-%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/*.py
-%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/*.json
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/hap_helper
-%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/hap_helper/*.py
-%dir %attr(750, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/dapi
-%attr(640, root, wazuh) %{_localstatedir}/framework/wazuh/core/cluster/dapi/*.py
-%dir %attr(750, root, wazuh) %{_localstatedir}/lib
-%attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhext.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libwazuhshared.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libdbsync.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libagent_metadata.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libagent_sync_protocol.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libschema_validator.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libsyscollector.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libsca.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libagent_info.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libsysinfo.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libjemalloc.so.2
-%attr(750, root, wazuh) %{_localstatedir}/lib/libstdc++.so.6
-%attr(750, root, wazuh) %{_localstatedir}/lib/libgcc_s.so.1
-%attr(750, root, wazuh) %{_localstatedir}/lib/libfimdb.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libfimebpf.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libbpf.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/modern.bpf.o
-%attr(750, root, wazuh) %{_localstatedir}/lib/libcontent_manager.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libindexer_connector.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libinventory_sync.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/libvulnerability_scanner.so
-%attr(750, root, wazuh) %{_localstatedir}/lib/librocksdb.so.8
-%attr(750, root, wazuh) %{_localstatedir}/lib/librouter.so
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework/scripts
+%attr(640, root, wazuh-manager) %{_localstatedir}/framework/scripts/*.py
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework/wazuh
+%attr(640, root, wazuh-manager) %{_localstatedir}/framework/wazuh/*.py
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster
+%attr(640, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster/*.py
+%attr(640, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster/*.json
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster/hap_helper
+%attr(640, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster/hap_helper/*.py
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster/dapi
+%attr(640, root, wazuh-manager) %{_localstatedir}/framework/wazuh/core/cluster/dapi/*.py
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/lib
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libwazuhext.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libwazuhshared.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libdbsync.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libagent_metadata.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libagent_sync_protocol.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libschema_validator.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libsyscollector.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libsca.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libagent_info.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libsysinfo.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libjemalloc.so.2
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libstdc++.so.6
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libgcc_s.so.1
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libfimdb.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libfimebpf.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libbpf.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/modern.bpf.o
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libcontent_manager.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libindexer_connector.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libinventory_sync.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/libvulnerability_scanner.so
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/librocksdb.so.8
+%attr(750, root, wazuh-manager) %{_localstatedir}/lib/librouter.so
 %{_localstatedir}/lib/libpython3.10.so.1.0
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/logs
-%attr(660, wazuh, wazuh)  %ghost %{_localstatedir}/logs/active-responses.log
-%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/api.log
-%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.log
-%attr(660, wazuh, wazuh) %ghost %{_localstatedir}/logs/ossec.json
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/api
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/archives
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/alerts
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/cluster
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/firewall
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/logs/wazuh
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/logs
+%attr(660, wazuh-manager, wazuh-manager)  %ghost %{_localstatedir}/logs/active-responses.log
+%attr(660, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/logs/api.log
+%attr(660, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/logs/ossec.log
+%attr(660, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/logs/ossec.json
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/logs/api
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/logs/archives
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/logs/alerts
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/logs/cluster
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/logs/firewall
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/logs/wazuh
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/add_localfiles.sh
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/gen_ossec.sh
-%attr(440, wazuh, wazuh) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/VERSION.json
+%attr(440, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/VERSION.json
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/src/
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/src/init/*
@@ -714,130 +744,130 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%attr(640, wazuh, wazuh) %missingok %{_localstatedir}/tmp/%{_vdfilename}
-%dir %attr(750, root, wazuh) %{_localstatedir}/queue
-%attr(600, root, wazuh) %{_localstatedir}/queue/agents-timestamp
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/alerts
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/cluster
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/db
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/diff
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agent_info
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agent_info/db
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/rids
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/tasks
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/sockets
-%dir %attr(660, root, wazuh) %{_localstatedir}/queue/vd
-%dir %attr(660, root, wazuh) %{_localstatedir}/queue/indexer
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/queue/router
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/keystore
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/tzdb
-%dir %attr(750, root, wazuh) %{_localstatedir}/ruleset
-%dir %attr(750, root, wazuh) %{_localstatedir}/etc/ruleset
-%dir %attr(770, root, wazuh) %{_localstatedir}/.ssh
-%dir %attr(1770, root, wazuh) %{_localstatedir}/tmp
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/mongodb
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/mongodb/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/nginx
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/nginx/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/oracledb
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/oracledb/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2023
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2023/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/9
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/9/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/10
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/10/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/21
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/21/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/22
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/22/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/23
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/23/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/24
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/24/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/25
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/25/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/9
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/9/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/10
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/10/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/15
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/15/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/16
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/16/*
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amazon
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amazon/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/*
-%dir %attr(750, root, wazuh) %{_localstatedir}/var
-%dir %attr(770, root, wazuh) %{_localstatedir}/var/db
-%attr(660, root, wazuh) %{_localstatedir}/var/db/mitre.db
-%dir %attr(770, root, wazuh) %{_localstatedir}/var/download
-%dir %attr(770, wazuh, wazuh) %{_localstatedir}/var/multigroups
-%dir %attr(770, root, wazuh) %{_localstatedir}/var/run
-%dir %attr(770, root, wazuh) %{_localstatedir}/var/selinux
-%attr(640, root, wazuh) %{_localstatedir}/var/selinux/*
-%dir %attr(770, root, wazuh) %{_localstatedir}/var/upgrade
+%attr(640, wazuh-manager, wazuh-manager) %missingok %{_localstatedir}/tmp/%{_vdfilename}
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/queue
+%attr(600, root, wazuh-manager) %{_localstatedir}/queue/agents-timestamp
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/alerts
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/cluster
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/db
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/diff
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/agent_info
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/agent_info/db
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/rids
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/tasks
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/sockets
+%dir %attr(660, root, wazuh-manager) %{_localstatedir}/queue/vd
+%dir %attr(660, root, wazuh-manager) %{_localstatedir}/queue/indexer
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/router
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/keystore
+%dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/queue/tzdb
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/ruleset
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/etc/ruleset
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/.ssh
+%dir %attr(1770, root, wazuh-manager) %{_localstatedir}/tmp
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/applications/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/generic/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/mongodb
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/mongodb/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/nginx
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/nginx/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/oracledb
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/oracledb/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/1/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2023
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/2023/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/sca.files
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/6/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/7/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/8/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/9
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/9/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/10
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/10/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/15/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/16/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/17/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/18/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/19/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/20/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/21
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/21/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/22
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/22/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/23
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/23/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/24
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/24/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/25
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/25/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/6/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/7/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/8/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/9
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/9/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/10
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/10/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/sca.files
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/12/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/15
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/15/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/16
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/16/*
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/sca.files
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/12/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amazon
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amazon/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/windows/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/*
+%dir %attr(750, wazuh-manager, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky
+%attr(640, root, wazuh-manager) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/*
+%dir %attr(750, root, wazuh-manager) %{_localstatedir}/var
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/db
+%attr(660, root, wazuh-manager) %{_localstatedir}/var/db/mitre.db
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/download
+%dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/var/multigroups
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/run
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/selinux
+%attr(640, root, wazuh-manager) %{_localstatedir}/var/selinux/*
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/upgrade
 
 %files -n wazuh-manager-debuginfo -f debugfiles.list
 


### PR DESCRIPTION
## Description

This PR aligns Wazuh manager packaging with the new default install path `/var/wazuh-manager`, updates manager ownership to `wazuh-manager` in **Debian** scripts and the **RPM** spec, and adds **both soft‑** and **hard‑block** protections (prevent installs into `/var/ossec` unless forced, and block direct upgrades from 4.x). It also makes `postrm` cleanup safer, updates build defaults and path substitutions in `generate_package.sh` and `helper_function.sh`, and refreshes `README.md` to reflect the new behavior.
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes
- Change default installation path from /var/ossec to /var/wazuh-manager
- Change user/group from wazuh to wazuh-manager in all debian scripts and wazuh-manager.spec
- Add soft block: prevent manager install into /var/ossec in generate-packages.sh
- Check first if if [ -d "${DIR}/api" ]; in postrm to avoid errors
- Add hard block: prevent direct upgrade from 4.x to 5.x `preinst` and `wazuh-manager.spec`
- Update generate_package.sh to use target-dependent default paths
- Update `helper_function.sh` sed pattern for new default path
- Update `README.md` and `wazuh/.github/workflows/5_builderpackage_manager-multiples.yml`
<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

#### SOFT BLOCK
<img width="1341" height="297" alt="softblock" src="https://github.com/user-attachments/assets/e0fb478d-98c9-47e8-8b9b-4c3164f875db" />

#### HARD BLOCK 
We will try to upgrade from 4.x to 5.x.
- **debs**
  - dpkg
  <img width="1115" height="624" alt="image" src="https://github.com/user-attachments/assets/53a0f286-e544-4205-b0f9-1f6c7dbc8c93" />
   - apt
   <img width="895" height="815" alt="image" src="https://github.com/user-attachments/assets/512c447c-c70c-40b0-bf78-4000ca3bf573" />

- **rpm**
  - yum
  
  <img width="1463" height="732" alt="log" src="https://github.com/user-attachments/assets/160a047c-0af0-4dc6-a445-82eb7e4d3eff" />

  
We should also try upgrade from 5.x to 5.x. (blocked)
- **debs**
  - dpkg
  - apt
- **rpm**
  - yum
  
Install manager clearly into `/var/wazuh-manager` and confirm user/group ownership. (blocked)
    
### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [X] Linux
- [X] Log syntax and correct language review

<!-- Depending on the affected OS
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests
 -->
### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
Debian/RPM manager packages
Manager install scripts (preinst/postinst/prerm/postrm)
Package builder scripts: 
  - wazuh/packages/generate_package.sh
  - wazuh/packages/rpms/utils/helper_function.sh
  - share/wazuh/packages/README.md
  
### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
Default manager path to `/var/wazuh-manager`
Manager user/group to `wazuh-manager`
Soft‑block for `/var/ossec` unless forced
Hard‑block for upgrades from <5.x

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
None
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
