### PR TITLE
Update CTI consumer document ID

### DIFF
--- a/src/shared_modules/content_manager/README.md
+++ b/src/shared_modules/content_manager/README.md
@@ -62,7 +62,7 @@ After all pages are processed, the downloader signals completion via `indexer_co
             },
             "index": ".cti-cves",
             "consumerStatusIndex": ".cti-consumers",
-            "consumerStatusId": "vd_1.0.0_vd_4.8.0",
+            "consumerStatusId": "t1-vulnerabilities-5_public-vulnerabilities-5",
             "pageSize": 250,
             "numSlices": 2
         }

--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -136,7 +136,7 @@ Example:
             },
             "index": ".cti-cves",
             "consumerStatusIndex": ".cti-consumers",
-            "consumerStatusId": "vd_1.0.0_vd_4.8.0",
+            "consumerStatusId": "t1-vulnerabilities-5_public-vulnerabilities-5",
             "pageSize": 250,
             "numSlices": 2
         }

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -52,7 +52,7 @@
  * {
  *   "index":               ".cti-cves",               // Indexer CVE index name
  *   "consumerStatusIndex": ".cti-consumers",          // Consumer status index (optional)
- *   "consumerStatusId":    "vd_1.0.0_vd_4.8.0",       // Consumer status document id (optional)
+ *   "consumerStatusId":    "t1-vulnerabilities-5_public-vulnerabilities-5", // Consumer status document id (optional)
  *   "pageSize":            250,                       // Documents per page (optional, default 250)
  *   "numSlices":           2,                         // Parallel PIT slices (optional, default 2)
  *   <standard IndexerConnector SSL/auth config>

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -18,7 +18,7 @@ OPENSEARCH_IP = "127.0.0.1:9200"
 OPENSEARCH_URL = f"http://{OPENSEARCH_IP}"
 CTI_FEED_INDEX = ".cti-cves"
 CTI_CONSUMERS_INDEX = ".cti-consumers"
-CTI_CONSUMER_DOC_ID = "vd_1.0.0_vd_4.8.0"
+CTI_CONSUMER_DOC_ID = "t1-vulnerabilities-5_public-vulnerabilities-5"
 CTI_FEED_FILE = Path("wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json")
 
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -38,7 +38,7 @@ namespace
 {
     constexpr std::string_view INDEXER_FEED_INDEX {".cti-cves"};
     constexpr std::string_view INDEXER_CONSUMER_STATUS_INDEX {".cti-consumers"};
-    constexpr std::string_view INDEXER_CONSUMER_STATUS_ID {"vd_1.0.0_vd_4.8.0"};
+    constexpr std::string_view INDEXER_CONSUMER_STATUS_ID {"t1-vulnerabilities-5_public-vulnerabilities-5"};
 
     bool shouldSkipPostUpdateScan()
     {


### PR DESCRIPTION
## Summary

Updates the CTI consumer document ID used to query the `.cti-consumers` index from `vd_1.0.0_vd_4.8.0` to `t1-vulnerabilities-5_public-vulnerabilities-5`.

## Context

The vulnerability scanner relies on the consumer status document in the `.cti-consumers` index to determine when the CTI feed is ready for consumption (see PR #35167). The document ID needs to be updated to align with the new naming convention used by the wazuh-indexer-plugins.

## Changes

- **Source code**: Updated `INDEXER_CONSUMER_STATUS_ID` constant in `vulnerabilityScannerFacade.cpp`
- **Tests**: Updated `CTI_CONSUMER_DOC_ID` in `test_efficacy_log.py`
- **Documentation**: Updated examples in:
  - `IndexerDownloader.hpp` (inline comments)
  - `content_manager/README.md`
  - `content_manager/doc/components/INDEXER_DOWNLOADER.md`

All references to the old ID have been replaced with the new one to ensure consistency across the codebase.

## Related issues

- Closes #35293
- Related: wazuh/wazuh-indexer-plugins#986
