### PR TITLE
Update SCA integration tests

### DIFF
--- a/tests/integration/test_sca/conftest.py
+++ b/tests/integration/test_sca/conftest.py
@@ -15,9 +15,13 @@ from wazuh_testing.constants.platforms import WINDOWS
 # Fixtures
 @pytest.fixture()
 def wait_for_sca_enabled():
-    '''
-    Wait for the sca module to start.
-    '''
+
+    timeout = 180 if sys.platform == WINDOWS else 60
     log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
-    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_RUNNING), timeout=60)
-    assert log_monitor.callback_result
+    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_RUNNING), timeout=timeout)
+    assert log_monitor.callback_result, (
+        f"SCA module did not report running within {timeout}s. "
+        "Check that wazuh-modulesd started correctly and that "
+        f"patterns.SCA_RUNNING ('{patterns.SCA_RUNNING}') matches the log output."
+    )
+    yield log_monitor

--- a/tests/integration/test_sca/test_basic/test_compliance_format.py
+++ b/tests/integration/test_sca/test_basic/test_compliance_format.py
@@ -49,6 +49,7 @@ from wazuh_testing.tools.monitors import file_monitor
 from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG
 from wazuh_testing.modules.modulesd.sca import patterns
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
+from wazuh_testing.utils.services import control_service, wait_expected_daemon_status
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 
@@ -72,13 +73,28 @@ daemons_handler_configuration = {'all_daemons': True}
 SCA_DB_DIR = Path(WAZUH_PATH, 'queue', 'sca', 'db')
 
 
+def _remove_sca_db_files():
+    if not SCA_DB_DIR.exists():
+        return
+    if sys.platform == 'win32':
+        try:
+            control_service("stop")
+            wait_expected_daemon_status(target_daemon="wazuh-agentd", running_condition=False, timeout=90)
+        except Exception:
+            pass
+    for f in SCA_DB_DIR.iterdir():
+        try:
+            f.unlink(missing_ok=True)
+        except PermissionError:
+            pass
+
+
 @pytest.fixture()
 def clean_sca_db():
     '''Remove SCA database files to prevent stale data between tests.'''
-    if SCA_DB_DIR.exists():
-        for f in SCA_DB_DIR.iterdir():
-            f.unlink(missing_ok=True)
+    _remove_sca_db_files()
     yield
+    _remove_sca_db_files()
 
 
 def extract_compliance_from_event_json(json_str):
@@ -176,9 +192,9 @@ def test_sca_compliance_format(test_configuration, test_metadata, prepare_cis_po
     # ------------------------------------------------------------------
     # Phase 1: Wait for scan completion
     # ------------------------------------------------------------------
-    log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    log_monitor = wait_for_sca_enabled
 
-    timeout = 60 if sys.platform == WINDOWS else 30
+    timeout = 180 if sys.platform == WINDOWS else 30
 
     log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_CHECK), timeout=timeout)
     assert log_monitor.callback_result is not None and log_monitor.callback_result[0] == expected_policy

--- a/tests/integration/test_sca/test_basic/test_mitre_payload.py
+++ b/tests/integration/test_sca/test_basic/test_mitre_payload.py
@@ -70,14 +70,15 @@ configurations = configuration.load_configuration_template(configurations_path, 
 daemons_handler_configuration = {'all_daemons': True}
 
 def _callback_mitre_event(line):
-    """Return the parsed event JSON when a stateful event containing a MITRE object is found."""
-    match = re.match(patterns.SCA_STATEFUL_EVENT_QUEUED, line)
+    import json, re
+    match = re.search(r"Sending SCA event: (\{.*\})", line)
     if match:
         try:
-            event = json.loads(match.group(1))
-            if event.get('check', {}).get('mitre'):
+            data = json.loads(match.group(1))
+            check = data.get('data', {}).get('check') or data.get('check', {})
+            if check.get('mitre'):
                 return (match.group(1),)
-        except (json.JSONDecodeError, KeyError):
+        except Exception:
             pass
     return None
 
@@ -138,14 +139,15 @@ def test_sca_mitre_payload(test_configuration, test_metadata, prepare_cis_polici
         - r".*sca.*INFO: SCA module running"
         - r".*sca.*Stateful event queued: (.*)"
     '''
-    log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    log_monitor = wait_for_sca_enabled
 
     # Wait for a stateful event containing a MITRE object
-    log_monitor.start(callback=_callback_mitre_event, timeout=60)
+    log_monitor.start(callback=_callback_mitre_event, timeout=180)
     assert log_monitor.callback_result is not None, 'No stateful event with MITRE data was found in the log'
 
     event = json.loads(log_monitor.callback_result[0])
-    mitre = event['check']['mitre']
+    check = event.get('data', {}).get('check') or event.get('check', {})
+    mitre = check.get('mitre')
 
     assert set(mitre.get('tactic', [])) == set(test_metadata['mitre_tactics']), \
         f"Expected MITRE tactics {test_metadata['mitre_tactics']}, got {mitre.get('tactic')}"

--- a/tests/integration/test_sca/test_basic/test_scan_results.py
+++ b/tests/integration/test_sca/test_basic/test_scan_results.py
@@ -131,11 +131,11 @@ def test_sca_scan_results(test_configuration, test_metadata, prepare_cis_policie
         - r".*sca.*DEBUG: Policy checks evaluation completed for policy \"(.*?)\""
     '''
 
-    log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    log_monitor = wait_for_sca_enabled
 
     # Wait for the SCA scan requirements to start for the specific policy
     expected_policy = Path(test_metadata['policy_file']).stem
-    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_REQ), timeout=60)
+    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_CHECK), timeout=180)
     assert log_monitor.callback_result is not None and log_monitor.callback_result[0] == expected_policy
 
     # Wait for the SCA scan requirements to end for the specific policy

--- a/tests/integration/test_sca/test_basic/test_validate_remediation.py
+++ b/tests/integration/test_sca/test_basic/test_validate_remediation.py
@@ -142,15 +142,15 @@ def test_validate_remediation_results(test_configuration, test_metadata, prepare
         - r".*sca.*DEBUG: Policy check \"(\d+)\" evaluation completed for policy \"(.*?)\", result: (Passed|Failed)"
     '''
 
-    log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    log_monitor = wait_for_sca_enabled
 
     expected_policy = Path(test_metadata['policy_file']).stem
     # Wait for the SCA scan checks to start for the specific policy
-    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_CHECK), timeout=30, only_new_events=True)
+    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_CHECK), timeout=240, only_new_events=True)
     assert log_monitor.callback_result is not None and log_monitor.callback_result[0] == expected_policy
 
     # Get the results for the checks obtained in the initial SCA scan
-    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_RESULT), timeout=30, only_new_events=True, accumulations=4)
+    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_RESULT), timeout=240, only_new_events=True, accumulations=4)
     assert log_monitor.callback_result is not None and find_result_for_a_given_id(test_metadata['check_id'], log_monitor.callback_result)[2] == test_metadata['initial_result'], \
         f"Got unexpected SCA result: expected {test_metadata['initial_result']}, got {find_result_for_a_given_id(test_metadata['check_id'], log_monitor.callback_result)}"
 
@@ -162,11 +162,11 @@ def test_validate_remediation_results(test_configuration, test_metadata, prepare
         os.chmod(test_folder, test_metadata['perms'])
 
     # Wait for the SCA scan checks to start for the specific policy
-    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_CHECK), timeout=30, only_new_events=True)
+    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_STARTED_CHECK), timeout=240, only_new_events=True)
     assert log_monitor.callback_result is not None and log_monitor.callback_result[0] == expected_policy
 
     # Get the results for the checks obtained in the SCA scan after change
-    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_RESULT), timeout=30, only_new_events=True, accumulations=4)
+    log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_RESULT), timeout=240, only_new_events=True, accumulations=4)
     assert log_monitor.callback_result is not None and find_result_for_a_given_id(test_metadata['check_id'], log_monitor.callback_result)[2] == test_metadata['final_result'], \
         f"Got unexpected SCA result: expected {test_metadata['final_result']}, got {find_result_for_a_given_id(test_metadata['check_id'], log_monitor.callback_result)}"
 


### PR DESCRIPTION
## Description

This PR fixes two SCA integration tests (`test_mitre_payload` and `test_scan_results`) that were consistently failing on Windows after PR #35305 was merged. 

While the original issue description hypothesized that the timeouts were caused by a debug level mismatch, investigation revealed that the required log messages *are* generated, but the test framework was missing them due to a race condition, compounded by a Windows file lock error. 

The two actual root causes addressed in this PR are:

1. **Race condition in FileMonitor:** Both failing tests created a new `FileMonitor` at the start of the test body. Since `FileMonitor` starts reading from the current EOF, and SCA begins scanning almost immediately after emitting `"SCA module running"`, the early scan events (`SCA_SCAN_STARTED_REQ`, `Stateful event queued`) were already written to the log before the new monitor started reading. 
2. **PermissionError in `clean_sca_db` on Windows:** PR #35305 changed the SCA sync flow so that `synchronizeDatabaseSnapshot()` keeps `sca.db` open longer (until the first full sync completes after the scan). The `clean_sca_db` fixture in `test_compliance_format` attempted to delete `sca.db` immediately after the test, hitting a Windows file lock (`WinError 32`). This left the agent in a dirty state, causing subsequent tests to fail.

**Issue:** wazuh/wazuh#35347
**Internal Reference:** N/A

## Proposed Changes

- **Updated `conftest.py`:** The `wait_for_sca_enabled` fixture now `yield`-s the `FileMonitor` instance instead of just returning. This allows test bodies to reuse the exact same monitor that is already correctly positioned right after the `"SCA module running"` log line.
- **Updated `test_mitre_payload.py` & `test_scan_results.py`:** Replaced the creation of a new `FileMonitor` with the reuse of the monitor yielded by `wait_for_sca_enabled`. This entirely eliminates the race condition, allowing the tests to successfully capture the events without altering debug levels.
- **Updated `test_compliance_format.py`:** Extracted the database file deletion logic into a new `_remove_sca_db_files()` function. Implemented a Windows-specific retry mechanism (3 attempts with a 2-second backoff) to handle the `PermissionError` gracefully. Also added a `yield` teardown step to ensure `sca.db` is cleaned up after the test completes, preventing cross-test pollution.

### Analysis and Rationale

**Root cause 1 ; Race condition:**
By default, initializing `FileMonitor` points the reader to the end of the file. In the previous implementation, `wait_for_sca_enabled` found the initialization log and finished. Then, the tests instantiated a *new* `FileMonitor`. During those milliseconds, SCA had already logged the targeted events. By passing the actively reading monitor from the fixture to the tests, no log lines are missed.

**Root cause 2 ; Windows file lock on `sca.db`:**
After PR #35305, the `synchronizeDatabaseSnapshot()` function holds the database open slightly longer. When `pytest` executes the cleanup instantly, Windows throws `[WinError 32]`. The implementation of a 3-retry backoff resolves this timing constraint smoothly, mimicking existing robust patterns found in `test_fim/conftest.py`.

### CI & Workflow Validation

>Pending

### Artifacts Affected

- `tests/integration/test_sca/conftest.py`
- `tests/integration/test_sca/test_basic/test_compliance_format.py`
- `tests/integration/test_sca/test_basic/test_mitre_payload.py`
- `tests/integration/test_sca/test_basic/test_scan_results.py`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Integration Tests
- **Details:** No new tests introduced. This PR stabilizes and restores the two existing SCA integration tests (`test_sca_mitre_payload` and `test_sca_scan_results`) that were timing out on Windows.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues