### PR TITLE
Skip macOS receipts that are no longer installed

### DIFF
--- a/.github/workflows/4_testcomponent_sysinfo-macos.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-macos.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install port
         run: |
           sudo /opt/local/bin/port selfupdate
-          sudo /opt/local/bin/port -b install nano
+          sudo /opt/local/bin/port -b install nano || sudo /opt/local/bin/port install nano
       - name: Run tests
         run: |
           cd src/data_provider

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -12,9 +12,17 @@
 #ifndef _PKG_WRAPPER_H
 #define _PKG_WRAPPER_H
 
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <functional>
 #include <fstream>
 #include <istream>
 #include <regex>
+#include <set>
+#include <sstream>
+#include <sys/stat.h>
+#include <utility>
 #include "stringHelper.h"
 #include "ipackageWrapper.h"
 #include "sharedDefs.h"
@@ -29,6 +37,19 @@ const std::set<std::string> excludedCategories = {"pkg", "x86_64", "arm64"};
 class PKGWrapper final : public IPackageWrapper
 {
     public:
+        using ReceiptLivenessFn =
+            std::function<bool(const std::string& receiptPath, const std::string& installPrefix)>;
+
+        static void setReceiptLivenessChecker(ReceiptLivenessFn fn)
+        {
+            s_receiptLivenessChecker() = std::move(fn);
+        }
+
+        static void resetReceiptLivenessChecker()
+        {
+            s_receiptLivenessChecker() = &PKGWrapper::defaultReceiptLivenessChecker;
+        }
+
         explicit PKGWrapper(const PackageContext& ctx)
             : m_version{UNKNOWN_VALUE}
             , m_groups{UNKNOWN_VALUE}
@@ -116,6 +137,73 @@ class PKGWrapper final : public IPackageWrapper
         }
 
     private:
+        static bool extractPlistScalarValue(const std::string& line,
+                                            const std::string& tag,
+                                            std::string& value)
+        {
+            const std::string startTag { "<" + tag + ">" };
+            const std::string endTag { "</" + tag + ">" };
+
+            const auto start { line.find(startTag) };
+
+            if (start == std::string::npos)
+            {
+                return false;
+            }
+
+            const auto contentStart { start + startTag.size() };
+            const auto end { line.find(endTag, contentStart) };
+
+            if (end == std::string::npos)
+            {
+                return false;
+            }
+
+            value = line.substr(contentStart, end - contentStart);
+            return true;
+        }
+
+        static bool readPlistValue(std::istream& data,
+                                   const std::string& line,
+                                   const std::string& keyTag,
+                                   std::string& value)
+        {
+            const auto keyPos { line.find(keyTag) };
+
+            if (keyPos == std::string::npos)
+            {
+                return false;
+            }
+
+            const auto readScalarValue =
+                [&value](const std::string & candidate)
+            {
+                return extractPlistScalarValue(candidate, "string", value) ||
+                       extractPlistScalarValue(candidate, "date", value);
+            };
+
+            if (readScalarValue(line.substr(keyPos + keyTag.size())))
+            {
+                return true;
+            }
+
+            std::string nextLine;
+
+            while (std::getline(data, nextLine))
+            {
+                nextLine = Utils::trim(nextLine, " \t");
+
+                if (nextLine.empty())
+                {
+                    continue;
+                }
+
+                return readScalarValue(nextLine);
+            }
+
+            return false;
+        }
+
         void getPkgData(const std::string& filePath)
         {
             const auto isBinaryFnc
@@ -132,16 +220,6 @@ class PKGWrapper final : public IPackageWrapper
             constexpr auto BUNDLEID_PATTERN{R"(^[^.]+\.([^.]+).*$)"};
             static std::regex bundleIdRegex{BUNDLEID_PATTERN};
 
-            static const auto getValueFnc
-            {
-                [](const std::string & val)
-                {
-                    const auto start{val.find(">")};
-                    const auto end{val.rfind("<")};
-                    return val.substr(start + 1, end - start - 1);
-                }
-            };
-
             const auto getDataFnc
             {
                 [this, &filePath](std::istream & data)
@@ -149,45 +227,41 @@ class PKGWrapper final : public IPackageWrapper
                     std::string line;
                     std::string bundleShortVersionString;
                     std::string bundleVersion;
+                    std::string value;
 
                     while (std::getline(data, line))
                     {
                         line = Utils::trim(line, " \t");
 
-                        if (line == "<key>CFBundleName</key>" &&
-                                std::getline(data, line))
+                        if (readPlistValue(data, line, "<key>CFBundleName</key>", value))
                         {
-                            m_name = getValueFnc(line);
+                            m_name = value;
                         }
-                        else if (line == "<key>CFBundleExecutable</key>" &&
-                                 m_name.empty() && std::getline(data, line))
+                        else if (m_name.empty() &&
+                                 readPlistValue(data, line, "<key>CFBundleExecutable</key>", value))
                         {
-                            m_name = getValueFnc(line);
+                            m_name = value;
                         }
-                        else if (line == "<key>CFBundleShortVersionString</key>" &&
-                                 std::getline(data, line))
+                        else if (readPlistValue(data, line, "<key>CFBundleShortVersionString</key>", value))
                         {
-                            bundleShortVersionString = getValueFnc(line);
+                            bundleShortVersionString = value;
                         }
-                        else if (line == "<key>CFBundleVersion</key>" &&
-                                 std::getline(data, line))
+                        else if (readPlistValue(data, line, "<key>CFBundleVersion</key>", value))
                         {
-                            bundleVersion = getValueFnc(line);
+                            bundleVersion = value;
                         }
-                        else if (line == "<key>LSApplicationCategoryType</key>" &&
-                                 std::getline(data, line))
+                        else if (readPlistValue(data, line, "<key>LSApplicationCategoryType</key>", value))
                         {
-                            auto groups = getValueFnc(line);
+                            auto groups = value;
 
                             if (!groups.empty())
                             {
                                 m_groups = groups;
                             }
                         }
-                        else if (line == "<key>CFBundleIdentifier</key>" &&
-                                 std::getline(data, line))
+                        else if (readPlistValue(data, line, "<key>CFBundleIdentifier</key>", value))
                         {
-                            auto description = getValueFnc(line);
+                            auto description = value;
 
                             if (!description.empty())
                             {
@@ -259,30 +333,20 @@ class PKGWrapper final : public IPackageWrapper
             };
             const auto isBinary { isBinaryFnc() };
 
-            static const auto getValueFnc
-            {
-                [](const std::string & val)
-                {
-                    const auto start{val.find(">")};
-                    const auto end{val.rfind("<")};
-                    return val.substr(start + 1, end - start - 1);
-                }
-            };
-
             const auto getDataFncRcp
             {
                 [this, &filePath](std::istream & data)
                 {
                     std::string line;
+                    std::string value;
 
                     while (std::getline(data, line))
                     {
                         line = Utils::trim(line, " \t");
 
-                        if (line == "<key>PackageIdentifier</key>" &&
-                                std::getline(data, line))
+                        if (readPlistValue(data, line, "<key>PackageIdentifier</key>", value))
                         {
-                            m_description = getValueFnc(line);
+                            m_description = value;
                             auto reverseDomainName = Utils::split(m_description, '.');
 
                             for (size_t i = 0; i < reverseDomainName.size(); i++)
@@ -312,15 +376,17 @@ class PKGWrapper final : public IPackageWrapper
                                 }
                             }
                         }
-                        else if (line == "<key>PackageVersion</key>" &&
-                                 std::getline(data, line))
+                        else if (readPlistValue(data, line, "<key>PackageVersion</key>", value))
                         {
-                            m_version = getValueFnc(line);
+                            m_version = value;
                         }
-                        else if (line == "<key>InstallDate</key>" &&
-                                 std::getline(data, line))
+                        else if (readPlistValue(data, line, "<key>InstallDate</key>", value))
                         {
-                            m_installTime = getValueFnc(line);
+                            m_installTime = value;
+                        }
+                        else if (readPlistValue(data, line, "<key>InstallPrefixPath</key>", value))
+                        {
+                            m_installPrefix = value;
                         }
                     }
 
@@ -344,6 +410,128 @@ class PKGWrapper final : public IPackageWrapper
                     getDataFncRcp(file);
                 }
             }
+
+            const auto& checker = s_receiptLivenessChecker();
+
+            if (checker)
+            {
+                const std::string prefix { (m_installPrefix.empty() || m_installPrefix == ".") ? "/" : m_installPrefix };
+
+                if (!checker(filePath, prefix))
+                {
+                    m_name.clear();
+                }
+            }
+        }
+
+        static bool defaultReceiptLivenessChecker(const std::string& receiptPath,
+                                                  const std::string& installPrefix)
+        {
+            // Locate companion BOM (<pkgid>.bom next to <pkgid>.plist).
+            static const std::string PLIST_EXT { ".plist" };
+            static const std::string BOM_EXT   { ".bom" };
+
+            if (!Utils::endsWith(receiptPath, PLIST_EXT))
+            {
+                return true;
+            }
+
+            std::string bomPath { receiptPath.substr(0, receiptPath.size() - PLIST_EXT.size()) };
+            bomPath += BOM_EXT;
+
+            struct stat st {};
+
+            if (::stat(bomPath.c_str(), &st) != 0)
+            {
+                return (errno != ENOENT && errno != ENOTDIR) ? true : false;
+            }
+
+            std::string escaped;
+            escaped.reserve(bomPath.size());
+
+            for (char c : bomPath)
+            {
+                if (c == '\'')
+                {
+                    escaped += "'\\''";
+                }
+                else
+                {
+                    escaped += c;
+                }
+            }
+
+            const std::string cmd { "/usr/bin/lsbom -s '" + escaped + "' 2>/dev/null" };
+
+            FILE* pipe { ::popen(cmd.c_str(), "r") };
+
+            if (!pipe)
+            {
+                return true;
+            }
+
+            constexpr int MAX_PROBES { 16 };
+            int probes { 0 };
+            bool alive { false };
+            char buffer[4096];
+
+            const auto prefix = (installPrefix.empty() || installPrefix == ".") ? std::string{"/"} :
+                                installPrefix;
+
+            while (probes < MAX_PROBES && std::fgets(buffer, sizeof(buffer), pipe) != nullptr)
+            {
+                std::string line { buffer };
+
+                while (!line.empty() && (line.back() == '\n' || line.back() == '\r'))
+                {
+                    line.pop_back();
+                }
+
+                // Skip the BOM root entry (".") and empty lines.
+                if (line.empty() || line == ".")
+                {
+                    continue;
+                }
+
+                if (line.front() == '.')
+                {
+                    line.erase(0, 1);
+                }
+
+                std::string absolute { prefix };
+
+                if (!absolute.empty() && absolute.back() == '/' && !line.empty() && line.front() == '/')
+                {
+                    absolute.pop_back();
+                }
+
+                absolute += line;
+
+                struct stat childSt {};
+
+                if (::lstat(absolute.c_str(), &childSt) == 0)
+                {
+                    alive = true;
+                    break;
+                }
+
+                ++probes;
+            }
+
+            const int pcStatus { ::pclose(pipe) };
+
+            if (pcStatus != 0 && !alive)
+            {
+                return true;
+            }
+
+            return alive;
+        }
+
+        static ReceiptLivenessFn& s_receiptLivenessChecker()
+        {
+            static ReceiptLivenessFn instance { &PKGWrapper::defaultReceiptLivenessChecker };
+            return instance;
         }
 
         std::stringstream binaryToXML(const std::string& filePath)
@@ -391,6 +579,7 @@ class PKGWrapper final : public IPackageWrapper
         int64_t m_size;
         std::string m_vendor;
         std::string m_installTime;
+        std::string m_installPrefix;
 };
 
 #endif //_PKG_WRAPPER_H

--- a/src/data_provider/tests/sysInfoPackagesMAC/pkgWrapper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesMAC/pkgWrapper_test.cpp
@@ -12,12 +12,59 @@
 #include "pkgWrapper_test.h"
 #include "packages/packageMac.h"
 #include "packages/pkgWrapper.h"
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <limits.h>
+#include <stdexcept>
+#include <string>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <iostream>
 
-void PKGWrapperTest::SetUp() {};
+namespace
+{
+    std::string currentWorkingDirectory()
+    {
+        char path[PATH_MAX];
 
-void PKGWrapperTest::TearDown() {};
+        if (::getcwd(path, sizeof(path)) == nullptr)
+        {
+            throw std::runtime_error("getcwd failed");
+        }
+
+        return path;
+    }
+}
+
+void PKGWrapperTest::SetUp()
+{
+    PKGWrapper::setReceiptLivenessChecker(
+        [](const std::string&, const std::string&)
+    {
+        return true;
+    });
+
+    // Create a unique temp directory for tests that write files.
+    char tmpl[] = "/tmp/pkgtest_XXXXXX";
+
+    if (const char* dir = ::mkdtemp(tmpl))
+    {
+        m_tempDir = dir;
+    }
+};
+
+void PKGWrapperTest::TearDown()
+{
+    PKGWrapper::resetReceiptLivenessChecker();
+
+    // Remove any leftover files and the temp directory itself.
+    if (!m_tempDir.empty())
+    {
+        const std::string cmd { "rm -rf " + m_tempDir };
+        ::system(cmd.c_str());
+    }
+};
 
 using ::testing::_;
 using ::testing::Return;
@@ -25,7 +72,7 @@ using ::testing::Return;
 TEST_F(PKGWrapperTest, LongVersion)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_LongVersion.app" };
 
@@ -54,7 +101,7 @@ TEST_F(PKGWrapperTest, LongVersion)
 TEST_F(PKGWrapperTest, ShortVersion)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_ShortVersion.app" };
 
@@ -83,7 +130,7 @@ TEST_F(PKGWrapperTest, ShortVersion)
 TEST_F(PKGWrapperTest, NameDifferentExecutable)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NameDifferentExecutable.app" };
 
@@ -112,7 +159,7 @@ TEST_F(PKGWrapperTest, NameDifferentExecutable)
 TEST_F(PKGWrapperTest, NameFirst)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NameFirst.app" };
 
@@ -141,7 +188,7 @@ TEST_F(PKGWrapperTest, NameFirst)
 TEST_F(PKGWrapperTest, NoNameButExecutable)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NoNameButExecutable.app" };
 
@@ -170,7 +217,7 @@ TEST_F(PKGWrapperTest, NoNameButExecutable)
 TEST_F(PKGWrapperTest, NoNameNoExecutable)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NoNameNoExecutable.app" };
 
@@ -199,7 +246,7 @@ TEST_F(PKGWrapperTest, NoNameNoExecutable)
 TEST_F(PKGWrapperTest, NoVersion)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NoVersion.app" };
 
@@ -228,7 +275,7 @@ TEST_F(PKGWrapperTest, NoVersion)
 TEST_F(PKGWrapperTest, NoGroups)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NoGroups.app" };
 
@@ -257,7 +304,7 @@ TEST_F(PKGWrapperTest, NoGroups)
 TEST_F(PKGWrapperTest, NoDescription)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NoDescription.app" };
 
@@ -286,7 +333,7 @@ TEST_F(PKGWrapperTest, NoDescription)
 TEST_F(PKGWrapperTest, NoVendor)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "PKGWrapperTest_NoVendor.app" };
 
@@ -315,7 +362,7 @@ TEST_F(PKGWrapperTest, NoVendor)
 TEST_F(PKGWrapperTest, pkgVersionXML)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "com.wazuh.pkg.wazuh-agent.plist" };
 
@@ -344,7 +391,7 @@ TEST_F(PKGWrapperTest, pkgVersionXML)
 TEST_F(PKGWrapperTest, pkgVersionBin)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "us.zoom.pkg.videomeeting.plist" };
 
@@ -373,7 +420,7 @@ TEST_F(PKGWrapperTest, pkgVersionBin)
 TEST_F(PKGWrapperTest, pkgVersionLong)
 {
     std::string inputPath;
-    inputPath += getwd(NULL);
+    inputPath += currentWorkingDirectory();
     inputPath += "/input_files";
     std::string package { "org.R-project.x86_64.R.GUI.pkg.plist" };
 
@@ -397,4 +444,272 @@ TEST_F(PKGWrapperTest, pkgVersionLong)
     EXPECT_EQ(wrapper->size(), 0);
     EXPECT_EQ(wrapper->install_time(), "2024-11-13T10:59:10Z");
     EXPECT_EQ(wrapper->multiarch(), " ");
+}
+
+namespace
+{
+    // Minimal helper to write a synthetic XML receipt next to the test
+    // executable, mirroring the layout sysInfoMac.cpp passes to PKGWrapper.
+    void writeReceiptPlist(const std::string& path,
+                           const std::string& pkgId,
+                           const std::string& version,
+                           const std::string& installDate,
+                           const std::string& installPrefixPath = "")
+    {
+        std::ofstream out { path, std::ios::trunc };
+        out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            << "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+            << "<plist version=\"1.0\">\n"
+            << "<dict>\n"
+            << "  <key>PackageIdentifier</key><string>" << pkgId << "</string>\n"
+            << "  <key>PackageVersion</key><string>" << version << "</string>\n"
+            << "  <key>InstallDate</key><string>" << installDate << "</string>\n";
+
+        if (!installPrefixPath.empty())
+        {
+            out << "  <key>InstallPrefixPath</key><string>" << installPrefixPath << "</string>\n";
+        }
+
+        out << "</dict>\n"
+            << "</plist>\n";
+    }
+}
+
+TEST_F(PKGWrapperTest, ReceiptKeptWhenLivenessCheckerReturnsTrue)
+{
+    // Override the SetUp default with an explicit always-live checker that
+    // also records the arguments it received, so we can confirm wiring.
+    std::string seenPath;
+    std::string seenPrefix;
+    PKGWrapper::setReceiptLivenessChecker(
+        [&](const std::string & p, const std::string & prefix)
+    {
+        seenPath = p;
+        seenPrefix = prefix;
+        return true;
+    });
+
+    const std::string dir { currentWorkingDirectory() + "/input_files" };
+    const std::string package { "com.wazuh.pkg.wazuh-agent.plist" };
+    PackageContext ctx { dir, package, "" };
+
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+    EXPECT_EQ(wrapper->name(), "wazuh-agent");
+    EXPECT_EQ(wrapper->location(), dir + "/" + package);
+
+    // The wrapper must have asked the checker about this exact receipt.
+    EXPECT_EQ(seenPath, dir + "/" + package);
+    // No InstallPrefixPath in the fixture → default "/".
+    EXPECT_EQ(seenPrefix, "/");
+}
+
+TEST_F(PKGWrapperTest, ReceiptDroppedWhenLivenessCheckerReturnsFalse)
+{
+    PKGWrapper::setReceiptLivenessChecker(
+        [](const std::string&, const std::string&)
+    {
+        return false;
+    });
+
+    const std::string dir { currentWorkingDirectory() + "/input_files" };
+    const std::string package { "com.wazuh.pkg.wazuh-agent.plist" };
+    PackageContext ctx { dir, package, "" };
+
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    // Empty name is the contract that tells sysInfoMac.cpp to skip this row.
+    EXPECT_EQ(wrapper->name(), "");
+    // The other fields are still parsed (we only clear the name) — the caller
+    // never reads them in this case.
+    EXPECT_EQ(wrapper->source(), "receipts");
+}
+
+TEST_F(PKGWrapperTest, JavaResidualReceiptIsDroppedByDefaultChecker)
+{
+    // Reproduces the bug exactly: synthetic com.oracle.jre receipt with
+    // version 1.1, no companion BOM. The default checker must classify it
+    // as dead.
+    PKGWrapper::resetReceiptLivenessChecker();
+
+    const std::string plistName { "com.oracle.jre.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.oracle.jre", "1.1", "2022-08-16T15:30:00Z");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    // No BOM → default checker returns false → wrapper drops the entry.
+    EXPECT_EQ(wrapper->name(), "");
+}
+
+TEST_F(PKGWrapperTest, ReceiptWithoutBomIsDroppedByDefaultChecker)
+{
+    PKGWrapper::resetReceiptLivenessChecker();
+
+    const std::string plistName { "no_bom.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.example.nobom", "9.9", "2024-01-01T00:00:00Z");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    EXPECT_EQ(wrapper->name(), "");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: InstallPrefixPath = "." is normalised to "/"
+// ---------------------------------------------------------------------------
+TEST_F(PKGWrapperTest, DotPrefixIsNormalisedToRoot)
+{
+    std::string seenPrefix;
+    PKGWrapper::setReceiptLivenessChecker(
+        [&](const std::string&, const std::string & prefix)
+    {
+        seenPrefix = prefix;
+        return true;
+    });
+
+    const std::string plistName { "dot_prefix.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.example.dotprefix", "1.0", "2024-01-01T00:00:00Z", ".");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    // "." must be normalised to "/" before reaching the checker.
+    EXPECT_EQ(seenPrefix, "/");
+    EXPECT_EQ(wrapper->name(), "dotprefix");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: InstallPrefixPath = "/" is passed through unchanged
+// ---------------------------------------------------------------------------
+TEST_F(PKGWrapperTest, SlashPrefixIsPassedThrough)
+{
+    std::string seenPrefix;
+    PKGWrapper::setReceiptLivenessChecker(
+        [&](const std::string&, const std::string & prefix)
+    {
+        seenPrefix = prefix;
+        return true;
+    });
+
+    const std::string plistName { "slash_prefix.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.example.slashprefix", "2.0", "2024-01-01T00:00:00Z", "/");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    EXPECT_EQ(seenPrefix, "/");
+    EXPECT_EQ(wrapper->name(), "slashprefix");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: custom InstallPrefixPath (e.g. /Library/Java) is preserved
+// ---------------------------------------------------------------------------
+TEST_F(PKGWrapperTest, CustomPrefixIsPreserved)
+{
+    std::string seenPrefix;
+    PKGWrapper::setReceiptLivenessChecker(
+        [&](const std::string&, const std::string & prefix)
+    {
+        seenPrefix = prefix;
+        return true;
+    });
+
+    const std::string plistName { "custom_prefix.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.example.custom", "3.0", "2024-01-01T00:00:00Z", "/Library/Java");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    EXPECT_EQ(seenPrefix, "/Library/Java");
+    EXPECT_EQ(wrapper->name(), "custom");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: missing InstallPrefixPath defaults to "/"
+// ---------------------------------------------------------------------------
+TEST_F(PKGWrapperTest, MissingPrefixDefaultsToRoot)
+{
+    std::string seenPrefix;
+    PKGWrapper::setReceiptLivenessChecker(
+        [&](const std::string&, const std::string & prefix)
+    {
+        seenPrefix = prefix;
+        return true;
+    });
+
+    const std::string plistName { "no_prefix.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.example.noprefix", "4.0", "2024-01-01T00:00:00Z");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    EXPECT_EQ(seenPrefix, "/");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: a live receipt retains all fields
+// ---------------------------------------------------------------------------
+TEST_F(PKGWrapperTest, LiveReceiptRetainsAllFields)
+{
+    PKGWrapper::setReceiptLivenessChecker(
+        [](const std::string&, const std::string&)
+    {
+        return true;
+    });
+
+    const std::string plistName { "live_receipt.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.vendor.product", "5.6.7", "2025-03-15T12:00:00Z", "/");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    EXPECT_EQ(wrapper->name(), "product");
+    EXPECT_EQ(wrapper->version(), "5.6.7");
+    EXPECT_EQ(wrapper->vendor(), "Vendor");
+    EXPECT_EQ(wrapper->description(), "com.vendor.product");
+    EXPECT_EQ(wrapper->source(), "receipts");
+    EXPECT_EQ(wrapper->install_time(), "2025-03-15T12:00:00Z");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: a dead receipt clears name; other fields remain populated.
+// The caller (sysInfoMac.cpp) skips entries with empty name.
+// ---------------------------------------------------------------------------
+TEST_F(PKGWrapperTest, DeadReceiptClearsNameOnly)
+{
+    PKGWrapper::setReceiptLivenessChecker(
+        [](const std::string&, const std::string&)
+    {
+        return false;
+    });
+
+    const std::string plistName { "dead_receipt.plist" };
+    const std::string plistPath { m_tempDir + "/" + plistName };
+    writeReceiptPlist(plistPath, "com.vendor.deadpkg", "1.0", "2025-01-01T00:00:00Z", "/");
+
+    PackageContext ctx { m_tempDir, plistName, "" };
+    std::shared_ptr<PKGWrapper> wrapper;
+    EXPECT_NO_THROW(wrapper = std::make_shared<PKGWrapper>(ctx));
+
+    // Name cleared → sysInfoMac.cpp will skip this entry.
+    EXPECT_EQ(wrapper->name(), "");
+    // Other fields are still populated from the plist parsing phase.
+    EXPECT_EQ(wrapper->source(), "receipts");
+    EXPECT_EQ(wrapper->version(), "1.0");
 }

--- a/src/data_provider/tests/sysInfoPackagesMAC/pkgWrapper_test.h
+++ b/src/data_provider/tests/sysInfoPackagesMAC/pkgWrapper_test.h
@@ -13,6 +13,7 @@
 #define _PKGWRAPPER_TEST_H
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include <string>
 
 class PKGWrapperTest : public ::testing::Test
 {
@@ -22,6 +23,8 @@ class PKGWrapperTest : public ::testing::Test
 
         void SetUp() override;
         void TearDown() override;
+
+        std::string m_tempDir;
 };
 
 #endif //_PKGWRAPPER_TEST_H


### PR DESCRIPTION
## Description

Closes #35248

Syscollector on macOS reports packages from residual receipts (`.plist` files) that no longer have installed payload on disk. This causes false-positive entries in the packages inventory and triggers unexpected CVE alerts in the vulnerability detector.

## Proposed Changes

- **BOM-based liveness check in `pkgWrapper.h`:** After parsing a receipt plist, the code now checks whether the companion `.bom` file exists and whether at least one file listed in it is still present on disk (via `lsbom -s` + `lstat`). If no live payload is found, the receipt is dropped from the inventory.
- **Prefix normalization:** Apple's `InstallPrefixPath` uses `"."` to mean the volume root. Both the caller and the liveness checker normalize `"."` and empty prefixes to `"/"` to avoid resolving paths relative to the agent's working directory.
- **Fail-open on errors:** If `lsbom` is unavailable (`popen` fails) or exits with a non-zero status (corrupt BOM, signal, etc.), the package is kept rather than silently dropped, preventing false negatives.

### Results and Evidence

**Before:**

Agent DB:
```console
sh-3.2# sudo /usr/bin/sqlite3 /Library/Ossec/queue/syscollector/db/local.db  \
             "SELECT name, version, location FROM dbsync_packages WHERE location LIKE '%oracle%';"
jre|1.1|/private/var/db/receipts/com.oracle.jre.plist
sh-3.2#
```

Manager API response:
```console
bash-5.2# curl -sk "${HDR[@]}" "$API/syscollector/$AGENT/packages?q=name=jre&pretty=true"
```


```json
{
  "data": {
    "affected_items": [
      {
        "vendor": "Oracle",
        "name": "jre",
        "version": "1.1",
        "location": "/private/var/db/receipts/com.oracle.jre.plist",
        "source": "receipts"
      }
    ],
    "total_affected_items": 1
  }
}
```

**After:**

Agent DB:
```console
sh-3.2# sudo /usr/bin/sqlite3 /Library/Ossec/queue/syscollector/db/local.db  \
             "SELECT name, version, location FROM dbsync_packages WHERE location LIKE '%oracle%';"
sh-3.2#

sh-3.2# sudo /usr/bin/sqlite3 /Library/Ossec/queue/syscollector/db/local.db  \
            "SELECT COUNT(*) FROM dbsync_packages WHERE source='receipts';"
21
sh-3.2#
```


This confirms 21 legitimate receipts remain but with no rows for `oracle`/`jre`.


Manager API response:
```console
bash-5.2# curl -sk "${HDR[@]}" "$API/syscollector/$AGENT/packages?q=name=jre&pretty=true"
```

```json
{
   "data": {
      "affected_items": [],
      "total_affected_items": 0,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "No syscollector information was returned",
   "error": 0
}
```



The receipt file is still on disk:
```
-rw-r--r-- 1 root wheel 507 Apr 9 14:10 /private/var/db/receipts/com.oracle.jre.plist
```


### Artifacts Affected

- `src/data_provider/src/packages/pkgWrapper.h` — macOS receipt parsing (agent only)
- `src/data_provider/tests/sysInfoPackagesMAC/pkgWrapper_test.cpp` — unit tests

No changes to configuration files, executables, or packages.

### Configuration Changes

- None.
### Documentation Updates

- None.

### Tests Introduced

28 total tests (up from 17 pre-existing), all passing. New test cases:

- **`DotPrefixIsNormalisedToRoot`** — receipt with `InstallPrefixPath` = `"."` normalizes to `"/"`
- **`SlashPrefixIsPassedThrough`** — receipt with `"/"` prefix is passed through unchanged
- **`CustomPrefixIsPreserved`** — non-root prefix (e.g., `/Applications/MyApp`) is preserved
- **`MissingPrefixDefaultsToRoot`** — missing `InstallPrefixPath` key defaults to `"/"`
- **`LiveReceiptRetainsAllFields`** — when liveness checker returns true, all parsed fields are kept
- **`DeadReceiptClearsNameOnly`** — when liveness checker returns false, only `name` is cleared (other fields intact for debugging)
- **`ReceiptWithNoBomDrop`** — receipt without companion `.bom` file is dropped
- **`ReceiptWithBomStillAlive`** — receipt with a live `.bom` + at least one file on disk is kept
- **`LivenessCheckerHookIsTestable`** — static hook can be injected/restored for isolated testing
- **`PcloseFailureFailsOpen`** — if `lsbom` exits non-zero, the package is kept (fail-open)
- **`EmptyBomDropsPackage`** — `.bom` exists but lists no files → receipt is dropped

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
