### PR TITLE
Improve buffer handling in regex match processing

### DIFF
--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -8,9 +8,7 @@
 #include "config.h"
 #include <regex.h>
 
-#define MAX_MATCHES 10
 #define MAX_STRING 1024
-#define MAX_STRING_LESS 30
 
 static const char *pattern = "^[A-Z][a-z][a-z] [ 0123][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] ([^ ]+)";
 static regex_t * regexCompiled; // Shared regex between write thread, AR thread and logtest thread

--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -614,6 +614,12 @@ int match_regex(regex_t* r, const char* to_match, char* results[MAX_MATCHES])
     int totalResults = 0;
     while(1) {
         int i = 0;
+
+        if (totalResults >= MAX_MATCHES) {
+            mdebug1("Reached maximum number of regex matches (%d), stopping.", MAX_MATCHES);
+            return totalResults;
+        }
+
         int nomatch = regexec(r, p, n_matches, m, 0);
         if(nomatch) {
             // printf ("No more matches.\n");
@@ -622,14 +628,29 @@ int match_regex(regex_t* r, const char* to_match, char* results[MAX_MATCHES])
         for(i = 0; i < n_matches; i++) {
             int start;
             int finish;
+            int match_len;
+
             if(m[i].rm_so == -1) {
                 break;
             }
             start = m[i].rm_so + (p - to_match);
             finish = m[i].rm_eo + (p - to_match);
             if(i > 0) {
-                sprintf(results[totalResults], "%.*s", (finish - start), to_match + start);
+                match_len = finish - start;
+                if (match_len >= MAX_STRING_LESS) {
+                    mdebug1("Match length (%d) exceeds buffer size, truncating to %d.",
+                           match_len, MAX_STRING_LESS - 1);
+                    match_len = MAX_STRING_LESS - 1;
+                }
+
+                snprintf(results[totalResults], MAX_STRING_LESS, "%.*s", match_len, to_match + start);
+                results[totalResults][MAX_STRING_LESS - 1] = '\0';
                 totalResults = totalResults + 1;
+
+                if (totalResults >= MAX_MATCHES) {
+                    mdebug1("Maximum results reached (%d), stopping.", MAX_MATCHES);
+                    return totalResults;
+                }
             }
         }
         p += m[0].rm_eo;

--- a/src/analysisd/format/json_extended.h
+++ b/src/analysisd/format/json_extended.h
@@ -11,6 +11,7 @@
 #include <regex.h>
 
 #define MAX_MATCHES 10
+#define MAX_STRING_LESS 30
 
 // Main function, call the others parsers.
 void W_ParseJSON(cJSON *root, const Eventinfo *lf);

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -185,6 +185,9 @@ list(APPEND analysisd_flags "-Wl,--wrap,asys_create_state_json -Wl,--wrap,OS_Bin
 LIST(APPEND analysisd_names "test_limits")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_minfo -Wl,--wrap,_mwarn")
 
+list(APPEND analysisd_names "test_json_extended")
+list(APPEND analysisd_flags "${DEBUG_OP_WRAPPERS}")
+
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/analysisd/test_json_extended.c
+++ b/src/unit_tests/analysisd/test_json_extended.c
@@ -1,0 +1,384 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../analysisd/format/json_extended.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+/* Setup/Teardown */
+
+static int setup_group(void **state) {
+    (void) state;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    (void) state;
+    return 0;
+}
+
+/* Helper function to allocate result buffers */
+static void allocate_results(char* results[MAX_MATCHES]) {
+    for (int i = 0; i < MAX_MATCHES; i++) {
+        results[i] = calloc(MAX_STRING_LESS, sizeof(char));
+        assert_non_null(results[i]);
+    }
+}
+
+/* Helper function to free result buffers */
+static void free_results(char* results[MAX_MATCHES]) {
+    for (int i = 0; i < MAX_MATCHES; i++) {
+        free(results[i]);
+    }
+}
+
+/* Tests for match_regex - Buffer Overflow Fix Validation */
+
+/**
+ * Test 1: Normal case - match within buffer limits
+ */
+void test_match_regex_normal_short_match(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    const char* input = "Test {CIS: 1.2.3} end";
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 1);
+    assert_string_equal(results[0], "CIS: 1.2.3");
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 2: Boundary case - match exactly at 29 bytes (safe)
+ */
+void test_match_regex_boundary_29_bytes(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    // Create a 29-byte match (MAX_STRING_LESS - 1)
+    const char* input = "Test {KEY: 123456789012345678901234} end";  // "KEY: 123456789012345678901234" = 29 bytes
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 1);
+    assert_int_equal(strlen(results[0]), 29);
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 3: SECURITY TEST - Oversized match gets truncated (buffer overflow prevention)
+ * This test validates the fix for the heap buffer overflow vulnerability
+ */
+void test_match_regex_oversized_match_truncated(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    // Create a match > MAX_STRING_LESS bytes (would overflow without fix)
+    char input[500];
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    // Create an 82-byte match (40 'A's + ": " + 40 'a's = 82 bytes) to test truncation
+    snprintf(input, sizeof(input),
+             "Test {AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: "
+             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} end");
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    // Expect debug message about truncation
+    expect_string(__wrap__mdebug1, formatted_msg, "Match length (82) exceeds buffer size, truncating to 29.");
+
+    count = match_regex(r, input, results);
+
+    // Should still return a result, but truncated
+    assert_int_equal(count, 1);
+    // Result must not overflow buffer (max 29 bytes + null terminator)
+    assert_int_equal(strlen(results[0]), 29);
+    // Buffer must be null-terminated
+    assert_int_equal(results[0][29], '\0');
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 4: SECURITY TEST - Maximum payload (402 bytes like PoC)
+ */
+void test_match_regex_exploit_payload_402_bytes(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    char input[500];
+    char key[210];
+    char value[210];
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    // Replicate exact PoC payload: 200-byte key + 200-byte value
+    memset(key, 'A', 200);
+    key[200] = '\0';
+    memset(value, 'a', 200);
+    value[200] = '\0';
+
+    snprintf(input, sizeof(input), "System Audit: {%s: %s}.", key, value);
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Match length (402) exceeds buffer size, truncating to 29.");
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 1);
+    // Must be truncated to 29 bytes
+    assert_int_equal(strlen(results[0]), 29);
+    // First 29 bytes should be 'A's (the key)
+    for (int i = 0; i < 29; i++) {
+        assert_int_equal(results[0][i], 'A');
+    }
+    assert_int_equal(results[0][29], '\0');
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 5: Multiple matches within limits
+ */
+void test_match_regex_multiple_matches(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    const char* input = "Test {CIS: 1.2.3} and {PCI: 2.4} and {GDPR: IV}";
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 3);
+    assert_string_equal(results[0], "CIS: 1.2.3");
+    assert_string_equal(results[1], "PCI: 2.4");
+    assert_string_equal(results[2], "GDPR: IV");
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 6: SECURITY TEST - Max matches boundary (MAX_MATCHES = 10)
+ */
+void test_match_regex_max_matches_limit(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    // Create input with 15 matches (more than MAX_MATCHES)
+    const char* input = "{A: 1} {B: 2} {C: 3} {D: 4} {E: 5} "
+                        "{F: 6} {G: 7} {H: 8} {I: 9} {J: 10} "
+                        "{K: 11} {L: 12} {M: 13} {N: 14} {O: 15}";
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Maximum results reached (10), stopping.");
+
+    count = match_regex(r, input, results);
+
+    // Should stop at MAX_MATCHES
+    assert_int_equal(count, MAX_MATCHES);
+    assert_string_equal(results[0], "A: 1");
+    assert_string_equal(results[9], "J: 10");
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 7: No matches found
+ */
+void test_match_regex_no_matches(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    const char* input = "No compliance tags here";
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 0);
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 8: SECURITY TEST - Null termination is guaranteed
+ */
+void test_match_regex_null_termination(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    char input[200];
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    // Create a match that will be truncated
+    memset(input, 0, sizeof(input));
+    snprintf(input, sizeof(input), "{KEY: %s}", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+    allocate_results(results);
+    // Fill buffer with non-zero to test null termination
+    memset(results[0], 'X', MAX_STRING_LESS);
+
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Match length (47) exceeds buffer size, truncating to 29.");
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 1);
+    // Defensive null termination must be present at position 29
+    assert_int_equal(results[0][29], '\0');
+    // String length must be valid (not reading past buffer)
+    assert_true(strlen(results[0]) <= 29);
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 9: Mixed normal and oversized matches
+ */
+void test_match_regex_mixed_sizes(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    const char* input = "{SHORT: 1} {VERYLONGKEYYYYYYYYYYYYYYYYYYYYYYYYYY: "
+                        "VERYLONGVALUEEEEEEEEEEEEEEEEEEEEE} {NORMAL: ok}";
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Match length (71) exceeds buffer size, truncating to 29.");
+
+    count = match_regex(r, input, results);
+
+    assert_int_equal(count, 3);
+    assert_string_equal(results[0], "SHORT: 1");
+    assert_int_equal(strlen(results[1]), 29);  // Truncated
+    assert_string_equal(results[2], "NORMAL: ok");
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/**
+ * Test 10: Empty match
+ */
+void test_match_regex_empty_match(void **state) {
+    (void) state;
+
+    const char* pattern = "\\{([A-Za-z0-9_]*: [A-Za-z0-9_., ]*)\\}";
+    const char* input = "Test {} end";
+    char* results[MAX_MATCHES];
+    regex_t* r;
+    int count;
+
+    allocate_results(results);
+    r = compile_regex(pattern);
+    assert_non_null(r);
+
+    count = match_regex(r, input, results);
+
+    // Empty braces won't match the pattern (requires key: value)
+    assert_int_equal(count, 0);
+
+    free_results(results);
+    regfree(r);
+    free(r);
+}
+
+/* Main test suite */
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_match_regex_normal_short_match),
+        cmocka_unit_test(test_match_regex_boundary_29_bytes),
+        cmocka_unit_test(test_match_regex_oversized_match_truncated),
+        cmocka_unit_test(test_match_regex_exploit_payload_402_bytes),
+        cmocka_unit_test(test_match_regex_multiple_matches),
+        cmocka_unit_test(test_match_regex_max_matches_limit),
+        cmocka_unit_test(test_match_regex_no_matches),
+        cmocka_unit_test(test_match_regex_null_termination),
+        cmocka_unit_test(test_match_regex_mixed_sizes),
+        cmocka_unit_test(test_match_regex_empty_match),
+    };
+
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+}


### PR DESCRIPTION
## Description

This PR enhances the robustness of string handling in the `match_regex()` function used for parsing compliance tags in rootcheck events. The changes add proper bounds checking and safe string operations to ensure reliable processing of variable-length input strings.

## Proposed Changes

### Code Changes

**File: `src/analysisd/format/json_extended.c`**

1. **Array bounds validation**: Added check before processing matches to prevent exceeding the `MAX_MATCHES` limit (10 results)
2. **Length validation**: Introduced match length validation before buffer write operations
3. **Safe string copy**: Replaced `sprintf()` with `snprintf()` for bounded writes
4. **Defensive null termination**: Added explicit null termination to ensure valid strings
5. **Post-increment validation**: Added additional bounds check after incrementing counter for defense in depth

### Results and Evidence

#### Before changes
- Function used unbounded `sprintf()` which could write beyond allocated buffer size
- No validation of match length before write operations
- No explicit handling of oversized compliance tags

#### After changes
- All string writes are bounded by buffer size (30 bytes)
- Oversized matches are safely truncated with logging
- Explicit null termination guarantees valid strings
- Array bounds are validated before access

#### Logs

Example log output when processing oversized tags:**
```
2026/03/24 17:18:09 wazuh-analysisd[8379] json_extended.c:641 at match_regex(): DEBUG: Match length (102) exceeds buffer size, truncating to 29.
```

### Artifacts Affected

- **wazuh-analysisd**: Core analysis daemon binary

### Configuration Changes

No configuration changes required. The improvements are transparent to existing deployments.

### Documentation Updates

No user-facing documentation updates required.

### Tests Introduced

**New test file:** `src/unit_tests/analysisd/test_json_extended.c`

Comprehensive test suite with 10 unit tests covering:

1. **Functional tests:**
   - Normal matches (< 30 bytes)
   - Boundary case (29 bytes)
   - Multiple matches in single input
   - No matches scenario
   - Empty patterns
2. **Robustness tests:**
   - Oversized match truncation (82 bytes → 29 bytes)
   - Maximum payload handling (402 bytes → 29 bytes)
   - Null termination validation
   - Mixed size matches
   - Array bounds limit (10 matches max)

#### Test Results

```
[==========] tests: Running 10 test(s).
[ RUN      ] test_match_regex_normal_short_match
[       OK ] test_match_regex_normal_short_match
[ RUN      ] test_match_regex_boundary_29_bytes
[       OK ] test_match_regex_boundary_29_bytes
[ RUN      ] test_match_regex_oversized_match_truncated
[       OK ] test_match_regex_oversized_match_truncated
[ RUN      ] test_match_regex_exploit_payload_402_bytes
[       OK ] test_match_regex_exploit_payload_402_bytes
[ RUN      ] test_match_regex_multiple_matches
[       OK ] test_match_regex_multiple_matches
[ RUN      ] test_match_regex_max_matches_limit
[       OK ] test_match_regex_max_matches_limit
[ RUN      ] test_match_regex_no_matches
[       OK ] test_match_regex_no_matches
[ RUN      ] test_match_regex_null_termination
[       OK ] test_match_regex_null_termination
[ RUN      ] test_match_regex_mixed_sizes
[       OK ] test_match_regex_mixed_sizes
[ RUN      ] test_match_regex_empty_match
[       OK ] test_match_regex_empty_match
[==========] tests: 10 test(s) run.
[  PASSED  ] 10 test(s).
```

#### Manual testing

- Verified normal Rootcheck events parse correctly
- Confirmed oversized compliance tags are truncated gracefully
- Validated debug logging appears for truncation events

## Credit

Thanks to @H0j3n for reporting this bug.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A - no changes)
- [x] Developer documentation reflects the changes (N/A - internal function)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
