### PR TITLE
Fix for rootcheck not generating findings

### DIFF
--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -445,37 +445,35 @@ int isfile_ondir(const char *file, const char *dir)
  */
 int is_file(char *file_name)
 {
-    struct  stat statbuf;
-    int     ret = 0;
-    FILE    *fp = NULL;
-    DIR     *dp = NULL;
-
     if (!file_name) {
         mtdebug2(ARGV0, "RK: Invalid file name: NULL!");
-        return ret;
+        return 0;
     }
 
-    dp = wopendir(file_name);
+    DIR* dp = wopendir(file_name);
     if (dp) {
         closedir(dp);
-        ret = 1;
+        return 1;
     }
 
-    /* Trying other calls */
-    if ((w_stat(file_name, &statbuf) < 0) &&
+    struct  stat statbuf;
+    if (w_stat(file_name, &statbuf) == 0) {
+        return 1;
+    }
+
 #ifndef WIN32
-            (waccess(file_name, F_OK) < 0) &&
+    if (waccess(file_name, F_OK) == 0) {
+        return 1;
+    }
 #endif
-            ((fp = wfopen(file_name, "r")) == NULL)) {
-        return ret;
-    }
 
+    FILE* fp = wfopen(file_name, "r");
     if (fp) {
-        ret = 1;
         fclose(fp);
+        return 1;
     }
 
-    return ret;
+    return 0;
 }
 
 /* Delete the process list */

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -359,6 +359,23 @@ if(NOT ${TARGET} STREQUAL "winagent")
   target_include_directories(test_check_rc_sys PRIVATE ${SRC_FOLDER}/rootcheck)
   target_link_libraries(test_check_rc_sys SYSCHECK_O ${TEST_DEPS} "${CHECK_RC_SYS_FLAGS}")
   add_test(NAME test_check_rc_sys COMMAND test_check_rc_sys)
+
+  set(COMMON_FLAGS "-Wl,--wrap,wopendir \
+                    -Wl,--wrap,closedir \
+                    -Wl,--wrap,w_stat \
+                    -Wl,--wrap,waccess \
+                    -Wl,--wrap,wfopen \
+                    -Wl,--wrap,fclose \
+                    -Wl,--wrap,OS_Regex \
+                    -Wl,--wrap,OS_Match2 \
+                    -Wl,--wrap,OSList_GetFirstNode \
+                    -Wl,--wrap,OSList_GetNextNode \
+                    ${DEBUG_OP_WRAPPERS}")
+
+  add_executable(test_common test_common.c)
+  target_include_directories(test_common PRIVATE ${SRC_FOLDER}/rootcheck)
+  target_link_libraries(test_common SYSCHECK_O ${TEST_DEPS} "${COMMON_FLAGS}")
+  add_test(NAME test_common COMMAND test_common)
 endif()
 
 # create_db.c tests

--- a/src/unit_tests/syscheckd/test_common.c
+++ b/src/unit_tests/syscheckd/test_common.c
@@ -1,0 +1,220 @@
+/* Copyright (C) 2026, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+#include "shared.h"
+#include "rootcheck.h"
+
+/* Required globals declared extern in rootcheck.h */
+rkconfig rootcheck;
+int rk_sys_count;
+char **rk_sys_file;
+char **rk_sys_name;
+int test_mode = 1;
+
+/* ===================================================================
+ * Wrappers
+ * =================================================================== */
+
+DIR *__wrap_wopendir(const char *name)
+{
+    check_expected(name);
+    return mock_type(DIR *);
+}
+
+int __wrap_closedir(DIR *dirp)
+{
+    (void)dirp;
+    return 0;
+}
+
+int __wrap_w_stat(const char *pathname, struct stat *buf)
+{
+    check_expected(pathname);
+    (void)buf;
+    return mock_type(int);
+}
+
+int __wrap_waccess(const char *path, int mode)
+{
+    check_expected(path);
+    (void)mode;
+    return mock_type(int);
+}
+
+FILE *__wrap_wfopen(const char *path, const char *mode)
+{
+    check_expected(path);
+    (void)mode;
+    return mock_type(FILE *);
+}
+
+int __wrap_fclose(FILE *stream)
+{
+    (void)stream;
+    return 0;
+}
+
+void __wrap__mtdebug1(__attribute__((unused)) const char *tag,
+                      __attribute__((unused)) const char *file,
+                      __attribute__((unused)) int line,
+                      __attribute__((unused)) const char *func,
+                      __attribute__((unused)) const char *msg, ...) {}
+
+void __wrap__mtdebug2(__attribute__((unused)) const char *tag,
+                      __attribute__((unused)) const char *file,
+                      __attribute__((unused)) int line,
+                      __attribute__((unused)) const char *func,
+                      __attribute__((unused)) const char *msg, ...) {}
+
+void __wrap__merror_exit(__attribute__((unused)) const char *tag,
+                         __attribute__((unused)) const char *file,
+                         __attribute__((unused)) int line,
+                         __attribute__((unused)) const char *func,
+                         __attribute__((unused)) const char *msg, ...) {}
+
+int __wrap_OS_Regex(__attribute__((unused)) const char *pattern,
+                    __attribute__((unused)) const char *str)
+{
+    return 0;
+}
+
+int __wrap_OS_Match2(__attribute__((unused)) const char *pattern,
+                     __attribute__((unused)) const char *str)
+{
+    return 0;
+}
+
+OSListNode *__wrap_OSList_GetFirstNode(__attribute__((unused)) OSList *list)
+{
+    return NULL;
+}
+
+OSListNode *__wrap_OSList_GetNextNode(__attribute__((unused)) OSList *list)
+{
+    return NULL;
+}
+
+/* ===================================================================
+ * Tests for is_file()
+ * =================================================================== */
+
+static void test_is_file_null_input(void **state)
+{
+    (void)state;
+    assert_int_equal(is_file(NULL), 0);
+}
+
+/* A directory counts as found — wopendir succeeds */
+static void test_is_file_found_by_opendir(void **state)
+{
+    (void)state;
+    DIR *fake_dp = (DIR *)0x1234;
+
+    expect_string(__wrap_wopendir, name, "/bin/some_dir");
+    will_return(__wrap_wopendir, fake_dp);
+
+    assert_int_equal(is_file("/bin/some_dir"), 1);
+}
+
+/* wopendir fails, w_stat succeeds */
+static void test_is_file_found_by_stat(void **state)
+{
+    (void)state;
+
+    expect_string(__wrap_wopendir, name, "/bin/ps");
+    will_return(__wrap_wopendir, NULL);
+
+    expect_string(__wrap_w_stat, pathname, "/bin/ps");
+    will_return(__wrap_w_stat, 0);
+
+    assert_int_equal(is_file("/bin/ps"), 1);
+}
+
+/* wopendir fails, w_stat fails, waccess succeeds */
+static void test_is_file_found_by_access(void **state)
+{
+    (void)state;
+
+    expect_string(__wrap_wopendir, name, "/bin/ps");
+    will_return(__wrap_wopendir, NULL);
+
+    expect_string(__wrap_w_stat, pathname, "/bin/ps");
+    will_return(__wrap_w_stat, -1);
+
+    expect_string(__wrap_waccess, path, "/bin/ps");
+    will_return(__wrap_waccess, 0);
+
+    assert_int_equal(is_file("/bin/ps"), 1);
+}
+
+/* wopendir fails, w_stat fails, waccess fails, wfopen succeeds */
+static void test_is_file_found_by_fopen(void **state)
+{
+    (void)state;
+    FILE *fake_fp = (FILE *)0x5678;
+
+    expect_string(__wrap_wopendir, name, "/bin/ps");
+    will_return(__wrap_wopendir, NULL);
+
+    expect_string(__wrap_w_stat, pathname, "/bin/ps");
+    will_return(__wrap_w_stat, -1);
+
+    expect_string(__wrap_waccess, path, "/bin/ps");
+    will_return(__wrap_waccess, -1);
+
+    expect_string(__wrap_wfopen, path, "/bin/ps");
+    will_return(__wrap_wfopen, fake_fp);
+
+    assert_int_equal(is_file("/bin/ps"), 1);
+}
+
+/* All methods fail → not found */
+static void test_is_file_not_found(void **state)
+{
+    (void)state;
+
+    expect_string(__wrap_wopendir, name, "/bin/ps");
+    will_return(__wrap_wopendir, NULL);
+
+    expect_string(__wrap_w_stat, pathname, "/bin/ps");
+    will_return(__wrap_w_stat, -1);
+
+    expect_string(__wrap_waccess, path, "/bin/ps");
+    will_return(__wrap_waccess, -1);
+
+    expect_string(__wrap_wfopen, path, "/bin/ps");
+    will_return(__wrap_wfopen, NULL);
+
+    assert_int_equal(is_file("/bin/ps"), 0);
+}
+
+/* ===================================================================
+ * Main
+ * =================================================================== */
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_is_file_null_input),
+        cmocka_unit_test(test_is_file_found_by_opendir),
+        cmocka_unit_test(test_is_file_found_by_stat),
+        cmocka_unit_test(test_is_file_found_by_access),
+        cmocka_unit_test(test_is_file_found_by_fopen),
+        cmocka_unit_test(test_is_file_not_found),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Description

Fixes #35069 — rootcheck was silently failing to detect files and directories, causing findings (including audit checks like `ps not found`) to not be generated.

The latent bug was introduced by [`8e7942eb69`](https://github.com/wazuh/wazuh/commit/8e7942eb69505d686e99dd97dfa93e348530721b) ("Simplify is_file()"), which changed the function's exit from an unconditional `return 1` to `return ret`, but only updated `ret = 1` inside the `if (fp)` branch. This meant that if `w_stat` or `waccess` succeeded (short-circuiting the AND), `fp` was never assigned and `ret` stayed 0 — a silent false negative.

This bug went unnoticed for years because the `ENOTDIR` branch above it was catching regular files before the broken fallback was ever reached: on Linux, `wopendir` on a regular file returns `ENOTDIR`, so ret was already 1 by the time the broken block ran.

[`d05e466051`](https://github.com/wazuh/wazuh/pull/34734/changes/d05e4660515e1063f6bdb785f46a3f89ae64b2f9) removed the `ENOTDIR` check to fix a legitimate false positive (paths like /dev/.blkid.tab/nonexistent). That fix was correct in isolation, but it stripped away the only thing shielding the `8e7942eb69` bug — regular files on Linux now fell through to the broken fallback and were reported as not found.

Closes #35069

## Proposed Changes

- **Fix `is_file()` logic** (`src/rootcheck/common.c`): rewrote the detection to use OR semantics — each of the four methods (opendir, stat, access, fopen) independently returns 1 on success, so any successful probe is sufficient. The original AND logic caused stat success to short-circuit without setting the return value.
- **Unit tests** (`src/unit_tests/syscheckd/test_common.c`): added 6 tests covering all code paths of `is _file()`.

### Results and Evidence

<details> 
<summary> Local run of `pytest -vv test_rootcheck_endpoints.tavern.yaml` (Was failing on 4.14.5 branch)  </summary>

```
(api-it) root@juan-desktop:~/wazuh/api/test/integration# pytest -vv test_rootcheck_endpoints.tavern.yaml
===================================================================================== test session starts ======================================================================================
platform linux -- Python 3.10.20, pytest-7.3.1, pluggy-0.13.1 -- /home/juan/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.20', 'Platform': 'Linux-6.17.0-19-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '0.13.1'}, 'Plugins': {'tavern': '1.23.5', 'metadata': '2
.0.4', 'html': '2.1.1', 'typeguard': '4.3.0'}}
rootdir: /home/juan/wazuh/api/test/integration
configfile: pytest.ini
plugins: tavern-1.23.5, metadata-2.0.4, html-2.1.1, typeguard-4.3.0
collected 4 items                                                                                                                                                                              

test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001/last_scan PASSED                                                                                                                [ 25%]
test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001 PASSED                                                                                                                          [ 50%]
test_rootcheck_endpoints.tavern.yaml::PUT /rootcheck PASSED                                                                                                                              [ 75%]
test_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id} PASSED                                                                                                                [100%]

======================================================================================= warnings summary =======================================================================================
../../../../api-it/lib/python3.10/site-packages/_pytest/config/__init__.py:1302
  /home/juan/api-it/lib/python3.10/site-packages/_pytest/config/__init__.py:1302: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

../../../../api-it/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/juan/api-it/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Pa
th) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rootcheck_endpoints.tavern.yaml: 10 warnings
  /home/juan/api-it/lib/python3.10/site-packages/urllib3/util/ssl_.py:260: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    context = SSLContext(ssl_version or PROTOCOL_TLS)

test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001/last_scan
test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001/last_scan
  /home/juan/api-it/lib/python3.10/site-packages/urllib3/connection.py:407: DeprecationWarning: ssl.match_hostname() is deprecated
    match_hostname(cert, asserted_hostname)

test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001/last_scan
test_rootcheck_endpoints.tavern.yaml::GET /rootcheck/001
test_rootcheck_endpoints.tavern.yaml::PUT /rootcheck
test_rootcheck_endpoints.tavern.yaml::DELETE /rootcheck/{agent_id}
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 4 passed, 18 warnings in 820.96s (0:13:40) ==========================================================================

```

</details>

Jenkins run triggered by server team also shows all tests passing. Linking the artifacts here:
[archive.zip](https://github.com/user-attachments/files/26607851/archive.zip)

### Artifacts Affected

- Executables: `wazuh-agentd` (Linux)

### Tests Introduced

**Unit tests** — `src/unit_tests/syscheckd/test_common.c`

| Test | What it covers |
|---|---|
| `test_is_file_null_input` | NULL input → returns 0 |
| `test_is_file_found_by_opendir` | `wopendir` succeeds → returns 1 |
| `test_is_file_found_by_stat` | `w_stat` succeeds → returns 1 |
| `test_is_file_found_by_access` | `waccess` succeeds → returns 1 |
| `test_is_file_found_by_fopen` | `wfopen` succeeds → returns 1 |
| `test_is_file_not_found` | all methods fail → returns 0 |


## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

