### PR TITLE
Fix Windows agent upgrade: Enable enrollment when WAZUH_MANAGER is set

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -125,7 +125,7 @@ public function config()
             End If
         End If
 
-        If WAZUH_REGISTRATION_SERVER <> "" or WAZUH_REGISTRATION_PORT <> "" or WAZUH_REGISTRATION_PASSWORD <> "" or WAZUH_REGISTRATION_CA <> "" or WAZUH_REGISTRATION_CERTIFICATE <> "" or WAZUH_REGISTRATION_KEY <> "" or WAZUH_AGENT_NAME <> "" or WAZUH_AGENT_GROUP <> "" or ENROLLMENT_DELAY <> "" Then
+        If WAZUH_REGISTRATION_SERVER <> "" or WAZUH_REGISTRATION_PORT <> "" or WAZUH_REGISTRATION_PASSWORD <> "" or WAZUH_REGISTRATION_CA <> "" or WAZUH_REGISTRATION_CERTIFICATE <> "" or WAZUH_REGISTRATION_KEY <> "" or WAZUH_AGENT_NAME <> "" or WAZUH_AGENT_GROUP <> "" or ENROLLMENT_DELAY <> "" or WAZUH_MANAGER <> "" Then
             enrollment_list = "    <enrollment>" & vbCrLf
             enrollment_list = enrollment_list & "      <enabled>yes</enabled>" & vbCrLf
             enrollment_list = enrollment_list & "    </enrollment>" & vbCrLf


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Windows agent service fails to start after an upgrade or installation when only `WAZUH_MANAGER` property is provided (without specific registration parameters) and no `client.keys` exists.

## Description
In the reported failure scenario (upgrade smoke test), the agent is installed with `WAZUH_MANAGER` set. The previous version is uninstalled (keeping files), but since it was not registered, `client.keys` is empty.
Upon starting the new agent (5.0.0), `local_start` invokes `start_agent`. If `client.keys` is empty, `w_agentd_keys_init` checks if enrollment is enabled. If disabled, it exits immediately (`merror_exit`).

The `InstallerScripts.vbs` script was only adding the `<enrollment>` section to `ossec.conf` if specific registration variables (`WAZUH_REGISTRATION_SERVER`, etc.) were set. If only `WAZUH_MANAGER` was set, the `<enrollment>` section was omitted.

This change ensures that if `WAZUH_MANAGER` is set, the `<enrollment>` section with `<enabled>yes</enabled>` is added to `ossec.conf`. This ensures the agent attempts to enroll (falling back to iterating the defined servers if `manager_address` is not explicitly set in the enrollment block) instead of exiting.

## Impact
- **Windows Installer:** The generated `ossec.conf` will now include enrollment configuration when `WAZUH_MANAGER` is passed to the MSI.
- **Agent Startup:** The agent will try to auto-enroll using the configured manager address(es) instead of potentially exiting if keys are missing.

## Testing
- Verified that `InstallerScripts.vbs` logic now includes `WAZUH_MANAGER` in the condition to write enrollment config.