### PR TITLE
Avoid creating new install paths on rollback upgrades

### DIFF
--- a/packages/debs/SPECS/wazuh-manager/debian/postrm
+++ b/packages/debs/SPECS/wazuh-manager/debian/postrm
@@ -2,8 +2,27 @@
 # postrm script for Wazuh
 # Wazuh, Inc 2015
 set -e
+DPKG_LIST_FILE="/var/lib/dpkg/info/wazuh-manager.list"
+
 DIR="/var/wazuh-manager"
+if [ "$1" = "abort-upgrade" ] || [ "$1" = "failed-upgrade" ]; then
+    DIR=$(grep -m 1 -E '/bin/(wazuh-manager-control|wazuh-control)$' "${DPKG_LIST_FILE}" 2>/dev/null \
+        | sed -E 's#/bin/(wazuh-manager-control|wazuh-control)$##')
+
+    if [ -z "${DIR}" ] || [ ! -d "${DIR}" ]; then
+        exit 0
+    fi
+fi
+
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
+ROLLBACK_MARKER="${WAZUH_TMP_DIR}/rollback_prepared"
+
+# If preinst did not prepare rollback state, abort safely.
+if [ "$1" = "abort-upgrade" ] || [ "$1" = "failed-upgrade" ]; then
+    if [ ! -f "${ROLLBACK_MARKER}" ]; then
+        exit 0
+    fi
+fi
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/packages/debs/SPECS/wazuh-manager/debian/preinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/preinst
@@ -8,13 +8,12 @@ WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 VERSION="$2"
 MAJOR=$(echo "$VERSION" | cut -dv -f2 | cut -d. -f1)
 
-# environment configuration
-if [ ! -d ${WAZUH_TMP_DIR} ]; then
-    mkdir -p ${WAZUH_TMP_DIR}
-else
-    rm -rf ${WAZUH_TMP_DIR}
-    mkdir -p ${WAZUH_TMP_DIR}
-fi
+prepare_tmp_dir() {
+    if [ -d "${WAZUH_TMP_DIR}" ]; then
+        rm -rf "${WAZUH_TMP_DIR}"
+    fi
+    mkdir -p "${WAZUH_TMP_DIR}"
+}
 
 case "$1" in
     install|upgrade)
@@ -87,6 +86,10 @@ EOF
                 exit 1
             fi
 
+            # environment configuration (original behavior, after hard-block checks)
+            prepare_tmp_dir
+            touch "${WAZUH_TMP_DIR}/rollback_prepared"
+
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-manager > /dev/null 2>&1; then
                 systemctl stop wazuh-manager.service > /dev/null 2>&1
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
@@ -139,13 +142,7 @@ EOF
                     rm -f /etc/rc.d/init.d/wazuh-api || true
                 fi
             fi
-        fi
 
-        if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/wazuh-manager.conf ] ; then
-            touch ${WAZUH_TMP_DIR}/create_conf
-        fi
-
-        if [ "$1" = "upgrade" ]; then
             # RBAC database
             if [ -f ${DIR}/api/configuration/security/rbac.db ]; then
                 cp -fp ${DIR}/api/configuration/security/rbac.db ${WAZUH_TMP_DIR}/rbac.db
@@ -160,6 +157,13 @@ EOF
             if [ -d ${DIR}/queue/agent-groups ]; then
                 mv -f ${DIR}/queue/agent-groups ${WAZUH_TMP_DIR}/
             fi
+        else
+            # environment configuration (original behavior for install)
+            prepare_tmp_dir
+        fi
+
+        if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/wazuh-manager.conf ] ; then
+            touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
         # Delete old service


### PR DESCRIPTION
# Description

Fix rollback path handling for Manager deb upgrades when installation directories differ.

Changes:
- `preinst`: avoid creating temp directories before 4.x -> 5.x hardblock validation.
- `postrm`: resolve the installed Manager directory first and apply rollback/restore on that directory.
- `postrm`: keep `abort-upgrade` / `failed-upgrade` fail-safe behavior (no-op) if directory resolution is not possible.



## Testing

- Clean environment:
```
root@ubuntu24:/home/vagrant/git/wazuh# ls /var/
backups  cache  crash  lib  local  lock  log  mail  opt  run  snap  spool  tmp
```



- Install 4.14.3 manager:

```
root@ubuntu24:/home/vagrant/git/wazuh# apt install /vagrant/packages/wazuh-manager_4.14.3-1_arm64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of '/vagrant/packages/wazuh-manager_4.14.3-1_arm64.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 93 not upgraded.
Need to get 0 B/475 MB of archives.
After this operation, 1,051 MB of additional disk space will be used.
Get:1 /vagrant/packages/wazuh-manager_4.14.3-1_arm64.deb wazuh-manager arm64 4.14.3-1 [475 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 120225 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.14.3-1_arm64.deb ...
Unpacking wazuh-manager (4.14.3-1) ...
Setting up wazuh-manager (4.14.3-1) ...
Processing triggers for libc-bin (2.39-0ubuntu8.7) ...
Scanning processes...
Scanning candidates...
Scanning linux images...

Running kernel seems to be up-to-date.

Restarting services...

Service restarts being deferred:
 /etc/needrestart/restart.d/dbus.service
 systemctl restart getty@tty1.service
 systemctl restart systemd-logind.service

No containers need to be restarted.

User sessions running outdated binaries:
 vagrant @ session #1: vmhgfs-fuse[2399]
 vagrant @ user manager service: systemd[1371]

No VM guests are running outdated hypervisor (qemu) binaries on this host.
```


- /var/ossec created:
```
root@ubuntu24:/home/vagrant/git/wazuh# ls /var
backups  cache  crash  lib  local  lock  log  mail  opt  ossec  run  snap  spool  tmp
root@ubuntu24:/home/vagrant/git/wazuh# ls /var/ossec/
active-response  api     bin  framework     lib   queue    stats      tmp  VERSION.json
agentless        backup  etc  integrations  logs  ruleset  templates  var  wodles
```




- Try to install manager 5.0.0, hard block:
```
root@ubuntu24:/home/vagrant/git/wazuh# apt install /vagrant/packages/wazuh-manager_5.0.0-0_arm64_bb27564.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of '/vagrant/packages/wazuh-manager_5.0.0-0_arm64_bb27564.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 93 not upgraded.
Need to get 0 B/453 MB of archives.
After this operation, 249 MB disk space will be freed.
Get:1 /vagrant/packages/wazuh-manager_5.0.0-0_arm64_bb27564.deb wazuh-manager arm64 5.0.0-0 [453 MB]
(Reading database ... 144426 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_5.0.0-0_arm64_bb27564.deb ...
==============================================================
ERROR: Direct upgrade from Wazuh Manager 4.X to 5.X is not supported.

Detected installed version: 4.14.3-1
==============================================================
dpkg: error processing archive /vagrant/packages/wazuh-manager_5.0.0-0_arm64_bb27564.deb (--unpack):
 new wazuh-manager package pre-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 /vagrant/packages/wazuh-manager_5.0.0-0_arm64_bb27564.deb
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

- Only /var/ossec exists:
```
root@ubuntu24:/home/vagrant/git/wazuh# ls /var/
backups  cache  crash  lib  local  lock  log  mail  opt  ossec  run  snap  spool  tmp
```