### PR TITLE
Fix #35068: use runtime max_upload_size in expect middleware

### DIFF
--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -27,7 +27,6 @@ from api import configuration
 from api.alogging import custom_logging
 from api.authentication import generate_keypair, JWT_ALGORITHM
 from api.api_exception import BlockedIPException, MaxRequestsException, ExpectFailedException
-from api.configuration import default_api_configuration
 
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
@@ -298,7 +297,7 @@ class CheckExpectHeaderMiddleware(BaseHTTPMiddleware):
             
             if 'Content-Length' in request.headers:
                 content_length = int(request.headers["Content-Length"])
-                max_upload_size = default_api_configuration["max_upload_size"]
+                max_upload_size = configuration.api_conf["max_upload_size"]
                 if content_length > max_upload_size:
                     raise ExpectFailedException(status=417, title="Expectation failed",
                                                 detail=f"Maximum content size limit ({max_upload_size}) exceeded "

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -390,4 +390,23 @@ async def test_check_expect_header_middleware(expect_value):
         returned_response = await middleware.dispatch(mock_request, call_next_mock)
         call_next_mock.assert_called_once_with(mock_request)
         assert returned_response == response
-        
+
+@pytest.mark.asyncio
+async def test_check_expect_header_middleware_uses_runtime_max_upload_size():
+    """Check Expect header uses current api configuration upload size limit."""
+    middleware = CheckExpectHeaderMiddleware(AsyncApp(__name__))
+
+    mock_request = MagicMock(headers={
+        'Expect': '100-continue',
+        'Content-Length': '10'
+    })
+
+    call_next_mock = AsyncMock(return_value=Response("Success"))
+
+    with patch('api.middlewares.configuration.api_conf', new={'max_upload_size': 5}):
+        with pytest.raises(ExpectFailedException) as exc_info:
+            await middleware.dispatch(mock_request, call_next_mock)
+
+    call_next_mock.assert_not_called()
+    assert exc_info.value.status == 417
+    assert "Maximum content size limit (5) exceeded" in exc_info.value.detail


### PR DESCRIPTION
## Description

Closes #35068.

`CheckExpectHeaderMiddleware` was validating `Content-Length` against
`default_api_configuration["max_upload_size"]` instead of the effective
runtime value from `configuration.api_conf`.

This caused inconsistent behavior in the `Expect: 100-continue` flow:
requests could be incorrectly accepted when the configured upload limit
was lower than the default value, or incorrectly rejected when the
configured limit was higher.

This pull request updates the middleware to always use the active
runtime upload size limit so the validation matches the effective API
configuration.

## Proposed Changes

- Replaced the use of `default_api_configuration["max_upload_size"]`
  with `configuration.api_conf["max_upload_size"]` in
  `CheckExpectHeaderMiddleware`
- Removed the now unnecessary import of `default_api_configuration`
- Added a unit test to verify that the middleware uses the runtime
  `max_upload_size` value during `Expect: 100-continue` validation
- Verified that the middleware now returns HTTP 417 using the configured
  runtime limit when the request exceeds it

### Results and Evidence

Before this change, the middleware checked upload size against the
default limit instead of the effective runtime configuration, which
could lead to incorrect request handling in the `Expect: 100-continue`
flow. After this change, the middleware consistently enforces the value
from `configuration.api_conf["max_upload_size"]`. The new unit test
covers this scenario by patching the runtime configuration to a smaller
limit and confirming that the request is rejected with status `417` and
the expected error detail. :contentReference[oaicite:2]{index=2}

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [x] Run API Integration Tests

Evidence:
- Unit test added for the runtime `max_upload_size` scenario
- Existing middleware tests remain consistent
- API/framework-related validation was updated and verified in the
  affected test suite :contentReference[oaicite:3]{index=3}

### Artifacts Affected

- API middleware for request validation:
  - `api/api/middlewares.py`
- API middleware unit tests:
  - `api/api/test/test_middlewares.py` :contentReference[oaicite:4]{index=4}

### Configuration Changes

N/A.

This pull request does not introduce new configuration parameters or
change default values. It only makes the middleware respect the already
active runtime value of `max_upload_size`. :contentReference[oaicite:5]{index=5}

### Tests Introduced

- Added a unit test for `CheckExpectHeaderMiddleware` to ensure that the
  `Expect: 100-continue` validation uses
  `configuration.api_conf["max_upload_size"]` instead of the default
  configuration value
- The test patches the runtime configuration, sends a request with
  `Content-Length` above the configured limit, and verifies that an
  `ExpectFailedException` with status `417` is raised :contentReference[oaicite:6]{index=6}

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR description includes the bug number, cause, and fix