### PR TITLE
Fix coverity findings in group validation paths

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -405,7 +405,6 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
         }
         w_auth_group_regex_compiled = true;
     }
-    w_mutex_unlock(&w_auth_group_regex_mutex);
 
     os_strdup(groups, tmp_groups);
     char *group = strtok_r(tmp_groups, delim, &save_ptr);
@@ -460,6 +459,7 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
         group = strtok_r(NULL, delim, &save_ptr);
         closedir(dp);
     }
+    w_mutex_unlock(&w_auth_group_regex_mutex);
     os_free(tmp_groups);
     return ret;
 }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1461,16 +1461,19 @@ w_err_t wdb_global_validate_group_name(const char *group_name) {
         }
         wdb_global_group_regex_compiled = true;
     }
-    w_mutex_unlock(&wdb_global_group_regex_mutex);
 
     if (strlen(group_name) > MAX_GROUP_NAME) {
         mwarn("Invalid group name. The group '%s' exceeds the maximum length of %d characters permitted", group_name, MAX_GROUP_NAME);
+        w_mutex_unlock(&wdb_global_group_regex_mutex);
         return OS_INVALID;
     }
     if (regexec(&wdb_global_group_regex, group_name, 0, NULL, 0) != 0) {
         mwarn("Invalid group name. '%s' contains invalid characters", group_name);
+        w_mutex_unlock(&wdb_global_group_regex_mutex);
         return OS_INVALID;
     }
+    w_mutex_unlock(&wdb_global_group_regex_mutex);
+
     /* Explicit check for directory references (. and ..) */
     if (strcmp(group_name, ".") == 0) {
         mwarn("Invalid group name. '.' represents the current directory in unix systems");


### PR DESCRIPTION
## Description

Two concurrent data access violations are solved in this PR.

## Proposed Changes

- Solve this issue in `w_auth_validate_groups `
- Solve this issue in `wdb_global_validate_group_name `

### Results and Evidence

Coverity link: https://github.com/wazuh/wazuh/actions/runs/24360967385

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues