### PR TITLE
Dynamic getWazuhHome

### DIFF
--- a/.github/scripts/run_with_retry.sh
+++ b/.github/scripts/run_with_retry.sh
@@ -9,6 +9,12 @@ max_delay=60
 timeout_seconds=""
 label=""
 
+print_command() {
+  printf '[retry] Command used:'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
 usage() {
   cat <<'EOF'
 Usage: run_with_retry.sh [options] -- command [args...]
@@ -70,6 +76,8 @@ if [[ $# -eq 0 ]]; then
   echo "[retry] A command is required." >&2
   usage >&2
   exit 1
+else
+  print_command "$@"
 fi
 
 use_timeout=false

--- a/etc/templates/config/generic/wodle-indexer.manager.template
+++ b/etc/templates/config/generic/wodle-indexer.manager.template
@@ -4,9 +4,9 @@
     </hosts>
     <ssl>
       <certificate_authorities>
-        <ca>/var/wazuh-manager/etc/certs/root-ca.pem</ca>
+        <ca>etc/certs/root-ca.pem</ca>
       </certificate_authorities>
-      <certificate>/var/wazuh-manager/etc/certs/manager.pem</certificate>
-      <key>/var/wazuh-manager/etc/certs/manager-key.pem</key>
+      <certificate>etc/certs/manager.pem</certificate>
+      <key>etc/certs/manager-key.pem</key>
     </ssl>
   </indexer>

--- a/src/engine/source/base/include/base/process.hpp
+++ b/src/engine/source/base/include/base/process.hpp
@@ -101,12 +101,18 @@ void privSepSetGroup(gid_t gid);
 /**
  * @brief Gets the Wazuh installation home directory path.
  *
- * This function determines the Wazuh home directory by reading the current
- * executable's path from /proc/self/exe and deriving the installation root.
- * It assumes the executable is located in the "bin" subdirectory of the
- * Wazuh installation (e.g., /var/wazuh-manager/bin/executable).
+ * It delegates the functionality to w_homedir() when manager is not standalone
+ * (libwazuhshared already loaded), the canonical Wazuh function used by
+ * every other daemon. It resolves the path via /proc/self/exe
+ * (e.g. /var/wazuh-manager/bin/wazuh-engine -> /var/wazuh-manager).
  *
- * @return std::filesystem::path The path to the Wazuh home directory ("/var/wazuh-manager").
+ * It returns the current working directory when the manager is in standalone
+ * mode or during unit tests (libwazuhshared not loaded). In standalone mode,
+ * runtime paths are expected to come from dedicated environment variables;
+ * this fallback can still be used to build defaults when those variables are
+ * not set.
+ *
+ * @return std::filesystem::path The path to the Wazuh home directory.
  *
  */
 std::filesystem::path getWazuhHome();

--- a/src/engine/source/base/src/process.cpp
+++ b/src/engine/source/base/src/process.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <optional>
 #include <pthread.h>
 #include <stdexcept>
@@ -21,6 +23,7 @@
 #include <fmt/format.h>
 
 #include <base/error.hpp>
+#include <base/libwazuhshared.hpp>
 #include <base/process.hpp>
 
 constexpr auto MAX_RBUFFER_SIZE = 65536;
@@ -174,7 +177,26 @@ void privSepSetGroup(gid_t gid)
 
 std::filesystem::path getWazuhHome()
 {
-    return std::filesystem::path("/var/wazuh-manager");
+    // Manager mode: libwazuhshared is loaded before this is called (see main.cpp).
+    // Delegate to w_homedir(), the canonical function used by every other Wazuh daemon.
+    // It resolves the home via /proc/self/exe internally.
+    if (base::libwazuhshared::getLibPtr())
+    {
+        using WHDir = char* (*)(char*);
+        char executablePath[] = "/proc/self/exe";
+        std::unique_ptr<char, decltype(&std::free)> home(
+            base::libwazuhshared::getFunction<WHDir>("w_homedir")(executablePath), &std::free);
+
+        if (home)
+        {
+            return std::filesystem::path(home.get());
+        }
+    }
+
+    // Standalone mode / unit tests: libwazuhshared is not loaded.
+    // conf::Conf may still use this value to build default paths when the
+    // dedicated environment variables are not set.
+    return std::filesystem::current_path();
 }
 
 void setThreadName(const std::string& name)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

This PR proposes some changes to `getWazuhHome` flow to make it work dynamically whenever it is called from the engine-standalone mode or the general wazuh-manager.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Minor changes

- `.github/scripts/run_with_retry.sh`: Added log entry for which command has being used.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

#### Normal manager usage testing

<details>
<summary>Installing wazuh-manager in another dest via package</summary>

<img width="1916" height="868" alt="image" src="https://github.com/user-attachments/assets/39c6d677-f3b4-4c17-949f-0e0b3f99c162" />


<img width="1915" height="856" alt="image" src="https://github.com/user-attachments/assets/8b0a51d2-af4c-4213-ac09-3f2398d3fca1" />


<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/1afd3f20-a226-4975-be1b-86b8dc0c3129" />



</details>

<details>
<summary>wazuh-manager installation after upgrade</summary>

```text
root@Linux-Manager-3:/home/vagrant/wazuh#./install.sh 
 Wazuh v5.0.0 (Rev. beta1) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux Linux-Manager-3 5.15.0-164-generic (ubuntu 22.04)
  - User: root
  - Host: Linux-Manager-3



1- Installation type:
   1) manager
   2) agent
   Select an option [1-2]: 1

  - Manager installation chosen.

2- Existing manager installation detected at:
   /wazuh
   1) Update existing installation
   2) Clean install in same directory (existing data will be removed)
   3) Exit
   Select an option [1-3]: 1
...

[100%] Built target inventory_sync_testtool
make[3]: Leaving directory '/home/vagrant/wazuh/src/build'
make[2]: Leaving directory '/home/vagrant/wazuh/src/build'
make[1]: Leaving directory '/home/vagrant/wazuh/src'
make settings
make[1]: Entering directory '/home/vagrant/wazuh/src'



Starting Wazuh...

 - Configuration finished properly.

 - To start Wazuh:
      /wazuh/bin/wazuh-manager-control start

 - To stop Wazuh:
      /wazuh/bin/wazuh-manager-control stop

 - The configuration can be viewed or modified at /wazuh/etc/wazuh-manager.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - Update completed.

[...]

```

For this test, I also installed another agent in another environment so the environment change (new manager installation) and also changed the agent used in the other caso so it is more visual:

<img width="1918" height="870" alt="image" src="https://github.com/user-attachments/assets/04500b1e-4c56-4982-b12f-78828e5ba88d" />

<img width="1917" height="865" alt="image" src="https://github.com/user-attachments/assets/05faed8e-bc9b-43d3-a23b-08a93bdfab8a" />

<img width="1915" height="861" alt="image" src="https://github.com/user-attachments/assets/2fc4c57e-44c7-4a08-be5e-1f12d6ead4f0" />

<img width="1917" height="867" alt="image" src="https://github.com/user-attachments/assets/c2378feb-cb88-41fb-b9f6-f77a6ec23c98" />

</details>

#### Standalone engine testing

<details>
<summary>Standalone correct usage</summary>

To test the standalone engine I had to follow numerous steps due having to create files for decoder, user, or namespace for the logtest endpoint functionality:

1. `Install Wazuh engine standalone`: For this step, I went into `wazuh/src/engine/standalone` and executed the `generate_package.sh`, which creates a `tar.gz` file in `output` folder which contains the standalone itself.
2. `Engine starts`: In the obtained engine folder, I executed the engine with the script `run_engine.sh`, which makes the engine run in foreground, so I needed to open another terminal in order to interact with the engine.
3. `Install engine-suite tools`: Installed the required Python packages:
- pip install wazuh/src/engine/tools/engine-suite
- pip install protobuf httpx
- pip install wazuh/src/engine/tools/api-communication
4. `Set environment variables`: Exported `PATH`, `PYTHONPATH` and `SOCKET` pointing to the engine API socket.
5. `Create a namespace`: Used `engine-private ns create user` to create the user namespace, since the standalone ships with no detection content.
6. `Create and upload a decoder`: Wrote `/tmp/decoder.yml` with a minimal syslog decoder and upserted it via `engine-private cm -n user upsert decoder <  /tmp/decoder.yml`. Retrieved its UUID with `engine-private cm -n user list decoder`.

```text
root@Linux-Manager-2:/home/vagrant/wazuh/src/engine/standalone/output/wazuh-engine-standalone-5.0.0/data/store# cat /tmp/decoder.yml 
name: decoder/test-syslog/0
enabled: true
metadata:
  module: test
  title: Test decoder
  description: Minimal test
  compatibility: ""
  versions: []
  author:
    name: test
    date: "2024/01/01"
  references: []
check:
  - event.original: +string_not_empty
normalize:
  - map:
    - _message: $event.original
```

7. `Create and upload an integration`: Wrote `/tmp/integration.yml` referencing the decoder UUID and upserted it via `engine-private cm -n user upsert integration < /tmp/integration.yml`.

```text
root@Linux-Manager-2:/home/vagrant/wazuh/src/engine/standalone/output/wazuh-engine-standalone-5.0.0/data/store# cat /tmp/integration.yml 
id: "fe129be1-8172-4ed1-a090-efa285931398"
metadata:
  title: test-integration
enabled: true
category: other
default_parent: e10d6123-6c4b-46ce-9268-54743af9df83
decoders:
  - "e10d6123-6c4b-46ce-9268-54743af9df83"
kvdbs: []
```

8. `Create and upload a policy`: Wrote `/tmp/policy.yml` referencing both the decoder UUID (as root_decoder and default_parent) and the integration UUID, then upserted it via `engine-private cm -n user policy-upsert < /tmp/policy.yml`.

```text
root@Linux-Manager-2:/home/vagrant/wazuh/src/engine/standalone/output/wazuh-engine-standalone-5.0.0/data/store# cat /tmp/policy.yml 
type: policy
enabled: true
metadata:
  title: Test Policy
hash: "test-hash"
enrichments: []
filters: []
index_unclassified_events: true
index_discarded_events: false
default_parent: e10d6123-6c4b-46ce-9268-54743af9df83
root_decoder: e10d6123-6c4b-46ce-9268-54743af9df83
cleanup_decoder_variables: false
integrations:
  - "fe129be1-8172-4ed1-a090-efa285931398"
```

9. `Create a tester session`: Called POST /tester/session/post via curl, binding the session name user to the user namespace.

10. `Run logtest`: Called `POST /logtest` via curl with a raw syslog event, obtaining a successful {"status":"OK"} response with full asset traces showing the event processed through the decoder pipeline.

```text
root@Linux-Manager-2:/home/vagrant/wazuh/src/engine/standalone/output/wazuh-engine-standalone-5.0.0/data/store# curl --unix-socket $SOCKET -X POST http://localhost/logtest     -H "Content-Type: application/json"     -d '{"queue": 1, "location": "test", "event": "Apr 20 12:50:00 myhost sshd[1234]: test", "namespaces": ["user"], "trace_level": "ALL", "space": "user"}'
{"status":"OK","result":{"output":{"wazuh":{"space":{"name":"UNDEFINED"},"protocol":{"location":"test","queue":1}},"event":{"original":"Apr 20 12:50:00 myhost sshd[1234]: test"}},"asset_traces":[{"asset":"decoder/test-syslog/0","success":false,"traces":["event.original: filter(\"+string_not_empty\") -\u003e Value missmatch for reference 'event.original'"]},{"asset":"filter/DiscardedEvents","success":true,"traces":["Discard_event() -\u003e Success: Event will be indexed (wazuh.space.event_discarded=false)"]},{"asset":"cleanup/DecoderTemporaryVariables","success":true,"traces":["cleanupDecoderTemporaryVariables() -\u003e Skipped: Cleanup disabled by policy"]}],"validation":{"valid":true,"errors":[]}}}
```

</details>

---

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
- [x] Log syntax and correct language review

- Engine _(Wazuh v5.x and above)_
  - [x] Test run in parallel
  - [x] ASAN for test (utest/ctest)
  - [x] TSAN for test and wazuh-engine.
  
<details>
<summary>Output parallel</summary>

```text
make deps -C src TARGET=manager -j$(nproc)
make -C src TARGET=manager ENGINE_TEST=y -j$(nproc)
cd src/build/engine
ctest -T test --output-on-failure -j$(nproc)

```

</details>

<details>
<summary>Output ASAN</summary>

```text
make deps -C src TARGET=manager -j$(nproc)
make -C src TARGET=manager TEST=y -j$(nproc)
cd src/build/engine
ASAN_OPTIONS=malloc_context_size=8:print_stats=0:fast_unwind_on_malloc=1 \
MALLOC_CHECK_=2 \
ctest -T test --output-on-failure -j$(nproc)
```

</details>

<details>
<summary>Output TSAN</summary>

```text
make deps -C src TARGET=manager -j$(nproc)
make -C src TARGET=manager ENGINE_TEST=y CMAKE_ENGINE_EXTRA_OPTS="-DENGINE_ENABLE_TSAN=ON" -j$(nproc)
cd src/build/engine
ctest -T test --output-on-failure -j$(nproc)
```

</details>

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

- `.github/scripts/run_with_retry.sh`
- `etc/templates/config/generic/wodle-indexer.manager.template`
- `src/engine/source/base/include/base/process.hpp`
- `src/engine/source/base/src/process.cpp`

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

- `etc/templates/config/generic/wodle-indexer.manager.template`: Adjusted certificates' path to use relative path.

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
