### PR TITLE
Fix RBAC integration tests

### DIFF
--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -292,11 +292,7 @@ stages:
 ---
 test_name: GET /cluster/configuration/validation
 
-marks:
-  - xfail #https://github.com/wazuh/wazuh/issues/34733
-
 stages:
-
   - name: Request cluster validation
     request:
       verify: False
@@ -319,18 +315,17 @@ stages:
           total_affected_items: 1
           total_failed_items: 0
 
-  - name: Request cluster validation
+  - name: Request cluster validation (with nodes_list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/"
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
         nodes_list: 'worker1,worker2'
-      timeout: 20
-      params:
         wait_for_complete: true
+      timeout: 20
     response:
       status_code: 200
       json:

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -350,9 +350,6 @@ stages:
 ---
 test_name: GET /cluster/configuration/validation
 
-marks:
-  - xfail #https://github.com/wazuh/wazuh/issues/34733
-
 stages:
 
   - name: Request cluster validation
@@ -388,9 +385,8 @@ stages:
         Authorization: "Bearer {test_login_token}"
       params:
         nodes_list: 'worker1,worker2'
-      timeout: 20
-      params:
         wait_for_complete: true
+      timeout: 20        
     response:
       status_code: 200
       json:


### PR DESCRIPTION
## Description

  This pull request fixes the RBAC integration tests for the /cluster/configuration/validation endpoint, which were previously failing and marked as xfail. These fixes ensure that the
  cluster configuration validation is correctly tested under different RBAC configurations (white and black lists).

  Closes #34733

## Proposed Changes

   - Removed xfail marks: Enabled the tests for GET /cluster/configuration/validation in both test_rbac_black_cluster_endpoints.tavern.yaml and
     test_rbac_white_cluster_endpoints.tavern.yaml.
   - Fixed test URLs: Corrected the endpoint URL in test_rbac_black_cluster_endpoints.tavern.yaml where it was pointing to a generic /cluster/ path instead of the specific validation
     path.
   - Corrected YAML structure: Fixed a syntax issue in the Tavern test files where the params key was duplicated, which could lead to parameters being ignored or causing parsing errors
     errors.
   - Improved test descriptions: Updated stage names to be more descriptive (e.g., adding (with nodes_list)).

### Results and Evidence

  The integration tests for RBAC cluster endpoints now correctly validate the configuration validation functionality without failing.
  https://jenkins-staging.qa.wazuh.info/job/5.0.0/job/Test_integration_endpoints/143/
  

- `test_rbac_white_cluster_endpoints.yaml`:
[staging_Test_integration_endpoints_B143_test_rbac_white_cluster_endpoints.txt](https://github.com/user-attachments/files/26420275/staging_Test_integration_endpoints_B143_test_rbac_white_cluster_endpoints.txt)
[staging_Test_integration_endpoints_B143_test_rbac_white_cluster_endpoints.zip](https://github.com/user-attachments/files/26420277/staging_Test_integration_endpoints_B143_test_rbac_white_cluster_endpoints.zip)

- `test_rbac_black_cluster_endpoints.yaml`:
[staging_Test_integration_endpoints_B143_test_rbac_black_cluster_endpoints.zip](https://github.com/user-attachments/files/26420400/staging_Test_integration_endpoints_B143_test_rbac_black_cluster_endpoints.zip)
[staging_Test_integration_endpoints_B143_test_rbac_black_cluster_endpoints.txt](https://github.com/user-attachments/files/26420401/staging_Test_integration_endpoints_B143_test_rbac_black_cluster_endpoints.txt)




### Manual tests with their corresponding evidence
> pytest -vvv --nobuild test_rbac_white_all_endpoints.tavern.yaml
```console
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.20, pytest-7.3.1, pluggy-1.6.0 -- /home/franco-rivero/wazuh/wazuh_unit_testing/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.20', 'Platform': 'Linux-6.8.0-060800-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'asyncio': '0.18.1', 'cov': '4.1.0', 'anyio': '4.1.0', 'trio': '0.8.0', 'html': '2.1.1', 'tavern': '1.23.5', 'metadata': '3.1.1'}}
rootdir: /home/franco-rivero/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, html-2.1.1, tavern-1.23.5, metadata-3.1.1
asyncio: mode=auto
collected 80 items                                                                                                                                                                    

test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents PASSED                                                                                                                [  1%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents PASSED                                                                                                                   [  2%]
test_rbac_white_all_endpoints.tavern.yaml::POST /agents PASSED                                                                                                                  [  3%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                                                          [  5%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                                                     [  6%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED                                                                                               [  7%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED                                                                                    [  8%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                                                                       [ 10%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                                                    [ 11%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                                                                                [ 12%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                                                                           [ 13%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/upgrade_custom PASSED                                                                                                    [ 15%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                                                    [ 16%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /agents/group PASSED                                                                                                          [ 17%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/group PASSED                                                                                                             [ 18%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                                                                          [ 20%]
test_rbac_white_all_endpoints.tavern.yaml::POST /agents/insert PASSED                                                                                                           [ 21%]
test_rbac_white_all_endpoints.tavern.yaml::POST /agents/insert/quick PASSED                                                                                                     [ 22%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                                                          [ 23%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                                                                            [ 25%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                                                          [ 26%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                                                                         [ 27%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                                                                           [ 28%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                                                    [ 30%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/summary PASSED                                                                                                           [ 31%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                                                        [ 32%]
test_rbac_white_all_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                                                    [ 33%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                       [ 35%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                            [ 36%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                      [ 37%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                     [ 38%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                           [ 40%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                       [ 41%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                                                                                                 [ 42%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                                                                                                   [ 43%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                          [ 45%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                          [ 46%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats PASSED                                                                                          [ 47%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                                                                                                   [ 48%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED                                                                                           [ 50%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                          [ 51%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                         [ 52%]
test_rbac_white_all_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                              [ 53%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /groups PASSED                                                                                                                [ 55%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups PASSED                                                                                                                   [ 56%]
test_rbac_white_all_endpoints.tavern.yaml::POST /groups PASSED                                                                                                                  [ 57%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                                                 [ 58%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                                                          [ 60%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                                                                          [ 61%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename} PASSED                                                                                       [ 62%]
test_rbac_white_all_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                                                  [ 63%]
test_rbac_white_all_endpoints.tavern.yaml::GET /overview/agents PASSED                                                                                                          [ 65%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/user/revoke PASSED                                                                                                     [ 66%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/users PASSED                                                                                                           [ 67%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/users PASSED                                                                                                          [ 68%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/users/{user_id}/run_as PASSED                                                                                          [ 70%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/users PASSED                                                                                                        [ 71%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/users/{user_id} PASSED                                                                                                 [ 72%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/roles PASSED                                                                                                           [ 73%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/roles PASSED                                                                                                          [ 75%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/roles PASSED                                                                                                        [ 76%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/roles/{role_id} PASSED                                                                                                 [ 77%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/rules PASSED                                                                                                           [ 78%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/rules PASSED                                                                                                          [ 80%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/rules/{rule_id} PASSED                                                                                                 [ 81%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/rules PASSED                                                                                                        [ 82%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/policies PASSED                                                                                                        [ 83%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/policies PASSED                                                                                                     [ 85%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/policies PASSED                                                                                                       [ 86%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/policies/{policy_id} PASSED                                                                                            [ 87%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/users/{user_id}/roles PASSED                                                                                          [ 88%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/users/{user_id}/roles PASSED                                                                                        [ 90%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/roles/{role_id}/policies PASSED                                                                                       [ 91%]
test_rbac_white_all_endpoints.tavern.yaml::POST /security/roles/{role_id}/rules PASSED                                                                                          [ 92%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/policies PASSED                                                                                     [ 93%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/roles/{role_id}/rules PASSED                                                                                        [ 95%]
test_rbac_white_all_endpoints.tavern.yaml::GET /security/config PASSED                                                                                                          [ 96%]
test_rbac_white_all_endpoints.tavern.yaml::PUT /security/config PASSED                                                                                                          [ 97%]
test_rbac_white_all_endpoints.tavern.yaml::DELETE /security/config PASSED                                                                                                       [ 98%]
test_rbac_white_all_endpoints.tavern.yaml::GET /tasks/status PASSED                                                                                                             [100%]

================================================================================== warnings summary ===================================================================================
../../../../wazuh_unit_testing/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/franco-rivero/wazuh/wazuh_unit_testing/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_white_all_endpoints.tavern.yaml: 80 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== 80 passed, 81 warnings in 441.00s (0:07:20) =====================================================================
```

> pytest -vvv --nobuild test_rbac_white_cluster_endpoints.tavern.yaml
```console
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.20, pytest-7.3.1, pluggy-1.6.0 -- /home/franco-rivero/wazuh/wazuh_unit_testing/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.20', 'Platform': 'Linux-6.8.0-060800-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'asyncio': '0.18.1', 'cov': '4.1.0', 'anyio': '4.1.0', 'trio': '0.8.0', 'html': '2.1.1', 'tavern': '1.23.5', 'metadata': '3.1.1'}}
rootdir: /home/franco-rivero/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, html-2.1.1, tavern-1.23.5, metadata-3.1.1
asyncio: mode=auto
collected 17 items                                                                                                                                                                    

test_rbac_white_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                                                     [  5%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                  [ 11%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                   [ 17%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                        [ 23%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/nodes/{node_id} PASSED                                                                                              [ 29%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                       [ 35%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                      [ 41%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                     [ 47%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                          [ 52%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                                                                                               [ 58%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                                                                                               [ 64%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED                                                                                       [ 70%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats PASSED                                                                                      [ 76%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                                                                                             [ 82%]
test_rbac_white_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                   [ 88%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/restart SKIPPED (execd socket no longer exists in manager after agent-manager separation)                           [ 94%]
test_rbac_white_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                      [100%]

================================================================================== warnings summary ===================================================================================
../../../../wazuh_unit_testing/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/franco-rivero/wazuh/wazuh_unit_testing/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_white_cluster_endpoints.tavern.yaml: 16 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 16 passed, 1 skipped, 17 warnings in 433.81s (0:07:13) ================================================================
```
> pytest -vvv --nobuild test_rbac_black_cluster_endpoints.tavern.yaml
```console
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.20, pytest-7.3.1, pluggy-1.6.0 -- /home/franco-rivero/wazuh/wazuh_unit_testing/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.20', 'Platform': 'Linux-6.8.0-060800-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'asyncio': '0.18.1', 'cov': '4.1.0', 'anyio': '4.1.0', 'trio': '0.8.0', 'html': '2.1.1', 'tavern': '1.23.5', 'metadata': '3.1.1'}}
rootdir: /home/franco-rivero/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, html-2.1.1, tavern-1.23.5, metadata-3.1.1
asyncio: mode=auto
collected 17 items                                                                                                                                                                    

test_rbac_black_cluster_endpoints.tavern.yaml::/cluster/local/config PASSED                                                                                                     [  5%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                  [ 11%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                   [ 17%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                        [ 23%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/nodes/{node_id} PASSED                                                                                              [ 29%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                       [ 35%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                      [ 41%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                     [ 47%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                          [ 52%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info PASSED                                                                                               [ 58%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs PASSED                                                                                               [ 64%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary PASSED                                                                                       [ 70%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats PASSED                                                                                      [ 76%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status PASSED                                                                                             [ 82%]
test_rbac_black_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                   [ 88%]
test_rbac_black_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                      [ 94%]
test_rbac_black_cluster_endpoints.tavern.yaml::PUT /cluster/restart SKIPPED (execd socket no longer exists in manager after agent-manager separation)                           [100%]

================================================================================== warnings summary ===================================================================================
../../../../wazuh_unit_testing/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/franco-rivero/wazuh/wazuh_unit_testing/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_black_cluster_endpoints.tavern.yaml: 16 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 16 passed, 1 skipped, 17 warnings in 429.53s (0:07:09) ================================================================

```
   - Compilation without warnings on every supported platform
     - [ ] Linux
     - [ ] Windows 
     - [ ] MAC OS X
   - [x] Log syntax and correct language review

   - Memory tests for Linux
     - [ ] Coverity
     - [ ] Valgrind (memcheck and descriptor leaks check)
     - [ ] AddressSanitizer
   - Memory tests for Windows
     - [ ] Coverity
     - [ ] UMDH
   - Memory tests for macOS
     - [ ] Leaks
     - [ ] AddressSanitizer

   - Decoder/Rule tests (Wazuh v4.x)
     - [ ] Added unit testing files ".ini"
     - [ ] runtests.py executed without errors

   - Engine (Wazuh v5.x and above)
     - [ ] Test run in parallel
     - [ ] ASAN for test (utest/ctest)
     - [ ] TSAN for test and wazuh-engine.

   - Wazuh server API/Framework
     - [x] Run API Integration Tests

### Artifacts Affected

   - API Integration Tests:
       - api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
       - api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml

### Configuration Changes

- N/A

### Tests Introduced
   - Scope: Integration tests for RBAC.
   - Coverage: Ensures that the /cluster/configuration/validation endpoint is correctly reachable and functional when RBAC is enabled, verifying both basic requests and requests with
     nodes_list and wait_for_complete parameters.
