### PR TITLE
Avoid warning on missing scanner source f…

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
@@ -20,6 +20,8 @@
 #include "numericHelper.h"
 #include "scanContext.hpp"
 #include "timeHelper.h"
+#include <algorithm>
+#include <cctype>
 #include <json.hpp>
 #include <sstream>
 
@@ -125,26 +127,44 @@ private:
                                  description.scoreVersion.empty() || description.severity.empty());
 
         // scanner.source (ADP description)
-        try
+        if (!detection.cnaSource.empty())
         {
-            if (!detection.cnaSource.empty())
+            std::string baseCna = detection.cnaSource;
+            const auto pos = baseCna.rfind('_');
+            if (pos != std::string::npos)
+            {
+                const auto suffix = baseCna.substr(pos + 1);
+                if (!suffix.empty() &&
+                    std::all_of(suffix.begin(), suffix.end(), [](unsigned char c) { return std::isdigit(c); }))
+                {
+                    baseCna = baseCna.substr(0, pos);
+                }
+            }
+
+            try
             {
                 vuln.scanner.source = TGlobalData::instance()
                                           .vendorMaps()
-                                          .at("adp_descriptions")
-                                          .at(detection.cnaSource)
+                                          .at(ADP_DESCRIPTIONS_MAP_KEY)
+                                          .at(baseCna)
                                           .at("adp")
                                           .template get<std::string>();
             }
-        }
-        catch (const std::exception& e)
-        {
-            logWarn(WM_VULNSCAN_LOGTAG,
-                    "Failed to get scanner source for CNA '%s': %s (using CNA name or leaving empty)",
-                    detection.cnaSource.c_str(),
-                    e.what());
-            if (!detection.cnaSource.empty())
+            catch (const nlohmann::json::out_of_range&)
             {
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "CNA '%s' not found in ADP descriptions map, using CNA name as scanner source",
+                        detection.cnaSource.c_str());
+                vuln.scanner.source = detection.cnaSource;
+            }
+            catch (const std::exception& e)
+            {
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Error while resolving CNA '%s' (base CNA '%s') in ADP descriptions map: %s. "
+                        "Using CNA name as scanner source",
+                        detection.cnaSource.c_str(),
+                        baseCna.c_str(),
+                        e.what());
                 vuln.scanner.source = detection.cnaSource;
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -733,6 +733,114 @@ TEST_F(EventDetailsBuilderTest, TestScannerSourceFallbackToCnaSource)
     EXPECT_EQ(event["vulnerability"]["scanner"]["source"].get<std::string>(), "custom-vendor");
 }
 
+TEST_F(EventDetailsBuilderTest, TestScannerSourceFallbackForVersionedCnaName)
+{
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    auto vulnerabilityDescriptionData = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(
+        fbBuilder,
+        "",
+        "redhat",
+        "NETWORK",
+        "",
+        "HIGH",
+        "CVSS:3.1",
+        "HIGH",
+        "CWE-787",
+        "2024-01-10T10:00:00Z",
+        "2024-02-15T12:00:00Z",
+        "Red Hat vulnerability",
+        "HIGH",
+        "NONE",
+        "https://access.redhat.com/security/cve/CVE-2024-9001",
+        "UNCHANGED",
+        7.5,
+        "3.1",
+        "HIGH",
+        "NONE",
+        NSEventDetailsBuilderTest::OFFSET.c_str());
+    fbBuilder.Finish(vulnerabilityDescriptionData);
+
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put("CVE-2024-9001", dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
+
+    Context ctx;
+    ctx.agentId = "015";
+    ctx.agentName = "centos9-agent";
+    ctx.agentVersion = "4.5.0";
+
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData>>(ctx);
+
+    PackageContextData pkg;
+    pkg.name = "openssl";
+    pkg.version = "3.0.7";
+    pkg.format = "rpm";
+
+    const std::string detectionId = "015_openssl_3.0.7_CVE-2024-9001";
+    const std::string detectionIdBase = "015_openssl_3.0.7";
+    scanContext->addPackageToContext(detectionIdBase, pkg, ElementOperation::Upsert);
+
+    CVEDetectionResult detection;
+    detection.cveId = "CVE-2024-9001";
+    detection.operation = ElementOperation::Upsert;
+    detection.componentType = AffectedComponentType::Package;
+    detection.matchCondition = "3.1.0";
+    detection.conditionType = MatchRuleCondition::LessThan;
+    // "redhat_9" is produced by cna-mapping-global.json for RHEL/CentOS 9 agents.
+    // It is NOT in adp_descriptions — only the base "redhat" is. The fix strips the
+    // trailing version suffix (_9) to derive the base name for the adp_descriptions lookup.
+    detection.cnaSource = "redhat_9";
+    detection.detectionIdBase = detectionIdBase;
+
+    scanContext->addDetectedCVE(detectionId, std::move(detection));
+    scanContext->m_vulnerabilitySource = {"redhat", "redhat_9"};
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    static const std::string managerNameStr = MANAGER_NAME;
+    EXPECT_CALL(*spGlobalDataMock, managerName()).WillRepeatedly(testing::ReturnRef(managerNameStr));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    TEventDetailsBuilder<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache, GlobalData>, TrampolineGlobalData>
+        eventDetailsBuilder(spDatabaseFeedManagerMock);
+
+    // Before fix, .at("redhat_9") failed and fell back to cnaSource ("redhat_9") with a logWarn.
+    // After fix, the version suffix is stripped and "redhat" resolves to "Red Hat CVE Database".
+    auto result = eventDetailsBuilder.handleRequest(scanContext);
+
+    ASSERT_NE(result, nullptr);
+    auto* eventJson = result->getECSEvent(detectionId);
+    ASSERT_NE(eventJson, nullptr);
+
+    auto event = nlohmann::json::parse(*eventJson);
+
+    // "redhat_9" not in adp_descriptions -> falls back to base "redhat" -> "Red Hat CVE Database"
+    EXPECT_EQ(event["vulnerability"]["scanner"]["source"].get<std::string>(), "Red Hat CVE Database");
+}
+
 TEST_F(EventDetailsBuilderTest, TestOsDeleteWithDeletedOSData)
 {
     flatbuffers::FlatBufferBuilder fbBuilder;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR fixes repeated `WARNING` logs generated during the vulnerability augmentation stage when processing versioned `CNA` names (e.g., redhat_9, alma_9).

The issue was caused by looking up versioned CNA names directly in `adp_descriptions`, while the feed only stores base CNA names (e.g., redhat, alma).

The fix ensures that version suffixes are stripped before performing the lookup, preventing unnecessary warnings and allowing correct scanner source resolution. 

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

- Strip trailing version suffix (_<digits>) from cnaSource before querying adp_descriptions (e.g., redhat_9 → redhat).
- Replace hardcoded "adp_descriptions" with ADP_DESCRIPTIONS_MAP_KEY.
- Add regression unit test TestScannerSourceFallbackForVersionedCnaName.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

To test the issue, we checked the alerts to see which cases cna.Source was causing trouble, and we indeed found some problematic instances. We are also keeping track of the number of vulnerabilities and packages to ensure no data loss occurs after the changes.


```
root@manager:~# grep -o '"source":"[^"]*"' /var/wazuh-manager/logs/alerts/alerts.json | sort -u
"source":"alma_9"
"source":"redhat_9"
root@manager:~# grep "total vulnerabilities found" /var/wazuh-manager/logs/wazuh-manager.log
2026/02/23 11:16:45 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 0 ms: 0 packages scanned, 0 skipped, 0 vulnerable packages, 0 total vulnerabilities found
2026/02/23 11:20:49 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 414 ms: 679 packages scanned, 0 skipped, 170 vulnerable packages, 39485 total vulnerabilities found
2026/02/23 11:29:48 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Packages scan completed in 109 ms: 671 packages scanned, 0 skipped, 4 vulnerable packages, 144 total vulnerabilities found
root@manager:~#
```

Post-change validation: We have initiated a new round of testing. We are specifically auditing the packages, cnaSources, and individual vulnerability entries to verify the fix and prevent regressions.

```
root@manager:~# grep "vulnerability-scanner" /var/wazuh-manager/logs/wazuh-manager.log
2026/02/24 11:10:18 wazuh-manager-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/02/24 11:10:18 wazuh-manager-modulesd:vulnerability-scanner: INFO: Schema validator initialized successfully from embedded resources.
2026/02/24 11:35:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Initiating feed update process.
2026/02/24 11:48:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed.
2026/02/24 11:48:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/02/24 11:48:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=feed_update
2026/02/24 11:48:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 71 ms: 671 packages scanned, 0 skipped, 4 vulnerable packages, 144 total vulnerabilities found
2026/02/24 11:48:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
2026/02/24 11:48:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=1, status=ok).
root@manager:~# grep -o '"source":"[^"]*"' /var/wazuh-manager/logs/alerts/alerts.json 2>/dev/null | sort -u
"source":"Alma Linux Security Oval"
root@manager:~# 
```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
