### PR TITLE
Resolve systemctl via PATH and fall back to wazuh-control when service is inactive 

### DIFF
--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -99,7 +99,7 @@ bool wm_control_wait_for_service_active(const char *service) {
 
                 if (strcmp(state, "inactive") == 0 || strcmp(state, "failed") == 0) {
                     pclose(fp);
-                    mterror(WM_CONTROL_LOGTAG, "Service %s is in state '%s', cannot reload", service, state);
+                    mtwarn(WM_CONTROL_LOGTAG, "Service %s is in state '%s', systemctl cannot reload", service, state);
                     return false;
                 }
 
@@ -142,7 +142,11 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
         case 0:
             if (use_systemd && strcmp(action, "reload") == 0) {
                 if (!wm_control_wait_for_service_active(service)) {
-                    mterror(WM_CONTROL_LOGTAG, "Service %s not active for reload", service);
+                    mtwarn(WM_CONTROL_LOGTAG, "Service %s not active for systemctl, falling back to wazuh-control", service);
+                    char *fallback_cmd[] = {"bin/wazuh-control", (char *)action, NULL};
+                    if (execvp(fallback_cmd[0], fallback_cmd) < 0) {
+                        mterror(WM_CONTROL_LOGTAG, "Error executing %s command via wazuh-control: %s (%d)", action, strerror(errno), errno);
+                    }
                     _exit(1);
                 }
             }

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -124,7 +124,7 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
     char *exec_cmd[4] = {NULL};
 
     if (use_systemd) {
-        exec_cmd[0] = "/usr/bin/systemctl";
+        exec_cmd[0] = "systemctl";
         exec_cmd[1] = (char *)action;
         exec_cmd[2] = (char *)service;
         mtinfo(WM_CONTROL_LOGTAG, "Executing '%s' on %s using systemctl", action, service);
@@ -146,7 +146,7 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
                     _exit(1);
                 }
             }
-            if (execv(exec_cmd[0], exec_cmd) < 0) {
+            if (execvp(exec_cmd[0], exec_cmd) < 0) {
                 mterror(WM_CONTROL_LOGTAG, "Error executing %s command: %s (%d)", action, strerror(errno), errno);
             }
             _exit(1);


### PR DESCRIPTION
# Description

On systems where `systemctl` is not located at `/usr/bin/systemctl` (e.g. Ubuntu 18.04, where it lives at `/bin/systemctl`), the control module fails to reload the agent with `ENOENT`. Additionally, when the agent service is not managed by systemd (inactive or failed state), the reload silently aborts instead of falling back to `wazuh-control`. Resolves #35376.

## Proposed Changes

- **`src/wazuh_modules/src/wm_control.c`** — Replace the hardcoded `exec_cmd[0] = "/usr/bin/systemctl"` with `"systemctl"` and switch from `execv` to `execvp`, so the binary is resolved via `$PATH` regardless of the distro's filesystem layout.
- **`src/wazuh_modules/src/wm_control.c`** — When `wm_control_wait_for_service_active()` detects the service is `inactive` or `failed`, downgrade the log from `ERROR` to `WARNING` (the situation is now recoverable).
- **`src/wazuh_modules/src/wm_control.c`** — In the child process, when systemctl cannot reload (service not active), emit a `WARNING` and fall back to executing `bin/wazuh-control reload` via `execvp` instead of aborting with `_exit(1)`.

### Results and Evidence

<details><summary>Before fix — ENOENT on Ubuntu 18.04 (systemctl not at /usr/bin/systemctl)</summary>

```bash
2026/04/10 09:28:40 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/04/10 09:28:40 wazuh-modulesd:control: INFO: Executing 'reload' on wazuh-agent using systemctl
2026/04/10 09:28:40 wazuh-modulesd:control: ERROR: Error executing reload command: No such file or directory (2)
```

</details>

<details><summary>Before fix — reload silently aborted when service is inactive</summary>

```bash
2026/04/10 09:18:48 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/04/10 09:18:48 wazuh-modulesd:control: INFO: Executing 'reload' on wazuh-agent using systemctl
2026/04/10 09:18:48 wazuh-modulesd:control: ERROR: Service wazuh-agent is in state 'inactive', cannot reload
2026/04/10 09:18:48 wazuh-modulesd:control: ERROR: Service wazuh-agent not active for reload
```

</details>

<details><summary>After fix — reload succeeds via systemctl (service active)</summary>

```bash
2026/04/10 12:57:33 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/04/10 12:57:33 wazuh-modulesd:control: INFO: Executing 'reload' on wazuh-agent using systemctl
2026/04/10 12:57:33 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/04/10 12:57:33 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/04/10 12:57:33 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/04/10 12:57:33 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/04/10 12:57:34 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/04/10 12:57:34 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/04/10 12:57:34 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/04/10 12:57:34 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/04/10 12:57:34 wazuh-modulesd:syscollector: INFO: Module finished.
2026/04/10 12:57:34 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/04/10 12:57:34 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/04/10 12:57:37 wazuh-execd: INFO: Started (pid: 9546).
2026/04/10 12:57:37 wazuh-syscheckd: INFO: Started (pid: 9557).
2026/04/10 12:57:37 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/04/10 12:57:37 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/04/10 12:57:38 wazuh-logcollector: INFO: Started (pid: 9572).
2026/04/10 12:57:39 wazuh-modulesd: INFO: Started (pid: 9593).
2026/04/10 12:57:39 wazuh-modulesd:control: INFO: Starting control thread.
2026/04/10 12:57:39 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/04/10 12:57:39 wazuh-modulesd:agent-info: INFO: AgentInfo initialized.
2026/04/10 12:57:39 wazuh-modulesd:sca: INFO: SCA initialized.
2026/04/10 12:57:39 wazuh-modulesd:sca: INFO: SCA module initialized successfully.
2026/04/10 12:57:39 wazuh-modulesd:sca: INFO: Started (pid: 9593).
2026/04/10 12:57:39 wazuh-modulesd:sca: INFO: SCA module already initialized.
2026/04/10 12:57:39 wazuh-modulesd:sca: INFO: SCA module running.
2026/04/10 12:57:39 wazuh-modulesd:sca: INFO: SCA module scan on start.
2026/04/10 12:57:39 wazuh-modulesd:syscollector: INFO: Module started.
2026/04/10 12:57:39 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/04/10 12:57:40 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/10 12:57:40 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/04/10 12:57:42 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/04/10 12:57:44 wazuh-rootcheck: INFO: Ending rootcheck scan.
```

</details>

<details><summary>After fix — reload falls back to wazuh-control when service is inactive/failed</summary>

```bash
2026/04/10 13:02:01 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/04/10 13:02:01 wazuh-modulesd:control: INFO: Executing 'reload' on wazuh-agent using systemctl
2026/04/10 13:02:01 wazuh-modulesd:control: WARNING: Service wazuh-agent is in state 'failed', systemctl cannot reload
2026/04/10 13:02:01 wazuh-modulesd:control: WARNING: Service wazuh-agent not active for systemctl, falling back to wazuh-control
2026/04/10 13:02:01 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/04/10 13:02:01 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/04/10 13:02:01 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/04/10 13:02:01 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/04/10 13:02:01 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/04/10 13:02:02 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/04/10 13:02:02 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/04/10 13:02:02 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/04/10 13:02:02 wazuh-modulesd:syscollector: INFO: Module finished.
2026/04/10 13:02:02 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/04/10 13:02:02 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/04/10 13:02:04 wazuh-execd: INFO: Started (pid: 11725).
2026/04/10 13:02:05 wazuh-syscheckd: INFO: Started (pid: 11739).
2026/04/10 13:02:05 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/04/10 13:02:06 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/04/10 13:02:06 wazuh-logcollector: INFO: Started (pid: 11754).
2026/04/10 13:02:07 wazuh-modulesd: INFO: Started (pid: 11775).
2026/04/10 13:02:07 wazuh-modulesd:control: INFO: Starting control thread.
2026/04/10 13:02:07 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/04/10 13:02:07 wazuh-modulesd:agent-info: INFO: AgentInfo initialized.
2026/04/10 13:02:07 wazuh-modulesd:sca: INFO: SCA initialized.
2026/04/10 13:02:07 wazuh-modulesd:sca: INFO: SCA module initialized successfully.
2026/04/10 13:02:07 wazuh-modulesd:sca: INFO: Started (pid: 11775).
2026/04/10 13:02:07 wazuh-modulesd:sca: INFO: SCA module already initialized.
2026/04/10 13:02:07 wazuh-modulesd:sca: INFO: SCA module running.
2026/04/10 13:02:07 wazuh-modulesd:syscollector: INFO: Module started.
2026/04/10 13:02:07 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/04/10 13:02:07 wazuh-modulesd:sca: INFO: SCA module scan on start.
2026/04/10 13:02:08 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/10 13:02:09 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/04/10 13:02:13 wazuh-rootcheck: INFO: Ending rootcheck scan.
2026/04/10 13:02:14 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

</details>

### Artifacts Affected

- `wazuh-modulesd` (control module thread)

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced._

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
