### PR TITLE
Copy Wazuh DLLs to test directory to prevent DLL hijack test flakiness

### DIFF
--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -32,6 +32,8 @@ jobs:
           cp src/win32/*.exe src/exe_files/
           # Copy DLL dependencies required by the executables
           cp src/win32/*.dll src/exe_files/ 2>/dev/null || true
+          cp src/build/bin/*.dll src/exe_files/ 2>/dev/null || true
+          cp src/*.dll src/exe_files/ 2>/dev/null || true
       - name: Upload Artifact executables
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description
This PR resolves the flaky test issue reported in #34319 ("Windows Agent 2025 DLL Test Failing").
The Windows Agent 2025 DLL hijack test was failing intermittently because the executables under test searched for Wazuh DLLs (e.g., `libagent_metadata.dll`, `libfimdb.dll`, `libwazuhext.dll`) in the test directory, triggering "NAME NOT FOUND" events that Process Monitor flagged as potential DLL hijacking. In production, these DLLs reside alongside the executables in the install directory, so the test was producing false positives. By copying the Wazuh DLLs to the test directory, the executables find them as they would in a real installation, eliminating the spurious failures.
## Proposed Changes
- **Modified `.github/workflows/5_testcomponent_windows-dll-hijack.yml`**:
  - Added copy commands to place all Wazuh DLLs alongside the executables in the test directory:
    - `src/win32/*.dll` — runtime DLLs (libwinpthread, libgcc, libstdc++)
    - `src/build/bin/*.dll` — CMake-built DLLs (agent_metadata, fimdb, dbsync, etc.)
    - `src/*.dll` — Makefile-built DLLs (libwazuhext)

### Results and Evidence
The flaky test behavior should be resolved as the executables will now find their dependent DLLs in the test directory, matching production layout and preventing false "NAME NOT FOUND" detections by Process Monitor.
Unit tests will provide evidence once executed on the Windows Agent 2025 pipeline.
### Artifacts Affected
- DLL hijack test CI workflow only. No changes to build artifacts, installer, or runtime behavior.
### Configuration Changes
None required. The change only affects the CI test environment.
### Documentation Updates
None required. This is a CI workflow fix.
### Tests Introduced
No new tests introduced. Existing tests should now pass consistently without flakiness.
## Review Checklist
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues