### PR TITLE
Change msi_output extension from txt to log

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -125,9 +125,9 @@ function get_msi_version {
     write-output "$(Get-Date -format u) - Extracting the version from MSI file." >> .\upgrade\upgrade.log
     try {
         # Extracting the version using msiexec and waiting for it to complete
-        Start-Process -FilePath "msiexec.exe" -ArgumentList "/a", "`"$msiPath`"", "/qn", "TARGETDIR=$env:TEMP", "/lv*", "`".\upgrade\msi_output.txt`"" -Wait
+        Start-Process -FilePath "msiexec.exe" -ArgumentList "/a", "`"$msiPath`"", "/qn", "TARGETDIR=$env:TEMP", "/lv*", "`".\upgrade\msi_output.log`"" -Wait
 
-        $msi_version = Get-MSIProductVersion ".\upgrade\msi_output.txt"
+        $msi_version = Get-MSIProductVersion ".\upgrade\msi_output.log"
         return $msi_version
 
     } catch {


### PR DESCRIPTION
# Fix MSI installer log extension in Windows agent upgrade

## Description

This PR changes the output file extension for the MSI version extraction process in the Windows agent upgrade script (`do_upgrade.ps1`). The extension has been changed from `.txt` to `.log`.

This change ensures that the MSI installer logs generated during the version extraction process are correctly identified as log files.

## Proposed Changes

- Modified `src/win32/do_upgrade.ps1`:
  - Changed `msi_output.txt` to `msi_output.log` in the `get_msi_version` function.
  - Updated the call to `Get-MSIProductVersion` to read from the new `.log` file.

### Results and Evidence

<!-- Please provide the agent log and a screenshot here as evidence of the fix working correctly. -->

### Artifacts Affected

- `wazuh-agent` (Windows)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

No new unit tests were introduced as this is a minor script modification. The changes were verified manually.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
