### PR TITLE
Add logic to close old stale sessions

### DIFF
--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -226,6 +226,11 @@ class InventorySyncFacadeImpl final
             {
                 // Check session limit before creating new session
                 std::unique_lock lock(m_agentSessionsMutex);
+
+                // Clean up any stale session for this agent+module combination
+                // This handles agent restart or modulesd restart scenarios
+                cleanupStaleSessionForAgentModule(std::string(agentId), std::string(moduleName));
+
                 if (m_agentSessions.size() >= static_cast<size_t>(m_maxSessions))
                 {
                     logWarn(LOGGER_DEFAULT_TAG,
@@ -1517,6 +1522,64 @@ private:
                      "InventorySyncFacade::deleteAgent: Failed to delete data for agent '%s': %s",
                      agentId.c_str(),
                      e.what());
+        }
+    }
+
+    /**
+     * @brief Clean up stale session for agent+module if one exists
+     * @param agentId Agent ID
+     * @param moduleName Module name
+     *
+     * This handles cases where agent or modulesd restarts, leaving orphaned sessions.
+     * When a new Start message arrives, we check if there's already a session for the
+     * same agent+module combination, and if so, clean it up before creating the new one.
+     *
+     * Note: Caller must hold m_agentSessionsMutex write lock
+     */
+    void cleanupStaleSessionForAgentModule(const std::string& agentId, const std::string& moduleName)
+    {
+        std::vector<uint64_t> staleSessionsToRemove;
+
+        // Find existing sessions for this agent+module combination
+        for (const auto& [existingSessionId, existingSession] : m_agentSessions)
+        {
+            const auto& existingContext = existingSession.getContext();
+            if (existingContext->agentId == agentId && existingContext->moduleName == moduleName)
+            {
+                logInfo(LOGGER_DEFAULT_TAG,
+                        "Found existing session %llu for agent %s module %s - "
+                        "cleaning up stale session",
+                        existingSessionId,
+                        agentId.c_str(),
+                        moduleName.c_str());
+                staleSessionsToRemove.push_back(existingSessionId);
+            }
+        }
+
+        // Clean up stale sessions
+        for (const auto& staleSessionId : staleSessionsToRemove)
+        {
+            auto it = m_agentSessions.find(staleSessionId);
+            if (it != m_agentSessions.end())
+            {
+                const auto& context = it->second.getContext();
+
+                // Unlock agent if this session owns the lock
+                if (context->ownsAgentLock)
+                {
+                    unlockAgent(agentId);
+                    logInfo(LOGGER_DEFAULT_TAG,
+                            "Stale session %llu owned agent lock - unlocked agent %s",
+                            staleSessionId,
+                            agentId.c_str());
+                }
+
+                // Delete data from database
+                m_dataStore->deleteByPrefix(std::to_string(staleSessionId));
+
+                // Remove session from map
+                m_agentSessions.erase(it);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds logic to handle stale sessions that occur when an agent closes its sessions locally before restarting, but the manager is not aware of that closure.

In these scenarios, the manager may keep sessions open that are no longer valid, leading to inconsistencies between the agent and manager states. This change ensures that such stale sessions are properly detected and closed on the manager side, keeping session state synchronized and avoiding accumulation of invalid sessions.

## Proposed changes

* Add logic to detect sessions that were closed by the agent prior to a restart but remain open on the manager.
* Implement cleanup mechanism on the manager to close these stale sessions.
* Ensure synchronization between agent and manager session states after agent restarts.
* Prevent buildup of invalid or orphaned sessions in the manager.

### Results and Evidence

```
2026/03/31 18:35:47 wazuh-manager-remoted: INFO: wazuh: Agent stopped: [003] (WIN-EU3L7MTBI50).
2026/03/31 18:37:31 logger-helper: INFO: Found existing session 7927859911899746655 for agent 003 module fim - cleaning up stale session (agent or modulesd restart)
2026/03/31 18:42:00 logger-helper: INFO: Locked agent 003 from creating new sessions - Reason: Metadata/groups update in progress
2026/03/31 18:42:04 IndexerConnector: INFO: Update by query completed: 26110 documents updated out of 26110 total (0 unchanged, 0 failures)
2026/03/31 18:42:04 logger-helper: INFO: Unlocked agent 003 for new sessions
```

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues