### PR TITLE
Serialize mtime as string to fix epoch display in FIM inventory

### DIFF
--- a/src/syscheckd/src/file/events.c
+++ b/src/syscheckd/src/file/events.c
@@ -9,6 +9,19 @@
 
 #include "syscheck.h"
 
+#ifdef WIN32
+#define gmtime_r(x, y) (gmtime_s(y, x) == 0 ? (y) : NULL)
+#endif
+
+bool fim_epoch_to_iso8601(time_t timestamp, char *buffer, size_t buffer_size) {
+    struct tm tm_info;
+    if (gmtime_r(&timestamp, &tm_info) &&
+        strftime(buffer, buffer_size, "%Y-%m-%dT%H:%M:%S.000Z", &tm_info) > 0) {
+        return true;
+    }
+    return false;
+}
+
 void fim_calculate_dbsync_difference(const directory_t *configuration,
                                      const cJSON* old_data,
                                      cJSON* changed_attributes,
@@ -116,7 +129,17 @@ void fim_calculate_dbsync_difference(const directory_t *configuration,
 
     if (configuration->options & CHECK_MTIME) {
         if (aux = cJSON_GetObjectItem(old_data, "mtime"), aux != NULL) {
-            cJSON_AddNumberToObject(old_attributes, "mtime", aux->valueint);
+            if (cJSON_IsString(aux)) {
+                cJSON_AddStringToObject(old_attributes, "mtime", cJSON_GetStringValue(aux));
+            } else if (cJSON_IsNumber(aux)) {
+                char mtime_str[25];
+                time_t t = (time_t)cJSON_GetNumberValue(aux);
+                if (fim_epoch_to_iso8601(t, mtime_str, sizeof(mtime_str))) {
+                    cJSON_AddStringToObject(old_attributes, "mtime", mtime_str);
+                } else {
+                    cJSON_AddNumberToObject(old_attributes, "mtime", cJSON_GetNumberValue(aux));
+                }
+            }
             cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("file.mtime"));
         }
     }
@@ -239,7 +262,12 @@ cJSON * fim_attributes_json(const cJSON *dbsync_event, const fim_file_data *data
         }
 
         if (configuration->options & CHECK_MTIME) {
-            cJSON_AddNumberToObject(attributes, "mtime", data->mtime);
+            char mtime_str[25];
+            if (fim_epoch_to_iso8601((time_t)data->mtime, mtime_str, sizeof(mtime_str))) {
+                cJSON_AddStringToObject(attributes, "mtime", mtime_str);
+            } else {
+                cJSON_AddNumberToObject(attributes, "mtime", data->mtime);
+            }
         }
 
         bool has_hash = false;
@@ -375,7 +403,17 @@ cJSON * fim_attributes_json(const cJSON *dbsync_event, const fim_file_data *data
 
         if (configuration->options & CHECK_MTIME) {
             if (aux = cJSON_GetObjectItem(dbsync_event, "mtime"), aux != NULL) {
-                cJSON_AddNumberToObject(attributes, "mtime", aux->valueint);
+                if (cJSON_IsString(aux)) {
+                    cJSON_AddStringToObject(attributes, "mtime", cJSON_GetStringValue(aux));
+                } else if (cJSON_IsNumber(aux)) {
+                    char mtime_str[25];
+                    time_t t = (time_t)cJSON_GetNumberValue(aux);
+                    if (fim_epoch_to_iso8601(t, mtime_str, sizeof(mtime_str))) {
+                        cJSON_AddStringToObject(attributes, "mtime", mtime_str);
+                    } else {
+                        cJSON_AddNumberToObject(attributes, "mtime", cJSON_GetNumberValue(aux));
+                    }
+                }
             }
         }
 

--- a/src/syscheckd/src/file/file.h
+++ b/src/syscheckd/src/file/file.h
@@ -200,6 +200,16 @@ void fim_handle_delete_by_path(const char *path,
 void fim_file_scan();
 
 /**
+ * @brief Convert a Unix epoch timestamp to ISO8601 format (%Y-%m-%dT%H:%M:%S.000Z).
+ *
+ * @param timestamp Unix epoch timestamp (seconds).
+ * @param buffer Output buffer to write the formatted string.
+ * @param buffer_size Size of the output buffer (must be >= 25).
+ * @return true on success, false if the conversion fails.
+ */
+bool fim_epoch_to_iso8601(time_t timestamp, char *buffer, size_t buffer_size);
+
+/**
  * @brief Create file attribute set JSON from a FIM entry structure
  *
  * @param dbsync_event Pointer to event dbsync JSON structure.

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -660,6 +660,29 @@ void expect_get_data (char *user, char *group, char *file_path, int calculate_ch
 }
 
 /* tests */
+
+/* fim_epoch_to_iso8601 */
+static void test_fim_epoch_to_iso8601_known_date(void **state) {
+    (void)state;
+    char buffer[25];
+    // 2019-10-04T10:17:03 UTC
+    assert_true(fim_epoch_to_iso8601(1570184223, buffer, sizeof(buffer)));
+    assert_string_equal(buffer, "2019-10-04T10:17:03.000Z");
+}
+
+static void test_fim_epoch_to_iso8601_epoch_zero(void **state) {
+    (void)state;
+    char buffer[25];
+    assert_true(fim_epoch_to_iso8601(0, buffer, sizeof(buffer)));
+    assert_string_equal(buffer, "1970-01-01T00:00:00.000Z");
+}
+
+static void test_fim_epoch_to_iso8601_buffer_too_small(void **state) {
+    (void)state;
+    char buffer[5];
+    assert_false(fim_epoch_to_iso8601(1570184223, buffer, sizeof(buffer)));
+}
+
 static void test_fim_attributes_json(void **state) {
     fim_data_t *fim_data = *state;
     directory_t configuration = { .options = -1 };
@@ -695,7 +718,7 @@ static void test_fim_attributes_json(void **state) {
     assert_string_equal(inode->valuestring, "606060");
     cJSON *mtime = cJSON_GetObjectItem(fim_data->json, "mtime");
     assert_non_null(mtime);
-    assert_int_equal(mtime->valueint, 1570184223);
+    assert_string_equal(mtime->valuestring, "2019-10-04T10:17:03.000Z");
     cJSON *hash = cJSON_GetObjectItem(fim_data->json, "hash");
     assert_non_null(hash);
     cJSON *hash_md5 = cJSON_GetObjectItem(hash, "md5");
@@ -3800,7 +3823,7 @@ void test_fim_calculate_dbsync_difference(void **state){
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "gid")->valuestring, "1000");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "owner")->valuestring, "root");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "group")->valuestring, "root");
-    assert_int_equal(cJSON_GetObjectItem(old_attributes, "mtime")->valueint, 123456789);
+    assert_string_equal(cJSON_GetObjectItem(old_attributes, "mtime")->valuestring, "1973-11-29T21:33:09.000Z");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "inode")->valuestring, "1");
     cJSON* hash = cJSON_GetObjectItem(old_attributes, "hash");
     assert_non_null(hash);
@@ -3903,7 +3926,7 @@ static void test_dbsync_attributes_json(void **state) {
     directory_t configuration = { .options = -1, .tag = "tag_name" };
     json_struct_t *data = *state;
 #ifndef TEST_WINAGENT
-    const char *result_str = "{\"size\":11,\"permissions\":[\"rw-r--r--\"],\"uid\":\"0\",\"owner\":\"root\",\"gid\":\"0\",\"group\":\"root\",\"inode\":\"271017\",\"device\":\"64768\",\"mtime\":1646124392,\"hash\":{\"md5\":\"d73b04b0e696b0945283defa3eee4538\",\"sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\"}}";
+    const char *result_str = "{\"size\":11,\"permissions\":[\"rw-r--r--\"],\"uid\":\"0\",\"owner\":\"root\",\"gid\":\"0\",\"group\":\"root\",\"inode\":\"271017\",\"device\":\"64768\",\"mtime\":\"2022-03-01T08:46:32.000Z\",\"hash\":{\"md5\":\"d73b04b0e696b0945283defa3eee4538\",\"sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\"}}";
     cJSON *dbsync_event = cJSON_Parse("{\"attributes\":\"\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\",\"device\":64768,\"gid\":\"0\",\"group_\":\"root\",\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"inode\":\"271017\",\"mtime\":1646124392,\"path\":\"/etc/testfile\",\"permissions\":\"rw-r--r--\",\"size\":11,\"uid\":\"0\",\"owner\":\"root\"}");
 #else
     cJSON *dbsync_event = cJSON_Parse("{\"size\":0, \"permissions\":\"{\\\"S-1-5-32-544\\\":{\\\"name\\\":\\\"Administrators\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]},\\\"S-1-5-18\\\":{\\\"name\\\":\\\"SYSTEM\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]},\\\"S-1-5-32-545\\\":{\\\"name\\\":\\\"Users\\\",\\\"allowed\\\":[\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"read_ea\\\",\\\"execute\\\",\\\"read_attributes\\\"]},\\\"S-1-5-11\\\":{\\\"name\\\":\\\"Authenticated Users\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]}}\", \"attributes\":\"ARCHIVE\", \"uid\":\"0\", \"gid\":\"0\", \
@@ -3916,7 +3939,7 @@ static void test_dbsync_attributes_json(void **state) {
         "\"{\\\"S-1-5-18\\\":{\\\"name\\\":\\\"SYSTEM\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]}}\","
         "\"{\\\"S-1-5-32-545\\\":{\\\"name\\\":\\\"Users\\\",\\\"allowed\\\":[\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"read_ea\\\",\\\"execute\\\",\\\"read_attributes\\\"]}}\","
         "\"{\\\"S-1-5-11\\\":{\\\"name\\\":\\\"Authenticated Users\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]}}\"],"
-        "\"uid\":\"0\",\"owner\":\"Administrators\",\"gid\":\"0\",\"inode\":\"0\",\"mtime\":1646145212,"
+        "\"uid\":\"0\",\"owner\":\"Administrators\",\"gid\":\"0\",\"inode\":\"0\",\"mtime\":\"2022-03-01T14:33:32.000Z\","
         "\"hash\":{\"md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"},"
         "\"attributes\":[\"ARCHIVE\"]}";
 
@@ -4096,9 +4119,15 @@ int main(void) {
         cmocka_unit_test(test_update_wildcards_config_remove_config),
         cmocka_unit_test(test_update_wildcards_config_list_null),
     };
+    const struct CMUnitTest epoch_to_iso8601_tests[] = {
+        cmocka_unit_test(test_fim_epoch_to_iso8601_known_date),
+        cmocka_unit_test(test_fim_epoch_to_iso8601_epoch_zero),
+        cmocka_unit_test(test_fim_epoch_to_iso8601_buffer_too_small),
+    };
     int retval;
 
-    retval = cmocka_run_group_tests(tests, setup_group, teardown_group);
+    retval = cmocka_run_group_tests(epoch_to_iso8601_tests, NULL, NULL);
+    retval += cmocka_run_group_tests(tests, setup_group, teardown_group);
     retval += cmocka_run_group_tests(fim_regex_tests, setup_fim_regex_group, teardown_group);
     retval += cmocka_run_group_tests(root_monitor_tests, setup_root_group, teardown_group);
     retval += cmocka_run_group_tests(wildcards_tests, setup_wildcards, teardown_wildcards);


### PR DESCRIPTION
## Description

Closes #35162

The FIM inventory dashboard shows `file.mtime` as `1970-01-01` for Linux and macOS agents, despite `fim.db` storing accurate timestamps. The root cause is that `fim_attributes_json()` in `events.c` serializes `mtime` as a raw Unix integer via `cJSON_AddNumberToObject`. OpenSearch's `date` field type interprets bare integers as **milliseconds** since epoch, so a most values are collapsing to early January 1970 in the dashboard.

In Wazuh 4.x, the manager's `analysisd/format/to_json.c` converted epoch integers to ISO8601 strings before indexing. When the 5.x stateful FIM inventory pipeline was introduced the integer serialization was carried over from 4.x's `create_db.c`, but the server-side date conversion was not replicated.

### Fix

Convert `mtime` from integer to ISO8601 string (`%Y-%m-%dT%H:%M:%S.000Z`) at the serialization point in `fim_attributes_json()` and `fim_calculate_dbsync_difference()`, using `gmtime_r`/`strftime`. On the unlikely event that time conversion fails, the original integer is preserved as fallback.

The fix is scoped to `events.c` only. `dbFileItem.cpp` and `dbRegistryKey.cpp` (`createJSON()`) are intentionally left unchanged: they feed `dbsync` which writes to `fim.db` where the schema declares `mtime INTEGER`. Converting to ISO8601 at the storage layer would cause SQLite to coerce the string to the year prefix (e.g., `"2020-01-03T..."` → `2020`), corrupting the DB roundtrip.

## Changed Files

| File | Change |
|---|---|
| `src/syscheckd/src/file/events.c` | Convert mtime to ISO8601 in `fim_attributes_json()` (both `data` and `dbsync_event` paths) and `fim_calculate_dbsync_difference()`. Add `#ifdef WIN32` shim mapping `gmtime_r` to `gmtime_s`. Use `cJSON_GetNumberValue` instead of `valueint` to avoid int32 truncation. |
| `src/unit_tests/syscheckd/test_fim_scan.c` | Update `test_fim_attributes_json`, `test_dbsync_attributes_json`, and `test_fim_calculate_dbsync_difference` assertions to expect ISO8601 strings. |


## Results and Evidence

### Before the fix

Querying the FIM inventory index for the unpatched agent returns raw Unix timestamps as integers. OpenSearch interprets these as milliseconds since epoch, so the dashboard renders dates near 1970-01-01.

```bash
$ curl -sk -u admin:admin 'https://localhost:9200/wazuh-states-fim-files/_search' \
    -H 'Content-Type: application/json' \
    -d '{"size":5,"sort":[{"file.mtime":{"order":"desc"}}],"query":{"term":{"wazuh.agent.id":"003"}}}' \
  | jq -r '.hits.hits[]._source | "\(.file.path) -> \(.file.mtime)"'

/etc/resolv.conf -> 1775046470
/etc/hosts -> 1775046470
/etc/hostname -> 1775046470
/etc/ld.so.cache -> 1775046421
/etc/group -> 1775046420
```

<img width="642" height="315" alt="image" src="https://github.com/user-attachments/assets/63b30f7b-fc0c-4dc4-8b2e-0796d443e1bf" />


### After the fix

The same query against the patched agent returns ISO8601 strings. OpenSearch interprets these correctly and the dashboard renders accurate modification dates.

```bash
$ curl -sk -u admin:admin 'https://localhost:9200/wazuh-states-fim-files/_search' \
    -H 'Content-Type: application/json' \
    -d '{"size":5,"sort":[{"file.mtime":{"order":"desc"}}],"query":{"term":{"wazuh.agent.id":"002"}}}' \
  | jq -r '.hits.hits[]._source | "\(.file.path) -> \(.file.mtime)"'

/etc/ld.so.cache -> 2026-03-30T14:07:30.000Z
/etc/group -> 2026-03-30T13:02:16.000Z
/etc/passwd -> 2026-03-30T13:02:16.000Z
/etc/shadow -> 2026-03-30T13:02:16.000Z
/etc/gshadow -> 2026-03-30T13:02:16.000Z
```
<img width="610" height="350" alt="image" src="https://github.com/user-attachments/assets/1b4f9e4e-15ce-4eb9-bbd5-e8302d438c45" />


## Artifacts Affected

- `wazuh-agentd` / `wazuh-syscheckd` (Linux, macOS) - FIM inventory sync and FIM change alerts
- `libfimdb.so` - `FileItem::createJSON()`, `RegistryKey::createJSON()`

## Configuration Changes

- N/A

## Documentation Updates

- N/A

## Tests Introduced

Updated expected values in `test_fim_scan.c` to reflect the new ISO8601 output:

| Test | Change |
|---|---|
| `test_fim_attributes_json` | `mtime->valueint == 1570184223` → `mtime->valuestring == "2019-10-04T10:17:03.000Z"` |
| `test_fim_calculate_dbsync_difference` | `mtime->valueint == 123456789` → `mtime->valuestring == "1973-11-29T21:33:09.000Z"` |
| `test_dbsync_attributes_json` | `"mtime":1646124392` → `"mtime":"2022-03-01T08:46:32.000Z"` (Linux), `"mtime":1646145212` → `"mtime":"2022-03-01T14:33:32.000Z"` (Windows) |


## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
