### PR TITLE
Fix Windows agent upgrade service start issue

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -125,7 +125,7 @@ public function config()
             End If
         End If
 
-        If WAZUH_REGISTRATION_SERVER <> "" or WAZUH_REGISTRATION_PORT <> "" or WAZUH_REGISTRATION_PASSWORD <> "" or WAZUH_REGISTRATION_CA <> "" or WAZUH_REGISTRATION_CERTIFICATE <> "" or WAZUH_REGISTRATION_KEY <> "" or WAZUH_AGENT_NAME <> "" or WAZUH_AGENT_GROUP <> "" or ENROLLMENT_DELAY <> "" Then
+        If WAZUH_REGISTRATION_SERVER <> "" or WAZUH_REGISTRATION_PORT <> "" or WAZUH_REGISTRATION_PASSWORD <> "" or WAZUH_REGISTRATION_CA <> "" or WAZUH_REGISTRATION_CERTIFICATE <> "" or WAZUH_REGISTRATION_KEY <> "" or WAZUH_AGENT_NAME <> "" or WAZUH_AGENT_GROUP <> "" or ENROLLMENT_DELAY <> "" or WAZUH_MANAGER <> "" Then
             enrollment_list = "    <enrollment>" & vbCrLf
             enrollment_list = enrollment_list & "      <enabled>yes</enabled>" & vbCrLf
             enrollment_list = enrollment_list & "    </enrollment>" & vbCrLf


### PR DESCRIPTION
# Fix Windows agent upgrade service start issue

## Description
I have worked on issue https://github.com/wazuh/wazuh-agent-packages/issues/626
This PR addresses an issue where the Windows agent service fails to start after an upgrade when only `WAZUH_MANAGER` is provided and no `client.keys` exists.

## Proposed Changes
- Modified `src/win32/InstallerScripts.vbs` to ensure the `<enrollment>` section with `<enabled>yes</enabled>` is added to `ossec.conf` whenever `WAZUH_MANAGER` is set.

### Results and Evidence

Run https://github.com/wazuh/wazuh-agent-packages/actions/runs/22098952398 🟢 🍏 

### Artifacts Affected
- `wazuh-agent` MSI installer (specifically `InstallerScripts.vbs`)

### Configuration Changes
- No new configuration option added.
- Existing `ossec.conf` generation behavior changed: `<enrollment>` block is now included when `WAZUH_MANAGER` is present.

### Documentation Updates
- None required

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues