### PR TITLE
Backport/fix fim registry crash 4.10.4

### DIFF
--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -842,7 +842,7 @@ void fim_read_values(HKEY key_handle,
                      TXN_HANDLE regval_txn_handler,
                      fim_val_txn_context_t *txn_ctx_regval) {
     fim_registry_value_data value_data;
-    TCHAR *value_buffer;
+    WCHAR *value_name_buffer;
     BYTE *data_buffer;
     DWORD i;
     fim_entry new;
@@ -858,8 +858,8 @@ void fim_read_values(HKEY key_handle,
     new.registry_entry.value = &value_data;
     new.registry_entry.key = NULL;
 
-    os_calloc(max_value_length + 1, sizeof(TCHAR), value_buffer);
-    os_calloc(max_value_data_length, sizeof(BYTE), data_buffer);
+    os_calloc(max_value_length + 1, sizeof(WCHAR), value_name_buffer);
+    os_calloc(max_value_data_length + 4, sizeof(BYTE), data_buffer);
 
     for (i = 0; i < value_count; i++) {
         DWORD value_size = max_value_length + 1;
@@ -871,12 +871,12 @@ void fim_read_values(HKEY key_handle,
             return;
         }
 
-        if (RegEnumValue(key_handle, i, value_buffer, &value_size, NULL, &data_type, data_buffer, &data_size) !=
+        if (RegEnumValueW(key_handle, i, value_name_buffer, &value_size, NULL, &data_type, data_buffer, &data_size) !=
             ERROR_SUCCESS) {
             break;
         }
 
-        new.registry_entry.value->name = value_buffer;
+        new.registry_entry.value->name = value_name_buffer;
         new.registry_entry.value->type = data_type <= REG_QWORD ? data_type : REG_UNKNOWN;
         new.registry_entry.value->size = data_size;
         new.registry_entry.value->last_event = time(NULL);

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -696,7 +696,7 @@ static void test_fim_registry_scan_base_line_generation(void **state) {
     will_return(__wrap_fim_db_transaction_sync_row, -1);
     expect_string(__wrap__merror, formatted_msg, "Dbsync registry transaction failed due to -1");
     will_return(__wrap_fim_db_transaction_sync_row, -1);
-    expect_RegEnumValue_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
+    expect_RegEnumValueW_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
 
     expect_fim_registry_value_diff("HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile\\FirstSubKey", "test_value",
                                    (const char *)&value_data, 4, REG_DWORD, NULL);
@@ -758,7 +758,7 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     will_return(__wrap_fim_db_transaction_sync_row, -1);
     will_return(__wrap_fim_db_transaction_sync_row, -1);
 
-    expect_RegEnumValue_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
+    expect_RegEnumValueW_call(value_name, value_type, (LPBYTE)&value_data, value_size, ERROR_SUCCESS);
 
 
     expect_fim_registry_value_diff("HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile\\FirstSubKey", "test_value",
@@ -1110,6 +1110,83 @@ static void test_fim_registry_free_entry(){
     fim_registry_free_entry(entry);
 }
 
+static void test_fim_read_values_unterminated_string_value(void **state) {
+    HKEY key_handle = (HKEY)123;
+    TXN_HANDLE mock_txn_handler = (TXN_HANDLE)456;
+    char *path = "HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile";
+    int arch = ARCH_64BIT;
+    DWORD value_count = 1;
+    DWORD max_value_length = 256;
+    DWORD max_value_data_length = 256;
+    event_data_t event_data = {.mode = FIM_SCHEDULED};
+    fim_val_txn_context_t txn_ctx = {.data = NULL, .evt_data = &event_data, .diff = NULL};
+
+    syscheck.registry = one_entry_config;
+    syscheck.registry[0].opts = CHECK_MD5SUM;
+
+    wchar_t *value_name = L"UnterminatedString";
+    WCHAR value_data[256];
+    const WCHAR *test_str = L"test_unterminated";
+    size_t str_len = wcslen(test_str);
+    memcpy(value_data, test_str, str_len * sizeof(WCHAR));
+    memset(value_data + str_len, 0xFF, sizeof(value_data) - (str_len * sizeof(WCHAR)));
+
+    DWORD value_type = REG_SZ;
+    DWORD value_size = str_len * sizeof(WCHAR);
+
+    expect_RegEnumValueW_call(value_name, value_type, (LPBYTE)value_data, value_size, ERROR_SUCCESS);
+    will_return(__wrap_fim_db_transaction_sync_row, 0);
+
+    fim_read_values(key_handle, path, arch, value_count, max_value_length, max_value_data_length,
+                    mock_txn_handler, &txn_ctx);
+
+    assert_non_null(txn_ctx.data);
+    assert_int_equal(txn_ctx.data->type, REG_SZ);
+    assert_int_equal(txn_ctx.data->size, value_size);
+}
+
+static void test_fim_read_values_unterminated_multi_string_value(void **state) {
+    HKEY key_handle = (HKEY)123;
+    TXN_HANDLE mock_txn_handler = (TXN_HANDLE)456;
+    char *path = "HKEY_LOCAL_MACHINE\\Software\\Classes\\batfile";
+    int arch = ARCH_64BIT;
+    DWORD value_count = 1;
+    DWORD max_value_length = 256;
+    DWORD max_value_data_length = 256;
+    event_data_t event_data = {.mode = FIM_SCHEDULED};
+    fim_val_txn_context_t txn_ctx = {.data = NULL, .evt_data = &event_data, .diff = NULL};
+
+    syscheck.registry = one_entry_config;
+    syscheck.registry[0].opts = CHECK_MD5SUM;
+
+    wchar_t *value_name = L"UnterminatedMultiString";
+    WCHAR value_data[256];
+    const WCHAR *first_str = L"FirstValue";
+    const WCHAR *second_str = L"SecondValue";
+    size_t first_len = wcslen(first_str);
+    size_t second_len = wcslen(second_str);
+
+    memcpy(value_data, first_str, first_len * sizeof(WCHAR));
+    value_data[first_len] = L'\0';
+    memcpy(value_data + first_len + 1, second_str, second_len * sizeof(WCHAR));
+    memset((BYTE *)(value_data + first_len + 1 + second_len), 0xFF,
+           sizeof(value_data) - ((first_len + 1 + second_len) * sizeof(WCHAR)));
+
+    DWORD value_type = REG_MULTI_SZ;
+    DWORD value_size = (first_len + 1 + second_len) * sizeof(WCHAR);
+
+    expect_RegEnumValueW_call(value_name, value_type, (LPBYTE)value_data, value_size, ERROR_SUCCESS);
+    will_return(__wrap_fim_db_transaction_sync_row, 0);
+
+    fim_read_values(key_handle, path, arch, value_count, max_value_length, max_value_data_length,
+                    mock_txn_handler, &txn_ctx);
+
+    assert_non_null(txn_ctx.data);
+    assert_int_equal(txn_ctx.data->type, REG_MULTI_SZ);
+    assert_int_equal(txn_ctx.data->size, value_size);
+}
+
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         /* fim_set_root_key test */
@@ -1183,7 +1260,10 @@ int main(void) {
         cmocka_unit_test(test_fim_registry_value_transaction_callback_max_rows),
 
         /* fim_registry_free_entry */
-        cmocka_unit_test(test_fim_registry_free_entry)
+        cmocka_unit_test(test_fim_registry_free_entry),
+        /* fim_read_values unterminated string tests (backport from 4.14.x) */
+        cmocka_unit_test(test_fim_read_values_unterminated_string_value),
+        cmocka_unit_test(test_fim_read_values_unterminated_multi_string_value),
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/wrappers/windows/winreg_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winreg_wrappers.h
@@ -19,10 +19,16 @@
 #define RegQueryInfoKeyA wrap_RegQueryInfoKeyA
 #undef RegEnumKeyEx
 #define RegEnumKeyEx wrap_RegEnumKeyEx
+#undef RegEnumKeyExW
+#define RegEnumKeyExW wrap_RegEnumKeyExW
 #undef RegOpenKeyEx
 #define RegOpenKeyEx wrap_RegOpenKeyEx
+#undef RegOpenKeyExW
+#define RegOpenKeyExW wrap_RegOpenKeyExW
 #undef RegEnumValue
 #define RegEnumValue wrap_RegEnumValue
+#undef RegEnumValueW
+#define RegEnumValueW wrap_RegEnumValueW
 #undef RegCloseKey
 #define RegCloseKey wrap_RegCloseKey
 #undef RegQueryValueEx
@@ -71,6 +77,17 @@ LONG wrap_RegEnumKeyEx(HKEY hKey,
 
 void expect_RegEnumKeyEx_call(LPSTR name, DWORD name_length, LONG return_value);
 
+LONG wrap_RegEnumKeyExW(HKEY hKey,
+                       DWORD dwIndex,
+                       LPWSTR lpName,
+                       LPDWORD lpcchName,
+                       LPDWORD lpReserved,
+                       LPWSTR lpClass,
+                       LPDWORD lpcchClass,
+                       PFILETIME lpftLastWriteTime);
+
+void expect_RegEnumKeyExW_call(const wchar_t *name, LONG return_value);
+
 LONG wrap_RegOpenKeyEx(HKEY hKey,
                        LPCSTR lpSubKey,
                        DWORD ulOptions,
@@ -78,6 +95,14 @@ LONG wrap_RegOpenKeyEx(HKEY hKey,
                        PHKEY phkResult);
 
 void expect_RegOpenKeyEx_call(HKEY hKey, LPCSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value);
+
+LONG wrap_RegOpenKeyExW(HKEY hKey,
+                       LPCWSTR lpSubKey,
+                       DWORD ulOptions,
+                       REGSAM samDesired,
+                       PHKEY phkResult);
+
+void expect_RegOpenKeyExW_call(HKEY hKey, LPCWSTR sub_key, DWORD options, REGSAM sam, PHKEY result, LONG return_value);
 
 LONG wrap_RegQueryValueEx(HKEY hKey,
                           LPCSTR lpValueName,
@@ -95,6 +120,16 @@ LONG wrap_RegEnumValue(HKEY hKey,
                        LPBYTE lpData,LPDWORD lpcbData);
 
 void expect_RegEnumValue_call(LPSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value);
+
+LONG wrap_RegEnumValueW(HKEY hKey,
+                       DWORD dwIndex,
+                       LPWSTR lpValueName,
+                       LPDWORD lpcchValueName,
+                       LPDWORD lpReserved,
+                       LPDWORD lpType,
+                       LPBYTE lpData,LPDWORD lpcbData);
+
+void expect_RegEnumValueW_call(LPWSTR value_name, DWORD type, LPBYTE data, DWORD data_length, LONG return_value);
 
 LONG wrap_RegCloseKey(HKEY hKey);
 


### PR DESCRIPTION
## Description
Backport of #34340 to the `4.10.4` LTS branch.

This PR fixes a Windows agent crash occurring during FIM Registry scanning when `RegEnumValueW()` returns string values without proper null terminators, as documented in the Microsoft API specification.

When Page Heap is enabled, the out-of-bounds read becomes deterministic and the agent crashes while processing large Registry values.

Closes #34631

## Proposed Changes
- Change buffer type from `TCHAR` to `WCHAR` for correct wide character handling.
- Rename `value_buffer` to `value_name_buffer` for clarity.
- Allocate 4 extra bytes at the end of the data buffer to safely cover null termination cases (required for `REG_MULTI_SZ` which needs two null terminators).

## Compatibility with 4.10.4
The affected file (`src/syscheckd/src/registry/registry.c`) required minor adaptation due to a variable rename (`value_buffer` → `value_name_buffer`) present in 4.10.4. The fix logic is functionally identical to the original PR.

## Results and Evidence
Evidence from the original PR #34340 is directly applicable. With Page Heap enabled:

**Before fix** — agent crashes during FIM Registry scan on large values (up to 128 KiB).

**After fix** — FIM Registry scan completes without crash:
```
wazuh-agent: INFO: (6008): File integrity monitoring scan started.
wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
```

## Artifacts Affected
- `wazuh-agent.exe` (Windows)

## Configuration Changes
None.

## Tests
Added two unit tests covering `RegEnumValueW()` returning buffers without null terminators:
1. `test_fim_read_values_unterminated_string_value`
2. `test_fim_read_values_unterminated_multi_string_value`