### PR TITLE
Fix token validation race condition after revoke

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -4,6 +4,7 @@
 
 import asyncio
 from functools import cache
+import fcntl
 import hashlib
 import json
 import jwt
@@ -95,39 +96,87 @@ JWT_ISSUER = 'wazuh'
 JWT_ALGORITHM = 'ES512'
 _private_key_path = os.path.join(SECURITY_PATH, 'private_key.pem')
 _public_key_path = os.path.join(SECURITY_PATH, 'public_key.pem')
+_keypair_lock_path = os.path.join(SECURITY_PATH, '.keypair.lock')
 
 @cache
 def generate_keypair():
     """Generate key files to keep safe or load existing public and private keys.
+
+    Uses file-based locking to prevent race conditions between reading and writing keypairs.
+    This ensures that if keys are regenerated (e.g., via revoke_tokens) while reading,
+    we won't cache stale keys.
 
     Raises
     ------
     WazuhInternalError(6003)
         If there was an error trying to load the JWT secret.
     """
+    lock_file = None
     try:
+        # Try to acquire lock file (best-effort, only if security dir exists)
+        try:
+            if os.path.isdir(os.path.dirname(_keypair_lock_path)):
+                lock_file = open(_keypair_lock_path, 'a+')
+        except (OSError, IOError):
+            pass  # Continue without locking
+
         if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
-            private_key, public_key = change_keypair()
-            try:
-                os.chown(_private_key_path, wazuh_uid(), wazuh_gid())
-                os.chown(_public_key_path, wazuh_uid(), wazuh_gid())
-            except PermissionError:
-                pass
-            os.chmod(_private_key_path, 0o640)
-            os.chmod(_public_key_path, 0o640)
+            # Need to create keys - acquire exclusive lock if available
+            if lock_file:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                except (OSError, IOError):
+                    pass  # Continue without exclusive lock
+            # Double-check after acquiring lock (another process might have created them)
+            if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
+                private_key, public_key = _write_new_keypair()
+            else:
+                private_key, public_key = _read_keypair_locked(lock_file)
         else:
-            with open(_private_key_path, mode='r') as key_file:
-                private_key = key_file.read()
-            with open(_public_key_path, mode='r') as key_file:
-                public_key = key_file.read()
+            # Keys exist - acquire shared lock for reading (if available)
+            private_key, public_key = _read_keypair_locked(lock_file)
     except IOError:
         raise WazuhInternalError(6003)
+    finally:
+        if lock_file:
+            lock_file.close()
 
     return private_key, public_key
 
 
-def change_keypair():
-    """Generate key files to keep safe."""
+def _read_keypair_locked(lock_file):
+    """Read keypair with shared lock (if available).
+
+    Parameters
+    ----------
+    lock_file : file or None
+        Open lock file descriptor, or None if locking not available.
+
+    Returns
+    -------
+    tuple
+        (private_key, public_key) strings.
+    """
+    if lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_SH)
+        except (OSError, IOError):
+            pass  # Continue without shared lock
+    with open(_private_key_path, mode='r') as key_file:
+        private_key = key_file.read()
+    with open(_public_key_path, mode='r') as key_file:
+        public_key = key_file.read()
+    return private_key, public_key
+
+
+def _write_new_keypair():
+    """Generate and write new keypair (exclusive lock already held).
+
+    Returns
+    -------
+    tuple
+        (private_key, public_key) strings.
+    """
     key_obj = ec.generate_private_key(ec.SECP521R1())
     private_key = key_obj.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -138,10 +187,56 @@ def change_keypair():
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo
     ).decode('utf-8')
+
     with open(_private_key_path, mode='w') as key_file:
         key_file.write(private_key)
     with open(_public_key_path, mode='w') as key_file:
         key_file.write(public_key)
+
+    try:
+        os.chown(_private_key_path, wazuh_uid(), wazuh_gid())
+        os.chown(_public_key_path, wazuh_uid(), wazuh_gid())
+    except PermissionError:
+        pass
+    os.chmod(_private_key_path, 0o640)
+    os.chmod(_public_key_path, 0o640)
+
+    return private_key, public_key
+
+
+def change_keypair():
+    """Generate key files to keep safe.
+
+    Uses exclusive file locking to prevent race conditions with concurrent reads.
+    Clears the cache after writing new keys to ensure they are reloaded.
+
+    Returns
+    -------
+    tuple
+        (private_key, public_key) strings.
+    """
+    lock_file = None
+    try:
+        # Try to acquire lock file (best-effort, only if security dir exists)
+        try:
+            if os.path.isdir(os.path.dirname(_keypair_lock_path)):
+                lock_file = open(_keypair_lock_path, 'a+')
+                # Acquire exclusive lock for writing
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                except (OSError, IOError):
+                    pass  # Continue without exclusive lock
+        except (OSError, IOError):
+            pass  # Continue without locking
+
+        private_key, public_key = _write_new_keypair()
+        # Clear cache so next call to generate_keypair() loads new keys
+        generate_keypair.cache_clear()
+    except IOError:
+        raise WazuhInternalError(6003)
+    finally:
+        if lock_file:
+            lock_file.close()
 
     return private_key, public_key
 
@@ -184,14 +279,16 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
                           logger=logging.getLogger('wazuh-api')
                           )
     result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
-    now = core_utils.get_utc_now().timestamp()
-    timestamp = int(now)
+    # Get timestamp with millisecond precision directly
+    now_ms = int(core_utils.get_utc_now().timestamp() * 1000)
+    now_seconds = now_ms // 1000
 
     payload = {
                   "iss": JWT_ISSUER,
                   "aud": "Wazuh API REST",
-                  "nbf": now,
-                  "exp": timestamp + result['auth_token_exp_timeout'],
+                  "nbf": now_seconds,  # Standard claim: integer seconds since epoch (RFC 7519)
+                  "nbf_ms": now_ms,  # Private claim: milliseconds for precise validation
+                  "exp": now_seconds + result['auth_token_exp_timeout'],
                   "sub": str(user_id),
                   "run_as": auth_context is not None,
                   "rbac_roles": data['roles'],
@@ -270,9 +367,11 @@ def decode_token(token: str) -> dict:
         payload = jwt.decode(token, generate_keypair()[1], algorithms=[JWT_ALGORITHM], audience='Wazuh API REST')
 
         # Check token and add processed policies in the Master node
+        # Use nbf_ms for millisecond precision validation, fallback to nbf * 1000 for backward compatibility
+        token_nbf_time = payload.get('nbf_ms', int(payload['nbf'] * 1000))
         dapi = DistributedAPI(f=check_token,
                               f_kwargs={'username': payload['sub'],
-                                        'roles': tuple(payload['rbac_roles']), 'token_nbf_time': int(payload['nbf'] * 1000),
+                                        'roles': tuple(payload['rbac_roles']), 'token_nbf_time': token_nbf_time,
                                         'run_as': payload['run_as'], 'origin_node_type': read_config()['node_type']},
                               request_type='local_master',
                               is_async=False,

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -184,15 +184,14 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
                           logger=logging.getLogger('wazuh-api')
                           )
     result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
-    timestamp = int(core_utils.get_utc_now().timestamp())
-    timestamp_ms = int(core_utils.get_utc_now().timestamp() * 1000)
+    now = core_utils.get_utc_now().timestamp()
+    timestamp = int(now)
 
     payload = {
                   "iss": JWT_ISSUER,
                   "aud": "Wazuh API REST",
-                  "nbf": timestamp,
+                  "nbf": now,
                   "exp": timestamp + result['auth_token_exp_timeout'],
-                  "nbf_ms": timestamp_ms,
                   "sub": str(user_id),
                   "run_as": auth_context is not None,
                   "rbac_roles": data['roles'],
@@ -216,7 +215,7 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) 
     roles : tuple
         Tuple of roles related with the current token.
     token_nbf_time : int
-        Issued at time of the current token.
+        Issued at time of the current token (milliseconds).
     run_as : bool
         Indicate if the token has been granted through authorization context endpoint.
 
@@ -273,7 +272,7 @@ def decode_token(token: str) -> dict:
         # Check token and add processed policies in the Master node
         dapi = DistributedAPI(f=check_token,
                               f_kwargs={'username': payload['sub'],
-                                        'roles': tuple(payload['rbac_roles']), 'token_nbf_time': payload['nbf_ms'],
+                                        'roles': tuple(payload['rbac_roles']), 'token_nbf_time': int(payload['nbf'] * 1000),
                                         'run_as': payload['run_as'], 'origin_node_type': read_config()['node_type']},
                               request_type='local_master',
                               is_async=False,
@@ -299,7 +298,7 @@ def decode_token(token: str) -> dict:
         current_rbac_mode = result['rbac_mode']
         current_expiration_time = result['auth_token_exp_timeout']
         if payload['rbac_policies']['rbac_mode'] != current_rbac_mode \
-                or (payload['exp'] - payload['nbf']) != current_expiration_time:
+                or (payload['exp'] - int(payload['nbf'])) != current_expiration_time:
             raise Unauthorized(EXPIRED_TOKEN)
 
         return payload

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -185,12 +185,14 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
                           )
     result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
     timestamp = int(core_utils.get_utc_now().timestamp())
+    timestamp_ms = int(core_utils.get_utc_now().timestamp() * 1000)
 
     payload = {
                   "iss": JWT_ISSUER,
                   "aud": "Wazuh API REST",
                   "nbf": timestamp,
                   "exp": timestamp + result['auth_token_exp_timeout'],
+                  "nbf_ms": timestamp_ms,
                   "sub": str(user_id),
                   "run_as": auth_context is not None,
                   "rbac_roles": data['roles'],
@@ -271,7 +273,7 @@ def decode_token(token: str) -> dict:
         # Check token and add processed policies in the Master node
         dapi = DistributedAPI(f=check_token,
                               f_kwargs={'username': payload['sub'],
-                                        'roles': tuple(payload['rbac_roles']), 'token_nbf_time': payload['nbf'],
+                                        'roles': tuple(payload['rbac_roles']), 'token_nbf_time': payload['nbf_ms'],
                                         'run_as': payload['run_as'], 'origin_node_type': read_config()['node_type']},
                               request_type='local_master',
                               is_async=False,

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -37,6 +37,7 @@ decoded_payload = {
     "iss": 'wazuh',
     "aud": 'Wazuh API REST',
     "nbf": 0,
+    "nbf_ms": 0,
     "exp": security_conf['auth_token_exp_timeout'],
     "sub": '001',
     "rbac_policies": {'value': 'test', 'rbac_mode': security_conf['rbac_mode']},
@@ -48,6 +49,7 @@ original_payload = {
     "iss": "wazuh",
     "aud": "Wazuh API REST",
     "nbf": 0,
+    "nbf_ms": 0,
     "exp": security_conf['auth_token_exp_timeout'],
     "sub": "001",
     "run_as": False,
@@ -79,31 +81,30 @@ async def test_check_user(mock_raise_if_exc, mock_distribute_function, mock_dapi
     mock_raise_if_exc.assert_called_once()
 
 
-@patch('api.authentication.change_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
-                                                          '-----BEGIN PUBLIC KEY-----'))
-@patch('os.chmod')
-@patch('os.chown')
-@patch('builtins.open')
-def test_generate_keypair(mock_open, mock_chown, mock_chmod, mock_change_keypair):
-    """Verify correct params when calling open method inside generate_keypair"""
-    result = generate_keypair()
-    assert result == ('-----BEGIN PRIVATE KEY-----',
-                      '-----BEGIN PUBLIC KEY-----')
-
-    calls = [call(_private_key_path, wazuh_uid(), wazuh_gid()),
-             call(_public_key_path, wazuh_uid(), wazuh_gid())]
-    mock_chown.assert_has_calls(calls)
-    calls = [call(_private_key_path, 0o640),
-             call(_public_key_path, 0o640)]
-    mock_chmod.assert_has_calls(calls)
+@patch('api.authentication._write_new_keypair', return_value=('-----BEGIN PRIVATE KEY-----',
+                                                               '-----BEGIN PUBLIC KEY-----'))
+def test_generate_keypair(mock_write_keypair):
+    """Verify generate_keypair creates keys when they don't exist"""
+    with patch('os.path.exists', return_value=False):
+        result = generate_keypair()
+        assert result == ('-----BEGIN PRIVATE KEY-----',
+                          '-----BEGIN PUBLIC KEY-----')
+        mock_write_keypair.assert_called_once()
 
     generate_keypair.cache_clear()
 
+    # Test reading existing keys
     with patch('os.path.exists', return_value=True):
-        generate_keypair()
-        calls = [call(_private_key_path, mode='r'),
-                 call(_public_key_path, mode='r')]
-        mock_open.assert_has_calls(calls, any_order=True)
+        with patch('builtins.open', create=True) as mock_open:
+            mock_file = MagicMock()
+            mock_file.__enter__ = MagicMock(return_value=mock_file)
+            mock_file.__exit__ = MagicMock(return_value=False)
+            mock_file.read = MagicMock(side_effect=['priv_key', 'pub_key'])
+            mock_file.fileno = MagicMock(return_value=99)
+            mock_open.return_value = mock_file
+
+            result = generate_keypair()
+            assert result == ('priv_key', 'pub_key')
 
 
 def test_generate_keypair_ko():
@@ -113,50 +114,50 @@ def test_generate_keypair_ko():
             with patch('os.chown', side_effect=PermissionError):
                 assert generate_keypair()
 
-@patch("os.chmod")
-@patch("os.chown")
-@patch("api.authentication.change_keypair", return_value=("priv", "pub"))
+@patch("api.authentication._write_new_keypair", return_value=("priv", "pub"))
 @patch("os.path.exists", return_value=False)
-def test_generate_keypair_cache_no_keys(mock_exists, mock_change_keypair, mock_chown, mock_chmod):
-
+def test_generate_keypair_cache_no_keys(mock_exists, mock_write_keypair):
+    """Verify caching works when keys don't exist"""
     first = generate_keypair()
     cached = generate_keypair()
 
     assert first == ("priv", "pub")
     assert first is cached
 
-    mock_exists.assert_called_once()
-    mock_change_keypair.assert_called_once()
-    assert mock_chown.call_count == 2
-    assert mock_chmod.call_count == 2
-
-@patch("builtins.open", return_value=MagicMock())
-@patch("os.path.exists", return_value=True)
-def test_generate_keypair_cache(mock_exists, mock_open,
-    clear_generate_keypair_cache):
-
-    file_mock = MagicMock()
-    file_mock.read.side_effect = ["priv", "pub"]
-    mock_open.return_value.__enter__.return_value = file_mock
-
-    first = generate_keypair()
-    cached = generate_keypair()
-
-    assert first == ("priv", "pub")
-    assert first is cached
-
+    # First call checks both private and public key paths
     assert mock_exists.call_count == 2
-    assert mock_open.call_count == 2
+    # But _write_new_keypair is called only once due to caching
+    mock_write_keypair.assert_called_once()
 
-@patch('builtins.open')
-def test_change_keypair(mock_open):
-    """Verify correct params when calling open method inside change_keypair"""
+@patch("os.path.exists", return_value=True)
+def test_generate_keypair_cache(mock_exists, clear_generate_keypair_cache):
+    """Verify caching works when keys exist"""
+    with patch('builtins.open', create=True) as mock_open:
+        mock_file = MagicMock()
+        mock_file.__enter__ = MagicMock(return_value=mock_file)
+        mock_file.__exit__ = MagicMock(return_value=False)
+        mock_file.read = MagicMock(side_effect=["priv", "pub"])
+        mock_file.fileno = MagicMock(return_value=99)
+        mock_open.return_value = mock_file
+
+        first = generate_keypair()
+        cached = generate_keypair()
+
+        assert first == ("priv", "pub")
+        assert first is cached
+
+        assert mock_exists.call_count == 2
+        # Should read files twice (private + public) only once due to caching
+        assert mock_file.read.call_count == 2
+
+@patch('api.authentication._write_new_keypair', return_value=('new_priv', 'new_pub'))
+def test_change_keypair(mock_write_keypair):
+    """Verify change_keypair generates new keys and clears cache"""
     result = change_keypair()
     assert isinstance(result[0], str)
     assert isinstance(result[1], str)
-    calls = [call(_private_key_path, mode='w'),
-             call(_public_key_path, mode='w')]
-    mock_open.assert_has_calls(calls, any_order=True)
+    assert result == ('new_priv', 'new_pub')
+    mock_write_keypair.assert_called_once()
 
 
 def test_get_security_conf():

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -38,6 +38,7 @@ decoded_payload = {
     "aud": 'Wazuh API REST',
     "nbf": 0,
     "exp": security_conf['auth_token_exp_timeout'],
+    "nbf_ms": 0,
     "sub": '001',
     "rbac_policies": {'value': 'test', 'rbac_mode': security_conf['rbac_mode']},
     "rbac_roles": [1],
@@ -49,6 +50,7 @@ original_payload = {
     "aud": "Wazuh API REST",
     "nbf": 0,
     "exp": security_conf['auth_token_exp_timeout'],
+    "nbf_ms": 0,
     "sub": "001",
     "run_as": False,
     "rbac_roles": [1],
@@ -224,7 +226,7 @@ async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_da
     assert result == decoded_payload
 
     # Check all functions are called with expected params
-    calls = [call(f=ANY, f_kwargs={'username': original_payload['sub'], 'token_nbf_time': original_payload['nbf'],
+    calls = [call(f=ANY, f_kwargs={'username': original_payload['sub'], 'token_nbf_time': original_payload['nbf_ms'],
                                    'run_as': False, 'roles': tuple(original_payload['rbac_roles']),
                                    'origin_node_type': 'master'},
                   request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -38,7 +38,6 @@ decoded_payload = {
     "aud": 'Wazuh API REST',
     "nbf": 0,
     "exp": security_conf['auth_token_exp_timeout'],
-    "nbf_ms": 0,
     "sub": '001',
     "rbac_policies": {'value': 'test', 'rbac_mode': security_conf['rbac_mode']},
     "rbac_roles": [1],
@@ -50,7 +49,6 @@ original_payload = {
     "aud": "Wazuh API REST",
     "nbf": 0,
     "exp": security_conf['auth_token_exp_timeout'],
-    "nbf_ms": 0,
     "sub": "001",
     "run_as": False,
     "rbac_roles": [1],
@@ -226,7 +224,7 @@ async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_da
     assert result == decoded_payload
 
     # Check all functions are called with expected params
-    calls = [call(f=ANY, f_kwargs={'username': original_payload['sub'], 'token_nbf_time': original_payload['nbf_ms'],
+    calls = [call(f=ANY, f_kwargs={'username': original_payload['sub'], 'token_nbf_time': int(original_payload['nbf'] * 1000),
                                    'run_as': False, 'roles': tuple(original_payload['rbac_roles']),
                                    'origin_node_type': 'master'},
                   request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -592,6 +592,11 @@ class TokenManager(RBACManager):
     This class provides all the methods needed for the administration of the TokenBlacklist objects.
     """
 
+    @staticmethod
+    def _normalize_timestamp(timestamp: int) -> int:
+        """Normalize persisted timestamps to milliseconds."""
+        return timestamp * 1000 if timestamp < 10_000_000_000 else timestamp
+
     def is_token_valid(self, token_nbf_time: int, user_id: int = None, role_id: int = None,
                        run_as: bool = False) -> bool:
         """Check if the specified token is valid.
@@ -616,9 +621,14 @@ class TokenManager(RBACManager):
             user_rule = self.session.scalars(select(UsersTokenBlacklist).filter_by(user_id=user_id).limit(1)).first()
             role_rule = self.session.scalars(select(RolesTokenBlacklist).filter_by(role_id=role_id).limit(1)).first()
             runas_rule = self.session.query(RunAsTokenBlacklist).first()
-            return (not user_rule or (token_nbf_time > user_rule.nbf_invalid_until)) and \
-                   (not role_rule or (token_nbf_time > role_rule.nbf_invalid_until)) and \
-                   (not run_as or (not runas_rule or (token_nbf_time > runas_rule.nbf_invalid_until)))
+
+            user_nbf_invalid_until = self._normalize_timestamp(user_rule.nbf_invalid_until) if user_rule else None
+            role_nbf_invalid_until = self._normalize_timestamp(role_rule.nbf_invalid_until) if role_rule else None
+            runas_nbf_invalid_until = self._normalize_timestamp(runas_rule.nbf_invalid_until) if runas_rule else None
+
+            return (not user_rule or (token_nbf_time > user_nbf_invalid_until)) and \
+                   (not role_rule or (token_nbf_time > role_nbf_invalid_until)) and \
+                   (not run_as or (not runas_rule or (token_nbf_time > runas_nbf_invalid_until)))
         except IntegrityError:
             return True
 
@@ -710,19 +720,24 @@ class TokenManager(RBACManager):
             users_tokens_in_blacklist = self.session.scalars(select(UsersTokenBlacklist)).all()
             for user_token in users_tokens_in_blacklist:
                 token_rule = self.session.query(UsersTokenBlacklist).filter_by(user_id=user_token.user_id)
-                if token_rule.first() and current_time > token_rule.first().is_valid_until:
+                rule = token_rule.first()
+                if rule and current_time > self._normalize_timestamp(rule.is_valid_until):
                     token_rule.delete()
                     self.session.commit()
                     list_users.append(user_token.user_id)
+
             roles_tokens_in_blacklist = self.session.scalars(select(RolesTokenBlacklist)).all()
             for role_token in roles_tokens_in_blacklist:
                 token_rule = self.session.query(RolesTokenBlacklist).filter_by(role_id=role_token.role_id)
-                if token_rule.first() and current_time > token_rule.first().is_valid_until:
+                rule = token_rule.first()
+                if rule and current_time > self._normalize_timestamp(rule.is_valid_until):
                     token_rule.delete()
                     self.session.commit()
                     list_roles.append(role_token.role_id)
+
             runas_token_in_blacklist = self.session.query(RunAsTokenBlacklist).first()
-            if runas_token_in_blacklist and runas_token_in_blacklist.to_dict()['is_valid_until'] < current_time:
+            if runas_token_in_blacklist and \
+                    self._normalize_timestamp(runas_token_in_blacklist.is_valid_until) < current_time:
                 self.session.delete(runas_token_in_blacklist)
                 self.session.commit()
 

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -158,8 +158,8 @@ class RunAsTokenBlacklist(_Base):
     __table_args__ = (UniqueConstraint('nbf_invalid_until', name='nbf_invalid_until_invalidation_rule'),)
 
     def __init__(self):
-        self.nbf_invalid_until = int(time())
-        self.is_valid_until = self.nbf_invalid_until + security_conf['auth_token_exp_timeout']
+        self.nbf_invalid_until = int(time() * 1000)
+        self.is_valid_until = self.nbf_invalid_until + (security_conf['auth_token_exp_timeout'] * 1000)
 
     def to_dict(self) -> dict:
         """Return the information of the RunAsTokenBlacklist object.
@@ -189,8 +189,8 @@ class UsersTokenBlacklist(_Base):
 
     def __init__(self, user_id):
         self.user_id = user_id
-        self.nbf_invalid_until = int(time())
-        self.is_valid_until = self.nbf_invalid_until + security_conf['auth_token_exp_timeout']
+        self.nbf_invalid_until = int(time() * 1000)
+        self.is_valid_until = self.nbf_invalid_until + (security_conf['auth_token_exp_timeout'] * 1000)
 
     def to_dict(self):
         """Return the information of the token rule
@@ -220,8 +220,8 @@ class RolesTokenBlacklist(_Base):
 
     def __init__(self, role_id):
         self.role_id = role_id
-        self.nbf_invalid_until = int(time())
-        self.is_valid_until = self.nbf_invalid_until + security_conf['auth_token_exp_timeout']
+        self.nbf_invalid_until = int(time() * 1000)
+        self.is_valid_until = self.nbf_invalid_until + (security_conf['auth_token_exp_timeout'] * 1000)
 
     def to_dict(self):
         """Return the information of the token rule
@@ -706,7 +706,7 @@ class TokenManager(RBACManager):
         """
         try:
             list_users, list_roles = list(), list()
-            current_time = int(time())
+            current_time = int(time() * 1000)
             users_tokens_in_blacklist = self.session.scalars(select(UsersTokenBlacklist)).all()
             for user_token in users_tokens_in_blacklist:
                 token_rule = self.session.query(UsersTokenBlacklist).filter_by(user_id=user_token.user_id)

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -97,6 +97,21 @@ def test_nbf_invalid(db_setup):
             assert not tm.is_token_valid(role_id=role, token_nbf_time=current_timestamp)
 
 
+def test_token_valid_after_revoke_same_second_ms(db_setup):
+    with db_setup.AuthenticationManager() as am:
+        am.add_user(username='timing_user', password='testingA1!')
+        user_id = am.get_user('timing_user')['id']
+
+    # Revoke en tiempo X (en segundos, pero convertido a ms internamente)
+    with patch('wazuh.rbac.orm.time', return_value=1000.100):
+        with db_setup.TokenManager() as tm:
+            assert tm.add_user_roles_rules(users={user_id})
+
+    # Token generado justo después (mismo segundo pero mayor en ms)
+    with db_setup.TokenManager() as tm:
+        assert tm.is_token_valid(user_id=user_id, token_nbf_time=1000101)
+
+
 def test_delete_all_rules(db_setup):
     """Check that rules are correctly deleted"""
     add_token(db_setup)

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -98,18 +98,29 @@ def test_nbf_invalid(db_setup):
 
 
 def test_token_valid_after_revoke_same_second_ms(db_setup):
+    """Ensure tokens issued within the same second as revoke are correctly validated using ms precision."""
     with db_setup.AuthenticationManager() as am:
         am.add_user(username='timing_user', password='testingA1!')
         user_id = am.get_user('timing_user')['id']
 
-    # Revoke en tiempo X (en segundos, pero convertido a ms internamente)
-    with patch('wazuh.rbac.orm.time', return_value=1000.100):
+    # Use a timestamp that represents milliseconds (>= 10_000_000_000) to avoid normalization
+    mocked_time = 1609459200.100  # 2021-01-01 00:00:00.100 UTC
+    with patch('wazuh.rbac.orm.time', return_value=mocked_time):
         with db_setup.TokenManager() as tm:
             assert tm.add_user_roles_rules(users={user_id})
 
-    # Token generado justo después (mismo segundo pero mayor en ms)
+    # Calculate the revoke timestamp the same way UsersTokenBlacklist.__init__ does
+    revoke_ts = int(mocked_time * 1000)
+
     with db_setup.TokenManager() as tm:
-        assert tm.is_token_valid(user_id=user_id, token_nbf_time=1000101)
+        # Token issued before revoke -> invalid
+        assert not tm.is_token_valid(user_id=user_id, token_nbf_time=revoke_ts - 1)
+
+        # Token issued exactly at revoke time -> invalid
+        assert not tm.is_token_valid(user_id=user_id, token_nbf_time=revoke_ts)
+
+        # Token issued after revoke -> valid
+        assert tm.is_token_valid(user_id=user_id, token_nbf_time=revoke_ts + 1)
 
 
 def test_delete_all_rules(db_setup):


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Fixes https://github.com/wazuh/wazuh/issues/35043.

Fix token validation race condition by using sub-second precision in nbf and millisecond-based comparison in validation logic.


<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/rbac/tests/test_orm.py 
/home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/pytest_html/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution, DistributionNotFound
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 64 items                                                                                                                                                                                          

framework/wazuh/rbac/tests/test_orm.py ................................................................                                                                                               [100%]

====================================================================================== 64 passed, 8 warnings in 30.68s ======================================================================================
```


```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest api/api/test/test_authentication.py 
/home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/pytest_html/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution, DistributionNotFound
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/Git/wazuh/api/api
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 13 items                                                                                                                                                                                          

api/api/test/test_authentication.py .............                                                                                                                                                     [100%]
====================================================================================== 13 passed, 8 warnings in 0.62s =======================================================================================

```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
