### PR TITLE
Use daily marker for GuardDuty log collector

### DIFF
--- a/wodles/aws/buckets_s3/guardduty.py
+++ b/wodles/aws/buckets_s3/guardduty.py
@@ -74,7 +74,7 @@ class AWSGuardDutyBucket(AWSCustomBucket):
 
         if self.type == "GuardDutyNative" and not iterating and 'StartAfter' in filter_args:
             start_after = filter_args['StartAfter']
-            match = re.match(r'(.*?/\d{4}/\d{2}/\d{2}/)', start_after)
+            match = re.match(r'(.*?/GuardDuty/[^/]+/\d{4}/\d{2}/\d{2}/)', start_after)
             if match:
                 filter_args['StartAfter'] = match.group(1)
                 aws_tools.debug(f"+++ GuardDuty: Rewound marker to day folder: {filter_args['StartAfter']}", 2)

--- a/wodles/aws/tests/test_guardduty.py
+++ b/wodles/aws/tests/test_guardduty.py
@@ -284,6 +284,9 @@ def test_aws_guardduty_bucket_already_processed(mock_custom_bucket, mock_type, m
     ("GuardDutyNative",
      "AWSLogs/123456789123/GuardDuty/us-east-1/",
      "AWSLogs/123456789123/GuardDuty/us-east-1/"),
+    ("GuardDutyNative",
+     "backfill/2026/03/20/AWSLogs/123456789123/GuardDuty/us-east-1/2026/03/25/9f7b0b8c-xxxx.jsonl.gz",
+     "backfill/2026/03/20/AWSLogs/123456789123/GuardDuty/us-east-1/2026/03/25/"),
 ])
 @patch('aws_bucket.AWSCustomBucket.build_s3_filter_args')
 @patch('guardduty.AWSGuardDutyBucket.check_guardduty_type')


### PR DESCRIPTION
## Description

Closes #34615

The AWS S3 wodle uses the last processed file's S3 key as a marker (`StartAfter` parameter) to resume log collection. Since S3 lists objects in lexicographic order, this works for services with timestamp-based filenames (CloudTrail, VPC Flow Logs). However, GuardDuty Native exports use random UUID filenames that have no relationship to creation time. New findings with UUIDs that sort before the stored marker are silently skipped, causing permanent data loss.

This PR fixes the issue by rewinding the `StartAfter` marker to the day folder level (`YYYY/MM/DD/`) for GuardDuty Native buckets, so all files in the current day are listed on every run. The existing `already_processed()` database check prevents duplicate ingestion.

## Proposed Changes

- Override `build_s3_filter_args` in `AWSGuardDutyBucket` to truncate the marker from the full file path to the day folder prefix for GuardDuty Native buckets.

### Results and Evidence

<details>
<summary>Before fix 🟡</summary>

**Setup**:  Wazuh manager connected to a real GuardDuty S3 bucket. First batch of sample findings generated and processed to set the marker. Second batch generated, new files have UUIDs sorting before the marker.

S3 bucket contents (4 files, 2 new ones sorting before the marker):

```console
$ aws s3 ls "s3://<BUCKET>/AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/"
2026-03-24 17:10:03       1823 7f4216a6-df79-4447-ad14-439974940a63.jsonl.gz   ← NEW (sorts before marker)
2026-03-24 17:10:02       1306 9bbedeab-4bd4-45d8-aa4f-bc11710526ad.jsonl.gz   ← NEW (sorts before marker)
2026-03-24 17:05:02       1565 ab63ebab-5004-409d-ba3f-15264e8cb304.jsonl.gz   ← processed (batch 1)
2026-03-24 17:05:02       1425 b1811273-0a1c-4f85-b46e-70d82f768845.jsonl.gz   ← processed (batch 1, MARKER)
```

Wodle run (unpatched, from inside the Wazuh manager container):

```console
bash-5.2# /var/ossec/wodles/aws/aws-s3 \
    --bucket <BUCKET> \
    --type guardduty \
    --aws_profile <PROFILE> \
    --regions us-east-1 \
    --debug 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Region 'us-east-1' added to the configuration
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'profile <PROFILE>' configuration
DEBUG: +++ Working on <ACCOUNT_ID> - us-east-1
DEBUG: +++ Marker: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/b1811273-0a1c-4f85-b46e-70d82f768845.jsonl.gz
DEBUG: +++ No logs to process in bucket: <ACCOUNT_ID>/us-east-1
DEBUG: +++ DB Maintenance
```

DB shows only 2 of 4 files processed:

```console
bash-5.2# sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db \
    "SELECT count(*) FROM guardduty WHERE log_key LIKE '%/2026/03/24/%';"
2
```

**Result**: 2 findings silently dropped (50%). S3 has 4 files, DB has 2.

</details>

<details>
<summary>After fix 🟢</summary>

Same wodle command after applying the patched `guardduty.py`:

```console
bash-5.2# /var/ossec/wodles/aws/aws-s3 \
    --bucket <BUCKET> \
    --type guardduty \
    --aws_profile <PROFILE> \
    --regions us-east-1 \
    --debug 2
DEBUG: +++ Debug mode on - Level: 2
DEBUG: +++ Region 'us-east-1' added to the configuration
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'profile <PROFILE>' configuration
DEBUG: +++ Working on <ACCOUNT_ID> - us-east-1
DEBUG: +++ Marker: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/b1811273-0a1c-4f85-b46e-70d82f768845.jsonl.gz
DEBUG: +++ GuardDuty: Rewound marker to day folder: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/
DEBUG: ++ Found new log: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/7f4216a6-df79-4447-ad14-439974940a63.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/9bbedeab-4bd4-45d8-aa4f-bc11710526ad.jsonl.gz
DEBUG: ++ Skipping previously processed file: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/ab63ebab-5004-409d-ba3f-15264e8cb304.jsonl.gz
DEBUG: ++ Skipping previously processed file: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/24/b1811273-0a1c-4f85-b46e-70d82f768845.jsonl.gz
DEBUG: +++ DB Maintenance
```

DB now matches S3:

```console
bash-5.2# sqlite3 /var/ossec/wodles/aws/s3_cloudtrail.db \
    "SELECT count(*) FROM guardduty WHERE log_key LIKE '%/2026/03/24/%';"
4
```

**Result**: All 4 findings processed, 0 duplicates, 0 findings lost.

</details>

<details>
<summary>After regex update (review feedback) 🟢</summary>

The original regex `r'(.*?/\d{4}/\d{2}/\d{2}/)'` was too generic and a custom S3 prefix containing a date-like segment (e.g., `backfill/2026/03/20/`) would cause the rewind to stop at the prefix date instead of the GuardDuty date. The regex was anchored to the GuardDuty native layout:

```python
# Before
re.match(r'(.*?/\d{4}/\d{2}/\d{2}/)', start_after)

# After
re.match(r'(.*?/GuardDuty/[^/]+/\d{4}/\d{2}/\d{2}/)', start_after)
```

**New test case** covering a prefix with a date-like segment:

| Input | Expected match |
|-------|---------------|
| `backfill/2026/03/20/AWSLogs/123456789012/GuardDuty/us-east-1/2026/03/25/uuid.jsonl.gz` | `backfill/2026/03/20/AWSLogs/123456789012/GuardDuty/us-east-1/2026/03/25/` |

Wodle run after anchored regex update with new findings generated and processed correctly on 2026-03-26:

```console
DEBUG: +++ Working on <ACCOUNT_ID> - us-east-1
DEBUG: +++ Marker: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/abe48b95-9db7-4beb-be68-508a3d5ec82b.jsonl.gz
DEBUG: +++ GuardDuty: Rewound marker to day folder: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/
DEBUG: ++ Found new log: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/089e354e-1493-4ea9-a8d7-17684dd35e28.jsonl.gz
DEBUG: ++ Skipping previously processed file: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/4ea19012-7f02-483e-8c10-51f9a479b817.jsonl.gz
DEBUG: ++ Found new log: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/63ee9367-7730-47cf-a68c-6b757e4c39f5.jsonl.gz
DEBUG: ++ Skipping previously processed file: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/66114e75-eee2-43cc-9e9c-19ea1f07b105.jsonl.gz
DEBUG: ++ Skipping previously processed file: AWSLogs/<ACCOUNT_ID>/GuardDuty/us-east-1/2026/03/26/abe48b95-9db7-4beb-be68-508a3d5ec82b.jsonl.gz
DEBUG: +++ DB Maintenance
```
</details>



<details>
<summary>Unit tests 🟢</summary>

```
test_guardduty.py::test_aws_guardduty_bucket_build_s3_filter_args[GuardDutyNative-...9f7b0b8c...] PASSED
test_guardduty.py::test_aws_guardduty_bucket_build_s3_filter_args[GuardDutyNative-prefix/...1a2b3c4d...] PASSED
test_guardduty.py::test_aws_guardduty_bucket_build_s3_filter_args[GuardDutyKinesis-...] PASSED
test_guardduty.py::test_aws_guardduty_bucket_build_s3_filter_args[GuardDutyNative-no-date-pattern] PASSED
test_guardduty.py::test_aws_guardduty_bucket_build_s3_filter_args_no_rewind_when_iterating PASSED
test_guardduty.py::test_aws_guardduty_bucket_build_s3_filter_args_no_start_after PASSED
```

</details>

### Artifacts Affected

- `wodles/aws/buckets_s3/guardduty.py` (GuardDuty S3 bucket handler)

### Configuration Changes

- None

### Documentation Updates

- None

### Tests Introduced

- `test_aws_guardduty_bucket_build_s3_filter_args`: 4 parametrized cases validating marker rewind for GuardDuty Native (with and without prefix), no rewind for Kinesis, and fallback when no date pattern is present.
- `test_aws_guardduty_bucket_build_s3_filter_args_no_rewind_when_iterating`: validates that marker rewind does not interfere with S3 pagination.
- `test_aws_guardduty_bucket_build_s3_filter_args_no_start_after`: validates graceful handling when `StartAfter` is absent from filter args.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
