### PR TITLE
Router coding style format

### DIFF
--- a/src/Doxyfile
+++ b/src/Doxyfile
@@ -1189,7 +1189,6 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
@@ -1470,7 +1469,6 @@ FORMULA_FONTSIZE       = 10
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
 # http://www.mathjax.org) which uses client side Javascript for the rendering
@@ -1758,7 +1756,6 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -1774,7 +1771,6 @@ LATEX_BIB_STYLE        = plain
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_TIMESTAMP        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output
@@ -1840,7 +1836,6 @@ RTF_EXTENSIONS_FILE    =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -1938,7 +1933,6 @@ DOCBOOK_OUTPUT         = docbook
 # The default value is: NO.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2125,7 +2119,6 @@ EXTERNAL_PAGES         = YES
 # powerful graphs.
 # The default value is: YES.
 
-CLASS_DIAGRAMS         = YES
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
@@ -2167,14 +2160,12 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = Helvetica
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.
 # Minimum value: 4, maximum value: 24, default value: 10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2400,7 +2391,6 @@ MAX_DOT_GRAPH_DEPTH    = 0
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/src/shared_modules/router/include/routerProvider.hpp
+++ b/src/shared_modules/router/include/routerProvider.hpp
@@ -43,8 +43,7 @@ public:
      * @param isLocal True for a local provider, false otherwise.
      */
     explicit RouterProvider(std::string topicName, const bool isLocal = true)
-        : m_topicName {std::move(topicName)}
-        , m_isLocal {isLocal}
+        : m_topicName {std::move(topicName)}, m_isLocal {isLocal}
     {
     }
     // LCOV_EXCL_START

--- a/src/shared_modules/router/include/routerSubscriber.hpp
+++ b/src/shared_modules/router/include/routerSubscriber.hpp
@@ -19,7 +19,6 @@
 #endif
 
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -46,25 +45,15 @@ public:
      * @param isLocal True for a local subscriber, false otherwise.
      */
     explicit RouterSubscriber(std::string topicName, std::string subscriberId, const bool isLocal = true)
-        : m_topicName {std::move(topicName)}
-        , m_subscriberId {std::move(subscriberId)}
-        , m_isLocal {isLocal}
+        : m_topicName {std::move(topicName)}, m_subscriberId {std::move(subscriberId)}, m_isLocal {isLocal}
     {
     }
 
-    // LCOV_EXCL_START
-    virtual ~RouterSubscriber()
-    {
-        try
-        {
-            unsubscribe();
-        }
-        catch (...)
-        {
-            std::cerr << "Error in ~RouterSubscriber()" << std::endl;
-        }
-    }
-    // LCOV_EXCL_STOP
+    /**
+     * @brief Class destructor.
+     *
+     */
+    virtual ~RouterSubscriber();
 
     /**
      * @brief Adds subscriber to the list.

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -11,6 +11,7 @@
 
 #include "logging_helper.h"
 #include <functional>
+#include <iostream>
 #include <string>
 static std::function<void(const modules_log_level_t, const std::string&)> GS_LOG_FUNCTION;
 
@@ -157,6 +158,20 @@ void RouterSubscriber::subscribe(const std::function<void(const std::vector<char
         RouterFacade::instance().addSubscriberRemote(m_topicName, m_subscriberId, callback);
     }
 }
+
+// LCOV_EXCL_START
+RouterSubscriber::~RouterSubscriber()
+{
+    try
+    {
+        unsubscribe();
+    }
+    catch (...)
+    {
+        std::cerr << "Error in ~RouterSubscriber()" << std::endl;
+    }
+}
+// LCOV_EXCL_STOP
 
 void RouterSubscriber::subscribe(const std::function<void(const std::vector<char>&)>& callback,
                                  const std::function<void()>& onConnect)

--- a/src/shared_modules/router/src/routerFacade.hpp
+++ b/src/shared_modules/router/src/routerFacade.hpp
@@ -81,8 +81,7 @@ public:
      * @param name Provider name.
      * @param onConnect Callback to be called when the provider is connected.
      */
-    void initProviderRemote(
-        const std::string& name, const std::function<void()>& onConnect = []() {});
+    void initProviderRemote(const std::string& name, const std::function<void()>& onConnect = []() {});
 
     /**
      * @brief Removes remote provider.

--- a/src/shared_modules/router/src/subscriber.hpp
+++ b/src/shared_modules/router/src/subscriber.hpp
@@ -34,8 +34,7 @@ public:
      * @param observerId Observer ID.
      */
     explicit Subscriber(const std::function<void(T)>& callback, std::string observerId)
-        : m_callback {callback}
-        , Observer<T>(std::move(observerId))
+        : m_callback {callback}, Observer<T>(std::move(observerId))
     {
     }
 

--- a/src/shared_modules/router/testtool/cmdArgsParser.hpp
+++ b/src/shared_modules/router/testtool/cmdArgsParser.hpp
@@ -84,7 +84,7 @@ public:
                   << "\t-t TOPIC\t\tSpecifies the topic to use.\n"
                   << "\t-s SUBSCRIBER_ID\tSpecifies the subscriber id to use.\n"
                   << "\t-f FBS_PATH\t\tSpecifies the path to the fbs to read flatbuffer messages.\n"
-                  << "\nExample:"
+                  << "\nExample:\n"
                   << "\n\t./router_testtool -m broker\n"
                   << "\n\t./router_testtool -m publisher -t TOPIC\n"
                   << "\n\t./router_testtool -m subscriber -t TOPIC -s SUBSCRIBER_ID\n"


### PR DESCRIPTION

# Description
Closes #34897
This PR solves router coding style format errors.


## Current format errors
```
warning: Tag 'HTML_TIMESTAMP' at line 1192 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'FORMULA_TRANSPARENT' at line 1473 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'LATEX_SOURCE_CODE' at line 1761 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'LATEX_TIMESTAMP' at line 1777 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'RTF_SOURCE_CODE' at line 1843 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'DOCBOOK_PROGRAMLISTING' at line 1941 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'CLASS_DIAGRAMS' at line 2128 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'DOT_FONTNAME' at line 2170 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'DOT_FONTSIZE' at line 2177 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'DOT_TRANSPARENT' at line 2403 of file 'src/shared_modules/router/doxygen_config.cfg' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
<~RouterSubscriber>:1: warning: parameters of member RouterSubscriber::~RouterSubscriber are not documented
```