### PR TITLE
Restore group access to chroot localtime

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -24,7 +24,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,183248,0.1
 /var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1
-/var/ossec/etc/localtime,root,root,640,file,-rw-r-----,118,0.1
+/var/ossec/etc/localtime,root,wazuh,640,file,-rw-r-----,118,0.1
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1
 /var/ossec/etc/ossec.conf,root,wazuh,640,file,-rw-r-----,4566,0.1
 /var/ossec/etc/local_internal_options.conf,root,wazuh,640,file,-rw-r-----,320,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -24,7 +24,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,118632,0.1
 /var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1
-/var/ossec/etc/localtime,root,root,640,file,-rw-r-----,118,0.1
+/var/ossec/etc/localtime,root,wazuh,640,file,-rw-r-----,118,0.1
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1
 /var/ossec/etc/ossec.conf,root,wazuh,640,file,-rw-r-----,4566,0.1
 /var/ossec/etc/local_internal_options.conf,root,wazuh,640,file,-rw-r-----,320,0.1

--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -31,7 +31,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/wazuh-manager/etc,root,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/etc/client.keys,wazuh-manager,wazuh-manager,660,file,-rw-rw----,,
 /var/wazuh-manager/etc/wazuh-manager-internal-options.conf,root,wazuh-manager,640,file,-rw-r-----,,
-/var/wazuh-manager/etc/localtime,root,root,640,file,-rw-r-----,,
+/var/wazuh-manager/etc/localtime,root,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/etc/outputs,wazuh-manager,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/etc/outputs/default,wazuh-manager,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/etc/outputs/default/file-output-integrations.yml,wazuh-manager,wazuh-manager,660,file,-rw-rw----,,

--- a/packages/debs/SPECS/wazuh-manager/debian/postinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/postinst
@@ -111,7 +111,7 @@ case "$1" in
     if [ -f /etc/localtime ]; then
         cp -pL /etc/localtime ${DIR}/etc/;
         chmod 640 ${DIR}/etc/localtime
-        chown root:root ${DIR}/etc/localtime
+        chown root:${GROUP} ${DIR}/etc/localtime
     fi
 
     if [ -f /etc/TIMEZONE ]; then

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -484,7 +484,7 @@ rm -rf %{_localstatedir}/backup/groups
 
 %triggerin -- glibc
 [ -r %{_sysconfdir}/localtime ] && cp -fpL %{_sysconfdir}/localtime %{_localstatedir}/etc
- chown root:root %{_localstatedir}/etc/localtime
+ chown root:wazuh-manager %{_localstatedir}/etc/localtime
  chmod 0640 %{_localstatedir}/etc/localtime
 
 %clean
@@ -529,7 +529,7 @@ rm -fr %{buildroot}
 %attr(640, root, root) %ghost %{_localstatedir}/etc/sslmanager.key
 %attr(660, wazuh-manager, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/wazuh-manager-internal-options.conf
-%attr(640, root, root) %{_localstatedir}/etc/localtime
+%attr(640, root, wazuh-manager) %{_localstatedir}/etc/localtime
 %dir %attr(770, root, wazuh-manager) %{_localstatedir}/etc/shared
 %dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/default
 %attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/agent-template.conf

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -792,7 +792,7 @@ InstallCommon()
 
     if [ -f /etc/localtime ]
     then
-         ${INSTALL} -m 0640 -o root -g 0 /etc/localtime ${INSTALLDIR}/etc
+         ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} /etc/localtime ${INSTALLDIR}/etc
     fi
 
   ${INSTALL} -d -m 1770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/tmp


### PR DESCRIPTION

## Description

`/var/wazuh-manager/etc/localtime` should be readable by manager processes running as `wazuh-manager`.

It was changed to `root:root 640`, but manager components such as `monitord` and `remoted` run inside the manager chroot as `wazuh-manager`, so they may not be able to read the file.

Expected permissions:

- owner: `root`
- group: `wazuh-manager`
- mode: `640`

Files to align:

- manager install script
- DEB postinst
- RPM spec
- manager `check_files` baseline

## Testing
- No desync in timestamp for differents modules:
```
2026/04/08 14:39:00 wazuh-manager-remoted: INFO: Started (pid: 1309788). Listening on port 1514/TCP (secure).
2026/04/08 14:39:00 wazuh-manager-monitord: INFO: Started (pid: 1309794).
2026/04/08 14:39:00 wazuh-manager-modulesd: INFO: Started (pid: 1309824).
2026/04/08 14:39:00 wazuh-manager-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
```

- Quick validation:

```bash
sudo install -m 0640 -o root -g wazuh-manager /usr/share/zoneinfo/Asia/Tokyo /var/wazuh-manager/etc/localtime
sudo systemctl restart wazuh-manager
```

- Validation evidence:

```text
2026/04/08 10:01:52 wazuh-manager-authd: INFO: Started (pid: 1206947).
2026/04/08 19:01:52 wazuh-manager-db: INFO: Started (pid: 1206956).
2026/04/08 19:01:53 wazuh-manager-remoted: INFO: Started (pid: 1207206). Listening on port 1514/TCP (secure).
2026/04/08 19:01:53 wazuh-manager-monitord: INFO: Started (pid: 1207225).
2026/04/08 10:01:53 wazuh-manager-modulesd: INFO: Started (pid: 1207242).
```

This is the proof that the change works:

- `wazuh-manager-db`, `wazuh-manager-remoted` and `wazuh-manager-monitord` move to the timezone copied into `/var/wazuh-manager/etc/localtime`
- `wazuh-manager-authd` and `wazuh-manager-modulesd` keep the original timestamp

This split shows that the chrooted manager processes are reading and using `etc/localtime` correctly.
