### PR TITLE
Use INSTALL_RPATH for active response binaries on Linux

### DIFF
--- a/src/active-response/CMakeLists.txt
+++ b/src/active-response/CMakeLists.txt
@@ -49,9 +49,11 @@ function(add_active_response_executable name source)
 
   # Platform-specific linker flags
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Linux: Add rpath for ../../lib, plus pthread, rt, dl
-    target_link_options(${name} PRIVATE "LINKER:-rpath,$ORIGIN/../../lib"
-                        -pthread)
+    # Linux: Set runtime library path and link system libraries
+    set_target_properties(${name} PROPERTIES
+      INSTALL_RPATH "$ORIGIN/../../lib"
+      BUILD_WITH_INSTALL_RPATH TRUE)
+    target_link_options(${name} PRIVATE -pthread)
 
     # Add system libraries
     target_link_libraries(${name} PRIVATE pthread rt dl m)


### PR DESCRIPTION
## Description

Closes #34644

The `restart-wazuh` active response binary on Linux fails to load `libwazuhext.so` at runtime because the embedded RPATH does not survive the packaging process. The build used `target_link_options` with `LINKER:-rpath` to set the runtime library path, which may cause path resolution errors.

## Proposed Changes

- Replaced `target_link_options(... "LINKER:-rpath,$ORIGIN/../../lib" -pthread)` with `set_target_properties(... INSTALL_RPATH "$ORIGIN/../../lib" BUILD_WITH_INSTALL_RPATH TRUE)` in the `add_active_response_executable()` CMake function for Linux.
- Kept `-pthread` as a separate `target_link_options` call.
- This aligns the Linux RPATH handling with the macOS approach already in place in the same file.

### Results and Evidence

**Before the fix:**
```console
root@NicolaiPC:/var/ossec# ls -la /var/ossec/lib/lib
libagent_info.so           libdbsync.so               libsca.so                  libsysinfo.so
libagent_metadata.so       libfimdb.so                libschema_validator.so     libwazuhext.so
libagent_sync_protocol.so  libfimebpf.so              libstdc++.so.6             
libbpf.so                  libgcc_s.so.1              libsyscollector.so

root@NicolaiPC:/var/ossec# ls -la /var/ossec/lib/libwazuhext.so 
-rwxr-x--- 1 root wazuh 12492824 Feb 24 06:56 /var/ossec/lib/libwazuhext.so

root@NicolaiPC:/var/ossec# ldd /var/ossec/active-response/bin/restart-wazuh 
	linux-vdso.so.1 (0x00007fff2b5b0000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fd4ce39e000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fd4ce399000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fd4ce394000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fd4ce2ab000)
	libwazuhext.so => not found
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd4ce000000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fd4ce3b1000)

root@NicolaiPC:/var/ossec# /var/ossec/active-response/bin/restart-wazuh
/var/ossec/active-response/bin/restart-wazuh: error while loading shared libraries: libwazuhext.so: cannot open shared object file: No such file or directory
```

Note that the `libwazuhext.so` binary is not found with the current approach:

```
	libwazuhext.so => not found
```

**After the fix:**
```console
root@NicolaiPC:/var/ossec# ls -la /var/ossec/lib/lib*
-rwxr-x--- 1 root wazuh   351360 Feb 26 10:44 /var/ossec/lib/libagent_info.so
-rwxr-x--- 1 root wazuh     9872 Feb 26 10:44 /var/ossec/lib/libagent_metadata.so
-rwxr-x--- 1 root wazuh   218488 Feb 26 10:44 /var/ossec/lib/libagent_sync_protocol.so
-rwxr-x--- 1 root wazuh   526040 Feb 26 10:44 /var/ossec/lib/libbpf.so
-rwxr-x--- 1 root wazuh   517648 Feb 26 10:44 /var/ossec/lib/libdbsync.so
-rwxr-x--- 1 root wazuh   247952 Feb 26 10:44 /var/ossec/lib/libfimdb.so
-rwxr-x--- 1 root wazuh    45376 Feb 26 10:44 /var/ossec/lib/libfimebpf.so
-rwxr-x--- 1 root wazuh   183248 Feb 26 10:44 /var/ossec/lib/libgcc_s.so.1
-rwxr-x--- 1 root wazuh   800872 Feb 26 10:44 /var/ossec/lib/libsca.so
-rwxr-x--- 1 root wazuh   364064 Feb 26 10:44 /var/ossec/lib/libschema_validator.so
-rwxr-x--- 1 root wazuh  2599704 Feb 26 10:44 /var/ossec/lib/libstdc++.so.6
-rwxr-x--- 1 root wazuh   794328 Feb 26 10:44 /var/ossec/lib/libsyscollector.so
-rwxr-x--- 1 root wazuh  2418600 Feb 26 10:44 /var/ossec/lib/libsysinfo.so
-rwxr-x--- 1 root wazuh 12492824 Feb 26 10:44 /var/ossec/lib/libwazuhext.so

root@NicolaiPC:/var/ossec# ls -la /var/ossec/lib/libwazuhext.so 
-rwxr-x--- 1 root wazuh 12492824 Feb 26 10:44 /var/ossec/lib/libwazuhext.so

root@NicolaiPC:/var/ossec# ldd /var/ossec/active-response/bin/restart-wazuh 
	linux-vdso.so.1 (0x00007ffebe6b4000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x000079077a9d0000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x000079077a9cb000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x000079077a9c6000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000079077a8dd000)
	libwazuhext.so => /var/ossec/active-response/bin/../../lib/libwazuhext.so (0x0000790779a00000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000790779600000)
	/lib64/ld-linux-x86-64.so.2 (0x000079077a9e3000)

root@NicolaiPC:/var/ossec# /var/ossec/active-response/bin/restart-wazuh
... (no library load error)
```

### Artifacts Affected

- All 12 active response binaries: `restart-wazuh`, `host-deny`, `disable-account`, `default-firewall-drop`, `pf`, `npf`, `ipfw`, `firewalld-drop`, `ip-customblock`, `route-null`, `kaspersky`, `wazuh-slack`
- Linux agent packages (`.deb`, `.rpm`)

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- N/A

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
