### PR TITLE
Fix Windows OS edition detection

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -71,7 +71,7 @@ os_info *get_win_version()
 
         snprintf(subkey, vsize - 1, "%s", "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion");
 
-        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &RegistryKey) != ERROR_SUCCESS) {
             merror(SK_REG_OPEN, subkey);
             info->os_name = strdup("Microsoft Windows undefined version");
         }
@@ -100,7 +100,7 @@ os_info *get_win_version()
         DWORD winMinor = 0;
         dwCount = size;
 
-        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &RegistryKey) != ERROR_SUCCESS) {
             merror(SK_REG_OPEN, subkey);
         }
 
@@ -256,7 +256,7 @@ os_info *get_win_version()
         dwCount = sizeof(DWORD);
         snprintf(subkey, vsize - 1, "%s", "SYSTEM\\CurrentControlSet\\Control\\Windows");
 
-        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &RegistryKey) != ERROR_SUCCESS) {
             merror(SK_REG_OPEN, subkey);
         }
         else {
@@ -296,7 +296,7 @@ os_info *get_win_version()
 
     snprintf(subkey, vsize - 1, "%s", "System\\CurrentControlSet\\Control\\Session Manager\\Environment");
 
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &RegistryKey) != ERROR_SUCCESS) {
         merror(SK_REG_OPEN, subkey);
     } else {
         char arch[64] = "";
@@ -323,7 +323,7 @@ os_info *get_win_version()
 
     snprintf(subkey, vsize - 1, "%s", "System\\CurrentControlSet\\Control\\ComputerName\\ActiveComputerName");
     char nodename[1024] = "";
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ, &RegistryKey) != ERROR_SUCCESS) {
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &RegistryKey) != ERROR_SUCCESS) {
         merror(SK_REG_OPEN, subkey);
     } else {
         dwCount = size;


### PR DESCRIPTION
## Description

After upgrading Windows agents to **v4.14.3**, Windows 11 **Pro** endpoints may be reported as Windows 11 **Enterprise** in both the agent startup log and the Agents dashboard.

Root cause: the agent determines the OS name by reading the `ProductName` value from:

- `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`

Later, the “Windows 11” naming is adjusted based on `CurrentBuildNumber`. However, because **wazuh-agent.exe is a 32-bit process**, registry redirection causes the agent to read from the 32-bit view:

- `HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion`

On affected systems, the redirected `ProductName` can incorrectly be `"Windows 10 Enterprise"`, which then becomes `"Windows 11 Enterprise"` after the build-based adjustment.

This behavior appears to be a regression related to **wazuh/wazuh#33831**.

## Proposed Changes

- Update Windows OS detection to read the **real `ProductName` from the native 64-bit registry view when available** (on 64-bit systems), falling back to the 32-bit view only when needed.
- Keep the existing logic that adjusts the “Windows 11” name based on `CurrentBuildNumber`, but ensure it operates on the correct base edition (Pro vs Enterprise).

### Results and Evidence

#### Agent log now reports the correct Windows edition.

Before fix:
```text
2026/02/16 08:18:59 wazuh-agent: INFO: Windows version is 6.0 or newer. (Microsoft Windows 11 Enterprise [Ver: 10.0.26200.7840] |ROCKET |x86_64 - Wazuh v4.14.3).
```

After fix:
```text
2026/02/16 09:09:53 wazuh-agent: INFO: Windows version is 6.0 or newer. (Microsoft Windows 11 Pro [Ver: 10.0.26200.7840] |ROCKET |x86_64 - Wazuh v4.14.4).
```

#### The OS name is now displayed correctly in the Agents dashboard:

|Before|After|
|--|--|
|<img width="1716" height="600" alt="Screenshot 2026-02-16 081946" src="https://github.com/user-attachments/assets/36349cf4-752d-45d9-a687-d740ab25b28b" />|<img width="1712" height="609" alt="Screenshot 2026-02-16 091054" src="https://github.com/user-attachments/assets/9934f298-c06a-4424-ad7b-1795b340fc3a" />|

### Artifacts Affected

- `wazuh-agent.exe` (Windows agent)

### Configuration Changes

- Not applicable.

### Documentation Updates

- Not applicable.

### Tests Introduced

- Not applicable.  
  No unit/integration tests were added for this change. System-level validation on Windows endpoints may be required and will be handled in a separate task.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues