### PR TITLE
Early populate metadata after handshake

### DIFF
--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -776,6 +776,11 @@ STATIC bool agent_handshake_to_server(int server_id, bool is_startup) {
                                 agent_agent_groups[sizeof(agent_agent_groups) - 1] = '\0';
                                 mdebug1("Agent groups: %s", agent_agent_groups);
 
+                                /* Populate shared memory before opening the startup gate so that
+                                 * any module that starts immediately after has full metadata
+                                 * (OS, hostname, groups, cluster info) available. */
+                                populate_early_metadata();
+
                                 startup_gate_process_handshake(is_startup, merged_sum_buffer);
 
                                 /* Check if limits changed and reload if auto_restart is enabled */
@@ -795,15 +800,12 @@ STATIC bool agent_handshake_to_server(int server_id, bool is_startup) {
                             }
                         } else {
                             mdebug1("No handshake JSON after ACK, using defaults");
+                            populate_early_metadata();
                             startup_gate_process_handshake(is_startup, NULL);
                         }
 
                         minfo(AG_CONNECTED, agt->server[server_id].rip,
                                 agt->server[server_id].port, "tcp");
-
-                        /* Populate shared memory before first keepalive so it
-                         * contains full metadata (OS, hostname, groups, cluster info). */
-                        populate_early_metadata();
 
                         if (is_startup) {
                             send_msg_on_startup();

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -13,6 +13,7 @@
 #include "sendmsg.h"
 #include "os_net.h"
 #include "../os_crypto/md5/md5_op.h"
+#include "metadata_provider.h"
 #include <ctype.h>
 
 #ifdef WAZUH_UNIT_TESTING
@@ -579,6 +580,104 @@ int try_enroll_to_server(const char * server_rip, uint32_t network_interface) {
     return enroll_result;
 }
 
+/* Populate shared memory with agent metadata so the first keepalive
+ * already contains full agent info. All data is local and available
+ * immediately after the handshake completes. */
+static void populate_early_metadata(void)
+{
+    agent_metadata_t metadata = {0};
+
+#ifdef WIN32
+    os_info *os = get_win_version();
+#else
+    os_info *os = get_unix_version();
+#endif
+
+    /* Agent identity */
+    if (keys.keysize > 0 && keys.keyentries[0]) {
+        strncpy(metadata.agent_id, keys.keyentries[0]->id, sizeof(metadata.agent_id) - 1);
+        strncpy(metadata.agent_name, keys.keyentries[0]->name, sizeof(metadata.agent_name) - 1);
+    }
+    strncpy(metadata.agent_version, __wazuh_version, sizeof(metadata.agent_version) - 1);
+
+    /* OS info */
+    if (os) {
+        if (os->os_name) {
+            strncpy(metadata.os_name, os->os_name, sizeof(metadata.os_name) - 1);
+        }
+        if (os->os_version) {
+            strncpy(metadata.os_version, os->os_version, sizeof(metadata.os_version) - 1);
+        }
+        if (os->os_platform) {
+            strncpy(metadata.os_platform, os->os_platform, sizeof(metadata.os_platform) - 1);
+        }
+        if (os->machine) {
+            strncpy(metadata.architecture, os->machine, sizeof(metadata.architecture) - 1);
+        }
+        if (os->nodename) {
+            strncpy(metadata.hostname, os->nodename, sizeof(metadata.hostname) - 1);
+        }
+        free_osinfo(os);
+    }
+
+    /* OS type (compile-time constant) */
+#ifdef WIN32
+    strncpy(metadata.os_type, "windows", sizeof(metadata.os_type) - 1);
+#elif defined(__MACH__)
+    strncpy(metadata.os_type, "macos", sizeof(metadata.os_type) - 1);
+#else
+    strncpy(metadata.os_type, "linux", sizeof(metadata.os_type) - 1);
+#endif
+
+    /* Cluster info from handshake */
+    strncpy(metadata.cluster_name, agent_cluster_name, sizeof(metadata.cluster_name) - 1);
+    strncpy(metadata.cluster_node, agent_cluster_node, sizeof(metadata.cluster_node) - 1);
+
+    /* Groups from handshake */
+    if (agent_agent_groups[0] != '\0') {
+        /* Count groups (comma-separated) */
+        size_t count = 1;
+        for (const char *p = agent_agent_groups; *p; p++) {
+            if (*p == ',') {
+                count++;
+            }
+        }
+
+        metadata.groups = (char **)calloc(count, sizeof(char *));
+        if (metadata.groups) {
+            char groups_copy[OS_SIZE_65536];
+            strncpy(groups_copy, agent_agent_groups, sizeof(groups_copy) - 1);
+            groups_copy[sizeof(groups_copy) - 1] = '\0';
+
+            size_t i = 0;
+            char *saveptr = NULL;
+            char *token = strtok_r(groups_copy, ",", &saveptr);
+            while (token && i < count) {
+                if (token[0] != '\0') {
+                    metadata.groups[i] = strdup(token);
+                    i++;
+                }
+                token = strtok_r(NULL, ",", &saveptr);
+            }
+            metadata.groups_count = i;
+        }
+    }
+
+    if (metadata_provider_update(&metadata) == 0) {
+        mdebug1("Early metadata populated into shared memory");
+    } else {
+        mdebug1("Failed to populate early metadata");
+    }
+
+    /* Free groups */
+    if (metadata.groups) {
+        for (size_t i = 0; i < metadata.groups_count; i++) {
+            free(metadata.groups[i]);
+        }
+        free(metadata.groups);
+    }
+}
+
 /**
  * @brief Holds handshake logic for an attempt to connect to server
  * @param server_id index of the specified server from agt servers list
@@ -701,6 +800,10 @@ STATIC bool agent_handshake_to_server(int server_id, bool is_startup) {
 
                         minfo(AG_CONNECTED, agt->server[server_id].rip,
                                 agt->server[server_id].port, "tcp");
+
+                        /* Populate shared memory before first keepalive so it
+                         * contains full metadata (OS, hostname, groups, cluster info). */
+                        populate_early_metadata();
 
                         if (is_startup) {
                             send_msg_on_startup();

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -48,7 +48,8 @@ set(START_AGENT_BASE_FLAGS "-Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl
                             -Wl,--wrap,fprintf -Wl,--wrap,fflush -Wl,--wrap,ReadSecMSG -Wl,--wrap,wnet_select \
                             -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_SendUDPbySize -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap,w_calloc_expression_t -Wl,--wrap,w_expression_compile -Wl,--wrap,w_expression_match \
-                            -Wl,--wrap,w_free_expression_t -Wl,--wrap,OS_CloseSocket")
+                            -Wl,--wrap,w_free_expression_t -Wl,--wrap,OS_CloseSocket \
+                            -Wl,--wrap,metadata_provider_update -Wl,--wrap,get_unix_version -Wl,--wrap,get_win_version -Wl,--wrap,free_osinfo")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap,os_random -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap,w_query_agentd")
 else()

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -28,6 +28,8 @@
 
 #include "agentd.h"
 #include "module_limits.h"
+#include "metadata_provider.h"
+#include "version_op.h"
 
 extern void send_msg_on_startup(void);
 extern bool agent_handshake_to_server(int server_id, bool is_startup);
@@ -38,6 +40,23 @@ extern int parse_handshake_json(const char *json_str, module_limits_t *limits,
                                 char *cluster_node, size_t cluster_node_size,
                                 char *agent_groups, size_t agent_groups_size,
                                 char *merged_sum, size_t merged_sum_size);
+
+/* Wrappers for populate_early_metadata dependencies */
+int __wrap_metadata_provider_update(const agent_metadata_t *metadata) {
+    return (int)mock();
+}
+
+os_info *__wrap_get_unix_version(void) {
+    return (os_info *)mock_ptr_type(os_info *);
+}
+
+os_info *__wrap_get_win_version(void) {
+    return (os_info *)mock_ptr_type(os_info *);
+}
+
+void __wrap_free_osinfo(os_info *osinfo) {
+    return;
+}
 
 int __wrap_send_msg(const char *msg, ssize_t msg_length) {
     check_expected(msg);
@@ -253,7 +272,15 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 2);
+    /* populate_early_metadata mocks */
+#ifdef TEST_WINAGENT
+    will_return(__wrap_get_win_version, NULL);
+#else
+    will_return(__wrap_get_unix_version, NULL);
+#endif
+    will_return(__wrap_metadata_provider_update, 0);
+
+    expect_any_count(__wrap__mdebug1, formatted_msg, 3);
     expect_any(__wrap__minfo, formatted_msg);
 
     handshaked = agent_handshake_to_server(0, false);
@@ -280,7 +307,15 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 3);
+    /* populate_early_metadata mocks */
+#ifdef TEST_WINAGENT
+    will_return(__wrap_get_win_version, NULL);
+#else
+    will_return(__wrap_get_unix_version, NULL);
+#endif
+    will_return(__wrap_metadata_provider_update, 0);
+
+    expect_any_count(__wrap__mdebug1, formatted_msg, 4);
     expect_any(__wrap__minfo, formatted_msg);
 
     handshaked = agent_handshake_to_server(1, false);
@@ -308,7 +343,15 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 3);
+    /* populate_early_metadata mocks */
+#ifdef TEST_WINAGENT
+    will_return(__wrap_get_win_version, NULL);
+#else
+    will_return(__wrap_get_unix_version, NULL);
+#endif
+    will_return(__wrap_metadata_provider_update, 0);
+
+    expect_any_count(__wrap__mdebug1, formatted_msg, 4);
     expect_any(__wrap__minfo, formatted_msg);
 
     handshaked = agent_handshake_to_server(1, true);


### PR DESCRIPTION
## Description

The agent's first keepalive can be sent before the `agent-info` module (running in `wazuh-modulesd`, a separate process) has populated metadata into shared memory. The `agent-info` module has significant startup latency (process launch, library loading, agcom handshake retries, 5-second module coordination delay) by which time `run_notify()` has already fired. This results in a "minimal" keepalive without host/OS/cluster data. Incomplete metadata affects stateless events on the manager side, since `remoted` enriches them using data from the last keepalive.

Closes #35278 

## Proposed Changes

- Add `populate_early_metadata()` in `start_agent.c`, called right after the handshake completes inside `agent_handshake_to_server()`. This function collects all metadata locally: agent ID/name from keys, OS info from `get_unix_version()` (or `get_win_version()` on Windows via `#ifdef WIN32`), cluster name/node and groups from the handshake globals, and writes it to shared memory via `metadata_provider_update()`

This change does not alter the message flow. No additional keepalives or messages are sent. The existing `run_notify()` cycle and `HC_STARTUP` path remain untouched. The only difference is that shared memory already contains full metadata by the time the first keepalive reads it, because the data is seeded by the same process (`agentd`) that already receives it during the handshake, removing the dependency on `wazuh-modulesd` startup timing.

When `agent-info` eventually starts, its `populateAgentMetadata()` overwrites shared memory with the same data, maintaining the existing refresh cycle.

### Results and Evidence

Test Environment

| VM | Role | IP | OS | Arch |
|---|---:|---:|---:|---:|
| aio | AIO | 192.168.139.95 | Ubuntu 24.04 | aarch64 |
| agent-main | Agent (baseline) | 192.168.139.66 | Ubuntu 24.04 | aarch64 |
| agent-dev | Agent (fix) | 192.168.139.238 | Ubuntu 24.04 | aarch64 |
| FABIO | WinAgent (fix) | 192.168.18.10 | Microsoft Windows 11 Pro | x86_64 |

#### Baseline

Manager

```
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:425 at validate_control_msg(): DEBUG: Agent agent-main sent HC_STARTUP from '192.168.139.66'
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:492 at validate_control_msg(): DEBUG: Sending module limits to agent 004
...
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'agent-main'
2026/04/14 19:43:56 wazuh-manager-remoted[1046] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 004
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '004'
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"merged_sum":"x"}}'
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:732 at assign_group_to_agent(): DEBUG: Agent '004' with file 'merged.mg' MD5 'x'
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:743 at assign_group_to_agent(): DEBUG: Group assigned: 'default'
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:686 at save_controlmsg(): DEBUG: Agent '004' sent incomplete keepalive, deferring cluster sync (syncreq) until complete metadata is received
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:1788 at wait_for_msgs(): DEBUG: Sending file 'default/merged.mg' to agent '004'.
2026/04/14 19:43:56 wazuh-manager-remoted[1046] manager.c:1804 at wait_for_msgs(): DEBUG: End sending file 'default/merged.mg' to agent '004'.
...
2026/04/14 19:44:16 wazuh-manager-remoted[1046] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'agent-main'
2026/04/14 19:44:16 wazuh-manager-remoted[1046] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 004
2026/04/14 19:44:16 wazuh-manager-remoted[1046] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '004'
2026/04/14 19:44:16 wazuh-manager-remoted[1046] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"merged_sum":"ca35f9148a3273413eccb79f149f4757"}}'
2026/04/14 19:44:16 wazuh-manager-remoted[1046] manager.c:1559 at lookfor_agent_group(): DEBUG: Agent '004' group is 'default'
2026/04/14 19:44:16 wazuh-manager-remoted[1046] manager.c:686 at save_controlmsg(): DEBUG: Agent '004' sent incomplete keepalive, deferring cluster sync (syncreq) until complete metadata is received
...
2026/04/14 19:44:36 wazuh-manager-remoted[1046] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'agent-main'
2026/04/14 19:44:36 wazuh-manager-remoted[1046] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 004
2026/04/14 19:44:36 wazuh-manager-remoted[1046] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '004'
2026/04/14 19:44:36 wazuh-manager-remoted[1046] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"id":"004","name":"agent-main","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"agent-main","architecture":"aarch64","ip":"192.168.139.66","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}'
2026/04/14 19:44:36 wazuh-manager-remoted[1046] manager.c:1559 at lookfor_agent_group(): DEBUG: Agent '004' group is 'default'
```

Agent

```
2026/04/14 19:43:56 wazuh-agentd[7330] start_agent.c:382 at connect_server(): DEBUG: Trying to connect to server ([192.168.139.95]:1514/tcp).
2026/04/14 19:43:56 wazuh-agentd[7330] start_agent.c:642 at agent_handshake_to_server(): DEBUG: Module limits received from manager
...
2026/04/14 19:43:56 wazuh-agentd[7330] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/14 19:43:56 wazuh-agentd[7330] notify.c:91 at build_json_keepalive(): DEBUG: Metadata not yet available, using minimal keepalive
2026/04/14 19:43:56 wazuh-agentd[7330] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"merged_sum":"x"}}
2026/04/14 19:43:56 wazuh-agentd[7330] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-agent ack '
...
2026/04/14 19:43:56 wazuh-agentd[7330] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-up file ca35f9148a3273413eccb79f149f4757 merged.mg'
2026/04/14 19:43:56 wazuh-agentd[7330] receiver.c:92 at receive_msg(): DEBUG: Received message: '#default
!76 agent.conf
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
'
2026/04/14 19:43:56 wazuh-agentd[7330] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-close file'
...
2026/04/14 19:44:16 wazuh-agentd[7330] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/14 19:44:16 wazuh-agentd[7330] notify.c:91 at build_json_keepalive(): DEBUG: Metadata not yet available, using minimal keepalive
2026/04/14 19:44:16 wazuh-agentd[7330] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"merged_sum":"ca35f9148a3273413eccb79f149f4757"}}
...
2026/04/14 19:44:17 wazuh-modulesd:agent-info[7461] wm_agent_info.c:583 at wm_agent_info_main(): DEBUG: Starting agent-info module.
...
2026/04/14 19:44:36 wazuh-agentd[7330] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/14 19:44:36 wazuh-agentd[7330] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"004","name":"agent-main","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"agent-main","architecture":"aarch64","ip":"192.168.139.66","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}
2026/04/14 19:44:36 wazuh-agentd[7330] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-agent ack ' 
```

#### Fix

**Unix**

Manager

```
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:425 at validate_control_msg(): DEBUG: Agent agent-dev sent HC_STARTUP from '192.168.139.238'
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:492 at validate_control_msg(): DEBUG: Sending module limits to agent 006
...
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'agent-dev'
2026/04/15 18:46:35 wazuh-manager-remoted[1024] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 006
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '006'
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"id":"006","name":"agent-dev","version":"v5.0.0","merged_sum":"x","groups":["default"]},"host":{"hostname":"agent-dev","architecture":"aarch64","ip":"192.168.139.238","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}'
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:732 at assign_group_to_agent(): DEBUG: Agent '006' with file 'merged.mg' MD5 'x'
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:743 at assign_group_to_agent(): DEBUG: Group assigned: 'default'
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:1788 at wait_for_msgs(): DEBUG: Sending file 'default/merged.mg' to agent '006'.
2026/04/15 18:46:35 wazuh-manager-remoted[1024] manager.c:1804 at wait_for_msgs(): DEBUG: End sending file 'default/merged.mg' to agent '006'.
...
2026/04/15 18:46:55 wazuh-manager-remoted[1024] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'agent-dev'
2026/04/15 18:46:55 wazuh-manager-remoted[1024] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 006
2026/04/15 18:46:55 wazuh-manager-remoted[1024] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '006'
2026/04/15 18:46:55 wazuh-manager-remoted[1024] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"id":"006","name":"agent-dev","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"agent-dev","architecture":"aarch64","ip":"192.168.139.238","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}'
```

Agent

```
2026/04/15 18:46:35 wazuh-agentd[6533] start_agent.c:383 at connect_server(): DEBUG: Trying to connect to server ([192.168.139.95]:1514/tcp).
2026/04/15 18:46:35 wazuh-agentd[6533] start_agent.c:741 at agent_handshake_to_server(): DEBUG: Module limits received from manager
...
2026/04/15 18:46:35 wazuh-agentd[6533] start_agent.c:667 at populate_early_metadata(): DEBUG: Early metadata populated into shared memory
...
2026/04/15 18:46:35 wazuh-agentd[6533] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/15 18:46:35 wazuh-agentd[6533] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"006","name":"agent-dev","version":"v5.0.0","merged_sum":"x","groups":["default"]},"host":{"hostname":"agent-dev","architecture":"aarch64","ip":"192.168.139.238","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}
2026/04/15 18:46:35 wazuh-agentd[6533] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-agent ack '
...
2026/04/15 18:46:35 wazuh-agentd[6533] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-up file ca35f9148a3273413eccb79f149f4757 merged.mg'
2026/04/15 18:46:35 wazuh-agentd[6533] receiver.c:92 at receive_msg(): DEBUG: Received message: '#default
!76 agent.conf
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
'
2026/04/15 18:46:35 wazuh-agentd[6533] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-close file'
...
2026/04/15 18:46:55 wazuh-agentd[6533] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/15 18:46:55 wazuh-agentd[6533] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"006","name":"agent-dev","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"agent-dev","architecture":"aarch64","ip":"192.168.139.238","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}} 
```

**Win**

Manager

```
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:425 at validate_control_msg(): DEBUG: Agent FABIO sent HC_STARTUP from '127.0.0.1'
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:492 at validate_control_msg(): DEBUG: Sending module limits to agent 010
...
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'FABIO'
2026/04/15 19:34:39 wazuh-manager-remoted[1024] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 010
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '010'
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"id":"010","name":"FABIO","version":"v5.0.0","merged_sum":"x","groups":["default"]},"host":{"hostname":"FABIO","architecture":"x86_64","ip":"192.168.18.10","os":{"name":"Microsoft Windows 11 Pro","version":"10.0.26200.8037","type":"windows"}},"cluster":{"name":"wazuh","node":"node01"}}'
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:732 at assign_group_to_agent(): DEBUG: Agent '010' with file 'merged.mg' MD5 'x'
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:743 at assign_group_to_agent(): DEBUG: Group assigned: 'default'
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:1788 at wait_for_msgs(): DEBUG: Sending file 'default/merged.mg' to agent '010'.
2026/04/15 19:34:39 wazuh-manager-remoted[1024] manager.c:1804 at wait_for_msgs(): DEBUG: End sending file 'default/merged.mg' to agent '010'.
...
2026/04/15 19:34:41 wazuh-manager-remoted[1024] manager.c:467 at validate_control_msg(): DEBUG: Received JSON keepalive from agent 'FABIO'
2026/04/15 19:34:41 wazuh-manager-remoted[1024] secure.c:847 at HandleSecureMessage(): DEBUG: Parsed JSON keepalive from agent 010
2026/04/15 19:34:41 wazuh-manager-remoted[1024] manager.c:556 at save_controlmsg(): DEBUG: Processing JSON keepalive from agent '010'
2026/04/15 19:34:41 wazuh-manager-remoted[1024] manager.c:627 at save_controlmsg(): DEBUG: save_controlmsg(): inserting '{"version":"1.0","agent":{"id":"010","name":"FABIO","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"FABIO","architecture":"x86_64","ip":"192.168.18.10","os":{"name":"Microsoft Windows 11 Pro","version":"10.0.26200.8037","type":"windows"}},"cluster":{"name":"wazuh","node":"node01"}}'
```

Agent

```
2026/04/15 19:34:39 wazuh-agent[18696] start_agent.c:383 at connect_server(): DEBUG: Trying to connect to server ([192.168.18.198]:1514/tcp).
2026/04/15 19:34:39 wazuh-agent[18696] start_agent.c:741 at agent_handshake_to_server(): DEBUG: Module limits received from manager
...
2026/04/15 19:34:39 wazuh-agent[18696] start_agent.c:667 at populate_early_metadata(): DEBUG: Early metadata populated into shared memory
...
2026/04/15 19:34:39 wazuh-agent[18696] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/15 19:34:39 wazuh-agent[18696] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"010","name":"FABIO","version":"v5.0.0","merged_sum":"x","groups":["default"]},"host":{"hostname":"FABIO","architecture":"x86_64","ip":"192.168.18.10","os":{"name":"Microsoft Windows 11 Pro","version":"10.0.26200.8037","type":"windows"}},"cluster":{"name":"wazuh","node":"node01"}}
2026/04/15 19:34:39 wazuh-agent[18696] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-agent ack '
2026/04/15 19:34:39 wazuh-agent[18696] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-up file ca35f9148a3273413eccb79f149f4757 merged.mg'
2026/04/15 19:34:39 wazuh-agent[18696] receiver.c:92 at receive_msg(): DEBUG: Received message: '#default
!76 agent.conf
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
'
2026/04/15 19:34:39 wazuh-agent[18696] receiver.c:92 at receive_msg(): DEBUG: Received message: '#!-close file'
...
2026/04/15 19:34:41 wazuh-agent[15788] notify.c:229 at run_notify(): DEBUG: Sending agent notification.
2026/04/15 19:34:41 wazuh-agent[15788] notify.c:281 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"010","name":"FABIO","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"FABIO","architecture":"x86_64","ip":"192.168.18.10","os":{"name":"Microsoft Windows 11 Pro","version":"10.0.26200.8037","type":"windows"}},"cluster":{"name":"wazuh","node":"node01"}}
```

#### Test agent connection with previous `.wazuh_agent_metadata` file

Agent

`.wazuh_agent_metadata`
```
root@agent-dev:~# cat /var/ossec/var/run/.wazuh_agent_metadata
001agent-devv5.0.0aarch64agent-devUbuntulinuxubuntu24.04.4 LTS (Noble Numbat)wazuhnode01default
```
`client.keys`
```
root@agent-dev:~# cat /var/ossec/etc/client.keys
001 agent-dev any fba105c8da5a1f2883baa7d6b15c28eaf8e9c4ab2822a3be6b9c1a7c2631d96e
```
Every module sync completed
```
2026/04/16 14:48:09 wazuh-modulesd:syscollector[1816] logging_helper.c:31 at taggedLogFunction(): INFO: Starting inventory synchronization.
2026/04/16 14:48:09 wazuh-modulesd:syscollector[1816] logging_helper.c:37 at taggedLogFunction(): DEBUG: No items to synchronize in DELTA mode
2026/04/16 14:48:09 wazuh-modulesd:syscollector[1816] logging_helper.c:37 at taggedLogFunction(): DEBUG: syscollector_vd: No items to synchronize in DELTA mode
2026/04/16 14:48:09 wazuh-modulesd:syscollector[1816] logging_helper.c:31 at taggedLogFunction(): INFO: Syscollector synchronization process finished successfully.
...
2026/04/16 14:49:10 wazuh-modulesd:sca[1816] wm_sca.c:292 at sca_log_callback(): INFO: Starting SCA synchronization.
2026/04/16 14:49:10 wazuh-modulesd:sca[1816] wm_sca.c:286 at sca_log_callback(): DEBUG: No items to synchronize in DELTA mode
2026/04/16 14:49:10 wazuh-modulesd:sca[1816] wm_sca.c:292 at sca_log_callback(): INFO: SCA synchronization finished successfully.
...
2026/04/16 14:49:35 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/04/16 14:49:35 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
```

Manager

```
root@aio:~/docs# sqlite3 /var/wazuh-manager/queue/db/global.db
SQLite version 3.45.1 2024-01-30 16:01:20
Enter ".help" for usage hints.
sqlite> SELECT * FROM agent;
1|agent-dev|192.168.139.238|any|fba105c8da5a1f2883baa7d6b15c28eaf8e9c4ab2822a3be6b9c1a7c2631d96e|Ubuntu|24.04.4 LTS (Noble Numbat)|24|04|ubuntu|aarch64|v5.0.0|ca35f9148a3273413eccb79f149f4757|node01|1776367963|1776370063|default|37a8eec1|syncreq|synced|disconnected|1776370075|synced|3
```

After stopping agent, removing `client.keys` (and manually from dashboard) and all db from syscollector, fim, sca and agent-info leaving only previous `.wazuh_agent_metadata`

```
root@agent-dev:~# /var/ossec/bin/wazuh-control stop
root@agent-dev:~# cat /var/ossec/var/run/.wazuh_agent_metadata
001agent-devv5.0.0aarch64agent-devUbuntulinuxubuntu24.04.4 LTS (Noble Numbat)wazuhnode01default
root@agent-dev:~# rm -f /var/ossec/etc/client.keys
root@agent-dev:~# rm -f /var/ossec/etc/shared/merged.mg
root@agent-dev:~# rm -f /var/ossec/queue/diff/*
root@agent-dev:~# rm -f /var/ossec/queue/rids/*
root@agent-dev:~# rm -f /var/ossec/queue/agent_info/db/*
root@agent-dev:~# rm -f /var/ossec/queue/alerts/*
root@agent-dev:~# rm -f /var/ossec/queue/fim/db/*
root@agent-dev:~# rm -f /var/ossec/queue/logcollector/*
root@agent-dev:~# rm -f /var/ossec/queue/sca/db/*
root@agent-dev:~# rm -f /var/ossec/queue/sockets/*
root@agent-dev:~# rm -f /var/ossec/queue/syscollector/db/*
root@agent-dev:~# rm -f /var/ossec/logs/ossec.log
root@agent-dev:~# /var/ossec/bin/wazuh-control start
```

Agent

`.wazuh_agent_metadata`
```
root@agent-dev:~# cat /var/ossec/var/run/.wazuh_agent_metadata
002agent-devv5.0.0aarch64agent-devUbuntulinuxubuntu24.04.4 LTS (Noble Numbat)wazuhnode01default
```
`client.keys`
```
root@agent-dev:~# cat /var/ossec/etc/client.keys
002 agent-dev any 85ccb82b3052e2f0c9cf9e217bdd222cf58137811206e48f815157c52222d811
```
Every module sync completed
```
2026/04/16 15:17:51 wazuh-modulesd:syscollector[2159] logging_helper.c:31 at taggedLogFunction(): INFO: Starting inventory synchronization.
...
2026/04/16 15:18:28 wazuh-modulesd:syscollector[2159] logging_helper.c:40 at taggedLogFunction(): DEBUG: syscollector_vd: Synchronization completed successfully.                                                                                                                         2026/04/16 15:18:28 wazuh-modulesd:syscollector[2159] logging_helper.c:31 at taggedLogFunction(): INFO: Syscollector synchronization process finished successfully.
...
2026/04/16 15:17:56 wazuh-modulesd:sca[2159] wm_sca.c:292 at sca_log_callback(): INFO: Starting SCA synchronization.
...
2026/04/16 15:18:08 wazuh-modulesd:sca[2159] wm_sca.c:292 at sca_log_callback(): INFO: SCA synchronization finished successfully.
...
2026/04/16 15:17:51 wazuh-syscheckd: INFO: Starting FIM synchronization.
...
2026/04/16 15:19:08 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
```

Manager

```
root@aio:~/docs# sqlite3 /var/wazuh-manager/queue/db/global.db
SQLite version 3.45.1 2024-01-30 16:01:20
Enter ".help" for usage hints.
sqlite> SELECT * FROM agent;
2|agent-dev|192.168.139.238|any|85ccb82b3052e2f0c9cf9e217bdd222cf58137811206e48f815157c52222d811|Ubuntu|24.04.4 LTS (Noble Numbat)|24|04|ubuntu|aarch64|v5.0.0|ca35f9148a3273413eccb79f149f4757|node01|1776370630|1776371110|default|37a8eec1|syncreq|synced|active|0|synced|0
```

### Artifacts Affected

- `wazuh-agentd` (all platforms)

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- Updated `test_start_agent.c` to account for the new `populate_early_metadata()` call on every successful handshake:
  - Added linker wrap flags for `metadata_provider_update`, `get_unix_version`, `get_win_version`, and `free_osinfo` in `CMakeLists.txt` so the test is isolated from real shared memory and OS queries
  - Added mock wrapper stubs (`__wrap_metadata_provider_update`, `__wrap_get_unix_version`, `__wrap_get_win_version`, `__wrap_free_osinfo`) that return controlled values
  - Each successful handshake sub-test in `test_agent_handshake_to_server` now sets up mock expectations: `get_unix_version`/`get_win_version` returns `NULL` (via `#ifdef TEST_WINAGENT`), `metadata_provider_update` returns 0 (success)
  - `mdebug1` expected call counts incremented by 1 for each successful handshake path (accounts for the `"Early metadata populated into shared memory"` log)

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...