### PR TITLE
Update DEB i386, amd64, RPM i386, amd64 libsca.so expected size

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -19,7 +19,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2599704,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,710864,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,705616,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,800872,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,345184,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,9744,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,183248,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -19,7 +19,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2123404,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,822776,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,734000,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,836900,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,402688,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,8816,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,118632,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -83,7 +83,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2530376,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,686912,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,693392,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,783864,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,340200,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14472,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,187064,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -83,7 +83,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,1984136,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,751124,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,701200,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,795908,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,416056,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,8768,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,111408,0.1


### PR DESCRIPTION
## Description

The package workflows were failing during the file integrity check because the expected size for `libsca.so` did not match the generated packages for several platforms. This pull request updates the expected file sizes so that the checkfiles tests pass for DEB i386, RPM AMD64, and RPM i386 builds.

## Proposed Changes

- Update the expected size of `libsca.so` for DEB i386, RPM AMD64, and RPM i386 agent packages in the checkfiles verification logic.
- Keep the rest of the file integrity expectations unchanged to avoid impacting other platforms or package types.

### Results and Evidence

- Package workflows completed successfully:
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/21745826326|
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/21745821343
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/21745801762
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/21745791366

### Artifacts Affected

- DEB i386 agent packages.
- RPM AMD64 agent packages.
- RPM i386 agent packages.
  - Checkfiles test for `libsca.so`.

### Configuration Changes

- No configuration changes introduced.

### Documentation Updates

- Not applicable.

### Tests Introduced

- No new tests added.
- Existing checkfiles tests for DEB i386, RPM AMD64, and RPM i386 now pass with the corrected expected sizes: TODO

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues