### PR TITLE
Escape document id in delete bulk operations

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -175,6 +175,13 @@ static void initConfiguration(SecureCommunication& secureCommunication, const nl
         .caRootCertificate(caRootCertificate);
 }
 
+/**
+ * @brief Appends id to bulkData, JSON-escaping any characters that would produce
+ * invalid JSON if emitted raw (control bytes, backslashes, double quotes).
+ *
+ * @param bulkData Output string being built for the bulk NDJSON request.
+ * @param id Document ID to append.
+ */
 static void appendEscapedId(std::string& bulkData, std::string_view id)
 {
     if (needEscape(id))

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -501,14 +501,19 @@ TEST_F(IndexerConnectorTest, PublishDeleted)
 
 /**
  * @brief Test the connection and posterior data publication into a server. The published data is checked against the
- * expected one. The publication contains a DELETED operation with a document ID that includes a control character.
- * Verifies that the ID is JSON-escaped in the bulk request, not emitted as a raw byte.
+ * expected one. The publication contains DELETED operations with document IDs that include characters requiring
+ * JSON escaping: a control byte (0x04), backslashes (as seen in Windows AD domain groups), and a double quote.
+ * Verifies that each ID is correctly escaped in the bulk delete request sent to the indexer.
  *
  */
 TEST_F(IndexerConnectorTest, PublishDeletedWithSpecialCharId)
 {
-    // ID with control byte 0x04 (^D) — as it would appear in memory after parsing a queued retry event.
-    const std::string specialId {"000_test\x04id"};
+    // IDs that require JSON escaping
+    const std::vector<std::string> specialIds {
+        "000_test\x04id",
+        "000_DOMAIN\\ggroup",
+        "000_test\"id",
+    };
 
     nlohmann::json expectedMetadata;
 
@@ -527,24 +532,31 @@ TEST_F(IndexerConnectorTest, PublishDeletedWithSpecialCharId)
     auto indexerConnector {IndexerConnector(indexerConfig, TEMPLATE_FILE_PATH, "", true, nullptr, INDEXER_TIMEOUT)};
     ASSERT_NO_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS));
 
-    nlohmann::json publishData;
-    expectedMetadata["index"]["_index"] = INDEXER_NAME;
-    expectedMetadata["index"]["_id"] = specialId;
-    publishData["id"] = specialId;
-    publishData["operation"] = "INSERTED";
-    publishData["data"] = "content";
-    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
-    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled.load(); }, MAX_INDEXER_PUBLISH_TIME_MS));
+    for (const auto& specialId : specialIds)
+    {
+        nlohmann::json publishData;
 
-    callbackCalled = false;
-    publishData.erase("data");
-    expectedMetadata.clear();
-    expectedMetadata["delete"]["_index"] = INDEXER_NAME;
-    expectedMetadata["delete"]["_id"] = specialId;
-    publishData["id"] = specialId;
-    publishData["operation"] = "DELETED";
-    ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
-    ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled.load(); }, MAX_INDEXER_PUBLISH_TIME_MS));
+        // INSERT first to populate the local RocksDB entry required by m_useSeekDelete.
+        callbackCalled = false;
+        expectedMetadata.clear();
+        expectedMetadata["index"]["_index"] = INDEXER_NAME;
+        expectedMetadata["index"]["_id"] = specialId;
+        publishData["id"] = specialId;
+        publishData["operation"] = "INSERTED";
+        publishData["data"] = "content";
+        ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+        ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled.load(); }, MAX_INDEXER_PUBLISH_TIME_MS));
+
+        callbackCalled = false;
+        publishData.erase("data");
+        expectedMetadata.clear();
+        expectedMetadata["delete"]["_index"] = INDEXER_NAME;
+        expectedMetadata["delete"]["_id"] = specialId;
+        publishData["id"] = specialId;
+        publishData["operation"] = "DELETED";
+        ASSERT_NO_THROW(indexerConnector.publish(publishData.dump()));
+        ASSERT_NO_THROW(waitUntil([&callbackCalled]() { return callbackCalled.load(); }, MAX_INDEXER_PUBLISH_TIME_MS));
+    }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR fixes `_id` not being escaped in `delete` bulk operations in `indexer-connector`, causing OpenSearch to reject requests with `json_parse_exception` when the document ID contains control characters.

## Proposed Changes

- The fix applies `needEscape / escapeJSONString` to the `_id` field in `builderBulkDelete`, matching the existing behavior in `builderBulkIndex`. To avoid duplicating the escape block in both builders, the logic was extracted into a shared static helper `appendEscapedId`, which both functions now call.
- Add component test `PublishDeletedWithSpecialCharId` to cover the control-byte ID path.


### Results and Evidence


<details><summary>Initial state - clean index</summary>

```console
root@manager:~# curl -s -k -u admin:admin \
  'https://10.2.0.9:9200/wazuh-states-inventory-system-*/_search?pretty' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"match_all":{}},"size":10}' | grep '"_id"'
        "_id" : "001_Ubuntu",
```

 **1 - inject a backslash into the agent's OS name**
 Single backslash followed by 'g': produces \g in JSON (invalid escape sequence)

```console
sed -i 's/^NAME=.*/NAME="Ubuntu\\gtest"/' /etc/os-release
systemctl restart wazuh-agent
```

**2 - verify INSERT in the system inventory index**

```console
root@manager:~# curl -s -k -u admin:admin \
  'https://10.2.0.9:9200/wazuh-states-inventory-system-*/_search?pretty' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"match_all":{}},"size":10}' | grep '"_id"'
        "_id" : "001_Ubuntu\\gtest",
```

-  INSERT succeeds because builderBulkIndex already escaped the _id.

 **3 - restore OS name to trigger the DELETED operation**

```console
sed -i 's/^NAME=.*/NAME="Ubuntu"/' /etc/os-release
systemctl restart wazuh-agent
```

**4 - DELETE fails: orphan document persists**

```console
root@manager:~# curl -s -k -u admin:admin \
  'https://10.2.0.9:9200/wazuh-states-inventory-system-*/_search?pretty' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"match_all":{}},"size":10}' | grep '"_id"'
        "_id" : "001_Ubuntu\\gtest",
        "_id" : "001_Ubuntu",

root@manager:~# grep -E "json_parse_exception" /var/ossec/logs/ossec.log
2026/03/31 08:02:42 indexer-connector: WARNING: Document operation failed for index 'wazuh-states-inventory-system-manager' - type: 'json_parse_exception', reason: 'Unrecognized character escape 'g' (code 103)
2026/03/31 08:02:42 indexer-connector: ERROR: Client error, status code: 400, response body: {"error":{"root_cause":[{"type":"json_parse_exception","reason":"Unrecognized character escape 'g' (code 103)\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 79]"}],"type":"json_parse_exception","reason":"Unrecognized character escape 'g' (code 103)\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 79]"},"status":400}.

```
</details>

<details><summary>Fixed - manager2 </summary>

```console
root@manager2:~# curl -s -k -u admin:admin \
  'https://10.2.0.11:9200/wazuh-states-inventory-system-*/_search?pretty' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"match_all":{}},"size":10}' | grep '"_id"'
        "_id" : "001_Ubuntu",
```

 (inject backslash on agent, same steps as above)

```console
root@manager2:~# curl -s -k -u admin:admin \
  'https://10.2.0.11:9200/wazuh-states-inventory-system-*/_search?pretty' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"match_all":{}},"size":10}' | grep '"_id"'
        "_id" : "001_Ubuntu\\gtest",
```

 (restore agent to trigger DELETE)

```console
root@manager2:~# curl -s -k -u admin:admin \
  'https://10.2.0.11:9200/wazuh-states-inventory-system-*/_search?pretty' \
  -H 'Content-Type: application/json' \
  -d '{"query":{"match_all":{}},"size":10}' | grep '"_id"'
        "_id" : "001_Ubuntu",
```

No warnings, no errors:

```console
root@manager2:~# grep -E "json_parse_exception" /var/ossec/logs/ossec.log
root@manager2:~#
```

</details>

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

Component test `PublishDeletedWithSpecialCharId` in `indexerConnector_test.cpp`: publishes a `DELETED` event with a control-byte ID (`\x04`) and verifies the bulk request sent to the indexer is valid JSON with the ID correctly escaped.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
