### PR TITLE
Make RocksDB queue path configurable per instance

### DIFF
--- a/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
+++ b/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
@@ -5,7 +5,6 @@
 
 #include <base/logging.hpp>
 #include <chrono>
-#include <filesystem>
 #include <thread>
 
 class WIndexerConnectorTest : public ::testing::Test

--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -296,10 +296,10 @@ public:
      *
      * @param config Indexer configuration, including servers and SSL settings.
      * @param queueId Identifier for this connector instance. Combined with basePath to form
-     *                the RocksDB queue directory: basePath + queueId.
+     *                the RocksDB queue directory: basePath / queueId.
      *                Must be unique per instance to guarantee queue isolation.
-     * @param basePath Base directory for the RocksDB queue. Defaults to "queue/indexer/".
      * @param logFunction Callback function to be called when trying to log a message.
+     * @param basePath Base directory for the RocksDB queue. Defaults to "queue/indexer/".
      */
     explicit IndexerConnectorAsync(
         const nlohmann::json& config,

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsync.cpp
@@ -24,11 +24,11 @@ private:
 
 public:
     Impl(const nlohmann::json& config,
-         std::string queueId,
-         std::string basePath,
          const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
-             logFunction)
-        : m_impl(config, logFunction, std::move(queueId), std::move(basePath))
+             logFunction,
+         std::string queueId,
+         std::string basePath)
+        : m_impl(config, logFunction, std::move(queueId), nullptr, nullptr, std::move(basePath))
     {
     }
 
@@ -99,7 +99,7 @@ IndexerConnectorAsync::IndexerConnectorAsync(
     const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
         logFunction,
     std::string basePath)
-    : m_impl(std::make_unique<Impl>(config, std::move(queueId), std::move(basePath), logFunction))
+    : m_impl(std::make_unique<Impl>(config, logFunction, std::move(queueId), std::move(basePath)))
 {
 }
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -129,17 +129,25 @@ public:
         const std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>&
             logFunction,
         std::string queueId,
-        std::string basePath = DATABASE_BASE_PATH,
         THttpRequest* httpRequest = nullptr,
-        std::unique_ptr<TSelector> selector = nullptr)
+        std::unique_ptr<TSelector> selector = nullptr,
+        std::string basePath = DATABASE_BASE_PATH)
         : m_httpRequest(httpRequest ? httpRequest : &THttpRequest::instance())
         , m_queueId(std::move(queueId))
-        , m_dbPath(std::move(basePath) + m_queueId)
+        , m_dbPath((std::filesystem::path(std::move(basePath)) / m_queueId).string())
     {
         if (m_queueId.empty())
         {
             throw IndexerConnectorException("queueId cannot be empty: each IndexerConnectorAsync instance "
                                             "must have a unique identifier (e.g. \"engine\", \"inventory-sync\").");
+        }
+
+        if (m_queueId.find('/') != std::string::npos || m_queueId.find('\\') != std::string::npos ||
+            m_queueId.find("..") != std::string::npos)
+        {
+            throw IndexerConnectorException(
+                "queueId must not contain path separators ('/', '\\') or traversal sequences ('..'): \"" + m_queueId +
+                "\".");
         }
 
         if (logFunction)

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp
@@ -144,16 +144,13 @@ protected:
 TEST_F(IndexerConnectorAsyncTest, ConstructorWithValidConfig)
 {
     EXPECT_CALL(mockServerSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
-    EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
-    });
+    EXPECT_NO_THROW({ IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest); });
 }
 
 TEST_F(IndexerConnectorAsyncTest, DestructorStopsThreadDispatcher)
 {
     EXPECT_CALL(mockServerSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
-    auto connector = std::make_unique<IndexerConnectorAsyncImplTest>(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
+    auto connector = std::make_unique<IndexerConnectorAsyncImplTest>(config, nullptr, "test-queue", &mockHttpRequest);
     connector.reset();
     SUCCEED();
 }
@@ -164,8 +161,7 @@ TEST_F(IndexerConnectorAsyncTest, BulkIndexAddsToQueue)
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
     EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
 
-    IndexerConnectorAsyncImplTest connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+    IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
     connector.bulkIndex("id2", "index2", R"({"field":"value"})");
 
     // Give some time for async processing
@@ -179,7 +175,7 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithMultipleHosts)
     EXPECT_CALL(mockServerSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
     config["hosts"] = nlohmann::json::array({"localhost:9200", "localhost:9201", "localhost:9202"});
     EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
+        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest);
         SUCCEED();
     });
 }
@@ -187,26 +183,20 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithMultipleHosts)
 TEST_F(IndexerConnectorAsyncTest, ConstructorWithEmptyHostsThrows)
 {
     config["hosts"] = nlohmann::json::array();
-    EXPECT_ANY_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
-    });
+    EXPECT_ANY_THROW({ IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest); });
 }
 
 TEST_F(IndexerConnectorAsyncTest, ConstructorWithMissingHostsThrows)
 {
     config.erase("hosts");
-    EXPECT_ANY_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
-    });
+    EXPECT_ANY_THROW({ IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest); });
 }
 
 TEST_F(IndexerConnectorAsyncTest, ConstructorWithInvalidJSONThrows)
 {
     nlohmann::json invalidConfig = "invalid";
-    EXPECT_ANY_THROW({
-        IndexerConnectorAsyncImplTest connector(
-            invalidConfig, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
-    });
+    EXPECT_ANY_THROW(
+        { IndexerConnectorAsyncImplTest connector(invalidConfig, nullptr, "test-queue", &mockHttpRequest); });
 }
 
 // SSL Configuration Tests
@@ -226,9 +216,7 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithSSLConfigurationValid)
     config["ssl"]["certificate"] = certFile;
     config["ssl"]["key"] = keyFile;
 
-    EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
-    });
+    EXPECT_NO_THROW({ IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest); });
 
     // Cleanup
     std::filesystem::remove(caFile);
@@ -242,32 +230,17 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithInvalidSSLPathsThrows)
     config["ssl"]["certificate"] = "/nonexistent/cert.pem";
     config["ssl"]["key"] = "/nonexistent/key.pem";
 
-    EXPECT_ANY_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
-    });
+    EXPECT_ANY_THROW({ IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest); });
 }
 
 // Queue path configuration tests
-TEST_F(IndexerConnectorAsyncTest, ConstructorWithCustomQueuePath)
-{
-    EXPECT_CALL(mockServerSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
-
-    EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(
-            config, nullptr, "custom-instance", DATABASE_BASE_PATH, &mockHttpRequest);
-        EXPECT_TRUE(std::filesystem::exists("queue/indexer/custom-instance"));
-    });
-
-    std::filesystem::remove_all("queue/indexer/custom-instance");
-}
-
 TEST_F(IndexerConnectorAsyncTest, ConstructorWithAbsoluteBasePath)
 {
     EXPECT_CALL(mockServerSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
 
     EXPECT_NO_THROW({
         IndexerConnectorAsyncImplTest connector(
-            config, nullptr, "test-instance", "/tmp/wazuh-test-indexer/", &mockHttpRequest);
+            config, nullptr, "test-instance", &mockHttpRequest, nullptr, "/tmp/wazuh-test-indexer/");
         EXPECT_TRUE(std::filesystem::exists("/tmp/wazuh-test-indexer/test-instance"));
     });
 
@@ -281,10 +254,9 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithoutDbPathUsesDefault)
     std::filesystem::remove_all("queue/indexer/test-default-path");
     ASSERT_FALSE(std::filesystem::exists("queue/indexer/test-default-path"));
 
-    // No explicit basePath: defaults to DATABASE_BASE_PATH, resulting path = DATABASE_BASE_PATH + queueId
+    // No explicit basePath: relies on the DATABASE_BASE_PATH default
     EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(
-            config, nullptr, "test-default-path", DATABASE_BASE_PATH, &mockHttpRequest);
+        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-default-path", &mockHttpRequest);
         EXPECT_TRUE(std::filesystem::exists("queue/indexer/test-default-path"));
     });
 
@@ -297,9 +269,9 @@ TEST_F(IndexerConnectorAsyncTest, MultipleInstancesWithDifferentQueuePaths)
 
     EXPECT_NO_THROW({
         IndexerConnectorAsyncImplTest connector1(
-            config, nullptr, "instance-1", "/tmp/wazuh-test-multi/", &mockHttpRequest);
+            config, nullptr, "instance-1", &mockHttpRequest, nullptr, "/tmp/wazuh-test-multi/");
         IndexerConnectorAsyncImplTest connector2(
-            config, nullptr, "instance-2", "/tmp/wazuh-test-multi/", &mockHttpRequest);
+            config, nullptr, "instance-2", &mockHttpRequest, nullptr, "/tmp/wazuh-test-multi/");
 
         EXPECT_TRUE(std::filesystem::exists("/tmp/wazuh-test-multi/instance-1"));
         EXPECT_TRUE(std::filesystem::exists("/tmp/wazuh-test-multi/instance-2"));
@@ -316,7 +288,7 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithMaxQueueSizeConfig)
     config["max_queue_size"] = 100;
 
     EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
+        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest);
         EXPECT_EQ(connector.getQueueSize(), 0); // Initially empty
     });
 }
@@ -327,7 +299,7 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithUnlimitedQueueSizeDefault)
 
     // No max_queue_size specified, should default to unlimited (0)
     EXPECT_NO_THROW({
-        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest);
+        IndexerConnectorAsyncImplTest connector(config, nullptr, "test-queue", &mockHttpRequest);
         EXPECT_EQ(connector.getQueueSize(), 0); // Initially empty
     });
 }
@@ -365,7 +337,7 @@ TEST_F(IndexerConnectorAsyncTest, QueueSizeLimitEnforcedWithSlowProcessing)
 
     // Use the small bulk implementation to trigger more frequent processing
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Push many documents quickly (more than max_queue_size)
     for (int i = 0; i < 20; ++i)
@@ -420,7 +392,7 @@ TEST_F(IndexerConnectorAsyncTest, UnlimitedQueueSizeAllowsAllEvents)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Push many documents
     for (int i = 0; i < 15; ++i)
@@ -506,7 +478,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleError413PayloadTooLarge)
             }));
 
     IndexerConnectorAsyncImplSmallBulkPair connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add large data to force bulk processing
     for (int i = 0; i < 2; ++i)
@@ -589,7 +561,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleError413PayloadTooLargeDouble)
             }));
 
     IndexerConnectorAsyncImplSmallBulkPair connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add large data to force bulk processing
     for (int i = 0; i < 2; ++i)
@@ -672,7 +644,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleError413PayloadTooLargeResetAfterSuccess
             }));
 
     IndexerConnectorAsyncImplSmallBulkPair connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add large data to force bulk processing
     for (int i = 0; i < 2; ++i)
@@ -765,7 +737,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleError409VersionConflict)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add data to trigger processing
     for (int i = 0; i < 5; ++i)
@@ -844,7 +816,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleError429TooManyRequests)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add data to trigger processing
     for (int i = 0; i < 5; ++i)
@@ -904,7 +876,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleError500InternalServerError)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add data to trigger processing
     for (int i = 0; i < 5; ++i)
@@ -964,7 +936,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleGenericError)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add data to trigger processing
     for (int i = 0; i < 5; ++i)
@@ -1026,7 +998,7 @@ TEST_F(IndexerConnectorAsyncTest, HandleGenericError)
 //                 }
 //             }));
 
-//     IndexerConnectorAsyncImplSmallBulk connector(config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest,
+//     IndexerConnectorAsyncImplSmallBulk connector(config, nullptr, "test-queue", &mockHttpRequest,
 //     std::move(mockSelector));
 
 //     // Add multiple documents to create bulk operations that will be split recursively
@@ -1180,7 +1152,7 @@ TEST_F(IndexerConnectorAsyncTest, SmallBulkSizeTriggersAsyncProcessing)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add many small operations to force async bulk processing
     for (int i = 0; i < 30; ++i)
@@ -1216,7 +1188,7 @@ TEST_F(IndexerConnectorAsyncTest, VerifyAsyncDataProcessing)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add specific test data
     connector.bulkIndex("test_id_1", "test_index", R"({"test":"data1"})");
@@ -1321,7 +1293,7 @@ TEST_F(IndexerConnectorAsyncTest, SplitAndProcessBulkWithAsyncDispatcher)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add multiple documents to create a bulk operation that will be split
     for (int i = 0; i < 8; ++i)
@@ -1389,7 +1361,7 @@ TEST_F(IndexerConnectorAsyncTest, ProcessBulkChunkRecursiveSplittingAsync)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add documents that will trigger recursive splitting
     for (int i = 0; i < 6; ++i)
@@ -1444,7 +1416,7 @@ TEST_F(IndexerConnectorAsyncTest, StoppingDuringAsyncProcessing)
             }));
 
     auto connector = std::make_unique<IndexerConnectorAsyncImplSmallBulk>(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add data to trigger async processing
     for (int i = 0; i < 5; ++i)
@@ -1477,7 +1449,7 @@ TEST_F(IndexerConnectorAsyncTest, ConstructorWithCustomQueueId)
 
     EXPECT_NO_THROW({
         IndexerConnectorAsyncImplTest connector(
-            config, nullptr, customQueueId, DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+            config, nullptr, customQueueId, &mockHttpRequest, std::move(mockSelector));
         SUCCEED();
     });
 }
@@ -1521,7 +1493,7 @@ TEST_F(IndexerConnectorAsyncTest, AsyncBulkDataFormatValidation)
             }));
 
     IndexerConnectorAsyncImplSmallBulkNoFlushInterval connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Add test documents
     connector.bulkIndex("doc1", "test_index", R"({"name":"document1"})");
@@ -1560,7 +1532,7 @@ TEST_F(IndexerConnectorAsyncTest, AsyncMixedOperations)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Mix different types of index operations
     connector.bulkIndex("index_id_1", "test_index", R"({"type":"index","data":"value1"})");
@@ -1592,7 +1564,7 @@ TEST_F(IndexerConnectorAsyncTest, AsyncQueuePersistence)
     // First connector instance - add some data
     {
         IndexerConnectorAsyncImplTest connector(
-            config, nullptr, customQueueId, DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+            config, nullptr, customQueueId, &mockHttpRequest, std::move(mockSelector));
 
         for (int i = 0; i < 3; ++i)
         {
@@ -1629,7 +1601,7 @@ TEST_F(IndexerConnectorAsyncTest, VerifyAsyncDataWithErrorProcessing)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     for (int i = 0; i < 5; ++i)
     {
@@ -1694,7 +1666,7 @@ TEST_F(IndexerConnectorAsyncTest, ErrorProcessingWithCreateOperation)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Send only 1 document to match the 1 item in response
     connector.bulkIndex("doc0", "test-data-stream", R"({"field":"value0"})");
@@ -1762,7 +1734,7 @@ TEST_F(IndexerConnectorAsyncTest, ErrorProcessingWithCausedBy)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Send only 1 document to match the 1 item in response
     connector.bulkIndex("test_doc", "test_index", R"({"field":"value0"})");
@@ -1829,7 +1801,7 @@ TEST_F(IndexerConnectorAsyncTest, ErrorProcessingWithCausedByTypeOnly)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Send 1 document to match the 1 item in response
     connector.bulkIndex("test_doc", "test_index", R"({"field":"value1"})");
@@ -1896,7 +1868,7 @@ TEST_F(IndexerConnectorAsyncTest, ErrorProcessingWithCausedByReasonOnly)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Send 1 document to match the 1 item in response
     connector.bulkIndex("test_doc", "test_index", R"({"field":"value1"})");
@@ -1941,7 +1913,7 @@ TEST_F(IndexerConnectorAsyncTest, BulkIndexWithVersionHandling)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Test with version
     connector.bulkIndex("doc1", "index1", R"({"field":"value1"})", "12345");
@@ -2002,7 +1974,7 @@ TEST_F(IndexerConnectorAsyncTest, BulkIndexEscapesSpecialCharactersInId)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Test various special characters that need escaping
     connector.bulkIndex("001_dum\\amy", "test_index", R"({"group":"dum\\amy"})");
@@ -2041,7 +2013,7 @@ TEST_F(IndexerConnectorAsyncTest, ErrorHandlingForInvalidInput)
     EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Test with empty index - should throw exception
     EXPECT_THROW(connector.bulkIndex("doc1", "", R"({"field":"value"})", "123"), IndexerConnectorException);
@@ -2093,7 +2065,7 @@ TEST_F(IndexerConnectorAsyncTest, VersionConflictHandling)
             }));
 
     IndexerConnectorAsyncImplSmallBulk connector(
-        config, nullptr, "test-queue", DATABASE_BASE_PATH, &mockHttpRequest, std::move(mockSelector));
+        config, nullptr, "test-queue", &mockHttpRequest, std::move(mockSelector));
 
     // Send a document with version that will cause conflict
     connector.bulkIndex("conflict_doc", "index1", R"({"field":"conflicting_value"})", "999");

--- a/src/shared_modules/indexer_connector/testtool/cmdArgParser.hpp
+++ b/src/shared_modules/indexer_connector/testtool/cmdArgParser.hpp
@@ -42,6 +42,7 @@ public:
         , m_loopSyncCount {paramValueOf(argc, argv, "-L", std::make_pair(false, "0"))}
         , m_loopDelaySeconds {paramValueOf(argc, argv, "-D", std::make_pair(false, "0"))}
         , m_asyncMode {paramValueOf(argc, argv, "-m", std::make_pair(false, "sync"))}
+        , m_extraConfigPaths {paramValuesOf(argc, argv, "-I")}
     {
     }
 
@@ -155,6 +156,15 @@ public:
     }
 
     /**
+     * @brief Gets the list of extra async instance config paths (from -I flags).
+     * @return Vector of config file paths.
+     */
+    const std::vector<std::string>& getExtraConfigPaths() const
+    {
+        return m_extraConfigPaths;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -172,6 +182,7 @@ public:
                   << "\t-D DELAY_SECONDS\tDelay in seconds between flush calls (default: 0) (sync mode only).\n"
                   << "\t-w WAIT_TIME\t\tWait time in seconds before closing (0 = wait for enter).\n"
                   << "\t-l LOG_FILE\t\tLog file path.\n"
+                  << "\t-I EXTRA_CONFIG\t\tAdd an extra async instance with this config (repeatable, async only).\n"
                   << "\nExamples:" << "\n\t# Index events from file sync mode:\n"
                   << "\t./indexer_connector_tool -c config.json -e events.json\n"
                   << "\n\t# Index events from file async mode:\n"
@@ -179,7 +190,9 @@ public:
                   << "\n\t# Auto-generate and index 1000 random events (also available for async mode):\n"
                   << "\t./indexer_connector_tool -c config.json -e template.json -a true -n 1000\n"
                   << "\n\t# Index events and run 30 flush cycles (sync mode):\n"
-                  << "\t./indexer_connector_tool -c config.json -e events.json -L 30 -D 1\n\n";
+                  << "\t./indexer_connector_tool -c config.json -e events.json -L 30 -D 1\n"
+                  << "\n\t# Test isolation with two async instances (each gets its own RocksDB queue):\n"
+                  << "\t./indexer_connector_tool -c config.json -I config2.json -e events.json -m async -w 10\n\n";
     }
 
 private:
@@ -206,6 +219,25 @@ private:
 
         return required.second;
     }
+
+    static std::vector<std::string> paramValuesOf(const int argc, const char* argv[], const std::string& switchValue)
+    {
+        std::vector<std::string> values;
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string currentValue {argv[i]};
+            if (currentValue == switchValue)
+            {
+                if (i + 1 >= argc)
+                {
+                    throw std::runtime_error {"Switch value: " + switchValue + " requires a following argument."};
+                }
+                values.push_back(argv[i + 1]);
+                ++i;
+            }
+        }
+        return values;
+    }
     const std::string m_templateFilePath;
     const std::string m_updateMappingsFilePath;
     const std::string m_configurationFilePath;
@@ -218,6 +250,7 @@ private:
     const std::string m_loopSyncCount;
     const std::string m_loopDelaySeconds;
     const std::string m_asyncMode;
+    const std::vector<std::string> m_extraConfigPaths;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/shared_modules/indexer_connector/testtool/main.cpp
+++ b/src/shared_modules/indexer_connector/testtool/main.cpp
@@ -1,7 +1,6 @@
 #include "cmdArgParser.hpp"
 #include "logging_helper.h"
 #include <chrono>
-#include <filesystem>
 #include <indexerConnector.hpp>
 #include <iomanip>
 #include <iostream>
@@ -160,8 +159,94 @@ int main(const int argc, const char* argv[])
             }
         };
 
-        // Create IndexerConnector (sync or async)
         const bool useAsync = cmdArgParser.getAsyncMode();
+
+        // Multi-instance mode: enabled when -I is given together with -m async.
+        // Each instance gets its own isolated RocksDB queue: queue/indexer/tool-1, tool-2, ...
+        const auto& extraConfigs = cmdArgParser.getExtraConfigPaths();
+        if (useAsync && !extraConfigs.empty())
+        {
+            std::vector<std::pair<std::string, std::string>> instanceDefs; // (configPath, queueId)
+            instanceDefs.push_back({cmdArgParser.getConfigurationFilePath(), "tool-1"});
+            for (size_t i = 0; i < extraConfigs.size(); ++i)
+                instanceDefs.push_back({extraConfigs[i], "tool-" + std::to_string(i + 2)});
+
+            std::cout << "Creating " << instanceDefs.size() << " IndexerConnectorAsync instances...\n";
+
+            std::vector<std::unique_ptr<IndexerConnectorAsync>> connectors;
+            std::vector<std::string> indexNames;
+            for (const auto& [cfgPath, queueId] : instanceDefs)
+            {
+                std::ifstream cfgFile(cfgPath);
+                if (!cfgFile.is_open())
+                    throw std::runtime_error("Could not open configuration file: " + cfgPath);
+                const auto cfg = nlohmann::json::parse(cfgFile);
+
+                connectors.push_back(std::make_unique<IndexerConnectorAsync>(cfg, queueId, loggingFunction));
+
+                std::string idxName = "wazuh-test";
+                if (cfg.contains("index") && cfg["index"].is_string())
+                    idxName = cfg["index"].get<std::string>();
+                indexNames.push_back(idxName);
+
+                std::cout << "  [" << queueId << "] config=" << cfgPath << ", index=" << idxName
+                          << ", queue=queue/indexer/" << queueId << "\n";
+            }
+
+            if (!cmdArgParser.getEventsFilePath().empty())
+            {
+                std::ifstream eventsFile(cmdArgParser.getEventsFilePath());
+                if (!eventsFile.is_open())
+                    throw std::runtime_error("Could not open events file.");
+                const nlohmann::json events = nlohmann::json::parse(eventsFile);
+
+                std::cerr << "Indexing " << events.size() << " events to each of " << connectors.size()
+                          << " instances...\n";
+                for (size_t ci = 0; ci < connectors.size(); ++ci)
+                {
+                    size_t idx = 0;
+                    for (const auto& event : events)
+                        connectors[ci]->index("doc-" + std::to_string(idx++), indexNames[ci], event.dump());
+                }
+
+                std::cout << "Waiting for all async queues to drain...\n";
+                const auto waitInterval = std::chrono::milliseconds(100);
+                int retries = 1;
+                const int timeout = static_cast<int>(events.size() / 1000 * 10000);
+                const int effectiveTimeout = timeout > 0 ? timeout : 5000;
+                int cumulativeWait = 0;
+                while (true)
+                {
+                    size_t totalPending = 0;
+                    for (const auto& c : connectors) totalPending += c->getQueueSize();
+                    if (totalPending == 0)
+                        break;
+                    std::this_thread::sleep_for(waitInterval * retries);
+                    cumulativeWait += static_cast<int>(waitInterval.count()) * retries;
+                    if (cumulativeWait > effectiveTimeout)
+                    {
+                        std::cerr << "Timeout waiting for async queues. Remaining:";
+                        for (size_t ci = 0; ci < connectors.size(); ++ci)
+                            std::cerr << " " << instanceDefs[ci].second << "=" << connectors[ci]->getQueueSize();
+                        std::cerr << "\n";
+                        break;
+                    }
+                    ++retries;
+                }
+                std::cerr << "Done!\n";
+            }
+
+            if (cmdArgParser.getWaitTime() > 0)
+                std::this_thread::sleep_for(std::chrono::seconds(cmdArgParser.getWaitTime()));
+            else
+            {
+                std::cout << "Press enter to stop the indexer connector tool...\n";
+                std::cin.get();
+            }
+            return 0;
+        }
+
+        // Create IndexerConnector (sync or async) — single instance
         std::unique_ptr<IndexerConnectorSync> syncConnector;
         std::unique_ptr<IndexerConnectorAsync> asyncConnector;
 


### PR DESCRIPTION
 ## Description

The `IndexerConnectorAsync` module uses a persistent queue backed by RocksDB. All instances previously shared the same hardcoded relative path (`queue/indexer/`), which causes a RocksDB lock conflict if multiple instances are created in the same process. This PR solves the problem by introducing an explicit `queueId` parameter and a configurable  `basePath`  in the `IndexerConnectorAsync` constructor, so each instance gets its own isolated RocksDB directory `basePath + queueId`. The path is et by each caller at compile time.

## Proposed Changes

* `IndexerConnectorAsync` constructor signature changed: `queueId` is now a required second parameter; `basePath` is an optional third parameter defaulting to `queue/indexer/`.
* The RocksDB directory is resolved at construction time as `basePath + queueId` and stored in the new m_dbPath member of `IndexerConnectorAsyncImpl`.
* `queueId` cannot be empty
* WIndexerConnector passes "engine" as queueId in both constructors, producing `queue/indexer/engine/` as the RocksDB path. Before this PR the engine used the root queue/indexer/ directory directly.
* The testtool passes "tool" as queueId, producing queue/indexer/tool/.

### Results and Evidence

*queue/indexer

```
rroot@manager:/home/vagrant/git/wazuh/src# ls -la /var/wazuh-manager/queue/indexer/engine/
total 76316
drwxr-x--- 2 root          wazuh-manager    4096 Apr  7 10:49 .
drwxrwx--- 3 wazuh-manager wazuh-manager    4096 Apr  7 10:28 ..
-rw-r----- 1 root          wazuh-manager 9775909 Apr  7 15:08 000008.log
-rw-r----- 1 root          wazuh-manager      16 Apr  7 10:49 CURRENT
-rw-r----- 1 root          wazuh-manager      36 Apr  7 10:28 IDENTITY
-rw-r----- 1 root          wazuh-manager       0 Apr  7 10:28 LOCK
-rw-r----- 1 root          wazuh-manager   57525 Apr  7 15:10 LOG
-rw-r----- 1 root          wazuh-manager   30555 Apr  7 10:49 LOG.old.1775558997167360
-rw-r----- 1 root          wazuh-manager      96 Apr  7 10:49 MANIFEST-000009
-rw-r----- 1 root          wazuh-manager    7078 Apr  7 10:28 OPTIONS-000007
-rw-r----- 1 root          wazuh-manager    7078 Apr  7 10:49 OPTIONS-000011


```

<details>
<summary>testtool</summary>


* config.json

```
root@manager:/home/vagrant/git/wazuh/src# cat /tmp/config.json 
{
  "hosts": [
    "https://localhost:9200"
  ],
  "index": "wazuh-test",
  "ssl": {
    "certificate_authorities": [
      "/var/wazuh-manager/etc/certs/root-ca.pem"
    ],
    "certificate": "/var/wazuh-manager/etc/certs/manager.pem",
    "key": "/var/wazuh-manager/etc/certs/manager-key.pem"
  }
}

```
* events.json

```
root@manager:/home/vagrant/git/wazuh/src# cat /tmp/events.json 
[
  {
    "id": "evt-001",
    "message": "Test event 1",
    "agent": {
      "id": "001",
      "name": "agent1"
    }
  },
  {
    "id": "evt-002",
    "message": "Test event 2",
    "agent": {
      "id": "002",
      "name": "agent2"
    }
  },
  {
    "id": "evt-003",
    "message": "Test event 3",
    "agent": {
      "id": "003",
      "name": "agent3"
    }
  },
  {
    "id": "evt-004",
    "message": "Test event 4",
    "agent": {
      "id": "004",
      "name": "agent4"
    }
  },
  {
    "id": "evt-005",
    "message": "Test event 5",
    "agent": {
      "id": "005",
      "name": "agent5"
    }
  }
]

```

* testool execution single instance

```
root@manager:/home/vagrant/git/wazuh/src# ./build/bin/indexer_connector_tool -c /tmp/config.json -e /tmp/events.json -m async -w 5
Using Indexer Connector ASYNC implementation.
keystore:keyStore.cpp:73 upgrade : Keystore upgrade failed, re-run the tool again for all keys to save them. Error: Private key file not found.
IndexerConnector:indexerConnectorAsyncImpl.hpp:199 IndexerConnectorAsyncImpl : No username and password found in the keystore, using default values.
Indexing 5 events from file...
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-0, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-1, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-2, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-3, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-4, using default versioning
Waiting for async queue to be empty...
Timeout waiting for async queue to be empty. Remaining size: 5
Done!
root@manager:/home/vagrant/git/wazuh/src# ls -la queue/indexer/
total 12
drwxr-xr-x 3 vagrant vagrant 4096 Apr  7 15:14 .
drwxr-xr-x 4 vagrant vagrant 4096 Apr  7 15:14 ..
drwxr-xr-x 2 vagrant vagrant 4096 Apr  7 15:26 tool

root@manager:/home/vagrant/git/wazuh/src# ls -la queue/indexer/tool/
total 56
drwxr-xr-x 2 root root  4096 Apr  7 15:14 .
drwxr-xr-x 3 root root  4096 Apr  7 15:14 ..
-rw-r--r-- 1 root root   845 Apr  7 15:14 000004.log
-rw-r--r-- 1 root root    16 Apr  7 15:14 CURRENT
-rw-r--r-- 1 root root    36 Apr  7 15:14 IDENTITY
-rw-r--r-- 1 root root     0 Apr  7 15:14 LOCK
-rw-r--r-- 1 root root 20936 Apr  7 15:14 LOG
-rw-r--r-- 1 root root    66 Apr  7 15:14 MANIFEST-000005
-rw-r--r-- 1 root root  7078 Apr  7 15:14 OPTIONS-000007

```
* testtool execution multiple instance

```
root@manager:/home/vagrant/git/wazuh/src# ./build/bin/indexer_connector_tool -c /tmp/config.json -I /tmp/config.json -e /tmp/events.json -m async -w 30
Creating 2 IndexerConnectorAsync instances...
IndexerConnector:indexerConnectorAsyncImpl.hpp:199 IndexerConnectorAsyncImpl : No username and password found in the keystore, using default values.
  [tool-1] config=/tmp/config.json, index=wazuh-test, queue=queue/indexer/tool-1
  [tool-2] config=/tmp/config.json, index=wazuh-test, queue=queue/indexer/tool-2
Indexing 5 events to each of 2 instances...
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-0, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-1, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-2, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-3, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-4, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-0, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-1, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-2, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-3, using default versioning
IndexerConnector:indexerConnectorAsyncImpl.hpp:557 bulkIndex : No version specified for document doc-4, using default versioning
Waiting for all async queues to drain...
Timeout waiting for async queues. Remaining: tool-1=5 tool-2=5
Done!
IndexerConnector:indexerConnectorAsyncImpl.hpp:478 operator() : Bulk data: {"index":{"_index":"wazuh-test","_id":"doc-0"}}
{"agent":{"id":"001","name":"agent1"},"id":"evt-001","message":"Test event 1"}
{"index":{"_index":"wazuh-test","_id":"doc-1"}}
{"agent":{"id":"002","name":"agent2"},"id":"evt-002","message":"Test event 2"}
{"index":{"_index":"wazuh-test","_id":"doc-2"}}
{"agent":{"id":"003","name":"agent3"},"id":"evt-003","message":"Test event 3"}
{"index":{"_index":"wazuh-test","_id":"doc-3"}}
{"agent":{"id":"004","name":"agent4"},"id":"evt-004","message":"Test event 4"}
{"index":{"_index":"wazuh-test","_id":"doc-4"}}
{"agent":{"id":"005","name":"agent5"},"id":"evt-005","message":"Test event 5"}

IndexerConnector:indexerConnectorAsyncImpl.hpp:478 operator() : Bulk data: {"index":{"_index":"wazuh-test","_id":"doc-0"}}
{"agent":{"id":"001","name":"agent1"},"id":"evt-001","message":"Test event 1"}
{"index":{"_index":"wazuh-test","_id":"doc-1"}}
{"agent":{"id":"002","name":"agent2"},"id":"evt-002","message":"Test event 2"}
{"index":{"_index":"wazuh-test","_id":"doc-2"}}
{"agent":{"id":"003","name":"agent3"},"id":"evt-003","message":"Test event 3"}
{"index":{"_index":"wazuh-test","_id":"doc-3"}}
{"agent":{"id":"004","name":"agent4"},"id":"evt-004","message":"Test event 4"}
{"index":{"_index":"wazuh-test","_id":"doc-4"}}
{"agent":{"id":"005","name":"agent5"},"id":"evt-005","message":"Test event 5"}

root@manager:/home/vagrant/git/wazuh/src# ls -la queue/indexer/
total 20
drwxr-xr-x 5 vagrant vagrant 4096 Apr  7 15:29 .
drwxr-xr-x 4 vagrant vagrant 4096 Apr  7 15:14 ..
drwxr-xr-x 2 vagrant vagrant 4096 Apr  7 15:26 tool
drwxr-xr-x 2 root    root    4096 Apr  7 15:29 tool-1
drwxr-xr-x 2 root    root    4096 Apr  7 15:29 tool-2

root@manager:/home/vagrant/git/wazuh/src# ls -la queue/indexer/tool-1
total 92
drwxr-xr-x 2 root    root     4096 Apr  7 15:29 .
drwxr-xr-x 5 vagrant vagrant  4096 Apr  7 15:29 ..
-rw-r--r-- 1 root    root     1050 Apr  7 15:29 000008.log
-rw-r--r-- 1 root    root       16 Apr  7 15:29 CURRENT
-rw-r--r-- 1 root    root       36 Apr  7 15:28 IDENTITY
-rw-r--r-- 1 root    root        0 Apr  7 15:28 LOCK
-rw-r--r-- 1 root    root    24885 Apr  7 15:29 LOG
-rw-r--r-- 1 root    root    20944 Apr  7 15:28 LOG.old.1775575747807387
-rw-r--r-- 1 root    root       96 Apr  7 15:29 MANIFEST-000009
-rw-r--r-- 1 root    root     7078 Apr  7 15:28 OPTIONS-000007
-rw-r--r-- 1 root    root     7078 Apr  7 15:29 OPTIONS-000011

root@manager:/home/vagrant/git/wazuh/src# ls -la queue/indexer/tool-2
total 56
drwxr-xr-x 2 root    root     4096 Apr  7 15:29 .
drwxr-xr-x 5 vagrant vagrant  4096 Apr  7 15:29 ..
-rw-r--r-- 1 root    root     1050 Apr  7 15:29 000004.log
-rw-r--r-- 1 root    root       16 Apr  7 15:29 CURRENT
-rw-r--r-- 1 root    root       36 Apr  7 15:29 IDENTITY
-rw-r--r-- 1 root    root        0 Apr  7 15:29 LOCK
-rw-r--r-- 1 root    root    24158 Apr  7 15:29 LOG
-rw-r--r-- 1 root    root       66 Apr  7 15:29 MANIFEST-000005
-rw-r--r-- 1 root    root     7078 Apr  7 15:29 OPTIONS-000007

```

</details>

* E2E
<img width="1862" height="909" alt="image" src="https://github.com/user-attachments/assets/525eed4c-952c-4d63-b3f5-b9c3f7c27dc1" />


### Artifacts Affected

- `libindexerconnector` shared module


## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues