### PR TITLE
Add outbound firewall rule in netsh AR to block IP in both directions

### DIFF
--- a/src/active-response/netsh.c
+++ b/src/active-response/netsh.c
@@ -121,7 +121,6 @@ int main (int argc, char **argv) {
         write_debug_file(argv[0], log_msg);
     }
 
-    char *exec_args_add[11] = { netsh_path, "advfirewall", "firewall", "add", "rule", name, "interface=any", "dir=in", "action=block", remoteip, NULL };
     char *exec_args_delete[8] = { netsh_path, "advfirewall", "firewall", "delete", "rule", name, remoteip, NULL };
 
     if ((action == ADD_COMMAND)) {
@@ -133,13 +132,36 @@ int main (int argc, char **argv) {
     }
 
     if (1 == checkVista()) {
-        wfd = wpopenv(netsh_path, (action == ADD_COMMAND) ? exec_args_add : exec_args_delete, W_BIND_STDERR);
-        if (!wfd) {
-            memset(log_msg, '\0', OS_MAXSTR);
-            snprintf(log_msg, OS_MAXSTR -1, "Unable to run netsh, action: '%s', rule: '%s'", (action == ADD_COMMAND) ? "ADD" : "DELETE", RULE_NAME);
-            write_debug_file(argv[0], log_msg);
+        char *exec_args_add_in[11] = { netsh_path, "advfirewall", "firewall", "add", "rule", name, "interface=any", "dir=in", "action=block", remoteip, NULL };
+        char *exec_args_add_out[11] = { netsh_path, "advfirewall", "firewall", "add", "rule", name, "interface=any", "dir=out", "action=block", remoteip, NULL };
+
+        if (action == ADD_COMMAND) {
+            wfd = wpopenv(netsh_path, exec_args_add_in, W_BIND_STDERR);
+            if (!wfd) {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR -1, "Unable to run netsh, action: 'ADD dir=in', rule: '%s'", RULE_NAME);
+                write_debug_file(argv[0], log_msg);
+            } else {
+                wpclose(wfd);
+            }
+
+            wfd = wpopenv(netsh_path, exec_args_add_out, W_BIND_STDERR);
+            if (!wfd) {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR -1, "Unable to run netsh, action: 'ADD dir=out', rule: '%s'", RULE_NAME);
+                write_debug_file(argv[0], log_msg);
+            } else {
+                wpclose(wfd);
+            }
         } else {
-            wpclose(wfd);
+            wfd = wpopenv(netsh_path, exec_args_delete, W_BIND_STDERR);
+            if (!wfd) {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR -1, "Unable to run netsh, action: 'DELETE', rule: '%s'", RULE_NAME);
+                write_debug_file(argv[0], log_msg);
+            } else {
+                wpclose(wfd);
+            }
         }
     } else {
         snprintf(description, OS_MAXSTR -1, "description=\"%s\"", RULE_NAME);


### PR DESCRIPTION
## Description
This PR fixes the `netsh` active response script on Windows, which was not effectively blocking IP addresses despite the firewall rule being created.

**Proposed Release:** v4.14.5

## Proposed Changes
- Updated `src/active-response/netsh.c`.
- Fixed missing outbound (`dir=out`) firewall rule in the `netsh` active response.
- The original code only created an inbound (`dir=in`) rule, allowing outbound traffic from the Windows endpoint toward the blocked IP to continue unaffected. This fix adds a second `wpopenv` call to also create an outbound rule, fully blocking communication in both directions.

## Results and Evidence

The fix was validated end-to-end using the compiled `netsh.exe` on a real Windows 11 agent (ID 002, `DESKTOP-UBHV152`) connected to a Wazuh manager.

The Active Response was triggered automatically by writing to the monitored log file:
```powershell
cmd /c "echo Test: 8.8.8.8 >> C:\test.log"
```

### 1. Alert triggered and AR dispatched by the manager

Rule `100101` fired and the manager dispatched the AR to the agent immediately:
```json
{"timestamp":"2026-03-03T12:10:09.852+0100", "rule":{"level":5, "description":"Test rule.", "id":"100101"}, "agent":{"id":"002", "name":"DESKTOP-UBHV152"}, "full_log":"Test: 8.8.8.8", "data":{"srcip":"8.8.8.8"}}
```

### 2. Both firewall rules created (inbound + outbound)

Before this fix, only the inbound rule was created, leaving outbound traffic to the blocked IP unrestricted — which is exactly the behavior reported in the issue.

```
Rule name: WAZUH ACTIVE RESPONSE BLOCKED IP
Direction: Out | Action: Block | RemoteIP: 8.8.8.8/32

Rule name: WAZUH ACTIVE RESPONSE BLOCKED IP
Direction: In  | Action: Block | RemoteIP: 8.8.8.8/32
```

### 3. IP effectively blocked

```powershell
PS> Test-NetConnection -ComputerName 8.8.8.8 -Port 80

PingSucceeded    : False
TcpTestSucceeded : False
```

### 4. Rules automatically removed after timeout (300s)

Agent `active-responses.log`:
```
2026/03/03 12:10:16 active-response/bin/netsh.exe: Starting
2026/03/03 12:10:16 ... "command":"add",    "data":{"srcip":"8.8.8.8"} ...
2026/03/03 12:10:17 ... "command":"check_keys", "keys":["8.8.8.8"] ...
2026/03/03 12:10:17 ... "command":"continue", "data":{"srcip":"8.8.8.8"} ...
2026/03/03 12:10:18 active-response/bin/netsh.exe: Ended

[... 5 minutes later ...]

2026/03/03 12:14:58 active-response/bin/netsh.exe: Starting
2026/03/03 12:14:58 ... "command":"delete",  "data":{"srcip":"8.8.8.8"} ...
2026/03/03 12:14:59 active-response/bin/netsh.exe: Ended
```

Firewall after delete:
```
PS> netsh advfirewall firewall show rule name="WAZUH ACTIVE RESPONSE BLOCKED IP"
No rules match the specified criteria.
```

## Artifacts Affected
- `src/active-response/netsh.c`

## Configuration Changes
N/A

## Documentation Updates
N/A

## Tests Introduced
- **Scope:** Manual end-to-end validation on Windows 11
- **Details:** The AR was triggered automatically from a monitored log file. Verified that with both `dir=in` and `dir=out` rules active, all TCP and ICMP traffic to the blocked IP is dropped. Also verified that the `DELETE` command correctly removes both rules after the configured timeout.

## Review Checklist
**Manual tests with their corresponding evidence:**
- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues