### PR TITLE
Copy MQ_Functions by value to prevent dangling pointer crash

### DIFF
--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -42,7 +42,8 @@ static query_module_callback_t g_query_module_callback = nullptr;
 
 // Global sync protocol parameters
 static const char* g_module_name = nullptr;
-static const MQ_Functions* g_mq_functions = nullptr;
+static MQ_Functions g_mq_functions = {nullptr, nullptr};
+static bool g_mq_functions_set = false;
 
 // Global cluster name storage (set from handshake, used by agent_info_impl)
 static char g_cluster_name[256] = {0};
@@ -230,7 +231,7 @@ void agent_info_start(const struct wm_agent_info_t* agent_info_config)
                                                  agent_info_config->sync.sync_max_eps);
 
             // Initialize sync protocol immediately after creating instance
-            if (g_module_name && g_mq_functions)
+            if (g_module_name && g_mq_functions_set)
             {
                 if (g_log_callback)
                 {
@@ -238,7 +239,7 @@ void agent_info_start(const struct wm_agent_info_t* agent_info_config)
                 }
 
                 g_agent_info_impl->initSyncProtocol(
-                    std::string(g_module_name), *g_mq_functions);
+                    std::string(g_module_name), g_mq_functions);
             }
             else
             {
@@ -305,7 +306,12 @@ void agent_info_stop()
 void agent_info_init_sync_protocol(const char* module_name, const MQ_Functions* mq_funcs)
 {
     g_module_name = module_name;
-    g_mq_functions = mq_funcs;
+
+    if (mq_funcs)
+    {
+        g_mq_functions = *mq_funcs;
+        g_mq_functions_set = true;
+    }
 }
 
 bool agent_info_parse_response(const uint8_t* data, size_t data_len)

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -25,7 +25,7 @@ static yaml_to_cjson_func g_yaml_to_cjson_func = NULL;
 
 static const char* g_module_name = NULL;
 static const char* g_sync_db_path = NULL;
-static const MQ_Functions* g_mq_functions = NULL;
+static MQ_Functions g_mq_functions = {NULL, NULL};
 static unsigned int g_sync_end_delay = 1;
 static unsigned int g_sync_timeout = 30;
 static unsigned int g_sync_retries = 3;
@@ -63,7 +63,12 @@ void sca_set_sync_parameters(const char* module_name, const char* sync_db_path, 
 {
     g_module_name = module_name;
     g_sync_db_path = sync_db_path;
-    g_mq_functions = mq_funcs;
+
+    if (mq_funcs)
+    {
+        g_mq_functions = *mq_funcs;
+    }
+
     g_sync_end_delay = sync_end_delay;
     g_sync_timeout = timeout;
     g_sync_retries = retries;
@@ -240,7 +245,7 @@ void SCA::init()
         {
             m_sca = std::make_unique<SecurityConfigurationAssessment>(SCA_DB_DISK_PATH);
 
-            m_sca->initSyncProtocol(g_module_name, g_sync_db_path, *g_mq_functions, std::chrono::seconds(g_sync_end_delay), std::chrono::seconds(g_sync_timeout), g_sync_retries, g_sync_max_eps,
+            m_sca->initSyncProtocol(g_module_name, g_sync_db_path, g_mq_functions, std::chrono::seconds(g_sync_end_delay), std::chrono::seconds(g_sync_timeout), g_sync_retries, g_sync_max_eps,
                                     std::chrono::seconds(g_integrity_interval));
 
             auto persistStatefulMessage = [](const std::string & id, Operation_t operation, const std::string & index, const std::string & message, uint64_t version) -> int


### PR DESCRIPTION

## Description

  In `wm_agent_info.c` (and `wm_sca.c`), `MQ_Functions` was declared inside                
  a narrow `if` block and its address was stored globally via                              
  `agent_info_init_sync_protocol` / `sca_set_sync_parameters`. After the block             
  ended, the stack memory was reused by subsequent local variables (notably a              
  64 KB `agent_groups` array in agent_info), corrupting the function pointers.             
  When `ensureQueueAvailable()` later called `m_mqFuncs.start(...)`, it jumped             
  to a garbage address.

## Proposed Changes

  - Fixed a dangling pointer bug in `agent_info` and `sca` modules where                   
    `g_mq_functions` stored a pointer to a stack-local `MQ_Functions` struct
    that went out of scope before being dereferenced, causing a SIGSEGV crash              
    in `MQueueTransport::ensureQueueAvailable`.                                            
  - Changed both modules to copy the `MQ_Functions` struct by value into the               
    global variable instead of storing a raw pointer.                                      

### Results and Evidence

Events are now being triggered, as the agent no longer crashes:
<img width="1863" height="844" alt="image" src="https://github.com/user-attachments/assets/f043494e-d471-43f8-8ad0-fb9bb0cbcd4e" />
<img width="467" height="70" alt="image" src="https://github.com/user-attachments/assets/6e63ca23-bc68-4623-9194-b3028d1ee8e9" />


```
2026/03/25 17:40:24 wazuh-agentd: INFO: Agent groups: default,test,asdf
...
2026/03/25 17:50:52 wazuh-modulesd:syscollector: INFO: Syscollector flush completed successfully
2026/03/25 17:51:09 wazuh-modulesd:agent-info: INFO: Resuming paused module: fim
2026/03/25 17:51:09 wazuh-modulesd:agent-info: INFO: Resuming paused module: sca
2026/03/25 17:51:09 wazuh-modulesd:agent-info: INFO: Resuming paused module: syscollector
2026/03/25 17:51:09 wazuh-modulesd:syscollector: INFO: Resuming Syscollector module
2026/03/25 17:51:09 wazuh-modulesd:agent-info: INFO: Synchronization coordination completed successfully
2026/03/25 17:51:09 wazuh-modulesd:agent-info: INFO: Successfully coordinated agent_groups
2026/03/25 17:51:25 wazuh-syscheckd: WARNING: Reached maximum files limit monitored, due to db_entry_limit configuration for files.
2026/03/25 17:51:30 wazuh-syscheckd: WARNING: Reached maximum files limit monitored, due to db_entry_limit configuration for files.
2026/03/25 17:53:37 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/03/25 17:53:37 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/03/25 17:53:44 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/03/25 17:53:44 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
2026/03/25 17:55:44 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/03/25 17:55:44 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
```

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
