### PR TITLE
Avoid cv2pdb locking issues in MSI generation

### DIFF
--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -107,21 +107,18 @@ function ExtractDebugSymbols(){
 	foreach ($file in $exeFiles)
 	{
 		Write-Host "Extracting dbg symbols from" $file.FullName
-		$procArgs = $file.FullName #source (exe/dll with debug symbols)
-		$procArgs += " "
-		$procArgs += $file.FullName  #destination (same as source - exe/dll is stripped of debug symbols)
-		$procArgs += " "
-		$procArgs += $file.BaseName
-		$procArgs += ".pdb"
-
-		$processes += Start-Process -FilePath "cv2pdb.exe" -ArgumentList $procArgs -WindowStyle Hidden -PassThru
+        & ".\cv2pdb.exe" $file.FullName $file.FullName "$($file.BaseName).pdb"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Skipping debug symbol extraction for $($file.FullName); cv2pdb exited with code $LASTEXITCODE"
+        }
 	}
-
-  Write-Host "Waiting for processes to finish"
-  $processes | Wait-Process
 
   #compress every pdb file in current folder
 	$pdbFiles = Get-ChildItem -Filter ".\*.pdb"
+    if ($pdbFiles.Count -eq 0) {
+        Write-Warning "No debug symbols were extracted. Skipping debug symbols archive generation."
+        return
+    }
 
     $ZIP_NAME = $MSI_NAME -replace 'wazuh-agent', 'wazuh-agent-debug-symbols' -replace '\.msi$', '.zip'
 


### PR DESCRIPTION
## Description

This pull request fixes file locking issues during Windows MSI generation in `generate_wazuh_msi.ps1`.

Closes #35282

The problem happens during debug symbol extraction with `cv2pdb.exe`. The previous implementation launched multiple `cv2pdb` processes in parallel and then continued with archive generation and cleanup. On Windows, that can leave `.pdb` files temporarily locked, causing intermittent failures in CI with errors such as `PermissionError: [WinError 32]`.

This change makes the extraction flow deterministic and avoids continuing while files may still be locked by background processes.

## Proposed Changes

- Replace parallel `cv2pdb.exe` execution with sequential execution.
- Check `$LASTEXITCODE` after each `cv2pdb.exe` invocation.
- Log a warning instead of aborting the whole process when symbol extraction fails for an individual binary.
- Skip debug symbols archive generation when no `.pdb` files were produced.

### Results and Evidence

Before:
- Multiple `cv2pdb.exe` processes could run at the same time.
- `.pdb` files could still be locked when the script tried to compress or remove them.
- Windows packaging could fail intermittently due to file locking issues.

After:
- Each binary is processed one by one.
- Failures in `cv2pdb.exe` are reported with `Write-Warning`.
- Archive generation is skipped safely if no debug symbols were extracted.
- The flow is more stable for Windows CI packaging jobs.

Issue reference:
- #35282 documents the intermittent locking problem and its impact on Windows package generation.

### Artifacts Affected

- Windows MSI packaging script
- Windows debug symbols archive generation flow
- Agent Windows packaging jobs

### Configuration Changes

- No user-facing configuration changes.
- No new configuration parameters were added.
- No default values were modified.

### Documentation Updates

- Not applicable.

### Tests Introduced

- No new automated tests were added.
- This change updates the packaging script behavior for Windows MSI generation.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] Manual validation on Windows packaging flow