### PR TITLE
Fix syscheckd RPATH configuration for macOS (arm64) compatibility

### DIFF
--- a/src/syscheckd/CMakeLists.txt
+++ b/src/syscheckd/CMakeLists.txt
@@ -166,5 +166,15 @@ elseif(NOT UNIT_TEST)
     LINKER_LANGUAGE CXX
     RUNTIME_OUTPUT_DIRECTORY ${SRC_FOLDER})
   target_link_libraries(wazuh-syscheckd PRIVATE syscheckd_lib)
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+
+  if(APPLE)
+    # macOS
+    set_target_properties(wazuh-syscheckd PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_RPATH "@executable_path/../lib"
+    )
+  else()
+    # Linux/Unix
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+  endif()
 endif()


### PR DESCRIPTION
## Description

This PR fixes the problem identified with the package build in macos for 5.0.0 as described in 
https://github.com/wazuh/wazuh/issues/34301.

The problem arose due to the following configuration inside src/syscheckd/CMakeLists.txt which did not differentiate MacOS from Linux, it was introduced in a recent commit https://github.com/wazuh/wazuh/commit/ad03c770cb92e4c088342d721f9c87bc1fa60c84 which explains this bug only appearing on main branch.
```cmake
# Only build Linux executable when not running unit tests
elseif(NOT UNIT_TEST)
  add_executable(wazuh-syscheckd "${CMAKE_CURRENT_SOURCE_DIR}/src/main.c")
  set_target_properties(wazuh-syscheckd PROPERTIES
    LINKER_LANGUAGE CXX
    RUNTIME_OUTPUT_DIRECTORY ${SRC_FOLDER})
  target_link_libraries(wazuh-syscheckd PRIVATE syscheckd_lib)
  string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
endif()
```

Closes #34301 

## Proposed Changes

Cmake file was changed in order to differentiate between linux and macos builds:
```cmake
elseif(NOT UNIT_TEST)
  add_executable(wazuh-syscheckd "${CMAKE_CURRENT_SOURCE_DIR}/src/main.c")
  set_target_properties(wazuh-syscheckd PROPERTIES
    LINKER_LANGUAGE CXX
    RUNTIME_OUTPUT_DIRECTORY ${SRC_FOLDER})
  target_link_libraries(wazuh-syscheckd PRIVATE syscheckd_lib)

  if(APPLE)
    # macOS:
    set_target_properties(wazuh-syscheckd PROPERTIES
        BUILD_WITH_INSTALL_RPATH TRUE
        INSTALL_RPATH "@executable_path/../lib"
    )
  else()
    # Linux/Unix
    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
  endif()
endif()
```

### Results and Evidence

The problem was tested on a Macos arm64 machine with a notarized package, it was also tested with a non notarized version, failling the same way in both builds, after building the package with the PR changes: https://github.com/wazuh/wazuh/actions/runs/21621929158

It was tested on the same machine with the following output
```sh
sh-3.2# echo WAZUH_MANAGER="10.0.0.2" > /tmp/wazuh_envs
sh-3.2# sudo installer -pkg wazuh-agent_5.0.0-1_arm64_6c0a9d9.pkg -target /
installer: Package name is wazuh-agent_5.0.0-1_arm64_6c0a9d9
installer: Installing at base path /
installer: The install was successful.
sh-3.2# sudo /Library/Ossec/bin/wazuh-control start
2026/02/03 00:05:25 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
2026/02/03 00:05:28 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [x] MAC OS X
- [ ] Log syntax and correct language review

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

5.0.0 MacOS arm64 Package

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
