### PR TITLE
feat: gcp workload identity support

### DIFF
--- a/src/config/src/wmodules-gcp.c
+++ b/src/config/src/wmodules-gcp.c
@@ -209,11 +209,6 @@ int wm_gcp_pubsub_read(xml_node **nodes, wmodule *module) {
         return OS_INVALID;
     }
 
-    if (!gcp->credentials_file) {
-        merror("No value defined for tag '%s' in module '%s'", XML_CREDENTIALS_FILE, WM_GCP_PUBSUB_CONTEXT.name);
-        return OS_INVALID;
-    }
-
     return 0;
 }
 int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
@@ -394,11 +389,6 @@ int wm_gcp_bucket_read(const OS_XML *xml, xml_node **nodes, wmodule *module) {
 
             if (!cur_bucket->bucket) {
                 merror("No value defined for tag '%s' in module '%s'.", XML_BUCKET_NAME, WM_GCP_BUCKET_CONTEXT.name);
-                clean_bucket(cur_bucket, gcp);
-                return OS_INVALID;
-            }
-            else if (!cur_bucket->credentials_file) {
-                merror("No value defined for tag '%s' in module '%s'.", XML_CREDENTIALS_FILE, WM_GCP_BUCKET_CONTEXT.name);
                 clean_bucket(cur_bucket, gcp);
                 return OS_INVALID;
             }

--- a/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
+++ b/src/unit_tests/wazuh_modules/gcp/test_wmodules_gcp.c
@@ -772,17 +772,21 @@ static void test_wm_gcp_pubsub_read_credentials_file_tag_file_not_found(void **s
 
 static void test_wm_gcp_pubsub_read_no_credentials_file_tag(void **state) {
     group_data_t *data = *state;
+    wm_gcp_pubsub *gcp;
     int ret;
 
     expect_value(__wrap_sched_scan_read, nodes, data->nodes);
     expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_PUBSUB_WM_NAME);
     will_return(__wrap_sched_scan_read, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "No value defined for tag 'credentials_file' in module 'gcp-pubsub'");
-
     ret = wm_gcp_pubsub_read(data->nodes, data->module);
 
-    assert_int_equal(ret, OS_INVALID);
+    assert_int_equal(ret, 0);
+
+    gcp = data->module->data;
+
+    assert_non_null(gcp);
+    assert_null(gcp->credentials_file);
 }
 
 static void test_wm_gcp_pubsub_read_max_messages_tag_empty(void **state) {
@@ -1311,11 +1315,13 @@ static void test_wm_gcp_bucket_read_no_credentials_file_tag(void **state) {
     expect_string(__wrap_IsFile, file, "credentials.json");
     will_return(__wrap_IsFile, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "No value defined for tag 'credentials_file' in module 'gcp-bucket'.");
+    expect_value(__wrap_sched_scan_read, nodes, data->nodes);
+    expect_string(__wrap_sched_scan_read, MODULE_NAME, GCP_BUCKET_WM_NAME);
+    will_return(__wrap_sched_scan_read, 0);
 
     ret = wm_gcp_bucket_read(data->xml, data->nodes, data->module);
 
-    assert_int_equal(ret, OS_INVALID);
+    assert_int_equal(ret, 0);
 }
 
 static void test_wm_gcp_bucket_read_run_on_start_tag_invalid(void **state) {

--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -22,6 +22,7 @@ from integration import WazuhGCloudIntegration
 try:
     from google.cloud import storage
     from google.api_core import exceptions as google_exceptions
+    import google.auth
     import pytz
 except ImportError as e:
     raise exceptions.WazuhIntegrationException(errcode=1003, package=e.name)
@@ -61,7 +62,11 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         self.bucket_name = bucket_name
         self.bucket = None
         try:
-            self.client = storage.client.Client.from_service_account_json(credentials_file)
+            if credentials_file:
+                self.client = storage.client.Client.from_service_account_json(credentials_file)
+            else:
+                credentials, project = google.auth.default()
+                self.client = storage.client.Client(credentials=credentials, project=project)
         except JSONDecodeError as error:
             raise exceptions.GCloudError(1000, credentials_file=credentials_file) from error
         except FileNotFoundError as error:

--- a/wodles/gcloud/pubsub/subscriber.py
+++ b/wodles/gcloud/pubsub/subscriber.py
@@ -18,6 +18,7 @@ from integration import WazuhGCloudIntegration
 try:
     from google.cloud import pubsub_v1 as pubsub
     import google.api_core.exceptions
+    import google.auth
 except ImportError as e:
     raise exceptions.GCloudError(errcode=1003, package=e.name)
 
@@ -31,7 +32,7 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
         Parameters
         ----------
         credentials_file : str
-            Path to credentials file.
+            Path to credentials file. If None, Application Default Credentials will be used.
         project : str
             Project name.
         subscription_id : str
@@ -62,14 +63,17 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
         Parameters
         ----------
         credentials_file : str
-            Path to credentials file.
+            Path to credentials file. If None, Application Default Credentials will be used.
 
         Returns
         -------
         pubsub.subscriber.Client
             Instance of subscriber client object created with the provided key.
         """
-        return pubsub.subscriber.Client.from_service_account_file(credentials_file)  # noqa: E501
+        if credentials_file:
+            return pubsub.subscriber.Client.from_service_account_file(credentials_file)  # noqa: E501
+        credentials, project = google.auth.default()
+        return pubsub.subscriber.Client(credentials=credentials)
 
     def get_subscription_path(self, project: str, subscription_id: str) -> str:
         """Get the subscription path.

--- a/wodles/gcloud/tests/test_subscriber.py
+++ b/wodles/gcloud/tests/test_subscriber.py
@@ -60,6 +60,19 @@ def test_WazuhGCloudSubscriber__init__(mock_client):
     mock_client.assert_called_once()
 
 
+@patch('pubsub.subscriber.google.auth.default')
+@patch('pubsub.subscriber.pubsub.subscriber.Client')
+def test_WazuhGCloudSubscriber__init__adc(mock_client, mock_auth_default):
+    """Test if an instance of WazuhGCloudSubscriber is created properly using Application Default Credentials."""
+    mock_credentials = MagicMock()
+    mock_auth_default.return_value = (mock_credentials, 'test_project')
+    pubsub = WazuhGCloudSubscriber(**get_wodle_config(credentials_file=None))
+    for attribute in ['logger', 'subscriber', 'subscription_path']:
+        assert hasattr(pubsub, attribute)
+    mock_auth_default.assert_called_once()
+    mock_client.assert_called_once_with(credentials=mock_credentials)
+
+
 @pytest.mark.parametrize('credentials_file, errcode', [
     ('invalid_credentials_file.json', 1000),
     ('unexistent_file', 1001)
@@ -78,6 +91,17 @@ def test_WazuhGCloudSubscriber_get_subscriber_client(mock_credentials):
     """Test get_subscriber_client attempts to create a client object using the provided credentials file."""
     WazuhGCloudSubscriber.get_subscriber_client("credentials.json")
     mock_credentials.assert_called_with("credentials.json")
+
+
+@patch('pubsub.subscriber.google.auth.default')
+@patch('pubsub.subscriber.pubsub.subscriber.Client')
+def test_WazuhGCloudSubscriber_get_subscriber_client_adc(mock_client, mock_auth_default):
+    """Test get_subscriber_client uses Application Default Credentials when no credentials file is provided."""
+    mock_credentials = MagicMock()
+    mock_auth_default.return_value = (mock_credentials, 'test_project')
+    WazuhGCloudSubscriber.get_subscriber_client(None)
+    mock_auth_default.assert_called_once()
+    mock_client.assert_called_once_with(credentials=mock_credentials)
 
 
 @patch('pubsub.subscriber.pubsub.subscriber.Client.from_service_account_file')

--- a/wodles/gcloud/tests/test_tools.py
+++ b/wodles/gcloud/tests/test_tools.py
@@ -24,9 +24,18 @@ def test_get_script_arguments(capsys):
     assert stderr == "", 'stderr was not empty'
 
 
+def test_get_script_arguments_no_credentials_file(capsys):
+    """Test get_script_arguments works without credentials_file, which is optional for ADC."""
+    with patch("sys.argv", ['main', '--integration_type', 'any']):
+        args = tools.get_script_arguments()
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "", 'stdout was not empty'
+    assert stderr == "", 'stderr was not empty'
+    assert args.credentials_file is None
+
+
 @pytest.mark.parametrize('args', [
     ['main'],
-    ['main', '--integration_type', 'any'],
     ['main', '--credentials_file', 'any'],
 ])
 def test_get_script_arguments_required(capsys, args):

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -49,7 +49,8 @@ def get_script_arguments():
                         help='Subscription name')
 
     parser.add_argument('-c', '--credentials_file', dest='credentials_file',
-                        help='Path to credentials file', required=True)
+                        help='Path to credentials file. If not provided, Application Default Credentials will be used',
+                        required=False, default=None)
 
     parser.add_argument('-m', '--max_messages', dest='max_messages', type=int,
                         help='Number of maximum messages pulled in each iteration', default=100)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

The gcp-pubsub and gcp-bucket modules currently require a <credentials_file> tag pointing to a valid service account JSON file. This makes it impossible to use Google Cloud's Application Default Credentials (ADC), which is the standard authentication method when running on GKE with Workload Identity Federation.

Users who want to use Workload Identity Federation today cannot do so for wazuh, https://docs.cloud.google.com/iam/docs/workload-identity-federation is a more secure way of giving creadentials and access in Google Cloud

This PR makes credentials_file optional. When omitted, the module authenticates using google.auth.default(), which supports Workload Identity Federation, the GCE metadata server, GOOGLE_APPLICATION_CREDENTIALS, and other ADC methods out of the box. When credentials_file is provided, behavior is identical to before.

## Proposed Changes

- wodles/gcloud/pubsub/subscriber.py: get_subscriber_client() now uses google.auth.default() when no credentials file is provided, falling back to the existing from_service_account_file() path when one is.
- wodles/gcloud/buckets/bucket.py: Same change for the GCS storage client.
- wodles/gcloud/tools.py: --credentials_file CLI argument changed from required to optional (defaults to None).
- src/config/src/wmodules-gcp.c: Removed the mandatory validation that rejects configs without a <credentials_file> tag, for both gcp-pubsub and gcp-bucket.
- Tests updated across Python and C to cover both code paths.

Existing configurations with <credentials_file> are completely unaffected,  all validation still applies when the tag is present.

### Results and Evidence

Python unit tests — 74/74 passing:
  tests/test_bucket.py          - 33 passed
  tests/test_gcloud.py          -  9 passed
  tests/test_integration.py     -  8 passed
  tests/test_subscriber.py      - 15 passed (includes 2 new ADC tests)
  tests/test_tools.py           -  9 passed (includes 1 new no-credentials test)

### Manual tests with their corresponding evidence

I have ran the tests using the docker deployment of an agent that was successfully able to use workload identity federation to access Google Cloud resources.

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- wodles/gcloud/gcloud (Python wodle — pubsub subscriber and bucket modules)
- wazuh-modulesd (C binary — config parser for gcp-pubsub and gcp-bucket)

### Configuration Changes

- <credentials_file> is now optional for both <gcp-pubsub> and <gcp-bucket> modules in ossec.conf.
- When omitted, authentication falls back to Google Application Default Credentials (google.auth.default()).
- When provided, behavior is unchanged — the file path is validated and used exactly as before.
- No changes to default values. No breaking changes to existing configurations.

Example — minimal config using Workload Identity Federation (no credentials file):
```  
<gcp-pubsub>
    <pull_on_start>yes</pull_on_start>
    <interval>30s</interval>
    <project_id>my-project</project_id>
    <subscription_name>my-subscription</subscription_name>
  </gcp-pubsub>
```
### Tests Introduced

- test_WazuhGCloudSubscriber__init__adc — verifies subscriber initialization using ADC when credentials_file=None
- test_WazuhGCloudSubscriber_get_subscriber_client_adc — verifies get_subscriber_client() calls google.auth.default() and passes credentials to the Client constructor
- test_get_script_arguments_no_credentials_file — verifies argparse accepts invocation without --credentials_file
- C test updates — test_wm_gcp_pubsub_read_no_credentials_file_tag and test_wm_gcp_bucket_read_no_credentials_file_tag updated to expect success (return 0) instead of OS_INVALID

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
