### PR TITLE
Normalize inode field to string for events and states to avoid warning

### DIFF
--- a/src/shared/src/fs_op.c
+++ b/src/shared/src/fs_op.c
@@ -106,7 +106,7 @@ short skipFS(const char *dir_name)
         int i;
         for ( i=0; skip_file_systems[i].name != NULL; i++ ) {
             if(skip_file_systems[i].f_type == stfs.f_type ) {
-                mdebug1("Skipping dir (FS %s): %s ", skip_file_systems[i].name, dir_name);
+                mdebug2("Skipping dir (FS %s): %s ", skip_file_systems[i].name, dir_name);
                 return skip_file_systems[i].flag;
             }
         }

--- a/src/syscheckd/src/db/src/file.cpp
+++ b/src/syscheckd/src/db/src/file.cpp
@@ -281,6 +281,16 @@ FIMDBErrorCode fim_db_file_update(fim_entry* data, callback_context_t callback)
                     }
                 }
 
+                if (patchedJson.contains("new"))
+                {
+                    convert_inode(patchedJson["new"]);
+                }
+
+                if (patchedJson.contains("old"))
+                {
+                    convert_inode(patchedJson["old"]);
+                }
+
                 const std::unique_ptr<cJSON, CJsonSmartDeleter> spJson
                 {
                     cJSON_Parse(patchedJson.dump().c_str())};

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
@@ -325,6 +325,70 @@ TEST_F(DBTestFixture, TestFimDBFileUpdateNullParameters)
     });
 }
 
+// Test callback to validate inode conversion to string
+static void callbackValidateInodeStringConversion(ReturnTypeCallback result_type,
+                                                   const cJSON* result_json,
+                                                   void* user_data)
+{
+    ASSERT_TRUE(result_json != NULL);
+    ASSERT_TRUE(user_data != NULL);
+
+    // Assert that we received a MODIFIED event (not INSERTED/DELETED)
+    ASSERT_EQ(result_type, ReturnTypeCallback::MODIFIED)
+        << "Expected MODIFIED event, but got type: " << static_cast<int>(result_type);
+
+    // For MODIFIED events, both "old" and "new" objects must be present
+    cJSON* old_obj = cJSON_GetObjectItem(result_json, "old");
+    ASSERT_TRUE(old_obj != NULL) << "MODIFIED event must contain 'old' object";
+
+    cJSON* new_obj = cJSON_GetObjectItem(result_json, "new");
+    ASSERT_TRUE(new_obj != NULL) << "MODIFIED event must contain 'new' object";
+
+    // Validate "old" object has inode as string
+    cJSON* old_inode = cJSON_GetObjectItem(old_obj, "inode");
+    ASSERT_TRUE(old_inode != NULL) << "old object must contain 'inode' field";
+    ASSERT_TRUE(cJSON_IsString(old_inode)) << "old.inode should be a string, but got type: "
+                                            << old_inode->type;
+    // Verify the value is correct
+    const char* old_inode_str = cJSON_GetStringValue(old_inode);
+    ASSERT_TRUE(old_inode_str != NULL);
+    ASSERT_STREQ(old_inode_str, "18277083") << "old.inode string value mismatch";
+
+    // Validate "new" object has inode as string
+    cJSON* new_inode = cJSON_GetObjectItem(new_obj, "inode");
+    ASSERT_TRUE(new_inode != NULL) << "new object must contain 'inode' field";
+    ASSERT_TRUE(cJSON_IsString(new_inode)) << "new.inode should be a string, but got type: "
+                                            << new_inode->type;
+    // Verify the value is correct
+    const char* new_inode_str = cJSON_GetStringValue(new_inode);
+    ASSERT_TRUE(new_inode_str != NULL);
+    ASSERT_STREQ(new_inode_str, "18457083") << "new.inode string value mismatch";
+}
+
+TEST_F(DBTestFixture, TestFimDBFileUpdateInodeConversion)
+{
+    // This test validates that fim_db_file_update converts inode fields
+    // from integer to string in both "old" and "new" JSON objects when
+    // processing MODIFIED events.
+
+    const auto fileFIMTest {std::make_unique<FileItem>(insertStatement1["data"].front())};
+    const auto fileFIMTestUpdated {std::make_unique<FileItem>(updateStatement1["data"].front())};
+
+    EXPECT_NO_THROW({
+        // First insert the file (INSERTED event)
+        auto result = fim_db_file_update(fileFIMTest->toFimEntry(), callback_data_added);
+        ASSERT_EQ(result, FIMDB_OK);
+
+        // Now update the file (MODIFIED event) with custom callback
+        callback_context_t callback_inode_validation;
+        callback_inode_validation.callback_txn = callbackValidateInodeStringConversion;
+        callback_inode_validation.context = &ctx1;
+
+        result = fim_db_file_update(fileFIMTestUpdated->toFimEntry(), callback_inode_validation);
+        ASSERT_EQ(result, FIMDB_OK);
+    });
+}
+
 TEST_F(DBTestFixture, TestFimDBGetPathNoFile)
 {
     callback_context_t callback_data {callBackTestFIMEntry, nullptr};


### PR DESCRIPTION
## Description
During the first FIM scan on 5.0 (development), `wazuh-syscheckd` could emit massive amounts of:

> `WARNING: (6960): Inode field received with a wrong type, it must be a string.`

The root cause was that inode normalization (int → string) was only applied to `data.attributes.inode` for state records, while event payloads (`new.inode` / `old.inode`) could still carry numeric values. This made the diff calculation receive `inode` with an unexpected type and log the warning repeatedly.

## Proposed Changes
- Apply inode conversion (int → string) consistently for:
  - `data.attributes.inode`
  - `new.inode`
  - `old.inode`
- Add a unit test covering the event diff scenario to prevent regressions.

### Results and Evidence
- After applying the change, the warning `WARNING: (6960): Inode field received with a wrong type, it must be a string.` is no longer observed during the first scan.

### Artifacts Affected
- `wazuh-syscheckd` (UNIX)

### Configuration Changes
- Not applicable.

### Documentation Updates
- Not applicable.

### Tests Introduced
- Added a unit test to validate inode normalization for event payloads (`new.inode` / `old.inode`) and ensure no type mismatch reaches the diff calculation.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues