### PR TITLE
Add `--set-as-main` flag support to repository bumper

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -23,6 +23,11 @@ on:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
         type: string
+      set-as-main:
+        description: 'Update version values only, preserving main branch references in URLs'
+        default: false
+        required: false
+        type: boolean
       id:
         description: 'Optional identifier for the run'
         required: false
@@ -82,16 +87,19 @@ jobs:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
           DATE: ${{ inputs.date }}
+          SET_AS_MAIN: ${{ inputs.set-as-main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
           date=${{ env.DATE }}
+          set_as_main=${{ env.SET_AS_MAIN }}
 
           # Both version and stage provided
           [[ -n "$version" ]] && script_params+="--version $version "
           [[ -n "$stage"   ]] && script_params+="--stage $stage "
           [[ -n "$date"    ]] && script_params+="--date $date "
+          [[ "$set_as_main" == "true" ]] && script_params+="--set-as-main "
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
           BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
@@ -108,13 +116,21 @@ jobs:
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
       - name: Commit and push changes
+        id: commit_changes
         run: |
           git add .
+          if git diff --cached --quiet; then
+            echo "No changes detected, skipping PR creation."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           git commit -m "feat: bump ${{ github.ref_name }}"
           git push origin ${{ steps.vars.outputs.branch_name }}
+          echo "has_changes=true" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         id: create_pr
+        if: steps.commit_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -127,6 +143,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.commit_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -15,6 +15,7 @@ PATTERN_STAGE='^(alpha|beta|rc)[0-9]{1,2}$'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 date_time=$(date '+%Y-%m-%d_%H-%M-%S')
 LOG_FILE="${SCRIPT_DIR}/repository_bumper_${date_time}.log"
+skip_urls=""
 
 log_action() {
     local message="$1"
@@ -325,13 +326,7 @@ update_file_api() {
             | sed -E "s/^[[:space:]]*version='([^']+)'.*/\1/"
         )
 
-        local current_spec_version
-        current_spec_version=$(
-            grep -E "^[[:space:]]*version:[[:space:]]*'" "$spec_file" \
-            | sed -E "s/^[[:space:]]*version:[[:space:]]*'([0-9]+\.[0-9]+\.[0-9]+)'.*/\1/"
-        )
-
-        # Only if the version in setup.py does NOT match new_version, we apply changes
+        # Only if the version in setup.py does NOT match new_version, update version fields
         if [[ "$current_setup_version" != "$new_version" ]]; then
             sed -i -E \
                 "s|^([[:space:]]*version=')[^']+(',)|\1${new_version}\2|" \
@@ -341,17 +336,24 @@ update_file_api() {
                 "s|^([[:space:]]*version:[[:space:]]*')[0-9]+\.[0-9]+\.[0-9]+(')|\1${new_version}\2|" \
                 "$spec_file"
 
-            sed -i -E \
-                "s|(\/v)[0-9]+\.[0-9]+\.[0-9]+(/)|\1${new_version}\2|g" \
-                "$spec_file"
-
-            local version_short
-            version_short=$(echo "$new_version" | awk -F. '{print $1 "." $2}')
-            sed -i -E \
-                "s|(com/)[0-9]+\.[0-9]+(/)|\1${version_short}\2|g" \
-                "$spec_file"
-
             log_action "Updated version to '${new_version}' in: $setup_file and $spec_file"
+        fi
+
+        # URL updates run independently of setup.py version to support two-step bump flow:
+        # step 1 (--set-as-main) updates version values only, skipping all URL rewrites;
+        # step 2 (no flag) replaces all URL refs (main or versioned) even when setup.py
+        # already has the target version.
+        local version_short
+        version_short=$(echo "$new_version" | awk -F. '{print $1 "." $2}')
+        if [[ -z "$skip_urls" ]]; then
+            # blob/ paths use 3-part version with v prefix (e.g. blob/v5.0.0/)
+            sed -i -E \
+                "s~(blob/)(v?main|v[0-9]+\.[0-9]+\.[0-9]+)(/)~\1v${new_version}\3~g" \
+                "$spec_file"
+            # documentation URLs use 2-part version without v prefix (e.g. wazuh.com/5.0/)
+            sed -i -E \
+                "s~(wazuh\.com/)(main|[0-9]+\.[0-9]+)(/)~\1${version_short}\3~g" \
+                "$spec_file"
         fi
     fi
 
@@ -548,10 +550,11 @@ update_version() {
 }
 
 usage() {
-    echo "Usage: $0 --version VERSION --stage STAGE --date DATE"
+    echo "Usage: $0 --version VERSION --stage STAGE --date DATE [--set-as-main]"
     echo "  --version VERSION   Version number (e.g., 4.9.1)"
     echo "  --stage STAGE       Stage name (e.g., alpha, beta, rc)"
     echo "  --date DATE         Release date in format YYYY-MM-DD (e.g., 2025-04-14)"
+    echo "  --set-as-main       Update version values only, skipping all URL rewrites"
 }
 
 parse_args() {
@@ -568,6 +571,10 @@ parse_args() {
         --date)
             new_date="$2"
             shift 2
+            ;;
+        --set-as-main)
+            skip_urls=true
+            shift
             ;;
         *)
             echo "Unknown option: $1"


### PR DESCRIPTION
Adds `--set-as-main` flag to `repository_bumper.sh` and the corresponding workflow input.

## Changes

- **`tools/repository_bumper.sh`**: new `--set-as-main` flag that sets `skip_urls=true`, preserving `main` branch references in URLs while still updating version/stage values
- **`.github/workflows/5_bumper_repository.yml`**: new `set-as-main` boolean input, forwarded to the script; no-op handling skips commit/PR if no files were modified

Closes #35171