### PR TITLE
Fix OS codename parsing for 5.x agent JSON keepalives

### DIFF
--- a/src/shared/src/remoted_op.c
+++ b/src/shared/src/remoted_op.c
@@ -320,7 +320,14 @@ int parse_json_keepalive(const char *json_str, agent_info_data *agent_data, char
     if (agent_uname && cJSON_IsString(agent_uname)) {
         char *uname_copy = NULL;
         os_strdup(agent_uname->valuestring, uname_copy);
-        os_strdup(agent_uname->valuestring, agent_data->osd->os_uname);
+
+        // Strip " - Wazuh vX.X.X" suffix before parsing (same cleanup as parse_agent_update_msg)
+        char *dash_separator = strstr(uname_copy, " - ");
+        if (dash_separator) {
+            *dash_separator = '\0';
+        }
+
+        os_strdup(uname_copy, agent_data->osd->os_uname);
         parse_uname_string(uname_copy, agent_data->osd);
         os_free(uname_copy);
     }

--- a/src/unit_tests/shared/test_remoted_op.c
+++ b/src/unit_tests/shared/test_remoted_op.c
@@ -588,6 +588,36 @@ void test_parse_json_keepalive_linux_complete(void **state)
     wdb_free_agent_info_data(agent_data);
 }
 
+void test_parse_json_keepalive_linux_codename_with_wazuh_suffix(void **state)
+{
+    char* json = "{\"version\":\"1.0\",\"agent\":{\"id\":\"002\",\"name\":\"agent2\",\"version\":\"v5.0.0\",\
+\"config_sum\":\"ab73af41699f13fdd81903b5f23d8d00\",\"merged_sum\":\"fd756ba04d9c32c8848d4608bec41251\",\
+\"ip\":\"192.168.1.101\",\
+\"uname\":\"Linux |523e34619338 |6.12.68-1-MANJARO |#1 SMP PREEMPT_DYNAMIC Sat Feb 22 10:37:40 UTC 2025 |x86_64 [Ubuntu|ubuntu: 24.04.4 LTS (Noble Numbat)] - Wazuh v5.0.0\"},\
+\"host\":{\"hostname\":\"523e34619338\",\"architecture\":\"x86_64\",\
+\"os\":{\"name\":\"Ubuntu\",\"version\":\"24.04.4 LTS\",\"platform\":\"ubuntu\",\"type\":\"linux\"}}}";
+
+    agent_info_data *agent_data = NULL;
+    os_calloc(1, sizeof(agent_info_data), agent_data);
+
+    int result = parse_json_keepalive(json, agent_data, NULL, NULL, NULL, NULL);
+
+    assert_int_equal(OS_SUCCESS, result);
+    assert_string_equal("Ubuntu", agent_data->osd->os_name);
+    assert_string_equal("24.04.4 LTS", agent_data->osd->os_version);
+    assert_string_equal("ubuntu", agent_data->osd->os_platform);
+    assert_string_equal("linux", agent_data->osd->os_type);
+    assert_string_equal("x86_64", agent_data->osd->os_arch);
+    assert_string_equal("523e34619338", agent_data->osd->hostname);
+    assert_string_equal("Noble Numbat", agent_data->osd->os_codename);
+    assert_string_equal("24", agent_data->osd->os_major);
+    assert_string_equal("04", agent_data->osd->os_minor);
+    // Verify " - Wazuh v5.0.0" suffix is stripped from os_uname
+    assert_null(strstr(agent_data->osd->os_uname, " - Wazuh"));
+
+    wdb_free_agent_info_data(agent_data);
+}
+
 void test_parse_json_keepalive_windows(void **state)
 {
     char* json = "{\"version\":\"1.0\",\"agent\":{\"version\":\"v5.0.0\",\"config_sum\":\"abc123\",\
@@ -1040,6 +1070,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_invalid_json, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_missing_agent, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_linux_complete, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_parse_json_keepalive_linux_codename_with_wazuh_suffix, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_windows, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_minimal, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_with_groups, setup_remoted_op, teardown_remoted_op),


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

When a 5.x agent sends a JSON keepalive to a 5.x manager, the `os_codename` field is stored incorrectly in `global.db`. For example, instead of `Noble Numbat`, the DB stores `Noble Numbat)] - Wazuh v5.0`. The "` - Wazuh vX.X.X`" suffix in the uname string is not stripped before calling `parse_uname_string()`, which corrupts the bracket based parsing.

The 4.x code path (`parse_agent_update_msg`) correctly strips this suffix by splitting on "` - `" before parsing. The 5.x code path (`parse_json_keepalive`) was missing this cleanup.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #34650 
-->

## Proposed Changes

- Strip the "` - Wazuh vX.X.X`" suffix from the uname string in `parse_json_keepalive()` before passing it to `parse_uname_string()`, matching the existing behavior in `parse_agent_update_msg()`.
- Store the cleaned uname (without the suffix) in `os_uname`, consistent with the 4.x code path.
- Added `test_parse_json_keepalive_linux_codename_with_wazuh_suffix` with the exact uname from the bug report.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

Agent 5.x
```
2026/02/26 14:22:28 wazuh-agentd[18032] notify.c:313 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"001","name":"ubuntu","version":"v5.0.0","config_sum":"ab73af41699f13fdd81903b5f23d8d00","merged_sum":"ca35f9148a3273413eccb79f149f4757","ip":"192.168.139.70","uname":"Linux |ubuntu |6.17.8-orbstack-00308-g8f9c941121b1 |#1 SMP PREEMPT Thu Nov 20 09:34:02 UTC 2025 |aarch64 [Ubuntu|ubuntu: 24.04.4 LTS (Noble Numbat)] - Wazuh v5.0.0","groups":["default"]},"host":{"hostname":"ubuntu","architecture":"aarch64","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}} 
```

Manager 5.x
```
2026/02/26 19:22:28 wazuh-manager-remoted[913] manager.c:665 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"id":"001","name":"ubuntu","version":"v5.0.0","config_sum":"ab73af41699f13fdd81903b5f23d8d00","merged_sum":"ca35f9148a3273413eccb79f149f4757","ip":"192.168.139.70","uname":"Linux |ubuntu |6.17.8-orbstack-00308-g8f9c941121b1 |#1 SMP PREEMPT Thu Nov 20 09:34:02 UTC 2025 |aarch64 [Ubuntu|ubuntu: 24.04.4 LTS (Noble Numbat)] - Wazuh v5.0.0","groups":["default"]},"host":{"hostname":"ubuntu","architecture":"aarch64","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}'
```

#### Global DB query

```
sqlite> select id,os_codename, version from agent where id>0;
1|Noble Numbat|v5.0.0
sqlite> select * from agent where id>0;
1|ubuntu|192.168.139.70|any|470805d184f38b7680e03a90b9c651ca66b5a0cb87b7f97c9214fa3c72debeb3|Ubuntu|24.04.4 LTS (Noble Numbat)|24|04|Noble Numbat||ubuntu|Linux |ubuntu |6.17.8-orbstack-00308-g8f9c941121b1 |#1 SMP PREEMPT Thu Nov 20 09:34:02 UTC 2025 |aarch64 [Ubuntu|ubuntu: 24.04.4 LTS (Noble Numbat)]|aarch64|v5.0.0|ab73af41699f13fdd81903b5f23d8d00|ca35f9148a3273413eccb79f149f4757|wazuh-manager|node01|1772132748|1772133468|default|37a8eec1|syncreq|synced|active|0|synced|0
```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected

- `wazuh-remoted` (all platforms)

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Tests Introduced

- Added `test_parse_json_keepalive_linux_codename_with_wazuh_suffix`: Reproduces the exact bug scenario from #34650  , asserting correct extraction of `os_codename`, `os_version`, `os_major`, and `os_minor`.

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
