### PR TITLE
Unify date format in restart.sh active response

### DIFF
--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -33,7 +33,7 @@ cd ../../
 PWD=`pwd`
 
 # Logging the call
-echo "`date` $0 $1 $2 $3 $4 $5" >> ${PWD}/logs/active-responses.log
+echo "$(date '+%Y/%m/%d %H:%M:%S') $0 $1 $2 $3 $4 $5" >> ${PWD}/logs/active-responses.log
 
 # Rules and decoders test
 if [ "$TYPE" = "manager" ]; then


### PR DESCRIPTION
## Description

This pull request unifies the date format in active response logs to address an inconsistency: shell scripts used locale-dependent timestamps while C components used a fixed format, making log parsing difficult in multi-locale environments.

## Proposed Changes

Changed the date command in `src/active-response/restart.sh` to use a fixed format that matches the C code implementation:

**Before:**
```bash
echo "`date` $0 $1 $2 $3 $4 $5" >> ${PWD}/logs/active-responses.log
```

**After:**
```bash
echo "$(date '+%Y/%m/%d %H:%M:%S') $0 $1 $2 $3 $4 $5" >> ${PWD}/logs/active-responses.log
```

This aligns with the `w_get_timestamp()` function format used in C components.

### Results and Evidence

**Before fix:**
```
Thu Dec 18 11:45:59 UTC 2025 /var/ossec/active-response/bin/restart.sh manager restart
```

**After fix:**
```
2025/12/18 11:46:00 /var/ossec/active-response/bin/restart.sh manager restart
```

Both shell scripts and C components now use the unified format: `YYYY/MM/DD HH:MM:SS`

### Artifacts Affected

- **Shell script**: `src/active-response/restart.sh`
- **Log file**: `/var/ossec/logs/active-responses.log` (format only, no functional changes)

No executables, packages, or configuration files are affected.

### Configuration Changes

N/A

### Documentation Updates

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues