### PR TITLE
Fix pthread_mutex_destroy invalid argument error on AIX in syscollector

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -154,6 +154,10 @@ void* wm_sys_main(wm_sys_t *sys) {
 
     sys->flags.running = true;
 
+    w_cond_init(&sys_stop_condition, NULL);
+    w_mutex_init(&sys_stop_mutex, NULL);
+    w_mutex_init(&sys_reconnect_mutex, NULL);
+
     if (!sys->flags.enabled) {
         mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting...");
         pthread_exit(NULL);


### PR DESCRIPTION
## Description

On AIX, `pthread_mutex_destroy()` returns `EINVAL` when called on a mutex that was only statically initialized with `PTHREAD_MUTEX_INITIALIZER` — without a prior explicit `pthread_mutex_init()` call. PR #34552 removed the explicit initialization calls from `wm_sys_main()` to fix a macOS crash (#34274) caused by a race condition where `wm_sys_destroy()` was destroying mutexes while the module thread was still using them. However, removing those calls introduced the AIX-specific failure. This PR restores the explicit initialization calls — placed before the `enabled` check so they always run regardless of module state — while preserving all fixes from #34552: destroys remain in `wm_sys_stop()` (which waits for the thread to finish before destroying), and failures remain non-fatal. Resolves #34892.

## Proposed Changes

- `src/wazuh_modules/wm_syscollector.c`: Restore explicit `w_cond_init()` and `w_mutex_init()` calls for `sys_stop_condition`, `sys_stop_mutex`, and `sys_reconnect_mutex` at the top of `wm_sys_main()`, before the `!sys->flags.enabled` early-exit check, ensuring the full `init → use → destroy` lifecycle is always completed on AIX. The destroy calls remain in `wm_sys_stop()` as introduced by #34552, preserving the macOS fix.

### Results and Evidence

<details><summary>Before fix — pthread_mutex_destroy error on AIX after syscollector shutdown</summary>

```bash
2026/03/11 20:20:57 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2026/03/11 20:20:57 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/03/11 20:20:57 wazuh-modulesd:syscollector: INFO: Module finished.
2026/03/11 20:20:57 wazuh-modulesd: ERROR: At pthread_mutex_destroy(): Invalid argument
2026/03/11 20:20:59 wazuh-execd: INFO: Started (pid: 15532284).
```

</details>

<details><summary>After fix — clean shutdown and restart cycle on AIX, no pthread errors</summary>

```bash
# grep ERROR /var/ossec/logs/ossec.log
#

# grep wazuh-modulesd /var/ossec/logs/ossec.log
2026/03/11 21:43:55 wazuh-modulesd: INFO: Started (pid: 13893882).
2026/03/11 21:43:55 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/03/11 21:43:55 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2026/03/11 21:43:55 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2026/03/11 21:43:55 wazuh-modulesd:syscollector: INFO: Module started.
2026/03/11 21:43:55 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/03/11 21:43:55 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/03/11 21:44:46 wazuh-modulesd: INFO: Agent is now online. Process unlocked, continuing...
2026/03/11 21:44:48 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2026/03/11 21:44:48 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/03/11 21:44:48 wazuh-modulesd:syscollector: INFO: Module finished.
2026/03/11 21:44:50 wazuh-modulesd: INFO: Started (pid: 11534498).
2026/03/11 21:44:50 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/03/11 21:44:50 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2026/03/11 21:44:50 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2026/03/11 21:44:50 wazuh-modulesd:syscollector: INFO: Module started.
2026/03/11 21:44:50 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/03/11 21:44:50 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

</details>

### Artifacts Affected

- `wazuh-modulesd` (AIX agent)

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced._

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
