### PR TITLE
Remove ossec-init.conf references and define upgrade constraints

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -179,11 +179,6 @@ case "$1" in
         fi
     fi
 
-    #Delete obsolete files
-    if [ -f /etc/ossec-init.conf ]; then
-        rm -f /etc/ossec-init.conf
-    fi
-
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/packages/debs/SPECS/wazuh-manager/debian/postinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/postinst
@@ -283,11 +283,6 @@ case "$1" in
         rm -f ${DIR}/bin/manage_agents
     fi
 
-    # Delete obsolete files
-    if [ -f /etc/ossec-init.conf ]; then
-        rm -f /etc/ossec-init.conf
-    fi
-
     # Delete installation scripts
     if [ -d ${SCRIPTS_DIR} ]; then
         rm -rf ${SCRIPTS_DIR}

--- a/packages/debs/SPECS/wazuh-manager/debian/preinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/preinst
@@ -51,11 +51,7 @@ case "$1" in
             fi
 
             # Get old package version
-            if [ -f /etc/ossec-init.conf ]; then
-                . /etc/ossec-init.conf
-            else
-                VERSION=$(${DIR}/bin/wazuh-control info -v)
-            fi
+            VERSION=$(${DIR}/bin/wazuh-control info -v)
 
             # Get the major and minor version
             MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -241,7 +241,6 @@ fi
 
 %post
 
-echo "VERSION=\"$(%{_localstatedir}/bin/wazuh-control info -v)\"" > /etc/ossec-init.conf
 if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
     rm -rf %{_localstatedir}/logs/wazuh
@@ -623,18 +622,12 @@ if [ -d %{_localstatedir}/queue/ossec ]; then
   rm -rf %{_localstatedir}/queue/ossec/
 fi
 
-if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-  rm -f %{_sysconfdir}/ossec-init.conf
-  rm -f %{_localstatedir}/etc/ossec-init.conf
-fi
-
 %clean
 rm -fr %{buildroot}
 
 %files
 %defattr(-,root,root)
 %config(missingok) %{_initrddir}/wazuh-agent
-%attr(640, root, wazuh) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
 /usr/lib/systemd/system/wazuh-agent.service
 %dir %attr(750, root, wazuh) %{_localstatedir}
 %attr(440, wazuh, wazuh) %{_localstatedir}/VERSION.json

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -268,13 +268,8 @@ if [ $1 = 2 ]; then
     rm -rf %{_localstatedir}/~api
   fi
 
-  if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-    # Import the variables from ossec-init.conf file
-    . %{_sysconfdir}/ossec-init.conf
-  else
-    # Ask wazuh-control the version
-    VERSION=$(%{_localstatedir}/bin/wazuh-control info -v)
-  fi
+  # Ask wazuh-control the version
+  VERSION=$(%{_localstatedir}/bin/wazuh-control info -v)
 
   # Get the major and minor version
   MAJOR=$(echo $VERSION | cut -dv -f2 | cut -d. -f1)
@@ -302,8 +297,6 @@ if [ $1 = 2 ]; then
 fi
 
 %post
-
-echo "VERSION=\"$(%{_localstatedir}/bin/wazuh-control info -v)\"" > /etc/ossec-init.conf
 
 # Upgrade install code block
 if [ $1 = 2 ]; then
@@ -620,11 +613,6 @@ if [ -d %{_localstatedir}/queue/ossec ]; then
   rm -rf %{_localstatedir}/queue/ossec/
 fi
 
-if [ -f %{_sysconfdir}/ossec-init.conf ]; then
-  rm -f %{_sysconfdir}/ossec-init.conf
-  rm -f %{_localstatedir}/etc/ossec-init.conf
-fi
-
 # Remove groups backup files
 rm -rf %{_localstatedir}/backup/groups
 
@@ -639,7 +627,6 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,wazuh)
 %config(missingok) %{_initrddir}/wazuh-manager
-%attr(640, root, wazuh) %verify(not md5 size mtime) %ghost %{_sysconfdir}/ossec-init.conf
 /usr/lib/systemd/system/wazuh-manager.service
 %dir %attr(750, root, wazuh) %{_localstatedir}
 %attr(440, wazuh, wazuh) %{_localstatedir}/VERSION.json

--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -28,7 +28,6 @@ else
     HOST=`uname -n`
 fi
 
-OSSEC_INIT="/etc/ossec-init.conf"
 NAMESERVERS=`cat /etc/resolv.conf | grep "^nameserver" | cut -d " " -sf 2`
 NAMESERVERS2=`cat /etc/resolv.conf | grep "^nameserver" | cut -sf 2`
 HOST_CMD=`command -v host 2>/dev/null`

--- a/src/init/update.sh
+++ b/src/init/update.sh
@@ -223,17 +223,6 @@ isWazuhInstalled()
 ##########
 getPreinstalledDir()
 {
-    # Checking ossec-init.conf for old wazuh versions
-    if [ -f "${OSSEC_INIT}" ]; then
-        . ${OSSEC_INIT}
-        if [ -d "$DIRECTORY" ]; then
-            PREINSTALLEDDIR="$DIRECTORY"
-            if isWazuhInstalled $PREINSTALLEDDIR; then
-                return 0;
-            fi
-        fi
-    fi
-
     # Getting preinstalled dir for Wazuh manager and hibrid installations
     pidir_service_name="wazuh-manager"
     if getPreinstalledDirByType && isWazuhInstalled $PREINSTALLEDDIR; then
@@ -257,16 +246,11 @@ getPreinstalledDir()
 
 getPreinstalledType()
 {
-    # Checking ossec-init.conf for old wazuh versions
-    if [ -f "${OSSEC_INIT}" ]; then
-        . ${OSSEC_INIT}
-    else
-        if [ "X$PREINSTALLEDDIR" = "X" ]; then
-            getPreinstalledDir
-        fi
-
-        TYPE=`$PREINSTALLEDDIR/bin/wazuh-control info -t`
+    if [ "X$PREINSTALLEDDIR" = "X" ]; then
+        getPreinstalledDir
     fi
+
+    TYPE=`$PREINSTALLEDDIR/bin/wazuh-control info -t`
 
     echo $TYPE
     return 0;
@@ -274,31 +258,18 @@ getPreinstalledType()
 
 getPreinstalledVersion()
 {
-    # Checking ossec-init.conf for old wazuh versions
-    if [ -f "${OSSEC_INIT}" ]; then
-        . ${OSSEC_INIT}
-    else
-        if [ "X$PREINSTALLEDDIR" = "X" ]; then
-            getPreinstalledDir
-        fi
-
-        VERSION=`$PREINSTALLEDDIR/bin/wazuh-control info -v`
+    if [ "X$PREINSTALLEDDIR" = "X" ]; then
+        getPreinstalledDir
     fi
+
+    VERSION=`$PREINSTALLEDDIR/bin/wazuh-control info -v`
 
     echo $VERSION
 }
 
 getPreinstalledName()
 {
-    NAME=""
-    # Checking ossec-init.conf for old wazuh versions. New versions
-    # do not provide this information at all.
-    if [ -f "${OSSEC_INIT}" ]; then
-        . ${OSSEC_INIT}
-    else
-        NAME="Wazuh"
-    fi
-
+    NAME="Wazuh"
     echo $NAME
 }
 

--- a/src/init/wazuh/wazuh.sh
+++ b/src/init/wazuh/wazuh.sh
@@ -197,12 +197,6 @@ WazuhUpgrade()
     rm -f $PREINSTALLEDDIR/active-response/bin/ossec-slack.sh
     rm -f $PREINSTALLEDDIR/active-response/bin/ossec-tweeter.sh
 
-    # Remove deprecated ossec-init.conf file and its link
-    if [ -f /etc/ossec-init.conf ]; then
-        rm -f $PREINSTALLEDDIR/etc/ossec-init.conf
-        rm -f /etc/ossec-init.conf
-    fi
-
     # Remove old databases if upgrading from pre 5.X to 5.X
     if [ $MAJOR -lt 5 ]; then
         if [ -f $PREINSTALLEDDIR/queue/syscollector/db/local.db ]; then


### PR DESCRIPTION
## Description

Closes #34202

This PR removes of all remaining references to `ossec-init.conf` from Wazuh codebase as part of the Agent/Manager separation effort for Wazuh 5.0.

The file `ossec-init.conf` was previously used to store installation metadata (version, type, directory) but was removed in Wazuh 4.2.0 (PR #7175). However, legacy code still referenced this file for backward compatibility with older installations.

In addition, this issue must clarify and document the supported agent upgrade path to 5.0, since removing all `ossec-init.conf` references has direct implications on backward compatibility with pre-4.2.0 versions.

Currently, the assumption is that agent upgrades to 5.0 are supported starting from Wazuh 4.2.0 or later.

## Proposed Changes

- Remove variable declarations pointing to `ossec-init.conf`
- Remove logic that reads/creates/deletes `ossec-init.conf`
- Replace detection methods to use `wazuh-control info` exclusively
- Update packaging scripts to remove `ossec-init.conf` handling

### Upgrade Constraints

Minimum version for agent upgrade to 5.0: Wazuh 4.2.0

Installations running versions prior to 4.2.0 must first upgrade to an intermediate version (4.2.0 or later) before upgrading to 5.0, as the version detection mechanism now relies exclusively on `wazuh-control info` commands which may not work reliably with the old `ossec-init.conf` file structure.

### Results and Evidence

#### Test from packages

- Agent RPM, DEB  - amd64: [Build + Install + Uninstall + Upgrade from 4.14.2 to 5.0.0](https://github.com/wazuh/wazuh/actions/runs/21521677639?pr=34255) :green_circle: 
- Agent RPM, DEB - arm64: [Build + Install + Uninstall + Upgrade from 4.14.2 to 5.0.0](https://github.com/wazuh/wazuh/actions/runs/21521677660?pr=34255) :green_circle:
- Manager  RPM, DEB - amd64, arm64: [Build + Install + Uninstall](https://github.com/wazuh/wazuh/actions/runs/21521677656?pr=34255) :green_circle: 

#### Test from sources

- Agent - Build + Install + Upgrade from 4.14.2 to 5.0.0 :green_circle: 

<details><summary>Build</summary>

```console
General settings:
    TARGET:             agent
    V:                  
    DEBUG:              
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:1a98c1aa40df0fe82136d790043c2f9cbf1a24c4
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -DCLIENT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -I./data_provider/include/ -I./shared_modules/ -I./shared_modules/agent_metadata/include -I./shared_modules/common/ -I./shared_modules/content_manager/include -I./shared_modules/router/include -I./shared_modules/sync_protocol/include -I./syscheckd/include -I./wazuh_modules/syscollector/include -I./wazuh_modules/vulnerability_scanner/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lbuild/lib 
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'

Done building agent
```
</details> 

<details><summary>Install</summary>

```console
# ./install.sh
 Wazuh v5.0.0 (Rev. alpha0) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux dd4c300576e9 6.8.0-90-generic (ubuntu 24.04)
  - User: root
  - Host: dd4c300576e9


  -- Press ENTER to continue or Ctrl-C to abort. --


1- What kind of installation do you want (manager, agent, local, hybrid or help)? agent

  - Agent (client) installation chosen.

2- Choose where to install Wazuh [/var/ossec]: 

    - Installation will be made at  /var/ossec .

3- Configuring Wazuh.

  3.1- What's the IP Address or hostname of the Wazuh server?: 192.168.56.30

   - Adding Server IP 

  3.2- Do you want to run the integrity check daemon? (y/n) [y]: 

   - Running syscheck (integrity check daemon).

  3.3- Do you want to run the rootkit detection engine? (y/n) [y]: 

   - Running rootcheck (rootkit detection).

  3.5 - Do you want to enable active response? (y/n) [y]: 

   - Active response enabled.

  3.6- Remote upgrades use packages signed by the system maintainer. The
       corresponding certificate (or root certificate) must be installed
       in the system in order to verify the WPK packages. By default,
       the root certificate by Wazuh is installed.

   - Do you want to add more certificates? (y/n)? [n]: 

  3.7- Setting the configuration to analyze the following logs:

    -- journald
    -- /var/ossec/logs/active-responses.log
    -- /var/log/dpkg.log

 - If you want to monitor any other file, just change
   the ossec.conf and add a new localfile entry.
   Any questions about the configuration can be answered
   by visiting us online at https://documentation.wazuh.com/.


   --- Press ENTER to continue ---


4- Installing the system

DIR="/var/ossec"
 - Running the Makefile

make build_wazuh_cmake
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'
mkdir -p build && cd build && cmake .. -DTARGET=agent -DENABLE_SYSC=ON -DINOTIFY_ENABLED=ON -DENABLE_AUDIT=ON -DCMAKE_SYMBOLS_IN_RELEASE=ON     && make
==============================================
Wazuh version: v5.0.0
Wazuh revision: alpha0
==============================================
-- Using flatc from: /workspaces/devcontainer-5x/wazuh/src/shared_modules/sync_protocol/../../external/flatbuffers/build/flatc
-- Proceeding with version: 23.5.26.0
-- CMAKE_CXX_FLAGS: -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2 -fPIC
-- SRC_FOLDER: /workspaces/devcontainer-5x/wazuh/src
-- FilesystemWrapper library not found, using target name
-- FileIO library not found, using target name
-- dbsync library not found, using target name
-- agent_metadata library not found, using target name
-- SRC_FOLDER: /workspaces/devcontainer-5x/wazuh/src
-- FilesystemWrapper library not found, using target name
-- FileIO library not found, using target name
-- dbsync library not found, using target name
-- Configuring done (0.0s)
-- Generating done (0.1s)
-- Build files have been written to: /workspaces/devcontainer-5x/wazuh/src/build
make[2]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[3]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  1%] Built target generate_flatbuffers
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  2%] Built target agent_metadata
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  4%] Built target services
[  7%] Built target FilesystemWrapper
[ 10%] Built target FileIO
[ 12%] Built target browser_extensions
[ 18%] Built target urlrequest
[ 18%] Built target groups
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 22%] Built target flatbuffers
[ 26%] Built target schema_validator
[ 27%] Built target fimebpf
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 32%] Built target dbsync
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 36%] Built target users
[ 38%] Built target dbsync_example
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 39%] Built target dbsync_test_tool
[ 46%] Built target agent_sync_protocol
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 47%] Built target sync_protocol_test_tool
[ 53%] Built target fimdb
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 63%] Built target sysinfo
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 65%] Built target fimdb_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 66%] Built target sysinfo_test_tool
[ 67%] Built target AGENT_INFO_IMPL
[ 70%] Built target syscollector
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 85%] Built target syscheckd_lib
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 93%] Built target SCAImpl
[ 95%] Built target syscollector_test_tool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 96%] Linking CXX shared library ../../lib/libagent_info.so
[ 98%] Built target wazuh-syscheckd
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 99%] Linking CXX shared library ../../lib/libsca.so
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 99%] Built target sca
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[100%] Built target agent_info
make[3]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[2]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'
make wazuh-agentd wazuh-logcollector wazuh-execd manage_agents active-responses wazuh-modulesd
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'
make[1]: 'wazuh-agentd' is up to date.
make[1]: 'wazuh-logcollector' is up to date.
make[1]: 'wazuh-execd' is up to date.
make[1]: 'manage_agents' is up to date.
make[1]: Nothing to be done for 'active-responses'.
make[1]: 'wazuh-modulesd' is up to date.
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'
make settings
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'

General settings:
    TARGET:             agent
    V:                  
    DEBUG:              
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:1a98c1aa40df0fe82136d790043c2f9cbf1a24c4
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -DCLIENT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -I./data_provider/include/ -I./shared_modules/ -I./shared_modules/agent_metadata/include -I./shared_modules/common/ -I./shared_modules/content_manager/include -I./shared_modules/router/include -I./shared_modules/sync_protocol/include -I./syscheckd/include -I./wazuh_modules/syscollector/include -I./wazuh_modules/vulnerability_scanner/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lbuild/lib 
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'

Done building agent

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


 - More information at: 
   https://documentation.wazuh.com/
```
</details> 

<details><summary>Upgrade from 4.14.2 to 5.0.0</summary>

```console
# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.14.2"
WAZUH_REVISION="rc4"
WAZUH_TYPE="agent"
# ./install.sh
 Wazuh v5.0.0 (Rev. alpha0) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux dd4c300576e9 6.8.0-90-generic (ubuntu 24.04)
  - User: root
  - Host: dd4c300576e9


  -- Press ENTER to continue or Ctrl-C to abort. --


 - You already have Wazuh installed. Do you want to update it? (y/n): y

    - Installation will be made at  /var/ossec .

4- Installing the system

DIR="/var/ossec"
 - Running the Makefile

make build_wazuh_cmake
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'
mkdir -p build && cd build && cmake .. -DTARGET=agent -DENABLE_SYSC=ON -DINOTIFY_ENABLED=ON -DENABLE_AUDIT=ON -DCMAKE_SYMBOLS_IN_RELEASE=ON     && make
==============================================
Wazuh version: v5.0.0
Wazuh revision: alpha0
==============================================
-- Using flatc from: /workspaces/devcontainer-5x/wazuh/src/shared_modules/sync_protocol/../../external/flatbuffers/build/flatc
-- Proceeding with version: 23.5.26.0
-- CMAKE_CXX_FLAGS: -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2 -fPIC
-- SRC_FOLDER: /workspaces/devcontainer-5x/wazuh/src
-- FilesystemWrapper library not found, using target name
-- FileIO library not found, using target name
-- agent_metadata library not found, using target name
-- SRC_FOLDER: /workspaces/devcontainer-5x/wazuh/src
-- FilesystemWrapper library not found, using target name
-- FileIO library not found, using target name
-- Configuring done (0.0s)
-- Generating done (0.1s)
-- Build files have been written to: /workspaces/devcontainer-5x/wazuh/src/build
make[2]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[3]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  2%] Built target agent_metadata
[  2%] Built target generate_flatbuffers
[  5%] Built target urlrequest
[  8%] Built target groups
[ 10%] Built target services
[ 13%] Built target FilesystemWrapper
[ 16%] Built target browser_extensions
[ 18%] Built target FileIO
[ 22%] Built target schema_validator
[ 26%] Built target flatbuffers
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 32%] Built target dbsync
[ 32%] Built target fimebpf
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 34%] Built target dbsync_example
[ 35%] Built target dbsync_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 39%] Built target users
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 46%] Built target agent_sync_protocol
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 52%] Built target fimdb
[ 53%] Built target sync_protocol_test_tool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 55%] Built target fimdb_test_tool
[ 65%] Built target sysinfo
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 66%] Built target sysinfo_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 67%] Built target AGENT_INFO_IMPL
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 70%] Built target syscollector
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 85%] Built target syscheckd_lib
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 86%] Linking CXX shared library ../../lib/libagent_info.so
[ 94%] Built target SCAImpl
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 96%] Built target syscollector_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 98%] Built target wazuh-syscheckd
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 99%] Linking CXX shared library ../../lib/libsca.so
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 99%] Built target sca
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[100%] Built target agent_info
make[3]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[2]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'
make wazuh-agentd wazuh-logcollector wazuh-execd manage_agents active-responses wazuh-modulesd
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'
make[1]: 'wazuh-agentd' is up to date.
make[1]: 'wazuh-logcollector' is up to date.
make[1]: 'wazuh-execd' is up to date.
make[1]: 'manage_agents' is up to date.
make[1]: Nothing to be done for 'active-responses'.
make[1]: 'wazuh-modulesd' is up to date.
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'
make settings
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'

General settings:
    TARGET:             agent
    V:                  
    DEBUG:              
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:1a98c1aa40df0fe82136d790043c2f9cbf1a24c4
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -DCLIENT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -I./data_provider/include/ -I./shared_modules/ -I./shared_modules/agent_metadata/include -I./shared_modules/common/ -I./shared_modules/content_manager/include -I./shared_modules/router/include -I./shared_modules/sync_protocol/include -I./syscheckd/include -I./wazuh_modules/syscollector/include -I./wazuh_modules/vulnerability_scanner/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lbuild/lib 
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'

Done building agent

Stopping Wazuh...
agent
Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Wait for success...
success
Starting Wazuh...
2026/01/30 19:53:18 wazuh-agentd: WARNING: Ignoring the 'protocol' option. Switching to TCP.
2026/01/30 19:53:18 wazuh-agentd: WARNING: Ignoring the 'crypto_method' option. Switching to AES.
2026/01/30 19:53:18 wazuh-agentd: ERROR: (4112): Invalid server address found: ''
2026/01/30 19:53:18 wazuh-agentd: ERROR: (1215): No client configured. Exiting.
wazuh-agentd: Configuration error. Exiting

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - Update completed.

# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v5.0.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="agent"
# find / -iname ossec-init.conf
#

```
</details> 

- Manager - Build + Install :green_circle: 

<details><summary>Build</summary>

```console
General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    INSTALLDIR:         
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:1a98c1aa40df0fe82136d790043c2f9cbf1a24c4
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -I./data_provider/include/ -I./shared_modules/ -I./shared_modules/agent_metadata/include -I./shared_modules/common/ -I./shared_modules/content_manager/include -I./shared_modules/router/include -I./shared_modules/sync_protocol/include -I./syscheckd/include -I./wazuh_modules/syscollector/include -I./wazuh_modules/vulnerability_scanner/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lbuild/lib 
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'

Done building server
```
</details> 

<details><summary>Install</summary>

```console
# ./install.sh
 Wazuh v5.0.0 (Rev. alpha0) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux dd4c300576e9 6.8.0-90-generic (ubuntu 24.04)
  - User: root
  - Host: dd4c300576e9


  -- Press ENTER to continue or Ctrl-C to abort. --


1- What kind of installation do you want (manager, agent, local, hybrid or help)? manager

  - Manager (server) installation chosen.

2- Choose where to install Wazuh [/var/ossec]: 

    - Installation will be made at  /var/ossec .

3- Configuring Wazuh.

  3.2- Do you want to run the integrity check daemon? (y/n) [y]: 

   - Running syscheck (integrity check daemon).

  3.3- Do you want to run the rootkit detection engine? (y/n) [y]: 

   - Running rootcheck (rootkit detection).

  3.5- Active response allows you to execute a specific
       command based on the events received.
       By default, no active responses are defined.

   - Default white list for the active response:
      - 192.168.100.1

   - Do you want to add more IPs to the white list? (y/n)? [n]: 

  3.6- Do you want to enable remote syslog (port 514 udp)? (y/n) [y]: 

   - Remote syslog enabled.

  3.7 - Do you want to run the Auth daemon? (y/n) [y]: 

   - Running Auth daemon.

  3.8- Do you want to start Wazuh after the installation? (y/n) [y]: 

   - Wazuh will start at the end of installation.

  3.9- Setting the configuration to analyze the following logs:

    -- journald
    -- /var/ossec/logs/active-responses.log
    -- /var/log/dpkg.log

 - If you want to monitor any other file, just change
   the ossec.conf and add a new localfile entry.
   Any questions about the configuration can be answered
   by visiting us online at https://documentation.wazuh.com/.


   --- Press ENTER to continue ---


4- Installing the system

DIR="/var/ossec"
 - Running the Makefile

make build_wazuh_cmake
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'
mkdir -p build && cd build && cmake .. -DTARGET=server -DENABLE_SYSC=ON -DINOTIFY_ENABLED=ON -DENABLE_AUDIT=ON -DCMAKE_SYMBOLS_IN_RELEASE=ON     && make
==============================================
Wazuh version: v5.0.0
Wazuh revision: alpha0
==============================================
PATH: /workspaces/devcontainer-5x/wazuh/src
--   → Imported static library fmt_fmt (from /workspaces/devcontainer-5x/wazuh/src/external/fmt/build/libfmt.a)
--   → Alias target fmt::fmt -> fmt_fmt
--   → Imported static library spdlog_spdlog (from /workspaces/devcontainer-5x/wazuh/src/external/spdlog/build/libspdlog.a)
--   → Alias target spdlog::spdlog -> spdlog_spdlog
--   → Imported static library yaml-cpp_yaml-cpp (from /workspaces/devcontainer-5x/wazuh/src/external/yaml-cpp/build/libyaml-cpp.a)
--   → Alias target yaml-cpp::yaml-cpp -> yaml-cpp_yaml-cpp
--   → Header-only interface target RapidJSON_RapidJSON
--   → Alias target RapidJSON::RapidJSON -> RapidJSON_RapidJSON
--   → Header-only interface target RxCpp_RxCpp
--   → Alias target RxCpp::RxCpp -> RxCpp_RxCpp
--   → Header-only interface target FastFloat_fast-float
--   → Alias target FastFloat::fast-float -> FastFloat_fast-float
--   → Header-only interface target Taskflow_Taskflow
--   → Alias target Taskflow::Taskflow -> Taskflow_Taskflow
--   → Header-only interface target unofficial-concurrentqueue_concurrentqueue
--   → Alias target unofficial-concurrentqueue::concurrentqueue -> unofficial-concurrentqueue_concurrentqueue
--   → Imported static library OpenSSL_SSL (from /workspaces/devcontainer-5x/wazuh/src/external/openssl/libssl.a)
--   → Alias target OpenSSL::SSL -> OpenSSL_SSL
--   → Imported static library OpenSSL_Crypto (from /workspaces/devcontainer-5x/wazuh/src/external/openssl/libcrypto.a)
--   → Alias target OpenSSL::Crypto -> OpenSSL_Crypto
--   → Imported static library ZLIB_ZLIB (from /workspaces/devcontainer-5x/wazuh/src/external/zlib/libz.a)
--   → Alias target ZLIB::ZLIB -> ZLIB_ZLIB
--   → Imported static library CURL_libcurl (from /workspaces/devcontainer-5x/wazuh/src/external/curl/lib/.libs/libcurl.a)
--   → Alias target CURL::libcurl -> CURL_libcurl
--   → Imported static library maxminddb_maxminddb (from /workspaces/devcontainer-5x/wazuh/src/external/libmaxminddb/build/libmaxminddb.a)
--   → Alias target maxminddb::maxminddb -> maxminddb_maxminddb
--   → Imported static library benchmark_benchmark (from /workspaces/devcontainer-5x/wazuh/src/external/benchmark/build/src/libbenchmark.a)
--   → Alias target benchmark::benchmark -> benchmark_benchmark
--   → Imported static library benchmark_benchmark_main (from /workspaces/devcontainer-5x/wazuh/src/external/benchmark/build/src/libbenchmark_main.a)
--   → Alias target benchmark::benchmark_main -> benchmark_benchmark_main
--   → Imported static library pugixml_pugixml (from /workspaces/devcontainer-5x/wazuh/src/external/pugixml/build/libpugixml.a)
--   → Alias target pugixml::pugixml -> pugixml_pugixml
--   → Imported static library protobuf_libprotobuf (from /workspaces/devcontainer-5x/wazuh/src/external/protobuf/build/libprotobuf.a)
--   → Alias target protobuf::libprotobuf -> protobuf_libprotobuf
--   → Header-only interface target date_date
--   → Alias target date::date -> date_date
--   → Imported static library date_date-tz (from /workspaces/devcontainer-5x/wazuh/src/external/date/build/libdate-tz.a)
--   → Alias target date::date-tz -> date_date-tz
--   → Imported libs from dir (recursive) /workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result: /workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_bad_any_cast_impl.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_bad_optional_access.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_bad_variant_access.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_base.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_city.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_civil_time.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_cord.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_cord_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_cordz_functions.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_cordz_handle.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_cordz_info.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_cordz_sample_token.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_crc32c.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_crc_cord_state.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_crc_cpu_detect.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_crc_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_debugging_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_demangle_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_die_if_null.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_examine_stack.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_exponential_biased.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_failure_signal_handler.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_commandlineflag.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_commandlineflag_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_config.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_marshalling.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_parse.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_private_handle_accessor.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_program_name.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_reflection.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_usage.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_flags_usage_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_graphcycles_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_hash.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_hashtablez_sampler.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_int128.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_kernel_timeout_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_leak_check.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_entry.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_flags.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_globals.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_initialize.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_check_op.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_conditions.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_fnmatch.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_format.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_globals.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_log_sink_set.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_message.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_nullguard.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_internal_proto.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_severity.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_log_sink.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_low_level_hash.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_malloc_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_periodic_sampler.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_distributions.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_distribution_test_util.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_platform.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_pool_urbg.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_randen.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_randen_hwaes.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_randen_hwaes_impl.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_randen_slow.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_internal_seed_material.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_seed_gen_exception.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_random_seed_sequences.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_raw_hash_set.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_raw_logging_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_scoped_set_env.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_spinlock_wait.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_stacktrace.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_status.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_statusor.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_str_format_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_strerror.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_string_view.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_strings.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_strings_internal.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_symbolize.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_synchronization.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_throw_delegate.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_time.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_time_zone.a;/workspaces/devcontainer-5x/wazuh/src/external/abseil-cpp/build/build_result/lib64/libabsl_vlog_config_internal.a
--   → Alias target absl::absl -> absl_absl
--   → Imported static library re2_re2 (from /workspaces/devcontainer-5x/wazuh/src/external/re2/build/libre2.a)
--   → Alias target re2::re2 -> re2_re2
-- Found protoc: /workspaces/devcontainer-5x/wazuh/src/external/protobuf/build/protoc
INFOENGINE_GENERATE_PROTO is OFF. Skipping Protobuf generation.
-- engine CMAKE_CXX_FLAGS: 
-- engine CMAKE_EXE_LINKER_FLAGS: 
-- engine CMAKE_SHARED_LINKER_FLAGS: 
-- engine CMAKE_MODULE_LINKER_FLAGS: 
-- Coverage report generation is not enabled.
-- Using flatc from: /workspaces/devcontainer-5x/wazuh/src/shared_modules/sync_protocol/../../external/flatbuffers/build/flatc
-- Proceeding with version: 23.5.26.0
-- CMAKE_CXX_FLAGS: -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2 -fPIC
-- Linking router from: /workspaces/devcontainer-5x/wazuh/src/shared_modules/sync_protocol/../../build/lib
-- Using flatc from: /workspaces/devcontainer-5x/wazuh/src/external/flatbuffers/build/flatc
Building inventorySync schema
/workspaces/devcontainer-5x/wazuh/src
/workspaces/devcontainer-5x/wazuh/src/shared_modules/utils/flatbuffers/schemas
-- SRC_FOLDER: /workspaces/devcontainer-5x/wazuh/src
-- FilesystemWrapper library not found, using target name
-- FileIO library not found, using target name
-- agent_metadata library not found, using target name
-- SRC_FOLDER: /workspaces/devcontainer-5x/wazuh/src
-- FilesystemWrapper library not found, using target name
-- FileIO library not found, using target name
-- Using flatc from: /workspaces/devcontainer-5x/wazuh/src/external/flatbuffers/build/flatc
Compiling schemas
-- Configuring done (0.1s)
-- Generating done (0.2s)
-- Build files have been written to: /workspaces/devcontainer-5x/wazuh/src/build
make[2]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[3]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  0%] Built target services
[  1%] Built target groups
[  2%] Built target browser_extensions
[  2%] Built target generate_flatbuffers
[  3%] Built target FileIO
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  4%] Built target FilesystemWrapper
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  5%] Built target urlrequest
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  6%] Built target agent_metadata
[  7%] Built target inventorySync_schema_input_target
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[  8%] Built target keystore
[  9%] Built target schema_validator
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 11%] Built target dbsync
[ 13%] Built target flatbuffers
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 14%] Built target packageTranslation_schema_vd_target
[ 15%] Built target cve5_schema_vd_target
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 16%] Built target vulnerabilityCandidate_schema_vd_target
[ 16%] Built target vulnerabilityDescription_schema_vd_target
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 17%] Built target vulnerabilityRemediations_schema_vd_target
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 17%] Built target compile_schemas_input
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 20%] Built target base
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 21%] Built target fimebpf
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 22%] Built target scan_orchestrator
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 23%] Built target wazuh-keystore
[ 24%] Built target users
[ 25%] Built target indexer_connector
[ 25%] Built target wazuh-keystore-testtool
[ 26%] Built target dbsync_example
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 27%] Built target rocks_db_query_testtool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 28%] Built target compile_schemas_vd
[ 28%] Built target dbsync_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 28%] Built target flatbuffer_tool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 29%] Built target indexer_connector_tool
[ 30%] Built target router
[ 33%] Built target fimdb
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 34%] Built target yml
[ 34%] Built target kvdbstore_kvdb
[ 35%] Built target bk_rx
[ 35%] Built target queue
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 38%] Built target eMessages
[ 38%] Built target defs
[ 40%] Built target content_manager
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 41%] Built target store_fileDriver
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 42%] Built target store
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 43%] Built target conf
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 46%] Built target sysinfo
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 48%] Built target router_router
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 49%] Built target scheduler_scheduler
[ 50%] Built target archiver_archive
[ 51%] Built target udgramsrv
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 51%] Built target wIndexerConnector_wIndexerConnector
[ 53%] Built target geo
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 53%] Built target cmsync_cmsync
[ 54%] Built target bk_taskf
[ 54%] Built target content_manager_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 54%] Built target cmcrud_cmcrud
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 56%] Built target cmstore_cmstore
[ 57%] Built target router_test_tool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 59%] Built target agent_sync_protocol
[ 65%] Built target hlp
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 65%] Built target fimdb_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 66%] Built target sysinfo_test_tool
[ 66%] Built target database_feed
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 67%] Built target streamlogger_streamlogger
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 67%] Built target httpsrv
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 67%] Built target AGENT_INFO_IMPL
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 67%] Built target sync_protocol_test_tool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 68%] Built target logpar
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 70%] Built target schemf
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 71%] Built target syscollector
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 72%] Built target api_geo
[ 72%] Built target api_router
[ 73%] Built target vulnerability_scanner
[ 73%] Built target api_event
[ 76%] Built target SCAImpl
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 77%] Built target api_archiver
[ 78%] Built target api_cmcrud
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 79%] Built target agent_info
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 80%] Built target syscollector_test_tool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 86%] Built target syscheckd_lib
[ 87%] Built target vd_scanner_testtool
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 88%] Built target sca
[ 89%] Built target api_tester
[ 89%] Built target inventory_sync
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 90%] Built target wazuh-syscheckd
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 91%] Built target inventory_sync_testtool
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[ 99%] Built target builder
make[4]: Entering directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[4]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
[100%] Built target wazuh-engine
make[3]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[2]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src/build'
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'
make wazuh-execd - wazuh-logcollector - wazuh-remoted utils active-responses wazuh-monitord wazuh-authd wazuh-modulesd wazuh-db
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'
make[1]: 'wazuh-execd' is up to date.
make[1]: 'wazuh-logcollector' is up to date.
make[1]: 'wazuh-remoted' is up to date.
make[1]: Nothing to be done for 'utils'.
make[1]: Nothing to be done for 'active-responses'.
make[1]: 'wazuh-monitord' is up to date.
make[1]: 'wazuh-authd' is up to date.
make[1]: 'wazuh-modulesd' is up to date.
make[1]: 'wazuh-db' is up to date.
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'
make settings
make[1]: Entering directory '/workspaces/devcontainer-5x/wazuh/src'

General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:1a98c1aa40df0fe82136d790043c2f9cbf1a24c4
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -I./data_provider/include/ -I./shared_modules/ -I./shared_modules/agent_metadata/include -I./shared_modules/common/ -I./shared_modules/content_manager/include -I./shared_modules/router/include -I./shared_modules/sync_protocol/include -I./syscheckd/include -I./wazuh_modules/syscollector/include -I./wazuh_modules/vulnerability_scanner/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lbuild/lib 
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/devcontainer-5x/wazuh/src'

Done building server

Wait for success...
success
mkdir -p /var/ossec/framework/python
cp external/cpython.tar.gz /var/ossec/framework/python/cpython.tar.gz && tar -xf /var/ossec/framework/python/cpython.tar.gz -C /var/ossec/framework/python && rm -rf /var/ossec/framework/python/cpython.tar.gz
find /var/ossec/framework/python -name "*libpython3.10.so.1.0" -exec ln -f {} /var/ossec/lib/libpython3.10.so.1.0 \;
cd ../framework && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /workspaces/devcontainer-5x/wazuh/framework
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-5.0.0-py3-none-any.whl size=277206 sha256=674914e73a741a06fc3e48fa4828dcff20dd507660e15e53494ef1e64084156a
  Stored in directory: /tmp/pip-ephem-wheel-cache-qs75a565/wheels/85/75/ec/4d0eec4411f2b7ca4277bd781d87d9b30c7c3aa7995aee19bb
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.3.2 -> 25.3
[notice] To update, run: /var/ossec/framework/python/bin/python3 -m pip install --upgrade pip
chown -R root:wazuh /var/ossec/framework/python
chmod -R o=- /var/ossec/framework/python
cd ../api && /var/ossec/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/ossec/framework/python && rm -rf build/
Processing /workspaces/devcontainer-5x/wazuh/api
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-5.0.0-py3-none-any.whl size=108595 sha256=11dcbfc373c842764ba551acdcd86d00517273f1f3ecb5192649c8af168cacac
  Stored in directory: /tmp/pip-ephem-wheel-cache-9n__h5fm/wheels/87/6f/81/1c016a817f32ddeee5a490ac6cc00ccfc27f05d0258366db23
Successfully built api
Installing collected packages: api
Successfully installed api-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.3.2 -> 25.3
[notice] To update, run: /var/ossec/framework/python/bin/python3 -m pip install --upgrade pip
Generating schema files...
Loading resources...
Loading WCS files from directory external/wcs-flat-files/...
Found 6 YAML files to merge: ['access-management-ecs-flat.yml', 'security-ecs-flat.yml', 'network-activity-ecs-flat.yml', 'other-ecs-flat.yml', 'applications-ecs-flat.yml', 'system-activity-ecs-flat.yml']
Loading access-management-ecs-flat.yml...
Loading applications-ecs-flat.yml...
Loading network-activity-ecs-flat.yml...
Loading other-ecs-flat.yml...
Loading security-ecs-flat.yml...
Loading system-activity-ecs-flat.yml...
Successfully merged 6 files into temporary file: /tmp/merged_wcs_01sdbrey.yml
Loading schema template...
Loading logpar overrides template...
Building field tree from WCS definition...
Success.
Generating engine schema...
Generating fields schema properties...
Success.
Generating clean properties mapping...
Success.
Generating logpar configuration...
Success.
Cleaned up temporary file: /tmp/merged_wcs_01sdbrey.yml
Saving files to "engine/ruleset/schemas/"...
Generated wazuh-decoders.json
Success.
Schema files generated successfully.
Copying store files...
Engine store installed successfully.
Engine output configuration files installed successfully.
Removing old SCA policies...
Installing SCA policies...
Installing additional SCA policies...
Generating self-signed certificate for wazuh-authd...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
server
2026/01/30 20:15:58 wazuh-modulesd: ERROR: File '/var/ossec/etc/certs/root-ca.pem' not found for 'indexer.ssl.certificate_authorities' in module 'indexer'. Check configuration
2026/01/30 20:15:58 wazuh-modulesd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-modulesd: Configuration error. Exiting

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


 - In order to connect agent and server, you need to add each agent to the server.

   More information at: 
   https://documentation.wazuh.com/

# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v5.0.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="server"
# find / -iname ossec-init.conf
#
```
</details> 

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Linux agent packages (RPM, DEB)
- Manager packages (RPM, DEB)
- Installation scripts: `upgrade.sh`, `wazuh.sh` 

### Configuration Changes

- N/A

### Tests Introduced

- N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
