### PR TITLE
Improve resilience of the 5.x manager package build flow

### DIFF
--- a/.github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh
+++ b/.github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh
@@ -1,9 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY_SCRIPT="${SCRIPT_DIR}/../../scripts/run_with_retry.sh"
+
 GITHUB_PUSH_SECRET=$1
 GITHUB_USER=$2
 DOCKER_IMAGE_NAME=$3
 BUILD_CONTEXT=$4
 DOCKERFILE_PATH="$BUILD_CONTEXT/Dockerfile"
-if [ -n "$5" ]; then
+if [ -n "${5:-}" ]; then
     DOCKER_IMAGE_TAG=$5
 else
     exit 1
@@ -15,15 +22,29 @@ IMAGE_ID_CACHE=$(echo ${IMAGE_ID_CACHE} | tr '[A-Z]' '[a-z]')
 IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
+export GITHUB_PUSH_SECRET GITHUB_USER
+
 # Login to GHCR
-echo ${GITHUB_PUSH_SECRET} | docker login https://ghcr.io -u $GITHUB_USER --password-stdin
+"${RETRY_SCRIPT}" --attempts 4 --delay 5 --backoff 2 --max-delay 20 --timeout 60 \
+    --label "Login to GHCR" -- \
+    bash -lc 'printf "%s" "$GITHUB_PUSH_SECRET" | docker login https://ghcr.io -u "$GITHUB_USER" --password-stdin'
 
 # Pull latest image id from cache
 echo pull ${IMAGE_ID_CACHE}
-docker pull ${IMAGE_ID_CACHE}
+cache_args=()
+if "${RETRY_SCRIPT}" --attempts 3 --delay 10 --backoff 2 --max-delay 40 --timeout 900 \
+    --label "Pull cache image ${IMAGE_ID_CACHE}" -- \
+    docker pull "${IMAGE_ID_CACHE}"; then
+    cache_args=(--cache-from "${IMAGE_ID_CACHE}")
+else
+    echo "Cache image ${IMAGE_ID_CACHE} is not available. Continuing without remote cache."
+fi
 
 # Build image
-echo build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ${IMAGE_ID_CACHE} -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
-docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ${IMAGE_ID_CACHE} -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
-docker push ${IMAGE_ID}
-
+echo build --build-arg BUILDKIT_INLINE_CACHE=1 "${cache_args[@]}" -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
+"${RETRY_SCRIPT}" --attempts 2 --delay 20 --backoff 2 --max-delay 60 --timeout 5400 \
+    --label "Build image ${IMAGE_ID}" -- \
+    docker build --build-arg BUILDKIT_INLINE_CACHE=1 "${cache_args[@]}" -t "${IMAGE_ID}" -f "${DOCKERFILE_PATH}" "${BUILD_CONTEXT}"
+"${RETRY_SCRIPT}" --attempts 4 --delay 15 --backoff 2 --max-delay 60 --timeout 1800 \
+    --label "Push image ${IMAGE_ID}" -- \
+    docker push "${IMAGE_ID}"

--- a/.github/actions/ghcr-pull-and-push/pull_image_from_ghcr.sh
+++ b/.github/actions/ghcr-pull-and-push/pull_image_from_ghcr.sh
@@ -1,8 +1,14 @@
-set -x
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY_SCRIPT="${SCRIPT_DIR}/../../scripts/run_with_retry.sh"
+
 GITHUB_PUSH_SECRET=$1
 GITHUB_USER=$2
 DOCKER_IMAGE_NAME=$3
-if [ -n "$4" ]; then
+if [ -n "${4:-}" ]; then
     DOCKER_IMAGE_TAG="$4"
 else
     exit 1
@@ -12,9 +18,15 @@ GITHUB_OWNER="wazuh"
 IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
+export GITHUB_PUSH_SECRET GITHUB_USER
+
 # Login to GHCR
-echo ${GITHUB_PUSH_SECRET} | docker login https://ghcr.io -u $GITHUB_USER --password-stdin
+"${RETRY_SCRIPT}" --attempts 4 --delay 5 --backoff 2 --max-delay 20 --timeout 60 \
+    --label "Login to GHCR" -- \
+    bash -lc 'printf "%s" "$GITHUB_PUSH_SECRET" | docker login https://ghcr.io -u "$GITHUB_USER" --password-stdin'
 
 # Pull and rename image
-docker pull ${IMAGE_ID}
-docker image tag ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+"${RETRY_SCRIPT}" --attempts 4 --delay 10 --backoff 2 --max-delay 45 --timeout 900 \
+    --label "Pull ${IMAGE_ID}" -- \
+    docker pull "${IMAGE_ID}"
+docker image tag "ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"

--- a/.github/actions/test-install-components/install_component.sh
+++ b/.github/actions/test-install-components/install_component.sh
@@ -12,7 +12,7 @@ fi
 echo "Installing Wazuh $target."
 
 if [ -n "$(command -v yum)" ]; then
-    install="yum install -y --nogpgcheck"
+    install="yum --setopt=retries=5 --setopt=timeout=30 install -y --nogpgcheck"
     installed_log="/var/log/yum.log"
 elif [ -n "$(command -v dpkg)" ]; then
     install="dpkg --install"

--- a/.github/scripts/run_with_retry.sh
+++ b/.github/scripts/run_with_retry.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+attempts=3
+delay=5
+backoff=2
+max_delay=60
+timeout_seconds=""
+label=""
+
+usage() {
+  cat <<'EOF'
+Usage: run_with_retry.sh [options] -- command [args...]
+
+Options:
+  --attempts N      Number of attempts. Default: 3
+  --delay SECONDS   Initial delay between attempts. Default: 5
+  --backoff FACTOR  Delay multiplier after each failure. Default: 2
+  --max-delay SEC   Maximum delay between attempts. Default: 60
+  --timeout SEC     Timeout applied to each attempt if GNU timeout is available
+  --label TEXT      Short label used in retry logs
+  -h, --help        Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --attempts)
+      attempts="$2"
+      shift 2
+      ;;
+    --delay)
+      delay="$2"
+      shift 2
+      ;;
+    --backoff)
+      backoff="$2"
+      shift 2
+      ;;
+    --max-delay)
+      max_delay="$2"
+      shift 2
+      ;;
+    --timeout)
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --label)
+      label="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "[retry] Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "[retry] A command is required." >&2
+  usage >&2
+  exit 1
+fi
+
+use_timeout=false
+if [[ -n "$timeout_seconds" ]]; then
+  if command -v timeout >/dev/null 2>&1; then
+    use_timeout=true
+  else
+    echo "[retry] GNU timeout is not available. Running without per-attempt timeout." >&2
+  fi
+fi
+
+current_delay="$delay"
+attempt=1
+
+while true; do
+  if [[ -n "$label" ]]; then
+    echo "[retry] ${label}: attempt ${attempt}/${attempts}" >&2
+  else
+    echo "[retry] Attempt ${attempt}/${attempts}: $*" >&2
+  fi
+
+  set +e
+  if $use_timeout; then
+    timeout --preserve-status "$timeout_seconds" "$@"
+  else
+    "$@"
+  fi
+  exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    exit 0
+  fi
+
+  if (( attempt >= attempts )); then
+    if [[ -n "$label" ]]; then
+      echo "[retry] ${label}: failed after ${attempt} attempts (exit code ${exit_code})." >&2
+    else
+      echo "[retry] Command failed after ${attempt} attempts (exit code ${exit_code})." >&2
+    fi
+    exit "$exit_code"
+  fi
+
+  echo "[retry] Command failed with exit code ${exit_code}. Retrying in ${current_delay}s." >&2
+  sleep "$current_delay"
+
+  attempt=$((attempt + 1))
+  next_delay=$((current_delay * backoff))
+  if (( next_delay > max_delay )); then
+    current_delay="$max_delay"
+  else
+    current_delay="$next_delay"
+  fi
+done

--- a/.github/workflows/5_builderpackage_manager.yml
+++ b/.github/workflows/5_builderpackage_manager.yml
@@ -104,9 +104,12 @@ jobs:
     env:
       SHOULD_UPLOAD: ${{ inputs.upload_package }}
       SHOULD_UPLOAD_CHECKSUM: ${{ inputs.checksum && inputs.upload_package }}
+      RETRY_SCRIPT: ${{ github.workspace }}/.github/scripts/run_with_retry.sh
+      AWS_MAX_ATTEMPTS: "10"
+      AWS_RETRY_MODE: adaptive
 
     runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
-    timeout-minutes: 45
+    timeout-minutes: 90
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
     steps:
@@ -160,6 +163,7 @@ jobs:
           echo "CONTAINER_NAME=pkg_${{ inputs.system }}_manager_builder_${{ env.PACKAGE_ARCH }}" >> $GITHUB_ENV
 
       - name: Download docker image for package building
+        timeout-minutes: 20
         run: |
           bash $GITHUB_WORKSPACE/.github/actions/ghcr-pull-and-push/pull_image_from_ghcr.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.actor}} $CONTAINER_NAME ${{ env.TAG }}
 
@@ -172,6 +176,7 @@ jobs:
           cat VERSION.json
 
       - name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
+        timeout-minutes: 45
         working-directory: packages
         run: |
           SHORT_COMMIT=$(git rev-parse --short HEAD)
@@ -204,6 +209,7 @@ jobs:
           echo "PACKAGE_SYMBOLS_NAME=${PACKAGE_SYMBOLS_NAME}" | tee -a $GITHUB_ENV
 
       - name: Test install built manager
+        timeout-minutes: 15
         run: |
           TESTS_PATH=$GITHUB_WORKSPACE/.github/actions/test-install-components/
           if [ -z "${{ env.PACKAGE_NAME }}" ]; then echo "No package found matching the pattern!"; exit 1; fi
@@ -252,6 +258,7 @@ jobs:
           fi
 
       - name: Test uninstall built manager
+        timeout-minutes: 10
         run: |
           if [ -z "${{ env.PACKAGE_NAME }}" ] || [ -z "${{ env.CONTAINER_ID }}" ]; then
             echo "No package or container found!";
@@ -263,12 +270,34 @@ jobs:
           sudo docker stop $CONTAINER_ID && sudo docker rm $CONTAINER_ID
 
       - name: Get latest Wazuh release from GitHub
+        timeout-minutes: 10
         run: |
-          apt-get update && apt-get install -y curl jq
+          if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+            "$RETRY_SCRIPT" --attempts 4 --delay 10 --backoff 2 --max-delay 45 --timeout 300 \
+              --label "Refresh apt metadata for release lookup" -- \
+              sudo apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 update
+            "$RETRY_SCRIPT" --attempts 4 --delay 10 --backoff 2 --max-delay 45 --timeout 300 \
+              --label "Install curl and jq for release lookup" -- \
+              sudo apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 install -y curl jq
+          fi
 
           CURRENT_TAG="${{ env.TAG }}"
-          PREVIOUS_TAG=$(curl -s https://api.github.com/repos/wazuh/wazuh/releases | jq -r '.[].tag_name' | grep -vE 'alpha|beta|rc' | sed 's/^v//' | grep -E '^5\.[0-9]+\.[0-9]+$' | \
+          RELEASES_FILE=$(mktemp)
+          trap 'rm -f "$RELEASES_FILE"' EXIT
+
+          "$RETRY_SCRIPT" --attempts 4 --delay 5 --backoff 2 --max-delay 30 --timeout 180 \
+            --label "Download Wazuh GitHub releases metadata" -- \
+            curl -fsSL --connect-timeout 20 --max-time 120 \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -o "$RELEASES_FILE" \
+              https://api.github.com/repos/wazuh/wazuh/releases
+
+          PREVIOUS_TAG=$(jq -r '.[].tag_name' "$RELEASES_FILE" | grep -vE 'alpha|beta|rc' | sed 's/^v//' | grep -E '^5\.[0-9]+\.[0-9]+$' | \
           grep -v "^${CURRENT_TAG}$" | sort -V | awk -v current="$CURRENT_TAG" '$0 < current' | tail -n1)
+
+          rm -f "$RELEASES_FILE"
+          trap - EXIT
 
           if [ -n "$PREVIOUS_TAG" ]; then
             echo "Latest release detected: $PREVIOUS_TAG"
@@ -281,6 +310,7 @@ jobs:
 
       - name: Download latest public wazuh-manager package
         if: env.HAS_PREVIOUS_RELEASE == 'true'
+        timeout-minutes: 10
         run: |
           ARCH=${{ env.ARCH }}
           VERSION=${{ env.PUBLIC_RELEASE_VERSION }}
@@ -298,25 +328,28 @@ jobs:
 
           PACKAGE_URL="$BASE_URL/$FILE_NAME_PUBLIC"
           echo "Downloading: $PACKAGE_URL"
-          curl -fSL "$PACKAGE_URL" -o "/tmp/$FILE_NAME_PUBLIC"
+          "$RETRY_SCRIPT" --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 \
+            --label "Download ${FILE_NAME_PUBLIC}" -- \
+            curl -fL --connect-timeout 20 --max-time 300 -o "/tmp/$FILE_NAME_PUBLIC" "$PACKAGE_URL"
           echo "PUBLIC_PACKAGE_NAME=$FILE_NAME_PUBLIC" >> $GITHUB_ENV
 
       - name: Run container and install public wazuh-manager
         if: env.HAS_PREVIOUS_RELEASE == 'true'
+        timeout-minutes: 20
         run: |
           FILE_NAME=${{ env.PUBLIC_PACKAGE_NAME }}
           SYSTEM=${{ inputs.system }}
 
           if [ "$SYSTEM" = "deb" ]; then
             BASE_IMAGE="ubuntu:22.04"
-            INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -f install -y"
-            UPDATE_CMD="apt-get update"
+            INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 -f install -y"
+            UPDATE_CMD="apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update"
             docker run --name wazuh_previous -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
             sleep 5
           else
             BASE_IMAGE="centos:8"
-            INSTALL_CMD="yum localinstall -y /packages/$FILE_NAME"
-            UPDATE_CMD="yum update -y"
+            INSTALL_CMD="yum --setopt=retries=5 --setopt=timeout=30 localinstall -y /packages/$FILE_NAME"
+            UPDATE_CMD="yum --setopt=retries=5 --setopt=timeout=30 update -y"
             docker run --name wazuh_previous -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
             # Configuring CentOS 8 repositories
             docker exec wazuh_previous bash -c "sed -i.bak 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*"
@@ -324,29 +357,37 @@ jobs:
             sleep 5
           fi
 
-          docker exec wazuh_previous bash -c "$UPDATE_CMD"
-          docker exec wazuh_previous bash -c "$INSTALL_CMD"
+          "$RETRY_SCRIPT" --attempts 4 --delay 10 --backoff 2 --max-delay 45 --timeout 600 \
+            --label "Refresh package repositories in upgrade test container" -- \
+            docker exec wazuh_previous bash -lc "$UPDATE_CMD"
+          "$RETRY_SCRIPT" --attempts 3 --delay 15 --backoff 2 --max-delay 45 --timeout 900 \
+            --label "Install previous public manager package" -- \
+            docker exec wazuh_previous bash -lc "$INSTALL_CMD"
           docker exec wazuh_previous bash -c "/var/wazuh-manager/bin/wazuh-manager-control info || echo 'Manager not started yet'"
 
       - name: Upgrade to current Wazuh version
         if: env.HAS_PREVIOUS_RELEASE == 'true'
+        timeout-minutes: 20
         run: |
           SYSTEM=${{ inputs.system }}
           FILE_NAME=${{ env.PACKAGE_NAME }}
 
           if [ "$SYSTEM" = "deb" ]; then
-            INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -f install -y"
+            INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 -f install -y"
           else
-            INSTALL_CMD="yum localinstall -y /packages/$FILE_NAME"
+            INSTALL_CMD="yum --setopt=retries=5 --setopt=timeout=30 localinstall -y /packages/$FILE_NAME"
           fi
 
           echo "Upgrading to current version with package: $FILE_NAME"
           docker cp /tmp/$FILE_NAME wazuh_previous:/packages/$FILE_NAME
-          docker exec wazuh_previous bash -c "$INSTALL_CMD"
+          "$RETRY_SCRIPT" --attempts 3 --delay 15 --backoff 2 --max-delay 45 --timeout 900 \
+            --label "Upgrade manager package in test container" -- \
+            docker exec wazuh_previous bash -lc "$INSTALL_CMD"
           docker exec wazuh_previous bash -c "/var/wazuh-manager/bin/wazuh-manager-control info || echo 'Manager not started yet after upgrade'"
 
       - name: Upload package to GitHub
         if: always()
+        timeout-minutes: 10
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}
@@ -355,6 +396,7 @@ jobs:
 
       - name: Upload debug symbols to GitHub
         if: always()
+        timeout-minutes: 10
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_SYMBOLS_NAME }}
@@ -371,30 +413,41 @@ jobs:
 
       - name: Upload package to S3
         if: ${{ env.SHOULD_UPLOAD == 'true' }}
+        timeout-minutes: 10
         working-directory: packages
         run: |
-          aws s3 cp /tmp/${{ env.PACKAGE_NAME }} s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
+          "$RETRY_SCRIPT" --attempts 3 --delay 10 --backoff 2 --max-delay 30 --timeout 600 \
+            --label "Upload package to S3" -- \
+            aws s3 cp /tmp/${{ env.PACKAGE_NAME }} s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
           s3uri="s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/${{ env.PACKAGE_NAME }}"
           echo "S3 URI: ${s3uri}"
 
       - name: Upload checksum to S3
         if: ${{ env.SHOULD_UPLOAD_CHECKSUM == 'true' }}
+        timeout-minutes: 10
         run: |
-          aws s3 cp /tmp/${{ env.PACKAGE_NAME }}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
-          aws s3 cp /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
+          "$RETRY_SCRIPT" --attempts 3 --delay 10 --backoff 2 --max-delay 30 --timeout 600 \
+            --label "Upload package checksum to S3" -- \
+            aws s3 cp /tmp/${{ env.PACKAGE_NAME }}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
           s3uri="s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/${{ env.PACKAGE_NAME }}.sha512"
           echo "S3 sha512 URI: ${s3uri}"
 
       - name: Upload debug symbols to S3
         if: ${{ env.SHOULD_UPLOAD == 'true' }}
+        timeout-minutes: 10
         run: |
-          aws s3 cp /tmp/${{ env.PACKAGE_SYMBOLS_NAME }} s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
+          "$RETRY_SCRIPT" --attempts 3 --delay 10 --backoff 2 --max-delay 30 --timeout 600 \
+            --label "Upload debug symbols to S3" -- \
+            aws s3 cp /tmp/${{ env.PACKAGE_SYMBOLS_NAME }} s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
           symbols="s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/${{ env.PACKAGE_SYMBOLS_NAME }}"
           echo "S3 symbols URI: ${symbols}"
 
       - name: Upload debug symbols checksum to S3
         if: ${{ env.SHOULD_UPLOAD_CHECKSUM == 'true' }}
+        timeout-minutes: 10
         run: |
-          aws s3 cp /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
+          "$RETRY_SCRIPT" --attempts 3 --delay 10 --backoff 2 --max-delay 30 --timeout 600 \
+            --label "Upload debug symbols checksum to S3" -- \
+            aws s3 cp /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}.sha512 s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/
           symbols="s3://xdrsiem-packages-dev-internal/development/wazuh/5.x/main/packages/${{ env.PACKAGE_SYMBOLS_NAME }}.sha512"
           echo "S3 symbols sha512 URI: ${symbols}"

--- a/.github/workflows/5_builderprecompiled_docker-images-upload-manager.yml
+++ b/.github/workflows/5_builderprecompiled_docker-images-upload-manager.yml
@@ -49,7 +49,7 @@ jobs:
       actions: write
 
     runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-22.04' }}
-    timeout-minutes: 140
+    timeout-minutes: 180
     name: Package - Upload pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
 
     steps:
@@ -76,7 +76,9 @@ jobs:
           echo "DOCKERFILE_PATH=$dockerfile_path" >> $GITHUB_ENV
           cp packages/build.sh $dockerfile_path
           cp packages/${{ inputs.system }}s/utils/* $dockerfile_path
+          cp .github/scripts/run_with_retry.sh $dockerfile_path/retry.sh
 
       - name: Build and push image pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ env.TAG }} to Github Container Registry
+        timeout-minutes: 165
         run:
           bash .github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.actor}} pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} ${{ env.DOCKERFILE_PATH }} ${{ env.TAG }}

--- a/packages/debs/amd64/manager/Dockerfile
+++ b/packages/debs/amd64/manager/Dockerfile
@@ -2,21 +2,34 @@ FROM debian:8
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ADD retry.sh /usr/local/bin/retry.sh
+RUN chmod +x /usr/local/bin/retry.sh
+
 # Installing necessary packages
 RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-resilience && \
     echo "deb http://archive.debian.org/debian jessie contrib main non-free" > /etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y --force-yes apt-utils && \
+    echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
+    apt-get update
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
+    apt-get install -y --force-yes apt-utils
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 900 -- \
     apt-get install -y --force-yes \
     curl g++ bzip2 debhelper gcc rename make sudo wget expect gnupg perl-base perl \
     libc-bin libc6 libc6-dev build-essential dpkg-dev\
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
     libdb5.3 libdb5.3-dev libssl1.0.0 libssl-dev procps git gawk libsigsegv2
 
-RUN echo "deb-src http://archive.debian.org/debian jessie contrib main non-free" >> /etc/apt/sources.list && \
-    apt-get update && apt-get build-dep python3 -y --force-yes
+RUN echo "deb-src http://archive.debian.org/debian jessie contrib main non-free" >> /etc/apt/sources.list
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
+    apt-get update
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 900 -- \
+    apt-get build-dep python3 -y --force-yes
 
-ADD https://packages.wazuh.com/utils/gcc/gcc_14.3-1_amd64.deb /tmp/gcc_14.3-1_amd64.deb
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/gcc_14.3-1_amd64.deb \
+    https://packages.wazuh.com/utils/gcc/gcc_14.3-1_amd64.deb
 RUN dpkg -i /tmp/gcc_14.3-1_amd64.deb && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/c++ && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/g++ && \
@@ -26,12 +39,16 @@ ENV CPLUS_INCLUDE_PATH "/opt/gcc-14/include/c++/14.3.0/"
 ENV LD_LIBRARY_PATH "/opt/gcc-14/lib64:${LD_LIBRARY_PATH}"
 ENV PATH "/opt/gcc-14/bin:${PATH}"
 
-ADD https://packages.wazuh.com/utils/binutils/binutils_2.38-1_amd64.deb /tmp/binutils_2.38-1_amd64.deb
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/binutils_2.38-1_amd64.deb \
+    https://packages.wazuh.com/utils/binutils/binutils_2.38-1_amd64.deb
 RUN dpkg -i /tmp/binutils_2.38-1_amd64.deb
 
 ENV PATH "/opt/binutils-2/bin:${PATH}"
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-x86_64.sh /tmp/cmake-3.30.4-linux-x86_64.sh
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/cmake-3.30.4-linux-x86_64.sh \
+    https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-x86_64.sh
 
 RUN mkdir -p /opt/cmake
 RUN sh /tmp/cmake-3.30.4-linux-x86_64.sh --prefix=/opt/cmake --skip-license

--- a/packages/debs/arm64/manager/Dockerfile
+++ b/packages/debs/arm64/manager/Dockerfile
@@ -2,11 +2,18 @@ FROM arm64v8/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ADD retry.sh /usr/local/bin/retry.sh
+RUN chmod +x /usr/local/bin/retry.sh
+
 # Installing necessary packages
 RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > /etc/apt/sources.list && \
     echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian stretch main" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y --allow-change-held-packages apt apt-utils  \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-resilience
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
+    apt-get update
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 900 -- \
+    apt-get install -y --allow-change-held-packages apt apt-utils  \
     curl gcc g++ make sudo expect gnupg \
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
@@ -14,11 +21,18 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 12
-RUN apt-get update &&  apt-get build-dep python3.5 -y --allow-change-held-packages
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
+    apt-get update
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 900 -- \
+    apt-get build-dep python3.5 -y --allow-change-held-packages
+RUN /usr/local/bin/retry.sh --attempts 4 --delay 10 --backoff 2 --max-delay 40 --timeout 300 -- \
+    bash -lc 'curl -fsSL --connect-timeout 20 --max-time 180 https://deb.nodesource.com/setup_12.x | bash -'
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
     apt-get install --allow-change-held-packages -y nodejs
 
-ADD https://packages.wazuh.com/utils/gcc/gcc_14.3-1_arm64.deb /tmp/gcc_14.3-1_arm64.deb
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/gcc_14.3-1_arm64.deb \
+    https://packages.wazuh.com/utils/gcc/gcc_14.3-1_arm64.deb
 RUN dpkg -i /tmp/gcc_14.3-1_arm64.deb && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/c++ && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/g++ && \
@@ -28,12 +42,16 @@ ENV CPLUS_INCLUDE_PATH "/opt/gcc-14/include/c++/14.3.0/"
 ENV LD_LIBRARY_PATH "/opt/gcc-14/lib64:${LD_LIBRARY_PATH}"
 ENV PATH "/opt/gcc-14/bin:${PATH}"
 
-ADD https://packages.wazuh.com/utils/binutils/binutils_2.38-1_arm64.deb /tmp/binutils_2.38-1_arm64.deb
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/binutils_2.38-1_arm64.deb \
+    https://packages.wazuh.com/utils/binutils/binutils_2.38-1_arm64.deb
 RUN dpkg -i /tmp/binutils_2.38-1_arm64.deb
 
 ENV PATH "/opt/binutils-2/bin:${PATH}"
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-aarch64.sh /tmp/cmake-3.30.4-linux-aarch64.sh
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/cmake-3.30.4-linux-aarch64.sh \
+    https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-aarch64.sh
 
 RUN mkdir -p /opt/cmake
 RUN sh /tmp/cmake-3.30.4-linux-aarch64.sh --prefix=/opt/cmake --skip-license

--- a/packages/debs/utils/helper_function.sh
+++ b/packages/debs/utils/helper_function.sh
@@ -45,7 +45,7 @@ set_debug(){
 }
 
 build_deps(){
-    mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y"
+    mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 -y"
 }
 
 build_package(){

--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -61,6 +61,7 @@ build_pkg() {
     # Copy the necessary files
     cp ${CURRENT_PATH}/build.sh ${DOCKERFILE_PATH}
     cp ${CURRENT_PATH}/${SYSTEM}s/utils/* ${DOCKERFILE_PATH}
+    cp ${WAZUH_PATH}/.github/scripts/run_with_retry.sh ${DOCKERFILE_PATH}/retry.sh
 
     # Build the Docker image
     if [[ ${BUILD_DOCKER} == "yes" ]]; then

--- a/packages/rpms/amd64/manager/Dockerfile
+++ b/packages/rpms/amd64/manager/Dockerfile
@@ -1,9 +1,13 @@
 FROM centos:7
 
+ADD retry.sh /usr/local/bin/retry.sh
+RUN chmod +x /usr/local/bin/retry.sh
+
 # Install all the necessary tools to build the packages
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN yum install -y gcc make wget git \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 1200 -- \
+    yum --setopt=retries=5 --setopt=timeout=30 install -y gcc make wget git \
     openssh-clients sudo gnupg file-devel\
     automake autoconf libtool policycoreutils-python \
     yum-utils system-rpm-config rpm-devel \
@@ -24,19 +28,22 @@ RUN yum install -y gcc make wget git \
     valgrind-devel python-rpm-macros python3
 
 # Install Perl 5.10
-RUN curl -OL http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o perl-5.10.1.tar.gz http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
     gunzip perl-5.10.1.tar.gz && tar -xf perl*.tar && \
     cd /perl-5.10.1 && ./Configure -des -Dcc='gcc' -Dusethreads && \
     make -j2 && make install && ln -fs /usr/local/bin/perl /bin/perl && \
     cd / && rm -rf /perl-5.10.1*
 
 # Update rpmbuild, rpm and autoconf
-RUN curl -O http://packages.wazuh.com/utils/autoconf/autoconf-2.69.tar.gz && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o autoconf-2.69.tar.gz http://packages.wazuh.com/utils/autoconf/autoconf-2.69.tar.gz && \
     gunzip autoconf-2.69.tar.gz && tar xvf autoconf-2.69.tar && \
     cd autoconf-2.69 && ./configure && make -j$(nproc) && \
     make install && cd / && rm -rf autoconf-*
 
-RUN curl -O http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o rpm-4.15.1.tar.bz2 http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 && \
     tar -xjf rpm-4.15.1.tar.bz2 && cd rpm-4.15.1 && \
     ./configure --without-lua && make -j$(nproc) && make install && cd / && rm -rf rpm-*
 
@@ -44,7 +51,9 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
-ADD https://packages.wazuh.com/utils/gcc/gcc-14.3-1.x86_64.rpm /tmp/gcc-14.3-1.x86_64.rpm
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/gcc-14.3-1.x86_64.rpm \
+    https://packages.wazuh.com/utils/gcc/gcc-14.3-1.x86_64.rpm
 RUN rpm -i /tmp/gcc-14.3-1.x86_64.rpm && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/c++ && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/g++ && \
@@ -54,12 +63,16 @@ ENV CPLUS_INCLUDE_PATH "/opt/gcc-14/include/c++/14.3.0/"
 ENV LD_LIBRARY_PATH "/opt/gcc-14/lib64:${LD_LIBRARY_PATH}"
 ENV PATH "/opt/gcc-14/bin:${PATH}"
 
-ADD https://packages.wazuh.com/utils/binutils/binutils-2.38-1.x86_64.rpm /tmp/binutils-2.38-1.x86_64.rpm
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/binutils-2.38-1.x86_64.rpm \
+    https://packages.wazuh.com/utils/binutils/binutils-2.38-1.x86_64.rpm
 RUN rpm -i /tmp/binutils-2.38-1.x86_64.rpm
 
 ENV PATH "/opt/binutils-2/bin:${PATH}"
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-x86_64.sh /tmp/cmake-3.30.4-linux-x86_64.sh
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/cmake-3.30.4-linux-x86_64.sh \
+    https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-x86_64.sh
 
 RUN mkdir -p /opt/cmake
 RUN sh /tmp/cmake-3.30.4-linux-x86_64.sh --prefix=/opt/cmake --skip-license

--- a/packages/rpms/arm64/manager/Dockerfile
+++ b/packages/rpms/arm64/manager/Dockerfile
@@ -1,14 +1,19 @@
 FROM arm64v8/centos:7
 
+ADD retry.sh /usr/local/bin/retry.sh
+RUN chmod +x /usr/local/bin/retry.sh
+
 # CentOS 7 is EOL, so we need to change the repositories to use the vault
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # Enable EPEL
-RUN yum install -y http://packages.wazuh.com/utils/pkg/epel-release-latest-7.noarch.rpm
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 600 -- \
+    yum --setopt=retries=5 --setopt=timeout=30 install -y http://packages.wazuh.com/utils/pkg/epel-release-latest-7.noarch.rpm
 
 # Install all the necessary tools to build the packages
-RUN yum install -y gcc make wget git \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 --timeout 1200 -- \
+    yum --setopt=retries=5 --setopt=timeout=30 install -y gcc make wget git \
     openssh-clients sudo gnupg file-devel\
     automake autoconf libtool policycoreutils-python \
     yum-utils system-rpm-config rpm-devel \
@@ -29,28 +34,33 @@ RUN yum install -y gcc make wget git \
     valgrind-devel python-rpm-macros python34 nodejs
 
 # Install Perl 5.10
-RUN curl -OL http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o perl-5.10.1.tar.gz http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
     gunzip perl-5.10.1.tar.gz && tar -xf perl*.tar && \
     cd /perl-5.10.1 && ./Configure -des -Dcc='gcc' -Dusethreads && \
     make -j2 && make install && ln -fs /usr/local/bin/perl /bin/perl && \
     cd / && rm -rf /perl-5.10.1*
 
-RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o openssl-1.1.1a.tar.gz http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
     tar -xzf openssl-1.1.1a.tar.gz && cd openssl* && \
     ./config -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' && \
     make -j $(nproc) && make install && cd / && rm -rf openssl-*
 
-RUN curl -O http://packages.wazuh.com/utils/nodejs/node-v12.16.1-linux-arm64.tar.xz && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o node-v12.16.1-linux-arm64.tar.xz http://packages.wazuh.com/utils/nodejs/node-v12.16.1-linux-arm64.tar.xz && \
     tar -xJf node-v12.16.1-linux-arm64.tar.xz && \
     cd node-v12.16* && cp -R * /usr/local/ && cd / && rm -rf node-v*
 
 # Update rpmbuild, rpm and autoconf
-RUN curl -O http://packages.wazuh.com/utils/autoconf/autoconf-2.69.tar.gz && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o autoconf-2.69.tar.gz http://packages.wazuh.com/utils/autoconf/autoconf-2.69.tar.gz && \
     gunzip autoconf-2.69.tar.gz && tar xvf autoconf-2.69.tar && \
     cd autoconf-2.69 && ./configure && \
     make -j $(nproc) && make install && cd / && rm -rf autoconf-*
 
-RUN curl -O http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 && \
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o rpm-4.15.1.tar.bz2 http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 && \
     tar -xjf rpm-4.15.1.tar.bz2 && cd rpm-4.15.1 && \
     ./configure --without-lua && make -j $(nproc) && \
     make install && cd / && rm -rf rpm-*
@@ -59,7 +69,9 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
 
-ADD https://packages.wazuh.com/utils/gcc/gcc-14.3-1.aarch64.rpm /tmp/gcc-14.3-1.aarch64.rpm
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/gcc-14.3-1.aarch64.rpm \
+    https://packages.wazuh.com/utils/gcc/gcc-14.3-1.aarch64.rpm
 RUN rpm -i /tmp/gcc-14.3-1.aarch64.rpm && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/c++ && \
     ln -fs /opt/gcc-14/bin/g++ /usr/bin/g++ && \
@@ -69,12 +81,16 @@ ENV CPLUS_INCLUDE_PATH "/opt/gcc-14/include/c++/14.3.0/"
 ENV LD_LIBRARY_PATH "/opt/gcc-14/lib64:${LD_LIBRARY_PATH}"
 ENV PATH "/opt/gcc-14/bin:${PATH}"
 
-ADD https://packages.wazuh.com/utils/binutils/binutils-2.38-1.aarch64.rpm /tmp/binutils-2.38-1.aarch64.rpm
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/binutils-2.38-1.aarch64.rpm \
+    https://packages.wazuh.com/utils/binutils/binutils-2.38-1.aarch64.rpm
 RUN rpm -i /tmp/binutils-2.38-1.aarch64.rpm
 
 ENV PATH "/opt/binutils-2/bin:${PATH}"
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-aarch64.sh /tmp/cmake-3.30.4-linux-aarch64.sh
+RUN /usr/local/bin/retry.sh --attempts 5 --delay 5 --backoff 2 --max-delay 30 --timeout 360 -- \
+    curl -fsSL --connect-timeout 20 --max-time 300 -o /tmp/cmake-3.30.4-linux-aarch64.sh \
+    https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-aarch64.sh
 
 RUN mkdir -p /opt/cmake
 RUN sh /tmp/cmake-3.30.4-linux-aarch64.sh --prefix=/opt/cmake --skip-license


### PR DESCRIPTION
Add retries and timeouts to the 5.x manager package build path. Harden GHCR pulls/pushes, public downloads and S3 uploads. Reinforce manager builder Dockerfiles and package install helpers.

<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
This PR hardens the 5.x manager package build path against transient infrastructure and network failures. It adds retries, backoff, and step timeouts to the workflows and scripts involved in building manager packages and their builder images, so failures are more likely to reflect real packaging issues instead of environment instability.

## Main changes

- Limit the work to the manager package build flow in 5.x.
- Add a shared retry helper and use it for GHCR operations, GitHub release lookups, public package downloads, and S3 uploads.
- Add and tune step and job timeouts for long-running manager packaging tasks.
- Harden manager builder Dockerfiles with retries and timeouts for `apt`, `yum`, and remote downloads.
- Reinforce install helpers used by manager package smoke checks.


## Manual execution builder image
- https://github.com/wazuh/wazuh/actions/runs/23339247290/job/67888588386