### PR TITLE
Fix Roundcube decoder regex to prevent `srcip` truncation in "Failed login ... in session" logs

### DIFF
--- a/ruleset/decoders/0255-roundcube_decoders.xml
+++ b/ruleset/decoders/0255-roundcube_decoders.xml
@@ -51,6 +51,6 @@
 <decoder name="roundcube-denied-new">
   <parent>roundcube</parent>
   <prematch>> \w+ Error: Login failed |> Failed login </prematch>
-  <regex offset="after_prematch">^for (\S+) from (\S+)\. |^for (\S+) from (\S+) in session |^for (\S+) against \S+ from (\S+)\. |^for (\S+) against \S+ from (\S+) in session </regex>
+  <regex offset="after_prematch">^for (\S+) from (\S+). |^for (\S+) from (\S+) in session |^for (\S+) against \S+ from (\S+). |^for (\S+) against \S+ from (\S+) in session </regex>
   <order>user, srcip</order>
 </decoder>


### PR DESCRIPTION
## Description

This PR fixes an incorrect `srcip` extraction in the stock Roundcube decoder affecting log lines like:

`Failed login for <user> from <ip> in session <id> (...)`

The root cause is the legacy OSSEC/Wazuh decoder regex flavor, where escaping semantics differ from PCRE-style engines: in this context, `\.` behaves as a wildcard metacharacter, while a literal dot is represented by `.`. Because the decoder used `(\S+)\.` in some branches, the match could consume the last character of the IP and stop early, resulting in truncated values such as `127.0.0.` or `194.71.124.23`.

## Proposed Changes

- Update the Roundcube decoder regex patterns that were using `\.` to match a literal trailing dot after the IP.
- Replace `\.` with `.` where the intent is to match a literal dot, ensuring `srcip` is captured completely for both “from … .” and “from … in session …” variants.

### Results and Evidence

#### Case 1: for X from Y.

```
[04-Oct-2017 17:03:30 +0200]: <jkgnfe79> IMAP Error: Login failed for username from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 193 (POST /roundcube/?_task=login&_action=login)
```

✅ **Before**: 127.0.0.1
✅ **After**: 127.0.0.1

#### Case 2: for X from Y in session (...)

```
[04-Oct-2017 16:08:01 +0200]: <lrpo6s0r> Failed login for test from 127.0.0.1 in session abcdefg (error: 0)
```

❌ **Before**: 127.0.0.
✅ **After**: 127.0.0.1

```
Mar 06 23:14:28 poczta roundcube[1826531]: <f69abde4> Failed login for 66754 from 194.71.124.239 in session f69abde4b8435a57 (error: 1)
```

❌ **Before**: 194.71.124.23
✅ **After**: 194.71.124.239

#### Case 3: for X against Z from Y.

```
[04-Oct-2017 17:03:30 +0200]: <jkgnfe79> IMAP Error: Login failed for username against mailhost.example.com from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 200 (POST /roundcube/?_task=login&_action=login)
```

✅ **Before**: 127.0.0.1
✅ **After**: 127.0.0.1

#### Case 4: for X against Z from Y in session (...)

```
[04-Oct-2017 16:08:01 +0200]: <lrpo6s0r> Failed login for test against mailhost.example.com from 127.0.0.1 in session abcdefg (error: 0)
```

❌ **Before**: 127.0.0.
✅ **After**: 127.0.0.1

### Artifacts Affected

- Roundcube decoder: `0255-roundcube_decoders.xml`

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

- No automated tests added.
- Manual validation performed with `wazuh-logtest` using the samples above (ruleset tests currently validate rule IDs and do not assert decoded field contents for this case).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues