### PR TITLE
Fix feed readiness validation when global maps are missing

### DIFF
--- a/docs/ref/modules/vulnerability-scanner/README.md
+++ b/docs/ref/modules/vulnerability-scanner/README.md
@@ -7,4 +7,6 @@ The CVE data comes from [CTI](https://cti.wazuh.com/vulnerabilities/cves), which
 - ECS-formatted documents indexed into `wazuh-states-vulnerabilities` via the Indexer Connector.
 - Engine alert events sent to `queue-http.sock` using the H/E protocol.
 
+Before starting a CTI feed download from the Indexer, VD waits until the feed consumer status is `idle`. Once the download finishes, VD only marks the local feed as ready if the required global maps are present in the local feed database.
+
 OS detection is supported for Windows and macOS (Darwin). On Linux, the kernel is treated as a package component.

--- a/docs/ref/modules/vulnerability-scanner/architecture.md
+++ b/docs/ref/modules/vulnerability-scanner/architecture.md
@@ -40,6 +40,9 @@ Orchestration selection is based on `Start.option` and the indices present in th
 - **`src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp`**
 The entry point for the vulnerability scanner. It initializes CTI feed databases, the Indexer Connector, and the scan orchestrator. It also manages the local state database used to track installed content versions.
 
+- **`src/shared_modules/content_manager/src/components/IndexerDownloader.hpp`**
+  Downloads the CTI feed from the Indexer. Before starting a download, it checks the CTI consumer status and waits until it becomes `idle`. If the status is empty or `updating`, the downloader postpones the operation and retries later.
+
 - **`src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/`**
   This implementation uses the `Chain of Responsibility` design pattern to represent different stages for detection based on InventorySync batches (Start, DataValue, DataContext). It builds the `ScanContext`, runs package/OS/hotfix detection for full scans and deltas, and emits results to the indexer and engine.
 
@@ -54,6 +57,16 @@ The entry point for the vulnerability scanner. It initializes CTI feed databases
   - Create CVSS, description, and other related tables to augment the vulnerability indexed information and alert reports.
   - Parse and process mapping details and translation information for OS and packages.
   - Parse and process offset information to keep the CVE database up to date.
+  - Validate that the local feed database is complete before marking it as ready for scans.
+
+## Feed update readiness
+
+The feed update path now separates remote readiness from local readiness:
+
+- The Indexer download starts only when the CTI consumer status is `idle`.
+- Once the download completes, the local feed is marked as ready only if the required global maps are present in the local RocksDB feed database.
+
+This prevents VD from starting scans with a partially downloaded or locally incomplete feed.
 
 ## Orchestration chains
 

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -16,6 +16,8 @@ All the XML configuration blocks mentioned in this section are present in the ma
 
 **feed-update-interval**: Default and minimum value, 60 min.
 
+Before each feed update starts, the manager checks the CTI consumer status in the Indexer. If the status is empty or `updating`, the update is postponed for one minute and retried later. The download only starts when the consumer status is `idle`.
+
 **pageSize**: Optional. Number of CVE documents fetched per PIT page during feed download. Default: `250`.
 
 **numSlices**: Optional. Number of parallel PIT slices used during the initial feed load. Default: `2`. Set to `1` to force sequential mode. Increasing this value can raise memory usage without delivering meaningful time savings, so benchmark before increasing it.
@@ -27,6 +29,8 @@ All the XML configuration blocks mentioned in this section are present in the ma
 ## Connection to Wazuh Indexer
 
 As mentioned above, the **Vulnerability Scanner** delegates indexing to the Indexer Connector module. It processes inventory batches (OS, packages, hotfixes) against the local CVE database and indexes detections into `wazuh-states-vulnerabilities`.
+
+The feed update process also depends on the CTI consumer status stored in the Indexer. VD starts downloading the feed only when that status is `idle`, and it will not mark the local feed as ready until the required global maps have been stored locally.
 
 - Default Indexer Connector configuration block
 ```xml

--- a/src/shared_modules/content_manager/README.md
+++ b/src/shared_modules/content_manager/README.md
@@ -38,6 +38,7 @@ The downloader automatically selects its mode based on the persisted cursor:
 
 - **Initial load** (no cursor stored): Downloads all documents from the index using `match_all`, sorted by `(offset, _id)`, paginated with PIT + `search_after`. Retries every 30 seconds if the index is empty.
 - **Incremental update** (cursor stored): Downloads only documents with `offset > lastCursor` using the same PIT + `search_after` strategy.
+- **Consumer readiness gate** (optional): If `consumerStatusIndex` and `consumerStatusId` are configured, the downloader polls the consumer status document and waits until it reaches `idle` before reading the feed index.
 
 After all pages are processed, the downloader signals completion via `indexer_complete`, including a `changed` flag that indicates whether any documents were fetched. Consumers use this flag to decide whether to trigger downstream actions (e.g. a full agent rescan).
 
@@ -60,6 +61,8 @@ After all pages are processed, the downloader signals completion via `indexer_co
                 "key": ""
             },
             "index": ".cti-cves",
+            "consumerStatusIndex": ".cti-consumers",
+            "consumerStatusId": "vd_1.0.0_vd_4.8.0",
             "pageSize": 250,
             "numSlices": 2
         }

--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -22,6 +22,17 @@ Triggered on subsequent runs. Downloads only documents whose `offset` field is s
 
 If the range query returns zero documents, the cycle completes without triggering a rescan on the consumer side (see [Completion signal](#completion-signal) below).
 
+### Consumer readiness gate
+
+If `consumerStatusIndex` and `consumerStatusId` are configured, the downloader polls the consumer status document before opening the PIT on the feed index:
+
+- missing document: wait 1 minute and retry
+- empty `status`: wait 1 minute and retry
+- `status = updating`: wait 1 minute and retry
+- `status = idle`: start the download
+
+This gate answers only one question: whether it is safe to start reading from Indexer. It does not replace the consumer-side validation of the downloaded local feed.
+
 ### PIT pagination
 
 Each download cycle (initial or incremental) opens a single Point-In-Time on the target index with a keep-alive of `5m`. All page requests within the cycle use this PIT, ensuring a consistent snapshot of the index throughout the download. The PIT is always deleted when the cycle finishes, even in error cases.
@@ -91,6 +102,8 @@ The `indexer` sub-object must be present under `configData` when `contentSource`
 | Field | Type | Description |
 |-------|------|-------------|
 | `index` | string | Target index name (e.g. `.cti-cves`) |
+| `consumerStatusIndex` | string | Index containing the consumer status document to poll before downloading (optional) |
+| `consumerStatusId` | string | Consumer status document id to poll before downloading (optional) |
 | `pageSize` | integer | Documents per page. Default: `250` |
 | `numSlices` | integer | Number of parallel PIT slices for initial load. Default: `2`. Set to `1` for sequential mode. Higher values can increase memory usage with limited time savings |
 | `hosts` | array | Indexer host URLs (e.g. `["https://localhost:9200"]`) |
@@ -122,6 +135,8 @@ Example:
                 "key": ""
             },
             "index": ".cti-cves",
+            "consumerStatusIndex": ".cti-consumers",
+            "consumerStatusId": "vd_1.0.0_vd_4.8.0",
             "pageSize": 250,
             "numSlices": 2
         }

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -21,7 +21,9 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <tuple>
 #include <vector>
@@ -48,15 +50,26 @@
  *
  * Configuration expected under configData["indexer"]:
  * {
- *   "index":    ".cti-cves",     // Indexer CVE index name
- *   "pageSize": 250,             // Documents per page (optional, default 250)
- *   "numSlices": 2,              // Parallel PIT slices (optional, default 2)
+ *   "index":               ".cti-cves",               // Indexer CVE index name
+ *   "consumerStatusIndex": ".cti-consumers",          // Consumer status index (optional)
+ *   "consumerStatusId":    "vd_1.0.0_vd_4.8.0",       // Consumer status document id (optional)
+ *   "pageSize":            250,                       // Documents per page (optional, default 250)
+ *   "numSlices":           2,                         // Parallel PIT slices (optional, default 2)
  *   <standard IndexerConnector SSL/auth config>
  * }
  */
 class IndexerDownloader final : public AbstractHandler<std::shared_ptr<UpdaterContext>>
 {
 private:
+    enum class ConsumerStatus
+    {
+        Missing,
+        Empty,
+        Updating,
+        Idle,
+        Unknown
+    };
+
     nlohmann::json m_config;
     mutable std::mutex m_callbackMutex; ///< Serializes processPage calls across parallel slices.
 
@@ -107,6 +120,162 @@ private:
                                                                       "document.containers.adp.datePublic",
                                                                       "document.containers.adp.title"})}};
         return filter;
+    }
+
+    /**
+     * @brief Reads the current consumer status document from `.cti-consumers`.
+     *
+     * The indexer-side contract guarantees that the document status is:
+     *   - empty / missing while the consumer is not ready yet,
+     *   - "updating" while the feed is still being indexed,
+     *   - "idle" only when the consumer can be queried safely.
+     */
+    ConsumerStatus readConsumerStatus(IndexerConnectorSync& syncConnector,
+                                      std::string_view consumerStatusIndex,
+                                      std::string_view consumerStatusId) const
+    {
+        const auto query =
+            nlohmann::json {{"ids", {{"values", nlohmann::json::array({std::string {consumerStatusId}})}}}};
+        const auto sourceFilter =
+            nlohmann::json {{"includes", nlohmann::json::array({"status"})}, {"excludes", nlohmann::json::array()}};
+        const auto searchQuery = nlohmann::json {{"size", 1}, {"query", query}, {"_source", sourceFilter}};
+
+        const auto searchResult = syncConnector.executeSearchQuery(std::string {consumerStatusIndex}, searchQuery);
+        if (!searchResult.contains("hits") || !searchResult.at("hits").is_object() ||
+            !searchResult.at("hits").contains("hits") || !searchResult.at("hits").at("hits").is_array() ||
+            searchResult.at("hits").at("hits").empty())
+        {
+            return ConsumerStatus::Missing;
+        }
+
+        const auto& hit = searchResult.at("hits").at("hits").front();
+        if (!hit.contains("_source") || !hit.at("_source").is_object())
+        {
+            return ConsumerStatus::Empty;
+        }
+
+        const auto& source = hit.at("_source");
+        if (!source.contains("status") || !source.at("status").is_string())
+        {
+            return ConsumerStatus::Empty;
+        }
+
+        std::string status;
+        source.at("status").get_to(status);
+        if (status.empty())
+        {
+            return ConsumerStatus::Empty;
+        }
+        if (status == "idle")
+        {
+            return ConsumerStatus::Idle;
+        }
+        if (status == "updating")
+        {
+            return ConsumerStatus::Updating;
+        }
+
+        return ConsumerStatus::Unknown;
+    }
+
+    /**
+     * @brief Waits until the consumer status document becomes `idle`.
+     *
+     * If the consumer status settings are not configured, the wait is skipped so
+     * non-VD users of IndexerDownloader keep the previous behaviour.
+     */
+    bool waitUntilConsumerIdle(UpdaterContext& context) const
+    {
+        static constexpr auto CONSUMER_STATUS_POLL_INTERVAL {std::chrono::minutes {1}};
+
+        const auto consumerStatusIndex = m_config.at("indexer").value("consumerStatusIndex", std::string {});
+        const auto consumerStatusId = m_config.at("indexer").value("consumerStatusId", std::string {});
+
+        if (consumerStatusIndex.empty() || consumerStatusId.empty())
+        {
+            return true;
+        }
+
+        IndexerConnectorSync syncConnector(m_config.at("indexer"));
+
+        while (true)
+        {
+            try
+            {
+                switch (readConsumerStatus(syncConnector, consumerStatusIndex, consumerStatusId))
+                {
+                    case ConsumerStatus::Idle:
+                        logInfo(WM_CONTENTUPDATER,
+                                "IndexerDownloader: Consumer '%s' in index '%s' is idle. Starting feed download.",
+                                consumerStatusId.c_str(),
+                                consumerStatusIndex.c_str());
+                        return true;
+
+                    case ConsumerStatus::Missing:
+                        logInfo(WM_CONTENTUPDATER,
+                                "IndexerDownloader: Consumer '%s' not found in '%s'. Waiting %zu s before retrying.",
+                                consumerStatusId.c_str(),
+                                consumerStatusIndex.c_str(),
+                                static_cast<size_t>(
+                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
+                                        .count()));
+                        break;
+
+                    case ConsumerStatus::Empty:
+                        logInfo(WM_CONTENTUPDATER,
+                                "IndexerDownloader: Consumer '%s' has empty status in '%s'. Waiting %zu s before "
+                                "retrying.",
+                                consumerStatusId.c_str(),
+                                consumerStatusIndex.c_str(),
+                                static_cast<size_t>(
+                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
+                                        .count()));
+                        break;
+
+                    case ConsumerStatus::Updating:
+                        logInfo(WM_CONTENTUPDATER,
+                                "IndexerDownloader: Consumer '%s' is still updating in '%s'. Waiting %zu s before "
+                                "retrying.",
+                                consumerStatusId.c_str(),
+                                consumerStatusIndex.c_str(),
+                                static_cast<size_t>(
+                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
+                                        .count()));
+                        break;
+
+                    case ConsumerStatus::Unknown:
+                        logWarn(WM_CONTENTUPDATER,
+                                "IndexerDownloader: Consumer '%s' in '%s' returned an unknown status. Waiting %zu s "
+                                "before retrying.",
+                                consumerStatusId.c_str(),
+                                consumerStatusIndex.c_str(),
+                                static_cast<size_t>(
+                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
+                                        .count()));
+                        break;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                logWarn(WM_CONTENTUPDATER,
+                        "IndexerDownloader: Failed to query consumer '%s' in '%s' (%s). Waiting %zu s before "
+                        "retrying.",
+                        consumerStatusId.c_str(),
+                        consumerStatusIndex.c_str(),
+                        e.what(),
+                        static_cast<size_t>(
+                            std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL).count()));
+            }
+
+            if (context.spUpdaterBaseContext->spStopCondition->waitFor(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(CONSUMER_STATUS_POLL_INTERVAL)))
+            {
+                logInfo(WM_CONTENTUPDATER,
+                        "IndexerDownloader: Stop requested while waiting for consumer '%s' to become idle.",
+                        consumerStatusId.c_str());
+                return false;
+            }
+        }
     }
 
     /**
@@ -639,6 +808,11 @@ public:
         }
 
         const bool forceInitialLoad = lastCursor.empty();
+        if (!waitUntilConsumerIdle(*context))
+        {
+            return AbstractHandler<std::shared_ptr<UpdaterContext>>::handleRequest(std::move(context));
+        }
+
         size_t totalProcessed = 0;
         if (forceInitialLoad)
         {

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -17,6 +17,8 @@ LOGGER = logging.getLogger(__name__)
 OPENSEARCH_IP = "127.0.0.1:9200"
 OPENSEARCH_URL = f"http://{OPENSEARCH_IP}"
 CTI_FEED_INDEX = ".cti-cves"
+CTI_CONSUMERS_INDEX = ".cti-consumers"
+CTI_CONSUMER_DOC_ID = "vd_1.0.0_vd_4.8.0"
 CTI_FEED_FILE = Path("wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json")
 
 
@@ -110,6 +112,48 @@ def seed_cti_feed_index():
 
     LOGGER.info("Seeded %s with %d reduced-feed documents", CTI_FEED_INDEX, len(bulk_lines) // 2)
 
+
+def seed_cti_consumer_status():
+    delete_response = requests.delete(f"{OPENSEARCH_URL}/{CTI_CONSUMERS_INDEX}")
+    if delete_response.status_code not in [200, 404]:
+        raise RuntimeError(
+            f"Failed to delete {CTI_CONSUMERS_INDEX}: {delete_response.status_code} {delete_response.text}"
+        )
+
+    create_response = requests.put(
+        f"{OPENSEARCH_URL}/{CTI_CONSUMERS_INDEX}",
+        json={
+            "settings": {
+                "index": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0,
+                }
+            },
+            "mappings": {
+                "properties": {
+                    "status": {"type": "keyword"},
+                }
+            },
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    if create_response.status_code not in [200, 201]:
+        raise RuntimeError(
+            f"Failed to create {CTI_CONSUMERS_INDEX}: {create_response.status_code} {create_response.text}"
+        )
+
+    status_response = requests.put(
+        f"{OPENSEARCH_URL}/{CTI_CONSUMERS_INDEX}/_doc/{CTI_CONSUMER_DOC_ID}?refresh=true",
+        json={"status": "idle"},
+        headers={"Content-Type": "application/json"},
+    )
+    if status_response.status_code not in [200, 201]:
+        raise RuntimeError(
+            f"Failed to seed {CTI_CONSUMERS_INDEX}: {status_response.status_code} {status_response.text}"
+        )
+
+    LOGGER.info("Seeded %s with idle consumer '%s'", CTI_CONSUMERS_INDEX, CTI_CONSUMER_DOC_ID)
+
 def init_opensearch(low_resources):
     client = docker.from_env()
     env_vars = {
@@ -150,6 +194,7 @@ def opensearch(request):
     client = init_opensearch(low_resources)
     reset_feed_runtime_state()
     seed_cti_feed_index()
+    seed_cti_consumer_status()
     yield client
     # Stop all containers
     for container in client.containers.list():

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -254,16 +254,27 @@ public:
             // We disable the automatic repair of the DB in case it's corrupted.
             m_feedDatabase = std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, false);
 
-            // This initializes the vendor and os cpe maps and should be called before any scan or message processing.
+            // Load the global maps needed by the local feed database before any scan or
+            // message processing can use it.
             if (reloadGlobalMapsStartup)
             {
-                // If the global maps are not available yet, force a full feed download on the next updater cycle.
+                // If the local feed database is incomplete, force a clean rebuild on the
+                // next updater cycle instead of reusing a partial on-disk state.
                 if (!reloadGlobalMaps())
                 {
-                    std::filesystem::remove_all(UPDATER_PATH);
-                    logWarn(WM_VULNSCAN_LOGTAG,
-                            "Global maps are not yet available in the feed database at startup. "
-                            "Clearing updater state to force a full feed reload.");
+                    if (std::filesystem::exists(UPDATER_PATH))
+                    {
+                        std::filesystem::remove_all(UPDATER_PATH);
+                        logWarn(WM_VULNSCAN_LOGTAG,
+                                "The local feed database is incomplete at startup: required global maps are missing. "
+                                "Clearing updater state to force a clean rebuild.");
+                    }
+                    else
+                    {
+                        logInfo(WM_VULNSCAN_LOGTAG,
+                                "No existing local vulnerability feed detected at startup. "
+                                "A full feed will be downloaded.");
+                    }
                 }
             }
         }
@@ -316,9 +327,8 @@ public:
                             return processMessageResult;
                         }
 
-                        // On completion signal: reload global maps and optionally trigger rescan.
-                        // reloadGlobalMaps is called only once here (not per-page) because global
-                        // maps are only needed for scanning, which starts after indexer_complete.
+                        // On completion signal, validate that the local feed database is now
+                        // usable for scanning before marking it ready or triggering rescans.
                         if (msgType == "indexer_complete")
                         {
                             if (!this->reloadGlobalMaps())
@@ -329,8 +339,9 @@ public:
                                 }
 
                                 logWarn(WM_VULNSCAN_LOGTAG,
-                                        "Feed update completed without all global maps available. "
-                                        "Feed remains unavailable and a full reload is required.");
+                                        "Feed download completed, but the local feed database is still incomplete: "
+                                        "required global maps are missing. Feed remains unavailable and the next "
+                                        "cycle must rebuild it.");
 
                                 return FileProcessingResult {0, "global_maps_missing", false};
                             }
@@ -339,7 +350,7 @@ public:
                                     "Feed update process completed (changed=%s).",
                                     changed ? "true" : "false");
 
-                            // Always write the sentinel — marks at least one complete download,
+                            // Always write the sentinel after a successful local validation,
                             // regardless of whether this cycle had new documents.
                             if (!m_feedDatabase->columnExists(FEED_METADATA_COLUMN))
                             {
@@ -773,9 +784,11 @@ public:
     /**
      * @brief Returns true if at least one complete feed download has finished successfully.
      *
-     * Checks for the FEED_COMPLETE_KEY written to FEED_METADATA_COLUMN exclusively at
-     * indexer_complete time. Column family existence alone is not used because other columns
-     * are created per-page and may persist from an interrupted previous download.
+     * Checks whether the local feed database is ready for scanning.
+     *
+     * Requires the FEED_COMPLETE_KEY written only after a validated completion signal and
+     * the three global-map documents needed by the scanner. Column existence alone is not
+     * enough because partial local ingestions can leave old column families behind.
      *
      * Used by VulnerabilityScannerFacade to gate per-agent scans during the initial load.
      */
@@ -815,7 +828,7 @@ private:
     bool m_shouldStop = false;
 
     /**
-     * @brief Reads the global maps from the database and loads them into memory.
+     * @brief Reads the global maps from the local feed database and loads them into memory.
      *
      * @return true if all required global maps are present and successfully loaded.
      * @return false if one or more global maps are still missing or incomplete.
@@ -850,27 +863,27 @@ private:
                               std::string& cnaMappingResult,
                               const bool logIssues) const
     {
-        // On a completely fresh install none of the feed column families exist yet.
-        // This is expected — the Indexer initial load will create them. Skip silently.
+        // On a fresh install, or after an interrupted rebuild, the local feed database may
+        // not contain the required columns yet.
         if (!m_feedDatabase->columnExists(VENDOR_MAP_COLUMN))
         {
             if (logIssues)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Global maps not yet available in DB, skipping reload.");
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Global maps are not yet available in the local feed database, skipping reload.");
             }
             return false;
         }
 
-        // vendor_map exists so a previous feed ingestion ran. All three column families are
-        // required. Missing ones indicate an incomplete ingestion or a data gap in the Indexer
-        // (e.g. OSCPE-GLOBAL not yet published). Warn so the problem is visible.
+        // All three column families are required. Missing ones indicate that the local feed
+        // database is incomplete and cannot be used for scanning yet.
         if (!m_feedDatabase->columnExists(OS_CPE_RULES_COLUMN) || !m_feedDatabase->columnExists(CNA_MAPPING_COLUMN))
         {
             if (logIssues)
             {
                 logWarn(WM_VULNSCAN_LOGTAG,
-                        "Global maps incomplete: oscpe_rules or cna_mapping column missing. "
-                        "Vulnerability scans will produce no results until all feed documents are available.");
+                        "The local feed database is incomplete: oscpe_rules or cna_mapping column is missing. "
+                        "The feed cannot be used for scanning until it is rebuilt.");
             }
             return false;
         }
@@ -879,7 +892,8 @@ private:
         {
             if (logIssues)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Global maps not yet available in DB, skipping reload.");
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Global maps are not yet available in the local feed database, skipping reload.");
             }
             return false;
         }
@@ -888,7 +902,8 @@ private:
         {
             if (logIssues)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Global maps not yet available in DB, skipping reload.");
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Global maps are not yet available in the local feed database, skipping reload.");
             }
             return false;
         }
@@ -898,7 +913,8 @@ private:
         {
             if (logIssues)
             {
-                logDebug2(WM_VULNSCAN_LOGTAG, "Global maps not yet available in DB, skipping reload.");
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Global maps are not yet available in the local feed database, skipping reload.");
             }
             return false;
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <mutex>
 #include <string>
+#include <string_view>
 
 constexpr auto STATES_VD_INDEX_NAME_PREFIX {"wazuh-states-vulnerabilities"};
 
@@ -35,6 +36,10 @@ extern "C" bool vdTesttoolSkipPostUpdateScan() __attribute__((weak));
 // LCOV_EXCL_START - only called from the DatabaseFeedManager callback inside start(), which is already excluded
 namespace
 {
+    constexpr std::string_view INDEXER_FEED_INDEX {".cti-cves"};
+    constexpr std::string_view INDEXER_CONSUMER_STATUS_INDEX {".cti-consumers"};
+    constexpr std::string_view INDEXER_CONSUMER_STATUS_ID {"vd_1.0.0_vd_4.8.0"};
+
     bool shouldSkipPostUpdateScan()
     {
         return vdTesttoolSkipPostUpdateScan && vdTesttoolSkipPostUpdateScan();
@@ -303,21 +308,36 @@ void VulnerabilityScannerFacade::start(
 
             // Build the indexer sub-config for IndexerDownloader reusing the same <indexer>
             // block from ossec.conf that IndexerConnectorSync already uses (hosts, SSL, auth).
-            if (!configData.contains("indexer"))
+            if (!configData.contains("indexer") || !configData.at("indexer").is_object())
             {
                 nlohmann::json indexerSubConfig = nlohmann::json::object();
                 if (configuration.contains("indexer") && configuration.at("indexer").is_object())
                 {
                     indexerSubConfig = configuration.at("indexer");
                 }
-                indexerSubConfig["index"] = ".cti-cves";
-                const auto& vdConfig = configuration.contains("vulnerability-detection") &&
-                                               configuration.at("vulnerability-detection").is_object()
-                                           ? configuration.at("vulnerability-detection")
-                                           : nlohmann::json::object();
-                indexerSubConfig["pageSize"] = static_cast<uint32_t>(std::stoul(vdConfig.value("pageSize", "250")));
-                indexerSubConfig["numSlices"] = static_cast<uint32_t>(std::stoul(vdConfig.value("numSlices", "2")));
                 configData["indexer"] = std::move(indexerSubConfig);
+            }
+
+            auto& indexerSubConfig = configData["indexer"];
+            if (!indexerSubConfig.contains("index"))
+            {
+                indexerSubConfig["index"] = std::string {INDEXER_FEED_INDEX};
+            }
+            if (!indexerSubConfig.contains("consumerStatusIndex"))
+            {
+                indexerSubConfig["consumerStatusIndex"] = std::string {INDEXER_CONSUMER_STATUS_INDEX};
+            }
+            if (!indexerSubConfig.contains("consumerStatusId"))
+            {
+                indexerSubConfig["consumerStatusId"] = std::string {INDEXER_CONSUMER_STATUS_ID};
+            }
+            if (!indexerSubConfig.contains("pageSize"))
+            {
+                indexerSubConfig["pageSize"] = static_cast<uint32_t>(std::stoul(vdConfig.value("pageSize", "250")));
+            }
+            if (!indexerSubConfig.contains("numSlices"))
+            {
+                indexerSubConfig["numSlices"] = static_cast<uint32_t>(std::stoul(vdConfig.value("numSlices", "2")));
             }
 
             return updaterConfig;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -857,7 +857,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidVendorMap)
     EXPECT_FALSE(std::filesystem::exists(COMMON_UPDATER_DIR));
 }
 
-TEST_F(DatabaseFeedManagerMessageProcessorTest, TestMissingGlobalMapsAtStartupClearsUpdaterDirectory)
+TEST_F(DatabaseFeedManagerMessageProcessorTest, TestIncompleteLocalFeedAtStartupClearsUpdaterDirectory)
 {
     {
         auto spRocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
@@ -944,10 +944,8 @@ void DatabaseFeedManagerVendorMapTest::SetUp()
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
 
-    std::shared_mutex mutex;
-
     m_spDatabaseFeedManager =
-        std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(mutex, updaterConfig, translationLruSize);
+        std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(m_mutex, updaterConfig, translationLruSize);
 }
 
 void DatabaseFeedManagerVendorMapTest::TearDown()
@@ -988,7 +986,7 @@ TEST_F(DatabaseFeedManagerVendorMapTest, TestGetCnaNameByFormat)
     EXPECT_EQ(cnaName, "");
 }
 
-TEST_F(DatabaseFeedManagerVendorMapTest, IsFeedReadyRequiresSentinelAndAllGlobalMaps)
+TEST_F(DatabaseFeedManagerVendorMapTest, IsFeedReadyRequiresSentinelAndLocalGlobalMaps)
 {
     EXPECT_FALSE(m_spDatabaseFeedManager->isFeedReady());
 
@@ -1005,12 +1003,11 @@ TEST_F(DatabaseFeedManagerVendorMapTest, IsFeedReadyRequiresSentinelAndAllGlobal
     }
 
     {
-        std::shared_mutex mutex;
         const auto updaterConfig = spPolicyManagerMock->getUpdaterConfiguration();
         const auto translationLruSize = spPolicyManagerMock->getTranslationLRUSize();
 
-        m_spDatabaseFeedManager =
-            std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(mutex, updaterConfig, translationLruSize);
+        m_spDatabaseFeedManager = std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(
+            m_mutex, updaterConfig, translationLruSize);
     }
 
     EXPECT_TRUE(m_spDatabaseFeedManager->isFeedReady());
@@ -1023,12 +1020,11 @@ TEST_F(DatabaseFeedManagerVendorMapTest, IsFeedReadyRequiresSentinelAndAllGlobal
     }
 
     {
-        std::shared_mutex mutex;
         const auto updaterConfig = spPolicyManagerMock->getUpdaterConfiguration();
         const auto translationLruSize = spPolicyManagerMock->getTranslationLRUSize();
 
-        m_spDatabaseFeedManager =
-            std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(mutex, updaterConfig, translationLruSize);
+        m_spDatabaseFeedManager = std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(
+            m_mutex, updaterConfig, translationLruSize);
     }
 
     EXPECT_FALSE(m_spDatabaseFeedManager->isFeedReady());

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.h
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.h
@@ -150,6 +150,14 @@ protected:
     void TearDown() override;
 
     /**
+     * @brief Mutex to protect access to the internal databases.
+     *
+     * Must be declared before m_spDatabaseFeedManager so it is destroyed after it,
+     * because TDatabaseFeedManager stores it by reference.
+     */
+    std::shared_mutex m_mutex;
+
+    /**
      * @brief DatabaseFeedManager smart pointer.
      *
      */


### PR DESCRIPTION
# Description

This PR makes the Vulnerability Scanner wait until the CTI consumer status is `idle` before starting a feed download from the Indexer.

It also keeps the manager-side validation that ensures the local feed is only marked as ready when the required global maps are already present in the local feed database.

## Changes

- Poll the CTI consumer status document before starting the feed download.
- Start the download only when the consumer status is `idle`.
- Wait 1 minute and retry when the status is empty, missing, or `updating`.
- Inject the default consumer status index and document id into the VD updater configuration.
- Keep the local feed readiness checks based on `FEED_COMPLETE_KEY` and the required global maps.
- Keep cursor invalidation when the final local feed validation fails.
- Update VD documentation to reflect the new feed update flow.

## Why

The new Indexer-side status provides the correct signal to decide when the manager can start reading the feed remotely.

However, the manager still needs to validate its own local RocksDB copy before enabling scans, because a finished download does not guarantee that the local feed database is already complete and usable.

## Result

The feed update flow now separates:

- remote readiness: wait for the CTI consumer to become `idle`
- local readiness: mark the feed as ready only after the required global maps are stored locally

This avoids starting scans from an incomplete feed state while keeping the implementation small and focused.



# Manual testing
- Logs related:
[ossec.log](https://github.com/user-attachments/files/26361242/ossec.log)
[wazuh-manager.log](https://github.com/user-attachments/files/26361243/wazuh-manager.log)

<img width="1500" height="696" alt="image" src="https://github.com/user-attachments/assets/cbcbc511-1801-44b6-843b-fac64a2b60ab" />
