### PR TITLE
Update embedded Python compilation with new installation path

### DIFF
--- a/framework/cpython/compile.sh
+++ b/framework/cpython/compile.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 WAZUH_HOST_DIR=/wazuh_host
 WAZUH_ROOT_DIR=/wazuh #Important: Do not change this path
-WAZUH_INSTALLDIR=/var/ossec
+WAZUH_INSTALLDIR=/var/wazuh-manager
 CPYTHON_DIR=$WAZUH_ROOT_DIR/src/external/cpython
 OUTPUT_DIR=/output
 

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -6,10 +6,6 @@ asgiref==3.7.2
 async-timeout==5.0.1
 asyncinotify==4.3.2
 attrs==23.1.0
-azure-core==1.38.0
-azure-storage-blob==12.20.0
-boto3==1.34.135
-botocore==1.34.135
 cachetools==4.1.0
 certifi==2024.7.4
 cffi==1.16.0


### PR DESCRIPTION
## Description

Closes #34512. This PR updates the installation path of the embedded Python during the compilation process.

## Proposed Changes

* Update installation patch to `/var/wazuh-server`
* Remove unnecessary requirements

### Results and Evidence

Workflow: https://github.com/wazuh/wazuh/actions/runs/21962782852/job/63444488248

<details><summary>Installation of the generated embedded</summary>
<p>

```console
[root@0e5b282ecdd6 wazuh]# echo "dbcf3ce679cfb48fdff7bb7dfb4feeff6628439bead6a7464427be266062d932 amd64-compiled.zip" | sha256sum --check
amd64-compiled.zip: OK
[root@0e5b282ecdd6 wazuh]# unzip amd64-compiled.zip
Archive:  amd64-compiled.zip
  inflating: cpython.tar.gz
[root@0e5b282ecdd6 wazuh]# cp cpython.tar.gz src/external/
cp: overwrite ‘src/external/cpython.tar.gz’? y
[root@0e5b282ecdd6 wazuh]# ./install.sh

  ** Para instalação em português, escolha [br].
  ** 要使用中文进行安装, 请选择 [cn].
  ** Für eine deutsche Installation, wählen Sie [de].
  ** Για εγκατάσταση στα Ελληνικά, επιλέξτε [el].
  ** For installation in English, choose [en].
  ** Para instalar en español, elija [es].
  ** Pour une installation en français, choisissez [fr]
  ** A Magyar nyelvű telepítéshez válassza [hu].
  ** Per l'installazione in Italiano, scegli [it].
  ** 日本語でインストールします．選択して下さい．[jp].
  ** Voor installatie in het Nederlands, kies [nl].
  ** Aby instalować w języku Polskim, wybierz [pl].
  ** Для инструкций по установке на русском ,введите [ru].
  ** Za instalaciju na srpskom, izaberi [sr].
  ** Türkçe kurulum için seçin [tr].
  (en/br/cn/de/el/es/fr/hu/it/jp/nl/pl/ru/sr/tr) [en]:
 Wazuh v5.0.0 (Rev. alpha0) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux 0e5b282ecdd6 6.17.9-76061709-generic (centos 7.9)
  - User: root
  - Host: 0e5b282ecdd6


  -- Press ENTER to continue or Ctrl-C to abort. --
...
Wait for success...
success
mkdir -p /var/wazuh-manager/framework/python
cp external/cpython.tar.gz /var/wazuh-manager/framework/python/cpython.tar.gz && tar -xf /var/wazuh-manager/framework/python/cpython.tar.gz -C /var/wazuh-manager/framework/python && rm -rf /var/wazuh-manager/framework/python/cpython.tar.gz
find /var/wazuh-manager/framework/python -name "*libpython3.12.so.1.0" -exec ln -f {} /var/wazuh-manager/lib/libpython3.12.so.1.0 \;
cd ../framework && /var/wazuh-manager/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/wazuh-manager/framework/python && rm -rf build/
Processing /wazuh/framework
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-5.0.0-py3-none-any.whl size=283368 sha256=32407d492975500f3332bbd16c50495c31c279c673d4f5a4c74490a34b95c0ed
  Stored in directory: /tmp/pip-ephem-wheel-cache-2wk0ug6n/wheels/e5/39/7e/fcd558134a5780c7c417ce211a38c6bcd1958e5337fba06438
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 25.3 -> 26.0.1
[notice] To update, run: /var/wazuh-manager/framework/python/bin/python3 -m pip install --upgrade pip
chown -R root:wazuh-manager /var/wazuh-manager/framework/python
chmod -R o=- /var/wazuh-manager/framework/python
cd ../api && /var/wazuh-manager/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/wazuh-manager/framework/python && rm -rf build/
Processing /wazuh/api
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-5.0.0-py3-none-any.whl size=115746 sha256=fc24457fde718c8533657685c4beddab31b83c1b7e6fe9bab60cc4f8d01993f8
  Stored in directory: /tmp/pip-ephem-wheel-cache-sv153gub/wheels/ec/7b/dc/647d6b142cd8de3ea07b95f12d0147f43a9522fd1c60f751c7
Successfully built api
Installing collected packages: api
Successfully installed api-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 25.3 -> 26.0.1
[notice] To update, run: /var/wazuh-manager/framework/python/bin/python3 -m pip install --upgrade pip
cd ../tools/mitre && /var/wazuh-manager/framework/python/bin/python3 mitredb.py -d /var/wazuh-manager/var/db/mitre.db
Generating schema files...
Loading resources...
...
Generating self-signed certificate for wazuh-manager-authd...


 - System is Redhat Linux.
 - Init script modified to start Wazuh during boot.

 - Configuration finished properly.

 - To start Wazuh:
      /var/wazuh-manager/bin/wazuh-control start

 - To stop Wazuh:
      /var/wazuh-manager/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/wazuh-manager/etc/wazuh-manager.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---


 - In order to connect agent and server, you need to add each agent to the server.

   More information at:
   https://documentation.wazuh.com/

[root@0e5b282ecdd6 wazuh]# ll /var/wazuh-manager/framework/python/
total 16
drwxr-x--- 2 root wazuh-manager 4096 Feb 12 20:26 bin
drwxr-x--- 3 root wazuh-manager 4096 Feb 12 20:26 include
drwxr-x--- 4 root wazuh-manager 4096 Feb 12 20:26 lib
drwxr-x--- 3 root wazuh-manager 4096 Feb 12 20:26 share

[root@0e5b282ecdd6 wazuh-manager]# bin/wazuh-control start
2026/02/13 19:21:00 wazuh-manager-modulesd:router: INFO: Loaded router module.
2026/02/13 19:21:00 wazuh-manager-modulesd:content_manager: INFO: Loaded content_manager module.
2026/02/13 19:21:00 wazuh-manager-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-execd...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
2026/02/13 19:21:08 wazuh-manager-modulesd:router: INFO: Loaded router module.
2026/02/13 19:21:08 wazuh-manager-modulesd:content_manager: INFO: Loaded content_manager module.
2026/02/13 19:21:08 wazuh-manager-modulesd:inventory-sync: INFO: Loaded Inventory sync module.
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
```

</p>
</details> 

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
