### PR TITLE
Improve disable-account active response to terminate active user sessions

### DIFF
--- a/src/active-response/src/disable-account.c
+++ b/src/active-response/src/disable-account.c
@@ -69,6 +69,36 @@ int main (int argc, char **argv) {
     }
 
     if (!strcmp("Linux", uname_buffer.sysname)) {
+        if (action == ADD_COMMAND) {
+            char *pkill_path = NULL;
+
+            if (get_binary_path("pkill", &pkill_path) == 0) {
+                char *exec_pkill[6] = { pkill_path, "-KILL", "-u", (char *)user, ".*", NULL };
+
+                wfd_t *wfd_pkill = wpopenv(pkill_path, exec_pkill, W_BIND_STDERR);
+                if (wfd_pkill) {
+                    int result = wpclose(wfd_pkill);
+                    if (WIFEXITED(result) && WEXITSTATUS(result) == 0) {
+                        write_debug_file(argv[0], "Terminated active user sessions");
+                    } else if (WIFEXITED(result) && WEXITSTATUS(result) == 1) {
+                        write_debug_file(argv[0], "No active sessions to terminate");
+                    } else {
+                        memset(log_msg, '\0', OS_MAXSTR);
+                        snprintf(log_msg, OS_MAXSTR -1, "Warning: pkill failed with exit code %d",
+                                 WIFEXITED(result) ? WEXITSTATUS(result) : -1);
+                        write_debug_file(argv[0], log_msg);
+                    }
+                } else {
+                    memset(log_msg, '\0', OS_MAXSTR);
+                    snprintf(log_msg, OS_MAXSTR -1, "Warning: Could not execute pkill: %s", strerror(errno));
+                    write_debug_file(argv[0], log_msg);
+                }
+                os_free(pkill_path);
+            } else {
+                write_debug_file(argv[0], "Warning: pkill not found, active sessions will not be terminated");
+            }
+        }
+
         // Checking if passwd is present
         if (get_binary_path("passwd", &cmd_path) < 0) {
             memset(log_msg, '\0', OS_MAXSTR);


### PR DESCRIPTION
## Description

Closes #35085

This PR enhances the `disable-account` active response executable to address a critical security gap where users with active sessions remain logged in after their account is blocked.

**Current behavior:** When `disable-account` is triggered, it executes `passwd -l <username>` to block the account. However, this only prevents new login attempts. Any existing active sessions (SSH, TTY, etc.) and running processes remain active, allowing the blocked user to continue working.

**Proposed solution:** Modify `disable-account` to terminate all active user sessions before blocking the account by executing `pkill -KILL -u <username>` followed by `passwd -l <username>`, ensuring complete account lockdown.

## Proposed Changes

Modified `src/active-response/src/disable-account.c` to add session termination logic in the ADD_COMMAND flow (lines 72-93):

- Executes `pkill -KILL -u <username>` before `passwd -l`
- Only runs on ADD command (blocking), not DELETE (unblocking)
- Graceful degradation: if `pkill` unavailable, logs warning and continues with account blocking
- Uses existing Wazuh utilities (`get_binary_path`, `wpopenv`, `write_debug_file`)
- Linux-only implementation (checked via `uname`)

### Results and Evidence

#### Stateless - user:  sshtest 🟢

<details><summary>ossec.log</summary>

```
2026/03/31 13:17:43 wazuh-execd[7703] execd.c:580 at ExecdStart(): DEBUG: Received message: '{"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateless"},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"}}'
2026/03/31 13:17:43 wazuh-execd[7703] execd.c:298 at ExecdRun(): DEBUG: Executing command 'active-response/bin/disable-account {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateless"},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"add"}'
```

</details> 

<details><summary>active-responses.log</summary>

```log
2026/03/31 13:17:43 active-response/bin/disable-account: Starting
2026/03/31 13:17:43 active-response/bin/disable-account: {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateless"},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"add"}

2026/03/31 13:17:43 active-response/bin/disable-account: {"version":1,"origin":{"name":"disable-account","module":"active-response"},"command":"check_keys","parameters":{"keys":["sshtest"]}}
2026/03/31 13:17:43 active-response/bin/disable-account: {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateless"},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"continue"}

2026/03/31 13:17:43 active-response/bin/disable-account: Terminated active user sessions
2026/03/31 13:17:43 active-response/bin/disable-account: Ended
```

</details>

<details><summary>Check</summary>

```console
# ssh sshtest@localhost -p 2222
sshtest@localhost's password: 
Welcome to Ubuntu 24.04.3 LTS (GNU/Linux 6.8.0-106-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.
Last login: Tue Mar 31 13:03:54 2026 from ::1
sshtest@dd4c300576e9:~$ Connection to localhost closed by remote host.
Connection to localhost closed.
# ssh sshtest@localhost -p 2222
sshtest@localhost's password: 
Permission denied, please try again.
sshtest@localhost's password: 
Permission denied, please try again.
sshtest@localhost's password: 
sshtest@localhost: Permission denied (publickey,password).
```

</details>  


#### Stateful - 60s - user:  sshtest 🟢

<details><summary>ossec.log</summary>

```
2026/03/31 13:32:52 wazuh-execd[7703] execd.c:580 at ExecdStart(): DEBUG: Received message: '{"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"}}'
2026/03/31 13:32:52 wazuh-execd[7703] execd.c:298 at ExecdRun(): DEBUG: Executing command 'active-response/bin/disable-account {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"add"}'
2026/03/31 13:32:52 wazuh-execd[7703] execd.c:445 at ExecdRun(): DEBUG: Adding command 'active-response/bin/disable-account {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"delete"}' to the timeout list, with a timeout of '60s'.
2026/03/31 13:33:53 wazuh-execd[7703] execd.c:169 at ExecdTimeoutRun(): DEBUG: Executing command 'active-response/bin/disable-account {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"delete"}' after a timeout of '60s'
```

</details> 

<details><summary>active-responses.log</summary>

```log
2026/03/31 13:32:52 active-response/bin/disable-account: Starting
2026/03/31 13:32:52 active-response/bin/disable-account: {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"add"}

2026/03/31 13:32:52 active-response/bin/disable-account: {"version":1,"origin":{"name":"disable-account","module":"active-response"},"command":"check_keys","parameters":{"keys":["sshtest"]}}
2026/03/31 13:32:52 active-response/bin/disable-account: {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"continue"}

2026/03/31 13:32:52 active-response/bin/disable-account: Terminated active user sessions
2026/03/31 13:32:52 active-response/bin/disable-account: Ended
2026/03/31 13:33:53 active-response/bin/disable-account: Starting
2026/03/31 13:33:53 active-response/bin/disable-account: {"wazuh":{"active_response":{"name":"disable-account","executable":"disable-account","location":"defined-agent","agent_id":"001","type":"stateful","stateful_timeout":60},"protocol":{"queue":49,"location":"journald"},"agent":{"host":{"os":{"name":"Ubuntu","version":"24.04.2 LTS","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"test-agent"},"id":"001","name":"test-agent","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"system-activity","name":"syslog","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0"]},"space":{"name":"standard"}},"event":{"original":"Test AR trigger from send_ar.py - srcip: 10.0.0.1, user: sshtest","start":"2025-01-01T00:00:00.000Z","kind":"event"},"@timestamp":"2025-01-01T00:00:05Z","process":{"pid":1,"name":"send_ar_test"},"message":"Test AR: disable-account, srcip=10.0.0.1, user=sshtest","host":{"hostname":"test-agent"},"related":{"hosts":["test-agent"]},"user":{"name":"sshtest"},"source":{"ip":"10.0.0.1","port":35132,"address":"10.0.0.1"},"command":"delete"}

2026/03/31 13:33:53 active-response/bin/disable-account: Ended
```

</details>

<details><summary>Check</summary>

```console
# ssh sshtest@localhost -p 2222
sshtest@localhost's password: 
Welcome to Ubuntu 24.04.3 LTS (GNU/Linux 6.8.0-106-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.
Last login: Tue Mar 31 13:09:23 2026 from ::1
sshtest@dd4c300576e9:~$ Connection to localhost closed by remote host.
Connection to localhost closed.
# ssh sshtest@localhost -p 2222
sshtest@localhost's password: 
Permission denied, please try again.
sshtest@localhost's password: 
Permission denied, please try again.
sshtest@localhost's password: 
sshtest@localhost: Permission denied (publickey,password).
```

After 60s:

```console
# ssh sshtest@localhost -p 2222
sshtest@localhost's password: 
Welcome to Ubuntu 24.04.3 LTS (GNU/Linux 6.8.0-106-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.
Last login: Tue Mar 31 13:31:38 2026 from ::1
sshtest@dd4c300576e9:~$
```

</details>  

### Artifacts Affected

- `active-response/bin/disable-account` (Linux agent binary)

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

