### PR TITLE
Fix cluster sync when keepalive is incomplete

### DIFF
--- a/src/remoted/src/manager.c
+++ b/src/remoted/src/manager.c
@@ -572,9 +572,14 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *pos
     if (data = OSHash_Get(pending_data, key->id), data && data->changed && data->message && msg && strcmp(data->message, msg) == 0) {
         w_mutex_unlock(&lastmsg_mutex);
 
-        char *sync_status = logr.worker_node ? (*post_startup ? "syncreq" : "syncreq_keepalive") : "synced";
+        // Only set syncreq if keepalive is complete (has full metadata)
+        bool is_complete = (msg[0] != '{') || is_keepalive_complete(msg);
+        char *sync_status = logr.worker_node ? (*post_startup && is_complete ? "syncreq" : "syncreq_keepalive") : "synced";
 
-        *post_startup = false;
+        // Only clear post_startup flag if keepalive is complete
+        if (is_complete) {
+            *post_startup = false;
+        }
 
         agent_id = atoi(key->id);
 
@@ -674,9 +679,18 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *pos
 
             agent_data->id = atoi(key->id);
             os_strdup(AGENT_CS_ACTIVE, agent_data->connection_status);
-            os_strdup(logr.worker_node ? (*post_startup ? "syncreq" : "syncreq_keepalive") : "synced", agent_data->sync_status);
 
-            *post_startup = false;
+            // Only set syncreq if keepalive is complete (has full metadata)
+            bool is_complete = (msg[0] != '{') || is_keepalive_complete(msg);
+            if (!is_complete && *post_startup) {
+                mdebug1("Agent '%s' sent incomplete keepalive, deferring cluster sync (syncreq) until complete metadata is received", key->id);
+            }
+            os_strdup(logr.worker_node ? (*post_startup && is_complete ? "syncreq" : "syncreq_keepalive") : "synced", agent_data->sync_status);
+
+            // Only clear post_startup flag if keepalive is complete
+            if (is_complete) {
+                *post_startup = false;
+            }
 
             w_mutex_lock(&lastmsg_mutex);
 

--- a/src/shared/include/remoted_op.h
+++ b/src/shared/include/remoted_op.h
@@ -61,3 +61,14 @@ int parse_json_keepalive(const char *json_str,
                          size_t *groups_count_out,
                          char **cluster_name_out,
                          char **cluster_node_out);
+
+/**
+ * @brief Check if a JSON keepalive message is complete (contains full metadata).
+ *        A minimal keepalive only has merged_sum, while a complete keepalive includes
+ *        host information (OS, hostname, architecture, etc.).
+ *
+ * @param[in] json_str The JSON keepalive message string to check.
+ * @retval true Keepalive is complete (has host metadata).
+ * @retval false Keepalive is minimal (no host metadata).
+ */
+bool is_keepalive_complete(const char *json_str);

--- a/src/shared/src/remoted_op.c
+++ b/src/shared/src/remoted_op.c
@@ -380,4 +380,23 @@ int parse_json_keepalive(const char *json_str, agent_info_data *agent_data, char
     return OS_SUCCESS;
 }
 
+/* Check if JSON keepalive is complete (has host metadata) */
+bool is_keepalive_complete(const char *json_str) {
+    if (!json_str || json_str[0] != '{') {
+        return false;
+    }
+
+    cJSON *root = cJSON_Parse(json_str);
+    if (!root) {
+        return false;
+    }
+
+    // A complete keepalive must have the "host" object with metadata
+    cJSON *host = cJSON_GetObjectItem(root, "host");
+    bool is_complete = (host != NULL);
+
+    cJSON_Delete(root);
+    return is_complete;
+}
+
 #endif

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -27,7 +27,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
                             -Wl,--wrap,w_copy_file -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Begin_ex \
                             -Wl,--wrap,req_save -Wl,--wrap,send_msg -Wl,--wrap,send_msg_with_key_control \
-                            -Wl,--wrap,wdb_update_agent_keepalive -Wl,--wrap,parse_agent_update_msg -Wl,--wrap,req_save \
+                            -Wl,--wrap,wdb_update_agent_keepalive -Wl,--wrap,parse_agent_update_msg -Wl,--wrap,parse_json_keepalive -Wl,--wrap,req_save \
                             -Wl,--wrap,wdb_update_agent_data -Wl,--wrap,linked_queue_push_ex \
                             -Wl,--wrap,wdb_update_agent_connection_status -Wl,--wrap,wdb_update_agent_status_code -Wl,--wrap,SendMSG -Wl,--wrap,StartMQ \
                             -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -4831,6 +4831,191 @@ void test_save_controlmsg_shutdown_wdb_fail(void **state)
     os_free(message);
 }
 
+void test_save_controlmsg_json_keepalive_incomplete(void **state)
+{
+    int wdb_sock = -1;
+    // Minimal/incomplete JSON keepalive without host metadata
+    char r_msg[OS_SIZE_512] = {0};
+    strcpy(r_msg, "{\"version\":\"1.0\",\"agent\":{\"merged_sum\":\"112359\"}}");
+
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool post_startup = true; // Simulating post_startup
+
+    keyentry key;
+    keyentry_init(&key, "TEST_AGENT", "003", "172.18.0.5", "test_key");
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 1);
+    pending_data = OSHash_Create();
+
+    pending_data_t* data;
+    os_calloc(1, sizeof(struct pending_data_t), data);
+    char* message = strdup("different message");
+    data->changed = false;
+    data->message = message;
+    memset(&data->merged_sum, 0, sizeof(os_md5));
+    snprintf(data->merged_sum, 7, "112359");
+
+    groups = (OSHash*)10;
+    multi_groups = (OSHash*)10;
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_value(__wrap_OSHash_Get, self, pending_data);
+    expect_string(__wrap_OSHash_Get, key, "003");
+    will_return(__wrap_OSHash_Get, data);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Processing JSON keepalive from agent '003'");
+    expect_string(__wrap__mdebug2, formatted_msg, "save_controlmsg(): inserting '{\"version\":\"1.0\",\"agent\":{\"merged_sum\":\"112359\"}}'");
+
+    char* group_name = NULL;
+    w_strdup("default", group_name);
+    expect_value(__wrap_wdb_get_agent_group, id, 3);
+    will_return(__wrap_wdb_get_agent_group, group_name);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent '003' group is 'default'");
+
+    group_t* group = NULL;
+    os_calloc(1, sizeof(group_t), group);
+    group->name = strdup("default");
+    snprintf(group->merged_sum, 7, "112359");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "default");
+    will_return(__wrap_OSHash_Get_ex, group);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    agent_info_data* agent_data;
+    os_calloc(1, sizeof(agent_info_data), agent_data);
+    agent_data->id = 3;
+    os_strdup("112359", agent_data->merged_sum);  // Match the group merged_sum
+
+    expect_string(__wrap_parse_json_keepalive, json_str, "{\"version\":\"1.0\",\"agent\":{\"merged_sum\":\"112359\"}}");
+    will_return(__wrap_parse_json_keepalive, agent_data);
+    will_return(__wrap_parse_json_keepalive, OS_SUCCESS);
+
+    // Expect incomplete keepalive debug message
+    expect_string(__wrap__mdebug1, formatted_msg, "Agent '003' sent incomplete keepalive, deferring cluster sync (syncreq) until complete metadata is received");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_any(__wrap_wdb_update_agent_data, agent_data);
+    will_return(__wrap_wdb_update_agent_data, OS_SUCCESS);
+
+    os_strdup("worker1", node_name);
+    logr.worker_node = true;
+
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
+
+    // post_startup should still be true because keepalive was incomplete
+    assert_true(post_startup);
+
+    logr.worker_node = false;
+    os_free(node_name);
+    os_free(group->name);
+    os_free(group);
+    os_free(agent_data);
+    free_keyentry(&key);
+    os_free(data->message);
+    os_free(data->group);
+    os_free(data);
+}
+
+void test_save_controlmsg_json_keepalive_complete(void **state)
+{
+    int wdb_sock = -1;
+    // Complete JSON keepalive with host metadata
+    char r_msg[OS_SIZE_1024] = {0};
+    strcpy(r_msg, "{\"version\":\"1.0\",\"agent\":{\"version\":\"v5.0.0\",\"merged_sum\":\"abc123\"},"
+                  "\"host\":{\"hostname\":\"wazuh-agent3\",\"os\":{\"name\":\"Ubuntu\"}}}");
+
+    bool is_startup = false;
+    bool is_shutdown = false;
+    bool post_startup = true; // Simulating post_startup after HC_STARTUP
+
+    keyentry key;
+    keyentry_init(&key, "TEST_AGENT", "003", "172.18.0.5", "test_key");
+
+    expect_function_call(__wrap_OSHash_Create);
+    will_return(__wrap_OSHash_Create, 1);
+    pending_data = OSHash_Create();
+
+    pending_data_t* data;
+    os_calloc(1, sizeof(struct pending_data_t), data);
+    char* message = strdup("different message");
+    data->changed = false;
+    data->message = message;
+    memset(&data->merged_sum, 0, sizeof(os_md5));
+    snprintf(data->merged_sum, 7, "abc123");
+
+    groups = (OSHash*)10;
+    multi_groups = (OSHash*)10;
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_value(__wrap_OSHash_Get, self, pending_data);
+    expect_string(__wrap_OSHash_Get, key, "003");
+    will_return(__wrap_OSHash_Get, data);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Processing JSON keepalive from agent '003'");
+    expect_string(__wrap__mdebug2, formatted_msg, "save_controlmsg(): inserting '{\"version\":\"1.0\",\"agent\":{\"version\":\"v5.0.0\",\"merged_sum\":\"abc123\"},\"host\":{\"hostname\":\"wazuh-agent3\",\"os\":{\"name\":\"Ubuntu\"}}}'");
+
+    char* group_name = NULL;
+    w_strdup("default", group_name);
+    expect_value(__wrap_wdb_get_agent_group, id, 3);
+    will_return(__wrap_wdb_get_agent_group, group_name);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent '003' group is 'default'");
+
+    group_t* group = NULL;
+    os_calloc(1, sizeof(group_t), group);
+    group->name = strdup("default");
+    snprintf(group->merged_sum, 7, "abc123");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_value(__wrap_OSHash_Get_ex, self, groups);
+    expect_string(__wrap_OSHash_Get_ex, key, "default");
+    will_return(__wrap_OSHash_Get_ex, group);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    agent_info_data* agent_data;
+    os_calloc(1, sizeof(agent_info_data), agent_data);
+    agent_data->id = 3;
+    os_strdup("v5.0.0", agent_data->version);
+    os_strdup("abc123", agent_data->merged_sum);
+
+    expect_string(__wrap_parse_json_keepalive, json_str, "{\"version\":\"1.0\",\"agent\":{\"version\":\"v5.0.0\",\"merged_sum\":\"abc123\"},\"host\":{\"hostname\":\"wazuh-agent3\",\"os\":{\"name\":\"Ubuntu\"}}}");
+    will_return(__wrap_parse_json_keepalive, agent_data);
+    will_return(__wrap_parse_json_keepalive, OS_SUCCESS);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_any(__wrap_wdb_update_agent_data, agent_data);
+    will_return(__wrap_wdb_update_agent_data, OS_SUCCESS);
+
+    os_strdup("worker1", node_name);
+    logr.worker_node = true;
+
+    save_controlmsg(&key, r_msg, &wdb_sock, &post_startup, is_startup, is_shutdown);
+
+    // post_startup should be false because complete keepalive was processed
+    assert_false(post_startup);
+
+    logr.worker_node = false;
+    os_free(node_name);
+    os_free(group->name);
+    os_free(group);
+    os_free(agent_data);
+    free_keyentry(&key);
+    os_free(data->message);
+    os_free(data->group);
+    os_free(data);
+}
+
 /* build_handshake_json tests */
 
 static void test_build_handshake_json_default_values(void **state) {
@@ -5283,6 +5468,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_save_controlmsg_startup, setup_globals, teardown_globals),
         cmocka_unit_test_setup_teardown(test_save_controlmsg_shutdown, setup_globals, teardown_globals),
         cmocka_unit_test_setup_teardown(test_save_controlmsg_shutdown_wdb_fail, setup_globals, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_json_keepalive_incomplete, setup_globals, teardown_globals),
+        cmocka_unit_test_setup_teardown(test_save_controlmsg_json_keepalive_complete, setup_globals, teardown_globals),
         // Tests build_handshake_json
         cmocka_unit_test(test_build_handshake_json_default_values),
         cmocka_unit_test_setup_teardown(test_build_handshake_json_custom_values, setup_cluster_globals, teardown_cluster_globals),

--- a/src/unit_tests/shared/test_remoted_op.c
+++ b/src/unit_tests/shared/test_remoted_op.c
@@ -1051,6 +1051,46 @@ static void test_parse_json_keepalive_with_cluster_and_groups(void **state)
     os_free(cluster_node);
 }
 
+/* Tests is_keepalive_complete */
+
+void test_is_keepalive_complete_minimal(void **state)
+{
+    // Minimal keepalive without host metadata
+    char* json = "{\"version\":\"1.0\",\"agent\":{\"merged_sum\":\"x\"}}";
+    bool result = is_keepalive_complete(json);
+    assert_false(result);
+}
+
+void test_is_keepalive_complete_with_host(void **state)
+{
+    // Complete keepalive with host metadata
+    char* json = "{\"version\":\"1.0\",\"agent\":{\"version\":\"v5.0.0\",\"merged_sum\":\"abc123\"},"
+                 "\"host\":{\"hostname\":\"test-host\",\"os\":{\"name\":\"Ubuntu\"}}}";
+    bool result = is_keepalive_complete(json);
+    assert_true(result);
+}
+
+void test_is_keepalive_complete_invalid_json(void **state)
+{
+    char* json = "invalid json";
+    bool result = is_keepalive_complete(json);
+    assert_false(result);
+}
+
+void test_is_keepalive_complete_null_input(void **state)
+{
+    bool result = is_keepalive_complete(NULL);
+    assert_false(result);
+}
+
+void test_is_keepalive_complete_non_json(void **state)
+{
+    // Legacy text format keepalive
+    char* msg = "some text keepalive";
+    bool result = is_keepalive_complete(msg);
+    assert_false(result);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] =
@@ -1095,7 +1135,13 @@ int main()
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_with_empty_cluster, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_with_empty_cluster_strings, setup_remoted_op, teardown_remoted_op),
         cmocka_unit_test_setup_teardown(test_parse_json_keepalive_cluster_null_outputs, setup_remoted_op, teardown_remoted_op),
-        cmocka_unit_test_setup_teardown(test_parse_json_keepalive_with_cluster_and_groups, setup_remoted_op, teardown_remoted_op)
+        cmocka_unit_test_setup_teardown(test_parse_json_keepalive_with_cluster_and_groups, setup_remoted_op, teardown_remoted_op),
+        // Tests is_keepalive_complete
+        cmocka_unit_test_setup_teardown(test_is_keepalive_complete_minimal, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_is_keepalive_complete_with_host, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_is_keepalive_complete_invalid_json, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_is_keepalive_complete_null_input, setup_remoted_op, teardown_remoted_op),
+        cmocka_unit_test_setup_teardown(test_is_keepalive_complete_non_json, setup_remoted_op, teardown_remoted_op)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/remoted/remoted_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/remoted_op_wrappers.c
@@ -21,7 +21,8 @@ int __wrap_parse_agent_update_msg(char *msg, __attribute__((unused)) agent_info_
 }
 
 int __wrap_parse_json_keepalive(const char *json_str, __attribute__((unused)) agent_info_data *agent_data,
-                                 __attribute__((unused)) char ***groups_out, __attribute__((unused)) size_t *groups_count_out) {
+                                 __attribute__((unused)) char ***groups_out, __attribute__((unused)) size_t *groups_count_out,
+                                 __attribute__((unused)) char **cluster_name_out, __attribute__((unused)) char **cluster_node_out) {
     check_expected(json_str);
     agent_info_data *aux = mock_ptr_type(agent_info_data*);
     memcpy(agent_data, aux, sizeof(agent_info_data));

--- a/src/unit_tests/wrappers/wazuh/remoted/remoted_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/remoted_op_wrappers.h
@@ -17,6 +17,8 @@ int __wrap_parse_agent_update_msg(char* msg, __attribute__((unused)) agent_info_
 int __wrap_parse_json_keepalive(const char* json_str,
                                 __attribute__((unused)) agent_info_data* agent_data,
                                 __attribute__((unused)) char*** groups_out,
-                                __attribute__((unused)) size_t* groups_count_out);
+                                __attribute__((unused)) size_t* groups_count_out,
+                                __attribute__((unused)) char** cluster_name_out,
+                                __attribute__((unused)) char** cluster_node_out);
 
 #endif


### PR DESCRIPTION
## Description

This PR fixes an issue in cluster synchronization when a node sends an incomplete or partial keepalive message.

In certain scenarios, the master node may interpret an incomplete keepalive as a valid state update, which can lead to inconsistent synchronization states or skipped sync operations. Since keepalive messages are used to determine node health and trigger synchronization flows, processing incomplete data may cause incorrect cluster behavior.

## Proposed Changes

* Add validation for keepalive messages to ensure they are complete before processing.
* Prevent synchronization triggers based on invalid keepalive data.
* Improve robustness of cluster communication handling in edge cases involving partial transmissions.
* Add safeguards to avoid inconsistent node state updates derived from malformed keepalive messages.

### Results and Evidence

API tests now working as expected:

<img width="653" height="336" alt="image" src="https://github.com/user-attachments/assets/b0d70c23-a6f5-4d85-9ba3-18474eb7e253" />

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

Add some tests to `is_keepalive_complete` and `save_controlmsg`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues