### PR TITLE
Read logcollector files from BOF during non-startup cycles

### DIFF
--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -31,7 +31,7 @@
 
 
 extern OSHash *files_status;
-extern volatile int _startup_completed;
+extern atomic_int_t _startup_completed;
 
 bool w_get_hash_context(logreader *lf, EVP_MD_CTX **context, int64_t position);
 ssize_t w_set_to_pos(logreader *lf, long pos, int mode);
@@ -87,7 +87,7 @@ static int setup_local_hashmap(void **state) {
 }
 
 static int teardown_local_hashmap(void **state) {
-    _startup_completed = 0;
+    atomic_int_set(&_startup_completed, 0);
     if (teardown_hashmap(state) != 0) {
         return 1;
     }
@@ -2103,7 +2103,7 @@ void test_w_set_to_last_line_read_OSHash_Get_ex_fail(void ** state) {
     logreader log_reader = {.fp = (FILE *)1, .file = "test"};
 
     test_position = &position_stack;
-    _startup_completed = 0;
+    atomic_int_set(&_startup_completed, 0);
 
     expect_function_call(__wrap_pthread_rwlock_wrlock);
     expect_function_call(__wrap_pthread_rwlock_unlock);
@@ -2148,7 +2148,7 @@ void test_w_set_to_last_line_read_no_bookmark_runtime(void ** state) {
 
     test_position = &position_stack;
 
-    _startup_completed = 1;
+    atomic_int_set(&_startup_completed, 1);
 
     expect_function_call(__wrap_pthread_rwlock_wrlock);
     expect_function_call(__wrap_pthread_rwlock_unlock);
@@ -2198,7 +2198,7 @@ void test_w_set_to_last_line_read_no_bookmark_runtime_hash_error(void ** state) 
 
     test_position = &position_stack;
 
-    _startup_completed = 1;
+    atomic_int_set(&_startup_completed, 1);
 
     expect_function_call(__wrap_pthread_rwlock_wrlock);
     expect_function_call(__wrap_pthread_rwlock_unlock);
@@ -2253,7 +2253,7 @@ void test_w_set_to_last_line_read_no_bookmark_startup_hash_error(void ** state) 
 
     test_position = &position_stack;
 
-    _startup_completed = 0;
+    atomic_int_set(&_startup_completed, 0);
 
     expect_function_call(__wrap_pthread_rwlock_wrlock);
     expect_function_call(__wrap_pthread_rwlock_unlock);


### PR DESCRIPTION
## Description

Closes #33382

Currently, Logcollector scans permanently loses all content written to runtime-discovered files from between their creation and discovery. This happens because when `check_pattern_expand()` finds a new file matching a wildcard, `handle_file()` always seeks to EOF (`SEEK_END`), discarding any pre-existing content. This affects all wildcard-monitored log files regardless of the `only-future-events` setting.

## Proposed Changes

- Added a `_startup_completed` flag in `logcollector.c` that distinguishes initial file scanning (startup) from runtime file discovery. The flag is set to `1` immediately after the first full scan loop completes in `LogCollectorStart()`.
- Modified `handle_file()` on the Linux path (and 3 equivalent Windows `#ifdef WIN32` paths) to route runtime-discovered files through `w_set_to_last_line_read()` instead of unconditional `SEEK_END`, even when `only-future-events=yes` (the default).
- Modified `w_set_to_last_line_read()` so that when no saved bookmark exists and `_startup_completed == 1`, the file is read from the beginning (`SEEK_SET`) instead of being skipped to the end (`SEEK_END`). Startup behavior (seek to end for pre-existing files) is preserved.
- Added 3 new CMocka unit tests covering the runtime no-bookmark, runtime hash-error, and startup hash-error scenarios.

### Results and Evidence

A test was executed where a new file was created during runtime (after startup) with 10 lines written. The logs show that the file is being detected and all the existing content at the moment of detection is read and processed as expected.
```
logcollector.c:1362 at check_pattern_expand(): INFO: (1957): New file that matches the
  '/var/log/test/wildcard/*.log' pattern: '/var/log/test/wildcard/deploy-test-1771965028.log'.

logcollector.c:2810 at w_set_to_last_line_read(): DEBUG: New file
  '/var/log/test/wildcard/deploy-test-1771965028.log' discovered at runtime with no bookmark.
  Reading from beginning.

read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Deploy started'
read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Pulling image'
read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Image pulled'
read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Container started'
read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Health check passed'
read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Deploy finished'
read_syslog.c:104: Reading syslog message: '2026-02-24 20:30:28 MARKER_RUNTIME Seven lines total'

read_syslog.c:152: Read 7 lines from /var/log/test/wildcard/deploy-test-1771965028.log
```

Before the fix, 0 of 7 lines would have been read (all skipped by `SEEK_END`).

### Artifacts Affected

- `wazuh-logcollector` (Linux, Windows)

### Configuration Changes

- N/A. No new configuration parameters. Existing `only-future-events` behavior is preserved for files discovered at startup. The change only affects files discovered at runtime (after the initial scan).

### Documentation Updates

- N/A

### Tests Introduced

- `test_w_set_to_last_line_read_no_bookmark_runtime` — Verifies that a file discovered at runtime with no saved bookmark is read from the beginning (`SEEK_SET` with offset 0).
- `test_w_set_to_last_line_read_no_bookmark_runtime_hash_error` — Verifies runtime discovery behavior when the hash table update fails (error path).
- `test_w_set_to_last_line_read_no_bookmark_startup_hash_error` — Verifies that startup behavior is preserved (`SEEK_END`) when the hash table update fails.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
