### PR TITLE
Add lock to delete by query map object 

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -696,6 +696,7 @@ public:
 
     void deleteByQuery(const std::string& index, const std::string& agentId)
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
         auto [it, success] = m_deleteByQuery.try_emplace(index, nlohmann::json::object());
         it->second["query"]["bool"]["filter"]["terms"]["agent.id"].push_back(agentId);
     }


### PR DESCRIPTION
## Description

It was found a crash in the indexer connector library, specifically in the delete by query logic close to the end of the synchronization with the agents.

This was reproduced adding 75 docker containers as agents. 

### Proposed Changes

- Add exclusion to `m_deleteByQuery` map member object. 

### Root cause analysis 

https://github.com/wazuh/wazuh/issues/34150#issuecomment-3841566129

```console
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
--Type <RET> for more, q to quit, c to continue without paging--
Core was generated by `/var/ossec/bin/wazuh-modulesd'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007e87e1cc7913 in std::_Rb_tree_increment(std::_Rb_tree_node_base*) () from /var/ossec/bin/../lib/libstdc++.so.6
[Current thread is 1 (Thread 0x7e87c3ff96c0 (LWP 286959))]
(gdb) bt
#0  0x00007e87e1cc7913 in std::_Rb_tree_increment(std::_Rb_tree_node_base*) () from /var/ossec/bin/../lib/libstdc++.so.6
#1  0x00007e87e50b94ba in std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > > >::operator++ (
    this=<synthetic pointer>) at /build_wazuh/manager/wazuh-manager-5.0.0/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp:306
#2  IndexerConnectorSyncImpl<TServerSelector<HTTPRequest>, HTTPRequest, 10485760ul, 1ul, 20ul>::processBulk (this=0x7e87de268140)
    at /build_wazuh/manager/wazuh-manager-5.0.0/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp:306
#3  0x00007e87e50ba6fb in IndexerConnectorSyncImpl<TServerSelector<HTTPRequest>, HTTPRequest, 10485760ul, 1ul, 20ul>::IndexerConnectorSyncImpl(nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, std::function<void (int, char const*, char const*, int, char const*, char const*, __va_list_tag*)> const&, HTTPRequest*, std::unique_ptr<TServerSelector<HTTPRequest>, std::default_delete<TServerSelector<HTTPRequest> > >)::{lambda()#1}::operator()() const (__closure=0x7e87de24c7a8)
    at /build_wazuh/manager/wazuh-manager-5.0.0/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp:676
#4  0x00007e87e1cde230 in ?? () from /var/ossec/bin/../lib/libstdc++.so.6
#5  0x00007e87e629caa4 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:447
#6  0x00007e87e6329c6c in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

### Manual tests with their corresponding evidence

Wazuh modulesd is running 

```console
root@noble:/home/vagrant/INDEXER#  date && tail -n 5 /var/ossec/logs/ossec.log
Wed Feb  4 11:20:40 AM -03 2026
2026/02/04 11:15:27 wazuh-analysisd: INFO: [CM::Sync] Changes detected for space 'standard', updating...
2026/02/04 11:15:27 wazuh-analysisd: WARNING: [CMSync::downloadNamespace('standard')] Attempt 1/3: Failed to create PIT. Error: Client error, Status code: 404, Response: {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"}],"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"},"status":404}
2026/02/04 11:15:32 wazuh-analysisd: WARNING: [CMSync::downloadNamespace('standard')] Attempt 2/3: Failed to create PIT. Error: Client error, Status code: 404, Response: {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"}],"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"},"status":404}
2026/02/04 11:15:37 wazuh-analysisd: WARNING: [CMSync::downloadNamespace('standard')] Attempt 3/3: Failed to create PIT. Error: Client error, Status code: 404, Response: {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"}],"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"},"status":404}
2026/02/04 11:15:37 wazuh-analysisd: WARNING: [CM::Sync] Failed to synchronize namespace for space 'standard': Failed to create PIT. Error: Client error, Status code: 404, Response: {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"}],"type":"index_not_found_exception","reason":"no such index [.cti-integration-decoders]","index":".cti-integration-decoders","resource.id":".cti-integration-decoders","resource.type":"index_or_alias","index_uuid":"_na_"},"status":404}
root@noble:/home/vagrant/INDEXER#  date && ps -aux | grep wazuh-modules | wc -l
Wed Feb  4 11:20:52 AM -03 2026
77
```

No crashes found 

<img width="1108" height="99" alt="image" src="https://github.com/user-attachments/assets/9c74ab36-aead-4ee8-b473-77813ae51aaa" />

Full logs

[logs.tar.gz](https://github.com/user-attachments/files/25074461/logs.tar.gz)

The delete by query error found before is not present in this log file 

```console
2026/02/03 10:55:29 IndexerConnector: ERROR: deleteByQuery error: Client error, status code: 400.
2026/02/03 10:55:29 IndexerConnector: ERROR: Error processing bulk: Client error
```

