### PR TITLE
feat(remoted): add TLS support to syslog TCP input listener

### DIFF
--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -31,6 +31,27 @@
     <protocol>tcp</protocol>
   </remote>
 
+  <!--
+    Optional: Syslog-over-TLS input listener.
+    Uncomment to accept encrypted syslog from firewalls, routers, and other
+    appliances that support RFC 5425 syslog-over-TLS (FortiGate, Cisco,
+    Palo Alto, rsyslog with omfwd, syslog-ng, etc.).
+
+    Supports server-authentication TLS (like HTTPS) by default, and optional
+    mutual TLS when <tls_ca_cert> is supplied.
+
+    <remote>
+      <connection>syslog</connection>
+      <protocol>tcp</protocol>
+      <port>6514</port>
+      <tls>yes</tls>
+      <tls_cert>etc/syslog-tls.crt</tls_cert>
+      <tls_key>etc/syslog-tls.key</tls_key>
+      <tls_min_version>1.2</tls_min_version>
+      <allowed-ips>0.0.0.0/0</allowed-ips>
+    </remote>
+  -->
+
   <!-- Policy monitoring -->
   <rootcheck>
     <disabled>no</disabled>

--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -63,6 +63,13 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     const char *xml_rids_closing_time = "rids_closing_time";
     const char *xml_connection_overtake_time = "connection_overtake_time";
 
+    /* TLS options for syslog input (per-block) */
+    const char *xml_tls = "tls";
+    const char *xml_tls_cert = "tls_cert";
+    const char *xml_tls_key = "tls_key";
+    const char *xml_tls_ca_cert = "tls_ca_cert";
+    const char *xml_tls_min_version = "tls_min_version";
+
     logr = (remoted *)d1;
 
     /* Getting allowed-ips */
@@ -118,7 +125,15 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     logr->proto = (int *) realloc(logr->proto, sizeof(int) * (pl + 2));
     logr->ipv6 = (int *) realloc(logr->ipv6, sizeof(int) * (pl + 2));
     logr->lip = (char **) realloc(logr->lip, sizeof(char *) * (pl + 2));
-    if (!logr->port || !logr->conn || !logr->proto || !logr->ipv6 || !logr->lip) {
+    logr->tls_enabled = (int *) realloc(logr->tls_enabled, sizeof(int) * (pl + 2));
+    logr->tls_cert = (char **) realloc(logr->tls_cert, sizeof(char *) * (pl + 2));
+    logr->tls_key = (char **) realloc(logr->tls_key, sizeof(char *) * (pl + 2));
+    logr->tls_ca_cert = (char **) realloc(logr->tls_ca_cert, sizeof(char *) * (pl + 2));
+    logr->tls_min_version = (int *) realloc(logr->tls_min_version, sizeof(int) * (pl + 2));
+    logr->ssl_ctx = (SSL_CTX **) realloc(logr->ssl_ctx, sizeof(SSL_CTX *) * (pl + 2));
+    if (!logr->port || !logr->conn || !logr->proto || !logr->ipv6 || !logr->lip ||
+        !logr->tls_enabled || !logr->tls_cert || !logr->tls_key || !logr->tls_ca_cert ||
+        !logr->tls_min_version || !logr->ssl_ctx) {
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
 
@@ -127,12 +142,24 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     logr->proto[pl] = 0;
     logr->ipv6[pl] = 0;
     logr->lip[pl] = NULL;
+    logr->tls_enabled[pl] = 0;
+    logr->tls_cert[pl] = NULL;
+    logr->tls_key[pl] = NULL;
+    logr->tls_ca_cert[pl] = NULL;
+    logr->tls_min_version[pl] = 12;     /* Default: TLS 1.2 floor */
+    logr->ssl_ctx[pl] = NULL;
 
     logr->port[pl + 1] = 0;
     logr->conn[pl + 1] = 0;
     logr->proto[pl + 1] = 0;
     logr->ipv6[pl + 1] = 0;
     logr->lip[pl + 1] = NULL;
+    logr->tls_enabled[pl + 1] = 0;
+    logr->tls_cert[pl + 1] = NULL;
+    logr->tls_key[pl + 1] = NULL;
+    logr->tls_ca_cert[pl + 1] = NULL;
+    logr->tls_min_version[pl + 1] = 12;
+    logr->ssl_ctx[pl + 1] = NULL;
 
     logr->rids_closing_time = DEFAULT_RIDS_CLOSING_TIME;
 
@@ -269,6 +296,46 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
 
             OS_ClearNode(children);
 
+        } else if (strcasecmp(node[i]->element, xml_tls) == 0) {
+            if (strcasecmp(node[i]->content, "yes") == 0) {
+                logr->tls_enabled[pl] = 1;
+            } else if (strcasecmp(node[i]->content, "no") == 0) {
+                logr->tls_enabled[pl] = 0;
+            } else {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+        } else if (strcasecmp(node[i]->element, xml_tls_cert) == 0) {
+            if (strlen(node[i]->content) == 0) {
+                merror("Empty value for element '%s'.", node[i]->element);
+                return (OS_INVALID);
+            }
+            os_free(logr->tls_cert[pl]);
+            os_strdup(node[i]->content, logr->tls_cert[pl]);
+        } else if (strcasecmp(node[i]->element, xml_tls_key) == 0) {
+            if (strlen(node[i]->content) == 0) {
+                merror("Empty value for element '%s'.", node[i]->element);
+                return (OS_INVALID);
+            }
+            os_free(logr->tls_key[pl]);
+            os_strdup(node[i]->content, logr->tls_key[pl]);
+        } else if (strcasecmp(node[i]->element, xml_tls_ca_cert) == 0) {
+            if (strlen(node[i]->content) == 0) {
+                merror("Empty value for element '%s'.", node[i]->element);
+                return (OS_INVALID);
+            }
+            os_free(logr->tls_ca_cert[pl]);
+            os_strdup(node[i]->content, logr->tls_ca_cert[pl]);
+        } else if (strcasecmp(node[i]->element, xml_tls_min_version) == 0) {
+            if (strcmp(node[i]->content, "1.2") == 0) {
+                logr->tls_min_version[pl] = 12;
+            } else if (strcmp(node[i]->content, "1.3") == 0) {
+                logr->tls_min_version[pl] = 13;
+            } else {
+                merror("Invalid value for '<%s>': '%s'. Allowed values are '1.2' or '1.3'.",
+                       node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);
@@ -305,6 +372,38 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     if (logr->conn[pl] == SYSLOG_CONN && defined_queue_size) {
         merror("Invalid option <%s> for Syslog remote connection.", xml_queue_size);
         return OS_INVALID;
+    }
+
+    /* TLS validation: enforce constraints on this block only. */
+    if (logr->tls_enabled[pl]) {
+        if (logr->conn[pl] != SYSLOG_CONN) {
+            merror("<tls> is only supported on syslog listeners. "
+                   "Agent communication is already encrypted by the Wazuh secure protocol.");
+            return OS_INVALID;
+        }
+
+        if (!(logr->proto[pl] & REMOTED_NET_PROTOCOL_TCP)) {
+            merror("<tls>yes</tls> requires <protocol>tcp</protocol>. "
+                   "TLS over UDP (DTLS) is not supported.");
+            return OS_INVALID;
+        }
+
+        if (logr->proto[pl] & REMOTED_NET_PROTOCOL_UDP) {
+            merror("<tls>yes</tls> cannot be combined with UDP. "
+                   "Use a dedicated <protocol>tcp</protocol> listener for TLS.");
+            return OS_INVALID;
+        }
+
+        if (!logr->tls_cert[pl] || !logr->tls_key[pl]) {
+            merror("<tls>yes</tls> requires both <tls_cert> and <tls_key> to be set.");
+            return OS_INVALID;
+        }
+    } else {
+        /* TLS is off: reject orphaned tls_* elements so typos don't go unnoticed. */
+        if (logr->tls_cert[pl] || logr->tls_key[pl] || logr->tls_ca_cert[pl]) {
+            merror("<tls_cert>, <tls_key>, and <tls_ca_cert> require <tls>yes</tls>.");
+            return OS_INVALID;
+        }
     }
 
     return (0);

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -31,6 +31,8 @@
 #include "shared.h"
 #include "global-config.h"
 
+#include <openssl/ssl.h>
+
 /* socklen_t header */
 typedef struct _remoted {
     int *proto;
@@ -43,6 +45,17 @@ typedef struct _remoted {
     os_ip **denyips;
 
     bool allow_higher_versions;
+
+    /* Per-listener-block TLS configuration for syslog input.
+     * Arrays are parallel to port[]/conn[]/proto[] and indexed by listener block.
+     * Populated by Read_Remote() at config parse time.
+     */
+    int *tls_enabled;           ///< 1 if TLS is enabled for this block, 0 otherwise
+    char **tls_cert;            ///< Path to server certificate (PEM), required when tls_enabled
+    char **tls_key;             ///< Path to server private key (PEM), required when tls_enabled
+    char **tls_ca_cert;         ///< Path to CA bundle for client cert verification (PEM), optional; presence enables mutual TLS
+    int *tls_min_version;       ///< Minimum TLS protocol: 12 for TLS 1.2 (default), 13 for TLS 1.3
+    SSL_CTX **ssl_ctx;          ///< OpenSSL context built at startup, NULL when tls_enabled is 0
 
     int m_queue;
     int tcp_sock;       ///< This socket is used to receive requests over TCP

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -160,8 +160,20 @@ int main(int argc, char **argv)
         merror_exit("Remoted connection is not configured.");
     }
 
+    /* Build TLS contexts for any syslog listener with <tls>yes</tls> set.
+     * This runs before daemonize, chroot, and privilege drop so that
+     * certificate, key, and CA paths can be normal filesystem paths
+     * (absolute or relative to the current working directory). The
+     * resulting SSL_CTX objects survive chroot and fork.
+     */
+    if (load_remoted_tls_contexts(&logr) < 0) {
+        merror_exit("Failed to initialize TLS for one or more syslog listeners. "
+                    "Refusing to start in a degraded state.");
+    }
+
     /* Exit if test_config is set */
     if (test_config) {
+        free_remoted_tls_contexts(&logr);
         exit(0);
     }
 

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -15,6 +15,10 @@
 #include "shared.h"
 #include "os_net/os_net.h"
 #include "remoted.h"
+#include "os_auth/auth.h"
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #define WM_STRCAT_NO_SEPARATOR 0
 
@@ -22,6 +26,114 @@
 keystore keys;
 remoted logr;
 char* node_name;
+
+/* Forward declaration of the local helper used by load_remoted_tls_contexts(). */
+static SSL_CTX *build_syslog_tls_context(const char *cert,
+                                         const char *key,
+                                         const char *ca_cert,
+                                         int min_version,
+                                         int block_index);
+
+int load_remoted_tls_contexts(remoted *logr_cfg)
+{
+    int i;
+    int any_failed = 0;
+
+    if (logr_cfg == NULL || logr_cfg->conn == NULL) {
+        return 0;
+    }
+
+    for (i = 0; logr_cfg->conn[i] != 0; i++) {
+        if (logr_cfg->conn[i] != SYSLOG_CONN || !logr_cfg->tls_enabled[i]) {
+            continue;
+        }
+
+        logr_cfg->ssl_ctx[i] = build_syslog_tls_context(logr_cfg->tls_cert[i],
+                                                        logr_cfg->tls_key[i],
+                                                        logr_cfg->tls_ca_cert[i],
+                                                        logr_cfg->tls_min_version[i],
+                                                        i);
+        if (logr_cfg->ssl_ctx[i] == NULL) {
+            any_failed = 1;
+        }
+    }
+
+    return any_failed ? -1 : 0;
+}
+
+void free_remoted_tls_contexts(remoted *logr_cfg)
+{
+    int i;
+
+    if (logr_cfg == NULL || logr_cfg->ssl_ctx == NULL || logr_cfg->conn == NULL) {
+        return;
+    }
+
+    for (i = 0; logr_cfg->conn[i] != 0; i++) {
+        if (logr_cfg->ssl_ctx[i] != NULL) {
+            SSL_CTX_free(logr_cfg->ssl_ctx[i]);
+            logr_cfg->ssl_ctx[i] = NULL;
+        }
+    }
+}
+
+static SSL_CTX *build_syslog_tls_context(const char *cert,
+                                         const char *key,
+                                         const char *ca_cert,
+                                         int min_version,
+                                         int block_index)
+{
+    SSL_CTX *ctx;
+    int verify_client = (ca_cert != NULL) ? 1 : 0;
+
+    /* Reuse the same helper that wazuh-authd uses for agent enrollment so every
+     * TLS endpoint in the Wazuh manager shares identical cipher and protocol
+     * policy. auto_method=0 pins the minimum protocol version to TLS 1.2.
+     */
+    ctx = os_ssl_keys(1,                /* is_server */
+                      NULL,             /* os_dir (paths below are already resolvable) */
+                      DEFAULT_CIPHERS,
+                      cert,
+                      key,
+                      ca_cert,          /* NULL disables client cert verification */
+                      0);               /* auto_method=0 -> TLS 1.2 floor */
+    if (ctx == NULL) {
+        merror("Failed to build TLS context for syslog listener block %d. "
+               "Check that the certificate and key files exist and are readable: "
+               "cert='%s', key='%s'.",
+               block_index, cert, key);
+        return NULL;
+    }
+
+    /* Promote the minimum protocol version to TLS 1.3 if the user asked for it.
+     * Older versions of OpenSSL lack SSL_CTX_set_min_proto_version; we require
+     * at least OpenSSL 1.1.0 via the existing authd dependency chain so this
+     * call is always available on supported platforms.
+     */
+    if (min_version >= 13) {
+        if (SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION) != 1) {
+            char err_buf[256];
+            ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
+            merror("Failed to enforce TLS 1.3 minimum on syslog listener block %d: %s",
+                   block_index, err_buf);
+            SSL_CTX_free(ctx);
+            return NULL;
+        }
+    }
+
+    /* When a CA bundle is supplied, enforce mutual TLS: any client that cannot
+     * present a certificate signed by one of the trusted CAs is rejected during
+     * the handshake. There is no "optional" client cert mode by design — a
+     * half-verified client is a footgun.
+     */
+    if (verify_client) {
+        SSL_CTX_set_verify(ctx,
+                           SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           NULL);
+    }
+
+    return ctx;
+}
 
 /* Handle remote connections */
 void HandleRemote(int uid)
@@ -114,19 +226,29 @@ void HandleRemote(int uid)
         merror_exit(REMOTED_NET_PROTOCOL_NOT_SET);
     }
 
-    minfo(STARTUP_MSG " Listening on port %d/%s (%s).",
+    minfo(STARTUP_MSG " Listening on port %d/%s (%s%s).",
         (int)getpid(),
         logr.port[position],
         str_protocol,
-        logr.conn[position] == SECURE_CONN ? "secure" : "syslog");
+        logr.conn[position] == SECURE_CONN ? "secure" : "syslog",
+        (logr.conn[position] == SYSLOG_CONN && logr.tls_enabled[position]) ? " - TLS" : "");
     os_free(str_protocol);
+
+    if (logr.conn[position] == SYSLOG_CONN && logr.tls_enabled[position]) {
+        const char *min_ver = (logr.tls_min_version[position] >= 13) ? "1.3" : "1.2";
+        const char *ca = logr.tls_ca_cert[position];
+        minfo("Syslog TLS ready on port %d (min protocol TLS %s, client cert %s).",
+              logr.port[position],
+              min_ver,
+              ca ? "required (mutual TLS)" : "not required");
+    }
 
     /* If secure connection, deal with it */
     if (logr.conn[position] == SECURE_CONN) {
         HandleSecure();
     }
     else if (logr.proto[position] == REMOTED_NET_PROTOCOL_TCP) {
-        HandleSyslogTCP();
+        HandleSyslogTCP(logr.ssl_ctx[position]);
     }
     else { /* If not, deal with syslog */
         HandleSyslog();

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -15,6 +15,8 @@
 #define ARGV0 "wazuh-remoted"
 #endif
 
+#include <openssl/ssl.h>
+
 #include "../config/config.h"
 #include "../config/remote-config.h"
 #include "../config/global-config.h"
@@ -73,11 +75,34 @@ void HandleRemote(int uid) __attribute__((noreturn));
 /* Handle Syslog */
 void HandleSyslog(void) __attribute__((noreturn));
 
-/* Handle Syslog TCP */
-void HandleSyslogTCP(void) __attribute__((noreturn));
+/* Handle Syslog TCP. If ssl_ctx is non-NULL, each accepted connection
+ * will perform a TLS handshake before any application data is read. */
+void HandleSyslogTCP(SSL_CTX *ssl_ctx) __attribute__((noreturn));
 
 /* Handle Secure connections */
 void HandleSecure() __attribute__((noreturn));
+
+/**
+ * @brief Build OpenSSL contexts for every syslog listener block that has TLS enabled.
+ *
+ * Must be called before chroot so that certificate, key, and CA bundle files can be
+ * located using natural filesystem paths (absolute or relative to the current working
+ * directory). The resulting SSL_CTX objects are stored on logr->ssl_ctx[] and survive
+ * chroot and fork.
+ *
+ * @param logr Remoted configuration structure populated by Read_Remote().
+ * @return 0 on success, -1 if any TLS-enabled listener failed to build a context.
+ */
+int load_remoted_tls_contexts(remoted *logr);
+
+/**
+ * @brief Release every SSL_CTX owned by logr and clear the pointers.
+ *
+ * Safe to call at any time; skips NULL entries.
+ *
+ * @param logr Remoted configuration structure.
+ */
+void free_remoted_tls_contexts(remoted *logr);
 
 /* Forward active response events */
 void *AR_Forward(void *arg) __attribute__((noreturn));

--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -12,6 +12,10 @@
 #include "os_net/os_net.h"
 #include "remoted.h"
 
+#include <ctype.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
 #ifdef WAZUH_UNIT_TESTING
 // Remove static qualifier when unit testing
 #define STATIC
@@ -46,138 +50,312 @@ static int OS_IPNotAllowed(char *srcip)
 }
 
 /**
- * @brief Function that sends a buffer to a queue.
- * @param socket_buffer sockbuffer_t structure that contains the data from the socket.
- * @param srcip String with the IP of the queue where the message will be sent.
+ * @brief Convert an SSL error code into a human-readable string.
+ *
+ * Fills the provided buffer with the OpenSSL error-queue text for the
+ * current thread. If the queue is empty, falls back to SSL_get_error's
+ * numeric code so the caller always has something useful to log.
  */
-void send_buffer(sockbuffer_t *socket_buffer, char *srcip) {
-    char *data_pt = socket_buffer->data;
-    int offset;
-    char * buffer_pt = NULL;
+static void format_ssl_error(SSL *ssl, int ret, char *buf, size_t buf_size)
+{
+    unsigned long err;
+    int ssl_err = SSL_get_error(ssl, ret);
 
-    buffer_pt = strchr(data_pt, '\n');
-
-    while(buffer_pt != NULL) {
-        // Get the position of '\n' in buffer
-        offset = ((int)(buffer_pt - data_pt));
-        *buffer_pt = '\0';
-        // Send message to the queue
-        if (SendMSG(logr.m_queue, data_pt + w_get_pri_header_len(data_pt), srcip, SYSLOG_MQ) < 0) {
-            merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-
-            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
-                merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
-            }
-        }
-        // Re-calculate the used size of buffer and remove the message from the buffer
-        socket_buffer->data_len = socket_buffer->data_len - (offset + 1);
-        data_pt += (offset + 1);
-        // Find the next '\n'
-        buffer_pt = strchr(data_pt, '\n');
+    err = ERR_get_error();
+    if (err != 0) {
+        ERR_error_string_n(err, buf, buf_size);
+    } else {
+        snprintf(buf, buf_size, "SSL_get_error=%d (no queued error)", ssl_err);
     }
-    memcpy(socket_buffer->data, data_pt, socket_buffer->data_len);
-
 }
 
-/* Handle each client */
-static void HandleClient(int client_socket, char *srcip)
+/**
+ * @brief Forward a single, already-framed syslog message to analysisd.
+ *
+ * Reconnects to the analysisd queue on failure and retries once; if that
+ * also fails, the daemon exits because there is no recovery path for a
+ * lost analysisd socket.
+ */
+static void forward_syslog_message(char *msg, char *srcip)
 {
-    int r_sz = 0;
+    if (SendMSG(logr.m_queue, msg + w_get_pri_header_len(msg), srcip, SYSLOG_MQ) < 0) {
+        merror(QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+
+        if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
+            merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
+        }
+    }
+}
+
+/**
+ * @brief Extract and forward every complete syslog record from the socket buffer.
+ *
+ * Supports both framing formats defined by RFC 6587:
+ *
+ *   - @b Non-transparent @b framing (§3.4.2): messages separated by '\n'.
+ *     This is what plain-text syslog has always used over TCP.
+ *
+ *   - @b Octet-counting @b framing (§3.4.1) / RFC 5425: each record is prefixed
+ *     with its byte length in ASCII followed by a single space. This is what
+ *     syslog-over-TLS senders (FortiGate, rsyslog omfwd, syslog-ng, Palo Alto,
+ *     Cisco ASA) use by default.
+ *
+ * The parser auto-detects framing per record by peeking at the first byte.
+ * A conforming syslog message per RFC 3164 / 5424 begins with the PRI header
+ * '<', never a digit, so the heuristic is unambiguous for well-formed input.
+ * Malformed data (bogus octet counts, unterminated records, zero lengths) is
+ * dropped with a warning rather than allowed to stall the connection.
+ *
+ * Any trailing partial record is preserved at the front of the buffer so it
+ * can be completed by the next read.
+ */
+void send_buffer(sockbuffer_t *socket_buffer, char *srcip)
+{
+    char *data_pt = socket_buffer->data;
+    unsigned long remaining = socket_buffer->data_len;
+
+    while (remaining > 0) {
+        /* Octet-counting framing: leading ASCII digits followed by a space. */
+        if (isdigit((unsigned char)data_pt[0])) {
+            unsigned long header_len = 0;
+            unsigned long msg_len = 0;
+            unsigned long i;
+            int saw_space = 0;
+
+            /* Cap the length-prefix scan to 11 characters. That is enough for
+             * any OS_MAXSTR value (currently 65536 -> 5 digits) and prevents
+             * a buffer full of digits from driving us into the rest of the
+             * payload on malformed input. */
+            for (i = 0; i < remaining && i < 11; i++) {
+                if (data_pt[i] == ' ') {
+                    saw_space = 1;
+                    header_len = i + 1;
+                    break;
+                }
+                if (!isdigit((unsigned char)data_pt[i])) {
+                    /* Neither digit nor space — not an octet count. */
+                    break;
+                }
+            }
+
+            if (saw_space) {
+                char *end = NULL;
+                msg_len = strtoul(data_pt, &end, 10);
+
+                if (msg_len == 0 || msg_len > (unsigned long)OS_MAXSTR) {
+                    mwarn("Dropping malformed octet-count framing from '%s' (len=%lu).",
+                          srcip, msg_len);
+                    data_pt++;
+                    remaining--;
+                    continue;
+                }
+
+                if (header_len + msg_len > remaining) {
+                    /* Incomplete record — wait for more data. */
+                    break;
+                }
+
+                /* Temporarily NUL-terminate the record so downstream string
+                 * handling works, then restore the original byte before we
+                 * advance past it. */
+                char saved = data_pt[header_len + msg_len];
+                data_pt[header_len + msg_len] = '\0';
+                forward_syslog_message(data_pt + header_len, srcip);
+                data_pt[header_len + msg_len] = saved;
+
+                data_pt += header_len + msg_len;
+                remaining -= header_len + msg_len;
+                continue;
+            }
+            /* Fall through to newline-delimited parsing if the octet count
+             * didn't actually materialize. */
+        }
+
+        /* Non-transparent framing: split on '\n'. */
+        {
+            char *newline = memchr(data_pt, '\n', remaining);
+            if (newline == NULL) {
+                /* Partial record — wait for more data. */
+                break;
+            }
+
+            unsigned long line_len = newline - data_pt;
+            *newline = '\0';
+            forward_syslog_message(data_pt, srcip);
+            data_pt += line_len + 1;
+            remaining -= line_len + 1;
+        }
+    }
+
+    /* Slide any unprocessed tail back to the front of the buffer so the
+     * next read continues where this one left off. */
+    if (remaining > 0 && data_pt != socket_buffer->data) {
+        memmove(socket_buffer->data, data_pt, remaining);
+    }
+    socket_buffer->data_len = remaining;
+}
+
+/**
+ * @brief Per-connection read loop. Reads bytes from the plain socket or from
+ *        the SSL wrapper and feeds them to send_buffer() for framing.
+ *
+ * Runs inside the forked child of HandleSyslogTCP(), so any exit from this
+ * function terminates that child without affecting the listener.
+ */
+static void HandleClient(int client_socket, SSL *ssl, char *srcip)
+{
     sockbuffer_t socket_buff;
+    int r_sz = 0;
+    char err_buf[256];
 
     os_calloc(OS_MAXSTR + 2, sizeof(char), socket_buff.data);
     socket_buff.data_len = 0;
 
-    /* Create PID file */
     if (CreatePID(ARGV0, getpid()) < 0) {
         merror_exit(PID_ERROR);
     }
-    while (1) {
-        /* If an error occurred, or received 0 bytes, we need to return and close the socket */
-        r_sz = recv(client_socket, socket_buff.data + socket_buff.data_len, OS_MAXSTR - socket_buff.data_len, 0);
-        socket_buff.data_len += r_sz;
 
-        socket_buff.data[socket_buff.data_len] = '\0';
-        switch (r_sz) {
-            case -1:
-                merror(RECV_ERROR, strerror(errno), errno);
-                // Fallthrough
-            case 0:
-                close(client_socket);
-                DeletePID(ARGV0);
-                os_free(socket_buff.data);
-                return;
-            default:
-                mdebug2("Received %d bytes from '%s'", r_sz, srcip);
-                break;
+    while (1) {
+        int space = OS_MAXSTR - (int)socket_buff.data_len;
+        if (space <= 0) {
+            merror("Syslog read buffer from '%s' exhausted without a complete message; "
+                   "dropping connection.", srcip);
+            break;
         }
+
+        if (ssl) {
+            r_sz = SSL_read(ssl, socket_buff.data + socket_buff.data_len, space);
+        } else {
+            r_sz = recv(client_socket, socket_buff.data + socket_buff.data_len, space, 0);
+        }
+
+        if (r_sz <= 0) {
+            if (r_sz < 0) {
+                if (ssl) {
+                    format_ssl_error(ssl, r_sz, err_buf, sizeof(err_buf));
+                    merror("TLS read error from '%s': %s", srcip, err_buf);
+                } else {
+                    merror(RECV_ERROR, strerror(errno), errno);
+                }
+            }
+            break;
+        }
+
+        socket_buff.data_len += (unsigned long)r_sz;
+        socket_buff.data[socket_buff.data_len] = '\0';
+
+        mdebug2("Received %d bytes from '%s'%s", r_sz, srcip, ssl ? " (TLS)" : "");
+
         send_buffer(&socket_buff, srcip);
     }
+
+    if (ssl) {
+        SSL_shutdown(ssl);
+        SSL_free(ssl);
+    }
+    close(client_socket);
+    DeletePID(ARGV0);
+    os_free(socket_buff.data);
 }
 
-/* Handle syslog TCP connections */
-void HandleSyslogTCP()
+/* Handle syslog TCP connections, with optional TLS wrapping. */
+void HandleSyslogTCP(SSL_CTX *ssl_ctx)
 {
     int childcount = 0;
     char srcip[IPSIZE + 1];
 
-    /* Initialize some variables */
     memset(srcip, '\0', IPSIZE + 1);
 
-    /* Connecting to the message queue
-     * Exit if it fails.
-     */
+    /* Connect to the analysisd message queue; exit if it fails. */
     if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0) {
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
     while (1) {
-        /* Wait for the children */
+        /* Reap any finished children before blocking on accept(). */
         while (childcount) {
-            int wp;
-            wp = waitpid((pid_t) - 1, NULL, WNOHANG);
+            int wp = waitpid((pid_t) - 1, NULL, WNOHANG);
             if (wp < 0) {
                 merror(WAITPID_ERROR, errno, strerror(errno));
-            }
-
-            /* if = 0, we still need to wait for the child process */
-            else if (wp == 0) {
+                break;
+            } else if (wp == 0) {
                 break;
             } else {
                 childcount--;
             }
         }
 
-        /* Accept new connections */
         int client_socket = OS_AcceptTCP(logr.tcp_sock, srcip, IPSIZE);
         if (client_socket < 0) {
             mwarn("Accepting TCP connection from client failed: %s (%d)", strerror(errno), errno);
             continue;
         }
 
-        /* Check if IP is allowed here */
         if (OS_IPNotAllowed(srcip)) {
             mwarn(DENYIP_WARN, srcip);
             close(client_socket);
             continue;
         }
 
-        /* Fork to deal with new client */
-        if (fork() == 0) {
-            HandleClient(client_socket, srcip);
-            exit(0);
-        } else {
-            childcount++;
+        /* Fork-per-connection: each child gets an isolated address space so a
+         * protocol bug in OpenSSL cannot corrupt other in-flight sessions. The
+         * SSL_CTX is reference-counted by OpenSSL and safe to share across
+         * forked children via copy-on-write; we only read from it per-connection
+         * via SSL_new(). This matches the model the plain-TCP syslog listener
+         * has always used, so TLS does not change the supervisor's contract. */
+        pid_t pid = fork();
+        if (pid == 0) {
+            SSL *ssl = NULL;
 
-            /* Close client socket, since the child is handling it */
+            if (ssl_ctx != NULL) {
+                ssl = SSL_new(ssl_ctx);
+                if (ssl == NULL) {
+                    char err_buf[256];
+                    ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
+                    merror("Failed to create TLS session for client '%s': %s", srcip, err_buf);
+                    close(client_socket);
+                    exit(1);
+                }
+
+                if (SSL_set_fd(ssl, client_socket) != 1) {
+                    char err_buf[256];
+                    ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
+                    merror("SSL_set_fd failed for client '%s': %s", srcip, err_buf);
+                    SSL_free(ssl);
+                    close(client_socket);
+                    exit(1);
+                }
+
+                int hs = SSL_accept(ssl);
+                if (hs <= 0) {
+                    char err_buf[256];
+                    format_ssl_error(ssl, hs, err_buf, sizeof(err_buf));
+                    merror("TLS handshake failed for client '%s': %s", srcip, err_buf);
+                    SSL_free(ssl);
+                    close(client_socket);
+                    exit(1);
+                }
+
+                minfo("Syslog TLS connection established from '%s' (protocol: %s, cipher: %s).",
+                      srcip,
+                      SSL_get_version(ssl),
+                      SSL_get_cipher_name(ssl));
+            }
+
+            HandleClient(client_socket, ssl, srcip);
+            exit(0);
+        } else if (pid > 0) {
+            childcount++;
             close(client_socket);
-            continue;
+        } else {
+            merror("fork() failed accepting syslog client from '%s': %s", srcip, strerror(errno));
+            close(client_socket);
         }
     }
 }
 
-STATIC size_t w_get_pri_header_len(const char * syslog_msg) {
-
+STATIC size_t w_get_pri_header_len(const char * syslog_msg)
+{
     size_t retval = 0;          // Offset
     char * pri_head_end = NULL; // end of <PRI> head
 

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -100,7 +100,7 @@ list(APPEND remoted_names "test_remote-config")
 list(APPEND remoted_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,ReadConfig -Wl,--wrap,getDefine_Int -Wl,--wrap,get_node_name")
 
 list(APPEND remoted_names "test_syslogtcp")
-list(APPEND remoted_flags "-W")
+list(APPEND remoted_flags "-Wl,--wrap,SendMSG -Wl,--wrap,StartMQ ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND remoted_names "test_remote-state")
 list(APPEND remoted_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \

--- a/src/unit_tests/remoted/test_syslogtcp.c
+++ b/src/unit_tests/remoted/test_syslogtcp.c
@@ -13,14 +13,20 @@
 #include <cmocka.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "../../remoted/remoted.h"
 #include "../../headers/shared.h"
 #include "../../os_net/os_net.h"
+#include "../wrappers/wazuh/shared/mq_op_wrappers.h"
 
-
-/* Forward declarations */
+/* Symbols under test (made non-static by WAZUH_UNIT_TESTING). */
 size_t w_get_pri_header_len(const char * syslog_msg);
+void send_buffer(sockbuffer_t *socket_buffer, char *srcip);
+
+/* The send_buffer helper reads logr.m_queue as an opaque fd to pass to
+ * SendMSG, which is wrapped in these tests — the actual value is unused. */
+remoted logr;
 
 /* setup/teardown */
 
@@ -34,52 +40,192 @@ static int group_teardown(void ** state) {
     return 0;
 }
 
-/* Wrappers */
-
-/* Tests */
-
-// w_get_pri_header_len
+/* --------------------------------------------------------------------
+ *   w_get_pri_header_len (existing tests, unchanged)
+ * -------------------------------------------------------------------- */
 
 void test_w_get_pri_header_len_null(void ** state) {
-
     const ssize_t expected_retval = 0;
     ssize_t retval = w_get_pri_header_len(NULL);
-
     assert_int_equal(retval, expected_retval);
 }
 
 void test_w_get_pri_header_len_no_pri(void ** state) {
-
     const ssize_t expected_retval = 0;
     ssize_t retval = w_get_pri_header_len("test log");
-
     assert_int_equal(retval, expected_retval);
 }
 
 void test_w_get_pri_header_len_w_pri(void ** state) {
-
     const ssize_t expected_retval = 4;
     ssize_t retval = w_get_pri_header_len("<18>test log");
-
     assert_int_equal(retval, expected_retval);
 }
 
 void test_w_get_pri_header_len_not_end(void ** state) {
-
     const ssize_t expected_retval = 0;
     ssize_t retval = w_get_pri_header_len("<18 test log");
-
     assert_int_equal(retval, expected_retval);
+}
+
+/* --------------------------------------------------------------------
+ *   send_buffer — framing parser
+ * -------------------------------------------------------------------- */
+
+/* Populate a sockbuffer_t from a literal C string. */
+static void fill_buffer(sockbuffer_t *buf, const char *bytes, size_t len) {
+    memcpy(buf->data, bytes, len);
+    buf->data_len = len;
+    buf->data[len] = '\0';
+}
+
+/* ---- Newline-delimited framing (RFC 6587 §3.4.2) ---- */
+
+void test_send_buffer_empty(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    storage[0] = '\0';
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
+}
+
+void test_send_buffer_single_newline_message(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    const char *input = "<13>Apr 10 12:00:00 host test message\n";
+    fill_buffer(&buf, input, strlen(input));
+
+    /* PRI header "<13>" is 4 bytes, so the forwarded message skips it. */
+    expect_SendMSG_call("Apr 10 12:00:00 host test message", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
+}
+
+void test_send_buffer_multiple_newline_messages(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    const char *input = "<13>first message\n<14>second message\n<15>third\n";
+    fill_buffer(&buf, input, strlen(input));
+
+    expect_SendMSG_call("first message", "10.0.0.1", SYSLOG_MQ, 0);
+    expect_SendMSG_call("second message", "10.0.0.1", SYSLOG_MQ, 0);
+    expect_SendMSG_call("third", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
+}
+
+void test_send_buffer_partial_newline_message(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    const char *input = "<13>complete\n<14>incomplete no newline";
+    fill_buffer(&buf, input, strlen(input));
+
+    expect_SendMSG_call("complete", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+
+    /* The incomplete trailing record should be preserved for the next read. */
+    assert_int_equal(buf.data_len, strlen("<14>incomplete no newline"));
+    assert_memory_equal(buf.data, "<14>incomplete no newline", buf.data_len);
+}
+
+/* ---- Octet-counting framing (RFC 5425 / RFC 6587 §3.4.1) ---- */
+
+void test_send_buffer_single_octet_counted(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    /* "25 <13>hello from fortigate" — 25 bytes after the space. */
+    const char *input = "25 <13>hello from fortigate";
+    fill_buffer(&buf, input, strlen(input));
+
+    expect_SendMSG_call("hello from fortigate", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
+}
+
+void test_send_buffer_multiple_octet_counted(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    /* Two back-to-back octet-counted messages, no newlines. */
+    const char *input = "10 <13>first!11 <14>second!";
+    fill_buffer(&buf, input, strlen(input));
+
+    expect_SendMSG_call("first!", "10.0.0.1", SYSLOG_MQ, 0);
+    expect_SendMSG_call("second!", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
+}
+
+void test_send_buffer_partial_octet_counted(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    /* Header says 25 bytes but only 12 have arrived so far. */
+    const char *input = "25 <13>hello";
+    fill_buffer(&buf, input, strlen(input));
+
+    /* No SendMSG expected — the record is incomplete. */
+    send_buffer(&buf, "10.0.0.1");
+
+    assert_int_equal(buf.data_len, strlen(input));
+    assert_memory_equal(buf.data, input, buf.data_len);
+}
+
+void test_send_buffer_mixed_framings(void ** state) {
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    /* Octet-counted record followed by a newline-delimited one. */
+    const char *input = "10 <13>first!<14>second\n";
+    fill_buffer(&buf, input, strlen(input));
+
+    expect_SendMSG_call("first!", "10.0.0.1", SYSLOG_MQ, 0);
+    expect_SendMSG_call("second", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
+}
+
+void test_send_buffer_newline_starts_with_lt(void ** state) {
+    /* A conforming RFC 3164/5424 message begins with '<', so the parser must
+     * NOT treat it as octet-counted framing even though the remaining bytes
+     * could look like a number later on. */
+    char storage[OS_MAXSTR + 2];
+    sockbuffer_t buf = { .data = storage, .data_len = 0 };
+    const char *input = "<13>123 looks like a count\n";
+    fill_buffer(&buf, input, strlen(input));
+
+    expect_SendMSG_call("123 looks like a count", "10.0.0.1", SYSLOG_MQ, 0);
+
+    send_buffer(&buf, "10.0.0.1");
+    assert_int_equal(buf.data_len, 0);
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        // Test w_get_pri_header_len
+        /* w_get_pri_header_len (existing) */
         cmocka_unit_test(test_w_get_pri_header_len_null),
         cmocka_unit_test(test_w_get_pri_header_len_no_pri),
         cmocka_unit_test(test_w_get_pri_header_len_w_pri),
         cmocka_unit_test(test_w_get_pri_header_len_not_end),
 
+        /* send_buffer — newline framing */
+        cmocka_unit_test(test_send_buffer_empty),
+        cmocka_unit_test(test_send_buffer_single_newline_message),
+        cmocka_unit_test(test_send_buffer_multiple_newline_messages),
+        cmocka_unit_test(test_send_buffer_partial_newline_message),
+
+        /* send_buffer — octet-counted framing */
+        cmocka_unit_test(test_send_buffer_single_octet_counted),
+        cmocka_unit_test(test_send_buffer_multiple_octet_counted),
+        cmocka_unit_test(test_send_buffer_partial_octet_counted),
+
+        /* send_buffer — framing auto-detect */
+        cmocka_unit_test(test_send_buffer_mixed_framings),
+        cmocka_unit_test(test_send_buffer_newline_starts_with_lt),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/11197|

## Description

Adds opt-in TLS encryption to the `wazuh-remoted` syslog TCP input listener so remote devices (firewalls, log shippers, cloud forwarders) can ship logs over untrusted networks without exposing data in plaintext.

The feature is opt-in per `<remote>` block. If a block does not set `<tls>yes</tls>`, the behaviour is unchanged — plain TCP and UDP syslog listeners keep working exactly as before. TLS is rejected at config-parse time on UDP (no DTLS) and on `secure` connections (agent traffic is already encrypted).

Implementation reuses `os_ssl_keys()` from `os_auth` so every TLS endpoint in the manager shares the same cipher policy and no new dependency is introduced. Certificate and key files are parsed before chroot and privilege drop, so paths can be absolute (e.g. `/etc/letsencrypt/live/<fqdn>/fullchain.pem`) regardless of install prefix.

The `syslogtcp.c` framing parser has also been updated to handle both RFC 6587 framings — non-transparent (newline) and octet-counting (RFC 5425) — auto-detected per record. The previous newline-only parser dropped records from senders like FortiGate and rsyslog `omfwd` that use octet counting over TLS.

## Configuration options

New optional XML elements inside `<remote>`:

```xml
<remote>
  <connection>syslog</connection>
  <protocol>tcp</protocol>
  <port>6514</port>

  <tls>yes</tls>
  <tls_cert>/etc/letsencrypt/live/wazuh.example.com/fullchain.pem</tls_cert>
  <tls_key>/etc/letsencrypt/live/wazuh.example.com/privkey.pem</tls_key>
  <tls_ca_cert>etc/syslog-client-ca.crt</tls_ca_cert>
  <tls_min_version>1.2</tls_min_version>

  <allowed-ips>0.0.0.0/0</allowed-ips>
</remote>
```

- `<tls>` — `yes`/`no` (default `no`)
- `<tls_cert>` / `<tls_key>` — required when TLS is enabled
- `<tls_ca_cert>` — optional; presence enables strict mutual TLS (clients without a valid cert are rejected at handshake)
- `<tls_min_version>` — `1.2` (default) or `1.3`

## Logs/Alerts example

Startup log with TLS enabled:

```
wazuh-remoted: INFO: Started (pid: 99517). Listening on port 6514/TCP (syslog - TLS).
wazuh-remoted: INFO: Syslog TLS ready on port 6514 (min protocol TLS 1.2, client cert not required).
wazuh-remoted: INFO: Syslog TLS connection established from '10.0.10.1' (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384).
```

FortiGate event received over the TLS listener and matched by the bundled `fortigate` decoder chain / rule `81619`:

```json
{
  "rule": {
    "level": 3,
    "id": "81619",
    "description": "Fortigate: Multiple high traffic events from same source.",
    "groups": ["fortigate", "syslog"]
  },
  "previous_output": "date=2026-04-10 time=21:32:21 devname=\"FGVMSLTMXXXXXXXX\" ... srcip=10.0.10.25 ..."
}
```

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows (N/A — server-only)
  - [ ] MAC OS X (N/A — server-only)
- [x] Source installation
- [ ] Package installation
- [x] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind
  - [ ] Dr. Memory
  - [ ] AddressSanitizer

- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [x] Configuration on demand reports new parameters
- [x] The data flow works as expected (agent-manager-api-app)
- [x] Added unit tests (for new features)
- [ ] Stress test for affected components

End-to-end validation was done on a stock Wazuh 4.14.4 all-in-one deployment (Ubuntu 24.04) with a real FortiOS VM shipping syslog over TLS 1.3 to a Let's Encrypt certificate. Events were decoded by the bundled `fortigate` decoders and matched existing rules end-to-end through Filebeat into the dashboard. Plain UDP/514 (UniFi switches) and TLS TCP/6514 (FortiGate) were also tested running simultaneously on the same `wazuh-remoted` instance.
