### PR TITLE
fix: ignore build directory, update checkCoverage regex to support both formats

### DIFF
--- a/src/ci/run_check.py
+++ b/src/ci/run_check.py
@@ -31,28 +31,25 @@ def checkCoverage(output):
     Raises:
         - ValueError: Raises an exception when fails for some reason.
     """
-    reLines = re.search("lines.*(% ).*(lines)", str(output))
-    reFunctions = re.search("functions.*%", str(output))
-    if reLines:
-        end = reLines.group().index('%')
-        start = reLines.group()[0:end].rindex(' ') + 1
-        linesCoverage = reLines.group()[start:end]
-    if reFunctions:
-        end = reFunctions.group().index('%')
-        start = reFunctions.group().rindex(' ') + 1
-        functionsCoverage = reFunctions.group()[start:end]
+    output_str = str(output)
+    matchLines = re.search(r"lines[\.\s]*:\s+([\d\.]+)\%", output_str)
+    matchFunctions = re.search(r"functions[\.\s]*:\s+([\d\.]+)\%", output_str)
+    linesCoverage = matchLines.group(1) if matchLines else "0.0"
+    functionsCoverage = matchFunctions.group(1) if matchFunctions else "0.0"
+
     if float(linesCoverage) >= 90.0:
-        utils.printGreen(msg="[Lines Coverage {}%: PASSED]"
-                         .format(linesCoverage))
+        utils.printGreen(msg="[Lines Coverage {}%: PASSED]".format(linesCoverage))
     else:
         utils.printFail(msg="[Lines Coverage {}%: LOW]".format(linesCoverage))
         errorString = "Low lines coverage: {}".format(linesCoverage)
         raise ValueError(errorString)
+
     if float(functionsCoverage) >= 90.0:
-        utils.printGreen(msg="[Functions Coverage {}%: PASSED]"
-                         .format(functionsCoverage))
+        utils.printGreen(
+            msg="[Functions Coverage {}%: PASSED]".format(functionsCoverage)
+        )
     else:
-        utils.printFail(msg="[Functions Coverage {functionsCoverage}%: LOW]")
+        utils.printFail(msg="[Functions Coverage {}%: LOW]".format(functionsCoverage))
         errorString = "Low functions coverage: {}".format(functionsCoverage)
         raise ValueError(errorString)
 
@@ -273,7 +270,7 @@ def runCppCheck(moduleName):
                       headerKey="cppcheck")
 
     currentDir = utils.moduleDirPath(moduleName)
-    cppcheckCommand = "cppcheck --force --std=c++14 --quiet {}".format(currentDir)
+    cppcheckCommand = "cppcheck --force --std=c++17 --quiet -i {}/build {}".format(currentDir, currentDir)
 
     out = subprocess.run(cppcheckCommand,
                          stdout=subprocess.PIPE,


### PR DESCRIPTION
## Description

This PR addresses CI failures encountered on **Ubuntu 24.04 (Noble)** due to updates in the development toolchain (Cppcheck 2.13+, and LCOV 2.0+). The current build scripts and unit tests were failing due to false positives in static analysis, and changes in the output format of coverage tools.

Closes #34236 

## Proposed Changes

- **CI / Cppcheck:** Updated `src/ci/run_check.py` to explicitly exclude the `build/` directory from Cppcheck analysis (`-i build`).
  - *Reason:* The build directory contains auto-generated CMake files (e.g., `CMakeCCompilerId.c`) with intentionally complex macros designed to embed compiler information. Cppcheck 2.13+ flags these as syntax errors, causing the build to fail.
- **CI / Coverage:** Updated the regex in the `checkCoverage` function (`src/ci/run_check.py`) to support both legacy and modern LCOV formats.
  - *Reason:* Previous versions of LCOV used dots for padding (`lines......: 96.5%`), while LCOV 2.0+ uses spaces (`lines: 96.5%`). The new regex handles both cases to ensure backward compatibility with Ubuntu 22.04.

### Results and Evidence

The build process, unit tests, and quality checks now pass successfully on **Ubuntu 24.04**, while maintaining compatibility with **Ubuntu 22.04**.

**Log evidence (Ubuntu 24.04):**
- `shared_modules/dbsync`
```java
python3 build.py -r shared_modules/dbsync --cpus 6
 <shared_modules/dbsync>=============== Running RTR checks  ===============<shared_modules/dbsync>
 <shared_modules/dbsync>=============== Running cppcheck    ===============<shared_modules/dbsync>
 [Cppcheck: PASSED]
 <shared_modules/dbsync>=============== Running AStyle      ===============<shared_modules/dbsync>
 [Cleanfolder : PASSED]
 [AStyle Check: PASSED]
 [CleanAll: PASSED]
 <agent>=============== Running Make Deps   ===============<agent>
 [MakeDeps: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <shared_modules/dbsync>=============== Running Tests       ===============<shared_modules/dbsync>
 [dbengine_unit_test: PASSED]
 [dbsync_unit_test: PASSED]
 [sqlite_unit_test: PASSED]
 [dbsyncPipelineFactory_unit_test: PASSED]
 <shared_modules/dbsync>[All tests: PASSED]<shared_modules/dbsync>
 <shared_modules/dbsync>=============== Running Coverage    ===============<shared_modules/dbsync>
geninfo: WARNING: RC option 'lcov_branch_coverage' is deprecated.  Consider using 'branch_coverage. instead.  (Backward-compatible support will be removed in the future
geninfo: WARNING: /home/vagrant/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp:286: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
geninfo: WARNING: /home/vagrant/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp:286: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	(use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
geninfo: WARNING: /home/vagrant/wazuh/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp:286: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	(use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
 [lcov info: GENERATED]
 [genhtml info: GENERATED]
 Report: /home/vagrant/wazuh/src/shared_modules/dbsync/coverage_report/index.html
 [Lines Coverage 93.5%: PASSED]
 [Functions Coverage 98.8%: PASSED]
 <shared_modules/dbsync>=============== Running Valgrind    ===============<shared_modules/dbsync>
 [dbengine_unit_test : PASSED]
 [dbsync_unit_test : PASSED]
 [sqlite_unit_test : PASSED]
 [dbsyncPipelineFactory_unit_test : PASSED]
 <shared_modules/dbsync>[Memory leak check: PASSED]<shared_modules/dbsync>
 [CleanInternals: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <shared_modules/dbsync>=============== Running ASAN        ===============<shared_modules/dbsync>
 [Cleanfolder : PASSED]
 <shared_modules/dbsync>=============== Running CMake Conf  ===============<shared_modules/dbsync>
 [ConfigureCMake: PASSED]
 <shared_modules/dbsync>=============== Compiling library   ===============<shared_modules/dbsync>
 [make: PASSED]
 [Cleanfolder : PASSED]
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a snapshotsUpdate/insertData.json,snapshotsUpdate/updateWithSnapshot.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a InsertionUpdateDeleteSelect/inputSyncRowInsert.json,InsertionUpdateDeleteSelect/inputSyncRowModified.json,InsertionUpdateDeleteSelect/deleteRows.json,InsertionUpdateDeleteSelect/inputSelectRows.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a txnOperation/createTxn.json,txnOperation/inputSyncRowInsertTxn.json,txnOperation/pksGetDeletedRows.json,txnOperation/inputSyncRowModifiedTxn.json,txnOperation/closeTxn.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a txnOperation/createTxn.json,txnOperation/inputSyncRowInsertTxn.json,txnOperation/fullyGetDeletedRows.json,txnOperation/inputSyncRowModifiedTxn.json,txnOperation/closeTxn.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a triggerActions/insertDataProcesses.json,triggerActions/insertDataSocket.json,triggerActions/addTableRelationship.json,triggerActions/deleteRows.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a triggerActions/insertDataProcesses.json,triggerActions/insertDataSocket.json,triggerActions/addTableRelationship.json,triggerActions/deleteRows.json -o ./output
 [ASAN: PASSED]
 <shared_modules/dbsync>[RTR: PASSED]<shared_modules/dbsync>
```
- `wazuh_modules/syscollector`
```java
python3 build.py -r wazuh_modules/syscollector --cpus 6
 <wazuh_modules/syscollector>=============== Running RTR checks  ===============<wazuh_modules/syscollector>
 <wazuh_modules/syscollector>=============== Running cppcheck    ===============<wazuh_modules/syscollector>
 [Cppcheck: PASSED]
 <wazuh_modules/syscollector>=============== Running AStyle      ===============<wazuh_modules/syscollector>
 [Cleanfolder : PASSED]
 [AStyle Check: PASSED]
 [CleanAll: PASSED]
 <agent>=============== Running Make Deps   ===============<agent>
 [MakeDeps: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <wazuh_modules/syscollector>=============== Running Tests       ===============<wazuh_modules/syscollector>
 [syscollectorimp_unit_test: PASSED]
 [sys_normalizer_unit_test: PASSED]
 <wazuh_modules/syscollector>[All tests: PASSED]<wazuh_modules/syscollector>
 <wazuh_modules/syscollector>=============== Running Coverage    ===============<wazuh_modules/syscollector>
geninfo: WARNING: RC option 'lcov_branch_coverage' is deprecated.  Consider using 'branch_coverage. instead.  (Backward-compatible support will be removed in the future
 [lcov info: GENERATED]
 [genhtml info: GENERATED]
 Report: /home/vagrant/wazuh/src/wazuh_modules/syscollector/coverage_report/index.html
 [Lines Coverage 96.5%: PASSED]
 [Functions Coverage 100.0%: PASSED]
 <wazuh_modules/syscollector>=============== Running Valgrind    ===============<wazuh_modules/syscollector>
 [syscollectorimp_unit_test : PASSED]
 [sys_normalizer_unit_test : PASSED]
 <wazuh_modules/syscollector>[Memory leak check: PASSED]<wazuh_modules/syscollector>
 [CleanInternals: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <wazuh_modules/syscollector>=============== Running ASAN        ===============<wazuh_modules/syscollector>
 [Cleanfolder : PASSED]
 <wazuh_modules/syscollector>=============== Running CMake Conf  ===============<wazuh_modules/syscollector>
 [ConfigureCMake: PASSED]
 <wazuh_modules/syscollector>=============== Compiling library   ===============<wazuh_modules/syscollector>
 [make: PASSED]
 [Cleanfolder : PASSED]
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/wazuh_modules/syscollector/build/bin/syscollector_test_tool 10
 [ASAN: PASSED]
 <wazuh_modules/syscollector>[RTR: PASSED]<wazuh_modules/syscollector>
```

**Log evidence (Ubuntu 22.04):**
- `wazuh_modules/syscollector`
```java
python3 build.py -r wazuh_modules/syscollector --cpus 6
 <wazuh_modules/syscollector>=============== Running RTR checks  ===============<wazuh_modules/syscollector>
 <wazuh_modules/syscollector>=============== Running cppcheck    ===============<wazuh_modules/syscollector>
 [Cppcheck: PASSED]
 <wazuh_modules/syscollector>=============== Running AStyle      ===============<wazuh_modules/syscollector>
 [Cleanfolder : PASSED]
 [AStyle Check: PASSED]
 [CleanAll: PASSED]
 <agent>=============== Running Make Deps   ===============<agent>
 [MakeDeps: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <wazuh_modules/syscollector>=============== Running Tests       ===============<wazuh_modules/syscollector>
 [syscollectorimp_unit_test: PASSED]
 [sys_normalizer_unit_test: PASSED]
 <wazuh_modules/syscollector>[All tests: PASSED]<wazuh_modules/syscollector>
 <wazuh_modules/syscollector>=============== Running Coverage    ===============<wazuh_modules/syscollector>
Subroutine read_intermediate_text redefined at /usr/bin/geninfo line 2623.
Subroutine read_intermediate_json redefined at /usr/bin/geninfo line 2655.
Subroutine intermediate_text_to_info redefined at /usr/bin/geninfo line 2703.
Subroutine intermediate_json_to_info redefined at /usr/bin/geninfo line 2792.
Subroutine get_output_fd redefined at /usr/bin/geninfo line 2872.
Subroutine print_gcov_warnings redefined at /usr/bin/geninfo line 2900.
Subroutine process_intermediate redefined at /usr/bin/geninfo line 2930.
 [lcov info: GENERATED]
 [genhtml info: GENERATED]
 Report: /home/vagrant/wazuh/src/wazuh_modules/syscollector/coverage_report/index.html
 [Lines Coverage 96.5%: PASSED]
 [Functions Coverage 100.0%: PASSED]
 <wazuh_modules/syscollector>=============== Running Valgrind    ===============<wazuh_modules/syscollector>
 [syscollectorimp_unit_test : PASSED]
 [sys_normalizer_unit_test : PASSED]
 <wazuh_modules/syscollector>[Memory leak check: PASSED]<wazuh_modules/syscollector>
 [CleanInternals: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <wazuh_modules/syscollector>=============== Running ASAN        ===============<wazuh_modules/syscollector>
 [Cleanfolder : PASSED]
 <wazuh_modules/syscollector>=============== Running CMake Conf  ===============<wazuh_modules/syscollector>
 [ConfigureCMake: PASSED]
 <wazuh_modules/syscollector>=============== Compiling library   ===============<wazuh_modules/syscollector>
 [make: PASSED]
 [Cleanfolder : PASSED]
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/wazuh_modules/syscollector/build/bin/syscollector_test_tool 10
 [ASAN: PASSED]
 <wazuh_modules/syscollector>[RTR: PASSED]<wazuh_modules/syscollector>
╭─vagrant@wazuh-dev-u22 ~/wazuh/src ‹test/4008-add-ut-sha256-null-arg●›
╰─$ nvim .
╭─vagrant@wazuh-dev-u22 ~/wazuh/src ‹test/4008-add-ut-sha256-null-arg●›
╰─$ python3 build.py -r wazuh_modules/syscollector --cpus 6
 <wazuh_modules/syscollector>=============== Running RTR checks  ===============<wazuh_modules/syscollector>
 <wazuh_modules/syscollector>=============== Running cppcheck    ===============<wazuh_modules/syscollector>
 [Cppcheck: PASSED]
 <wazuh_modules/syscollector>=============== Running AStyle      ===============<wazuh_modules/syscollector>
 [Cleanfolder : PASSED]
 [AStyle Check: PASSED]
 [CleanAll: PASSED]
 <agent>=============== Running Make Deps   ===============<agent>
 [MakeDeps: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <wazuh_modules/syscollector>=============== Running Tests       ===============<wazuh_modules/syscollector>
 [syscollectorimp_unit_test: PASSED]
 [sys_normalizer_unit_test: PASSED]
 <wazuh_modules/syscollector>[All tests: PASSED]<wazuh_modules/syscollector>
 <wazuh_modules/syscollector>=============== Running Coverage    ===============<wazuh_modules/syscollector>
Subroutine read_intermediate_text redefined at /usr/bin/geninfo line 2623.
Subroutine read_intermediate_json redefined at /usr/bin/geninfo line 2655.
Subroutine intermediate_text_to_info redefined at /usr/bin/geninfo line 2703.
Subroutine intermediate_json_to_info redefined at /usr/bin/geninfo line 2792.
Subroutine get_output_fd redefined at /usr/bin/geninfo line 2872.
Subroutine print_gcov_warnings redefined at /usr/bin/geninfo line 2900.
Subroutine process_intermediate redefined at /usr/bin/geninfo line 2930.
 [lcov info: GENERATED]
 [genhtml info: GENERATED]
 Report: /home/vagrant/wazuh/src/wazuh_modules/syscollector/coverage_report/index.html
 [Lines Coverage 96.5%: PASSED]
 [Functions Coverage 100.0%: PASSED]
 <wazuh_modules/syscollector>=============== Running Valgrind    ===============<wazuh_modules/syscollector>
 [syscollectorimp_unit_test : PASSED]
 [sys_normalizer_unit_test : PASSED]
 <wazuh_modules/syscollector>[Memory leak check: PASSED]<wazuh_modules/syscollector>
 [CleanInternals: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <wazuh_modules/syscollector>=============== Running ASAN        ===============<wazuh_modules/syscollector>
 [Cleanfolder : PASSED]
 <wazuh_modules/syscollector>=============== Running CMake Conf  ===============<wazuh_modules/syscollector>
 [ConfigureCMake: PASSED]
 <wazuh_modules/syscollector>=============== Compiling library   ===============<wazuh_modules/syscollector>
 [make: PASSED]
 [Cleanfolder : PASSED]
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/wazuh_modules/syscollector/build/bin/syscollector_test_tool 10
 [ASAN: PASSED]
 <wazuh_modules/syscollector>[RTR: PASSED]<wazuh_modules/syscollector>
╭─vagrant@wazuh-dev-u22 ~/wazuh/src ‹test/4008-add-ut-sha256-null-arg●›
╰─$
╭─vagrant@wazuh-dev-u22 ~/wazuh/src ‹test/4008-add-ut-sha256-null-arg●›
╰─$ python3 build.py -r shared_modules/dbsync --cpus 6
 <shared_modules/dbsync>=============== Running RTR checks  ===============<shared_modules/dbsync>
 <shared_modules/dbsync>=============== Running cppcheck    ===============<shared_modules/dbsync>
 [Cppcheck: PASSED]
 <shared_modules/dbsync>=============== Running AStyle      ===============<shared_modules/dbsync>
 [Cleanfolder : PASSED]
 [AStyle Check: PASSED]
 [CleanAll: PASSED]
 <agent>=============== Running Make Deps   ===============<agent>
 [MakeDeps: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <shared_modules/dbsync>=============== Running Tests       ===============<shared_modules/dbsync>
 [sqlite_unit_test: PASSED]
 [dbengine_unit_test: PASSED]
 [dbsync_unit_test: PASSED]
 [dbsyncPipelineFactory_unit_test: PASSED]
 <shared_modules/dbsync>[All tests: PASSED]<shared_modules/dbsync>
 <shared_modules/dbsync>=============== Running Coverage    ===============<shared_modules/dbsync>
Subroutine read_intermediate_text redefined at /usr/bin/geninfo line 2623.
Subroutine read_intermediate_json redefined at /usr/bin/geninfo line 2655.
Subroutine intermediate_text_to_info redefined at /usr/bin/geninfo line 2703.
Subroutine intermediate_json_to_info redefined at /usr/bin/geninfo line 2792.
Subroutine get_output_fd redefined at /usr/bin/geninfo line 2872.
Subroutine print_gcov_warnings redefined at /usr/bin/geninfo line 2900.
Subroutine process_intermediate redefined at /usr/bin/geninfo line 2930.
 [lcov info: GENERATED]
 [genhtml info: GENERATED]
 Report: /home/vagrant/wazuh/src/shared_modules/dbsync/coverage_report/index.html
 [Lines Coverage 93.4%: PASSED]
 [Functions Coverage 98.8%: PASSED]
 <shared_modules/dbsync>=============== Running Valgrind    ===============<shared_modules/dbsync>
 [sqlite_unit_test : PASSED]
 [dbengine_unit_test : PASSED]
 [dbsync_unit_test : PASSED]
 [dbsyncPipelineFactory_unit_test : PASSED]
 <shared_modules/dbsync>[Memory leak check: PASSED]<shared_modules/dbsync>
 [CleanInternals: PASSED]
 <agent>=============== Running Make project ==============<agent>
 [MakeTarget: PASSED]
 <shared_modules/dbsync>=============== Running ASAN        ===============<shared_modules/dbsync>
 [Cleanfolder : PASSED]
 <shared_modules/dbsync>=============== Running CMake Conf  ===============<shared_modules/dbsync>
 [ConfigureCMake: PASSED]
 <shared_modules/dbsync>=============== Compiling library   ===============<shared_modules/dbsync>
 [make: PASSED]
 [Cleanfolder : PASSED]
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a snapshotsUpdate/insertData.json,snapshotsUpdate/updateWithSnapshot.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a InsertionUpdateDeleteSelect/inputSyncRowInsert.json,InsertionUpdateDeleteSelect/inputSyncRowModified.json,InsertionUpdateDeleteSelect/deleteRows.json,InsertionUpdateDeleteSelect/inputSelectRows.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a txnOperation/createTxn.json,txnOperation/inputSyncRowInsertTxn.json,txnOperation/pksGetDeletedRows.json,txnOperation/inputSyncRowModifiedTxn.json,txnOperation/closeTxn.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a txnOperation/createTxn.json,txnOperation/inputSyncRowInsertTxn.json,txnOperation/fullyGetDeletedRows.json,txnOperation/inputSyncRowModifiedTxn.json,txnOperation/closeTxn.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a triggerActions/insertDataProcesses.json,triggerActions/insertDataSocket.json,triggerActions/addTableRelationship.json,triggerActions/deleteRows.json -o ./output
 <TESTTOOL>=============== Running TEST TOOL   ===============<TESTTOOL>
 /home/vagrant/wazuh/src/shared_modules/dbsync/build/bin/dbsync_test_tool -c config.json -a triggerActions/insertDataProcesses.json,triggerActions/insertDataSocket.json,triggerActions/addTableRelationship.json,triggerActions/deleteRows.json -o ./output
 [ASAN: PASSED]
 <shared_modules/dbsync>[RTR: PASSED]<shared_modules/dbsync>
```