### PR TITLE
Improving the windows agent restart mechanism used by the control channel

### DIFF
--- a/src/client-agent/src/control.c
+++ b/src/client-agent/src/control.c
@@ -26,7 +26,8 @@
  * @param output  Allocated response string set by this function.
  * @return size_t Length of *output.
  */
-static size_t control_run_detached(const char *action, char **output) {
+static size_t control_run_detached(const char *action, char **output)
+{
     STARTUPINFOA si;
     PROCESS_INFORMATION pi;
     char exe[MAX_PATH];
@@ -44,15 +45,18 @@ static size_t control_run_detached(const char *action, char **output) {
         return strlen(*output);
     }
 
-    snprintf(cmd, sizeof(cmd), "\"%s\" service-restart", exe);
+    int ret = snprintf(cmd, sizeof(cmd), "\"%s\" service-restart", exe);
+
+    if (ret < 0 || ret >= (int)sizeof(cmd)) {
+        os_strdup("err command line too long", *output);
+        return strlen(*output);
+    }
 
     ZeroMemory(&si, sizeof(si));
     si.cb = sizeof(si);
     ZeroMemory(&pi, sizeof(pi));
 
-    if (!CreateProcessA(NULL, cmd, NULL, NULL, FALSE,
-                        CREATE_NO_WINDOW | DETACHED_PROCESS,
-                        NULL, NULL, &si, &pi)) {
+    if (!CreateProcessA(NULL, cmd, NULL, NULL, FALSE, CREATE_NO_WINDOW | DETACHED_PROCESS, NULL, NULL, &si, &pi)) {
         mdebug1("CONTROL: CreateProcess failed for '%s' (error %lu).", action, GetLastError());
         os_strdup("err CreateProcess failed", *output);
         return strlen(*output);
@@ -66,7 +70,8 @@ static size_t control_run_detached(const char *action, char **output) {
     return strlen(*output);
 }
 
-size_t control_dispatch(char *command, char **output) {
+size_t control_dispatch(char *command, char **output)
+{
     char *args = strchr(command, ' ');
     if (args) {
         *args = '\0';

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -328,12 +328,14 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam,
                         config_read(hwnd);
                         gen_server_info(hwnd);
 
-                        SendMessage(hStatus, SB_SETTEXT, 0, (LPARAM)"Stopped");
-                        MessageBox(hwnd, "Agent stopped",
-                                   "Agent Stopped", MB_OK);
-                    } else {
-                        MessageBox(hwnd, "Agent already stopped",
-                                   "Agent Stopped", MB_OK);
+                        SendMessage(hStatus, SB_SETTEXT, 0, (LPARAM) "Stopped");
+                        MessageBox(hwnd, "Agent stopped", "Agent Stopped", MB_OK);
+                    }
+                    else if (ret_code == -1) {
+                        MessageBox(hwnd, "Agent already stopped", "Agent Stopped", MB_OK);
+                    }
+                    else {
+                        MessageBox(hwnd, "Unable to stop agent", "Error -- Unable to Stop Agent", MB_OK);
                     }
                     break;
                 case UI_MENU_MANAGE_STATUS:

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -51,6 +51,10 @@ int main(int argc, char **argv)
     char mypath[OS_MAXSTR + 1];
     char myfinalpath[OS_MAXSTR + 1];
     char myfile[OS_MAXSTR + 1];
+    DWORD startTime = 0;
+    const DWORD timeoutMs = 30000;           // 30 seconds
+    const DWORD sleepIntervalMs = 500;       // 0.5 seconds
+    const DWORD waitForServiceStopMs = 1000; // 1 second
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -90,12 +94,27 @@ int main(int argc, char **argv)
             /* Invoked by control_run_detached() as a detached process.
              * Sleep briefly so the calling service has time to send its "ok"
              * response before we stop it, then perform stop + start. */
-            Sleep(1000);
-            os_stop_service();
-            while (CheckServiceRunning()) {
-                Sleep(500);
+            Sleep(waitForServiceStopMs);
+            /* Attempt to send the SERVICE_CONTROL_STOP command.
+             * If this fails, the stop signal was not delivered to the SCM,
+             * so there is no point in waiting for the service to stop. */
+            if (os_stop_service() == 0) {
+                plain_merror("Failure running stop service.");
+                return 1;
             }
-            os_start_service();
+            /* Wait until the service fully transitions to the STOPPED state. */
+            startTime = GetTickCount();
+            while (CheckServiceRunning()) {
+                if (GetTickCount() - startTime > timeoutMs) {
+                    plain_merror("Failure service did not stop within the expected time.");
+                    return 1;
+                }
+                Sleep(sleepIntervalMs);
+            }
+            if (os_start_service() == 0) {
+                plain_merror("Failure running start service.");
+                return 1;
+            }
             return 0;
         } else if (strcmp(argv[1], "/?") == 0) {
             agent_help();

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -81,6 +81,9 @@ int os_stop_service()
             if (ControlService(schService, SERVICE_CONTROL_STOP, &lpServiceStatus)) {
                 rc = 1;
             }
+            else if (GetLastError() == ERROR_SERVICE_NOT_ACTIVE) {
+                rc = -1; /* already stopped — not a real error */
+            }
 
             CloseServiceHandle(schService);
         }
@@ -92,7 +95,9 @@ int os_stop_service()
     * Sleep for a short period of time to avoid possible race-conditions with
     * newer instances of wazuh-agent.
     */
-    Sleep(300); //milliseconds
+    if (rc == 1 || rc == -1) {
+        Sleep(300);
+    }
 
     return (rc);
 }


### PR DESCRIPTION

<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description
  This PR improves the robustness of the Windows agent restart/reload mechanism triggered via the control channel.
                                                                                                                                                                              
  Changes
                                                                                                                                                                              
  src/win32/win_agent.c                                                                                                                                                       
  - Added a timeout guard (30 s) to the service-restart stop loop — the agent now exits with an error if the service fails to reach STOPPED within the expected time,
  preventing an infinite spin.                                                                                                                                                
  - Added return-value checks for both os_stop_service() and os_start_service(): if either call fails, the error code is logged and the process exits immediately instead of
  silently continuing.                                                                                                                                                        
  - Extracted the magic timeout/sleep literals (1000, 500, 30000) into named constants (waitForServiceStopMs, sleepIntervalMs, timeoutMs) for readability and easier future   
  tuning.
                                                                                                                                                                              
  src/client-agent/src/control.c
  - Added a bounds check on the snprintf result that builds the service-restart command line, returning a proper error message if the path is unexpectedly long.   

src/win32/ui/os_win32ui.c 
src/win32/win_services.c

  - Add a new result code to os_stop_service and propagate it to callers
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

### API restart
```
herna@LAPTOP-J631ENT0:~$ TOKEN=$(curl -sk -X POST -u wazuh:wazuh  "https://localhost:55000/security/user/authenticate"  | jq -r '.data.token')
herna@LAPTOP-J631ENT0:~$ curl -k -X PUT "https://localhost:55000/agents/restart"     -H "Authorization: Bearer $TOKEN"
{"data": {"affected_items": ["002"], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "Restart command was sent to all agents", "error": 0}
```

### Agent Log

```
2026/04/01 14:41:23 wazuh-modulesd:syscollector: ERROR: Discarding invalid Syscollector message (table: dbsync_network_protocol)
2026/04/01 14:41:23 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/04/01 14:41:23 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/01 14:41:26 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/04/01 14:41:28 wazuh-rootcheck: INFO: Ending rootcheck scan.
2026/04/01 14:41:39 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/04/01 14:41:43 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2026/04/01 14:41:43 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
2026/04/01 14:43:58 wazuh-agent: INFO: Agent control: restart command received.
2026/04/01 14:43:58 wazuh-agent: INFO: Agent control: 'restart' command received, detached restart process spawned.
2026/04/01 14:44:08 wazuh-agent: INFO: Received exit signal. Starting exit process.
2026/04/01 14:44:08 wazuh-agent: INFO: Set pending exit signal.
2026/04/01 14:44:08 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/04/01 14:44:08 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/04/01 14:44:08 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/04/01 14:44:08 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/04/01 14:44:08 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/04/01 14:44:08 wazuh-modulesd:syscollector: INFO: Module finished.
2026/04/01 14:44:08 wazuh-agent: INFO: Exit completed successfully.
2026/04/01 14:44:08 wazuh-agent: INFO: (1314): Shutdown received. Deleting responses.
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
wazuh-agent.exe
<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes
N-A
<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced
N-A
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist
N-A
<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
