### PR TITLE
Added unit test for OS_MD5_File null path robustness

### DIFF
--- a/src/unit_tests/os_crypto/md5/test_md5_op.c
+++ b/src/unit_tests/os_crypto/md5/test_md5_op.c
@@ -76,11 +76,28 @@ void test_md5_file_fail(void **state) {
     assert_int_equal(OS_MD5_File(path, buffer, OS_TEXT), -1);
 }
 
+void test_OS_MD5_File_null_path(void **state) {
+    os_md5 output;
+
+    memset(output, '1', sizeof(output));
+
+    const char *volatile null_path = NULL;
+
+    int ret = OS_MD5_File(null_path, output, OS_BINARY);
+
+    assert_int_equal(ret, -1);
+
+    char expected[sizeof(output)];
+    memset(expected, 0, sizeof(expected));
+    assert_memory_equal(output, expected, sizeof(output));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_md5_string),
         cmocka_unit_test_setup_teardown(test_md5_file, setup_group, teardown_group),
-        cmocka_unit_test_setup_teardown(test_md5_file_fail, setup_group, teardown_group)
+        cmocka_unit_test_setup_teardown(test_md5_file_fail, setup_group, teardown_group),
+        cmocka_unit_test(test_OS_MD5_File_null_path)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Description

This pull request improves the test coverage for the os_crypto library, specifically targeting the MD5 operations. It introduces a new unit test for the function `OS_MD5_File` to verify its robustness and error handling capabilities.

The new test ensures that the function handles NULL arguments gracefully by validating runtime safety mechanisms, mirroring similar tests already present in SHA1 and SHA256 implementations (see PR #34170).

Closes task 11 Issue [4007](https://github.com/wazuh/internal-devel-requests/issues/4007)

## Proposed Changes

- Added a new unit test case: `test_OS_MD5_File_null_path` in `src/unit_tests/os_crypto/md5/test_md5_op.c`.
- Registered the new test in the main execution array of the MD5 test suite.
- The test validates that:
  1. Passing a NULL pointer as the file path argument results in a controlled error return code (-1) instead of a crash.
  2. The output buffer is properly initialized to 0 by the function's internal `memset`, even when the file path is NULL.

## Results and Evidence

Local compilation test output:
```plaintext
[==========] tests: Running 4 test(s).
[ RUN      ] test_md5_string
[       OK ] test_md5_string
[ RUN      ] test_md5_file
[       OK ] test_md5_file
[ RUN      ] test_md5_file_fail
[       OK ] test_md5_file_fail
[ RUN      ] test_OS_MD5_File_null_path
/home/dario/wazuh/src/unit_tests/os_crypto/md5/test_md5_op.c:87:15: runtime error: null pointer passed as argument 1, which is declared to never be null
[       OK ] test_OS_MD5_File_null_path
[==========] tests: 4 test(s) run.
[  PASSED  ] 4 test(s).
```

**Note:** The runtime error warning from UBSan is expected behavior (same as PR #34170 for SHA256). The test passes successfully and validates that the function does not crash and properly initializes the output buffer.

### Manual tests with their corresponding evidence

**Compilation without warnings on every supported platform**

- [x] Linux
- [ ] Windows (CI will validate)
- [ ] MAC OS X (CI will validate)
- [x] Log syntax and correct language review

**Memory tests for Linux**

- [ ] Coverity (CI will validate)
- [ ] Valgrind (memcheck and descriptor leaks check) (CI will validate)
- [ ] AddressSanitizer (CI will validate)

**Memory tests for Windows**

- [ ] Coverity (CI will validate)
- [ ] UMDH (CI will validate)

**Memory tests for macOS**

- [ ] Leaks (CI will validate)
- [ ] AddressSanitizer (CI will validate)

**Decoder/Rule tests (Wazuh v4.x)**

- [ ] Added unit testing files ".ini"
- [ ] runtests.py executed without errors

**Engine (Wazuh v5.x and above)**

- [ ] Test run in parallel (CI will validate)
- [ ] ASAN for test (utest/ctest) (CI will validate)
- [ ] TSAN for test and wazuh-engine. (CI will validate)

**Wazuh server API/Framework**

- [ ] Run API Integration Tests

## Artifacts Affected

- `src/unit_tests/os_crypto/md5/test_md5_op.c`
- Unit Test Binary: `test_md5_op`

## Configuration Changes

None

## Tests Introduced

**Unit Test:** `test_OS_MD5_File_null_path`

- **Scope:** Validates input sanitization for OS_MD5_File.
- **Coverage:** Adds a negative test case to the MD5 suite to ensure the agent does not crash upon receiving invalid internal arguments and that the output buffer is properly initialized.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

---

**Implementation Note:** This PR follows the exact pattern approved in PR #34170 for SHA256 unit tests.