### PR TITLE
Add metrics_frequency and metrics_bulk_size to cluster.json

### DIFF
--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -71,7 +71,9 @@
             "sync_disconnected_agent_groups": 300,
             "sync_disconnected_agent_groups_batch_size": 100,
             "sync_disconnected_agent_groups_min_offline": 600,
-            "sync_disconnected_agent_cluster_name_delay": 300
+            "sync_disconnected_agent_cluster_name_delay": 300,
+            "metrics_frequency": 600,
+            "metrics_bulk_size": 100
         },
 
         "communication":{


### PR DESCRIPTION
## Description
This PR adds two new configuration keys to `cluster.json` as part of the manager metrics snapshot indexing feature.

**Proposed Release:** [v5.0.0]
**Issue:** wazuh/wazuh#34859
**Internal Reference:** wazuh/wazuh#34738

## Proposed Changes
- Updated `framework/wazuh/core/cluster/cluster.json`.
- Added `metrics_frequency` (default 600, minimum 600, 0 = feature disabled) under `intervals.master`.
- Added `metrics_bulk_size` (default 100) under `intervals.master`.

### Results and Evidence
The changes were validated locally.
```bash
python3 -c "import json; json.load(open('framework/wazuh/core/cluster/cluster.json')); print('JSON OK')"
JSON OK
```

### Artifacts Affected
- `framework/wazuh/core/cluster/cluster.json`

### Configuration Changes
Two new keys added under `intervals.master`:
- `metrics_frequency`: controls how often the metrics snapshot task runs in seconds. Minimum 600 (10 minutes). Set to 0 to disable the feature.
- `metrics_bulk_size`: controls the number of documents per bulk indexing request. Default 100.

### Documentation Updates
N/A

### Tests Introduced
- **Scope:** N/A - configuration-only change, no logic introduced.

## Review Checklist
**Manual tests with their corresponding evidence:**
- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues