### PR TITLE
Use macOS-compatible rpath for wazuh-modulesd

### DIFF
--- a/src/wazuh_modules/CMakeLists.txt
+++ b/src/wazuh_modules/CMakeLists.txt
@@ -201,5 +201,13 @@ elseif(NOT UNIT_TEST)
     PROPERTIES LINKER_LANGUAGE C RUNTIME_OUTPUT_DIRECTORY ${SRC_FOLDER})
   target_link_libraries(${WAZUH_MODULESD_DAEMON_NAME}
                         PRIVATE wazuh_modulesd_lib)
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+
+  if(APPLE)
+    set_target_properties(
+      ${WAZUH_MODULESD_DAEMON_NAME} PROPERTIES
+      BUILD_WITH_INSTALL_RPATH TRUE
+      INSTALL_RPATH "@executable_path/../lib")
+  else()
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+  endif()
 endif()


### PR DESCRIPTION

## Description

The Wazuh Agent for macOS fails to start due to a dynamic linker (`dyld`) error. The `wazuh-modulesd` binary was originally built with an `rpath` value of `$ORIGIN/../lib`. The macOS Hardened Runtime strictly forbids relative paths using `$ORIGIN`, which results in a fatal crash (`Abort trap: 6`) when attempting to load `libagent_info.dylib`.

Closes https://github.com/wazuh/wazuh/issues/34556

## Proposed Changes

Modified `src/wazuh_modules/CMakeLists.txt` to apply platform-appropriate linker flags:
* Implemented `set_target_properties` to define `INSTALL_RPATH` as `@executable_path/../lib` strictly for `APPLE` builds.
* Preserved the legacy `$ORIGIN/../lib` configuration via `CMAKE_EXE_LINKER_FLAGS` for non-Apple environments.

### Results and Evidence

**Before the fix (Crash):**
```ruby
sh-3.2# sudo /Library/Ossec/bin/wazuh-control start
2026/02/19 01:10:16 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
2026/02/19 01:10:18 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.

sh-3.2# codesign -d -v /Library/Ossec/bin/wazuh-modulesd
Executable=/Library/Ossec/bin/wazuh-modulesd
Identifier=wazuh-modulesd
Format=Mach-O thin (arm64)
CodeDirectory v=20400 size=5191 flags=0x20002(adhoc,linker-signed) hashes=159+0 location=embedded
Signature=adhoc
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
Internal requirements=none

sh-3.2# codesign --force --options runtime --sign - /Library/Ossec/bin/wazuh-modulesd
/Library/Ossec/bin/wazuh-modulesd: replacing existing signature"

sh-3.2# sudo /Library/Ossec/bin/wazuh-control start
dyld[7483]: Library not loaded: @rpath/libagent_info.dylib
  Referenced from: <3F12F3A0-CDF7-3EBD-8505-17CC7147F116> /Library/Ossec/bin/wazuh-modulesd
  Reason: tried: '$ORIGIN/../lib/libagent_info.dylib' (relative path not allowed in hardened program)
/Library/Ossec/bin/wazuh-control: line 122:  7483 Abort trap: 6
wazuh-modulesd: Configuration error. Exiting
```

**After the fix:**
```ruby
sh-3.2# codesign -d -v /Library/Ossec/bin/wazuh-modulesd
Executable=/Library/Ossec/bin/wazuh-modulesd
Identifier=wazuh-modulesd
Format=Mach-O thin (arm64)
CodeDirectory v=20400 size=5191 flags=0x20002(adhoc,linker-signed) hashes=159+0 location=embedded
Signature=adhoc
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
Internal requirements=none

sh-3.2# codesign --force --options runtime --sign - /Library/Ossec/bin/wazuh-modulesd
/Library/Ossec/bin/wazuh-modulesd: replacing existing signature

sh-3.2# sudo /Library/Ossec/bin/wazuh-control start
2026/02/19 01:22:53 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
dyld[19907]: Library not loaded: @rpath/libagent_info.dylib
  Referenced from: <16C27FAD-6291-35D6-8EA4-36A74821974C> /Library/Ossec/bin/wazuh-modulesd
  Reason: tried: '/Library/Ossec/lib/libagent_info.dylib' (code signature in <23E3E56B-0A1F-3E52-A568-5F098758D128> '/Library/Ossec/lib/libagent_info.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/Library/Ossec/lib/libagent_info.dylib' (code signature in <23E3E56B-0A1F-3E52-A568-5F098758D128> '/Library/Ossec/lib/libagent_info.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs)
/Library/Ossec/bin/wazuh-control: line 122: 19907 Abort trap: 6           ${DIR}/bin/${i} -t
wazuh-modulesd: Configuration error. Exiting


# Which is a different error which would not happen in the nightly build,
# forcing the certificates to be like in the nightly we finally get

sh-3.2# sudo /Library/Ossec/bin/wazuh-control start
2026/02/19 01:30:50 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
2026/02/19 01:30:51 wazuh-syscheckd: WARNING: Deprecated option 'scan_on_start' is not longer available.
Started wazuh-syscheckd...
Started wazuh-logcollector...
```