### PR TITLE
Refine JSON event fields

### DIFF
--- a/docs/ref/modules/vulnerability-scanner/api-reference.md
+++ b/docs/ref/modules/vulnerability-scanner/api-reference.md
@@ -16,7 +16,7 @@ For a quick reference, the vulnerabilities can be retrieved using the **GET /waz
 - `host.os.full` is built from OS `name` + `version` (macOS uses `codename`).
 - `host.os.version` is built from `major.minor.patch.build`, not the raw OS version string.
 - For OS detections, `package.*` is populated with OS data to represent the affected component.
-- `package.path` and `package.type` are indexed as `""` when empty, and queries use `""` for those fields.
+- `package.path` and `package.type` are indexed as `null` when empty, and delete queries treat those cases as missing fields.
 - `@timestamp` and `event.*` are intentionally not set in indexed documents because the mapping is strict.
 
 # Indexed vulnerabilities

--- a/docs/ref/modules/vulnerability-scanner/architecture.md
+++ b/docs/ref/modules/vulnerability-scanner/architecture.md
@@ -113,7 +113,7 @@ VD generates ECS JSON documents (no internal alert struct) that are:
 
 - OS scan is supported only for Windows and Darwin. Linux OS scan is not supported (the kernel is treated as a package).
 - `host.os.full` is built from OS `name` + `version` (macOS uses `codename`), and `host.os.version` from `major.minor.patch.build`.
-- `package.path` and `package.type` are indexed as `""` when empty.
+- `package.path` and `package.type` are indexed as `null` when empty.
 
 ## High-Level diagram
 

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp
@@ -303,8 +303,8 @@ namespace InventorySyncQueryBuilder
     /// @param agentId        Agent ID to match
     /// @param packageName    Package name to match
     /// @param packageVersion Package version to match
-    /// @param packagePath    Package path/location to match (package.path)
-    /// @param packageType    Package type/format to match (package.type)
+    /// @param packagePath    Package path/location to match (package.path). Empty means missing field.
+    /// @param packageType    Package type/format to match (package.type). Empty means missing field.
     /// @param size           Maximum number of results to return
     /// @param searchAfter    Optional search_after value for pagination [_id]
     /// @return JSON search query body with bool query and sort
@@ -316,19 +316,36 @@ namespace InventorySyncQueryBuilder
                                            std::size_t size,
                                            const std::string& searchAfter = "")
     {
-        nlohmann::json query = {// Only fetch vulnerability.id; _id is part of hit metadata
-                                {"_source", nlohmann::json::array({"vulnerability.id"})},
-                                {"size", size},
-                                {"query", {{"bool", {{"must", nlohmann::json::array()}}}}},
-                                {"sort", {{{"_id", {{"order", "asc"}}}}}}};
+        nlohmann::json query = {
+            // Only fetch vulnerability.id; _id is part of hit metadata
+            {"_source", nlohmann::json::array({"vulnerability.id"})},
+            {"size", size},
+            {"query", {{"bool", {{"must", nlohmann::json::array()}, {"must_not", nlohmann::json::array()}}}}},
+            {"sort", {{{"_id", {{"order", "asc"}}}}}}};
 
         auto& must = query["query"]["bool"]["must"];
+        auto& mustNot = query["query"]["bool"]["must_not"];
 
         must.push_back({{"term", {{"wazuh.agent.id", agentId}}}});
         must.push_back({{"term", {{"package.name", packageName}}}});
         must.push_back({{"term", {{"package.version", packageVersion}}}});
-        must.push_back({{"term", {{"package.path", packagePath}}}});
-        must.push_back({{"term", {{"package.type", packageType}}}});
+        if (packagePath.empty())
+        {
+            mustNot.push_back({{"exists", {{"field", "package.path"}}}});
+        }
+        else
+        {
+            must.push_back({{"term", {{"package.path", packagePath}}}});
+        }
+
+        if (packageType.empty())
+        {
+            mustNot.push_back({{"exists", {{"field", "package.type"}}}});
+        }
+        else
+        {
+            must.push_back({{"term", {{"package.type", packageType}}}});
+        }
 
         if (!searchAfter.empty())
         {

--- a/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityDescription.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/vulnerabilityDescription.fbs
@@ -8,6 +8,7 @@ table VulnerabilityDescription {
   availabilityImpact: string;
   confidentialityImpact: string;
   cweId: string;
+  datePublished: string;
   dateUpdated: string;
   integrityImpact: string;
   privilegesRequired: string;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -67,6 +67,7 @@ public:
             std::string vulnDescFBScoreVersionStr;
             std::string vulnDescFBAssignerStr;
             std::string vulnDescFBCWEIdStr;
+            std::string vulnDescFBDatePublishedStr;
             std::string vulnDescFBDataUpdatedStr;
             std::string vulnDescFBAccessComplexityStr;
             std::string vulnDescFBAttackVectorStr;
@@ -164,6 +165,8 @@ public:
             {
                 vulnDescFBAssignerStr =
                     (cve5Metadata->assignerShortName()) ? cve5Metadata->assignerShortName()->str() : "";
+                vulnDescFBDatePublishedStr =
+                    (cve5Metadata->datePublished()) ? cve5Metadata->datePublished()->str() : "";
                 vulnDescFBDataUpdatedStr = (cve5Metadata->dateUpdated()) ? cve5Metadata->dateUpdated()->str() : "";
             }
 
@@ -195,6 +198,7 @@ public:
                                                                              vulnDescFBAvailabilityStr.c_str(),
                                                                              vulnDescFBConfidentialityImpactStr.c_str(),
                                                                              vulnDescFBCWEIdStr.c_str(),
+                                                                             vulnDescFBDatePublishedStr.c_str(),
                                                                              vulnDescFBDataUpdatedStr.c_str(),
                                                                              vulnDescFBIntegrityImpactStr.c_str(),
                                                                              vulnDescFBPrivilegesRequiredStr.c_str(),

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -61,6 +61,11 @@ struct CveDescription final
     std::string_view cweId = DEFAULT_STR_VALUE;
 
     /**
+     * @brief Date when the CVE was officially published.
+     */
+    std::string_view datePublished = DEFAULT_STR_VALUE;
+
+    /**
      * @brief Date when the vulnerability was last updated.
      */
     std::string_view dateUpdated = DEFAULT_TIMESTAMP;
@@ -290,6 +295,7 @@ public:
         {
             assignValue(cveDescription.assignerShortName, descriptionData.data->assignerShortName()->string_view());
             assignValue(cveDescription.cweId, descriptionData.data->cweId()->string_view());
+            assignValue(cveDescription.datePublished, descriptionData.data->datePublished()->string_view());
             assignValue(cveDescription.dateUpdated, descriptionData.data->dateUpdated()->string_view());
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
@@ -110,6 +110,10 @@ private:
         // Core vulnerability fields from the CVE description.
         vuln.id = detection.cveId;
         vuln.detected_at = Utils::getCurrentISO8601();
+        if (!description.datePublished.empty())
+        {
+            vuln.published_at = std::string(description.datePublished);
+        }
 
         vuln.severity =
             FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(std::string {description.severity}));
@@ -253,7 +257,14 @@ private:
             {
                 json["package"]["version"] = packageCtx->version;
             }
-            json["package"]["type"] = packageCtx->format;
+            if (!packageCtx->format.empty())
+            {
+                json["package"]["type"] = packageCtx->format;
+            }
+            else
+            {
+                json["package"]["type"] = nullptr;
+            }
             if (!packageCtx->architecture.empty())
             {
                 json["package"]["architecture"] = packageCtx->architecture;
@@ -262,7 +273,14 @@ private:
             {
                 json["package"]["description"] = packageCtx->description;
             }
-            json["package"]["path"] = packageCtx->location;
+            if (!packageCtx->location.empty())
+            {
+                json["package"]["path"] = packageCtx->location;
+            }
+            else
+            {
+                json["package"]["path"] = nullptr;
+            }
             if (packageCtx->size > 0)
             {
                 json["package"]["size"] = packageCtx->size;
@@ -350,6 +368,10 @@ private:
         if (!vuln.detected_at.empty())
         {
             json["vulnerability"]["detected_at"] = vuln.detected_at;
+        }
+        if (!vuln.published_at.empty())
+        {
+            json["vulnerability"]["published_at"] = vuln.published_at;
         }
         if (!vuln.severity.empty())
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -197,6 +197,7 @@ struct Vulnerability
 {
     std::string id;                // vulnerability.id
     std::string detected_at;       // vulnerability.detected_at
+    std::string published_at;      // vulnerability.published_at
     std::string severity;          // vulnerability.severity
     std::string category;          // vulnerability.category
     bool under_evaluation {false}; // vulnerability.under_evaluation

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -259,6 +259,7 @@ void DatabaseFeedManagerTest::SetUp()
                                                                      "AvailabilityStrNvd",
                                                                      "ConfidentialityImpactStrNvd",
                                                                      "CWEIdStrNvd",
+                                                                     "",
                                                                      "DataUpdatedStr",
                                                                      "IntegrityImpactStrNvd",
                                                                      "PrivilegesRequiredStrNvd",

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -174,6 +174,7 @@ TEST_F(EventDetailsBuilderTest, TestPackageVulnerabilityWithCVSS2)
                                                                      "PARTIAL",              // availabilityImpact
                                                                      "PARTIAL",              // confidentialityImpact
                                                                      "CWE-89",               // cweId
+                                                                     "2021-01-01T00:00:00Z", // datePublished
                                                                      "2021-02-20T15:30:00Z", // dateUpdated
                                                                      "PARTIAL",              // integrityImpact
                                                                      "",                     // privilegesRequired
@@ -286,6 +287,7 @@ TEST_F(EventDetailsBuilderTest, TestPackageVulnerabilityWithCVSS2)
     EXPECT_EQ(event["package"]["version"].get<std::string>(), "1.0.0");
     EXPECT_EQ(event["package"]["architecture"].get<std::string>(), "amd64");
     EXPECT_EQ(event["package"]["type"].get<std::string>(), "deb");
+    EXPECT_TRUE(event["package"]["path"].is_null());
     EXPECT_EQ(event["package"]["size"].get<int64_t>(), 1024);
 
     // Verify vulnerability fields
@@ -295,7 +297,7 @@ TEST_F(EventDetailsBuilderTest, TestPackageVulnerabilityWithCVSS2)
     EXPECT_FALSE(event["vulnerability"].contains("description"));
     EXPECT_FALSE(event["vulnerability"]["detected_at"].get<std::string>().empty());
     EXPECT_FALSE(event["vulnerability"].contains("enumeration"));
-    EXPECT_FALSE(event["vulnerability"].contains("published_at"));
+    EXPECT_EQ(event["vulnerability"]["published_at"].get<std::string>(), "2021-01-01T00:00:00Z");
     EXPECT_FALSE(event["vulnerability"].contains("reference"));
     EXPECT_EQ(event["vulnerability"]["severity"].get<std::string>(), "High");
     EXPECT_EQ(event["vulnerability"]["score"]["base"].get<double>(), 7.5);
@@ -331,6 +333,7 @@ TEST_F(EventDetailsBuilderTest, TestDarwinToMacOSConversion)
                                                                      "HIGH",
                                                                      "NONE",
                                                                      "CWE-787",
+                                                                     "",
                                                                      "2023-04-15T12:00:00Z",
                                                                      "NONE",
                                                                      "LOW",
@@ -438,6 +441,7 @@ TEST_F(EventDetailsBuilderTest, TestDefaultStatusCondition)
                                                                      "PARTIAL",
                                                                      "PARTIAL",
                                                                      "CWE-22",
+                                                                     "",
                                                                      "2020-07-05T10:00:00Z",
                                                                      "PARTIAL",
                                                                      "",
@@ -537,6 +541,7 @@ TEST_F(EventDetailsBuilderTest, TestUnknownConditionType)
                                                                      "HIGH",
                                                                      "NONE",
                                                                      "CWE-416",
+                                                                     "",
                                                                      "2023-10-05T16:00:00Z",
                                                                      "LOW",
                                                                      "NONE",
@@ -636,6 +641,7 @@ TEST_F(EventDetailsBuilderTest, TestScannerSourceFallbackToCnaSource)
                                                                      "PARTIAL",
                                                                      "PARTIAL",
                                                                      "CWE-89",
+                                                                     "",
                                                                      "2021-12-15T12:00:00Z",
                                                                      "NONE",
                                                                      "",
@@ -735,6 +741,7 @@ TEST_F(EventDetailsBuilderTest, TestScannerSourceFallbackForVersionedCnaName)
                                                                      "HIGH",
                                                                      "HIGH",
                                                                      "CWE-787",
+                                                                     "",
                                                                      "2024-02-15T12:00:00Z",
                                                                      "HIGH",
                                                                      "NONE",
@@ -839,6 +846,7 @@ TEST_F(EventDetailsBuilderTest, TestOsDeleteWithDeletedOSData)
                                                                      "HIGH",
                                                                      "HIGH",
                                                                      "CWE-269",
+                                                                     "",
                                                                      "2022-03-15T11:00:00Z",
                                                                      "HIGH",
                                                                      "LOW",
@@ -1042,6 +1050,7 @@ TEST_F(EventDetailsBuilderTest, TestAgentWithEmptyOptionalFields)
                                                                      "HIGH",
                                                                      "HIGH",
                                                                      "CWE-502",
+                                                                     "",
                                                                      "2023-06-10T12:00:00Z",
                                                                      "HIGH",
                                                                      "LOW",
@@ -1095,7 +1104,6 @@ TEST_F(EventDetailsBuilderTest, TestAgentWithEmptyOptionalFields)
     PackageContextData pkg;
     pkg.name = "minimal-pkg";
     pkg.version = "1.0.0";
-    pkg.format = "deb";
 
     const std::string detectionId = "018_minimal-pkg_1.0.0_CVE-2024-2222";
     const std::string detectionIdBase = "018_minimal-pkg_1.0.0";
@@ -1140,6 +1148,12 @@ TEST_F(EventDetailsBuilderTest, TestAgentWithEmptyOptionalFields)
     EXPECT_FALSE(event["wazuh"]["agent"]["host"].contains("ip"));
     EXPECT_FALSE(event["wazuh"]["agent"].contains("groups"));
 
+    EXPECT_TRUE(event.contains("package"));
+    EXPECT_EQ(event["package"]["name"].get<std::string>(), "minimal-pkg");
+    EXPECT_EQ(event["package"]["version"].get<std::string>(), "1.0.0");
+    EXPECT_TRUE(event["package"]["type"].is_null());
+    EXPECT_TRUE(event["package"]["path"].is_null());
+
     EXPECT_TRUE(event["host"].contains("os"));
     EXPECT_EQ(event["host"]["os"]["name"].get<std::string>(), "Ubuntu");
 }
@@ -1156,6 +1170,7 @@ TEST_F(EventDetailsBuilderTest, TestOsVulnerabilityWithCVSS3)
                                                                      "HIGH",
                                                                      "NONE",
                                                                      "CWE-20",
+                                                                     "",
                                                                      "2022-04-15T12:00:00Z",
                                                                      "NONE",
                                                                      "NONE",
@@ -1332,6 +1347,7 @@ TEST_F(EventDetailsBuilderTest, TestUnderEvaluationFlag)
                                                                      "",
                                                                      "",
                                                                      "",
+                                                                     "",
                                                                      0.0,
                                                                      "",
                                                                      "",
@@ -1419,6 +1435,7 @@ TEST_F(EventDetailsBuilderTest, TestManagerAgentProcessing)
                                                                      "HIGH",
                                                                      "LOW",
                                                                      "CWE-119",
+                                                                     "",
                                                                      "2022-06-15T12:00:00Z",
                                                                      "LOW",
                                                                      "LOW",
@@ -1529,6 +1546,7 @@ TEST_F(EventDetailsBuilderTest, TestDeleteOperation)
                                                                      "COMPLETE",
                                                                      "COMPLETE",
                                                                      "CWE-264",
+                                                                     "",
                                                                      "2020-04-20T10:00:00Z",
                                                                      "COMPLETE",
                                                                      "",
@@ -1634,6 +1652,7 @@ TEST_F(EventDetailsBuilderTest, TestPackageWithOptionalFields)
                                                                      "LOW",
                                                                      "NONE",
                                                                      "CWE-200",
+                                                                     "",
                                                                      "2021-08-25T16:30:00Z",
                                                                      "NONE",
                                                                      "NONE",
@@ -1757,6 +1776,7 @@ TEST_F(EventDetailsBuilderTest, TestUnderEvaluationFalseWithValidScore)
                                                                      "PARTIAL",
                                                                      "NONE",
                                                                      "CWE-79",
+                                                                     "",
                                                                      "2019-12-10T11:00:00Z",
                                                                      "PARTIAL",
                                                                      "",
@@ -1862,6 +1882,7 @@ TEST_F(EventDetailsBuilderTest, TestOsDeleteOperation)
                                                                      "COMPLETE",
                                                                      "COMPLETE",
                                                                      "CWE-20",
+                                                                     "",
                                                                      "2022-09-15T16:00:00Z",
                                                                      "COMPLETE",
                                                                      "HIGH",

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventGetCve_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventGetCve_test.cpp
@@ -99,6 +99,59 @@ TEST_F(EventGetCveTest, AddsDeleteDetectionFromIndexerHits)
     EXPECT_EQ(detection.componentType, AffectedComponentType::Package);
 }
 
+TEST_F(EventGetCveTest, UsesMissingFieldQueriesForEmptyPathAndType)
+{
+    auto mockConnector = std::make_shared<MockIndexerConnector>();
+    const auto cveId = std::string {"CVE-2024-5678"};
+
+    auto scanContext = createScanContext();
+    PackageContextData pkg;
+    pkg.name = "libcustom";
+    pkg.version = "1.0.0";
+
+    const auto detectionBase = scanContext->buildPackageDetectionIdBase("pkg123");
+    scanContext->addPackageToContext(detectionBase, pkg, ElementOperation::Delete);
+
+    const std::string detectionId = detectionBase + "_" + cveId;
+    auto response = nlohmann::json::parse(R"(
+        {
+            "hits": {
+                "hits": [
+                    {
+                        "_id": "DUMMY",
+                        "_source": {
+                            "vulnerability": {
+                                "id": "CVE-9999-0000"
+                            }
+                        }
+                    }
+                ]
+            }
+        })");
+    response["hits"]["hits"][0]["_id"] = detectionId;
+    response["hits"]["hits"][0]["_source"]["vulnerability"]["id"] = cveId;
+
+    EXPECT_CALL(*mockConnector, executeSearchQueryWithPagination(_, _, _))
+        .WillOnce(Invoke(
+            [&](const std::string& index,
+                const nlohmann::json& query,
+                std::function<void(const nlohmann::json&)> callback)
+            {
+                EXPECT_EQ(index, "wazuh-states-vulnerabilities");
+                ASSERT_TRUE(query["query"]["bool"].contains("must_not"));
+                ASSERT_EQ(query["query"]["bool"]["must_not"].size(), 2U);
+                EXPECT_EQ(query["query"]["bool"]["must_not"][0]["exists"]["field"], "package.path");
+                EXPECT_EQ(query["query"]["bool"]["must_not"][1]["exists"]["field"], "package.type");
+                callback(response);
+            }));
+
+    TEventGetCve<MockIndexerConnector, TScanContext<>> handler(mockConnector);
+
+    EXPECT_NO_THROW(handler.handleRequest(scanContext));
+    ASSERT_EQ(scanContext->cveCount(), 1U);
+    ASSERT_TRUE(scanContext->hasCVE(detectionId));
+}
+
 TEST_F(EventGetCveTest, SkipDeletedPackageWithoutNameOrVersion)
 {
     auto mockConnector = std::make_shared<MockIndexerConnector>();


### PR DESCRIPTION
## Summary

- Edit `package.path` from generated vulnerability events, now empty fields should have null, not empty string.
- Adds `vulnerability.published_at` populated from the CVE metadata `datePublished` field — enables filtering and prioritization by official CVE publication date.

## Evidences

- Two different documents can be observed in `wazuh-states-vulnerabilities` for `Django 3.2.13`.
- Both documents share the same `package.name`, `package.version`, and `package.type`, but they have different `package.path` values.
- They also have different `_id` values, which confirms that VD is treating them as two independent detections.
- The captured `delete` event points specifically to the `/usr/local/lib/python3.12/dist-packages/...` installation.
- After processing the delete, only one `CVE-2025-64458` document remains in VD, which matches the expected behavior.

## Evidence

<details>
<summary>VD document 1: Django 3.2.13 in <code>/usr/lib/python3/dist-packages</code></summary>

```json
{
  "_index": "wazuh-states-vulnerabilities",
  "_id": "001_db294813c057074fd46919fe5ab6ff7c958797a6_CVE-2025-64458",
  "_score": 0,
  "_source": {
    "host": {
      "os": {
        "full": "Ubuntu 24.04.3 LTS (Noble Numbat)",
        "kernel": "6.8.0-86-generic",
        "name": "Ubuntu",
        "platform": "ubuntu",
        "type": "linux",
        "version": "24.04.3"
      }
    },
    "package": {
      "description": "A high-level Python Web framework that encourages rapid development and clean, pragmatic design.",
      "name": "Django",
      "path": "/usr/lib/python3/dist-packages/Django-3.2.13.dist-info/METADATA",
      "type": "pypi",
      "version": "3.2.13"
    },
    "vulnerability": {
      "category": "Packages",
      "detected_at": "2026-04-06T11:46:16.733Z",
      "id": "CVE-2025-64458",
      "published_at": "2025-11-05T15:15:40Z",
      "scanner": {
        "condition": "Package less than 4.2.26",
        "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2025-64458",
        "source": "Open Source Vulnerabilities",
        "vendor": "Wazuh"
      },
      "score": {
        "base": 7.5,
        "version": "3.1"
      },
      "severity": "High",
      "under_evaluation": false
    },
    "wazuh": {
      "agent": {
        "groups": [
          "default"
        ],
        "host": {
          "architecture": "aarch64",
          "hostname": "ubuntu24",
          "os": {
            "name": "Ubuntu",
            "platform": "ubuntu",
            "type": "linux",
            "version": "24.04.3 LTS (Noble Numbat)"
          }
        },
        "id": "001",
        "name": "ubuntu24",
        "version": "v5.0.0"
      },
      "cluster": {
        "name": "wazuh"
      },
      "schema": {
        "version": "1.0.0"
      }
    }
  },
  "fields": {
    "vulnerability.detected_at": [
      "2026-04-06T11:46:16.733Z"
    ],
    "vulnerability.published_at": [
      "2025-11-05T15:15:40.000Z"
    ]
  }
}
```

</details>

<details>
<summary>VD document 2: Django 3.2.13 in <code>/usr/local/lib/python3.12/dist-packages</code></summary>

```json
{
  "_index": "wazuh-states-vulnerabilities",
  "_id": "001_4db5c49b511c476ffff7b6db3e56d1e3a7aa9cf9_CVE-2025-64458",
  "_score": 0,
  "_source": {
    "host": {
      "os": {
        "full": "Ubuntu 24.04.3 LTS (Noble Numbat)",
        "kernel": "6.8.0-86-generic",
        "name": "Ubuntu",
        "platform": "ubuntu",
        "type": "linux",
        "version": "24.04.3"
      }
    },
    "package": {
      "description": "A high-level Python Web framework that encourages rapid development and clean, pragmatic design.",
      "name": "Django",
      "path": "/usr/local/lib/python3.12/dist-packages/Django-3.2.13.dist-info/METADATA",
      "type": "pypi",
      "version": "3.2.13"
    },
    "vulnerability": {
      "category": "Packages",
      "detected_at": "2026-04-06T11:46:16.777Z",
      "id": "CVE-2025-64458",
      "published_at": "2025-11-05T15:15:40Z",
      "scanner": {
        "condition": "Package less than 4.2.26",
        "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2025-64458",
        "source": "Open Source Vulnerabilities",
        "vendor": "Wazuh"
      },
      "score": {
        "base": 7.5,
        "version": "3.1"
      },
      "severity": "High",
      "under_evaluation": false
    },
    "wazuh": {
      "agent": {
        "groups": [
          "default"
        ],
        "host": {
          "architecture": "aarch64",
          "hostname": "ubuntu24",
          "os": {
            "name": "Ubuntu",
            "platform": "ubuntu",
            "type": "linux",
            "version": "24.04.3 LTS (Noble Numbat)"
          }
        },
        "id": "001",
        "name": "ubuntu24",
        "version": "v5.0.0"
      },
      "cluster": {
        "name": "wazuh"
      },
      "schema": {
        "version": "1.0.0"
      }
    }
  },
  "fields": {
    "vulnerability.detected_at": [
      "2026-04-06T11:46:16.777Z"
    ],
    "vulnerability.published_at": [
      "2025-11-05T15:15:40.000Z"
    ]
  }
}
```

</details>

<details>
<summary><code>delete</code> event: only for the <code>/usr/local/lib/python3.12/dist-packages</code> installation</summary>

```json
{
  "_index": ".ds-wazuh-events-v5-security-000001",
  "_id": "03ioYp0BRDLdHEkIXP7p",
  "_version": 1,
  "_score": null,
  "_source": {
    "wazuh": {
      "protocol": {
        "queue": 118,
        "location": "vulnerability-scanner"
      },
      "agent": {
        "groups": [
          "default"
        ],
        "host": {
          "architecture": "aarch64",
          "hostname": "ubuntu24",
          "os": {
            "name": "Ubuntu",
            "platform": "ubuntu",
            "type": "linux",
            "version": "24.04.3 LTS (Noble Numbat)"
          }
        },
        "id": "001",
        "name": "ubuntu24",
        "version": "v5.0.0"
      },
      "integration": {
        "category": "security",
        "name": "wazuh-vd",
        "decoders": [
          "decoder/core-wazuh-message/0",
          "decoder/integrations/0",
          "decoder/wazuh-vd/0"
        ]
      },
      "space": {
        "name": "standard"
      }
    },
    "event": {
      "original": "{\"collector\":\"packages\",\"data\":{\"event\":{\"created\":\"2026-04-06T11:57:57.799Z\",\"type\":\"delete\"},\"host\":{\"os\":{\"full\":\"Ubuntu 24.04.3 LTS (Noble Numbat)\",\"name\":\"Ubuntu\",\"platform\":\"ubuntu\",\"type\":\"linux\"}},\"package\":{\"description\":\"A high-level Python Web framework that encourages rapid development and clean, pragmatic design.\",\"name\":\"Django\",\"path\":\"/usr/local/lib/python3.12/dist-packages/Django-3.2.13.dist-info/METADATA\",\"type\":\"pypi\",\"version\":\"3.2.13\"},\"vulnerability\":{\"category\":\"Packages\",\"detected_at\":\"2026-04-06T11:57:57.796Z\",\"id\":\"CVE-2024-27351\",\"published_at\":\"2024-03-15T20:15:09Z\",\"scanner\":{\"condition\":\"Unknown\",\"reference\":\"https://cti.wazuh.com/vulnerabilities/cves/CVE-2024-27351\",\"vendor\":\"Wazuh\"},\"score\":{\"base\":5.3,\"version\":\"3.1\"},\"severity\":\"Medium\",\"under_evaluation\":false}},\"module\":\"vulnerability-scanner\",\"wazuh\":{\"cluster\":{\"name\":\"wazuh\",\"node\":\"node01\"}}}",
      "category": [
        "vulnerability"
      ],
      "dataset": "wazuh.vd",
      "kind": "event",
      "start": "2026-04-06T11:57:57.796Z",
      "type": [
        "delete"
      ],
      "provider": "packages"
    },
    "@timestamp": "2026-04-06T11:57:57Z",
    "data_stream": {
      "dataset": "wazuh.vd",
      "type": "logs"
    },
    "vulnerability": {
      "id": "CVE-2024-27351",
      "severity": "Medium",
      "score": {
        "base": 5.3,
        "version": "3.1"
      },
      "category": [
        "Packages"
      ],
      "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2024-27351"
    },
    "observer": {
      "vendor": "Wazuh"
    },
    "package": {
      "name": "Django",
      "version": "3.2.13",
      "type": "pypi",
      "description": "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
    }
  },
  "fields": {
    "@timestamp": [
      "2026-04-06T11:57:57.000Z"
    ],
    "event.start": [
      "2026-04-06T11:57:57.796Z"
    ]
  },
  "highlight": {
    "package.name": [
      "@opensearch-dashboards-highlighted-field@Django@/opensearch-dashboards-highlighted-field@"
    ]
  },
  "sort": [
    1775476677000
  ]
}
```

</details>

## Conclusion

- This confirms that two installations of the same package in two different `path` values generate two different VD documents.
- This also confirms that the captured `delete` event targets only one specific installation.
- Since only one `CVE-2025-64458` document remains in VD after the delete, the final behavior is correct: only the vulnerabilities associated with the removed installation were solved, while the remaining installation stayed active.
<img width="1618" height="304" alt="image" src="https://github.com/user-attachments/assets/71ac0c58-c9b9-4918-91dc-5d09ea9c4488" />




Closes #35246
