### PR TITLE
Update windows syscollector to include command arguments

### DIFF
--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -220,7 +220,7 @@ add_library(sysinfo SHARED
     ${SRC_FOLDER}/${RESOURCE_OBJ})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  target_link_libraries(sysinfo psapi iphlpapi ws2_32 wbemuuid uuid wuguid ole32 oleaut32 groups users services browser_extensions)
+  target_link_libraries(sysinfo psapi iphlpapi ws2_32 wbemuuid uuid wuguid ole32 oleaut32 ntdll shell32 groups users services browser_extensions)
   set_target_properties(sysinfo PROPERTIES
       PREFIX ""
       SUFFIX ".dll"

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -15,6 +15,7 @@
 #include <winternl.h>
 #include <ntstatus.h>
 #include <iphlpapi.h>
+#include <shellapi.h>
 #include <memory>
 #include <list>
 #include <set>
@@ -65,6 +66,8 @@ static const std::map<std::string, DWORD> gs_firmwareTableProviderSignature
     {"RSMB", 0x52534D42}
 };
 
+static constexpr auto ProcessCommandLineInformation = static_cast<PROCESSINFOCLASS>(60);
+
 class SysInfoProcess final
 {
     public:
@@ -97,6 +100,37 @@ class SysInfoProcess final
             }
 
             // else: Unable to retrieve executable path from current process.
+            return ret;
+        }
+
+        std::wstring cmdLineW()
+        {
+            std::wstring ret;
+            ULONG size = 0;
+
+            auto status = NtQueryInformationProcess(
+                              m_hProcess, ProcessCommandLineInformation, nullptr, 0, &size);
+
+            if (STATUS_INFO_LENGTH_MISMATCH != status && STATUS_BUFFER_OVERFLOW != status
+                    && STATUS_BUFFER_TOO_SMALL != status)
+            {
+                return ret;
+            }
+
+            auto buffer = std::make_unique<BYTE[]>(size);
+            status = NtQueryInformationProcess(
+                         m_hProcess, ProcessCommandLineInformation, buffer.get(), size, &size);
+
+            if (NT_SUCCESS(status))
+            {
+                const auto* unicodeStr = reinterpret_cast<UNICODE_STRING*>(buffer.get());
+
+                if (unicodeStr->Buffer && unicodeStr->Length > 0)
+                {
+                    ret.assign(unicodeStr->Buffer, unicodeStr->Length / sizeof(WCHAR));
+                }
+            }
+
             return ret;
         }
 
@@ -348,7 +382,6 @@ static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
 
         // Current process information
         jsProcessInfo["name"]       = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(processName(processEntry));
-        jsProcessInfo["cmd"]        = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8((isSystemProcess(pId)) ? "none" : process.cmd());
         jsProcessInfo["stime"]      = process.kernelModeTime();
         jsProcessInfo["size"]       = process.pageFileUsage();
         jsProcessInfo["ppid"]       = processEntry.th32ParentProcessID;
@@ -359,6 +392,29 @@ static nlohmann::json getProcessInfo(const PROCESSENTRY32& processEntry)
         jsProcessInfo["utime"]      = process.userModeTime();
         jsProcessInfo["vm_size"]    = process.virtualSize();
         jsProcessInfo["start_time"] = process.creationTime();
+
+        if (isSystemProcess(pId))
+        {
+            jsProcessInfo["cmd"]    = "none";
+            jsProcessInfo["argvs"]  = "";
+        }
+        else
+        {
+            const auto fullCmdLineW = process.cmdLineW();
+            const auto parsed = parseProcessCommandLine(fullCmdLineW);
+
+            if (!parsed.cmd.empty())
+            {
+                jsProcessInfo["cmd"]   = parsed.cmd;
+                jsProcessInfo["argvs"] = parsed.argvs;
+            }
+            else
+            {
+                jsProcessInfo["cmd"]   = Utils::EncodingWindowsHelper::stringAnsiToStringUTF8(process.cmd());
+                jsProcessInfo["argvs"] = "";
+            }
+        }
+
         CloseHandle(processHandle);
     }
 

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -18,6 +18,8 @@
 
 #include "utilsWrapperWin.hpp"
 
+#include <shellapi.h>
+
 
 // Implement WMI functions
 HRESULT ComHelper::CreateWmiLocator(IWbemLocator*& pLoc)
@@ -179,6 +181,80 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)
     pSvc->Release();
     pLoc->Release();
     pEnumerator->Release();
+}
+
+ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW)
+{
+    ProcessCmdLine result;
+
+    if (fullCmdLineW.empty())
+    {
+        return result;
+    }
+
+    // Convert full command line from UTF-16 to UTF-8
+    const int utf8Size = WideCharToMultiByte(
+                             CP_UTF8, 0, fullCmdLineW.c_str(), static_cast<int>(fullCmdLineW.size()),
+                             nullptr, 0, nullptr, nullptr);
+
+    if (utf8Size > 0)
+    {
+        result.cmd.assign(static_cast<std::size_t>(utf8Size), '\0');
+        const int written = WideCharToMultiByte(
+                                CP_UTF8, 0, fullCmdLineW.c_str(), static_cast<int>(fullCmdLineW.size()),
+                                result.cmd.data(), utf8Size, nullptr, nullptr);
+
+        if (written > 0)
+        {
+            if (written < utf8Size)
+            {
+                result.cmd.resize(static_cast<std::size_t>(written));
+            }
+        }
+        else
+        {
+            result.cmd.clear();
+        }
+    }
+
+    // Parse arguments using CommandLineToArgvW for proper Windows command-line tokenization
+    int argc = 0;
+    const auto argv = CommandLineToArgvW(fullCmdLineW.c_str(), &argc);
+
+    if (argv && argc > 1)
+    {
+        for (int i = 1; i < argc; ++i)
+        {
+            const int argSize = WideCharToMultiByte(
+                                    CP_UTF8, 0, argv[i], -1, nullptr, 0, nullptr, nullptr);
+
+            if (argSize > 0)
+            {
+                std::string arg(argSize, '\0');
+                const int convertedSize = WideCharToMultiByte(
+                                              CP_UTF8, 0, argv[i], -1, arg.data(), argSize, nullptr, nullptr);
+
+                if (convertedSize > 0)
+                {
+                    arg.resize(static_cast<std::size_t>(convertedSize - 1));
+
+                    if (!result.argvs.empty())
+                    {
+                        result.argvs += " ";
+                    }
+
+                    result.argvs += arg;
+                }
+            }
+        }
+    }
+
+    if (argv)
+    {
+        LocalFree(argv);
+    }
+
+    return result;
 }
 
 void QueryWUHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -77,3 +77,15 @@ EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& com
 // Queries Windows Update Agent (WUA) for installed update history,
 // extracts hotfixes, and adds them to the provided set.
 EXPORTED void QueryWUHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper);
+
+// Result of parsing a wide-string command line into UTF-8 components.
+struct ProcessCmdLine
+{
+    std::string cmd;    // Full command line in UTF-8
+    std::string argvs;  // Arguments only (after the executable), space-separated, UTF-8
+};
+
+// Converts a UTF-16 command line into UTF-8 cmd and argvs fields.
+// Uses WideCharToMultiByte for encoding and CommandLineToArgvW for argument tokenization.
+// Returns empty fields if the input is empty or conversion fails.
+ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW);

--- a/src/data_provider/tests/sysInfoWin/CMakeLists.txt
+++ b/src/data_provider/tests/sysInfoWin/CMakeLists.txt
@@ -19,6 +19,10 @@ link_directories("${CMAKE_SOURCE_DIR}/lib/")
 target_link_libraries(sysInfoWindows_unit_test
     wbemuuid
     wuguid
+    psapi
+    iphlpapi
+    ws2_32
+    shell32
     debug gtestd
     debug gmockd
     debug gtest_maind

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -272,3 +272,84 @@ TEST_F(SysInfoWinTest, GetHistoryTest)
     EXPECT_EQ(hotfixSet.size(), static_cast<unsigned int>(1));
     EXPECT_EQ(*hotfixSet.begin(), "KB123456");
 }
+
+// Tests for parseProcessCommandLine() — the UTF-16 to UTF-8 conversion and
+// argument parsing logic used by the Windows process inventory.
+
+// Empty input returns empty fields.
+TEST_F(SysInfoWinTest, ParseCmdLineEmptyInput)
+{
+    const auto result = parseProcessCommandLine(L"");
+    EXPECT_TRUE(result.cmd.empty());
+    EXPECT_TRUE(result.argvs.empty());
+}
+
+// Simple executable path with no arguments.
+TEST_F(SysInfoWinTest, ParseCmdLineNoArguments)
+{
+    const auto result = parseProcessCommandLine(L"C:\\Windows\\notepad.exe");
+    EXPECT_EQ(result.cmd, "C:\\Windows\\notepad.exe");
+    EXPECT_TRUE(result.argvs.empty());
+}
+
+// Executable with a single argument.
+TEST_F(SysInfoWinTest, ParseCmdLineSingleArgument)
+{
+    const auto result = parseProcessCommandLine(L"app.exe --help");
+    EXPECT_EQ(result.cmd, "app.exe --help");
+    EXPECT_EQ(result.argvs, "--help");
+}
+
+// Executable with multiple arguments (svchost-style).
+TEST_F(SysInfoWinTest, ParseCmdLineMultipleArguments)
+{
+    const auto result = parseProcessCommandLine(
+                            L"C:\\Windows\\system32\\svchost.exe -k netsvcs -p");
+    EXPECT_EQ(result.cmd, "C:\\Windows\\system32\\svchost.exe -k netsvcs -p");
+    EXPECT_EQ(result.argvs, "-k netsvcs -p");
+}
+
+// Quoted executable path with spaces in the path.
+TEST_F(SysInfoWinTest, ParseCmdLineQuotedPathWithSpaces)
+{
+    const auto result = parseProcessCommandLine(
+                            L"\"C:\\Program Files\\My App\\app.exe\" --flag value");
+    EXPECT_EQ(result.cmd, "\"C:\\Program Files\\My App\\app.exe\" --flag value");
+    EXPECT_EQ(result.argvs, "--flag value");
+}
+
+// Quoted argument values are unquoted by CommandLineToArgvW.
+TEST_F(SysInfoWinTest, ParseCmdLineQuotedArguments)
+{
+    const auto result = parseProcessCommandLine(
+                            L"app.exe --name \"hello world\" --verbose");
+    EXPECT_EQ(result.cmd, "app.exe --name \"hello world\" --verbose");
+    EXPECT_EQ(result.argvs, "--name hello world --verbose");
+}
+
+// Unicode characters in the command line are properly converted to UTF-8.
+TEST_F(SysInfoWinTest, ParseCmdLineUnicodeCharacters)
+{
+    // L"app.exe café" — é is U+00E9
+    const auto result = parseProcessCommandLine(L"app.exe caf\u00E9");
+    EXPECT_EQ(result.cmd, "app.exe caf\xC3\xA9");
+    EXPECT_EQ(result.argvs, "caf\xC3\xA9");
+}
+
+// Command with many arguments preserves order and spacing.
+TEST_F(SysInfoWinTest, ParseCmdLineManyArguments)
+{
+    const auto result = parseProcessCommandLine(L"cmd.exe /c dir /s /b /a-d");
+    EXPECT_EQ(result.cmd, "cmd.exe /c dir /s /b /a-d");
+    EXPECT_EQ(result.argvs, "/c dir /s /b /a-d");
+}
+
+// Calling the function twice with the same input produces the same result.
+TEST_F(SysInfoWinTest, ParseCmdLineDeterministic)
+{
+    const std::wstring input = L"svchost.exe -k DcomLaunch -p";
+    const auto result1 = parseProcessCommandLine(input);
+    const auto result2 = parseProcessCommandLine(input);
+    EXPECT_EQ(result1.cmd, result2.cmd);
+    EXPECT_EQ(result1.argvs, result2.argvs);
+}


### PR DESCRIPTION
## Description

Closes #33448

The Windows Syscollector process inventory only reported the executable path (e.g., `C:\Windows\system32\svchost.exe`) in the `cmd` field, without including command line arguments. This made it impossible to distinguish between different instances of the same process (e.g., multiple `svchost.exe` with different `-k` flags) and reduced the value of the process inventory for security analysis. The `argvs` field was never populated on Windows.

This PR adds full command line retrieval for Windows processes using `NtQueryInformationProcess` with `ProcessCommandLineInformation`, available on Windows 8.1+. When the API call fails (e.g., for protected system processes), it falls back to the previous behavior of reporting only the executable path.

## Proposed Changes

- Add `cmdLineW()` method to the `SysInfoProcess` class in `sysInfoWin.cpp` that retrieves the full process command line via `NtQueryInformationProcess`
- Update `getProcessInfo()` to use `cmdLineW()` and populate both `cmd` (full command line) and `argvs` (parsed arguments) fields
- Use `CommandLineToArgvW` for proper Windows command line tokenization when splitting arguments
- Link `ntdll` (for `NtQueryInformationProcess`) and `shell32` (for `CommandLineToArgvW`) in `CMakeLists.txt`
- Gracefully handle system processes (PID 0, 4) and access-denied scenarios with fallback to path-only

### Results and Evidence

The change was tested on a Windows 11 machine, and the scan data was retrieved from the dashboard IT Hygiene / Processes section. It was shown that the upgraded version now captures the full command, including the parameters, and the `args` and `args_count`.

<details><summary>1. Initial behavior: only executable path</summary>

- Process scans:
<img width="1509" height="716" alt="image" src="https://github.com/user-attachments/assets/4f864f70-b7df-41d2-87cc-97943d0a9915" />

- Process detail:
<img width="690" height="600" alt="image" src="https://github.com/user-attachments/assets/e1bd0552-d625-4889-a5d9-aca5184275ca" />
</details> 

<details><summary>2. Upgraded behavior: full command and args field</summary>

- Process scans:
<img width="1746" height="703" alt="image" src="https://github.com/user-attachments/assets/83a5f882-6d2f-4884-ab17-b7078417313b" />

- Process detail:
<img width="786" height="628" alt="image" src="https://github.com/user-attachments/assets/72a2f0b6-4d36-407a-a1cb-03c720924a9a" />
</details> 

Additionally, a battery of tests was executed on both versions to determine behavioral changes and measure performance under high traffic conditions. The results show that no performance degradation is causes by the new API usage, and that the behavior is consistent on different test cases.

<details><summary> Test results</summary>
- **Test 1: Baseline scan**
Starts the agent service with no extra processes, waits for the first Syscollector evaluation cycle to complete, and verifies that the local SQLite DB is populated with the system's running processes (~285 processes). Confirms the agent's basic data collection is functional.

  | Previous version | Patched version |
  |---|---|
  | PASS 🟢 | PASS 🟢 |


- **Test 2: Known process detection**
Verifies that well-known OS processes (`svchost.exe`, `winlogon.exe`, etc.) are present in the DB and that no non-system process has an empty `cmd` field. This test passes on both agents because even the stock agent reports the executable path.

  | Previous version | Patched version |
  |---|---|
  | PASS 🟢 | PASS 🟢 |

- **Test 3: `svchost.exe` arguments**
Checks that `svchost.exe` entries include their `-k <service_group>` arguments in the `argvs` field. The stock agent reports only the executable path while the patched agent captures the full command line.

  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |

  Old agent output:
  ```
  1496,svchost.exe,C:\Windows\System32\svchost.exe,
  1540,svchost.exe,C:\Windows\System32\svchost.exe,
  ```

  Patched agent output:
  ```
  1496,svchost.exe,"C:\WINDOWS\system32\svchost.exe -k LocalServiceNetworkRestricted","-k LocalServiceNetworkRestricted"
  1540,svchost.exe,"C:\WINDOWS\system32\svchost.exe -k LocalService -p","-k LocalService -p"
  ```

- **Test 4: `ping.exe` command line**
Spawns `ping.exe -n 99999 127.0.0.1` and verifies the `cmd` field contains the full command including `127.0.0.1`. The stock agent only stores the executable path.

  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |


- **Test 5: `ping.exe` arguments**
Same spawned `ping.exe` process but verifies that the `argvs` field contains `-n`. The stock agent leaves `argvs` empty.

  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |

- **Test 6: `cmd.exe` arguments**
Spawns `cmd.exe /c ping ...` and verifies the `argvs` field contains `/c`. The stock agent leaves `argvs` empty.
  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |

- **Test 7: Non-empty `cmd` field**
Verifies that no non-system process has a completely empty `cmd` field. Both agents populate at least the executable path.
  | Previous version | Patched version |
  |---|---|
  | PASS 🟢 | PASS 🟢 |

- **Test 8: Stress 500 processes**
Spawns 500 concurrent `ping.exe` processes (total ~1,286 system processes) and verifies the full command lines and arguments are captured for all of them.

  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |

  Patched agent sample:
  ```
  2012,PING.EXE,"""C:\WINDOWS\system32\PING.EXE"" -n 99999 -l 1 10.255.0.59","-n 99999 -l 1 10.255.0.59"
  ```

- **Test 9: Stress 2000 processes**
Spawns 2,000 concurrent `ping.exe` processes (total ~4,283 system processes) and verifies full command lines are captured. Tests that the implementation scales under heavy process load without missing entries or truncating data.

  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |

- **Test 10: Long argument strings: presence**
Spawns 50 processes with ~4,000-character command lines (`cmd.exe /c "ping -n 99999 127.0.0.1 > nul & rem BBBB..."`) and verifies all 50 are present in the DB.

  | Previous version | Patched version |
  |---|---|
  | PASS 🟢 | PASS 🟢 |


- **Test 11: Long argument strings: content**
Same 50 long-argument processes: verifies the `cmd` field contains the full ~4K padding string. The stock agent stores only the executable path, losing the entire argument payload.

  | Previous version | Patched version |
  |---|---|
  | FAIL 🔴 | PASS 🟢 |
</details> 


### Artifacts Affected

- `sysinfo.dll` (Windows data_provider library)
- Windows agent packages (all editions)

### Configuration Changes

- None. No new parameters or configuration needed.

### Documentation Updates

- None required. The `cmd` and `argvs` fields already existed in the schema; they are now populated on Windows.

### Tests Introduced

- The Windows-specific unit tests (`sysInfoWindows_unit_test`) require COM/WMI interfaces and must be executed on a Windows host. Cross-compilation build was validated on Linux using MinGW.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
