### PR TITLE
Fix missing `compare` keyword for numeric checks in SCA policies

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_2.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2.yml
@@ -4023,8 +4023,8 @@ checks:
       - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare <= 900'
       - 'c:sshd -T -> r:clientalivecountmax\s*\t*0'
       - 'not f:/etc/ssh/sshd_config -> r:^ClientAliveInterval\s*\t*0'
-      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) > 900'
-      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) > 0'
+      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) compare > 900'
+      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) compare > 0'
 
   # 5.3.17 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
   - id: 20650

--- a/ruleset/sca/centos/10/cis_centos10_linux.yml
+++ b/ruleset/sca/centos/10/cis_centos10_linux.yml
@@ -4761,8 +4761,8 @@ checks:
       - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare <= 900'
       - 'c:sshd -T -> r:clientalivecountmax\s*\t*0'
       - 'not f:/etc/ssh/sshd_config -> r:^ClientAliveInterval\s*\t*0'
-      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) > 900'
-      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) > 0'
+      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) compare > 900'
+      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) compare > 0'
 
   # 5.3.1 Ensure sudo is installed. (Automated)
   - id: 37679

--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -4761,8 +4761,8 @@ checks:
       - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare <= 900'
       - 'c:sshd -T -> r:clientalivecountmax\s*\t*0'
       - 'not f:/etc/ssh/sshd_config -> r:^ClientAliveInterval\s*\t*0'
-      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) > 900'
-      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) > 0'
+      - 'not f:/etc/ssh/sshd_config -> n:^ClientAliveInterval\s*\t*(\d+) compare > 900'
+      - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) compare > 0'
 
   # 5.3.1 Ensure sudo is installed. (Automated)
   - id: 6680

--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -3533,8 +3533,8 @@ checks:
       subtechnique: ["T1556.001", "T1550.001", "T1550.002"]
     condition: any
     rules:
-      - 'f:/etc/security/pwquality.conf -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) < 0'
-      - 'd:/etc/security/pwquality.conf.d/* -> r:.+\.conf$ -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) < 0'
+      - 'f:/etc/security/pwquality.conf -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) compare < 0'
+      - 'd:/etc/security/pwquality.conf.d/* -> r:.+\.conf$ -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) compare < 0'
 
   # 5.3.3.2.4 Ensure password same consecutive characters is configured. (Automated)
   - id: 33196

--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -3533,8 +3533,8 @@ checks:
       subtechnique: ["T1556.001", "T1550.001", "T1550.002"]
     condition: any
     rules:
-      - 'f:/etc/security/pwquality.conf -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) < 0'
-      - 'd:/etc/security/pwquality.conf.d/* -> r:.+\.conf$ -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) < 0'
+      - 'f:/etc/security/pwquality.conf -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) compare < 0'
+      - 'd:/etc/security/pwquality.conf.d/* -> r:.+\.conf$ -> n:ucredit\s*\t*=\s*\t*(\d+) compare < 0 && n:lcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:dcredit\s*\t*=\s*\t*(\d+) compare < 0 && n:ocredit\s*\t*=\s*\t*(\d+) compare < 0'
 
   # 5.3.3.2.4 Ensure password same consecutive characters is configured. (Automated)
   - id: 33196


### PR DESCRIPTION
## Description

SCA numeric comparison expressions in multiple CIS policies were missing the required `compare` keyword, causing errors such as: `Invalid expression format, 'compare' keyword missing`. This PR updates the affected rules to use the correct numeric comparison format so SCA evaluation runs cleanly.

## Proposed Changes

- Update CIS policy checks to include the `compare` keyword for numeric comparisons (e.g., `(\d+) compare > N`) across the affected OS policies:
  - CentOS 8
  - CentOS 10
  - Amazon Linux 2
  - Debian 12
  - Debian 13

### Results and Evidence

After the updates, SCA no longer throws expression-format errors and the scan completes successfully:

```
2026/04/10 10:18:27 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/10 10:18:36 wazuh-modulesd:sca: INFO: SCA scan ended.
```

### Artifacts Affected

- CIS SCA policy files for:
  - CentOS 8
  - CentOS 10
  - Amazon Linux 2
  - Debian 12
  - Debian 13

### Configuration Changes

None.

### Documentation Updates

Not applicable.

### Tests Introduced

Not applicable (content-only policy updates; no unit/integration tests added).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues