### PR TITLE
Replace RHEL init script with SUSE variant on SLES 11

### DIFF
--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -287,6 +287,11 @@ if [ $1 = 1 ]; then
   %{_localstatedir}/packages_files/agent_installation_scripts/src/init/register_configure_agent.sh %{_localstatedir} > /dev/null || :
 fi
 
+if [ -r /etc/SuSE-release ] && grep -q "VERSION = 11" /etc/SuSE-release 2>/dev/null; then
+    cp -p %{_localstatedir}/packages_files/agent_installation_scripts/src/init/ossec-hids-suse.init /etc/init.d/wazuh-agent
+    chmod 755 /etc/init.d/wazuh-agent
+fi
+
 if [[ -d /run/systemd/system ]]; then
   rm -f %{_initrddir}/wazuh-agent
 fi


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/31065

The EL5 RPM package installs the RHEL init script (`ossec-hids-rh.init`) into `%{_initrddir}` (`/etc/rc.d/init.d/`). On RHEL/CentOS 5, `/etc/init.d` is a symlink to `/etc/rc.d/init.d`, so the script is reachable at `/etc/init.d/wazuh-agent` and `chkconfig` works.

On SLES 11 the layout is reversed: `/etc/init.d` is the real directory and `/etc/rc.d/init.d` is a symlink to it. Although the file physically lands in `/etc/init.d` through the symlink, its content is the RHEL variant which sources `/etc/init.d/functions` (absent on SLES) and lacks the LSB `BEGIN INIT INFO` header required by SLES's `insserv`/`chkconfig`. This causes `chkconfig --add wazuh-agent` to fail with `unknown service`.

## Proposed Changes

Added a block in the `%post` scriptlet (outside the `$1 = 1` guard so it runs on both install and upgrade) that detects SLES 11 via `/etc/SuSE-release` and overwrites the init script at `/etc/init.d/wazuh-agent` with the SUSE-specific variant (`ossec-hids-suse.init`). This runs before `packages_files` is cleaned up.

No removal of `/etc/rc.d/init.d/wazuh-agent` is needed because on SLES 11 it is a symlink to `/etc/init.d`, so overwriting the target updates both paths.

### Results and Evidence
**Before fix** — RHEL init script placed at `%{_initrddir}` (`/etc/rc.d/init.d/`), which resolves to `/etc/init.d/init.d/`:
```
$ ls -la /etc/init.d/wazuh-agent
ls: cannot access /etc/init.d/wazuh-agent: No such file or directory
$ ls -la /etc/init.d/init.d/wazuh-agent
-rwxr-xr-x 1 root root 455 Feb 19 02:29 /etc/init.d/init.d/wazuh-agent
$ chkconfig --add wazuh-agent
wazuh-agent: unknown service
$ service wazuh-agent status
service: no such service wazuh-agent
```
**After fix** — SUSE init script placed directly at `/etc/init.d/wazuh-agent`:
```
$ ls -la /etc/init.d/wazuh-agent
-rwxr-xr-x 1 root root 711 Feb 19 02:30 /etc/init.d/wazuh-agent
$ chkconfig --add wazuh-agent
wazuh-agent  0:off  1:off  2:on  3:on  4:off  5:on  6:off
$ chkconfig --list wazuh-agent
wazuh-agent  0:off  1:off  2:on  3:on  4:off  5:on  6:off
$ service wazuh-agent status
/var/ossec/bin/wazuh-control not installed
(service is recognized; fails only because wazuh binaries are not present in VM)
```

### Artifacts Affected

- `packages/rpms/SPECS/wazuh-agent.spec`

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
