### PR TITLE
Use warning instead of info for non succesful message

### DIFF
--- a/src/shared/src/cryptography.c
+++ b/src/shared/src/cryptography.c
@@ -533,8 +533,8 @@ w_err_t verify_hash_and_pe_signature(wchar_t *file_path) {
     if (ERROR_SUCCESS != pe_result) {
         hash_result = verify_hash_catalog(file_path, hash_error_message, OS_SIZE_1024);
         if (ERROR_SUCCESS != hash_result) {
-            plain_minfo("Trust verification of a module failed by using the signature method. %s", pe_error_message);
-            plain_minfo("Trust verification of a module failed by using the hash method. %s", hash_error_message);
+            plain_mwarn("Trust verification of a module failed by using the signature method. %s", pe_error_message);
+            plain_mwarn("Trust verification of a module failed by using the hash method. %s", hash_error_message);
             retval = OS_INVALID;
         } else {
             plain_mdebug1("%s", hash_error_message);


### PR DESCRIPTION
## Description

This PR changes the log level of trust verification failure messages from INFO to WARNING to accurately reflect the error state.

Closes #18952

## Proposed Changes

- Replaced `plain_minfo` with `plain_mwarn` in `src/shared/src/cryptography.c`.

### Results and Evidence

N/A

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
