### PR TITLE
Coding style clang format

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -159,6 +159,9 @@ public:
         const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
             logFunction = {});
 
+    /**
+     * @brief Class destructor.
+     */
     ~IndexerConnector();
 
     /**

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -212,6 +212,9 @@ class Monitoring final
     }
 
 public:
+    /**
+     * @brief Class destructor.
+     */
     ~Monitoring()
     {
         m_stop = true;

--- a/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
@@ -57,6 +57,9 @@ public:
     {
     }
 
+    /**
+     * @brief Class destructor.
+     */
     ~FakeIndexer()
     {
         m_server.stop();

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -66,6 +66,9 @@ public:
         }
     }
 
+    /**
+     * @brief Class destructor.
+     */
     ~FakeOpenSearchServer()
     {
         m_server.stop();

--- a/src/shared_modules/indexer_connector/testtool/cmdArgParser.hpp
+++ b/src/shared_modules/indexer_connector/testtool/cmdArgParser.hpp
@@ -163,8 +163,8 @@ public:
                   << "\t-w WAIT_TIME\tSpecifies the wait time before close.\n"
                   << "\t-u UPDATE_MAPPINGS_FILE\tSpecifies the update mappings file.\n"
                   << "\t-l LOG_FILE\tSpecifies the log file path.\n"
-                  << "\nExample:"
-                  << "\n\t./indexer_connector_testtool -c config.json -t template.json\n"
+                  << "\nExample:\n"
+                  << "\t./indexer_connector_testtool -c config.json -t template.json\n"
                   << "\n\t./indexer_connector_testtool -c config.json -t template.json -s 000 -L 30\n"
                   << "\n\t./indexer_connector_testtool -c config.json -t template.json -s 000 -L 3 -D 120\n\n";
     }

--- a/src/shared_modules/router/testtool/cmdArgsParser.hpp
+++ b/src/shared_modules/router/testtool/cmdArgsParser.hpp
@@ -85,7 +85,7 @@ public:
                   << "\t-s SUBSCRIBER_ID\tSpecifies the subscriber id to use.\n"
                   << "\t-f FBS_PATH\t\tSpecifies the path to the fbs to read flatbuffer messages.\n"
                   << "\nExample:\n"
-                  << "\n\t./router_testtool -m broker\n"
+                  << "\t./router_testtool -m broker\n"
                   << "\n\t./router_testtool -m publisher -t TOPIC\n"
                   << "\n\t./router_testtool -m subscriber -t TOPIC -s SUBSCRIBER_ID\n"
                   << "\n\t./router_testtool -m subscriber -t TOPIC -s SUBSCRIBER_ID -f path/to/file.fbs\n"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
Fast fix for clang format


```
src/shared_modules/indexer_connector/testtool/cmdArgParser.hpp:166:34: warning: code should be clang-formatted [-Wclang-format-violations]
                  << "\nExample:"
                                 ^
```

```
<~FakeIndexer>:1: warning: parameters of member FakeIndexer::~FakeIndexer are not documented
<~FakeOpenSearchServer>:1: warning: parameters of member FakeOpenSearchServer::~FakeOpenSearchServer are not documented
<~IndexerConnector>:1: warning: parameters of member IndexerConnector::~IndexerConnector are not documented
<~Monitoring>:1: warning: parameters of member Monitoring::~Monitoring are not documented
```
