### PR TITLE
Change default sync_eps and internals limits

### DIFF
--- a/docs/ref/modules/fim/configuration.md
+++ b/docs/ref/modules/fim/configuration.md
@@ -450,7 +450,7 @@ Controls how the agent synchronizes its local FIM database with the manager to e
   <enabled>yes</enabled>
   <interval>300</interval>
   <response_timeout>60</response_timeout>
-  <max_eps>50</max_eps>
+  <max_eps>75</max_eps>
   <integrity_interval>86400</integrity_interval>
 </synchronization>
 ```
@@ -462,7 +462,7 @@ Controls how the agent synchronizes its local FIM database with the manager to e
 | `enabled` | `yes` | `yes`, `no` | Enable or disable FIM synchronization persistence. When disabled, FIM only generates stateless events. |
 | `interval` | `300` (5 minutes) | Any integer ≥ 1, with optional suffix `s`, `m`, `h`, `d` | How often the agent initiates a sync with the manager. |
 | `response_timeout` | `60` | Any integer ≥ 1, with optional suffix `s`, `m`, `h`, `d` | Seconds to wait for a manager response before marking the synchronization attempt as failed or timed out. A value that is too low causes unnecessary retries; a value that is too high delays failure detection. |
-| `max_eps` | `50` | Integer `0`–`1000000` (`0` = unlimited) | Maximum synchronization messages per second. |
+| `max_eps` | `75` | Integer `0`–`1000000` (`0` = unlimited) | Maximum synchronization messages per second. |
 | `integrity_interval` | `86400` (24h)| Any integer ≥ 1, with optional suffix `s`, `m`, `h`, `d` | How often the agent performs a full integrity validation by comparing checksums with the manager. |
 
 > **Note:** The retry logic automatically retries failed sync operations up to **3 times** before giving up. Database files are stored at fixed paths: `queue/fim/db/fim.db` and `queue/fim/db/fim_sync.db`.
@@ -578,7 +578,7 @@ Specific key configurations take precedence over wildcard configurations:
   <process_priority>10</process_priority>
   <max_eps>50</max_eps>
   <synchronization>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
   </synchronization>
 </syscheck>
 ```
@@ -599,7 +599,7 @@ Specific key configurations take precedence over wildcard configurations:
   <process_priority>10</process_priority>
   <max_eps>50</max_eps>
   <synchronization>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
   </synchronization>
 </syscheck>
 ```
@@ -622,7 +622,7 @@ Specific key configurations take precedence over wildcard configurations:
   <process_priority>10</process_priority>
   <max_eps>50</max_eps>
   <synchronization>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
   </synchronization>
 </syscheck>
 ```
@@ -639,7 +639,7 @@ Specific key configurations take precedence over wildcard configurations:
   <process_priority>10</process_priority>
   <max_eps>50</max_eps>
   <synchronization>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
   </synchronization>
 </syscheck>
 ```
@@ -712,7 +712,7 @@ For environments that require full audit trails on critical configuration files:
     <enabled>yes</enabled>
     <interval>5m</interval>
     <response_timeout>60</response_timeout>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
     <integrity_interval>86400</integrity_interval>
   </synchronization>
 </syscheck>

--- a/docs/ref/modules/sca/configuration.md
+++ b/docs/ref/modules/sca/configuration.md
@@ -34,7 +34,7 @@ This enables the SCA module with default settings:
     <enabled>yes</enabled>
     <interval>300</interval>
     <response_timeout>60</response_timeout>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
     <integrity_interval>86400</integrity_interval>
   </synchronization>
 </sca>
@@ -67,7 +67,7 @@ This enables the SCA module with default settings:
 | `synchronization/enabled` | boolean | `yes` | Enable database synchronization |
 | `synchronization/interval` | time | `300s` | Database synchronization interval |
 | `synchronization/response_timeout` | time | `60s` | Synchronization response timeout |
-| `synchronization/max_eps` | number | `50` | Max events per second for sync |
+| `synchronization/max_eps` | number | `75` | Max events per second for sync |
 | `synchronization/integrity_interval` | time | `86400s` | Interval between integrity checks for recovery (0 = disabled) |
 
 ---

--- a/docs/ref/modules/syscollector/configuration.md
+++ b/docs/ref/modules/syscollector/configuration.md
@@ -36,7 +36,7 @@ Syscollector is configured in the agent's `ossec.conf` file using the `<wodle na
         <enabled>yes</enabled>                    <!-- Enable/disable persistence -->
         <interval>300</interval>                  <!-- Sync interval in seconds -->
         <response_timeout>60</response_timeout>   <!-- Response timeout in seconds -->
-        <max_eps>50</max_eps>                    <!-- Max sync events per second (0 = unlimited) -->
+        <max_eps>75</max_eps>                    <!-- Max sync events per second (0 = unlimited) -->
         <integrity_interval>86400</integrity_interval>  <!-- Integrity check interval in seconds (24 hours) -->
     </synchronization>
 </wodle>
@@ -89,7 +89,7 @@ The synchronization feature enables persistent inventory state management throug
 | `enabled` | Boolean | `yes` | `yes`/`no` | Enable or disable Syscollector synchronization persistence |
 | `interval` | Integer | `300` | `1` - `∞` | How often to trigger synchronization with the manager (seconds) |
 | `response_timeout` | Integer | `60` | `1` - `∞` | Timeout for waiting manager responses during sync (seconds) |
-| `max_eps` | Integer | `50` | `0` - `1000000` | Maximum events per second for **sync messages** (0 = unlimited) |
+| `max_eps` | Integer | `75` | `0` - `1000000` | Maximum events per second for **sync messages** (0 = unlimited) |
 | `integrity_interval` | Integer | `86400` | `60` - `∞` | Time between integrity checks for each inventory table (seconds) |
 
 ---
@@ -160,7 +160,7 @@ Controls the rate of synchronization messages sent to the manager:
 
 ```xml
 <synchronization>
-    <max_eps>50</max_eps>
+    <max_eps>75</max_eps>
 </synchronization>
 ```
 
@@ -266,7 +266,7 @@ Syscollector implements separate rate controls for different event types:
 
 ```xml
 <synchronization>
-    <max_eps>50</max_eps>  <!-- Inside synchronization block -->
+    <max_eps>75</max_eps>  <!-- Inside synchronization block -->
 </synchronization>
 ```
 
@@ -332,7 +332,7 @@ For environments with frequent inventory changes:
     <processes>yes</processes>
     <ports>yes</ports>
     <synchronization>
-        <max_eps>50</max_eps>
+        <max_eps>75</max_eps>
     </synchronization>
 </wodle>
 ```

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -16,7 +16,7 @@
     <!-- Agent buffer options -->
     <disabled>no</disabled>
     <queue_size>5000</queue_size>
-    <events_per_second>500</events_per_second>
+    <events_per_second>600</events_per_second>
   </client_buffer>
 
   <!-- Policy monitoring -->
@@ -41,7 +41,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>
@@ -94,7 +94,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/README.md
+++ b/etc/templates/config/README.md
@@ -52,7 +52,7 @@
           <!-- Agent buffer options -->
           <disabled>no</disabled>
           <queue_size>5000</queue_size>
-          <events_per_second>500</events_per_second>
+          <events_per_second>600</events_per_second>
         </client_buffer>
 
         logging.template

--- a/etc/templates/config/bsd/wodle-syscollector.template
+++ b/etc/templates/config/bsd/wodle-syscollector.template
@@ -18,7 +18,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>

--- a/etc/templates/config/darwin/sca.template
+++ b/etc/templates/config/darwin/sca.template
@@ -8,6 +8,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <integrity_interval>24h</integrity_interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
     </synchronization>
   </sca>

--- a/etc/templates/config/darwin/syscheck.agent.template
+++ b/etc/templates/config/darwin/syscheck.agent.template
@@ -44,7 +44,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/darwin/wodle-syscollector.template
+++ b/etc/templates/config/darwin/wodle-syscollector.template
@@ -18,7 +18,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>

--- a/etc/templates/config/generic/sca.template
+++ b/etc/templates/config/generic/sca.template
@@ -8,6 +8,6 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <integrity_interval>24h</integrity_interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
     </synchronization>
   </sca>

--- a/etc/templates/config/generic/syscheck.agent.template
+++ b/etc/templates/config/generic/syscheck.agent.template
@@ -44,7 +44,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </syscheck>

--- a/etc/templates/config/generic/wodle-syscollector.template
+++ b/etc/templates/config/generic/wodle-syscollector.template
@@ -18,7 +18,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -46,7 +46,7 @@ int ClientConf(const char *cfgfile)
     agt->profile = NULL;
     agt->buffer = 1;
     agt->buflength = 5000;
-    agt->events_persec = 500;
+    agt->events_persec = 600;
     agt->flags.auto_restart = 1;
     agt->notify_time = 0;
     agt->max_time_reconnect_try = 0;

--- a/src/config/src/syscheck-config.c
+++ b/src/config/src/syscheck-config.c
@@ -116,7 +116,7 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->sync_interval                   = 300;
     syscheck->sync_end_delay                  = 1;
     syscheck->sync_response_timeout           = 60;
-    syscheck->sync_max_eps                    = 50;
+    syscheck->sync_max_eps                    = 75;
     syscheck->integrity_interval              = 24 * 60 * 60;  // 24 hours
     syscheck->max_eps                         = 50;
     syscheck->notify_first_scan               = 0; // Default value, no notification on first scan

--- a/src/config/src/wmodules-sca.c
+++ b/src/config/src/wmodules-sca.c
@@ -165,7 +165,7 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
         sca->sync.sync_interval = 300;
         sca->sync.sync_end_delay = 1;
         sca->sync.sync_response_timeout = 60;
-        sca->sync.sync_max_eps = 50;
+        sca->sync.sync_max_eps = 75;
         sca->sync.integrity_interval = 86400;
     }
 

--- a/src/config/src/wmodules-syscollector.c
+++ b/src/config/src/wmodules-syscollector.c
@@ -124,7 +124,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
         syscollector->sync.sync_interval = 300;
         syscollector->sync.sync_end_delay = 1;
         syscollector->sync.sync_response_timeout = 60;
-        syscollector->sync.sync_max_eps = 50;
+        syscollector->sync.sync_max_eps = 75;
         syscollector->sync.integrity_interval = 86400;  // Integrity check every 24 hours (86400 seconds)
 
         syscollector->max_eps = 50;

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -349,7 +349,7 @@ WriteAgent()
     echo "    <!-- Agent buffer options -->" >> $NEWCONFIG
     echo "    <disabled>no</disabled>" >> $NEWCONFIG
     echo "    <queue_size>5000</queue_size>" >> $NEWCONFIG
-    echo "    <events_per_second>500</events_per_second>" >> $NEWCONFIG
+    echo "    <events_per_second>600</events_per_second>" >> $NEWCONFIG
     echo "  </client_buffer>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 

--- a/src/remoted/src/config.c
+++ b/src/remoted/src/config.c
@@ -61,27 +61,27 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
 
     /* Read module limits from internal_options.conf */
     /* FIM limits */
-    manager_module_limits.fim.file = getDefine_Int_default("fim", "file_limit", 0, INT_MAX, 0);
-    manager_module_limits.fim.registry_key = getDefine_Int_default("fim", "registry_key_limit", 0, INT_MAX, 0);
-    manager_module_limits.fim.registry_value = getDefine_Int_default("fim", "registry_value_limit", 0, INT_MAX, 0);
+    manager_module_limits.fim.file = getDefine_Int_default("fim", "file_limit", 0, INT_MAX, 30000);
+    manager_module_limits.fim.registry_key = getDefine_Int_default("fim", "registry_key_limit", 0, INT_MAX, 30000);
+    manager_module_limits.fim.registry_value = getDefine_Int_default("fim", "registry_value_limit", 0, INT_MAX, 30000);
 
     /* Syscollector limits */
-    manager_module_limits.syscollector.hotfixes = getDefine_Int_default("syscollector", "hotfixes_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.packages = getDefine_Int_default("syscollector", "packages_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.processes = getDefine_Int_default("syscollector", "processes_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.ports = getDefine_Int_default("syscollector", "ports_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.network_iface = getDefine_Int_default("syscollector", "network_iface_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.network_protocol = getDefine_Int_default("syscollector", "network_protocol_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.network_address = getDefine_Int_default("syscollector", "network_address_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.hardware = getDefine_Int_default("syscollector", "hardware_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.os_info = getDefine_Int_default("syscollector", "os_info_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.users = getDefine_Int_default("syscollector", "users_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.groups = getDefine_Int_default("syscollector", "groups_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.services = getDefine_Int_default("syscollector", "services_limit", 0, INT_MAX, 0);
-    manager_module_limits.syscollector.browser_extensions = getDefine_Int_default("syscollector", "browser_extensions_limit", 0, INT_MAX, 0);
+    manager_module_limits.syscollector.hotfixes = getDefine_Int_default("syscollector", "hotfixes_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.packages = getDefine_Int_default("syscollector", "packages_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.processes = getDefine_Int_default("syscollector", "processes_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.ports = getDefine_Int_default("syscollector", "ports_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.network_iface = getDefine_Int_default("syscollector", "network_iface_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.network_protocol = getDefine_Int_default("syscollector", "network_protocol_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.network_address = getDefine_Int_default("syscollector", "network_address_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.hardware = getDefine_Int_default("syscollector", "hardware_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.os_info = getDefine_Int_default("syscollector", "os_info_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.users = getDefine_Int_default("syscollector", "users_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.groups = getDefine_Int_default("syscollector", "groups_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.services = getDefine_Int_default("syscollector", "services_limit", 0, INT_MAX, 30000);
+    manager_module_limits.syscollector.browser_extensions = getDefine_Int_default("syscollector", "browser_extensions_limit", 0, INT_MAX, 30000);
 
     /* SCA limits */
-    manager_module_limits.sca.checks = getDefine_Int_default("sca", "checks_limit", 0, INT_MAX, 0);
+    manager_module_limits.sca.checks = getDefine_Int_default("sca", "checks_limit", 0, INT_MAX, 30000);
 
     modules |= CREMOTE;
 

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -596,7 +596,7 @@ void test_getSyscheckConfig_no_directories(void **state)
     cJSON *interval = cJSON_GetObjectItem(synchronization, "interval");
     assert_int_equal(interval->valueint, 300);
     cJSON *sync_max_eps = cJSON_GetObjectItem(synchronization, "max_eps");
-    assert_int_equal(sync_max_eps->valueint, 50);
+    assert_int_equal(sync_max_eps->valueint, 75);
 }
 #endif
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -20,7 +20,7 @@
   <client_buffer>
     <disabled>no</disabled>
     <queue_size>5000</queue_size>
-    <events_per_second>500</events_per_second>
+    <events_per_second>600</events_per_second>
   </client_buffer>
 
   <!-- Log analysis -->
@@ -64,7 +64,7 @@
       <enabled>yes</enabled>
       <interval>5m</interval>
       <integrity_interval>24h</integrity_interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
     </synchronization>
   </sca>
 
@@ -153,7 +153,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </syscheck>
@@ -178,7 +178,7 @@
     <synchronization>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <max_eps>50</max_eps>
+      <max_eps>75</max_eps>
       <integrity_interval>24h</integrity_interval>
     </synchronization>
   </wodle>


### PR DESCRIPTION
## Description

Adjusts default values for stateful module sync EPS, agent client buffer output throughput, and manager-side module item limits.

## Proposed Changes

- **Agent – sync EPS (FIM, SCA, IT Hygiene):** increase default `sync_max_eps` from `50` to `75` in FIM (`syscheck`), SCA, and Syscollector modules.
- **Agent – client buffer output throughput:** increase default `events_per_second` from `500` to `600`.
- **Manager – module item limits:** set default item-count limit to `30000` (previously `0` = unlimited) for all FIM, Syscollector, and SCA synchronized tables.

### Results and Evidence

```
2026/04/08 13:45:24 wazuh-agentd[127534] start_agent.c:642 at agent_handshake_to_server(): DEBUG: Module limits received from manager
2026/04/08 13:45:24 wazuh-agentd[127534] start_agent.c:644 at agent_handshake_to_server(): DEBUG: Received FIM limits: file=30000, registry_key=30000, registry_value=30000
2026/04/08 13:45:24 wazuh-agentd[127534] start_agent.c:647 at agent_handshake_to_server(): DEBUG: Received Syscollector limits: hotfixes=30000, packages=30000, processes=30000, ports=30000
2026/04/08 13:45:24 wazuh-agentd[127534] start_agent.c:652 at agent_handshake_to_server(): DEBUG: Received Syscollector limits: net_iface=30000, net_proto=30000, net_addr=30000
2026/04/08 13:45:24 wazuh-agentd[127534] start_agent.c:656 at agent_handshake_to_server(): DEBUG: Received Syscollector limits: hw=30000, os=30000, users=30000, groups=30000, services=30000, browser_ext=30000
2026/04/08 13:45:24 wazuh-agentd[127534] start_agent.c:663 at agent_handshake_to_server(): DEBUG: Received SCA limits: checks=30000
```

<details><summary>cat /var/ossec/etc/ossec.conf</summary> 

```xml
<!--
  Wazuh - Agent - Default configuration for ubuntu 22.04
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <client>
    <manager>
      <address>192.168.1.233</address>
      <port>1514</port>
    </manager>
    <config-profile>ubuntu, ubuntu22, ubuntu22.04</config-profile>
    <notify_time>20</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>yes</auto_restart>
  </client>

  <client_buffer>
    <!-- Agent buffer options -->
    <disabled>no</disabled>
    <queue_size>5000</queue_size>
    <events_per_second>600</events_per_second>
  </client_buffer>

  <!-- Policy monitoring -->
  <rootcheck>
    <disabled>no</disabled>
    <check_dev>yes</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>yes</check_pids>
    <check_ports>yes</check_ports>
    <check_if>yes</check_if>

    <!-- Frequency that rootcheck is executed - every 12 hours -->
    <frequency>43200</frequency>

    <skip_nfs>yes</skip_nfs>

    <ignore>/var/lib/containerd</ignore>
    <ignore>/var/lib/docker/overlay2</ignore>
  </rootcheck>

  <!-- System inventory -->
  <wodle name="syscollector">
    <disabled>no</disabled>
    <interval>1h</interval>
    <scan_on_start>yes</scan_on_start>
    <hardware>yes</hardware>
    <os>yes</os>
    <network>yes</network>
    <packages>yes</packages>
    <ports all="yes">yes</ports>
    <processes>yes</processes>
    <users>yes</users>
    <groups>yes</groups>
    <services>yes</services>
    <browser_extensions>yes</browser_extensions>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>75</max_eps>
      <integrity_interval>24h</integrity_interval>
    </synchronization>
  </wodle>

  <sca>
    <enabled>yes</enabled>
    <scan_on_start>yes</scan_on_start>
    <interval>12h</interval>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <integrity_interval>24h</integrity_interval>
      <max_eps>75</max_eps>
    </synchronization>
  </sca>

  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
    <ignore>/etc/random-seed</ignore>
    <ignore>/etc/random.seed</ignore>
    <ignore>/etc/adjtime</ignore>
    <ignore>/etc/httpd/logs</ignore>
    <ignore>/etc/utmpx</ignore>
    <ignore>/etc/wtmpx</ignore>
    <ignore>/etc/cups/certs</ignore>
    <ignore>/etc/dumpdates</ignore>
    <ignore>/etc/svc/volatile</ignore>

    <!-- File types to ignore -->
    <ignore type="sregex">.log$|.swp$</ignore>

    <!-- Check the file, but never compute the diff -->
    <nodiff>/etc/ssl/private.key</nodiff>

    <skip_nfs>yes</skip_nfs>
    <skip_dev>yes</skip_dev>
    <skip_proc>yes</skip_proc>
    <skip_sys>yes</skip_sys>

    <!-- Nice value for Syscheck process -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>50</max_eps>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>75</max_eps>
      <integrity_interval>24h</integrity_interval>
    </synchronization>
  </syscheck>

  <!-- Log analysis -->
  <localfile>
    <log_format>journald</log_format>
    <location>journald</location>
  </localfile>

  <localfile>
    <log_format>audit</log_format>
    <location>/var/log/audit/audit.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/ossec/logs/active-responses.log</location>
  </localfile>

  <localfile>
    <log_format>syslog</log_format>
    <location>/var/log/dpkg.log</location>
  </localfile>

  <localfile>
    <log_format>command</log_format>
    <command>df -P</command>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
    <alias>netstat listening ports</alias>
    <frequency>360</frequency>
  </localfile>

  <localfile>
    <log_format>full_command</log_format>
    <command>last -n 20</command>
    <frequency>360</frequency>
  </localfile>

  <!-- Active response -->
  <active-response>
    <disabled>no</disabled>
    <ca_store>etc/wpk_root.pem</ca_store>
    <ca_verification>yes</ca_verification>
  </active-response>

  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
  <logging>
    <log_format>plain</log_format>
  </logging>

</ossec_config>
```

</details>

### Artifacts Affected

| Artifact | Change |
|---|---|
| `agentd` | `events_per_second` default: 500 → 600 |
| `syscheckd` | `sync_max_eps` default: 50 → 75 |
| `wazuh-modulesd` (SCA) | `sync_max_eps` default: 50 → 75 |
| `wazuh-modulesd` (Syscollector) | `sync_max_eps` default: 50 → 75 |
| `remoted` | FIM/Syscollector/SCA item limit defaults: 0 → 30000 |

### Configuration Changes

**Agent (`ossec.conf`):**
```xml
<!-- client_buffer: output throughput -->
<events_per_second>600</events_per_second>   <!-- was: 500 -->

<!-- FIM synchronization block -->
<max_eps>75</max_eps>   <!-- was: 50 -->

<!-- SCA synchronization block -->
<max_eps>75</max_eps>   <!-- was: 50 -->

<!-- Syscollector synchronization block -->
<max_eps>75</max_eps>   <!-- was: 50 -->
```

### Documentation Updates

- `docs/ref/modules/fim/configuration.md`: updated default value for `synchronization/max_eps` to `75` in reference table and configuration examples.
- `docs/ref/modules/sca/configuration.md`: updated default value for `synchronization/max_eps` to `75` in reference table and configuration example.
- `docs/ref/modules/syscollector/configuration.md`: updated default value for `synchronization/max_eps` to `75` in reference table and configuration examples.

### Tests Introduced


## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
