### PR TITLE
Add  Engine EndPoint Post

### DIFF
--- a/docs/ref/modules/engine/spec-events.yaml
+++ b/docs/ref/modules/engine/spec-events.yaml
@@ -76,3 +76,73 @@ paths:
               examples:
                 orchestratorUnavailable:
                   value: {"error":"Internal server error","code":500}
+  /events/local:
+    post:
+      tags:
+        - Events
+      summary: Ingest manager-generated local events
+      description: |
+        Accepts events from local manager modules.
+        The engine parses them and pushes them to the orchestrator queue.
+        Socket path: /var/ossec/queue/sockets/queue-http.sock
+      requestBody:
+        required: true
+        content:
+          application/x-ndjson:
+            schema:
+              type: string
+              description: |
+                H/E protocol: first line is "H {json}", followed by one or more
+                "E queue:location:message" lines.
+            examples:
+              singleAgentEvent:
+                summary: Agent lifecycle event
+                value: |-
+                  H {"agent":{"id":"001","name":"tomas2"}}
+                  E w:wazuh-remoted:{"event":{"collector":"manager","action":"agent-added"}}
+              multipleEvents:
+                summary: Multiple manager events
+                value: |-
+                  H {"agent":{"id":"001","name":"tomas2"}}
+                  E w:wazuh-remoted:{"event":{"collector":"manager","action":"agent-added"}}
+                  E w:wazuh-monitord:{"event":{"collector":"manager","action":"manager-started"}}
+              managerLifecycle:
+                summary: Manager lifecycle event (no agent context)
+                value: |-
+                  H {}
+                  E w:wazuh-remoted:{"event":{"collector":"manager","action":"manager-started"}}
+      responses:
+        "200":
+          description: Events accepted and enqueued. (Empty body)
+        "400":
+          description: Invalid payload (malformed H/E protocol or invalid JSON).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: integer
+                required: [error, code]
+              examples:
+                invalidHeader:
+                  value: {"error":"NDJson parser error, ...","code":400}
+                missingHeader:
+                  value: {"error":"NDJson parser error, unexpected line outside of an event","code":400}
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: integer
+                required: [error, code]
+              examples:
+                orchestratorUnavailable:
+                  value: {"error":"Internal server error","code":500}

--- a/src/engine/source/api/event/include/api/event/ndJsonParser.hpp
+++ b/src/engine/source/api/event/include/api/event/ndJsonParser.hpp
@@ -56,6 +56,10 @@ inline ProtocolHandler getNDJsonParser()
             };
 
             // ---- Single header at the start: "H {json}" (assumed valid) ----
+            if (lines.empty())
+            {
+                throw std::runtime_error {"empty batch"};
+            }
             // We assume there's always JSON after "H "; no length checks here.
             json::Json header(lines.front().substr(2).data());
 

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -663,6 +663,10 @@ int main(int argc, char* argv[])
                 httpsrv::Method::POST,
                 "/events/enriched", // TODO: Double check route
                 api::event::handlers::pushEvent(orchestrator, api::event::protocol::getNDJsonParser(), archiver));
+            engineRemoteServer->addRoute(
+                httpsrv::Method::POST,
+                "/events/local",
+                api::event::handlers::pushEvent(orchestrator, api::event::protocol::getNDJsonParser(), archiver));
 
             // starting in a new thread
             engineRemoteServer->start(confManager.get<std::string>(conf::key::SERVER_ENRICHED_EVENTS_SOCKET));

--- a/src/engine/test/integration_tests/events_local/environment.py
+++ b/src/engine/test/integration_tests/events_local/environment.py
@@ -1,0 +1,15 @@
+import os
+from engine_handler.handler import EngineHandler
+
+engine_handler = EngineHandler(
+    os.getenv('BINARY_DIR', ""), os.getenv('CONF_FILE', ""))
+
+
+def before_all(context):
+    context.shared_data = {}
+    engine_handler.start()
+    context.shared_data['engine_instance'] = engine_handler
+
+
+def after_all(context):
+    engine_handler.stop()

--- a/src/engine/test/integration_tests/events_local/features/events_local.feature
+++ b/src/engine/test/integration_tests/events_local/features/events_local.feature
@@ -1,0 +1,21 @@
+Feature: Local Events Endpoint
+
+  Scenario: Single manager event accepted
+    When I send a local event with header and one event
+    Then the response status should be 200
+
+  Scenario: Multiple manager events accepted
+    When I send a local event with header and two events
+    Then the response status should be 200
+
+  Scenario: Malformed body rejected
+    When I send a local event with invalid body
+    Then the response status should be 400
+
+  Scenario: Missing header rejected
+    When I send a local event without header line
+    Then the response status should be 400
+
+  Scenario: Empty body rejected
+    When I send a local event with empty body
+    Then the response status should be 400

--- a/src/engine/test/integration_tests/events_local/steps/events_local_steps.py
+++ b/src/engine/test/integration_tests/events_local/steps/events_local_steps.py
@@ -1,0 +1,72 @@
+import os
+
+import httpx
+from behave import when, then
+
+ENV_DIR = os.environ.get("ENV_DIR", "")
+EVENTS_SOCKET = ENV_DIR + "/queue/sockets/queue-http.sock"
+
+
+def post_local_event(body: str):
+    transport = httpx.HTTPTransport(uds=EVENTS_SOCKET)
+    with httpx.Client(transport=transport) as client:
+        response = client.post(
+            "http://localhost/events/local",
+            content=body,
+            headers={"Content-Type": "application/x-wev1"},
+        )
+    return response.status_code, response.text
+
+
+@when("I send a local event with header and one event")
+def step_send_single(context):
+    body = (
+        "H {\"agent\":{\"id\":\"001\",\"name\":\"tomas2\"}}\n"
+        "E w:wazuh-remoted:{\"event\":{\"collector\":\"manager\",\"action\":\"agent-added\"}}"
+    )
+    status, resp_body = post_local_event(body)
+    context.shared_data["status"] = status
+    context.shared_data["body"] = resp_body
+
+
+@when("I send a local event with header and two events")
+def step_send_multiple(context):
+    body = (
+        "H {\"agent\":{\"id\":\"001\",\"name\":\"tomas2\"}}\n"
+        "E w:wazuh-remoted:{\"event\":{\"collector\":\"manager\",\"action\":\"agent-added\"}}\n"
+        "E w:wazuh-monitord:{\"event\":{\"collector\":\"manager\",\"action\":\"manager-started\"}}"
+    )
+    status, resp_body = post_local_event(body)
+    context.shared_data["status"] = status
+    context.shared_data["body"] = resp_body
+
+
+@when("I send a local event with invalid body")
+def step_send_invalid(context):
+    body = "H {invalid\nE w:wazuh-remoted:{\"event\":{\"collector\":\"manager\"}}"
+    status, resp_body = post_local_event(body)
+    context.shared_data["status"] = status
+    context.shared_data["body"] = resp_body
+
+
+@when("I send a local event without header line")
+def step_send_no_header(context):
+    body = "E w:wazuh-remoted:{\"event\":{\"collector\":\"manager\"}}"
+    status, resp_body = post_local_event(body)
+    context.shared_data["status"] = status
+    context.shared_data["body"] = resp_body
+
+
+@when("I send a local event with empty body")
+def step_send_empty(context):
+    status, resp_body = post_local_event("")
+    context.shared_data["status"] = status
+    context.shared_data["body"] = resp_body
+
+
+@then("the response status should be {expected_status:d}")
+def step_check_status(context, expected_status):
+    assert context.shared_data["status"] == expected_status, (
+        f"Expected {expected_status}, got {context.shared_data['status']}. "
+        f"Body: {context.shared_data['body']}"
+    )


### PR DESCRIPTION
## Description

New `POST /events/local` endpoint for the engine to receive events generated by internal manager modules (remoted, monitord, apid, VD, etc.).

Uses the same H/E NDJSON protocol and parser as `/events/enriched`. Events are enqueued directly into the orchestrator without enrichment. Registered on the same HTTP server and socket (`queue-http.sock`).

## Proposed Changes

### Endpoint registration
- Added `POST /events/local` route on `engineRemoteServer`, reusing `pushEvent` handler and `getNDJsonParser()`.

### Unit tests
- **`src/engine/source/api/event/test/src/unit/handlers_test.cpp`** — Added 2 test cases for `pushEvent` with real H/E payloads: single manager event and multiple manager events using `getNDJsonParser()`.
- **`src/engine/source/api/event/test/src/unit/ndJsonParser_test.cpp`** — Added `HDR_LOCAL`, `EV_LOCAL1`, `EV_LOCAL2` constants and 4 test cases: 2 success (single/multiple local events) and 2 failure (empty body, empty queue byte).


### Integration tests
- Behave environment setup using `EngineHandler`.
- 5 scenarios: single event (200), multiple events (200), malformed body (400), missing header (400), empty body (400).
- Step definitions using `httpx` with Unix socket transport against `queue-http.sock`.

### Documentation
- Added OpenAPI 3.0.3 definition for `POST /events/local` with request schema, 3 examples, and 200/400/500 response definitions.


## Results and Evidence

### Build & Install

```bash

General settings:
    TARGET:             server
    V:                  
    DEBUG:              
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:1a98c1aa40df0fe82136d790043c2f9cbf1a24c4
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          yes
    DISABLE_SYSC:       no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT
Compiler:
    CFLAGS            -pthread -Iexternal/pacman/lib/libalpm/ -Iexternal/libarchive/libarchive -Iexternal/audit-userspace/lib -g -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_AUDIT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -I./data_provider/include/ -I./shared_modules/ -I./shared_modules/agent_metadata/include -I./shared_modules/common/ -I./shared_modules/content_manager/include -I./shared_modules/router/include -I./shared_modules/sync_protocol/include -I./syscheckd/include -I./wazuh_modules/syscollector/include -I./wazuh_modules/vulnerability_scanner/include 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lbuild/lib 
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building server

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/33607-EndPoint-event-local› 
╰─# service wazuh-manager status
wazuh-clusterd is running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...

```

### Unit Test

<p align="center">
  <img src="https://github.com/user-attachments/assets/0e292cf5-ecfe-4061-8e65-802486af7995"  width="466" height="885">
  <br>
  <em>
    Unit test part 1
  </em>
</p>


<p align="center">
  <img src="https://github.com/user-attachments/assets/bdcdae52-f6a5-48e6-9adf-d901c15d788f"  width="493" height="142">
  <br>
  <em>
    Unit test part 2
  </em>
</p>


