### PR TITLE
Improve Active Response command names

### DIFF
--- a/src/active-response/include/active_responses.h
+++ b/src/active-response/include/active_responses.h
@@ -17,7 +17,7 @@
 
 #define COMMANDSIZE_4096 4096
 
-#define VERSION 1
+#define AR_VERSION 1
 #define AR_MODULE_NAME "active-response"
 #define CHECK_KEYS_ENTRY "check_keys"
 
@@ -25,8 +25,8 @@
  * Enumeration of the available commands
  * */
 typedef enum _ar_command_list {
-    ADD_COMMAND = 0,
-    DELETE_COMMAND,
+    ENABLE_COMMAND = 0,
+    DISABLE_COMMAND,
     CONTINUE_COMMAND,
     ABORT_COMMAND
 } ar_command_list;

--- a/src/active-response/src/active_responses.c
+++ b/src/active-response/src/active_responses.c
@@ -73,10 +73,10 @@ int setup_and_check_message(char **argv, cJSON **message) {
         return OS_INVALID;
     }
 
-    if (!strcmp("add", action)) {
-        ret = ADD_COMMAND;
-    } else if (!strcmp("delete", action)) {
-        ret = DELETE_COMMAND;
+    if (!strcmp("enable", action)) {
+        ret = ENABLE_COMMAND;
+    } else if (!strcmp("disable", action)) {
+        ret = DISABLE_COMMAND;
     } else {
         write_debug_file(argv[0], "Invalid value of 'command'");
         cJSON_Delete(input_json);
@@ -315,7 +315,7 @@ static char* build_json_keys_message(const char *ar_name, char **keys) {
 
     cJSON *message = cJSON_CreateObject();
 
-    cJSON_AddNumberToObject(message, "version", VERSION);
+    cJSON_AddNumberToObject(message, "version", AR_VERSION);
 
     _object = cJSON_CreateObject();
     cJSON_AddItemToObject(message, "origin", _object);

--- a/src/active-response/src/block-ip-macos.c
+++ b/src/active-response/src/block-ip-macos.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 
     // Setup and parse JSON input
     action = setup_and_check_message(argv, &input_json);
-    if ((action != ADD_COMMAND) && (action != DELETE_COMMAND)) {
+    if ((action != ENABLE_COMMAND) && (action != DISABLE_COMMAND)) {
         return OS_INVALID;
     }
 
@@ -41,8 +41,8 @@ int main(int argc, char **argv) {
         return OS_INVALID;
     }
 
-    // Send keys and check for abort (ADD command only)
-    if (action == ADD_COMMAND) {
+    // Send keys and check for abort (ENABLE command only)
+    if (action == ENABLE_COMMAND) {
         char **keys = NULL;
         os_calloc(2, sizeof(char *), keys);
         os_strdup(srcip, keys[0]);
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
 
     if (result == FIREWALL_SUCCESS) {
         log_firewall_action(argv[0], LOG_LEVEL_INFO, "pf", "success",
-                          action == ADD_COMMAND ? "IP blocked successfully" : "IP unblocked successfully");
+                          action == ENABLE_COMMAND ? "IP blocked successfully" : "IP unblocked successfully");
         write_debug_file(argv[0], "Ended");
         cJSON_Delete(input_json);
         return OS_SUCCESS;
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
 
     if (result == FIREWALL_SUCCESS) {
         log_firewall_action(argv[0], LOG_LEVEL_INFO, "hostsdeny", "success",
-                          action == ADD_COMMAND ? "IP blocked successfully" : "IP unblocked successfully");
+                          action == ENABLE_COMMAND ? "IP blocked successfully" : "IP unblocked successfully");
         write_debug_file(argv[0], "Ended");
         cJSON_Delete(input_json);
         return OS_SUCCESS;
@@ -275,7 +275,7 @@ firewall_result_t try_pf_macos(const char *srcip, int action, int ip_version, co
     }
 
     // Add or delete IP from table
-    const char *table_operation = (action == ADD_COMMAND) ? "add" : "delete";
+    const char *table_operation = (action == ENABLE_COMMAND) ? "add" : "delete";
     char *exec_cmd2[] = {pfctl_path, "-t", "wazuh_fwtable", "-T", (char *)table_operation, (char *)srcip, NULL};
 
     wfd = wpopenv(pfctl_path, exec_cmd2, W_BIND_STDOUT | W_BIND_STDERR);
@@ -316,7 +316,7 @@ firewall_result_t try_pf_macos(const char *srcip, int action, int ip_version, co
     }
 
     // If adding, also kill existing connections from this IP
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         memset(log_msg, '\0', OS_MAXSTR);
         snprintf(log_msg, OS_MAXSTR - 1, "Killing existing connections from %s", srcip);
         write_debug_file(argv0, log_msg);
@@ -370,7 +370,7 @@ firewall_result_t try_hostsdeny_macos(const char *srcip, int action, int ip_vers
         return FIREWALL_EXECUTION_FAILED;
     }
 
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         // Open file for reading to check for duplicates
         host_deny_fp = wfopen(DEFAULT_HOSTS_DENY_PATH, "r");
         if (!host_deny_fp) {
@@ -416,7 +416,7 @@ firewall_result_t try_hostsdeny_macos(const char *srcip, int action, int ip_vers
         fclose(host_deny_fp);
 
     } else {
-        // DELETE_COMMAND: Remove IP from hosts.deny
+        // DISABLE_COMMAND: Remove IP from hosts.deny
         FILE *temp_host_deny_fp = NULL;
         char temp_hosts_deny_path[COMMANDSIZE_4096];
         bool write_fail = false;

--- a/src/active-response/src/block-ip-unix.c
+++ b/src/active-response/src/block-ip-unix.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 
     // Setup and parse JSON input
     action = setup_and_check_message(argv, &input_json);
-    if ((action != ADD_COMMAND) && (action != DELETE_COMMAND)) {
+    if ((action != ENABLE_COMMAND) && (action != DISABLE_COMMAND)) {
         return OS_INVALID;
     }
 
@@ -70,8 +70,8 @@ int main(int argc, char **argv) {
         return OS_INVALID;
     }
 
-    // Send keys and check for abort (ADD command only)
-    if (action == ADD_COMMAND) {
+    // Send keys and check for abort (ENABLE command only)
+    if (action == ENABLE_COMMAND) {
         char **keys = NULL;
         os_calloc(2, sizeof(char *), keys);
         os_strdup(srcip, keys[0]);
@@ -184,7 +184,7 @@ firewall_result_t try_firewalld(const char *srcip, int action, int ip_version, c
 
     // Build firewall-cmd command
     const char *family = (ip_version == 4) ? "ipv4" : "ipv6";
-    const char *operation = (action == ADD_COMMAND) ? "--add-rich-rule" : "--remove-rich-rule";
+    const char *operation = (action == ENABLE_COMMAND) ? "--add-rich-rule" : "--remove-rich-rule";
 
     char rule[COMMANDSIZE_4096];
     memset(rule, '\0', COMMANDSIZE_4096);
@@ -236,8 +236,8 @@ firewall_result_t try_iptables(const char *srcip, int action, int ip_version, co
         return FIREWALL_EXECUTION_FAILED;
     }
 
-    // Determine argument for add/delete
-    const char *arg = (action == ADD_COMMAND) ? "-I" : "-D";
+    // Determine argument for enable/disable
+    const char *arg = (action == ENABLE_COMMAND) ? "-I" : "-D";
 
     firewall_result_t final_result = FIREWALL_SUCCESS;
 
@@ -343,7 +343,7 @@ firewall_result_t try_ipfw(const char *srcip, int action, int ip_version, const 
     }
 
     // Add or delete IP from table
-    const char *table_operation = (action == ADD_COMMAND) ? "add" : "delete";
+    const char *table_operation = (action == ENABLE_COMMAND) ? "add" : "delete";
     char *exec_cmd4[] = {ipfw_path, "-q", "table", "00001", (char *)table_operation, (char *)srcip, NULL};
 
     wfd = wpopenv(ipfw_path, exec_cmd4, W_BIND_STDERR);
@@ -408,7 +408,7 @@ firewall_result_t try_pf(const char *srcip, int action, int ip_version, const ch
     }
 
     // Add or delete IP from table
-    const char *table_operation = (action == ADD_COMMAND) ? "add" : "delete";
+    const char *table_operation = (action == ENABLE_COMMAND) ? "add" : "delete";
     char *exec_cmd2[] = {pfctl_path, "-t", "wazuh_fwtable", "-T", (char *)table_operation, (char *)srcip, NULL};
 
     wfd = wpopenv(pfctl_path, exec_cmd2, W_BIND_STDERR);
@@ -419,7 +419,7 @@ firewall_result_t try_pf(const char *srcip, int action, int ip_version, const ch
     wpclose(wfd);
 
     // If adding, also kill existing connections
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         char *exec_cmd3[] = {pfctl_path, "-k", (char *)srcip, NULL};
         wfd = wpopenv(pfctl_path, exec_cmd3, W_BIND_STDERR);
         if (wfd) wpclose(wfd);
@@ -491,7 +491,7 @@ firewall_result_t try_npf(const char *srcip, int action, int ip_version, const c
     }
 
     // Add or delete IP from table
-    const char *table_operation = (action == ADD_COMMAND) ? "add" : "del";
+    const char *table_operation = (action == ENABLE_COMMAND) ? "add" : "del";
     char *exec_cmd2[] = {npfctl_path, "table", "wazuh_blacklist", (char *)table_operation, (char *)srcip, NULL};
 
     wfd = wpopenv(npfctl_path, exec_cmd2, W_BIND_STDERR);
@@ -525,7 +525,7 @@ firewall_result_t try_route(const char *srcip, int action, int ip_version, const
 
 #ifdef PLATFORM_LINUX
     // Linux: route add <ip> reject / route del <ip> reject
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         char *exec_cmd[] = {route_path, "add", (char *)srcip, "reject", NULL};
         wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
     } else {
@@ -534,7 +534,7 @@ firewall_result_t try_route(const char *srcip, int action, int ip_version, const
     }
 #elif defined(PLATFORM_FREEBSD)
     // FreeBSD: route -q add <ip> 127.0.0.1 -blackhole
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         char *exec_cmd[] = {route_path, "-q", "add", (char *)srcip, "127.0.0.1", "-blackhole", NULL};
         wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
     } else {
@@ -543,7 +543,7 @@ firewall_result_t try_route(const char *srcip, int action, int ip_version, const
     }
 #elif defined(PLATFORM_OPENBSD) || defined(PLATFORM_NETBSD)
     // OpenBSD/NetBSD: Similar to FreeBSD
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         char *exec_cmd[] = {route_path, "-q", "add", (char *)srcip, "127.0.0.1", "-blackhole", NULL};
         wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
     } else {
@@ -617,7 +617,7 @@ firewall_result_t try_hostsdeny(const char *srcip, int action, int ip_version, c
         return FIREWALL_EXECUTION_FAILED;
     }
 
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         // Open file for reading to check for duplicates
         host_deny_fp = wfopen(hosts_deny_path, "r");
         if (!host_deny_fp) {
@@ -663,7 +663,7 @@ firewall_result_t try_hostsdeny(const char *srcip, int action, int ip_version, c
         fclose(host_deny_fp);
 
     } else {
-        // DELETE_COMMAND: Remove IP from hosts.deny
+        // DISABLE_COMMAND: Remove IP from hosts.deny
         FILE *temp_host_deny_fp = NULL;
         char temp_hosts_deny_path[COMMANDSIZE_4096];
         bool write_fail = false;

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
 
     // Setup and parse JSON input
     action = setup_and_check_message(argv, &input_json);
-    if ((action != ADD_COMMAND) && (action != DELETE_COMMAND)) {
+    if ((action != ENABLE_COMMAND) && (action != DISABLE_COMMAND)) {
         return OS_INVALID;
     }
 
@@ -45,8 +45,8 @@ int main(int argc, char **argv) {
         return OS_INVALID;
     }
 
-    // Send keys and check for abort (ADD command only)
-    if (action == ADD_COMMAND) {
+    // Send keys and check for abort (ENABLE command only)
+    if (action == ENABLE_COMMAND) {
         char **keys = NULL;
         os_calloc(2, sizeof(char *), keys);
         os_strdup(srcip, keys[0]);
@@ -146,7 +146,7 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
     // Build netsh command
     wfd_t *wfd = NULL;
 
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         // netsh advfirewall firewall add rule name="..." interface=any dir=in action=block remoteip=<IP>/32
         char remote_ip_arg[OS_MAXSTR];
         memset(remote_ip_arg, '\0', OS_MAXSTR);
@@ -271,7 +271,7 @@ firewall_result_t try_route_windows(const char *srcip, int action, int ip_versio
         return FIREWALL_NOT_AVAILABLE;
     }
 
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         // Need to find default gateway using ipconfig
         if (check_binary_available("ipconfig.exe", &ipconfig_path, argv0) != FIREWALL_SUCCESS) {
             log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "check",

--- a/src/active-response/src/disable-account.c
+++ b/src/active-response/src/disable-account.c
@@ -19,7 +19,7 @@ int main (int argc, char **argv) {
     struct utsname uname_buffer;
 
     action = setup_and_check_message(argv, &input_json);
-    if ((action != ADD_COMMAND) && (action != DELETE_COMMAND)) {
+    if ((action != ENABLE_COMMAND) && (action != DISABLE_COMMAND)) {
         return OS_INVALID;
     }
 
@@ -31,7 +31,7 @@ int main (int argc, char **argv) {
         return OS_INVALID;
     }
 
-    if (action == ADD_COMMAND) {
+    if (action == ENABLE_COMMAND) {
         char **keys = NULL;
         int action2 = OS_INVALID;
 
@@ -80,7 +80,7 @@ int main (int argc, char **argv) {
         }
 
         memset(args, '\0', COMMANDSIZE_4096);
-        if (action == ADD_COMMAND) {
+        if (action == ENABLE_COMMAND) {
             snprintf(args, COMMANDSIZE_4096 -1, "-l");
         } else {
             snprintf(args, COMMANDSIZE_4096 -1, "-u");

--- a/src/active-response/src/helpers/firewall_helpers.c
+++ b/src/active-response/src/helpers/firewall_helpers.c
@@ -206,7 +206,7 @@ int execute_firewall_chain(
                 snprintf(log_msg, OS_MAXSTR - 1,
                          "IP %s successfully %s",
                          srcip,
-                         action == ADD_COMMAND ? "blocked" : "unblocked");
+                         action == ENABLE_COMMAND ? "blocked" : "unblocked");
                 log_firewall_action(argv0, LOG_LEVEL_INFO, methods[i].name, "success", log_msg);
                 write_debug_file(argv0, "Ended");
                 return OS_SUCCESS;  // Early exit on first success

--- a/src/active-response/src/helpers/firewall_helpers.h
+++ b/src/active-response/src/helpers/firewall_helpers.h
@@ -54,7 +54,7 @@ typedef struct {
 /**
  * Firewall method function pointer type
  * @param srcip Source IP address to block/unblock
- * @param action ADD_COMMAND or DELETE_COMMAND
+ * @param action ENABLE_COMMAND or DISABLE_COMMAND
  * @param ip_version 4 for IPv4, 6 for IPv6
  * @param argv0 Program name for logging
  * @return firewall_result_t indicating operation result
@@ -145,7 +145,7 @@ const char* firewall_result_to_string(firewall_result_t result);
  * @brief Execute a chain of firewall methods with fallback
  * @param methods NULL-terminated array of firewall methods
  * @param srcip Source IP address to block/unblock
- * @param action ADD_COMMAND or DELETE_COMMAND
+ * @param action ENABLE_COMMAND or DISABLE_COMMAND
  * @param ip_version 4 for IPv4, 6 for IPv6
  * @param argv0 Program name for logging
  * @return OS_SUCCESS (always, to avoid retry loops in execd)

--- a/src/os_execd/include/execd.h
+++ b/src/os_execd/include/execd.h
@@ -16,10 +16,10 @@
 #endif
 
 /* Arguments for the commands */
-#define ADD_ENTRY       "add"
-#define DELETE_ENTRY    "delete"
-#define CONTINUE_ENTRY  "continue"
-#define ABORT_ENTRY     "abort"
+#define ENABLE_ENTRY       "enable"
+#define DISABLE_ENTRY      "disable"
+#define CONTINUE_ENTRY     "continue"
+#define ABORT_ENTRY        "abort"
 
 /* Maximum number of active responses active */
 #define MAX_AR      64

--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -291,7 +291,7 @@ void ExecdRun(char *exec_msg, int *childcount)
     }
 
     /* Add command field for AR script protocol compatibility */
-    cJSON_AddStringToObject(json_root, "command", ADD_ENTRY);
+    cJSON_AddStringToObject(json_root, "command", ENABLE_ENTRY);
     cmd_parameters = cJSON_PrintUnformatted(json_root);
 
     /* Execute command */
@@ -423,12 +423,12 @@ void ExecdRun(char *exec_msg, int *childcount)
 #endif
             /* If it wasn't added before, do it now */
             if (!added_before) {
-                /* Timeout parameters - change command to delete */
+                /* Timeout parameters - change command to disable */
                 cJSON *existing_command = cJSON_GetObjectItem(json_root, "command");
                 if (existing_command) {
-                    cJSON_ReplaceItemInObject(json_root, "command", cJSON_CreateString(DELETE_ENTRY));
+                    cJSON_ReplaceItemInObject(json_root, "command", cJSON_CreateString(DISABLE_ENTRY));
                 } else {
-                    cJSON_AddStringToObject(json_root, "command", DELETE_ENTRY);
+                    cJSON_AddStringToObject(json_root, "command", DISABLE_ENTRY);
                 }
 
                 /* Create the timeout entry */

--- a/src/unit_tests/os_execd/test_execd.c
+++ b/src/unit_tests/os_execd/test_execd.c
@@ -167,7 +167,7 @@ static void test_ExecdStart_ok(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -193,7 +193,7 @@ static void test_ExecdStart_ok(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(__wrap_fprintf, 0);
 
@@ -325,7 +325,7 @@ static void test_ExecdStart_timeout_not_repeated(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -352,7 +352,7 @@ static void test_ExecdStart_timeout_not_repeated(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(__wrap_fprintf, 0);
 
@@ -418,7 +418,7 @@ static void test_ExecdStart_timeout_not_repeated(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"delete\""
+                                                                                        "\"command\":\"disable\""
                                                                                     "}' to the timeout list, with a timeout of '10s'.");
 
     ExecdStart(queue);
@@ -509,7 +509,7 @@ static void test_ExecdStart_timeout_repeated(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -536,7 +536,7 @@ static void test_ExecdStart_timeout_repeated(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(__wrap_fprintf, 0);
 
@@ -667,7 +667,7 @@ static void test_ExecdStart_wpopenv_err(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, NULL);
@@ -759,7 +759,7 @@ static void test_ExecdStart_fgets_err(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -785,7 +785,7 @@ static void test_ExecdStart_fgets_err(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(__wrap_fprintf, 0);
 

--- a/src/unit_tests/os_execd/test_win_execd.c
+++ b/src/unit_tests/os_execd/test_win_execd.c
@@ -129,7 +129,7 @@ static void test_WinExecdRun_ok(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -155,7 +155,7 @@ static void test_WinExecdRun_ok(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(wrap_fprintf, 0);
 
@@ -253,7 +253,7 @@ static void test_WinExecdRun_timeout_not_repeated(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -280,7 +280,7 @@ static void test_WinExecdRun_timeout_not_repeated(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(wrap_fprintf, 0);
 
@@ -346,7 +346,7 @@ static void test_WinExecdRun_timeout_not_repeated(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"delete\""
+                                                                                        "\"command\":\"disable\""
                                                                                     "}' to the timeout list, with a timeout of '10s'.");
 
     ExecdRun(message);
@@ -403,7 +403,7 @@ static void test_WinExecdRun_timeout_repeated(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -430,7 +430,7 @@ static void test_WinExecdRun_timeout_repeated(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(wrap_fprintf, 0);
 
@@ -529,7 +529,7 @@ static void test_WinExecdRun_wpopenv_err(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                            "\"command\":\"add\""
+                                                                                            "\"command\":\"enable\""
                                                                                         "}'");
 
     will_return(__wrap_wpopenv, NULL);
@@ -588,7 +588,7 @@ static void test_WinExecdRun_fgets_err(void **state) {
                                                                                         "\"user\":{"
                                                                                             "\"name\":\"root\""
                                                                                         "},"
-                                                                                        "\"command\":\"add\""
+                                                                                        "\"command\":\"enable\""
                                                                                     "}'");
 
     will_return(__wrap_wpopenv, wfd);
@@ -614,7 +614,7 @@ static void test_WinExecdRun_fgets_err(void **state) {
                                                     "\"user\":{"
                                                         "\"name\":\"root\""
                                                     "},"
-                                                    "\"command\":\"add\""
+                                                    "\"command\":\"enable\""
                                                 "}\n");
     will_return(wrap_fprintf, 0);
 


### PR DESCRIPTION
## Description

Closes #35085

This PR improves the naming conventions for Active Response commands by replacing the generic terms `add`/`delete` with the more descriptive and semantically accurate `enable`/`disable`. This change enhances code readability and better reflects the actual behavior of active response actions, where we are enabling or disabling security measures rather than adding or deleting entries.

Additionally, this PR resolves a compiler warning caused by the generic `VERSION` macro name conflicting with build system definitions by renaming it to `AR_VERSION`.


## Proposed Changes

### Core Command Renaming
- **Command strings**: Changed from `"add"`/`"delete"` to `"enable"`/`"disable"` in the active response protocol
- **Macro definitions**: 
  - `ADD_ENTRY` → `ENABLE_ENTRY`
  - `DELETE_ENTRY` → `DISABLE_ENTRY`
- **Enum values**:
  - `ADD_COMMAND` → `ENABLE_COMMAND`
  - `DELETE_COMMAND` → `DISABLE_COMMAND`

### Additional Improvements
- **VERSION macro**: Renamed to `AR_VERSION` to avoid conflicts with build system definitions and resolve compiler warnings

### Results and Evidence

#### Test block-ip - Stateless :green_circle: 

- Agent OS: Ubuntu 24.04
- Active response executable: `block-ip`
- Method: `iptables`
- IP address: 1.1.1.1

<details><summary>Check initial status</summary>

```console
root@ip-172-31-72-169:/home/ubuntu# sudo iptables -L -n
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
root@ip-172-31-72-169:/home/ubuntu# ping -c 3 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=1.57 ms
64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=1.28 ms
64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=1.27 ms

--- 1.1.1.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2002ms
rtt min/avg/max/mdev = 1.273/1.371/1.565/0.137 ms

```

</details> 

<details><summary>ossec.log</summary>

```log
2026/03/31 18:41:29 wazuh-execd[1651212] execd.c:580 at ExecdStart(): DEBUG: Received message: '{"@timestamp": "2026-03-31T18:40:17Z", "event": {"original": "Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso", "start": "2026-03-31T18:38:15.000Z", "kind": "event", "dataset": "system-auth", "outcome": "success", "action": "ssh_login", "category": ["authentication", "session"], "type": ["info"]}, "wazuh": {"protocol": {"location": "journald", "queue": 49}, "agent": {"host": {"hostname": "vm-ubuntu2404-agent", "os": {"name": "Ubuntu", "type": "linux", "version": "24.04 LTS (Noble Numbat)", "platform": "ubuntu"}, "architecture": "x86_64"}, "name": "vm-ubuntu2404-agent", "groups": ["default"], "id": "012", "version": "v5.0.0"}, "cluster": {"node": "node01", "name": "wazuh"}, "integration": {"name": "system", "decoders": ["decoder/core-wazuh-message/0", "decoder/integrations/0", "decoder/syslog/0", "decoder/system-auth/0"], "category": "system-activity"}, "space": {"name": "standard"}, "active_response": {"name": "block-ip", "executable": "block-ip", "extra_arguments": "extraarg", "location": "defined-agent", "agent_id": "012", "type": "stateless", "stateful_timeout": 0}}, "process": {"pid": 2329, "name": "sshd"}, "message": "Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso", "host": {"hostname": "vm-ubuntu2404-agent"}, "related": {"hosts": ["vm-ubuntu2404-agent"], "user": ["vagrant"], "ip": ["1.1.1.1"]}, "user": {"name": "vagrant"}, "source": {"ip": "1.1.1.1", "port": 35132, "address": "1.1.1.1"}}'
2026/03/31 18:41:29 wazuh-execd[1651212] execd.c:298 at ExecdRun(): DEBUG: Executing command 'active-response/bin/block-ip {"@timestamp":"2026-03-31T18:40:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateless","stateful_timeout":0}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"enable"}'

```

</details> 

<details><summary>active-responses.log</summary>

```log
2026/03/31 18:41:29 active-response/bin/block-ip: Starting
2026/03/31 18:41:29 active-response/bin/block-ip: {"@timestamp":"2026-03-31T18:40:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateless","stateful_timeout":0}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"enable"}

2026/03/31 18:41:29 active-response/bin/block-ip: {"version":1,"origin":{"name":"block-ip","module":"active-response"},"command":"check_keys","parameters":{"keys":["1.1.1.1"]}}
2026/03/31 18:41:29 active-response/bin/block-ip: {"@timestamp":"2026-03-31T18:40:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateless","stateful_timeout":0}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"continue"}

2026/03/31 18:41:29 active-response/bin/block-ip: [INFO] Method=firewalld Action=start Details=Attempting method: firewalld (lock=yes)
2026/03/31 18:41:29 active-response/bin/block-ip: Binary 'firewall-cmd' not found in default paths: firewall-cmd (2)
2026/03/31 18:41:29 active-response/bin/block-ip: [WARNING] Method=firewalld Action=skipped Details=Method not available on this system - trying next
2026/03/31 18:41:29 active-response/bin/block-ip: [INFO] Method=iptables Action=start Details=Attempting method: iptables (lock=yes)
2026/03/31 18:41:29 active-response/bin/block-ip: [INFO] Method=iptables Action=success Details=IP 1.1.1.1 successfully blocked
2026/03/31 18:41:29 active-response/bin/block-ip: Ended
```

</details> 

<details><summary>Check IP address blocked</summary>

```console
root@ip-172-31-72-169:/home/ubuntu# iptables -L -n
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
DROP       0    --  1.1.1.1              0.0.0.0/0           

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         
DROP       0    --  1.1.1.1              0.0.0.0/0           

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
root@ip-172-31-72-169:/home/ubuntu# ping -c 3 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.

--- 1.1.1.1 ping statistics ---
3 packets transmitted, 0 received, 100% packet loss, time 2027ms
```

</details> 

#### Test block-ip - Stateful :green_circle: 

- Agent OS: Ubuntu 24.04
- Active response executable: `block-ip`
- Method: `iptables`
- IP address: 1.1.1.1
- Stateful timeout: 60

<details><summary>Check initial status</summary>

```console
root@ip-172-31-72-169:/home/ubuntu# iptables -L -n
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
root@ip-172-31-72-169:/home/ubuntu# ping -c 3 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=1.28 ms
64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=1.21 ms
64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=1.24 ms

--- 1.1.1.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2005ms
rtt min/avg/max/mdev = 1.214/1.243/1.277/0.025 ms
```

</details> 

<details><summary>ossec.log</summary>

```log
2026/03/31 18:58:32 wazuh-execd[1651212] execd.c:580 at ExecdStart(): DEBUG: Received message: '{"@timestamp": "2026-03-31T18:58:17Z", "event": {"original": "Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso", "start": "2026-03-31T18:38:15.000Z", "kind": "event", "dataset": "system-auth", "outcome": "success", "action": "ssh_login", "category": ["authentication", "session"], "type": ["info"]}, "wazuh": {"protocol": {"location": "journald", "queue": 49}, "agent": {"host": {"hostname": "vm-ubuntu2404-agent", "os": {"name": "Ubuntu", "type": "linux", "version": "24.04 LTS (Noble Numbat)", "platform": "ubuntu"}, "architecture": "x86_64"}, "name": "vm-ubuntu2404-agent", "groups": ["default"], "id": "012", "version": "v5.0.0"}, "cluster": {"node": "node01", "name": "wazuh"}, "integration": {"name": "system", "decoders": ["decoder/core-wazuh-message/0", "decoder/integrations/0", "decoder/syslog/0", "decoder/system-auth/0"], "category": "system-activity"}, "space": {"name": "standard"}, "active_response": {"name": "block-ip", "executable": "block-ip", "extra_arguments": "extraarg", "location": "defined-agent", "agent_id": "012", "type": "stateful", "stateful_timeout": 60}}, "process": {"pid": 2329, "name": "sshd"}, "message": "Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso", "host": {"hostname": "vm-ubuntu2404-agent"}, "related": {"hosts": ["vm-ubuntu2404-agent"], "user": ["vagrant"], "ip": ["1.1.1.1"]}, "user": {"name": "vagrant"}, "source": {"ip": "1.1.1.1", "port": 35132, "address": "1.1.1.1"}}'
2026/03/31 18:58:32 wazuh-execd[1651212] execd.c:298 at ExecdRun(): DEBUG: Executing command 'active-response/bin/block-ip {"@timestamp":"2026-03-31T18:58:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateful","stateful_timeout":60}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"enable"}'
2026/03/31 18:58:32 wazuh-execd[1651212] execd.c:445 at ExecdRun(): DEBUG: Adding command 'active-response/bin/block-ip {"@timestamp":"2026-03-31T18:58:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateful","stateful_timeout":60}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"disable"}' to the timeout list, with a timeout of '60s'.
2026/03/31 18:58:50 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/03/31 18:58:50 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
2026/03/31 18:59:33 wazuh-execd[1651212] execd.c:169 at ExecdTimeoutRun(): DEBUG: Executing command 'active-response/bin/block-ip {"@timestamp":"2026-03-31T18:58:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateful","stateful_timeout":60}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"disable"}' after a timeout of '60s'

```

</details> 

<details><summary>active-responses.log</summary>

```log
2026/03/31 18:58:32 active-response/bin/block-ip: Starting
2026/03/31 18:58:32 active-response/bin/block-ip: {"@timestamp":"2026-03-31T18:58:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateful","stateful_timeout":60}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"enable"}

2026/03/31 18:58:32 active-response/bin/block-ip: {"version":1,"origin":{"name":"block-ip","module":"active-response"},"command":"check_keys","parameters":{"keys":["1.1.1.1"]}}
2026/03/31 18:58:32 active-response/bin/block-ip: {"@timestamp":"2026-03-31T18:58:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateful","stateful_timeout":60}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"continue"}

2026/03/31 18:58:32 active-response/bin/block-ip: [INFO] Method=firewalld Action=start Details=Attempting method: firewalld (lock=yes)
2026/03/31 18:58:32 active-response/bin/block-ip: Binary 'firewall-cmd' not found in default paths: firewall-cmd (2)
2026/03/31 18:58:32 active-response/bin/block-ip: [WARNING] Method=firewalld Action=skipped Details=Method not available on this system - trying next
2026/03/31 18:58:32 active-response/bin/block-ip: [INFO] Method=iptables Action=start Details=Attempting method: iptables (lock=yes)
2026/03/31 18:58:32 active-response/bin/block-ip: [INFO] Method=iptables Action=success Details=IP 1.1.1.1 successfully blocked
2026/03/31 18:58:32 active-response/bin/block-ip: Ended
2026/03/31 18:59:33 active-response/bin/block-ip: Starting
2026/03/31 18:59:33 active-response/bin/block-ip: {"@timestamp":"2026-03-31T18:58:17Z","event":{"original":"Mar 31 18:38:15 vm-ubuntu2404-agent sshd[2329]: Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","start":"2026-03-31T18:38:15.000Z","kind":"event","dataset":"system-auth","outcome":"success","action":"ssh_login","category":["authentication","session"],"type":["info"]},"wazuh":{"protocol":{"location":"journald","queue":49},"agent":{"host":{"hostname":"vm-ubuntu2404-agent","os":{"name":"Ubuntu","type":"linux","version":"24.04 LTS (Noble Numbat)","platform":"ubuntu"},"architecture":"x86_64"},"name":"vm-ubuntu2404-agent","groups":["default"],"id":"012","version":"v5.0.0"},"cluster":{"node":"node01","name":"wazuh"},"integration":{"name":"system","decoders":["decoder/core-wazuh-message/0","decoder/integrations/0","decoder/syslog/0","decoder/system-auth/0"],"category":"system-activity"},"space":{"name":"standard"},"active_response":{"name":"block-ip","executable":"block-ip","extra_arguments":"extraarg","location":"defined-agent","agent_id":"012","type":"stateful","stateful_timeout":60}},"process":{"pid":2329,"name":"sshd"},"message":"Accepted publickey for vagrant from 1.1.1.1 port 35132 ssh2: RSA SHA256:NNOfI40vSSweeehA3xkFUz/oOMmfPULyPi1Sz2Bknso","host":{"hostname":"vm-ubuntu2404-agent"},"related":{"hosts":["vm-ubuntu2404-agent"],"user":["vagrant"],"ip":["1.1.1.1"]},"user":{"name":"vagrant"},"source":{"ip":"1.1.1.1","port":35132,"address":"1.1.1.1"},"command":"disable"}

2026/03/31 18:59:33 active-response/bin/block-ip: [INFO] Method=firewalld Action=start Details=Attempting method: firewalld (lock=yes)
2026/03/31 18:59:33 active-response/bin/block-ip: Binary 'firewall-cmd' not found in default paths: firewall-cmd (2)
2026/03/31 18:59:33 active-response/bin/block-ip: [WARNING] Method=firewalld Action=skipped Details=Method not available on this system - trying next
2026/03/31 18:59:33 active-response/bin/block-ip: [INFO] Method=iptables Action=start Details=Attempting method: iptables (lock=yes)
2026/03/31 18:59:33 active-response/bin/block-ip: [INFO] Method=iptables Action=success Details=IP 1.1.1.1 successfully unblocked
2026/03/31 18:59:33 active-response/bin/block-ip: Ended

```

</details> 

<details><summary>Check IP address blocked</summary>

```console
root@ip-172-31-72-169:/home/ubuntu# iptables -L -n
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
DROP       0    --  1.1.1.1              0.0.0.0/0           

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         
DROP       0    --  1.1.1.1              0.0.0.0/0           

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
root@ip-172-31-72-169:/home/ubuntu# ping -c 3 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.

--- 1.1.1.1 ping statistics ---
3 packets transmitted, 0 received, 100% packet loss, time 2056ms


```

</details> 

<details><summary>Check IP address unblocked after 60s</summary>

```console
root@ip-172-31-72-169:/home/ubuntu# iptables -L -n
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
root@ip-172-31-72-169:/home/ubuntu# ping -c 3 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=1.33 ms
64 bytes from 1.1.1.1: icmp_seq=2 ttl=57 time=1.34 ms
64 bytes from 1.1.1.1: icmp_seq=3 ttl=57 time=1.22 ms

--- 1.1.1.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2002ms
rtt min/avg/max/mdev = 1.217/1.295/1.340/0.055 ms
```

</details> 

### Artifacts Affected

- `execd`
- Active response executables: `block-ip`, `disable-account`

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

No new tests introduced, but all existing unit tests have been updated to use the new command names:
- Updated test cases in `test_execd.c` for Unix systems
- Updated test cases in `test_win_execd.c` for Windows systems

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

