### PR TITLE
docs: fix macOS agent instalation steps

### DIFF
--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -255,10 +255,10 @@ Install the agent:
 sudo installer -pkg wazuh-agent-*.pkg -target /
 ```
 
-You can optionally specify configuration parameters:
+You can optionally specify configuration parameters by writing them to `/tmp/wazuh_envs` before running the installer:
 
 ```bash
-sudo WAZUH_MANAGER='10.0.0.2' WAZUH_AGENT_NAME='macbook-01' installer -pkg wazuh-agent-*.pkg -target /
+echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && echo "WAZUH_AGENT_NAME='macbook-01'" >> /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-*.pkg -target /
 ```
 
 Start the agent service:


### PR DESCRIPTION
## Description 

Closes #34700

The macOS agent installation documentation for 5.0 incorrectly uses environment variable prefix syntax (`WAZUH_MANAGER='...' installer ...`) to pass deployment variables. The macOS `installer` command does not propagate parent shell environment variables to package scripts, so this syntax has no effect and the manager address placeholder remains unreplaced in `ossec.conf`.

The correct mechanism is to write deployment variables to `/tmp/wazuh_envs` before invoking `installer`. The `register_configure_agent.sh` postinstall script reads and consumes this file.

### Proposed Changes

- Fix the macOS installation command in `docs/ref/getting-started/installation.md` to use the `/tmp/wazuh_envs` pattern instead of environment variable prefix syntax.
- Update the explanatory text to clarify the mechanism.

### Results and Evidence

- N/A

### Artifacts Affected

- Internal documentation only (`docs/ref/getting-started/installation.md`)

### Configuration Changes

- N/A.

### Documentation Updates

- `docs/ref/getting-started/installation.md`: macOS section updated with correct deployment variable syntax.

### Tests Introduced

- N/A.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
