### PR TITLE
Fix macOS 13 Ventura SCA policy incorrectly passing pmset checks

### DIFF
--- a/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
+++ b/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
@@ -645,7 +645,7 @@ checks:
       - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "c:pmset -b -g -> r:^DestroyFVKeyOnStandby 1"
+      - 'c:pmset -b -g -> r:^\s*\t*DestroyFVKeyOnStandby\s*\t*1'
 
   # 2.9.2 Ensure Power Nap Is Disabled for Intel Macs. (Automated)
   - id: 30027
@@ -666,7 +666,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'not c:sh -c "pmset -g custom" -> r:powernap\s*\t*1'
+      - 'not c:sh -c "pmset -g custom" -> r:^\s*\t*powernap\s*\t*1'
 
   # 2.9.3 Ensure Wake for Network Access Is Disabled. (Automated)
   - id: 30028
@@ -686,7 +686,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6"]
     condition: any
     rules:
-      - 'c:sh -c "pmset -g | grep -e womp" -> r:0'
+      - 'not c:sh -c "pmset -g custom" -> r:^\s*\t*womp\s*\t*1'
       - 'not c:sh -c "profiles -P -o stdout | grep ''Wake On LAN''" -> n:=\s*(\d) compare != 0'
       - 'not c:sh -c "profiles -P -o stdout | grep ''Wake On Modem Ring''" -> n:=\s*(\d) compare != 0'
 


### PR DESCRIPTION
## Description

The macOS 13 (Ventura) SCA policy (`cis_apple_macOS_13.x.yml`) had three `pmset`-related rules whose regex patterns did not properly handle the leading whitespace present in `pmset` command output. Each setting line in `pmset -g custom` output is prefixed with a space (e.g., ` powernap             1`), and the old patterns lacked the `^\s*\t*` anchoring that newer policies (macOS 14+, 15+, 26+) already use.

Additionally, the `womp` check used a fragile approach piping `pmset -g` through `grep`, instead of directly checking `pmset -g custom` output like the other rules and all newer policies do.

Closes #16760

## Proposed Changes

- **DestroyFVKeyOnStandby**: Changed pattern from `r:^DestroyFVKeyOnStandby 1` to `r:^\s*\t*DestroyFVKeyOnStandby\s*\t*1` to handle leading whitespace in pmset output
- **powernap**: Changed pattern from `r:powernap\s*\t*1` to `r:^\s*\t*powernap\s*\t*1` to add start-of-line anchoring and handle leading whitespace
- **womp**: Changed from `c:sh -c "pmset -g | grep -e womp" -> r:0` to `not c:sh -c "pmset -g custom" -> r:^\s*\t*womp\s*\t*1`, using the correct command (`pmset -g custom`) and proper negation logic consistent with newer policies

All three patterns are now aligned with the macOS 14, 15, and 26 policies already in production.

### Results and Evidence

A standalone C test was compiled against the real Wazuh OSREGEX engine (`os_regex_compile.c`, `os_regex_execute.c`, `os_regex_free_pattern.c`, `os_regex_maps.c`) using the same `OS_RETURN_SUBSTRING` flag that SCA uses. The test feeds simulated `pmset -g custom` output lines with various whitespace formats to `OSRegex_Compile` + `OSRegex_Execute` and verifies correct matching for both old and new patterns.

**16/16 tests passed:**

```
==================================================================
  Test: SCA pmset pattern matching for macOS 13 Ventura (#16760)
==================================================================

--- Rule: DestroyFVKeyOnStandby ---

[PASS] OLD pattern vs space-prefixed line (should fail)
       Pattern: ^DestroyFVKeyOnStandby 1
       Input:   " DestroyFVKeyOnStandby 1"
       Expected: NO MATCH, Got: NO MATCH

[PASS] NEW pattern vs space-prefixed line (should match)
       Pattern: ^\s*\t*DestroyFVKeyOnStandby\s*\t*1
       Input:   " DestroyFVKeyOnStandby 1"
       Expected: MATCH, Got: MATCH

[PASS] NEW pattern vs tab-prefixed line (should match)
       Pattern: ^\s*\t*DestroyFVKeyOnStandby\s*\t*1
       Input:   "	DestroyFVKeyOnStandby	1"
       Expected: MATCH, Got: MATCH

[PASS] NEW pattern vs no-prefix line (should match)
       Pattern: ^\s*\t*DestroyFVKeyOnStandby\s*\t*1
       Input:   "DestroyFVKeyOnStandby 1"
       Expected: MATCH, Got: MATCH

[PASS] NEW pattern vs value 0 (should NOT match)
       Pattern: ^\s*\t*DestroyFVKeyOnStandby\s*\t*1
       Input:   " DestroyFVKeyOnStandby 0"
       Expected: NO MATCH, Got: NO MATCH

--- Rule: powernap ---

[PASS] OLD pattern vs space-prefixed 'powernap 1' (old matched, not anchored)
       Pattern: powernap\s*\t*1
       Input:   " powernap 1"
       Expected: MATCH, Got: MATCH

[PASS] NEW pattern vs space-prefixed 'powernap 1' (should match)
       Pattern: ^\s*\t*powernap\s*\t*1
       Input:   " powernap 1"
       Expected: MATCH, Got: MATCH

[PASS] NEW pattern vs tab-prefixed 'powernap' (should match)
       Pattern: ^\s*\t*powernap\s*\t*1
       Input:   "	powernap	1"
       Expected: MATCH, Got: MATCH

[PASS] NEW pattern vs 'powernap 0' (should NOT match)
       Pattern: ^\s*\t*powernap\s*\t*1
       Input:   " powernap 0"
       Expected: NO MATCH, Got: NO MATCH

--- Rule: womp (Wake on LAN) ---

[PASS] NEW womp pattern vs ' womp 1' (matches -> negated = FAIL in SCA)
       Pattern: ^\s*\t*womp\s*\t*1
       Input:   " womp 1"
       Expected: MATCH, Got: MATCH

[PASS] NEW womp pattern vs ' womp 0' (no match -> negated = PASS in SCA)
       Pattern: ^\s*\t*womp\s*\t*1
       Input:   " womp 0"
       Expected: NO MATCH, Got: NO MATCH

[PASS] NEW womp pattern vs tab-prefixed 'womp 1'
       Pattern: ^\s*\t*womp\s*\t*1
       Input:   "	womp	1"
       Expected: MATCH, Got: MATCH

[PASS] NEW womp pattern vs '  womp   0' (extra spaces, should NOT match 1)
       Pattern: ^\s*\t*womp\s*\t*1
       Input:   "  womp   0"
       Expected: NO MATCH, Got: NO MATCH

--- Edge cases ---

[PASS] NEW DestroyFVKey pattern vs multiple leading spaces
       Pattern: ^\s*\t*DestroyFVKeyOnStandby\s*\t*1
       Input:   "   DestroyFVKeyOnStandby 1"
       Expected: MATCH, Got: MATCH

[PASS] NEW DestroyFVKey pattern vs mixed space+tab prefix
       Pattern: ^\s*\t*DestroyFVKeyOnStandby\s*\t*1
       Input:   " 	DestroyFVKeyOnStandby	1"
       Expected: MATCH, Got: MATCH

[PASS] NEW powernap pattern vs 'powernap 10' (starts with 1, still matches)
       Pattern: ^\s*\t*powernap\s*\t*1
       Input:   " powernap 10"
       Expected: MATCH, Got: MATCH

==================================================================
  Results: 16/16 passed, 0 failed
==================================================================
```

### Artifacts Affected

- `ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml` — SCA policy file for macOS 13 Ventura (3 rule patterns updated)

No executables, packages, or default configuration files are affected. This is a policy-only change.

### Configuration Changes

No configuration changes. No new parameters, no changes to default values. Fully backward compatible.

### Documentation Updates

N/A — no documentation updates required. The SCA policy file is self-documenting.

### Tests Introduced

A standalone OSREGEX engine test (`test_sca_pmset_patterns.c`) was written to validate the pattern changes. It compiles against the real Wazuh `os_regex` source files and exercises all three updated rule patterns across 16 test cases covering:

- Old patterns failing on whitespace-prefixed input (demonstrating the bug)
- New patterns correctly handling space prefix, tab prefix, no prefix, and mixed whitespace
- New patterns correctly rejecting non-matching values (e.g., value `0` when expecting `1`)
- Edge cases: multiple leading spaces, mixed space+tab, multi-digit values starting with `1`

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] Patterns aligned with macOS 14/15/26 policies already in production