### PR TITLE
Add enrichment trace failure if there is no match

### DIFF
--- a/src/engine/source/builder/src/builders/enrichment/geo.cpp
+++ b/src/engine/source/builder/src/builders/enrichment/geo.cpp
@@ -209,10 +209,12 @@ bool mapAStoECS(const std::string& ip,
 base::Expression getEachEnrichTerm(const std::shared_ptr<geo::ILocator>& cityLocator,
                                    const std::shared_ptr<geo::ILocator>& asLocator,
                                    const MappingConfig& mappingConfig,
-                                   bool trace)
+                                   bool trace,
+                                   const std::shared_ptr<bool>& enrichmentApplied)
 {
 
-    auto opFn = [cityLocator, asLocator, mappingConfig, trace](base::Event event) -> base::result::Result<base::Event>
+    auto opFn = [cityLocator, asLocator, mappingConfig, trace, enrichmentApplied](
+                    base::Event event) -> base::result::Result<base::Event>
     {
         // Get source IP, can be an string o a array of strings, in that case we take the first one.
         const auto ipOpt = [&]() -> std::optional<std::string>
@@ -242,6 +244,11 @@ base::Expression getEachEnrichTerm(const std::shared_ptr<geo::ILocator>& cityLoc
 
         const bool geoSuccess =
             geoConfigured ? mapGeoToECS(ip, cityLocator, mappingConfig.geoEcsPath.value(), *event) : false;
+
+        if (asSuccess || geoSuccess)
+        {
+            *enrichmentApplied = true;
+        }
 
         // Generate trace message using lookup lambda
         const auto getTraceMessage = [&]() -> std::string
@@ -338,17 +345,39 @@ std::pair<base::Expression, std::string> geoEnrichmentBuilder(const std::shared_
     auto& asLocator = base::getResponse(as);
     auto& cityLocator = base::getResponse(city);
 
+    // Shared flag to track if any enrichment was applied
+    auto enrichmentApplied = std::make_shared<bool>(false);
+
     // Create enrichment terms for each mapping config
     std::vector<base::Expression> enrichmentTerms;
     for (const auto& config : mappingConfigs)
     {
-        enrichmentTerms.push_back(getEachEnrichTerm(cityLocator, asLocator, config, trace));
+        enrichmentTerms.push_back(getEachEnrichTerm(cityLocator, asLocator, config, trace, enrichmentApplied));
     }
 
     // Combine terms into a single expression
     base::Expression enrichmentExpr = base::Chain::create(GEO_ENRICHMENT_TRACEABLE_NAMES, enrichmentTerms);
 
-    return {makeTraceableSuccessExpression(enrichmentExpr, trace), GEO_ENRICHMENT_TRACEABLE_NAMES};
+    if (!trace)
+    {
+        return {enrichmentExpr, GEO_ENRICHMENT_TRACEABLE_NAMES};
+    }
+
+    // Only emit SUCCESS if at least one enrichment was applied
+    auto conditionalSuccess =
+        base::Term<base::EngineOp>::create("ConditionalAccept",
+                                           [enrichmentApplied](auto e) -> base::result::Result<base::Event>
+                                           {
+                                               if (*enrichmentApplied)
+                                               {
+                                                   *enrichmentApplied = false;
+                                                   return base::result::makeSuccess(e, "SUCCESS");
+                                               }
+                                               return base::result::makeFailure(e, std::string {});
+                                           });
+
+    return {base::Implication::create("TraceableConditional", enrichmentExpr, conditionalSuccess),
+            GEO_ENRICHMENT_TRACEABLE_NAMES};
 };
 
 } // namespace

--- a/src/engine/source/builder/src/builders/enrichment/ioc.cpp
+++ b/src/engine/source/builder/src/builders/enrichment/ioc.cpp
@@ -232,9 +232,10 @@ std::vector<IocMappingConfig> loadIocMappingConfigs(const json::Json& config, st
 
 base::Expression getEachIocEnrichTerm(const std::shared_ptr<ioc::kvdb::IKVDBManager>& kvdbIocManager,
                                       const IocMappingConfig& config,
-                                      bool trace)
+                                      bool trace,
+                                      const std::shared_ptr<bool>& matchFound)
 {
-    auto opFn = [kvdbIocManager, config, trace](base::Event event) -> base::result::Result<base::Event>
+    auto opFn = [kvdbIocManager, config, trace, matchFound](base::Event event) -> base::result::Result<base::Event>
     {
         const auto keyOpt = buildLookupKey(event, config);
         if (!keyOpt.has_value())
@@ -266,6 +267,7 @@ base::Expression getEachIocEnrichTerm(const std::shared_ptr<ioc::kvdb::IKVDBMana
         }();
 
         event->appendJson(enrichmentMatch, IOC_ENRICHMENT_TARGET_PATH);
+        *matchFound = true;
 
         const auto traceMsg =
             trace ? fmt::format(FMT_IOC_MATCH_TRACE, config.iocType, config.sourceFields, lookupKey) : std::string {};
@@ -287,16 +289,38 @@ iocEnrichmentBuilder(const std::shared_ptr<ioc::kvdb::IKVDBManager>& kvdbIocMana
         throw std::runtime_error("IOC enrichment requires a valid KVDB IOC manager");
     }
 
+    // Shared flag to track if any IOC match was found
+    auto matchFound = std::make_shared<bool>(false);
+
     std::vector<base::Expression> enrichmentTerms;
     enrichmentTerms.reserve(mappingConfigs.size());
 
     for (const auto& config : mappingConfigs)
     {
-        enrichmentTerms.push_back(getEachIocEnrichTerm(kvdbIocManager, config, trace));
+        enrichmentTerms.push_back(getEachIocEnrichTerm(kvdbIocManager, config, trace, matchFound));
     }
 
     base::Expression enrichmentExpr = base::Chain::create(traceableName, enrichmentTerms);
-    return {makeTraceableSuccessExpression(enrichmentExpr, trace), traceableName};
+
+    if (!trace)
+    {
+        return {enrichmentExpr, traceableName};
+    }
+
+    // Only emit SUCCESS if at least one IOC match was found
+    auto conditionalSuccess =
+        base::Term<base::EngineOp>::create("ConditionalAccept",
+                                           [matchFound](auto e) -> base::result::Result<base::Event>
+                                           {
+                                               if (*matchFound)
+                                               {
+                                                   *matchFound = false;
+                                                   return base::result::makeSuccess(e, "SUCCESS");
+                                               }
+                                               return base::result::makeFailure(e, std::string {});
+                                           });
+
+    return {base::Implication::create("TraceableConditional", enrichmentExpr, conditionalSuccess), traceableName};
 }
 
 } // namespace


### PR DESCRIPTION

## Description

Currently, enrichment stages (such as Geo and IOC) are always marked as `success` in the trace, even when no actual enrichment match occurs.

In many cases, enrichment attempts fail due to missing fields or lack of matching data (e.g. no IP found, no IOC match), but the overall stage is still reported as successful. This leads to misleading traces where enrichment appears to have been applied even though no data was added to the event.

This PR addresses that issue by introducing a mechanism to determine whether any enrichment actually produced a match during runtime.

With this change:

- Enrichment stages are marked as `success` only if at least one enrichment term produces a valid match
- If all enrichment attempts fail (no data added, no matches), the stage is marked as `failed`

This improves trace accuracy, observability, and debugging by ensuring that the reported st

## Proposed Changes

This change introduces a mechanism to correctly track whether an enrichment actually produced a match, allowing the trace to reflect a failure when no enrichment occurs.

To achieve this, a shared mutable state is required between enrichment terms and the `ConditionalAccept` logic.

### Rationale

Enrichment terms and `ConditionalAccept` are implemented as independent lambdas that are created at build-time but executed at runtime. Because of this, they need to share a mutable state.

The problem is that when capturing a `bool` inside a lambda, it is captured by value by default. This means each lambda would operate on its own independent copy of the variable. If one enrichment term sets its `bool` to `true`, the `ConditionalAccept` lambda would not observe that change, since it would still hold its own copy set to `false`.

### Solution

A `std::shared_ptr<bool>` is used to store the shared state.

- Each lambda captures the `shared_ptr` by value
- All lambdas point to the same underlying `bool` allocated on the heap
- Any update performed by one lambda is visible to all others

This allows enrichment terms to signal when a match occurs, and enables `ConditionalAccept` to make a corr

### Results and Evidence

### Geo match

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer 
╰─# engine-test run test01 -s testing -dd                                            

Enter any events [ENTER to send event, CTRL+C to finish]:

hello


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ _tmp_json: parse_json($event.original) -> Parser parser failed at: hello
  ↳ source.ip: map("8.8.8.8") -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🟢] enrichment/Geo -> success
  ↳ Geo()|AS() -> Failure: IP not found at field 'client.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'destination.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'host.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'observer.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'server.ip'
  ↳ Geo(8.8.8.8)|AS(8.8.8.8) -> Success: Geo and AS enrichment applied for IP at field 'source.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'wazuh.agent.host.ip'
[🔴] enrichment/Ioc/connection -> failed
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.ip, client.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.nat.ip, client.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.ip, destination.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.nat.ip, destination.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.ip, server.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.nat.ip, server.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.ip, source.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.nat.ip, source.nat.port'
[🔴] enrichment/Ioc/url_full -> failed
  ↳ IOC(url_full) -> Failure: Source field(s) not found for 'url.full'
  ↳ IOC(url_full) -> Failure: Source field(s) not found for 'url.original'
[🔴] enrichment/Ioc/url_domain -> failed
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.hostname'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.name'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.top_level_domain'
[🔴] enrichment/Ioc/hash_md5 -> failed
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'dll.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'email.attachments.file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.parent.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.client.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.server.hash.md5'
[🔴] enrichment/Ioc/hash_sha1 -> failed
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'dll.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.parent.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.client.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.server.hash.sha1'
[🔴] enrichment/Ioc/hash_sha256 -> failed
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'dll.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.parent.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.client.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.server.hash.sha256'
[🟢] output/file-output-integrations/0 -> success
  ↳ write.output(file/testing-wazuh-events-v5) -> Success

output:
  '@timestamp': '2026-04-07T20:53:04Z'
  event:
    original: hello
  source:
    as:
      number: 15169
      organization:
        name: Google LLC
    geo:
      continent_code: NA
      continent_name: North America
      country_iso_code: US
      country_name: United States
      location:
        lat: 37.751
        lon: -97.822
      timezone: America/Chicago
    ip: 8.8.8.8
  wazuh:
    integration:
      category: security
      decoders:
      - decoder/core-wazuh-message/0
      - decoder/integrations/0
      name: integration/wazuh-core/0
    protocol:
      location: /tmp
      queue: 49
    space:
      name: testing
```

### IOC match

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer 
╰─# engine-test run test01 -s testing -dd                                            

Enter any events [ENTER to send event, CTRL+C to finish]:

hello


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ _tmp_json: parse_json($event.original) -> Parser parser failed at: hello
  ↳ url.full: map("http://10.2.10.224:80/jzsf") -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🔴] enrichment/Geo -> failed
  ↳ Geo()|AS() -> Failure: IP not found at field 'client.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'destination.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'host.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'observer.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'server.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'source.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'wazuh.agent.host.ip'
[🔴] enrichment/Ioc/connection -> failed
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.ip, client.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.nat.ip, client.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.ip, destination.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.nat.ip, destination.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.ip, server.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.nat.ip, server.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.ip, source.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.nat.ip, source.nat.port'
[🟢] enrichment/Ioc/url_full -> success
  ↳ IOC(url_full) -> Success: IOC match found for field 'url.full' with key 'http://10.2.10.224:80/jzsf'
  ↳ IOC(url_full) -> Failure: Source field(s) not found for 'url.original'
[🔴] enrichment/Ioc/url_domain -> failed
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.hostname'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.name'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.top_level_domain'
[🔴] enrichment/Ioc/hash_md5 -> failed
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'dll.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'email.attachments.file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.parent.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.client.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.server.hash.md5'
[🔴] enrichment/Ioc/hash_sha1 -> failed
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'dll.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.parent.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.client.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.server.hash.sha1'
[🔴] enrichment/Ioc/hash_sha256 -> failed
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'dll.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.parent.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.client.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.server.hash.sha256'
[🟢] output/file-output-integrations/0 -> success
  ↳ write.output(file/testing-wazuh-events-v5) -> Success

output:
  '@timestamp': '2026-04-07T20:51:47Z'
  event:
    original: hello
  threat:
    enrichments:
    - indicator:
        confidence: 75
        feed:
          name: abuse_ch
        first_seen: '2025-12-14T20:45:24.000Z'
        id: '1679077'
        last_seen: '2025-12-14T20:45:24.000Z'
        name: http://10.2.10.224:80/jZSF
        provider: threat-fox
        software:
          alias:
          - Cobalt Strike
          - Agentemis
          - BEACON
          - CobaltStrike
          - cobeacon
          name: win.cobalt_strike
          type: botnet_cc
        tags:
        - cobaltstrike
        type: url_full
      matched:
        field: url.full
  url:
    full: http://10.2.10.224:80/jzsf
  wazuh:
    integration:
      category: security
      decoders:
      - decoder/core-wazuh-message/0
      - decoder/integrations/0
      name: integration/wazuh-core/0
    protocol:
      location: /tmp
      queue: 49
    space:
      name: testing
```

### IOC and GEO match
```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer 
╰─# engine-test run test01 -s testing -dd                                                

Enter any events [ENTER to send event, CTRL+C to finish]:

hello


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ _tmp_json: parse_json($event.original) -> Parser parser failed at: hello
  ↳ source.ip: map("8.8.8.8") -> Success
  ↳ url.full: map("http://10.2.10.224:80/jzsf") -> Success
  ↳ client.ip: map("1.116.196.153") -> Success
  ↳ client.port: map(9999) -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🟢] enrichment/Geo -> success
  ↳ Geo(1.116.196.153)|AS(1.116.196.153) -> Success: Geo and AS enrichment applied for IP at field 'client.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'destination.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'host.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'observer.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'server.ip'
  ↳ Geo(8.8.8.8)|AS(8.8.8.8) -> Success: Geo and AS enrichment applied for IP at field 'source.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'wazuh.agent.host.ip'
[🟢] enrichment/Ioc/connection -> success
  ↳ IOC(connection) -> Success: IOC match found for field 'client.ip, client.port' with key '1.116.196.153:9999'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.nat.ip, client.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.ip, destination.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.nat.ip, destination.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.ip, server.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.nat.ip, server.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.ip, source.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.nat.ip, source.nat.port'
[🟢] enrichment/Ioc/url_full -> success
  ↳ IOC(url_full) -> Success: IOC match found for field 'url.full' with key 'http://10.2.10.224:80/jzsf'
  ↳ IOC(url_full) -> Failure: Source field(s) not found for 'url.original'
[🔴] enrichment/Ioc/url_domain -> failed
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.hostname'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.name'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.top_level_domain'
[🔴] enrichment/Ioc/hash_md5 -> failed
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'dll.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'email.attachments.file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.parent.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.client.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.server.hash.md5'
[🔴] enrichment/Ioc/hash_sha1 -> failed
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'dll.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.parent.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.client.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.server.hash.sha1'
[🔴] enrichment/Ioc/hash_sha256 -> failed
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'dll.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.parent.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.client.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.server.hash.sha256'
[🟢] output/file-output-integrations/0 -> success
  ↳ write.output(file/testing-wazuh-events-v5) -> Success

output:
  '@timestamp': '2026-04-07T21:14:19Z'
  client:
    as:
      number: 45090
      organization:
        name: Shenzhen Tencent Computer Systems Company Limited
    geo:
      city_name: Shanghai
      continent_code: AS
      continent_name: Asia
      country_iso_code: CN
      country_name: China
      location:
        lat: 31.2222
        lon: 121.4581
      region_iso_code: SH
      region_name: Shanghai
      timezone: Asia/Shanghai
    ip: 1.116.196.153
    port: 9999
  event:
    original: hello
  source:
    as:
      number: 15169
      organization:
        name: Google LLC
    geo:
      continent_code: NA
      continent_name: North America
      country_iso_code: US
      country_name: United States
      location:
        lat: 37.751
        lon: -97.822
      timezone: America/Chicago
    ip: 8.8.8.8
  threat:
    enrichments:
    - indicator:
        confidence: 100
        feed:
          name: 0xThiebaut
        first_seen: '2025-11-03T12:08:49.000Z'
        id: '1631674'
        last_seen: '2025-11-04T07:30:32.000Z'
        name: 1.116.196.153:9999
        provider: threat-fox
        software:
          alias:
          - VShell
          name: win.vshell
          type: botnet_cc
        tags:
        - C2
        - NVISO
        - VShell
        type: connection
      matched:
        field: client.ip, client.port
    - indicator:
        confidence: 75
        feed:
          name: abuse_ch
        first_seen: '2025-12-14T20:45:24.000Z'
        id: '1679077'
        last_seen: '2025-12-14T20:45:24.000Z'
        name: http://10.2.10.224:80/jZSF
        provider: threat-fox
        software:
          alias:
          - Cobalt Strike
          - Agentemis
          - BEACON
          - CobaltStrike
          - cobeacon
          name: win.cobalt_strike
          type: botnet_cc
        tags:
        - cobaltstrike
        type: url_full
      matched:
        field: url.full
  url:
    full: http://10.2.10.224:80/jzsf
  wazuh:
    integration:
      category: security
      decoders:
      - decoder/core-wazuh-message/0
      - decoder/integrations/0
      name: integration/wazuh-core/0
    protocol:
      location: /tmp
      queue: 49
    space:
      name: testing
```


### Any match

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer 
╰─# engine-test run test01 -s testing -dd                                            

Enter any events [ENTER to send event, CTRL+C to finish]:

hello


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integrations/0 -> success
  ↳ _tmp_json: parse_json($event.original) -> Parser parser failed at: hello
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🔴] enrichment/Geo -> failed
  ↳ Geo()|AS() -> Failure: IP not found at field 'client.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'destination.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'host.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'observer.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'server.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'source.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'wazuh.agent.host.ip'
[🔴] enrichment/Ioc/connection -> failed
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.ip, client.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'client.nat.ip, client.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.ip, destination.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'destination.nat.ip, destination.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.ip, server.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'server.nat.ip, server.nat.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.ip, source.port'
  ↳ IOC(connection) -> Failure: Source field(s) not found for 'source.nat.ip, source.nat.port'
[🔴] enrichment/Ioc/url_full -> failed
  ↳ IOC(url_full) -> Failure: Source field(s) not found for 'url.full'
  ↳ IOC(url_full) -> Failure: Source field(s) not found for 'url.original'
[🔴] enrichment/Ioc/url_domain -> failed
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'client.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'destination.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'dns.question.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.hostname'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'host.name'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'server.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'source.top_level_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.registered_domain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.subdomain'
  ↳ IOC(url_domain) -> Failure: Source field(s) not found for 'url.top_level_domain'
[🔴] enrichment/Ioc/hash_md5 -> failed
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'dll.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'email.attachments.file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'file.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'process.parent.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.client.hash.md5'
  ↳ IOC(hash_md5) -> Failure: Source field(s) not found for 'tls.server.hash.md5'
[🔴] enrichment/Ioc/hash_sha1 -> failed
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'dll.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'file.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'process.parent.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.client.hash.sha1'
  ↳ IOC(hash_sha1) -> Failure: Source field(s) not found for 'tls.server.hash.sha1'
[🔴] enrichment/Ioc/hash_sha256 -> failed
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'dll.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'email.attachments.file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'file.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'process.parent.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.client.hash.sha256'
  ↳ IOC(hash_sha256) -> Failure: Source field(s) not found for 'tls.server.hash.sha256'
[🟢] output/file-output-integrations/0 -> success
  ↳ write.output(file/testing-wazuh-events-v5) -> Success

output:
  '@timestamp': '2026-04-07T20:53:30Z'
  event:
    original: hello
  wazuh:
    integration:
      category: security
      decoders:
      - decoder/core-wazuh-message/0
      - decoder/integrations/0
      name: integration/wazuh-core/0
    protocol:
      location: /tmp
      queue: 49
    space:
      name: testing
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
