### PR TITLE
Accept empty metadata object on logtest request

### DIFF
--- a/docs/ref/modules/engine/spec.yaml
+++ b/docs/ref/modules/engine/spec.yaml
@@ -270,15 +270,12 @@ paths:
         - If `location` matches the legacy agent format (`"[ID] (Name) IP->Module"`), it is parsed and may
           rewrite the final stored location to just the module.
         - If not legacy, host metadata is merged into the event before setting location/message.
-        - `metadata` is **required** and must be a **JSON object** (not a JSON-encoded string, number, or array).
-          If `metadata` is missing, not an object, contains invalid nested fields, or includes top-level keys other than `wazuh`,
+        - `metadata` is **not required** and can be an empty **JSON object**, it can't be a JSON-encoded string, number, or array.
+          If `metadata` is present and it contains invalid nested fields, or includes top-level keys other than `wazuh`,
           the request is rejected with a clear error message.
         - `metadata` is restricted to the top-level `wazuh` key. Arbitrary sibling fields such as `metadata.name` are not allowed.
         - `metadata.wazuh` must be a JSON object when present.
           Use it to provide only fields accepted by the Wazuh event schema.
-        - An empty top-level object (`{}`) is rejected because the implementation requires `metadata.wazuh`.
-        - An empty `metadata.wazuh` object is also rejected by the current validation.
-          Provide at least one schema-valid leaf field under `wazuh`, for example `{ "wazuh": { "agent": { "id": "001" } } }`.
 
       requestBody:
         required: true
@@ -341,8 +338,8 @@ paths:
                   event: "File /etc/passwd modified"
                   trace_level: "ALL"
 
-              metadata_wazuh_empty_invalid:
-                summary: INVALID - empty wazuh metadata object
+              metadata_wazuh_empty_valid:
+                summary: VALID - empty wazuh metadata object
                 value:
                   space: "test"
                   queue: 1
@@ -352,8 +349,8 @@ paths:
                   event: "File /etc/passwd modified"
                   trace_level: "ALL"
 
-              metadata_empty_object_invalid:
-                summary: INVALID - empty metadata object without `wazuh`
+              metadata_empty_object_valid:
+                summary: VALID - empty metadata object
                 value:
                   queue: 1
                   location: "syscheck"
@@ -452,24 +449,11 @@ paths:
                     status: "ERROR"
                     error: "Error parsing event: <details>"
 
-
-                metadata_required:
-                  summary: metadata must include `wazuh`
-                  value:
-                    status: "ERROR"
-                    error: "metadata is required and must be a JSON object"
-
                 metadata_wrong_type_struct:
                   summary: metadata must be an object (Struct); a string, number, or array is invalid
                   value:
                     status: "ERROR"
                     error: "metadata is required and must be a JSON object"
-
-                metadata_invalid_nested:
-                  summary: metadata contains an invalid empty object under `wazuh`
-                  value:
-                    status: "ERROR"
-                    error: "Metadata field 'wazuh' is an empty object, which is not allowed"
 
                 metadata_unknown_top_level_field:
                   summary: metadata contains unsupported top-level fields

--- a/src/engine/source/api/tester/src/handlers.cpp
+++ b/src/engine/source/api/tester/src/handlers.cpp
@@ -95,20 +95,26 @@ parseAndValidatePublicMetadata(const google::protobuf::Struct& protoMetadata)
     }
 
     const auto& metadata = std::get<json::Json>(metadataOrError);
-    if (!metadata.isObject() || metadata.isEmpty())
+    if (!metadata.isObject())
     {
-        return base::Error {"Metadata must be a non-empty JSON object"};
+        return base::Error {"Metadata must be a JSON object"};
     }
 
-    if (metadata.size() != 1)
+    if (metadata.size() > 1)
     {
-        return base::Error {"Metadata must contain only 'wazuh' as the top-level key"};
+        return base::Error {"If not empty metadata must contain only 'wazuh' as the top-level key"};
+    }
+
+    // Empty metadata is allowed, but in that case we return an empty object for the 'wazuh' metadata
+    // to avoid issues in the protocol handler
+    if (metadata.isEmpty())
+    {
+        return std::make_pair(json::Json("{}"), json::Json("{}"));
     }
 
     auto wazuhMetadataObject = metadata.getJson("/wazuh");
     auto wazuhRootObjectOpt = wazuhMetadataObject ? wazuhMetadataObject->getJson() : std::nullopt;
-    if (!wazuhMetadataObject.has_value() || !wazuhMetadataObject->isObject() || !wazuhRootObjectOpt.has_value()
-        || wazuhRootObjectOpt->isEmpty())
+    if (!wazuhMetadataObject.has_value() || !wazuhMetadataObject->isObject())
     {
         return base::Error {"Metadata should contain 'wazuh' as root"};
     }
@@ -127,11 +133,6 @@ bool validateMetadataLeaves(const json::Json& node,
         if (!objOpt.has_value())
         {
             return true;
-        }
-        else if (objOpt.value().empty())
-        {
-            error = fmt::format("Metadata field '{}' is an empty object, which is not allowed", currentPath);
-            return false;
         }
 
         for (const auto& [key, value] : objOpt.value())
@@ -159,9 +160,8 @@ bool validateMetadataLeaves(const json::Json& node,
         const auto& dotPath = DotPath(currentPath);
         if (base::isError(schemaValidator->validate(dotPath, node)))
         {
-            error =
-                fmt::format("Metadata field '{}' doesn't exist or doesn't match the expected one from the schema",
-                            dotPath.str());
+            error = fmt::format("Metadata field '{}' doesn't exist or doesn't match the expected one from the schema",
+                                dotPath.str());
             return false;
         }
     }
@@ -541,38 +541,38 @@ adapter::RouteHandler publicRunPost(const std::shared_ptr<::router::ITesterAPI>&
             return;
         }
 
-        if (!protoReq.has_metadata())
+        json::Json metadata {"{}"};
+        std::string eventStr {};
+        if (protoReq.has_metadata())
         {
-            res = adapter::userErrorResponse<ResponseType>("Metadata is required and must be a JSON object");
-            return;
+            // Ensure schemaValidator is available
+            auto schemaValidatorLocked = wSchemaValidator.lock();
+            if (!schemaValidatorLocked)
+            {
+                res = adapter::userErrorResponse<ResponseType>("Schema is not available");
+                return;
+            }
+
+            auto metadataOrError = parseAndValidatePublicMetadata(protoReq.metadata());
+            if (base::isError(metadataOrError))
+            {
+                res = adapter::userErrorResponse<ResponseType>(base::getError(metadataOrError).message);
+                return;
+            }
+
+            auto [tempMetadata, wazuhMetadataObject] = base::getResponse(metadataOrError);
+            metadata = std::move(tempMetadata);
+
+            std::string badFieldMsg {};
+            std::string metadataPath {"wazuh"};
+            if (!validateMetadataLeaves(wazuhMetadataObject, schemaValidatorLocked, metadataPath, badFieldMsg))
+            {
+                res = adapter::userErrorResponse<ResponseType>(badFieldMsg);
+                return;
+            }
         }
 
-        // Ensure schemaValidator is available
-        auto schemaValidatorLocked = wSchemaValidator.lock();
-        if (!schemaValidatorLocked)
-        {
-            res = adapter::userErrorResponse<ResponseType>("Schema is not available");
-            return;
-        }
-
-        auto metadataOrError = parseAndValidatePublicMetadata(protoReq.metadata());
-        if (base::isError(metadataOrError))
-        {
-            res = adapter::userErrorResponse<ResponseType>(base::getError(metadataOrError).message);
-            return;
-        }
-
-        auto [metadata, wazuhMetadataObject] = base::getResponse(metadataOrError);
-
-        std::string badFieldMsg {};
-        std::string metadataPath {"wazuh"};
-        if (!validateMetadataLeaves(wazuhMetadataObject, schemaValidatorLocked, metadataPath, badFieldMsg))
-        {
-            res = adapter::userErrorResponse<ResponseType>(badFieldMsg);
-            return;
-        }
-
-        const std::string eventStr = protoReq.event();
+        eventStr = protoReq.event();
         if (eventStr.empty()
             || std::all_of(eventStr.begin(), eventStr.end(), [](unsigned char c) { return std::isspace(c); }))
         {

--- a/src/engine/source/api/tester/test/src/unit/handlers_test.cpp
+++ b/src/engine/source/api/tester/test/src/unit/handlers_test.cpp
@@ -496,7 +496,7 @@ INSTANTIATE_TEST_SUITE_P(
             []() { return makeSchemaValidator(true); },
         },
         LogtestPostCase {
-            "MissingMetadata",
+            "Ok Without Metadata",
             []()
             {
                 eEngine::tester::PublicRunPost_Request protoReq;
@@ -504,15 +504,22 @@ INSTANTIATE_TEST_SUITE_P(
                 protoReq.set_location("/var/log/test");
                 protoReq.set_event("some event");
                 protoReq.set_trace_level("NONE");
+                protoReq.set_space("test-session");
                 // No metadata set
                 return protoReq;
             },
-            [](auto& tester) { EXPECT_CALL(tester, ingestTest(testing::_, testing::_)).Times(0); },
-            []()
+            [](auto& tester)
             {
-                return userErrorResponse<eEngine::tester::RunPost_Response>(
-                    "Metadata is required and must be a JSON object");
+                EXPECT_CALL(tester, ingestTest(testing::_, testing::_))
+                    .WillOnce(
+                        [](auto&&, auto&&)
+                        {
+                            std::promise<base::RespOrError<::router::test::Output>> p;
+                            p.set_value(makeOutput(R"({"status":"ok"})"));
+                            return p.get_future();
+                        });
             },
+            []() { return makeRunPostSuccessResponse(R"({"status":"ok"})"); },
             []() { return makeSchemaValidator(true); },
         },
         LogtestPostCase {

--- a/src/engine/source/proto/src/tester.proto
+++ b/src/engine/source/proto/src/tester.proto
@@ -172,9 +172,10 @@ message PublicRunPost_Request
     string location = 2;
 
     // Metadata associated with the event/agent.
-    // Must be a Struct whose contents are rooted under the top-level "wazuh" key,
+    // Can be a Struct whose contents are rooted under the top-level "wazuh" key,
     // and only schema-approved fields under that root are accepted by the engine.
     // Non-approved keys or alternative roots may be rejected or ignored by validation.
+    // Can be also used with empty JSONs.
     google.protobuf.Struct metadata = 3;
 
     // Raw event payload to test.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes #35126 
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

Handle empty metadata without errors.
Allow the non existence of metadata in logtest request

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

```console
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                   130 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing"
Error: Request failed: {"status":"ERROR","error":"The 'testing' environment does not exist."}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata ''
Error: Request failed: {"status":"ERROR","error":"The 'testing' environment does not exist."}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{}'
Error: Request failed: {"status":"ERROR","error":"The 'testing' environment does not exist."}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"wazuh":{}}'
Error: Request failed: {"status":"ERROR","error":"The 'testing' environment does not exist."}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"wazuh":{"agent":{"id":"1234"}}}'
Error: Request failed: {"status":"ERROR","error":"The 'testing' environment does not exist."}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"wazuh":{"agent":{"id":1234}}}'
Error: Request failed: {"status":"ERROR","error":"Metadata field 'wazuh.agent.id' doesn't exist or doesn't match the expected one from the schema"}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"wazuh":{"agent":{"Randomid":"1234"}}}'
Error: Request failed: {"status":"ERROR","error":"Metadata field 'wazuh.agent.Randomid' doesn't exist or doesn't match the expected one from the schema"}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"wazuh":{"agent":{"Randomid":"1234"}'  
Error: Invalid metadata JSON: Expecting ',' delimiter: line 1 column 38 (char 37)
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"random":{"agent":{"Randomid":"1234"}}}'
Error: Request failed: {"status":"ERROR","error":"Metadata should contain 'wazuh' as root"}
(venv) ╭─root@9d57312a2ebf /workspaces/devContainer 
╰─# python3 send_logtest.py --socket /var/wazuh-manager/queue/sockets/analysis \                     1 ↵
    --queue 1 \
    --location test \
    --event 'CEF:0|Acme|Demo|1.0|100|Test event|5|' --session "testing" \
    --metadata '{"agent":{"Randomid":"1234"}}'  
Error: Request failed: {"status":"ERROR","error":"Metadata should contain 'wazuh' as root"}
```

Generated events

<img width="1907" height="851" alt="image" src="https://github.com/user-attachments/assets/4038d110-9a5e-4c41-b21c-5fed61831e64" />

Agent enrolled

<img width="1907" height="851" alt="image" src="https://github.com/user-attachments/assets/432f066f-ed65-4d43-920c-cc425eaea57a" />
<img width="1907" height="851" alt="image" src="https://github.com/user-attachments/assets/7d9575eb-e688-41b7-ba8a-c9b351eca0b1" />

Logtest from dashboard with empty metadata

<img width="1907" height="915" alt="image" src="https://github.com/user-attachments/assets/abe3e284-fccd-4c88-a938-75205c688b66" />

Previously without the changes:

<img width="1903" height="939" alt="Screenshot From 2026-03-25 13-54-13" src="https://github.com/user-attachments/assets/39d686fb-91ea-4196-9e02-81432c62be9f" />

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
