### PR TITLE
Update service check from WMI to sc.exe

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -360,18 +360,26 @@ Public Function CheckSvcRunning()
     scPath = WshShell.ExpandEnvironmentStrings("%SystemRoot%") & "\System32\sc.exe"
 
     Set objExec = WshShell.Exec(scPath & " query OssecSvc")
-    strOutput = objExec.StdOut.ReadAll()
-    If InStr(strOutput, "RUNNING") > 0 Then
+    If IsStateRunning(objExec.StdOut.ReadAll()) Then
         Session.Property("OSSECRUNNING") = "Running"
     End If
 
     Set objExec = WshShell.Exec(scPath & " query WazuhSvc")
-    strOutput = objExec.StdOut.ReadAll()
-    If InStr(strOutput, "RUNNING") > 0 Then
+    If IsStateRunning(objExec.StdOut.ReadAll()) Then
         Session.Property("WAZUHRUNNING") = "Running"
     End If
 
     CheckSvcRunning = 0
+End Function
+
+Private Function IsStateRunning(scOutput)
+    IsStateRunning = False
+    For Each line In Split(scOutput, vbCrLf)
+        If InStr(line, "STATE") > 0 And InStr(line, ": 4 ") > 0 Then
+            IsStateRunning = True
+            Exit For
+        End If
+    Next
 End Function
 
 Public Function KillGUITask()


### PR DESCRIPTION
## Description

Closes #18145

The Windows MSI installer fails on systems where the WMI repository is corrupted or the `Win32_Service` class is unregistered. The `CheckSvcRunning` VBScript custom action queries WMI to detect whether `OssecSvc` or `WazuhSvc` are running before an upgrade, but on affected systems it throws error (`WBEM_E_INVALID_CLASS`), aborting the entire installation.

This PR replaces the WMI-based service detection with a direct query to the Windows Service Control Manager via `sc.exe`, which does not depend on WMI.

## Proposed Changes

- Replaced `GetObject("winmgmts://./root/cimv2")` and `Win32_Service` WMI queries with `sc.exe query` invocations using absolute path (`%SystemRoot%\System32\sc.exe`) to prevent PATH hijacking.
- Added `IsStateRunning` helper function that parses the `STATE` line from `sc query` output and matches the numeric state code `4` (`SERVICE_RUNNING`), avoiding any dependency on locale-specific text.
- Added `On Error Resume Next` so that if `sc.exe` fails for any reason, the installer proceeds gracefully (service simply won't auto-restart after upgrade).
- The `OSSECRUNNING` and `WAZUHRUNNING` MSI properties are set to `"Running"` (title case), matching the existing WiX condition in `wazuh-installer.wxs` that triggers `StartWazuhSvc` after upgrade.

### Results and Evidence

<!-- TODO: Add screenshots or MSI log excerpts showing:
  1. Baseline: successful install on a healthy system
  2. Before fix: install failure with corrupted WMI (error 1720/1603 in log)
  3. After fix: successful install with corrupted WMI
  4. Upgrade test: service auto-restarts after upgrade when it was running before
-->

### Artifacts Affected

- `src/win32/InstallerScripts.vbs` — Windows MSI installer VBScript custom actions
- Windows MSI installer package (`.msi`)

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

Manual testing performed on a Windows 10 Pro VM (Vagrant/VirtualBox):

- **WMI corruption simulation**: Deleted `Win32_Service` class using the following commands:
```powershell
$class = [wmiclass]"\\.\root\cimv2:Win32_Service"
$class.Delete()
```

- **Install with corrupted WMI**: Verified the patched MSI installs successfully (exit code 0) despite `Win32_Service` being unavailable.

<img width="498" height="391" alt="Image" src="https://github.com/user-attachments/assets/d5ff5c49-6b22-4d73-af34-e0d13804ee15" />

- **Install with healthy WMI**: Verified no regression on systems with a working WMI repository.

<img width="1132" height="505" alt="image" src="https://github.com/user-attachments/assets/bd165770-245a-452d-a18f-42a6d0c76c64" />

<img width="307" height="105" alt="image" src="https://github.com/user-attachments/assets/ee810f7f-e364-4b7a-845b-5b68589941f4" />

- **Upgrade with running service**: Verified `WazuhSvc` is auto-restarted after upgrade when it was running before the upgrade.

<img width="507" height="406" alt="image" src="https://github.com/user-attachments/assets/c6e367c2-dad5-404d-a64f-7043033ccd9f" />


## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

