### PR TITLE
Fix inconsistent state after WPK upgrade

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
@@ -947,6 +947,8 @@ void test_wm_agent_upgrade_router_callback_success(void **state)
     will_return(__wrap_OS_SendSecureTCP, 0);
 
     wm_agent_upgrade_router_callback(input_message);
+
+    os_free(input_message);
 }
 
 void test_wm_agent_upgrade_router_callback_null_message(void **state)

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -254,7 +254,6 @@ STATIC void wm_agent_upgrade_router_callback(const char* message) {
         mtdebug1(WM_AGENT_UPGRADE_LOGTAG, "Sending router-triggered upgrade message: '%s'", message);
 
         OS_SendSecureTCP(sock, strlen(message), message);
-        os_free(message);
         close(sock);
     }
 }


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                   
                                                                                                                                                                                                                   
                               
  After a WPK upgrade the agent writes `upgrade_result` and sends an ACK to the manager, but the manager intermittently fails to process it. The root cause is that `wm_agent_upgrade_router_callback` calls
  `os_free()` on a `const char*` that points into the router library's internal `std::vector<char>` buffer — memory the router owns and manages via RAII. Freeing it corrupts the heap, so the first ACK is
  processed correctly but every subsequent delivery receives garbage, causing the manager to never send `clear_upgrade_result` back to the agent. The agent then retries indefinitely with exponential backoff
  while the manager task times out, leaving the agent in an inconsistent state that blocks all future upgrade attempts. Resolves #34752.

  ## Proposed Changes

  - **`src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c`** — Removed the invalid `os_free(message)` call inside `wm_agent_upgrade_router_callback`. The pointer is owned by the router
  library; freeing it caused heap corruption that silently broke all ACK deliveries after the first, preventing `clear_upgrade_result` from ever reaching the agent.

  ### Results and Evidence

  <details><summary>Before fix — 10 consecutive upgrade attempts with a real WPK (1 success, then stuck state blocking all further upgrades)</summary>

  ```bash
  root@wazuh-aio:/home/ubuntu/packages# for i in $(seq 1 10); do /var/wazuh-manager/bin/agent_upgrade -a 001 -f /home/ubuntu/packages/wazuh-agent_5.0.0-0_x86_64_71d8fac.rpm.wpk -F; done

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Failed upgrades:
      Agent 001 status: Timeout reached while waiting for the response from the agent, check the result manually on the agent for more information

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error

  Upgrading...

  Failed upgrades:
      Agent 001 status: Send open file error
  ```

  </details>

  <details><summary>After fix — 10 consecutive upgrade attempts with a real WPK (all succeed consistently)</summary>

  ```bash
  root@wazuh-aio:/home/ubuntu/packages# for i in $(seq 1 10); do /var/wazuh-manager/bin/agent_upgrade -a 001 -f /home/ubuntu/packages/wazuh-agent_5.0.0-0_x86_64_71d8fac.rpm.wpk -F; done

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0

  Upgrading...

  Upgraded agents:
      Agent 001 upgraded: v5.0.0 -> v5.0.0
  ```

  </details>

  ### Artifacts Affected

  - `wazuh-manager` / agent upgrade manager module (`wm_agent_upgrade_manager.c`)

  ### Configuration Changes

  _No configuration changes._

  ### Documentation Updates

  _No documentation changes required._

  ### Tests Introduced

  _No new tests introduced. Existing unit tests for `wm_agent_upgrade_router_callback` should be updated to cover the removed `os_free`._

  ## Review Checklist

  - [x] Code changes reviewed
  - [x] Relevant evidence provided
  - [x] Tests cover the new functionality
  - [ ] Configuration changes documented
  - [ ] Developer documentation reflects the changes
  - [x] Meets requirements and/or definition of done
  - [x] No unresolved dependencies with other issues
