### PR TITLE
Remove manager-side agent logic and references from agent modules

### DIFF
--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -144,10 +144,14 @@ static int read_main_elements(const OS_XML *xml, int modules,
         }
         else if (strcmp(node[i]->element, osagent_info) == 0)
         {
+#ifdef CLIENT
             if ((modules & CWMODULE) && (Read_AGENT_INFO(xml, node[i], d1) < 0))
             {
                 goto fail;
             }
+#else
+            mdebug2("Agent-info module is not supported on manager. Ignoring configuration.");
+#endif
         }
         else if (strcmp(node[i]->element, osvulndetection) == 0)
         {

--- a/src/shared_modules/agent_metadata/include/metadata_provider.h
+++ b/src/shared_modules/agent_metadata/include/metadata_provider.h
@@ -25,7 +25,7 @@ extern "C" {
  */
 typedef struct
 {
-    char agent_id[256];           ///< Agent identifier (e.g., "001", "000" for server)
+    char agent_id[256];           ///< Agent identifier (e.g., "001")
     char agent_name[256];         ///< Agent name
     char agent_version[256];      ///< Wazuh agent version
     char architecture[256];       ///< System architecture (e.g., "x86_64")

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -461,13 +461,6 @@ int wm_agent_info_read(__attribute__((unused)) const OS_XML* xml, xml_node** nod
     agent_info->sync.sync_response_timeout = 30;
     agent_info->sync.sync_retries = 3;
     agent_info->sync.sync_max_eps = 50;
-#ifdef CLIENT
-    agent_info->is_agent = true;
-#else
-    agent_info->is_agent = false;
-    mdebug2("Agent-info module is not supported on manager. Ignoring configuration.");
-    return 0;
-#endif
 
     module->context = &WM_AGENT_INFO_CONTEXT;
     module->tag = strdup(module->context->name);

--- a/src/wazuh_modules/src/wm_agent_info.h
+++ b/src/wazuh_modules/src/wm_agent_info.h
@@ -31,7 +31,6 @@ typedef struct wm_agent_info_sync_flags_t
 
 typedef struct wm_agent_info_t
 {
-    bool is_agent;       // True if the module is running on an agent, false if on a manager
     int interval;        // Update interval in seconds (for delta updates)
     int integrity_interval; // Integrity check interval in seconds (for full metadata/groups verification), default 86400 (24h)
     wm_agent_info_sync_flags_t sync;


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Closes #34205

After the analysis on agent-side daemons, all references to agent ID `"000"` were confirmed to be either manager-only or only documentary. This PR removes the remaining agent-side references including the runtime `is_agent` flag pattern in `agent_info` and cleaning up a stale documentation reference.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- **`wm_agent_info.c`**: Replaced the runtime `is_agent` flag logic with compile-time `#ifndef CLIENT` guard to skip module configuration on manager builds. Wrapped the agentd handshake query block with `#ifdef CLIENT` to prevent compilation in manager context.
- **`wm_agent_info.h`**: Removed the `is_agent` field from `wm_agent_info_t`, as the compile-time guard makes it unnecessary.
- **`metadata_provider.h`**: Removed the `"000" for server` reference from the `agent_id` field documentation comment.

### Results and Evidence

- N/A

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->


### Artifacts Affected

- `wazuh-modulesd` module.

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
- N/A

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

- N/A. None of the documentation files found in `docs/ref/modules/agent_info` mention manager-side agent behavior, as this is used for internal logic only. There is no mention to a `000` agent id neither.

### Tests Introduced
- N/A

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->


## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
