### PR TITLE
Update the index and alias names on wazuh-engine

### DIFF
--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -21,8 +21,7 @@ namespace
 /**
  * @brief List of policy resource aliases in the indexer
  */
-const std::vector<std::string> POLICY_ALIASES = {
-    ".cti-kvdbs", ".cti-decoders", ".cti-integration-decoders", ".cti-policies"};
+const std::vector<std::string> POLICY_ALIASES = {".cti-kvdbs", ".cti-decoders", ".cti-integrations", ".cti-policies"};
 
 constexpr std::string_view PIT_KEEP_ALIVE {"5m"};          ///< Keep alive duration for Point In Time
 constexpr std::string_view POLICY_INDEX {".cti-policies"}; ///< Policy index name
@@ -42,10 +41,10 @@ IndexResourceType fromIndexName(std::string_view indexName)
 {
     // Static regex patterns compiled once
     static const std::array<std::pair<std::regex, IndexResourceType>, 4> patterns = {
-        {{std::regex(R"(.*-kvdb$)"), IndexResourceType::KVDB},
-         {std::regex(R"(.*-decoder$)"), IndexResourceType::DECODER},
-         {std::regex(R"(.*-integration$)"), IndexResourceType::INTEGRATION_DECODER},
-         {std::regex(R"(.*-policy$)"), IndexResourceType::POLICY}}};
+        {{std::regex(R"(.*-kvdbs$)"), IndexResourceType::KVDB},
+         {std::regex(R"(.*-decoders$)"), IndexResourceType::DECODER},
+         {std::regex(R"(.*-integrations$)"), IndexResourceType::INTEGRATION_DECODER},
+         {std::regex(R"(.*-policies$)"), IndexResourceType::POLICY}}};
 
     for (const auto& [pattern, resourceType] : patterns)
     {
@@ -357,7 +356,7 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
     }
 
     // Enrich policy with origin_space if not present
-    if(policyMap.policy.isObject() && policyMap.policy.size() > 0)
+    if (policyMap.policy.isObject() && policyMap.policy.size() > 0)
     {
         policyMap.policy.setString(space, "/origin_space");
     }


### PR DESCRIPTION
## Description

Closes #34278


## Proposed Changes

Update index names

### Results and Evidence

```
2026/02/01 20:57:30 wazuh-analysisd[35224] cmsync.cpp:482 at synchronize(): DEBUG: [CM::Sync] Checking for namespace updates to synchronize
2026/02/01 20:57:30 wazuh-analysisd[35224] cmsync.cpp:492 at synchronize(): DEBUG: [CM::Sync] Synchronizing namespace for space 'standard'
2026/02/01 20:57:30 wazuh-analysisd[35224] cmsync.cpp:527 at synchronize(): INFO: [CM::Sync] Changes detected for space 'standard', updating...
2026/02/01 20:57:35 wazuh-analysisd[35224] channel.cpp:702 at createWriter(): DEBUG: Created ChannelWriter for channel 'alerts'. Active writers: 3
2026/02/01 20:57:35 wazuh-analysisd[35224] channel.cpp:719 at onWriterDestroyed(): DEBUG: ChannelWriter destroyed for channel 'alerts'. Active writers: 2
2026/02/01 20:57:39 wazuh-analysisd[35224] channel.cpp:702 at createWriter(): DEBUG: Created ChannelWriter for channel 'alerts'. Active writers: 3
2026/02/01 20:57:40 wazuh-analysisd[35224] channel.cpp:719 at onWriterDestroyed(): DEBUG: ChannelWriter destroyed for channel 'alerts'. Active writers: 2
2026/02/01 20:57:40 wazuh-analysisd[35224] fileDriver.cpp:130 at updateDoc(): DEBUG: FileDriver updateDoc name: 'router/router/0'.
2026/02/01 20:57:40 wazuh-analysisd[35224] orchestrator.cpp:449 at hotSwapNamespace(): INFO: [Router::hotSwapSpace] Hot swapped namespace for entry 'cmsync_standard' to 'cmsync_standard_bcc8'
2026/02/01 20:57:40 wazuh-analysisd[35224] fileDriver.cpp:130 at updateDoc(): DEBUG: FileDriver updateDoc name: 'cmsync/status/0'.
2026/02/01 20:57:40 wazuh-analysisd[35224] cmsync.cpp:587 at synchronize(): INFO: [CM::Sync] Successfully synchronized space 'standard'
2026/02/01 20:57:40 wazuh-analysisd[35224] cmsync.cpp:492 at synchronize(): DEBUG: [CM::Sync] Synchronizing namespace for space 'custom'
2026/02/01 20:57:40 wazuh-analysisd[35224] cmsync.cpp:496 at synchronize(): DEBUG: [CM::Sync] Space 'custom' does not exist in remote indexer, skipping synchronization
2026/02/01 20:57:40 wazuh-analysisd[35224] cmsync.cpp:596 at synchronize(): DEBUG: [CM::Sync] Finished synchronization of spaces
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
