### PR TITLE
Allow etc backups for cluster config updates

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -60,7 +60,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/wazuh-manager/etc/local_internal_options.conf,root,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/etc/localtime,root,root,640,file,-rw-r-----,,
 /var/wazuh-manager/etc/ruleset,root,wazuh-manager,750,directory,drwxr-x---,,
-/var/wazuh-manager/etc/shared,root,wazuh-manager,750,directory,drwxr-x---,,
+/var/wazuh-manager/etc/shared,root,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/etc/shared/agent-template.conf,wazuh-manager,wazuh-manager,660,file,-rw-rw----,,
 /var/wazuh-manager/etc/shared/default,wazuh-manager,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/etc/shared/default/agent.conf,wazuh-manager,wazuh-manager,660,file,-rw-rw----,,

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -557,7 +557,7 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh-manager) %{_localstatedir}/etc/internal_options*
 %attr(640, root, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(640, root, root) %{_localstatedir}/etc/localtime
-%dir %attr(750, root, wazuh-manager) %{_localstatedir}/etc/shared
+%dir %attr(770, root, wazuh-manager) %{_localstatedir}/etc/shared
 %dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/default
 %attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/agent-template.conf
 %attr(660, wazuh-manager, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/shared/default/*

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -935,11 +935,7 @@ InstallCommon()
     fi
 
 
-  if [ "X${INSTYPE}" = "Xagent" ]; then
-    ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/etc/shared
-  else
-    ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/etc/shared
-  fi
+  ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/etc/shared
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/active-response
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/active-response/bin
 


### PR DESCRIPTION
# Description

Adjust manager runtime directory permissions to preserve current API/cluster write flows:
- `/var/wazuh-manager/etc` -> `770` (allows in-place backup creation for `wazuh-manager.conf` updates, avoiding `1019`).
- `/var/wazuh-manager/etc/shared` -> `770` (allows centralized configuration operations that create/remove shared assets).

