### PR TITLE
test: add regression tests for SCA command output pattern matching (#16760)

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/tests/sca_utils_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_utils_test.cpp
@@ -288,5 +288,98 @@ TEST(PatternMatchesTest, REG_MULTI_SZtest)
     EXPECT_TRUE(*patternMatch);
 }
 
-// NOLINTEND(bugprone-unchecked-optional-access, modernize-raw-string-literal)
+// Regression test for GitHub issue #16760:
+// SCA ignores some lines in command outputs in macOS Ventura.
+// The pattern r:powernap\s*\t*1 must match the line " powernap             1"
+// in the full pmset -g custom output.
+TEST(PatternMatchesTest, Issue16760_PmsetPowernapMatchesInFullOutput)
+{
+    const std::string content = "Battery Power:\n"
+                                " Sleep On Power Button 1\n"
+                                " lowpowermode         0\n"
+                                " standby              1\n"
+                                " ttyskeepawake        1\n"
+                                " hibernatemode        3\n"
+                                " powernap             1\n"
+                                " hibernatefile        /var/vm/sleepimage\n"
+                                " displaysleep         2\n"
+                                " womp                 0\n"
+                                " networkoversleep     0\n"
+                                " sleep                1\n"
+                                " lessbright           1\n"
+                                " tcpkeepalive         1\n"
+                                " disksleep            10\n"
+                                "AC Power:\n"
+                                " Sleep On Power Button 1\n"
+                                " lowpowermode         0\n"
+                                " standby              1\n"
+                                " ttyskeepawake        1\n"
+                                " hibernatemode        3\n"
+                                " powernap             1\n"
+                                " hibernatefile        /var/vm/sleepimage\n"
+                                " displaysleep         10\n"
+                                " womp                 1\n"
+                                " networkoversleep     0\n"
+                                " sleep                1\n"
+                                " tcpkeepalive         1\n"
+                                " disksleep            10";
+    const std::string pattern = "r:powernap\\s*\\t*1";
+    const auto patternMatch = PatternMatches(content, pattern);
+    ASSERT_TRUE(patternMatch.has_value());
+    // The pattern MUST match - powernap 1 is present in the output
+    EXPECT_TRUE(*patternMatch);
+}
 
+// Same scenario but with negated pattern (as used in the actual SCA rule)
+TEST(PatternMatchesTest, Issue16760_NegatedPmsetPowernapDetectsMatch)
+{
+    const std::string content = "Battery Power:\n"
+                                " Sleep On Power Button 1\n"
+                                " lowpowermode         0\n"
+                                " standby              1\n"
+                                " ttyskeepawake        1\n"
+                                " hibernatemode        3\n"
+                                " powernap             1\n"
+                                " hibernatefile        /var/vm/sleepimage\n"
+                                " displaysleep         2\n"
+                                " womp                 0\n"
+                                " networkoversleep     0\n"
+                                " sleep                1\n"
+                                " lessbright           1\n"
+                                " tcpkeepalive         1\n"
+                                " disksleep            10\n"
+                                "AC Power:\n"
+                                " Sleep On Power Button 1\n"
+                                " lowpowermode         0\n"
+                                " standby              1\n"
+                                " ttyskeepawake        1\n"
+                                " hibernatemode        3\n"
+                                " powernap             1\n"
+                                " hibernatefile        /var/vm/sleepimage\n"
+                                " displaysleep         10\n"
+                                " womp                 1\n"
+                                " networkoversleep     0\n"
+                                " sleep                1\n"
+                                " tcpkeepalive         1\n"
+                                " disksleep            10";
+    // Negated pattern: "not c:pmset -g -> r:powernap\s*\t*1"
+    // The negation is handled externally by CommandRuleEvaluator;
+    // PatternMatches receives the inner pattern prefixed with '!'
+    const std::string pattern = "!r:powernap\\s*\\t*1";
+    const auto patternMatch = PatternMatches(content, pattern);
+    ASSERT_TRUE(patternMatch.has_value());
+    // The negated match should FAIL (return false) because powernap 1 IS present
+    EXPECT_FALSE(*patternMatch);
+}
+
+// Test that a single line with powernap matches correctly
+TEST(PatternMatchesTest, Issue16760_SingleLinePowernapMatch)
+{
+    const std::string content = " powernap             1";
+    const std::string pattern = "r:powernap\\s*\\t*1";
+    const auto patternMatch = PatternMatches(content, pattern);
+    ASSERT_TRUE(patternMatch.has_value());
+    EXPECT_TRUE(*patternMatch);
+}
+
+// NOLINTEND(bugprone-unchecked-optional-access, modernize-raw-string-literal)


### PR DESCRIPTION
## Summary

- Adds 3 regression tests to `sca_utils_test.cpp` for GitHub issue #16760, which reported that SCA ignores some lines in command outputs on macOS Ventura
- The underlying bug was fixed during the C-to-C++ refactoring of the SCA module; these tests ensure the fix is not regressed

## Description

Issue #16760 reported that the SCA pattern `r:powernap\s*\t*1` failed to match the line ` powernap             1` in the output of `pmset -g custom` on macOS Ventura. The old C implementation (`wm_sca_read_command` / `wm_sca_pattern_matches`) had a bug where it could skip lines in multi-line command output.

The new C++ implementation (`PatternMatches` in `sca_utils.cpp`) correctly:
1. Splits entire command output into individual lines via `std::getline`
2. Tests every line against the pattern
3. Uses PCRE2 with `PCRE2_MULTILINE | PCRE2_CASELESS` flags

### Tests added

| Test | What it verifies |
|------|-----------------|
| `Issue16760_PmsetPowernapMatchesInFullOutput` | Pattern `r:powernap\s*\t*1` matches against full `pmset -g custom` output (30 lines) |
| `Issue16760_NegatedPmsetPowernapDetectsMatch` | Negated pattern `!r:powernap\s*\t*1` correctly returns `false` when the line is present |
| `Issue16760_SingleLinePowernapMatch` | Pattern matches against a single line ` powernap             1` |

All 31 tests pass (28 existing + 3 new).

Closes #16760