### PR TITLE
Add dashboard to Docker dev environment

### DIFF
--- a/api/tools/env/certs-generator/config.yml
+++ b/api/tools/env/certs-generator/config.yml
@@ -13,3 +13,6 @@ nodes:
     - name: wazuh2.worker
       ip: wazuh2.worker
       node_type: worker
+  dashboard:
+    - name: wazuh.dashboard
+      ip: wazuh.dashboard

--- a/api/tools/env/certs-generator/generate_certs.sh
+++ b/api/tools/env/certs-generator/generate_certs.sh
@@ -21,5 +21,17 @@ fi
 echo "Copying and renaming certificates to ${CERTS_DIR}..."
 chmod 644 wazuh-certificates/*
 cp -r wazuh-certificates/* "${CERTS_DIR}/"
+DASHBOARD_DIR="/export/dashboard"
+
+echo "=== PREPARING DASHBOARD CERTIFICATES ==="
+
+mkdir -p "${DASHBOARD_DIR}"
+
+cp "wazuh-certificates/root-ca.pem" "${DASHBOARD_DIR}/"
+cp "wazuh-certificates/wazuh.dashboard.pem" "${DASHBOARD_DIR}/"
+cp "wazuh-certificates/wazuh.dashboard-key.pem" "${DASHBOARD_DIR}/"
+
+echo "Setting dashboard-specific permissions..."
+chmod 555 "${DASHBOARD_DIR}/wazuh.dashboard-key.pem"
 
 echo "Certificates generated successfully."

--- a/api/tools/env/docker-compose.yml
+++ b/api/tools/env/docker-compose.yml
@@ -6,6 +6,8 @@ services:
                 WAZUH_BRANCH: ${WAZUH_BRANCH}
         pull_policy: never
         image: dev-wazuh-base
+        networks:
+            - wazuh-net
 
     certs-generator:
         build:
@@ -14,8 +16,11 @@ services:
         pull_policy: never
         volumes:
             - wazuh-certs:/certificates
+            - ./config/wazuh_dashboard_certs:/export/dashboard
             - ./certs-generator/config.yml:/config/config.yml:ro
         restart: "no"
+        networks:
+            - wazuh-net
 
     wazuh.indexer:
         image: quay.io/wazuh/wazuh-indexer:5.0.0-0
@@ -23,7 +28,10 @@ services:
         hostname: wazuh.indexer
         ports:
             - "9200:9200"
-            - "9300:9300"
+        networks:
+            wazuh-net:
+                aliases:
+                    - wazuh.indexer
         volumes:
             - wazuh-indexer-data:/var/lib/wazuh-indexer
             - wazuh-certs:/etc/wazuh-indexer/certs
@@ -47,6 +55,8 @@ services:
         pull_policy: never
         image: dev-wazuh-manager
         hostname: wazuh.master
+        networks:
+            - wazuh-net
         ports:
             - "55050:55000"
         volumes:
@@ -57,7 +67,7 @@ services:
             - ${WAZUH_LOCAL_PATH}/api/api:/var/wazuh-manager/framework/python/lib/python${WAZUH_PYTHON_VERSION}/site-packages/api
         environment:
             OPENDISTRO_SECURITY_ENABLED: "false"
-            NODE_NAME: "wazuh-master"
+            NODE_NAME: "wazuh.master"
         entrypoint:
             - /scripts/entrypoint.sh
             - wazuh.master
@@ -73,6 +83,8 @@ services:
         image: dev-wazuh-manager
         hostname: wazuh.worker
         pull_policy: never
+        networks:
+            - wazuh-net
         volumes:
             - wazuh-certs:/var/wazuh-manager/etc/certs
             - ${WAZUH_LOCAL_PATH}/framework/scripts:/var/wazuh-manager/framework/scripts
@@ -95,6 +107,8 @@ services:
         image: dev-wazuh-manager
         hostname: wazuh.worker
         pull_policy: never
+        networks:
+            - wazuh-net
         volumes:
             - wazuh-certs:/var/wazuh-manager/etc/certs
             - ${WAZUH_LOCAL_PATH}/framework/scripts:/var/wazuh-manager/framework/scripts
@@ -120,7 +134,9 @@ services:
         pull_policy: never
         restart: on-failure:5
         ports:
-            - "443:443"
+            - "1514:1514"
+        networks:
+            - wazuh-net
         depends_on:
             wazuh.master:
                 condition: service_started
@@ -136,6 +152,8 @@ services:
             context: ./wazuh-agent
         image: dev-wazuh-agent
         pull_policy: never
+        networks:
+            - wazuh-net
         entrypoint:
             - /scripts/entrypoint.sh
             - nginx-lb
@@ -144,6 +162,27 @@ services:
             nginx-lb:
                 condition: service_started
 
+    wazuh.dashboard:
+        image: public.ecr.aws/wazuh-cicd/wazuh/wazuh-dashboard:5.0.0-latest
+        container_name: wazuh.dashboard
+        hostname: wazuh.dashboard
+        networks:
+            - wazuh-net
+        ports:
+            - "443:5601"
+        volumes:
+            - ./config/wazuh_dashboard_certs:/tmp/certs
+            - ./wazuh-dashboard/wazuh.dashboard.yml:/usr/share/wazuh-dashboard/config/opensearch_dashboards.yml:ro
+            - wazuh-dashboard-custom:/usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom
+        depends_on:
+            wazuh.indexer:
+                condition: service_healthy
+
 volumes:
   wazuh-indexer-data:
   wazuh-certs:
+  wazuh-dashboard-custom:
+
+networks:
+  wazuh-net:
+    driver: bridge

--- a/api/tools/env/nginx-lb/nginx.conf
+++ b/api/tools/env/nginx-lb/nginx.conf
@@ -1,15 +1,12 @@
-
 user  nginx;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
-
 events {
     worker_connections  1024;
 }
-
 
 http {
     include       /etc/nginx/mime.types;
@@ -20,17 +17,10 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/nginx/access.log  main;
-
     sendfile        on;
-    #tcp_nopush     on;
-
     keepalive_timeout  65;
-
-    #gzip  on;
-
     include /etc/nginx/conf.d/*.conf;
 }
-
 
 stream {
     upstream mycluster {

--- a/api/tools/env/wazuh-dashboard/wazuh.dashboard.yml
+++ b/api/tools/env/wazuh-dashboard/wazuh.dashboard.yml
@@ -1,0 +1,54 @@
+# -----------------------
+# Server configuration
+# -----------------------
+server.host: 0.0.0.0
+server.port: 5601
+
+server.ssl.enabled: true
+server.ssl.certificate: /tmp/certs/wazuh.dashboard.pem
+server.ssl.key: /tmp/certs/wazuh.dashboard-key.pem
+
+# -----------------------
+# OpenSearch (Indexer)
+# -----------------------
+opensearch.hosts:
+  - https://wazuh.indexer:9200
+
+opensearch.username: admin
+opensearch.password: admin
+
+opensearch.ssl.verificationMode: certificate
+opensearch.ssl.certificateAuthorities:
+  - /tmp/certs/root-ca.pem
+
+opensearch.requestHeadersAllowlist:
+  - securitytenant
+  - Authorization
+
+# Security plugin settings
+opensearch_security.multitenancy.enabled: false
+opensearch_security.readonly_mode.roles:
+  - kibana_read_only
+
+# -----------------------
+# UI
+# -----------------------
+uiSettings.overrides.defaultRoute: /app/wz-home
+
+# -----------------------
+# Session settings
+# -----------------------
+opensearch_security.cookie.ttl: 900000
+opensearch_security.session.ttl: 900000
+opensearch_security.session.keepalive: true
+
+# -----------------------
+# Wazuh API configuration
+# -----------------------
+wazuh_core.hosts:
+  default:
+    url: https://wazuh.master
+    port: 55000
+    username: wazuh
+    password: wazuh
+    run_as: true


### PR DESCRIPTION
## Description

This pull request integrates the Wazuh Dashboard into the Docker-based development environment located in `api/tools/env/`.

Currently, the local development stack launched via `docker-compose` includes the Wazuh indexer and manager, but lacks the dashboard. This forces developers to install and configure it separately, leading to inconsistencies and inefficiency. By adding the dashboard to the compose setup, we provide a complete, out-of-the-box environment that mirrors a real-world deployment, significantly improving the developer experience for testing and feature development.

Closes #33934

## Proposed Changes

- **Added `wazuh.dashboard` service:** The `api/tools/env/docker-compose.yml` file is updated to include the Wazuh Dashboard service, using the official image `quay.io/wazuh/wazuh-dashboard:5.0.0-0`.
- **Network Configuration:** A dedicated bridge network, `wazuh-net`, is established to allow seamless and reliable communication between all services (indexer, manager, workers, and dashboard).
- **Certificate Generation:** The `certs-generator` script (`generate_certs.sh`) is extended to automatically generate and provision the necessary TLS certificates for the dashboard, ensuring secure communication with the indexer.
- **Dashboard Configuration:** A new configuration file (`wazuh.dashboard.yml`) is added to configure the dashboard to connect to the `wazuh.indexer` service within the Docker network.
- **Volume Management:** Necessary volumes are configured for the dashboard to persist data and mount the required certificates and configuration files.

### Results and Evidence

After these changes, running `docker-compose up -d` in `api/tools/env/` will launch the complete Wazuh stack, including the dashboard.

**Before:**
The environment only consisted of the Wazuh indexer, manager, and agent containers.

**After:**
The `wazuh.dashboard` container is now part of the stack and is accessible from the host machine.

**Evidence:**

*Logs showing the successful startup of all containers:*
```bash
$ docker-compose psf6b79a05e668   dev-wazuh-agent                                                "/scripts/entrypoint…"   5 minutes ago   Up 3 minutes (health: starting)                                                          env-wazuh-agent-1
20d76e49169f   dev-nginx-lb                                                   "/scripts/entrypoint…"   5 minutes ago   Up 3 minutes                      80/tcp, 0.0.0.0:1514->1514/tcp, :::1514->1514/tcp      env-nginx-lb-1
2457525a4e85   dev-wazuh-manager                                              "/scripts/entrypoint…"   5 minutes ago   Up 3 minutes (health: starting)   0.0.0.0:55052->55000/tcp, [::]:55052->55000/tcp        env-wazuh2.worker-1
09d9a3c1bc3e   dev-wazuh-manager                                              "/scripts/entrypoint…"   5 minutes ago   Up 3 minutes (health: starting)   0.0.0.0:55051->55000/tcp, [::]:55051->55000/tcp        env-wazuh.worker-1
006d77139c94   public.ecr.aws/wazuh-cicd/wazuh/wazuh-dashboard:5.0.0-latest   "/entrypoint.sh"         5 minutes ago   Up 3 minutes                      443/tcp, 0.0.0.0:443->5601/tcp, [::]:443->5601/tcp   wazuh.dashboard
2b252b1c2891   dev-wazuh-manager                                              "/scripts/entrypoint…"   5 minutes ago   Up 3 minutes (healthy)            0.0.0.0:55050->55000/tcp, [::]:55050->55000/tcp        env-wazuh.master-1
35dead93a6a6   quay.io/wazuh/wazuh-indexer:5.0.0-0                            "/entrypoint.sh open…"   5 minutes ago   Up 5 minutes (healthy)            0.0.0.0:9200->9200/tcp, :::9200->9200/tcp              wazuh.indexer
f380401a771c   dev-wazuh-base                                                 "/bin/bash"              5 minutes ago   Exited (0) 5 minutes ago                                                                 env-wazuh-base-1
f1eaa0223158   wazuh-certs-generator                                          "/tmp/generate_certs…"   5 minutes ago   Exited (0) 5 minutes ago                                                                 env-certs-generator-1
```

*Screenshot of the Wazuh Dashboard login page accessed via `https://localhost:5601`:*
<img width="1872" height="933" alt="Screenshot from 2026-02-13 15-35-30" src="https://github.com/user-attachments/assets/1e53a23d-e981-48b1-b4e9-89dea79e13f4" />
<img width="1872" height="933" alt="Screenshot from 2026-02-13 15-34-46" src="https://github.com/user-attachments/assets/1880e2fa-41a0-4a58-8994-dfc0ddecb232" />

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform (N/A - Changes are related to Docker configuration)
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [X] Log syntax and correct language review (Verified dashboard and other container logs for errors during startup and connection).

<!-- Depending on the affected OS -->
- Memory tests for Linux (N/A)
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows (N/A)
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS (N/A)
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests (N/A)
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine (N/A)
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [X] Run API Integration Tests against the newly provisioned environment to ensure full connectivity and functionality.

### Artifacts Affected

N/A. This change only affects the local Docker-based development environment and does not alter any production artifacts or packages.

### Configuration Changes

This PR introduces and modifies configuration files related to the development environment only:

- **Modified:** `api/tools/env/docker-compose.yml` - To add the new service and network.
- **Modified:** `api/tools/env/certs-generator/config.yml` - To include the dashboard node for certificate generation.
- **New:** `api/tools/env/wazuh-dashboard/wazuh.dashboard.yml` - To configure the dashboard's connection to the indexer.

No changes are made to default production configuration files (`ossec.conf`, etc.).

### Tests Introduced

N/A. This pull request adds a feature to the development environment and does not include new automated unit or integration tests. Existing tests were run against the new environment to validate it.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (Existing tests were executed successfully on the new environment)
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes (A follow-up might be needed to update the `README.md` for the dev environment)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] The branch has been rebased with `main` and the commit message is clean.