### PR TITLE
Add unit test for OSHash_Add

### DIFF
--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -365,6 +365,8 @@ if("${TARGET}" STREQUAL "winagent")
 else()
     list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 endif()
+list(APPEND shared_tests_names "test_hash_op")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
 # Compiling tests
 list(LENGTH shared_tests_names count)

--- a/src/unit_tests/shared/test_hash_op.c
+++ b/src/unit_tests/shared/test_hash_op.c
@@ -1,0 +1,51 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "shared.h"
+
+int setup_queue(void **state) {
+    OSHash *hash = OSHash_Create();
+    *state = hash;
+    return 0;
+}
+
+int teardown_queue(void **state) {
+    OSHash *hash = *state;
+    OSHash_Free(hash);
+    return 0;
+}
+
+/* tests */
+
+/* oshash_add */
+
+void test_oshash_add_ok(void **state)
+{
+    OSHash *hash = *state;
+    char *key = "key";
+    char *value = "value";
+    int ret;
+    ret = OSHash_Add(hash, key, value);
+    assert_int_equal(ret, 2);
+}
+
+void test_oshash_add_same_elem(void **state)
+{
+    OSHash *hash = *state;
+    char *key = "key";
+    char *value = "value";
+    int ret;
+    ret = OSHash_Add(hash, key, value);
+    ret = OSHash_Add(hash, key, value);
+    assert_int_equal(ret, 1);
+}
+
+int main(void) {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_oshash_add_ok, setup_queue, teardown_queue),
+        cmocka_unit_test_setup_teardown(test_oshash_add_same_elem, setup_queue, teardown_queue)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This pull request improves the test coverage for the hash_op library. Its include two unit test for the function OSHash_Add where validate the insertion of elements into the map.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

- Add a new file into the unit test tree.
- Add the new unit test file to CMakeList.txt 
- Add unit test: test_oshash_add_ok
- Add unit test : test_oshash_add_same_elem

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<img width="1161" height="619" alt="Screenshot 2026-02-18 175319" src="https://github.com/user-attachments/assets/6d145d48-0c11-4e21-be32-c86c36c1ba36" />

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

src/unit_test/shared/test_hash_op.c
src/unit_test/CMakeList.txt

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

**test_oshash_add_ok**
- Scope:  Validate the insertion of and element on a hash map.

**test_oshash_add_same**
- Scope:  Validate the error when inserting 2 elements with the same key into the hash map.

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
