### PR TITLE
Fix empty-message failure in Windows enrollment integration test

### DIFF
--- a/tests/integration/test_enrollment/conftest.py
+++ b/tests/integration/test_enrollment/conftest.py
@@ -80,7 +80,6 @@ def configure_socket_listener(request, test_metadata):
 
     yield
 
-    control_service('stop', daemon=AGENT_DAEMON)
     socket_listener.shutdown()
 
 

--- a/tests/integration/test_enrollment/test_agent/test_agent_auth_enrollment.py
+++ b/tests/integration/test_enrollment/test_agent/test_agent_auth_enrollment.py
@@ -85,7 +85,7 @@ def launch_agent_with_retry(configuration, retries=5, delay=1):
 # Test function.
 @pytest.mark.parametrize('test_configuration, test_metadata',  zip(test_configuration, test_metadata), ids=cases_ids)
 def test_agent_auth_enrollment(test_configuration, test_metadata, set_wazuh_configuration, daemons_handler_module,
-                               set_keys, set_password, configure_socket_listener):
+                               shutdown_agentd, set_keys, set_password, configure_socket_listener):
     """
     description:
         "Check that different configuration generates the adequate enrollment message or the corresponding


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
This PR fixes a race condition in the teardown phase of the configure_socket_listener fixture, where the simulator socket was being closed while the agent could still hold an  active connection, causing empty messages to be received.

https://github.com/wazuh/wazuh/issues/35034
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<img width="1353" height="271" alt="Image" src="https://github.com/user-attachments/assets/a81b345e-81bd-48cc-b34d-3cd108edf80e" />


<img width="766" height="791" alt="Image" src="https://github.com/user-attachments/assets/ea358fa0-0d16-494c-8ab6-9c736bf74ac0" />

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
N-A
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes
N-A
<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced
N-A
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
