### PR TITLE
Remove JSON↔YAML Conversion in CM CRUD Pipeline

### DIFF
--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -44,17 +44,6 @@ json::Json yamlToJson(std::string_view document)
     return json::Json {std::move(doc)};
 }
 
-std::string jsonToYaml(const json::Json& jsonDoc)
-{
-    rapidjson::Document doc;
-    doc.Parse(jsonDoc.str().c_str());
-
-    auto ymlNode = yml::Converter::jsonToYaml(doc);
-    YAML::Emitter ymlEmitter;
-    ymlEmitter << ymlNode;
-    return ymlEmitter.c_str();
-}
-
 cm::store::dataType::Policy policyFromDocument(std::string_view policyDocument)
 {
     return cm::store::dataType::Policy::fromJson(yamlToJson(policyDocument));
@@ -269,8 +258,8 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                             }
 
                             const std::string& name = integ.getName();
-                            const std::string yml = jsonToYaml(integ.toJson());
-                            ns->createResource(name, type, yml);
+                            const std::string jsonStr = integ.toJson().str();
+                            ns->createResource(name, type, jsonStr);
                             break;
                         }
 
@@ -279,8 +268,8 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                             auto kvdb = cm::store::dataType::KVDB::fromJson(item, /*requireUUID:*/ true);
 
                             const std::string& name = kvdb.getName();
-                            const std::string yml = jsonToYaml(kvdb.toJson());
-                            ns->createResource(name, type, yml);
+                            const std::string jsonStr = kvdb.toJson().str();
+                            ns->createResource(name, type, jsonStr);
                             break;
                         }
 
@@ -316,9 +305,9 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                                 validateAsset(nsReader, assetJson);
                             }
 
-                            const std::string yml = jsonToYaml(assetJson);
+                            const std::string jsonStr = assetJson.str();
                             const std::string nameStr = name.toStr();
-                            ns->createResource(nameStr, type, yml);
+                            ns->createResource(nameStr, type, jsonStr);
                             break;
                         }
 
@@ -506,21 +495,13 @@ CrudService::getResourceByUUID(const cm::store::NamespaceId& nsId, const std::st
             case cm::store::ResourceType::INTEGRATION:
             {
                 auto integ = nsView->getIntegrationByUUID(uuid);
-                if (asJson)
-                {
-                    return integ.toJson().str();
-                }
-                return jsonToYaml(integ.toJson());
+                return integ.toJson().str();
             }
 
             case cm::store::ResourceType::KVDB:
             {
                 auto kvdb = nsView->getKVDBByUUID(uuid);
-                if (asJson)
-                {
-                    return kvdb.toJson().str();
-                }
-                return jsonToYaml(kvdb.toJson());
+                return kvdb.toJson().str();
             }
 
             case cm::store::ResourceType::DECODER:
@@ -528,11 +509,7 @@ CrudService::getResourceByUUID(const cm::store::NamespaceId& nsId, const std::st
             case cm::store::ResourceType::FILTER:
             {
                 auto assetJson = nsView->getAssetByUUID(uuid);
-                if (asJson)
-                {
-                    return assetJson.str();
-                }
-                return jsonToYaml(assetJson);
+                return assetJson.str();
             }
 
             default: throw std::runtime_error("Unsupported resource type for getResourceByUUID");

--- a/src/engine/test/integration_tests/crud_cm/steps/crud_cm.py
+++ b/src/engine/test/integration_tests/crud_cm/steps/crud_cm.py
@@ -622,10 +622,29 @@ def step_impl(context, space):
     uuid = getattr(context, "resource_uuid", None)
     assert uuid is not None, "No resource UUID stored in context"
 
-    err, resp = request_resource_get(space, uuid, as_json=False)
+    err, resp = request_resource_get(space, uuid, as_json=True)
     assert err is None, f"{err}"
     assert resp.status == api_engine.OK, f"{resp}"
-    assert "test.updated: true" in resp.content, f"{resp.content}"
+
+    # Parse the JSON content to verify the field exists
+    import json
+    content = json.loads(resp.content)
+
+    # Check that normalize[0].map contains {"_test.updated": true}
+    assert "normalize" in content, f"Missing 'normalize' in response: {resp.content}"
+    assert len(content["normalize"]) > 0, f"Empty 'normalize' array: {resp.content}"
+    assert "map" in content["normalize"][0], f"Missing 'map' in normalize[0]: {resp.content}"
+
+    # Find the _test.updated field in the map array
+    map_items = content["normalize"][0]["map"]
+    found_updated = False
+    for item in map_items:
+        if "_test.updated" in item:
+            assert item["_test.updated"] is True, f"Expected _test.updated to be true, got {item['_test.updated']}"
+            found_updated = True
+            break
+
+    assert found_updated, f"Field '_test.updated' not found in map: {resp.content}"
 
 
 # ============================================================


### PR DESCRIPTION
## Description
This pull request aims to eliminate the JSON-to-YAML transformation performed in the CRUD API. The CMstore already attempts to read the content as JSON, and if it cannot, it treats it as YAML. Converting JSON to YAML results in data type loss, leading to validation errors.

Closes #35035


## Proposed Changes

- Delete transform yaml to json in API CRUD

### Results and Evidence

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer 
╰─# engine-test run test -s testing -dd

Enter any events [ENTER to send event, CTRL+C to finish]:

whats


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ _json: parse_json($event.original) -> Parser parser failed at: whats
[🔴] decoder/suricata/0 -> failed
  ↳ [check: ((exists($_json.timestamp) AND exists($_json.event_type) AND exists($_json.flow_id)) OR (exists($_json.timestamp) AND exists($_json.event_type) AND $_json.event_type == "stats"))] -> Failure
[🟢] filter/UnclassifiedEvents -> success
  ↳ dropUnclassifiedEvent() -> Event is unclassified but policy index_unclassified_events=true, allowing event
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (index_discarded_events=true)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Skipped: Cleanup disabled by policy
[🟢] enrichment/Geo -> success
  ↳ Geo()|AS() -> Failure: IP not found at field 'client.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'destination.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'host.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'observer.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'server.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'source.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'wazuh.agent.host.ip'
[🟢] enrichment/Ioc/connection -> success
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.ip, client.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.nat.ip, client.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.ip, destination.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.nat.ip, destination.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.ip, server.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.nat.ip, server.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.ip, source.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.nat.ip, source.nat.port'
[🟢] filter/postfilter/0 -> success
  ↳ [check: array_contains($wazuh.integration.decoders, 'decoder/integrations/0')] -> Success
[🟢] output/indexer/0 -> success
  ↳ [check: $wazuh.integration.category != "cloud-services" OR (NOT starts_with($wazuh.integration.name, "aws") AND NOT starts_with($wazuh.integration.name, "azure") AND NOT starts_with($wazuh.integration.name, "gcp"))] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-${wazuh.integration.category}) -> Success

output:
  '@timestamp': '2026-03-18T17:38:42Z'
  event:
    original: whats
  wazuh:
    integration:
      category: unclassified
      decoders:
      - decoder/core-wazuh-message/0
      - decoder/integrations/0
      name: integration/wazuh-core/0
    protocol:
      location: location
      queue: 49
    space:
      name: test
```
<img width="1828" height="954" alt="Screenshot from 2026-03-18 14-39-20" src="https://github.com/user-attachments/assets/b2b6b22e-6a2b-4a14-9eba-2593e7d5b832" />


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
