### PR TITLE
Fix Windows Agent startup race

### DIFF
--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -182,6 +182,16 @@ int local_start()
         merror_exit("Error creating mutex.");
     }
 
+    /* Set wait lock before starting threads */
+    os_setwait();
+
+    /* Initialize buffer before starting threads that may use it */
+    if (agt->buffer) {
+        buffer_init();
+    } else {
+        minfo(DISABLED_BUFFER);
+    }
+
     /* Start syscheck thread */
     w_create_thread(NULL,
                      0,
@@ -257,9 +267,6 @@ int local_start()
         }
     }
 
-    /* Try to connect to server */
-    os_setwait();
-
     /* Socket connection */
     agt->sock = -1;
 
@@ -279,16 +286,13 @@ int local_start()
     }
 
     /* Launch dispatch thread */
-    if (agt->buffer){
-        buffer_init();
+    if (agt->buffer) {
         w_create_thread(NULL,
                          0,
                          dispatch_buffer,
                          NULL,
                          0,
                          (LPDWORD)&threadID);
-    } else {
-        minfo(DISABLED_BUFFER);
     }
 
     /* Configure and start statistics */


### PR DESCRIPTION
## Description

This PR addresses a Windows agent startup crash caused by a race condition introduced by the current initialization order. 

```
Faulting application name: wazuh-agent.exe, version: 4.14.3.0, time stamp: 0x6984c8d1
Faulting module name: wazuh-agent.exe, version: 4.14.3.0, time stamp: 0x6984c8d1
Exception code: 0xc0000005
Fault offset: 0x000103fb
Faulting process id: 0x9F78
Faulting application start time: 0x1DC96BEE3FD208C
Faulting application path: C:\Program Files (x86)\ossec-agent\wazuh-agent.exe
Faulting module path: C:\Program Files (x86)\ossec-agent\wazuh-agent.exe
```

Some module threads can attempt to enqueue messages (via the agent buffer) before the send-block is enabled and before the buffer is initialized, which can lead to a NULL-pointer dereference in `buffer_append()` during early startup.

By moving the send-blocking initialization and the buffer initialization earlier in the Windows startup sequence—before any module threads are created—we remove the time window where modules can enqueue data against an uninitialized buffer, preventing the crash and making the startup flow consistent with the intended behavior (modules should not send/enqueue messages until the agent is ready/connected).

## Proposed Changes

Reorder the Windows agent startup sequence to:
- Initialize send-blocking earlier.
- Initialize the agent buffer earlier.
- Start module threads only after both are ready.

### Results and Evidence

After applying the startup reordering, **no additional Windows agent crashes were observed**.

### Artifacts Affected

- `wazuh-agent.exe` (Windows)

### Configuration Changes

Not applicable.

### Documentation Updates

Not applicable.

### Tests Introduced

Manual testing performed.

> [!NOTE]
> During development a guard was added to detect attempts to append data while the buffer was `NULL`. This is not required as a “detection” mechanism since the original behavior manifests as a crash, and the previous reproduction method no longer triggers the issue due to the reordered initialization calls.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues