### PR TITLE
Fix downloading indexer plugins using certs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -621,8 +621,8 @@ $(INDEXER_PLUGINS_DIR)/alerts.json: | $(INDEXER_PLUGINS_DIR)
 	@success=0; \
 	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
 		url="$(INDEXER_PLUGINS_BASE_URL)/$$ref/$(INDEXER_PLUGINS_STREAMS_PATH)/$(notdir $@)"; \
-		echo "curl -f -s -o $@ $$url"; \
-		if curl -f -s -o $@ "$$url" 2>/dev/null; then \
+		echo "$(CURL) $@ $(CACERT_OPT) -f $$url"; \
+		if $(CURL) $@ $(CACERT_OPT) -f "$$url" 2>/dev/null; then \
 			success=1; \
 			break; \
 		fi; \
@@ -637,8 +637,8 @@ $(INDEXER_PLUGINS_DIR)/%.json: | $(INDEXER_PLUGINS_DIR)
 	@success=0; \
 	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
 		url="$(INDEXER_PLUGINS_BASE_URL)/$$ref/$(INDEXER_PLUGINS_STATES_PATH)/$(notdir $@)"; \
-		echo "curl -f -s -o $@ $$url"; \
-		if curl -f -s -o $@ "$$url" 2>/dev/null; then \
+		echo "$(CURL) $@ $(CACERT_OPT) -f $$url"; \
+		if $(CURL) $@ $(CACERT_OPT) -f "$$url" 2>/dev/null; then \
 			success=1; \
 			break; \
 		fi; \
@@ -658,8 +658,8 @@ $(WCS_FLAT_DIR)/%-ecs-flat.yml: | $(WCS_FLAT_DIR)
 	subdir=$(patsubst %-ecs-flat.yml,%,$(@F)); \
 	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
 		url="$(INDEXER_PLUGINS_BASE_URL)/$$ref/$(WCS_FLAT_STATELESS_PATH)/$$subdir/docs/ecs_flat.yml"; \
-		echo "curl -f -s -o $@ $$url"; \
-		if curl -f -s -o $@ "$$url" 2>/dev/null; then \
+		echo "$(CURL) $@ $(CACERT_OPT) -f $$url"; \
+		if $(CURL) $@ $(CACERT_OPT) -f "$$url" 2>/dev/null; then \
 			success=1; \
 			break; \
 		fi; \


### PR DESCRIPTION

## Description

The parameter `--cacert /etc/ssl/certs/ca-certificates.crt` has been added so that it can find the correct certificate and the GitHub download can work.

## Proposed Changes

- Add the certificates alongside the `curl` command so that there are no issues in the environment when downloading.

### Results and Evidence

- https://github.com/wazuh/wazuh-agent-packages/actions/runs/22682647505 - :green_circle: 
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/22682324024 - :green_circle: 


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
