### PR TITLE
Fix active config endpoint and Integration tests

### DIFF
--- a/api/test/integration/common.yaml
+++ b/api/test/integration/common.yaml
@@ -8,7 +8,8 @@ description: File with information such as global variables or repeteable stages
 variables:
   protocol: https
   host: localhost
-  port: 55010
+  balanced_port: 55010
+  master_port: 55000
   user: testing
   user_auth_context: wazuh-wui
   pass: wazuh

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -28,7 +28,7 @@ results = dict()
 
 with open(common_file, 'r') as stream:
     common = yaml.safe_load(stream)['variables']
-login_url = f"{common['protocol']}://{common['host']}:{common['port']}/{common['login_endpoint']}"
+login_url = f"{common['protocol']}://{common['host']}:{common['master_port']}/{common['login_endpoint']}"
 basic_auth = f"{common['user']}:{common['pass']}".encode()
 login_headers = {'Content-Type': 'application/json',
                  'Authorization': f'Basic {b64encode(basic_auth).decode()}'}

--- a/api/test/integration/test_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_active_response_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Runs an Active Response command on a specified agent with version >= 4.2.0
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -29,7 +29,7 @@ stages:
   - name: Send a message to an agent with version < 4.2.0 (Status=Active)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -52,7 +52,7 @@ stages:
   - name: Send a message to a list of agents (Status=Active)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -79,7 +79,7 @@ stages:
   - name: Try to send a message to an agent (status=disconnected/never_connected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -106,7 +106,7 @@ stages:
   - name: Try to send a message to an unexisting agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Try to send a message to an agent, without body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -145,7 +145,7 @@ stages:
   - name: Try to send a message to an agent, malformed body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -161,7 +161,7 @@ stages:
   - name: Send a message to one agent (Active response disabled)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -194,7 +194,7 @@ stages:
   - name: Runs an Active Response command on all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -234,7 +234,7 @@ stages:
   - name: Try to send a message to all agents, malformed body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Try to remove agent 000 (manager) from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -20,7 +20,7 @@ stages:
   - name: Try to remove non existing agent from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -33,7 +33,7 @@ stages:
   - name: Try to remove wrong agent_id from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/wrong_id/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -47,7 +47,7 @@ stages:
   - name: Try to remove agent 001 from a wrong_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/wrong_group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/wrong_group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -60,7 +60,7 @@ stages:
   - name: Try to remove agent 001 from a group where it is not assigned (group2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -73,7 +73,7 @@ stages:
   - name: Try to remove agent 004 (only assigned to default) from group default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/default"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/group/default"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -86,7 +86,7 @@ stages:
   - name: Remove agent 001 from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -99,7 +99,7 @@ stages:
   - name: Remove agent 002 from default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/default"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/group/default"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Remove agent 002 from group2 when it is the only group assigned
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -132,7 +132,7 @@ stages:
   - name: Try to remove agent 000 (manager) from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -145,7 +145,7 @@ stages:
   - name: Try to remove non existing agent from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -156,7 +156,7 @@ stages:
   - name: Try to remove wrong agent_id from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/bad_id/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -169,7 +169,7 @@ stages:
   - name: Remove agent 005 from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -187,7 +187,7 @@ stages:
   - name: Remove agent 008 from group1 and group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -212,7 +212,7 @@ stages:
   - name: Try to remove agents from non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -228,7 +228,7 @@ stages:
   - name: Try to remove agents 000 and 002(not assigned to group1) from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -257,7 +257,7 @@ stages:
   - name: Try to remove agents 998 and 999 from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -284,7 +284,7 @@ stages:
   - name: Remove agents 006 and 010 from group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -306,7 +306,7 @@ stages:
   - name: Remove all agents from group2 (008)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -326,7 +326,7 @@ stages:
   - name: Remove all agents from group2 (invalid agents_list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -340,7 +340,7 @@ stages:
   - name: Remove all agents from group2 (invalid agents_list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -358,7 +358,7 @@ stages:
   - name: Try to delete non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -382,7 +382,7 @@ stages:
   - name: Try to delete default group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -406,7 +406,7 @@ stages:
   - name: Delete group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -426,7 +426,7 @@ stages:
   - name: Delete group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -450,7 +450,7 @@ stages:
   - name: Delete groups with no groups_list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -468,7 +468,7 @@ stages:
   - name: Try to delete non existing groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -493,7 +493,7 @@ stages:
   - name: Delete groups group1 and default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -519,7 +519,7 @@ stages:
   - name: Delete all groups (group2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -543,7 +543,7 @@ stages:
   - name: Try to delete agent with a wrong agents_list
     request: &delete_agents
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -818,7 +818,7 @@ stages:
   - name: Delete all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get wazuh version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -19,7 +19,7 @@ stages:
   - name: Get all agents
     request: &get_agents
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1286,7 +1286,7 @@ stages:
   - name: Basic response agent
     request: &get_agent
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1326,7 +1326,7 @@ stages:
   - name: Try to show not existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1350,7 +1350,7 @@ stages:
   - name: Try show not existing agent by name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1464,7 +1464,7 @@ stages:
   - name: Get client configuration from agent component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/client"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1485,7 +1485,7 @@ stages:
   - name: Get buffer configuration from agent component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/buffer"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/agent/buffer"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1502,7 +1502,7 @@ stages:
   - name: Get labels configuration from agent component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/labels"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/agent/labels"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1516,7 +1516,7 @@ stages:
   - name: Get internal configuration from agent component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/agent/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1554,7 +1554,7 @@ stages:
   - name: Get global configuration from analysis component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/analysis/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1583,7 +1583,7 @@ stages:
   - name: Get active_response configuration from analysis component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/active_response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/analysis/active_response"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1597,7 +1597,7 @@ stages:
   - name: Get alerts configuration from analysis component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/alerts"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/analysis/alerts"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1613,7 +1613,7 @@ stages:
   - name: Get command configuration from analysis component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/command"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/analysis/command"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1627,7 +1627,7 @@ stages:
   - name: Get internal configuration from analysis component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/analysis/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/analysis/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1655,7 +1655,7 @@ stages:
   - name: Get auth configuration from auth component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/auth/auth"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/auth/auth"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1680,7 +1680,7 @@ stages:
   - name: Get active-response configuration from com component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/com/active-response"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1695,7 +1695,7 @@ stages:
   - name: Get active-response configuration from com component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/com/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/com/active-response"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1710,7 +1710,7 @@ stages:
   - name: Get internal configuration from com component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/com/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1727,7 +1727,7 @@ stages:
   - name: Get internal configuration from com component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/com/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/com/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1744,7 +1744,7 @@ stages:
   - name: Get localfile configuration from logcollector component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/localfile"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/logcollector/localfile"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1758,7 +1758,7 @@ stages:
   - name: Get localfile configuration from logcollector component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/localfile"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/logcollector/localfile"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1772,7 +1772,7 @@ stages:
   - name: Get socket configuration from logcollector component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/socket"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/logcollector/socket"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1782,7 +1782,7 @@ stages:
   - name: Get socket configuration from logcollector component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/socket"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/logcollector/socket"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1792,7 +1792,7 @@ stages:
   - name: Get internal configuration from logcollector component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/logcollector/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/logcollector/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1822,7 +1822,7 @@ stages:
   - name: Get internal configuration from logcollector component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/logcollector/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/logcollector/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1852,7 +1852,7 @@ stages:
   - name: Get internal configuration from monitor component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/monitor/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/monitor/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1875,7 +1875,7 @@ stages:
   - name: Get remote configuration from request component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/request/remote"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/request/remote"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1894,7 +1894,7 @@ stages:
   - name: Get internal configuration from request component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/request/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/request/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1927,7 +1927,7 @@ stages:
   - name: Get syscheck configuration from syscheck component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/syscheck/syscheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1949,7 +1949,7 @@ stages:
   - name: Get syscheck configuration from syscheck component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/syscheck/syscheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1971,7 +1971,7 @@ stages:
   - name: Get rootcheck configuration from syscheck component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/syscheck/rootcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1999,7 +1999,7 @@ stages:
   - name: Get rootcheck configuration from syscheck component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/syscheck/rootcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2027,7 +2027,7 @@ stages:
   - name: Get internal configuration from syscheck component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/syscheck/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/syscheck/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2050,7 +2050,7 @@ stages:
   - name: Get internal configuration from syscheck component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/syscheck/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/syscheck/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2073,7 +2073,7 @@ stages:
   - name: Get internal configuration from wazuh-db component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wazuh-db/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/wazuh-db/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2091,7 +2091,7 @@ stages:
   - name: Get wdb configuration from wazuh-db component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wazuh-db/wdb"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/wazuh-db/wdb"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2110,7 +2110,7 @@ stages:
   - name: Get wmodules configuration from wmodules component (Manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/wmodules/wmodules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/wmodules/wmodules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2124,7 +2124,7 @@ stages:
   - name: Get wmodules configuration from wmodules component (Agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wmodules/wmodules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/wmodules/wmodules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2138,7 +2138,7 @@ stages:
   - name: Try to show config of a non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/config/mail/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/config/mail/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2150,7 +2150,7 @@ stages:
   - name: Try to show config of an invalid agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_name/config/mail/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/wrong_name/config/mail/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2162,7 +2162,7 @@ stages:
   - name: Request Error Component Parameter
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wrong_component/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/wrong_component/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2174,7 +2174,7 @@ stages:
   - name: Request Error Configuration Parameter
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/mail/wrong_configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/mail/wrong_configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2186,7 +2186,7 @@ stages:
   - name: Request Error Component and Configuration Parameters
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/wrong_component/wrong_configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/wrong_component/wrong_configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2198,7 +2198,7 @@ stages:
   - name: Request error on invalid component and configuration pair
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/wmodules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/agent/wmodules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2218,7 +2218,7 @@ stages:
 - name: Get cluster configuration from com component (Manager)
   request:
     verify: False
-    url: "{protocol:s}://{host:s}:{port:d}/agents/000/config/com/cluster"
+    url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/config/com/cluster"
     method: GET
     headers:
       Authorization: "Bearer {test_login_token}"
@@ -2245,7 +2245,7 @@ stages:
   - name: Try to get sync of agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2266,7 +2266,7 @@ stages:
   - name: Try to get sync of a non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2287,7 +2287,7 @@ stages:
   - name: Try get sync agent by name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/bad_id/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2299,7 +2299,7 @@ stages:
   - name: Get agent sync
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2323,7 +2323,7 @@ stages:
   - name: Try get key agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/key"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/key"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2344,7 +2344,7 @@ stages:
   - name: Try get key not existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/key"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/key"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2365,7 +2365,7 @@ stages:
   - name: Try get key agent by name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/bad_id/key"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/bad_id/key"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2377,7 +2377,7 @@ stages:
   - name: Get agent key
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/key"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/key"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2400,7 +2400,7 @@ stages:
   - name: Try to get daemon stats from agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2421,7 +2421,7 @@ stages:
   - name: Get all daemons' stats from agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2450,7 +2450,7 @@ stages:
   - name: Try to get all daemons' stats from agent 001 with a wrong daemons list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/daemons/stats"
       method: GET
       params:
         daemons_list: wrong_daemon_1,wrong_daemon_2
@@ -2465,7 +2465,7 @@ stages:
   - name: Get all daemons' stats from agent 001 with a specified daemons list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/daemons/stats"
       method: GET
       params:
         daemons_list: wazuh-remoted
@@ -2490,7 +2490,7 @@ stages:
   - name: Try to get daemon stats from a non-existent agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/021/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/021/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2516,7 +2516,7 @@ stages:
   - name: Get logcollector stats from agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/stats/logcollector"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/stats/logcollector"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2541,7 +2541,7 @@ stages:
   - name: Get wazuh-agentd stats from agent 000 (manager, not allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/stats/agent"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/stats/agent"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2562,7 +2562,7 @@ stages:
   - name: Get logcollector stats from agent 002
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/stats/logcollector"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2580,7 +2580,7 @@ stages:
   - name: Get wazuh-agentd stats from agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/stats/agent"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/stats/agent"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2604,7 +2604,7 @@ stages:
   - name: Try to get logcollector stats from agent 007 (incompatible version)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/007/stats/logcollector"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/007/stats/logcollector"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2625,7 +2625,7 @@ stages:
   - name: Try to get logcollector stats from agent 017 (non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/logcollector"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/017/stats/logcollector"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2646,7 +2646,7 @@ stages:
   - name: Try to get invalid component stats from agent 000
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/017/stats/invalid_component"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/017/stats/invalid_component"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2664,7 +2664,7 @@ stages:
   - name: Basic response agents groups
     request: &get_agents_groups
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2998,7 +2998,7 @@ stages:
   - name: Try get all agents in one group
     request: &groups_id_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group3/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3102,7 +3102,7 @@ stages:
   - name: Params, bad group name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_group/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3114,7 +3114,7 @@ stages:
   - name: Params, invalid group name (not alphanumeric)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_%_group/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3440,7 +3440,7 @@ stages:
   - name: Get wazuh version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3479,7 +3479,7 @@ stages:
   - name: Try get the configuration of a group
     request: &groups_id_config_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3498,7 +3498,7 @@ stages:
   - name: Try get the configuration of a bad group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_group/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3510,7 +3510,7 @@ stages:
   - name: Try get the configuration of a bad group (not alphanumeric)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%group/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_%group/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3608,7 +3608,7 @@ stages:
   - name: Try get the files of a group
     request: &groups_id_files_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3724,7 +3724,7 @@ stages:
   - name: Try get the files of a bad group name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_group/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3747,7 +3747,7 @@ stages:
   - name: Try get the files of a bad group name (no alphanumeric)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_%_group/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3947,7 +3947,7 @@ stages:
   - name: Get one file of a group (JSON)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3960,7 +3960,7 @@ stages:
   - name: Get one file of a group (XML)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3974,7 +3974,7 @@ stages:
   - name: Get one file of a group (plain text)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/merged.mg"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/merged.mg"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3988,7 +3988,7 @@ stages:
   - name: Try get one file of a group, bad group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/files/agent.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_group/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3998,7 +3998,7 @@ stages:
   - name: Try get one file of a group, bad group (not aplhanumeric)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_%_group/files/agent.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_%_group/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4010,7 +4010,7 @@ stages:
   - name: Try get one file of a group, non existent file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.mg"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/agent.mg"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4027,7 +4027,7 @@ stages:
   - name: Basic response agents name
     request: &get_agents_by_name
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4048,7 +4048,7 @@ stages:
   - name: Error agent name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents?name=wrong_agent"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents?name=wrong_agent"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4125,7 +4125,7 @@ stages:
   - name: Get the agents without group
     request: &no_group_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/no_group"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4332,7 +4332,7 @@ stages:
   - name: Get the agents without group, sort
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/no_group"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4348,7 +4348,7 @@ stages:
   - name: Select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/no_group"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4372,7 +4372,7 @@ stages:
   - name: Get the outdated agents
     request: &agents_outdated_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/outdated"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4611,7 +4611,7 @@ stages:
   - name: Returns all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination.
     request: &distinct_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/stats/distinct"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4689,7 +4689,7 @@ stages:
   - name: Get the different combinations for os.platform, search
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/stats/distinct"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4922,7 +4922,7 @@ stages:
   - name: Get the different combinations for all fields
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/stats/distinct"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4946,7 +4946,7 @@ stages:
   - name: Get the agents status summary
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -4976,7 +4976,7 @@ stages:
   - name: Get the agents status summary
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5004,7 +5004,7 @@ stages:
   - name: Get the summary/os of all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5027,7 +5027,7 @@ stages:
   - name: Upgrade all agents (only old agents will appear in affected_items). We use q to leave agent 008 with no tasks in DB
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5054,7 +5054,7 @@ stages:
   - name: Try to get upgrade result from agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5077,7 +5077,7 @@ stages:
   - name: Try to get upgrade result from a not existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5101,7 +5101,7 @@ stages:
   - name: Try to get upgrade results with an invalid agents list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5115,7 +5115,7 @@ stages:
   - name: Try to get upgrade results from a list of agents that cannot be upgraded (000, not existing and non active agents)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5157,7 +5157,7 @@ stages:
   - name: Try to get upgrade result from agent with no task in DB
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5182,7 +5182,7 @@ stages:
   - name: Try to get upgrade results from a list of agents with filters not matching them
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -5210,7 +5210,7 @@ stages:
   - name: Get upgrade results from all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agent_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_POST_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Create a new agent with a valid IPV6
     request: &agent_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -72,7 +72,7 @@ stages:
   - name: Check all registered IPV6 agents
     request: &agent_list_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -299,7 +299,7 @@ stages:
   - name: Try to create a group without body
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -312,7 +312,7 @@ stages:
   - name: Create a group called group4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -327,7 +327,7 @@ stages:
   - name: Try to create a group that already exists
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -342,7 +342,7 @@ stages:
   - name: Try to create a group with an invalid name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -357,7 +357,7 @@ stages:
   - name: Try to create a group with a forbidden name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -377,7 +377,7 @@ stages:
   - name: Try to create a new agent without body
     request: &agent_insert_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -602,7 +602,7 @@ stages:
   - name: Create new agent specifying its name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -621,7 +621,7 @@ stages:
   - name: Try to create agent with an invalid name (invalid_character)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -636,7 +636,7 @@ stages:
   - name: Try to create an already existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Try to assign all agents to a non existing group
     request: &put_agents_group
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -36,7 +36,7 @@ stages:
   - name: Try to assign all agents to an invalid group id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -50,7 +50,7 @@ stages:
   - name: Try to assign an agent to a forbidden group id (it must count as non existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -64,7 +64,7 @@ stages:
   - name: Try to assign non existing agents to group default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -90,7 +90,7 @@ stages:
   - name: Try to assign 000 and a non existing agent to group default
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -119,7 +119,7 @@ stages:
   - name: Try to assign agents 001 and 002 to group default where they already belong
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -145,7 +145,7 @@ stages:
   - name: Assign agents 003, 004 and 005 to group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -177,7 +177,7 @@ stages:
   - name: Assign all agents to group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -207,7 +207,7 @@ stages:
   - name: Assign all agents to group2 with force_single_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -249,7 +249,7 @@ stages:
   - name: Update group2 configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group2/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group2/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -269,7 +269,7 @@ stages:
   - name: Try to update configuration of a non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/wrong_group/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/wrong_group/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -283,7 +283,7 @@ stages:
   - name: Try to update configuration using an empty file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -297,7 +297,7 @@ stages:
   - name: Try to update configuration using an invalid configuration file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -313,7 +313,7 @@ stages:
   - name: Try to update configuration using a wrong configuration file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -328,7 +328,7 @@ stages:
   - name: Try to update configuration using a complex configuration file (no agents in group1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -341,7 +341,7 @@ stages:
   - name: Ensure the config now has the expected value
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -369,7 +369,7 @@ stages:
   - name: Restart all agents from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group1/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/group1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -387,7 +387,7 @@ stages:
   - name: Restart all agents from group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group2/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/group2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -415,7 +415,7 @@ stages:
   - name: Restart all agents from a group which does not exist
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/not_exists/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/not_exists/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -431,7 +431,7 @@ stages:
   - name: Try to reconnect agent with wrong_id
     request: &agent_reconnect_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -516,7 +516,7 @@ stages:
   - name: Try to reconnect all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -548,7 +548,7 @@ stages:
   - name: Try to restart agent with wrong_id
     request: &agent_restart_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -636,7 +636,7 @@ stages:
   - name: Try to restart all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -671,7 +671,7 @@ stages:
   - name: Assign agent 001 to group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -693,7 +693,7 @@ stages:
   - name: Try to assign an agent with an invalid id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/wrong_id/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -706,7 +706,7 @@ stages:
   - name: Try to assign a non existing agent to group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/group3"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/group/group3"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -728,7 +728,7 @@ stages:
   - name: Assign agent 002 to group3 with force_single_group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group3?force_single_group=true"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/group/group3?force_single_group=true"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -757,7 +757,7 @@ stages:
   - name: Try to restart agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/000/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/000/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -779,7 +779,7 @@ stages:
   - name: Try to restart a not existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -801,7 +801,7 @@ stages:
   - name: Try to restart an agent with an invalid id
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/wrong_id/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/wrong_id/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -814,7 +814,7 @@ stages:
   - name: Restart an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/003/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/003/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -839,7 +839,7 @@ stages:
   - name: Get agents belonging to a node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -856,7 +856,7 @@ stages:
   - name: Restart all agents belonging to a node (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker1/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/worker1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -872,7 +872,7 @@ stages:
   - name: Restart all agents belonging to a node (it does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/notexists/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/notexists/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -896,7 +896,7 @@ stages:
   - name: Try to upgrade a non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -922,7 +922,7 @@ stages:
   - name: Try to upgrade agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -948,7 +948,7 @@ stages:
   - name: Try to upgrade a list of agents with an invalid agents_list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -962,7 +962,7 @@ stages:
   - name: Create task to upgrade an agent to the latest version (agent will be upgraded if the corresponding WPK exists)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -984,7 +984,7 @@ stages:
   - name: Try to upgrade an agent that is updated to the latest version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1008,7 +1008,7 @@ stages:
   - name: Upgrade an agent using http and wpk repo
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1031,7 +1031,7 @@ stages:
   - name: Try to upgrade a list of agents that cannot be upgraded (000, not existing and non active agents)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1074,7 +1074,7 @@ stages:
   - name: Try to upgrade a list of agents expecting socket error (agent version greater or equal)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1102,7 +1102,7 @@ stages:
   - name: Try to upgrade a list of agents with filters not matching them
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1131,7 +1131,7 @@ stages:
   - name: Upgrade all agents in group group1 (only 001 is in group1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1153,7 +1153,7 @@ stages:
   - name: Upgrade all agents with os version 18.04.5 LTS and query
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1183,7 +1183,7 @@ stages:
   - name: Try to customly upgrade a non existing agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1196,7 +1196,7 @@ stages:
   - name: Try to customly upgrade agent 000 (manager)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1209,7 +1209,7 @@ stages:
   - name: Try to customly upgrade an agent without parameters
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1223,7 +1223,7 @@ stages:
   - name: Try to customly upgrade an agent using default installer (WPK does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1245,7 +1245,7 @@ stages:
   - name: Try to customly upgrade an agent selecting installer (WPK does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1268,7 +1268,7 @@ stages:
   - name: Try to customly upgrade a list of agents with an invalid agents_list
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1283,7 +1283,7 @@ stages:
   - name: Try to customly upgrade a list of agents that cannot be upgraded (000, not existing and non active agents)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1296,7 +1296,7 @@ stages:
   - name: Try to customly upgrade a list of agents with filters not matching them
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_cdb_list_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request: &get_lists
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -259,7 +259,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -272,7 +272,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -291,7 +291,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -310,7 +310,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -341,7 +341,7 @@ stages:
     request: &get_lists_files
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -501,7 +501,7 @@ stages:
     request: &get_audit_keys_list
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -536,7 +536,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/aws-eventnames"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/aws-eventnames"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -554,7 +554,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/unknown"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/unknown"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -575,7 +575,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/..%2F..%2Faudit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/..%2F..%2Faudit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -586,7 +586,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -601,7 +601,7 @@ stages:
   - name: Upload a new list file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_list"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -621,7 +621,7 @@ stages:
   - name: Try to upload same list file (overwrite=False)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_list"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -643,7 +643,7 @@ stages:
   - name: Upload same list file (overwrite=True)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_list"
       method: PUT
       data: "{new_cdb_list:s}"
       params:
@@ -665,7 +665,7 @@ stages:
   - name: Try to upload list file with repeated name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/aws-eventnames"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/aws-eventnames"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -687,7 +687,7 @@ stages:
   - name: Try to upload invalid list file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_list"
       method: PUT
       data: "{new_cdb_list_with_syntax_error:s}"
       params:
@@ -711,7 +711,7 @@ stages:
   - name: Try to upload list with invalid name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/invalid.txt"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/invalid.txt"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -726,7 +726,7 @@ stages:
   - name: Try to upload CDB list (invalid file 2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/..%2F..%2Faudit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/..%2F..%2Faudit-keys"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -743,7 +743,7 @@ stages:
   - name: Delete an existent list file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_list"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -762,7 +762,7 @@ stages:
   - name: Try to delete same file (it does not exist now)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_list"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -783,7 +783,7 @@ stages:
   - name: Try to delete CDB list (invalid file)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/..%2F..%2Faudit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/..%2F..%2Faudit-keys"
       method: DELETE
       data: "{new_cdb_list:s}"
       headers:

--- a/api/test/integration/test_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_ciscat_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/001/results"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -26,7 +26,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/251/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/251/results"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
   - name: Get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -42,7 +42,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -75,7 +75,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -117,7 +117,7 @@ stages:
   - name: Get cluster ruleset synchronization status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -140,7 +140,7 @@ stages:
   - name: Get cluster ruleset synchronization status (specific node)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -161,7 +161,7 @@ stages:
   - name: Get cluster ruleset synchronization status (node does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -192,7 +192,7 @@ stages:
   - name: Get cluster node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{master_port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -220,7 +220,7 @@ stages:
   - name: Get cluster nodes
     request: &get_cluster_nodes
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -493,7 +493,7 @@ stages:
   - name: Get cluster {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -531,7 +531,7 @@ stages:
   - name: Get cluster nodes with select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -557,7 +557,7 @@ stages:
   - name: Get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -580,7 +580,7 @@ stages:
   - name: Request (master-node)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -613,7 +613,7 @@ stages:
   - name: Request (worker)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -646,7 +646,7 @@ stages:
   - name: Filters -> section=alerts (master-node)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -669,7 +669,7 @@ stages:
   - name: Filters -> section=syscheck (master)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -698,7 +698,7 @@ stages:
   - name: Filters -> section=syscollector (master)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -727,7 +727,7 @@ stages:
   - name: Filters -> section=alerts (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -749,7 +749,7 @@ stages:
   - name: Filters -> section=syscheck (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -778,7 +778,7 @@ stages:
   - name: Filters -> section=syscollector (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -815,7 +815,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -847,7 +847,7 @@ stages:
   - name: Get API configuration for all nodes
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -922,7 +922,7 @@ stages:
   - name: Get API configuration for worker1 and worker2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -955,7 +955,7 @@ stages:
   - name: Show the config of analisys/global on worker1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -988,7 +988,7 @@ stages:
   - name: Show the config of analysis/active_response on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/analysis/active_response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/analysis/active_response"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1006,7 +1006,7 @@ stages:
   - name: Show the config of analysis/alerts on worker1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/alerts"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/analysis/alerts"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1025,7 +1025,7 @@ stages:
 
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/analysis/command"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/analysis/command"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1043,7 +1043,7 @@ stages:
   - name: Show the config of authd/authd on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/auth/auth"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/auth/auth"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1071,7 +1071,7 @@ stages:
   - name: Show the config of com/internal on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/com/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/com/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1092,7 +1092,7 @@ stages:
   - name: Show the config of analysis/internal on worker1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/analysis/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1124,7 +1124,7 @@ stages:
   - name: Show the config of logcollector/localfile on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/localfile"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/logcollector/localfile"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1142,7 +1142,7 @@ stages:
   - name: Show the config of logcollector/socket on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/socket"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/logcollector/socket"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1159,7 +1159,7 @@ stages:
   - name: Show the config of logcollector/internal on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/logcollector/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/logcollector/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1193,7 +1193,7 @@ stages:
   - name: Show the config of monitor/internal on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/monitor/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/monitor/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1220,7 +1220,7 @@ stages:
   - name: Show the config of monitor/reports in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/reports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/configuration/monitor/reports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1238,7 +1238,7 @@ stages:
   - name: Show the config of request/remote on worker2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/request/remote"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/configuration/request/remote"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1261,7 +1261,7 @@ stages:
   - name: Show the config of request/internal on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/request/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/request/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1301,7 +1301,7 @@ stages:
   - name: Show the config of syscheck/syscheck on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/syscheck/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1320,7 +1320,7 @@ stages:
   - name: Show the config of syscheck/rootcheck on worker1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/syscheck/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1353,7 +1353,7 @@ stages:
   - name: Show the config of syscheck/internal on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/syscheck/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/syscheck/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1380,7 +1380,7 @@ stages:
   - name: Show the config of wazuh-db/internal on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wazuh-db/internal"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/wazuh-db/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1402,7 +1402,7 @@ stages:
   - name: Show the config of wazuh-db/wdb on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wazuh-db/wdb"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/wazuh-db/wdb"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1425,7 +1425,7 @@ stages:
   - name: Show the config of wmodules/wmodules on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/wmodules/wmodules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/wmodules/wmodules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1443,7 +1443,7 @@ stages:
   - name: Try to show the invalid config of component in the master node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration/agent/wmodules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration/agent/wmodules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1469,7 +1469,7 @@ stages:
   - name: Read info {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1508,7 +1508,7 @@ stages:
   - name: Read logs {node_id}
     request: &get_cluster_logs
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1783,7 +1783,7 @@ stages:
   - name: Read logs summary {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1816,7 +1816,7 @@ stages:
   - name: Get all daemons' statistics from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1837,7 +1837,7 @@ stages:
   - name: Get statistics from a single daemon from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1858,7 +1858,7 @@ stages:
   - name: Get statistics from a list of daemons from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1881,7 +1881,7 @@ stages:
   - name: Try to get statistics from a wrong daemon from {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1907,7 +1907,7 @@ stages:
   - name: Cluster stats {node_id} today
     request: &get_cluster_stats
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1950,7 +1950,7 @@ stages:
   - name: Unexisting_node stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/unexisting-node/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/unexisting-node/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1984,7 +1984,7 @@ stages:
   - name: Analysisd stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2052,7 +2052,7 @@ stages:
   - name: Hourly node stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/hourly"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2085,7 +2085,7 @@ stages:
   - name: Remoted stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/remoted"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2124,7 +2124,7 @@ stages:
   - name: Weekly node stats {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/stats/weekly"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2176,7 +2176,7 @@ stages:
   - name: Read status {node_id}
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/{node_id}/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2201,7 +2201,7 @@ stages:
   - name: Reload analysisd on worker1 and worker2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2224,7 +2224,7 @@ stages:
   - name: Reload analysisd on all nodes
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2255,7 +2255,7 @@ stages:
   - name: Restart cluster (worker1, worker2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2277,7 +2277,7 @@ stages:
   - name: Restart cluster all nodes
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2307,7 +2307,7 @@ stages:
   - name: Upload a valid configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -2328,7 +2328,7 @@ stages:
   - name: Ensure the new config has been applied by checking a field
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -2352,7 +2352,7 @@ stages:
   - name: Try to upload an invalid configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{invalid_ossec_conf:s}"
       headers:
@@ -2376,7 +2376,7 @@ stages:
   - name: Try to upload an invalid xml
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{invalid_ossec_xml:s}"
       headers:
@@ -2400,7 +2400,7 @@ stages:
   - name: Try to upload an empty configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{invalid_ossec_conf:s}"
       headers:
@@ -2424,7 +2424,7 @@ stages:
   - name: Ensure the config didn't change
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_decoder_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request: &get_decoders
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -411,7 +411,7 @@ stages:
     request: &get_decoders_with_name
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -581,7 +581,7 @@ stages:
     request: &get_decoders_files
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -892,7 +892,7 @@ stages:
     request: &get_decoders_parents
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/parents"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1069,7 +1069,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1087,7 +1087,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1100,7 +1100,7 @@ stages:
   - name: Download decoder (it does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/no_exists.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/no_exists.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1121,7 +1121,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1143,7 +1143,7 @@ stages:
   - name: Download decoder (invalid file 1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/decoderxml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/decoderxml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1152,7 +1152,7 @@ stages:
   - name: Download decoder (invalid file 2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/..%2F..%2Fetc%local_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/..%2F..%2Fetc%local_decoder.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1166,7 +1166,7 @@ stages:
   - name: Upload new valid decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1186,7 +1186,7 @@ stages:
   - name: Upload same decoder (overwrite=False)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1209,7 +1209,7 @@ stages:
   - name: Upload same decoder (overwrite=True)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1223,7 +1223,7 @@ stages:
   - name: Upload decoder with relative_dirname
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1246,7 +1246,7 @@ stages:
   - name: Upload decoder with invalid name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_Decoder"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_Decoder"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1258,7 +1258,7 @@ stages:
   - name: Upload invalid decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/invalid_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/invalid_decoder.xml"
       method: PUT
       data: "{new_decoder_with_syntax_error:s}"
       headers:
@@ -1281,7 +1281,7 @@ stages:
   - name: Upload empty xml decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/empty_file.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/empty_file.xml"
       method: PUT
       data: "{empty_file_xml:s}"
       headers:
@@ -1309,7 +1309,7 @@ stages:
   - name: Delete user decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1327,7 +1327,7 @@ stages:
   - name: Delete user decoder in subdir
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1347,7 +1347,7 @@ stages:
   - name: Delete same user decoder (it does not exist now)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1368,7 +1368,7 @@ stages:
   - name: Delete ruleset decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0010-active-response_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0010-active-response_decoders.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1389,7 +1389,7 @@ stages:
   - name: Delete invalid decoder
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/ossec.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/ossec.conf"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_default_endpoints.tavern.yaml
+++ b/api/test/integration/test_default_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_event_endpoints.tavern.yaml
+++ b/api/test/integration/test_event_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Send bulk with one element
     request: &event_request
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/events"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/events"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_experimental_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -29,7 +29,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -65,7 +65,7 @@ stages:
   - name: Try to delete syscheck scans (Some failed, agents are newer than expected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -86,7 +86,7 @@ stages:
   - name: Try to delete syscheck scans (Failed, agents are newer than expected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -117,7 +117,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -139,7 +139,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -177,7 +177,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -209,7 +209,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -242,7 +242,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -274,7 +274,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -318,7 +318,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -350,7 +350,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -382,7 +382,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -414,7 +414,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -455,7 +455,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -487,7 +487,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -504,7 +504,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -528,7 +528,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -566,7 +566,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -595,7 +595,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -612,7 +612,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -636,7 +636,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -655,7 +655,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_logtest_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Run logtest with an invalid body (invalid key)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -19,7 +19,7 @@ stages:
   - name: Run logtest with a token with no session started
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -46,7 +46,7 @@ stages:
   - name: Run logtest with a valid body but no token (start session)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -65,7 +65,7 @@ stages:
   - name: Run logtest using a token from a running session
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -92,7 +92,7 @@ stages:
   - name: Run logtest in order to generate the session token
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Try to end logtest session using an invalid token
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest/sessions/wrong_token"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest/sessions/wrong_token"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -126,7 +126,7 @@ stages:
   - name: End logtest session
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest/sessions/{delete_session_token:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest/sessions/{delete_session_token:s}"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -140,7 +140,7 @@ stages:
   - name: Check the logtest session has ended
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest/sessions/{delete_session_token:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest/sessions/{delete_session_token:s}"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -47,7 +47,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/info"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -99,7 +99,7 @@ stages:
   - name: Request all sections
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -117,7 +117,7 @@ stages:
   - name: Request all sections in raw format
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -137,7 +137,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -172,7 +172,7 @@ stages:
   - name: Request section and field (1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -195,7 +195,7 @@ stages:
   - name: Request section and field (2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -218,7 +218,7 @@ stages:
   - name: Request invalid section
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -231,7 +231,7 @@ stages:
   - name: Request invalid field
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -255,7 +255,7 @@ stages:
   - name: Get ruleset decoder_dir section distinct configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -271,7 +271,7 @@ stages:
   - name: Get ruleset rule_dir section distinct configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
           Authorization: "Bearer {test_login_token}"
@@ -293,7 +293,7 @@ stages:
   - name: Get all daemons' statistics
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -314,7 +314,7 @@ stages:
   - name: Get statistics from a single daemon
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -335,7 +335,7 @@ stages:
   - name: Get statistics from a list of daemons
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -358,7 +358,7 @@ stages:
   - name: Try to get statistics from a wrong daemon
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -376,7 +376,7 @@ stages:
   - name: Manager stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -388,7 +388,7 @@ stages:
   - name: Manager stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -414,7 +414,7 @@ stages:
   - name: Manager stats with old date
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -434,7 +434,7 @@ stages:
   - name: Hourly stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -458,7 +458,7 @@ stages:
   - name: Weekly stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -501,7 +501,7 @@ stages:
   - name: Analysisd stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -560,7 +560,7 @@ stages:
   - name: Remoted stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -591,7 +591,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -609,7 +609,7 @@ stages:
   - name: Filters -> limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -637,7 +637,7 @@ stages:
   - name: Filters -> limit=2, sort=-level
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -656,7 +656,7 @@ stages:
   - name: Filters -> offset=3, limit=3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -680,7 +680,7 @@ stages:
   - name: Filters -> offset=3, level=info, limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -706,7 +706,7 @@ stages:
   - name: Filters -> tag=wazuh-analysisd, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -728,7 +728,7 @@ stages:
   - name: Filters -> tag=wazuh-syscheckd, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -749,7 +749,7 @@ stages:
   - name: Filters by query (tag=wazuh-syscheckd, level=info)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -770,7 +770,7 @@ stages:
   - name: Filters by query (timestamp<2021-07-01)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -789,7 +789,7 @@ stages:
   - name: Filter by non-existent tag
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -808,7 +808,7 @@ stages:
   - name: Read logs using valid select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -831,7 +831,7 @@ stages:
   - name: Try to read logs using invalid select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -845,7 +845,7 @@ stages:
   - name: Get distinct manager logs
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -865,7 +865,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -888,7 +888,7 @@ stages:
   - name: Get API configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -962,7 +962,7 @@ stages:
   - name: Request validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -986,7 +986,7 @@ stages:
   - name: Show the config of analysis/global in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1004,7 +1004,7 @@ stages:
   - name: Show the config of analysis/active_response in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/active_response"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/analysis/active_response"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1023,7 +1023,7 @@ stages:
   - name: Show the config of analysis/alerts in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/alerts"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/analysis/alerts"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1041,7 +1041,7 @@ stages:
   - name: Show the config of analysis/command in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/command"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/analysis/command"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1059,7 +1059,7 @@ stages:
   - name: Show the config of analysis/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/analysis/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1077,7 +1077,7 @@ stages:
   - name: Show the config of auth in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/auth/auth"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/auth/auth"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1095,7 +1095,7 @@ stages:
   - name: Show the config of com/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/com/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/com/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1113,7 +1113,7 @@ stages:
   - name: Show the config of logcollector/localfile in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/localfile"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/logcollector/localfile"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1131,7 +1131,7 @@ stages:
   - name: Show the config of logcollector/socket in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/socket"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/logcollector/socket"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1148,7 +1148,7 @@ stages:
   - name: Show the config of logcollector/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/logcollector/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/logcollector/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1166,7 +1166,7 @@ stages:
   - name: Show the config of monitor/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/monitor/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1184,7 +1184,7 @@ stages:
   - name: Show the config of monitor/reports in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/monitor/reports"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/monitor/reports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1202,7 +1202,7 @@ stages:
   - name: Show the config of request/remote in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/request/remote"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/request/remote"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1220,7 +1220,7 @@ stages:
   - name: Show the config of request/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/request/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/request/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1238,7 +1238,7 @@ stages:
   - name: Show the config of syscheck/syscheck in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/syscheck"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/syscheck/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1256,7 +1256,7 @@ stages:
   - name: Show the config of syscheck/rootcheck in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/rootcheck"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/syscheck/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1274,7 +1274,7 @@ stages:
   - name: Show the config of syscheck/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/syscheck/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/syscheck/internal"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1292,7 +1292,7 @@ stages:
   - name: Show the config of wazuh-db/internal in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/wazuh-db/internal"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/wazuh-db/internal"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1314,7 +1314,7 @@ stages:
   - name: Show the config of wazuh-db/wdb in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/wazuh-db/wdb"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/wazuh-db/wdb"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1337,7 +1337,7 @@ stages:
   - name: Try to show the config of wmodules/wmodules in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/wmodules/wmodules"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/wmodules/wmodules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1355,7 +1355,7 @@ stages:
   - name: Try to show the invalid config of component in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/agent/wmodules"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/agent/wmodules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1372,7 +1372,7 @@ stages:
   - name: Reload analysisd on master
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1397,7 +1397,7 @@ stages:
   - name: Upload a valid configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -1418,7 +1418,7 @@ stages:
   - name: Ensure the new config has been applied by checking a field
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1442,7 +1442,7 @@ stages:
   - name: Try to upload an invalid configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{invalid_ossec_conf:s}"
       headers:
@@ -1466,7 +1466,7 @@ stages:
   - name: Try to upload an empty configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{invalid_ossec_conf:s}"
       headers:
@@ -1489,7 +1489,7 @@ stages:
   - name: Try to upload an invalid xml
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{invalid_ossec_xml:s}"
       headers:
@@ -1513,7 +1513,7 @@ stages:
   - name: Try to upload an invalid configuration with an invalid content-type
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{invalid_ossec_conf:s}"
       headers:
@@ -1528,7 +1528,7 @@ stages:
   - name: Ensure the config didn't change
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1555,7 +1555,7 @@ stages:
   - name: Get wazuh version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{master_port:d}/"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1568,7 +1568,7 @@ stages:
   - name: Get available updates
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/version/check"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1583,7 +1583,7 @@ stages:
   - name: Get available updates with force option
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/version/check"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1604,7 +1604,7 @@ stages:
   - name: Get wazuh version
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{master_port:d}/"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1617,7 +1617,7 @@ stages:
   - name: Enable update check
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{valid_ossec_conf_with_update_check_enabled:s}"
       headers:
@@ -1637,7 +1637,7 @@ stages:
   - name: Restart manager to apply the configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1656,7 +1656,7 @@ stages:
   - name: Get available updates
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/version/check"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1673,7 +1673,7 @@ stages:
   - name: Get available updates with force option
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/version/check"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1697,7 +1697,7 @@ stages:
   - name: Set an invalid CTI url
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{ossec_conf_with_invalid_cti_url:s}"
       headers:
@@ -1717,7 +1717,7 @@ stages:
   - name: Restart manager to apply the configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1736,7 +1736,7 @@ stages:
   - name: Try to get available updates
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/version/check"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1748,7 +1748,7 @@ stages:
   - name: Try to get available updates with force option
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/version/check"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1768,7 +1768,7 @@ stages:
   - name: Restart manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_mitre_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Request MITRE metadata
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/metadata"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -33,7 +33,7 @@ stages:
   - name: Show one mitigation
     request: &general_mitigations_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/mitigations"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/mitigations"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -360,7 +360,7 @@ stages:
   - name: Show one reference
     request: &general_references_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/references"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -642,7 +642,7 @@ stages:
   - name: Show one tactic
     request: &general_tactics_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/tactics"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/tactics"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -950,7 +950,7 @@ stages:
   - name: Show one technique
     request: &general_techniques_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/techniques"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1268,7 +1268,7 @@ stages:
   - name: Show one group
     request: &general_groups_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1597,7 +1597,7 @@ stages:
   - name: Show one software
     request: &general_software_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/software"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_overview_endpoints.tavern.yaml
@@ -5,7 +5,7 @@ stages:
  - name: Get full agents overview
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_active_response_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Runs an Active Response command on a specified agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -24,7 +24,7 @@ stages:
   - name: Send a message to an agent (Status=Active) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -47,7 +47,7 @@ stages:
   - name: Send a message to a list of agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -81,7 +81,7 @@ stages:
   - name: Try to send a message to an agent (status=disconnected/never_connected) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -97,7 +97,7 @@ stages:
   - name: Try to send a message to unexisting agents (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -131,7 +131,7 @@ stages:
   - name: Runs an Active Response command on all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -29,7 +29,7 @@ stages:
   - name: Get a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -43,7 +43,7 @@ stages:
   - name: Get a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -70,7 +70,7 @@ stages:
   - name: Get a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -97,7 +97,7 @@ stages:
   - name: Try to get agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -109,7 +109,7 @@ stages:
   - name: Get agent 009 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Try to get client configuration from agent component for agent 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/config/agent/client"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -143,7 +143,7 @@ stages:
   - name: Get client configuration from agent component for agent 003 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/003/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -158,7 +158,7 @@ stages:
   - name: Try to get sync of agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -168,7 +168,7 @@ stages:
   - name: Get agent sync (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/007/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/007/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -192,7 +192,7 @@ stages:
  - name: Try get key agent 006 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/006/key"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/006/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -202,7 +202,7 @@ stages:
  - name: Get agent key for 005 (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/005/key"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -225,7 +225,7 @@ stages:
   - name: Get daemons stats from agent 001 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -254,7 +254,7 @@ stages:
   - name: Try to get daemon stats from agent 002 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -269,7 +269,7 @@ stages:
  - name: Try to get logcollector stats from agent 002 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/stats/logcollector"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -279,7 +279,7 @@ stages:
  - name: Try to get logcollector stats from agent 003 (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/003/stats/logcollector"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -294,7 +294,7 @@ stages:
  - name: Get all groups (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -313,7 +313,7 @@ stages:
  - name: Try to read group1 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -325,7 +325,7 @@ stages:
  - name: Get a list of groups (Partially allowed, user aware)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -350,7 +350,7 @@ stages:
  - name: Get a list of groups (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -376,7 +376,7 @@ stages:
  - name: Try get all agents in one group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -400,7 +400,7 @@ stages:
  - name: Try to get the configuration of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/default/configuration"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -410,7 +410,7 @@ stages:
  - name: Try get the configuration of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/configuration"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group2/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -425,7 +425,7 @@ stages:
  - name: Try get the files of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group1/files"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -435,7 +435,7 @@ stages:
  - name: Try get the files of a group (Allow)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -464,7 +464,7 @@ stages:
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -474,7 +474,7 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files/agent.conf"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group2/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -489,7 +489,7 @@ stages:
  - name: Basic response agents name (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -505,7 +505,7 @@ stages:
  - name: Basic response agents name (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -531,7 +531,7 @@ stages:
  - name: Get the agents without group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -554,7 +554,7 @@ stages:
  - name: Get the outdated agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/outdated"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -579,7 +579,7 @@ stages:
  - name: Get the different combinations for os.platform (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -607,7 +607,7 @@ stages:
  - name: Get the agents summary (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -633,7 +633,7 @@ stages:
  - name: Get the agents status summary (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/status"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -661,7 +661,7 @@ stages:
  - name: Get the summary/os of all agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/os"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -684,7 +684,7 @@ stages:
  - name: Try to get upgrade results from agents 003 and 004 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -701,7 +701,7 @@ stages:
   - name: Try to remove agent 004 from group2 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -711,7 +711,7 @@ stages:
   - name: Try to remove agent 001 from group1 (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -721,7 +721,7 @@ stages:
   - name: Try to remove agent 004 from group1 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -733,7 +733,7 @@ stages:
   - name: Remove agent 005 from group1 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -754,7 +754,7 @@ stages:
   - name: Try to remove agent 008 from all groups (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -764,7 +764,7 @@ stages:
   - name: Try to remove agent 009 from group2 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/009/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -776,7 +776,7 @@ stages:
   - name: Remove agent 009 from all groups (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/009/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -795,7 +795,7 @@ stages:
   - name: Try to remove agent 005 from a list of groups (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -828,7 +828,7 @@ stages:
   - name: Try to remove all agents from group2 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -841,7 +841,7 @@ stages:
   - name: Remove all agents from group1 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -861,7 +861,7 @@ stages:
   - name: Remove a list of agents from group1 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -897,7 +897,7 @@ stages:
   - name: Try to delete group1 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -909,7 +909,7 @@ stages:
   - name: Try to delete group antonio (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -937,7 +937,7 @@ stages:
   - name: Try to delete all groups (All denied, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -956,7 +956,7 @@ stages:
   - name: Try to delete a list of groups (denied, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -991,7 +991,7 @@ stages:
   - name: Try to delete agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1004,7 +1004,7 @@ stages:
   - name: Delete agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1032,7 +1032,7 @@ stages:
   - name: Try to delete a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1045,7 +1045,7 @@ stages:
   - name: Try to delete agents (group=group2, q=id<=6) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1070,7 +1070,7 @@ stages:
   - name: Try to delete a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1096,7 +1096,7 @@ stages:
   - name: Try to delete a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1128,7 +1128,7 @@ stages:
   - name: Try to delete all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1156,7 +1156,7 @@ stages:
   - name: Try to create a new agent (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1174,7 +1174,7 @@ stages:
   - name: Try to create a new agent specifying id, ip, key and name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1194,7 +1194,7 @@ stages:
   - name: Try to create new agent specifying its name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1211,7 +1211,7 @@ stages:
   - name: Try to create a group called group4 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1228,7 +1228,7 @@ stages:
   - name: Try to assign all agents to group2 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1240,7 +1240,7 @@ stages:
   - name: Try to assign a list of agents to group1 (Agents denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1253,7 +1253,7 @@ stages:
   - name: Try to assign a list of agents to group1 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1283,7 +1283,7 @@ stages:
   - name: Try to assign all agents to group1 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1308,7 +1308,7 @@ stages:
   - name: Update group1 configuration (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1325,7 +1325,7 @@ stages:
   - name: Try to update group3 configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group3/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1344,7 +1344,7 @@ stages:
   - name: Restart all agents from group1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group1/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/group1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1357,7 +1357,7 @@ stages:
   - name: Restart all agents from group2 (Only agent 005 will have both permissions -> group:read & agent:restart)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group2/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/group2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1384,7 +1384,7 @@ stages:
   - name: Try to reconnect agent 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1396,7 +1396,7 @@ stages:
   - name: Try to reconnect a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1423,7 +1423,7 @@ stages:
   - name: Try to reconnect all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1449,7 +1449,7 @@ stages:
   - name: Try to restart agent 001 (Denied)default,group1,group3,pepito
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1461,7 +1461,7 @@ stages:
   - name: Try to restart a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1491,7 +1491,7 @@ stages:
   - name: Try to restart all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1520,7 +1520,7 @@ stages:
   - name: Try to assign agent 003 to group1 (Agent denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/003/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/003/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1530,7 +1530,7 @@ stages:
   - name: Try to assign agent 009 to group3 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group/group3"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/009/group/group3"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1540,7 +1540,7 @@ stages:
   - name: Try to assign agent 005 to group1 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1566,7 +1566,7 @@ stages:
   - name: Try to restart agent 008 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1576,7 +1576,7 @@ stages:
   - name: Restart agent 005 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1603,7 +1603,7 @@ stages:
   - name: Try to upgrade agents 003 and 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1620,7 +1620,7 @@ stages:
   - name: Try to customly upgrade agents 003 and 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1638,7 +1638,7 @@ stages:
   - name: Get unknown-node on failed response
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1660,7 +1660,7 @@ stages:
   - name: Restart all agents belonging to master-node (Allow node_id - Could deny agent_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/master-node/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/master-node/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1676,7 +1676,7 @@ stages:
   - name: Restart all agents belonging to worker1 (Allow node_id - Could deny agent_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker1/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/worker1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1692,7 +1692,7 @@ stages:
   - name: Restart all agents belonging to worker2 (Allow node_id - Could deny agent_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker2/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/worker2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1713,7 +1713,7 @@ stages:
   - name: Check user's permission to uninstall agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/uninstall"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/uninstall"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Show the lists of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -32,7 +32,7 @@ stages:
   - name: Show an specified filename (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -54,7 +54,7 @@ stages:
   - name: Try to show an specified path (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -74,7 +74,7 @@ stages:
   - name: Show the lists files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -102,7 +102,7 @@ stages:
   - name: Try to show content from a list (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/aws-eventnames"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/aws-eventnames"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -112,7 +112,7 @@ stages:
   - name: Show content from a list (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/security-eventchannel"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -133,7 +133,7 @@ stages:
   - name: Try to update audit-keys list, overwrite=False (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -144,7 +144,7 @@ stages:
   - name: Try to update audit-keys list, overwrite=True (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -161,7 +161,7 @@ stages:
   - name: Try to delete a CDB list (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -171,7 +171,7 @@ stages:
   - name: Delete a CDB list (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/security-eventchannel"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE

--- a/api/test/integration/test_rbac_black_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_ciscat_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get ciscat result for agent 001 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/001/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Get ciscat result for agent 002 (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/002/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/002/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -35,7 +35,7 @@ stages:
   - name: Get ciscat result for agent 003 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/003/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/003/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -53,7 +53,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -82,7 +82,7 @@ stages:
   - name: Get cluster ruleset synchronization status (partial response, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -101,7 +101,7 @@ stages:
   - name: Get cluster ruleset synchronization status (permission denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Get cluster ruleset synchronization status (partial response, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -143,7 +143,7 @@ stages:
   - name: Get cluster node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -158,7 +158,7 @@ stages:
   - name: Get cluster nodes
     request: &get_cluster_nodes
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -238,7 +238,7 @@ stages:
   - name: Get cluster (worker2) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -250,7 +250,7 @@ stages:
   - name: Get cluster (worker1) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -271,7 +271,7 @@ stages:
   - name: Get cluster (master-node,worker1,worker2) (Allow, Deny, Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -304,7 +304,7 @@ stages:
   - name: Get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -319,7 +319,7 @@ stages:
   - name: Request (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -352,7 +352,7 @@ stages:
   - name: Request (master-node) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -367,7 +367,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -386,7 +386,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -418,7 +418,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -428,7 +428,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -443,7 +443,7 @@ stages:
   - name: Request (worker2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -453,7 +453,7 @@ stages:
   - name: Request (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -468,7 +468,7 @@ stages:
   - name: Request (worker1) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -478,7 +478,7 @@ stages:
   - name: Request (worker2) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -493,7 +493,7 @@ stages:
   - name: Request (worker1) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -503,7 +503,7 @@ stages:
   - name: Request (worker2) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -518,7 +518,7 @@ stages:
   - name: Request daemons statistics from worker2 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -528,7 +528,7 @@ stages:
   - name: Request daemons statistics from worker1 (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -543,7 +543,7 @@ stages:
   - name: Cluster stats (worker2) today (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -553,7 +553,7 @@ stages:
   - name: Cluster stats (worker1) today (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -570,7 +570,7 @@ stages:
   - name: Request (worker1) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -580,7 +580,7 @@ stages:
   - name: Request (worker2) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -595,7 +595,7 @@ stages:
   - name: Request API config (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -624,7 +624,7 @@ stages:
   - name: Reload cluster nodes ruleset (worker1, worker2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -641,7 +641,7 @@ stages:
   - name: Upload a valid configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -661,7 +661,7 @@ stages:
   - name: Try to upload a valid configuration (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -678,7 +678,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -690,7 +690,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Try to show the decoders of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -40,7 +40,7 @@ stages:
   - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -59,7 +59,7 @@ stages:
   - name: Try to show the decoders of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -91,7 +91,7 @@ stages:
   - name: Try to show the decoders files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -125,7 +125,7 @@ stages:
   - name: Try to show the decoders files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -154,7 +154,7 @@ stages:
   - name: Try to show the decoders files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -173,7 +173,7 @@ stages:
   - name: Get one decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0025-apache_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0025-apache_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -183,7 +183,7 @@ stages:
   - name: Try to get one decoder file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -198,7 +198,7 @@ stages:
   - name: Try to update one decoder file (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/local_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/local_decoder.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -214,7 +214,7 @@ stages:
   - name: Delete a decoder file (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder_file.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder_file.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -224,7 +224,7 @@ stages:
   - name: Try to delete a decoder file (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/local_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/local_decoder.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -239,7 +239,7 @@ stages:
   - name: Try to show the decoder parents in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/parents"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_event_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_event_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Send webhook events (Allowed)
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/events"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/events"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_experimental_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -26,7 +26,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -39,7 +39,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -63,7 +63,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -94,7 +94,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -147,7 +147,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -164,7 +164,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -193,7 +193,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -215,7 +215,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -246,7 +246,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -260,7 +260,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -291,7 +291,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -305,7 +305,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -336,7 +336,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -350,7 +350,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -381,7 +381,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -395,7 +395,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -426,7 +426,7 @@ stages:
   - name:  Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -443,7 +443,7 @@ stages:
   - name:  Request all agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -460,7 +460,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -497,7 +497,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -526,7 +526,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -543,7 +543,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -572,7 +572,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -591,7 +591,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_logtest_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Run logtest (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -28,7 +28,7 @@ stages:
   - name: End logtest session (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest/sessions/token"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest/sessions/token"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Request manager configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -26,7 +26,7 @@ stages:
   - name: Request manager configuration validation (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -41,7 +41,7 @@ stages:
   - name: Request manager component configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/analysis/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -56,7 +56,7 @@ stages:
   - name: Request manager info (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -71,7 +71,7 @@ stages:
   - name: Request manager logs (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -86,7 +86,7 @@ stages:
   - name: Request manager logs summary (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -101,7 +101,7 @@ stages:
   - name: Request daemons statistics (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -116,7 +116,7 @@ stages:
   - name: Request manager stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Request manager analysisd stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -148,7 +148,7 @@ stages:
   - name: Request manager hourly stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -163,7 +163,7 @@ stages:
   - name: Request manager remoted stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -178,7 +178,7 @@ stages:
   - name: Request manager weekly stats (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -193,7 +193,7 @@ stages:
   - name: Request manager status (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -208,7 +208,7 @@ stages:
   - name: Request API config (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -225,7 +225,7 @@ stages:
   - name: Attempt to upload a valid configuration (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -242,12 +242,13 @@ stages:
   - name: Restart manager (Allowed) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
       <<: *permission_allowed
+      status_code: 202
 
 ---
 test_name: PUT /manager/analysisd/reload
@@ -257,7 +258,7 @@ stages:
   - name: Reload manager analysisd (Allowed) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_mitre_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Request MITRE metadata (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/metadata"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -26,7 +26,7 @@ stages:
   - name: Request MITRE mitigations (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/mitigations"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/mitigations"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -42,7 +42,7 @@ stages:
   - name: Request MITRE references (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/references"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -58,7 +58,7 @@ stages:
   - name: Request MITRE techniques (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/techniques"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -74,7 +74,7 @@ stages:
   - name: Request MITRE tactics (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/tactics"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/tactics"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -90,7 +90,7 @@ stages:
   - name: Request MITRE groups (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -106,7 +106,7 @@ stages:
   - name: Request MITRE software (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/software"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_overview_endpoints.tavern.yaml
@@ -5,7 +5,7 @@ stages:
  - name: Get full agents overview
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rootcheck_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response: &permission_denied
@@ -19,7 +19,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -41,7 +41,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -58,7 +58,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -73,7 +73,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -83,7 +83,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -107,7 +107,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -124,7 +124,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -149,7 +149,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:

--- a/api/test/integration/test_rbac_black_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_rule_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Try to show the rules of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -45,7 +45,7 @@ stages:
   - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -64,7 +64,7 @@ stages:
   - name: Try to show the rules of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -98,7 +98,7 @@ stages:
   - name: Try to show the rules files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -129,7 +129,7 @@ stages:
   - name: Try to show the rules files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -153,7 +153,7 @@ stages:
   - name: Try to show the rules files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -180,7 +180,7 @@ stages:
   - name: Try to show the rules files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -199,7 +199,7 @@ stages:
   - name: Get one rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0350-amazon_rules.xml"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -213,7 +213,7 @@ stages:
   - name: Try to get one rule file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0010-rules_config.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0010-rules_config.xml"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -232,7 +232,7 @@ stages:
   - name: Try to update one rule file (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/local_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/local_rules.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -244,7 +244,7 @@ stages:
   - name: Try to update one rule file (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/local_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/local_rules.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -262,7 +262,7 @@ stages:
   - name: Delete a rule file (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule_file.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule_file.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -272,7 +272,7 @@ stages:
   - name: Try to delete a rule file (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/local_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/local_rules.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -287,7 +287,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -309,7 +309,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/pci_dss"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -331,7 +331,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/mitre"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_sca_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Request sca for agent 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/000"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/000"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -19,7 +19,7 @@ stages:
   - name: Request sca for agent 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -31,7 +31,7 @@ stages:
   - name: Request sca for agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -44,7 +44,7 @@ stages:
   - name: Request sca for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -54,7 +54,7 @@ stages:
   - name: Request sca for agent 004 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/004"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/004"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -67,7 +67,7 @@ stages:
   - name: Request sca for agent 005 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/005"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/005"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -82,7 +82,7 @@ stages:
   - name: Request policy checks for 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/000/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/000/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -95,7 +95,7 @@ stages:
   - name: Request policy checks for 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -51,7 +51,7 @@ stages:
   - name: Get a specified user by its username (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -76,7 +76,7 @@ stages:
   - name: Get a specified user by its username (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -90,7 +90,7 @@ stages:
   - name: Get a list of users by its username (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -127,7 +127,7 @@ stages:
   - name: Get a list of users by its username (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -139,7 +139,7 @@ stages:
   - name: Get a list of users by its username (Both)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -182,7 +182,7 @@ stages:
   - name: Get all roles in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -199,7 +199,7 @@ stages:
   - name: Get a specified role by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -216,7 +216,7 @@ stages:
   - name: Get all rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -240,7 +240,7 @@ stages:
   - name: Get a specified rule by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -257,7 +257,7 @@ stages:
   - name: Get all policies in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -275,7 +275,7 @@ stages:
   - name: Get a specified policy by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -294,7 +294,7 @@ stages:
   - name: Get a specified policy by its id (It doesn't exist but we have all the permissions on the resource policies)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -318,7 +318,7 @@ stages:
   - name: Get a list of policies by its id (Existent and no existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -347,7 +347,7 @@ stages:
   - name: Get current security config (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -362,7 +362,7 @@ stages:
   - name: Update default security config (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -379,7 +379,7 @@ stages:
   - name: Update one specified user in the system (All allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/105"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/105"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -401,7 +401,7 @@ stages:
   - name: Update one specified user in the system (All allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -428,7 +428,7 @@ stages:
   - name: Update one specified user's allow_run_as flag (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/104/run_as"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -445,7 +445,7 @@ stages:
   - name: Update one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -466,7 +466,7 @@ stages:
   - name: Update one specified role in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -478,7 +478,7 @@ stages:
   - name: Update one admin role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -506,7 +506,7 @@ stages:
   - name: Update one specified rule in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/105"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/105"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -533,7 +533,7 @@ stages:
   - name: Update one specified rule in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -548,7 +548,7 @@ stages:
   - name: Update one admin rule in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/1"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -579,7 +579,7 @@ stages:
   - name: Update one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -617,7 +617,7 @@ stages:
   - name: Update one specified policy in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -642,7 +642,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow and Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -680,7 +680,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/102/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/102/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -714,7 +714,7 @@ stages:
   - name: Create one specified user (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -742,7 +742,7 @@ stages:
   - name: Create one specified role (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -754,7 +754,7 @@ stages:
   - name: Create one specified policy (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -778,7 +778,7 @@ stages:
   - name: Delete one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -811,7 +811,7 @@ stages:
   - name: Create one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/104/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/104/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -845,7 +845,7 @@ stages:
   - name: Delete one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/104/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/104/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -878,7 +878,7 @@ stages:
   - name: Create one specified link between one role and a list of rules (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/101/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/101/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -911,7 +911,7 @@ stages:
   - name: Delete one specified link between one role and a list of rules (Partially allow) (Agnostic user)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/101/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/101/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -933,7 +933,7 @@ stages:
   - name: Delete one specified link between one role and a list of rules (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/101/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/101/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -951,7 +951,7 @@ stages:
   - name: Delete one specified user in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -973,7 +973,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1013,7 +1013,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1032,7 +1032,7 @@ stages:
   - name: Delete a list of users in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1068,7 +1068,7 @@ stages:
   - name: Delete one specified rule in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1089,7 +1089,7 @@ stages:
     delay_after: 5
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1117,7 +1117,7 @@ stages:
   - name: Delete one specified rule in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1134,7 +1134,7 @@ stages:
   - name: Delete one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1164,7 +1164,7 @@ stages:
   - name: Delete all policies in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1189,7 +1189,7 @@ stages:
   - name: Delete one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -1209,7 +1209,7 @@ stages:
   - name: Delete all roles in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1234,7 +1234,7 @@ stages:
   - name: Revoke all tokens (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -1244,7 +1244,7 @@ stages:
   - name: Revoke all tokens (Invalid token after previous call)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT

--- a/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscheck_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response: &permission_denied
@@ -19,7 +19,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -41,7 +41,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/000/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -51,7 +51,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -75,7 +75,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -92,7 +92,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -117,7 +117,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -134,7 +134,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -155,7 +155,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_syscollector_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get os from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -38,7 +38,7 @@ stages:
   - name: Get os from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -55,7 +55,7 @@ stages:
   - name: Get hardware from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -83,7 +83,7 @@ stages:
   - name: Get hardware from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -98,7 +98,7 @@ stages:
   - name: Get netaddr from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -120,7 +120,7 @@ stages:
   - name: Get netaddr from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -135,7 +135,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -168,7 +168,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -183,7 +183,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -204,7 +204,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -219,7 +219,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -250,7 +250,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -265,7 +265,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -296,7 +296,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/006/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -311,7 +311,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -359,7 +359,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/006/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -374,7 +374,7 @@ stages:
   - name: Get all hotfixes from an agent (Deny)
     request: &hotfix_request_deny
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -396,7 +396,7 @@ stages:
   - name: Get users from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -411,7 +411,7 @@ stages:
   - name: Get users from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -426,7 +426,7 @@ stages:
   - name: Get groups from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -441,7 +441,7 @@ stages:
   - name: Get groups from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -456,7 +456,7 @@ stages:
   - name: Get browser extensions from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/browser_extensions"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -471,7 +471,7 @@ stages:
   - name: Get browser extensions from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/browser_extensions"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -486,7 +486,7 @@ stages:
   - name: Get services from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/services"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -501,7 +501,7 @@ stages:
   - name: Get services from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/services"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_black_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_task_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all existent tasks (At this point there is no task created)
     request: &get_tasks
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_active_response_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Runs an Active Response command on a specified agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -29,7 +29,7 @@ stages:
   - name: Send a message to an agent (Status=Active) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -50,7 +50,7 @@ stages:
   - name: Send a message to a list of agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -84,7 +84,7 @@ stages:
   - name: Try to send a message to an agent (status=disconnected/never_connected) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -111,7 +111,7 @@ stages:
   - name: Try to send a message to an unexisting agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -133,7 +133,7 @@ stages:
   - name: Runs an Active Response command on all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -30,7 +30,7 @@ stages:
   - name: Get a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -47,7 +47,7 @@ stages:
   - name: Get a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -74,7 +74,7 @@ stages:
   - name: Get a list of agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -101,7 +101,7 @@ stages:
   - name: Try to get agent 009 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Get agent 010 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -137,7 +137,7 @@ stages:
   - name: Try to get client configuration from agent component for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/003/config/agent/client"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/003/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -147,7 +147,7 @@ stages:
   - name: Get client configuration from agent component for agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/config/agent/client"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -162,7 +162,7 @@ stages:
   - name: Try to get sync of agent 011 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/011/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/011/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -172,7 +172,7 @@ stages:
   - name: Get agent sync (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -196,7 +196,7 @@ stages:
  - name: Try get key agent 005 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/005/key"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -206,7 +206,7 @@ stages:
  - name: Get agent key for 006 (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/006/key"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/006/key"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -229,7 +229,7 @@ stages:
   - name: Try to get daemon stats from agent 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -239,7 +239,7 @@ stages:
   - name: Get all daemons' stats from agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -273,7 +273,7 @@ stages:
  - name: Try to get logcollector stats from agent 002 (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/002/stats/logcollector"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/stats/logcollector"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -283,7 +283,7 @@ stages:
  - name: Try to get logcollector stats from agent 003 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/003/stats/logcollector"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/003/stats/logcollector"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -298,7 +298,7 @@ stages:
  - name: Get all groups (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -318,7 +318,7 @@ stages:
  - name: Try to read group3 (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -330,7 +330,7 @@ stages:
  - name: Get a list of groups (Partially allowed, user aware)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -355,7 +355,7 @@ stages:
  - name: Get a list of groups (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -381,7 +381,7 @@ stages:
  - name: Try get all agents in one group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group2/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -407,7 +407,7 @@ stages:
  - name: Try to get the configuration of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/configuration"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -417,7 +417,7 @@ stages:
  - name: Try get the configuration of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -432,7 +432,7 @@ stages:
  - name: Try get the files of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -442,7 +442,7 @@ stages:
  - name: Try get the files of a group (Allow)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group2/files"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group2/files"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -471,7 +471,7 @@ stages:
  - name: Try get one file of a group (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/group3/files/agent.conf"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group3/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -481,7 +481,7 @@ stages:
  - name: Try get one file of a group (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/agent.conf"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -496,7 +496,7 @@ stages:
  - name: Basic response agents name (Denied)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -512,7 +512,7 @@ stages:
  - name: Basic response agents name (Allowed)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -538,7 +538,7 @@ stages:
  - name: Get the agents without group (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/no_group"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -561,7 +561,7 @@ stages:
  - name: Get the outdated agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/outdated"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -586,7 +586,7 @@ stages:
  - name: Get the different combinations for os.platform (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/stats/distinct"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -614,7 +614,7 @@ stages:
  - name: Get the agents summary (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -640,7 +640,7 @@ stages:
  - name: Get the agents status summary (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/status"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -668,7 +668,7 @@ stages:
  - name: Get the summary/os of all agents (Partially allowed, user agnostic)
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/os"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -691,7 +691,7 @@ stages:
   - name: Try to remove agent 001 from group1 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -701,7 +701,7 @@ stages:
   - name: Try to remove agent 004 from group3 (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group3"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/group/group3"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -711,7 +711,7 @@ stages:
   - name: Try to remove agent 999 from default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/default"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/group/default"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -723,7 +723,7 @@ stages:
   - name: Try to remove agent 999 from group1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/999/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/999/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -733,7 +733,7 @@ stages:
   - name: Try to remove agent 002 from group3 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group3"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/group/group3"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -745,7 +745,7 @@ stages:
   - name: Remove agent 002 from group2 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/002/group/group2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/002/group/group2"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -760,7 +760,7 @@ stages:
   - name: Try to remove agent 009 from all groups (Denied agent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/009/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/009/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -770,7 +770,7 @@ stages:
   - name: Try to remove agent 001 from group1 (Denied group)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -782,7 +782,7 @@ stages:
   - name: Remove agent 006 from all groups (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/006/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/006/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -801,7 +801,7 @@ stages:
   - name: Try to remove agent 005 from all groups (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -819,7 +819,7 @@ stages:
   - name: Try to remove agent 007 from a list of groups (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/007/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/007/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -856,7 +856,7 @@ stages:
   - name: Try to remove all agents from a non existing group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -871,7 +871,7 @@ stages:
   - name: Try to remove all agents from group1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -884,7 +884,7 @@ stages:
   - name: Remove all agents from group2 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -905,7 +905,7 @@ stages:
   - name: Remove a list of agents from group3 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -939,7 +939,7 @@ stages:
   - name: Remove a list of agents from group default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -971,7 +971,7 @@ stages:
   - name: Try to delete group2 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -983,7 +983,7 @@ stages:
   - name: Delete group3
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1009,7 +1009,7 @@ stages:
   - name: Try to delete all groups (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1029,7 +1029,7 @@ stages:
   - name: Try to delete a list of groups (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1067,7 +1067,7 @@ stages:
   - name: Try to delete agent 002 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1080,7 +1080,7 @@ stages:
   - name: Delete agent 001 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1108,7 +1108,7 @@ stages:
   - name: Try to delete a list of agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1121,7 +1121,7 @@ stages:
   - name: Try to delete a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1149,7 +1149,7 @@ stages:
   - name: Try to delete all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1179,7 +1179,7 @@ stages:
   - name: Try to create a new agent (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1197,7 +1197,7 @@ stages:
   - name: Try to create a new agent specifying id, ip, key and name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1217,7 +1217,7 @@ stages:
   - name: Try to create new agent specifying its name (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1234,7 +1234,7 @@ stages:
   - name: Try to create a group called group4 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1251,7 +1251,7 @@ stages:
   - name: Try to assign all agents to a non existing group (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1263,7 +1263,7 @@ stages:
   - name: Try to assign all agents to group1 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1275,7 +1275,7 @@ stages:
   - name: Try to assign a list of agents to group2 (Agents denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1288,7 +1288,7 @@ stages:
   - name: Try to assign a list of agents to group2 (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1319,7 +1319,7 @@ stages:
   - name: Try to assign all agents to group2 (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1349,7 +1349,7 @@ stages:
   - name: Update group2 configuration (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group2/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group2/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1367,7 +1367,7 @@ stages:
   - name: Try to update group1 configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1386,7 +1386,7 @@ stages:
   - name: Restart all agents from group default (Partially allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/default/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/default/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1422,7 +1422,7 @@ stages:
   - name: Try to reconnect non existing agent (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1445,7 +1445,7 @@ stages:
   - name: Try to reconnect agent 010 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1457,7 +1457,7 @@ stages:
   - name: Try to reconnect a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1491,7 +1491,7 @@ stages:
   - name: Try to reconnect all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1515,7 +1515,7 @@ stages:
   - name: Try to restart non existing agent (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1538,7 +1538,7 @@ stages:
   - name: Try to restart agent 010 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1550,7 +1550,7 @@ stages:
   - name: Try to restart a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1587,7 +1587,7 @@ stages:
   - name: Try to restart all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1614,7 +1614,7 @@ stages:
   - name: Try to assign agent 004 to group2 (Agent denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/group/group2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/group/group2"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1624,7 +1624,7 @@ stages:
   - name: Try to assign agent 008 to group1 (Group denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1634,7 +1634,7 @@ stages:
   - name: Try to assign agent 008 to group3 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/group3"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group/group3"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1644,7 +1644,7 @@ stages:
   - name: Try to assign agent 001 to group2 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group2"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1666,7 +1666,7 @@ stages:
   - name: Remove agent 008 from group default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1691,7 +1691,7 @@ stages:
   - name: Assign agent 008 to default (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/008/group/default"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/008/group/default"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1718,7 +1718,7 @@ stages:
   - name: Try to restart agent 001 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1739,7 +1739,7 @@ stages:
   - name: Try to restart agent 010 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/010/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/010/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1749,7 +1749,7 @@ stages:
   - name: Restart agent 004 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/004/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/004/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1776,7 +1776,7 @@ stages:
   - name: Upgrade agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1789,7 +1789,7 @@ stages:
   - name: Try to upgrade agents 003 and 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1806,7 +1806,7 @@ stages:
   - name: Customly upgrade agents 007 and 008 using default installer (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1819,7 +1819,7 @@ stages:
   - name: Try to customly upgrade agents 003 and 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1837,7 +1837,7 @@ stages:
   - name: Get upgrade result from agents list (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1849,7 +1849,7 @@ stages:
   - name: Try get upgrade result agents 003 and 004 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1866,7 +1866,7 @@ stages:
   - name: Get unknown-node on failed response
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1883,7 +1883,7 @@ stages:
   - name: Restart all agents belonging to master-node (Deny node_id)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/master-node/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/master-node/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1898,7 +1898,7 @@ stages:
   - name: Check user's permission to uninstall agents (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/uninstall"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/uninstall"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -15,7 +15,7 @@ stages:
   - name: Try to run an Active Response command (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -36,7 +36,7 @@ stages:
   - name: Try to run an Active Response command (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/active-response"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/active-response"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -58,7 +58,7 @@ stages:
   - name: Try to remove all agents (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       params:
         agents_list: all
@@ -71,7 +71,7 @@ stages:
   - name: Try to remove one agent (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: DELETE
       params:
         agents_list: '001'
@@ -88,7 +88,7 @@ stages:
   - name: Try to get all agents (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -98,7 +98,7 @@ stages:
   - name: Try to get one agent (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: GET
       params:
         agents_list: '001'
@@ -114,7 +114,7 @@ stages:
   - name: Try to create a new agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -131,7 +131,7 @@ stages:
   - name: Try to get daemon stats from agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -146,7 +146,7 @@ stages:
   - name: Try to get client configuration from agent component
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/config/agent/client"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/config/agent/client"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -160,7 +160,7 @@ stages:
   - name: Try to remove agent 005 from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/005/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/005/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -174,7 +174,7 @@ stages:
   - name: Try to get agent sync
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/is_sync"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/is_sync"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -188,7 +188,7 @@ stages:
   - name: Try to remove agent 001 from group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group1"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -202,7 +202,7 @@ stages:
   - name: Try to remove agent 005 from all groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/group/group1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/group/group1"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -216,7 +216,7 @@ stages:
   - name: Try get agent's 001 key
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/key"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/key"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -230,7 +230,7 @@ stages:
   - name: Try to restart agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/001/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/001/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -244,7 +244,7 @@ stages:
   - name: Try to upgrade all agents (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -257,7 +257,7 @@ stages:
   - name: Try to upgrade agent 008
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -273,7 +273,7 @@ stages:
   - name: Try to customly upgrade all agents (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -286,7 +286,7 @@ stages:
   - name: Try to customly upgrade agent 008 using default installer
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_custom"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_custom"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -303,7 +303,7 @@ stages:
   - name: Try to get all upgrade results (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -313,7 +313,7 @@ stages:
   - name: Try to get agent 007 upgrade result (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade_result"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade_result"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -329,7 +329,7 @@ stages:
   - name: Try to remove agents 006 and 010 from group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -346,7 +346,7 @@ stages:
   - name: Try to assign all agents to group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -362,7 +362,7 @@ stages:
   - name: Try to restart agents from group2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/group/group2/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/group/group2/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -376,7 +376,7 @@ stages:
   - name: Try to create a new agent specifying id, ip, key and name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -395,7 +395,7 @@ stages:
   - name: Try to create new agent specifying its name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/insert/quick"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/insert/quick"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -411,7 +411,7 @@ stages:
   - name: Try to get agents without group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/no_group"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/no_group"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -425,7 +425,7 @@ stages:
   - name: Try to restart all agents belonging to a node (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/node/worker1/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/node/worker1/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -439,7 +439,7 @@ stages:
   - name: Try to get the outdated agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/outdated"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/outdated"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -453,7 +453,7 @@ stages:
   - name: Try to reconnect all agents (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -463,7 +463,7 @@ stages:
   - name: Try to reconnect agent 001 (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/reconnect"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/reconnect"
       method: PUT
       params:
         agents_list: '001'
@@ -479,7 +479,7 @@ stages:
   - name: Try to restart all agents (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -489,7 +489,7 @@ stages:
   - name: Try to restart agent 001 (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/restart"
       method: PUT
       params:
         agents_list: '001'
@@ -505,7 +505,7 @@ stages:
   - name: Try to return all different combinations that agents have
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/stats/distinct"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/stats/distinct"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -521,7 +521,7 @@ stages:
  - name: Try to get the agents summary
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+     url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"
@@ -545,7 +545,7 @@ stages:
   - name: Try to get the summary/os of all agents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/summary/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -559,7 +559,7 @@ stages:
   - name: Try to get the agents status summary
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/summary/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/summary/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -586,7 +586,7 @@ stages:
   - name: Try to get ciscat results for agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/001/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -600,7 +600,7 @@ stages:
   - name: Try to get cluster node info
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -614,7 +614,7 @@ stages:
   - name: Try to get cluster nodes
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -628,7 +628,7 @@ stages:
   - name: Try to get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -643,7 +643,7 @@ stages:
   - name: Get cluster ruleset synchronization status (empty response, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -660,7 +660,7 @@ stages:
   - name: Get cluster ruleset synchronization status (specific node, permission denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -676,7 +676,7 @@ stages:
   - name: Try to get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -690,7 +690,7 @@ stages:
   - name: Try to get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -704,7 +704,7 @@ stages:
   - name: Try to get all nodes api config (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -715,7 +715,7 @@ stages:
   - name: Try to get master-node api config (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/api/config"
       method: GET
       params:
         nodes_list: master-node
@@ -731,7 +731,7 @@ stages:
   - name: Try to get status (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -745,7 +745,7 @@ stages:
   - name: Try to get info (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -759,7 +759,7 @@ stages:
   - name: Try to get configuration (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -773,7 +773,7 @@ stages:
   - name: Try to update configuration (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -789,7 +789,7 @@ stages:
   - name: Try to get all daemons' statistics from a specified node (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -803,7 +803,7 @@ stages:
   - name: Try to get stats (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -817,7 +817,7 @@ stages:
   - name: Try to get hourly stats (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats/hourly"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -831,7 +831,7 @@ stages:
   - name: Try to get weekly stats (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats/weekly"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -845,7 +845,7 @@ stages:
   - name: Try to get analysisd stats (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -859,7 +859,7 @@ stages:
   - name: Try to get remoted stats (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats/remoted"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -873,7 +873,7 @@ stages:
   - name: Try to get logs (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -887,7 +887,7 @@ stages:
   - name: Try to get summary logs (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -901,7 +901,7 @@ stages:
   - name: Try to restart all nodes (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -911,7 +911,7 @@ stages:
   - name: Try to restart master-node node (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       params:
         nodes_list: master-node
@@ -927,7 +927,7 @@ stages:
   - name: Try to reload all nodes analysisd (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -937,7 +937,7 @@ stages:
   - name: Try to reload master-node analysisd (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/analysisd/reload"
       method: PUT
       params:
         nodes_list: master-node
@@ -953,7 +953,7 @@ stages:
   - name: Try to request cluster validation (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -963,7 +963,7 @@ stages:
   - name: Try to request master-node validation (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       params:
         nodes_list: master-node
@@ -979,7 +979,7 @@ stages:
   - name: Try to get analysis global configuration (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/analysis/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -993,7 +993,7 @@ stages:
   - name: Try to get decoders (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1003,7 +1003,7 @@ stages:
   - name: Try to one decoder (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       method: GET
       params:
         decoder_names: agent-buffer
@@ -1020,7 +1020,7 @@ stages:
   - name: Try to get decoders files (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1030,7 +1030,7 @@ stages:
   - name: Try to get one decoder file (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       method: GET
       params:
         filename: local_decoder.xml
@@ -1046,7 +1046,7 @@ stages:
   - name: Try to get decoder file content
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1060,7 +1060,7 @@ stages:
   - name: Try to delete decoder file content
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1074,7 +1074,7 @@ stages:
   - name: Try to upload decoder file content
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       method: PUT
       data: "{new_decoder:s}"
       headers:
@@ -1090,7 +1090,7 @@ stages:
   - name: Try to get information about all decoders parents
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/parents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1104,7 +1104,7 @@ stages:
   - name: Try to delete rootcheck data (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       method: DELETE
       params:
         agents_list: all
@@ -1116,7 +1116,7 @@ stages:
   - name: Try to delete agent 001 rootcheck data (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       method: DELETE
       params:
         agents_list: '001'
@@ -1132,7 +1132,7 @@ stages:
   - name: Try to delete all experimental syscheck data (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       params:
         agents_list: all
@@ -1144,7 +1144,7 @@ stages:
   - name: Try to delete agent 001 experimental syscheck data (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       params:
         agents_list: '001'
@@ -1160,7 +1160,7 @@ stages:
   - name: Try to get agents ciscat results (experimental) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1170,7 +1170,7 @@ stages:
   - name: Try to get agent 001 ciscat results (experimental) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       params:
         agents_list: '001'
       method: GET
@@ -1186,7 +1186,7 @@ stages:
   - name: Try to get agents hardware (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1196,7 +1196,7 @@ stages:
   - name: Try to get agent 001 hardware (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       params:
         agents_list: '001'
@@ -1212,7 +1212,7 @@ stages:
   - name: Try to get agents netaddr (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1222,7 +1222,7 @@ stages:
   - name: Try to get agent 001 netaddr (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       params:
         agents_list: '001'
@@ -1238,7 +1238,7 @@ stages:
   - name: Try to get agents netiface (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1248,7 +1248,7 @@ stages:
   - name: Try to get agent 001 netiface (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       params:
         agents_list: '001'
@@ -1264,7 +1264,7 @@ stages:
   - name: Try to get agents netproto (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1274,7 +1274,7 @@ stages:
   - name: Try to get agent 001 netproto (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       params:
         agents_list: '001'
@@ -1290,7 +1290,7 @@ stages:
   - name: Try to get agents OS (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1300,7 +1300,7 @@ stages:
   - name: Try to get agent 001 OS (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       params:
         agents_list: '001'
@@ -1316,7 +1316,7 @@ stages:
   - name: Try to get agents packages (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1326,7 +1326,7 @@ stages:
   - name: Try to get agent 001 packages (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages"
       method: GET
       params:
         agents_list: '001'
@@ -1342,7 +1342,7 @@ stages:
   - name: Try to get agents ports (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1352,7 +1352,7 @@ stages:
   - name: Try to get agent 001 ports (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       params:
         agents_list: '001'
@@ -1368,7 +1368,7 @@ stages:
   - name: Try to get agents processes (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1378,7 +1378,7 @@ stages:
   - name: Try to get agent 001 processes (experimental syscollector) (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       params:
         agents_list: '001'
@@ -1394,7 +1394,7 @@ stages:
   - name: Try to get agents hotfixes (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1404,7 +1404,7 @@ stages:
   - name: Try to get agent 001 hotfixes (experimental syscollector) (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       params:
         agents_list: '001'
@@ -1420,7 +1420,7 @@ stages:
   - name: Try to delete all groups (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       params:
         groups_list: all
@@ -1432,7 +1432,7 @@ stages:
   - name: Try to delete group3 (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: DELETE
       params:
         groups_list: group3
@@ -1448,7 +1448,7 @@ stages:
   - name: Try to get all groups (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1458,7 +1458,7 @@ stages:
   - name: Try to get group1 (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: GET
       params:
         groups_list: group1
@@ -1474,7 +1474,7 @@ stages:
   - name: Try to create new group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups"
       method: POST
       json:
         group_id: "group5"
@@ -1490,7 +1490,7 @@ stages:
   - name: Try to get agents in group1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/agents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1504,7 +1504,7 @@ stages:
   - name: Try to get group1 configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1518,7 +1518,7 @@ stages:
   - name: Try to update group1 configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/group1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/group1/configuration"
       method: PUT
       data:
         "{file_xml:s}"
@@ -1535,7 +1535,7 @@ stages:
   - name: Try to get one file of a group
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files/agent.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files/agent.conf"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1549,7 +1549,7 @@ stages:
   - name: Try to get group files
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/groups/default/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/groups/default/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1563,7 +1563,7 @@ stages:
   - name: Try to get all CDB lists (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1573,7 +1573,7 @@ stages:
   - name: Try to get one CDB list (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       method: GET
       params:
         relative_dirname: etc/lists
@@ -1590,7 +1590,7 @@ stages:
   - name: Try to get CDB list file content
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1604,7 +1604,7 @@ stages:
   - name: Try to upload CDB list file content
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new-list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new-list"
       method: PUT
       data: "{new_cdb_list:s}"
       headers:
@@ -1620,7 +1620,7 @@ stages:
   - name: Try to delete CDB list file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1634,7 +1634,7 @@ stages:
   - name: Try to get all CDB lists paths (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1644,7 +1644,7 @@ stages:
   - name: Try to get one CDB list path (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files"
       method: GET
       params:
         relative_dirname: etc/lists
@@ -1661,7 +1661,7 @@ stages:
   - name: Try to run logtest
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1681,7 +1681,7 @@ stages:
   - name: Try to end logtest session
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest/sessions/testtoken"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest/sessions/testtoken"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1695,7 +1695,7 @@ stages:
   - name: Try to get manager status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1709,7 +1709,7 @@ stages:
   - name: Try to get manager info
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1723,7 +1723,7 @@ stages:
   - name: Try to get manager configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1737,7 +1737,7 @@ stages:
   - name: Try to update manager configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -1753,7 +1753,7 @@ stages:
   - name: Try to get all daemons' statistics
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1767,7 +1767,7 @@ stages:
   - name: Try to get manager stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1781,7 +1781,7 @@ stages:
   - name: Try to get manager hourly stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1795,7 +1795,7 @@ stages:
   - name: Try to get manager weekly stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1809,7 +1809,7 @@ stages:
   - name: Try to get manager analysisd stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1823,7 +1823,7 @@ stages:
   - name: Try to get manager remoted stats
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1837,7 +1837,7 @@ stages:
   - name: Try to get manager logs
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1851,7 +1851,7 @@ stages:
   - name: Try to get manager summary logs
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1865,7 +1865,7 @@ stages:
   - name: Try to get manager API config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1879,7 +1879,7 @@ stages:
   - name: Try to restart manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1893,7 +1893,7 @@ stages:
   - name: Try to reload manager analysisd
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1907,7 +1907,7 @@ stages:
   - name: Try to show the config of analysis/global in the manager
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/configuration/analysis/global"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1921,7 +1921,7 @@ stages:
   - name: Try to validate manager configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1935,7 +1935,7 @@ stages:
   - name: Try to get MITRE metadata
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/metadata"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1950,7 +1950,7 @@ stages:
   - name: Try to get MITRE mitigations
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/mitigations"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/mitigations"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1965,7 +1965,7 @@ stages:
   - name: Try to get MITRE references
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/references"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1980,7 +1980,7 @@ stages:
   - name: Try to get MITRE techniques
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/techniques"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1995,7 +1995,7 @@ stages:
   - name: Try to get MITRE tactics
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/tactics"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/tactics"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2010,7 +2010,7 @@ stages:
   - name: Try to get MITRE groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2025,7 +2025,7 @@ stages:
   - name: Try to get MITRE software
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/software"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2039,7 +2039,7 @@ stages:
   - name: Try to get agents overview
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
+      url: "{protocol:s}://{host:s}:{master_port:d}/overview/agents"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2071,7 +2071,7 @@ stages:
   - name: Try to run rootcheck scan (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2081,7 +2081,7 @@ stages:
   - name: Try to run rootcheck scan (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       method: PUT
       params:
         agents_list: '001'
@@ -2098,7 +2098,7 @@ stages:
   - name: Try to delete agent 001 rootcheck data
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2112,7 +2112,7 @@ stages:
   - name: Try to get last scan date for agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001/last_scan"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2126,7 +2126,7 @@ stages:
   - name: Try to get rootcheck results for agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2140,7 +2140,7 @@ stages:
   - name: Try to get all rules (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2150,7 +2150,7 @@ stages:
   - name: Try to get a rule (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       method: GET
       params:
         rule_ids: 1
@@ -2165,7 +2165,7 @@ stages:
   - name: Try to get rules groups
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2179,7 +2179,7 @@ stages:
   - name: Try to get rules with pci_dss requirement
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/pci_dss"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2193,7 +2193,7 @@ stages:
   - name: Try to get rule file content
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/local_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/local_rules.xml"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2207,7 +2207,7 @@ stages:
   - name: Try to get rules files (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2217,7 +2217,7 @@ stages:
   - name: Try to get rules file (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       method: GET
       params:
         relative_dirname: ruleset/rules
@@ -2234,7 +2234,7 @@ stages:
   - name: Try to upload rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -2250,7 +2250,7 @@ stages:
   - name: Try to delete rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2264,7 +2264,7 @@ stages:
   - name: Try to revoke all JWT tokens
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2278,7 +2278,7 @@ stages:
   - name: Try to get API users (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2288,7 +2288,7 @@ stages:
   - name: Try to get API user (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2304,7 +2304,7 @@ stages:
   - name: Try to add API user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       method: POST
       json:
         username: newUser
@@ -2321,7 +2321,7 @@ stages:
   - name: Try to change the allow_run_as field of a user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/1/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/1/run_as"
       method: PUT
       params:
         allow_run_as: false
@@ -2337,7 +2337,7 @@ stages:
   - name: Try to delete API users (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       method: DELETE
       params:
         user_ids: all
@@ -2349,7 +2349,7 @@ stages:
   - name: Try to delete API user (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       method: DELETE
       params:
         user_ids: 002
@@ -2365,7 +2365,7 @@ stages:
   - name: Try to update API user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/1"
       method: PUT
       json:
         password: stringB1!
@@ -2381,7 +2381,7 @@ stages:
   - name: Try to get API roles (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2391,7 +2391,7 @@ stages:
   - name: Try to get API role (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       method: GET
       params:
         role_ids: 1
@@ -2407,7 +2407,7 @@ stages:
   - name: Try to add API role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       method: POST
       json:
         name: test_role
@@ -2423,7 +2423,7 @@ stages:
   - name: Try to delete API roles (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       method: DELETE
       params:
         role_ids: all
@@ -2436,7 +2436,7 @@ stages:
   - name: Try to delete API role (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       method: DELETE
       params:
         role_ids: 8
@@ -2452,7 +2452,7 @@ stages:
   - name: Try to update API role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/8"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/8"
       method: PUT
       json:
         name: new_name
@@ -2468,7 +2468,7 @@ stages:
   - name: Try to get API rules (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2478,7 +2478,7 @@ stages:
   - name: Try to get API rule (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       method: GET
       params:
         rule_ids: 1
@@ -2494,7 +2494,7 @@ stages:
   - name: Try to add API rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       method: POST
       json:
         name: new_rule
@@ -2513,7 +2513,7 @@ stages:
   - name: Try to update API rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/1"
       method: PUT
       json:
         name: changed_name
@@ -2532,7 +2532,7 @@ stages:
   - name: Try to delete API rules (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       method: DELETE
       params:
         rule_ids: all
@@ -2544,7 +2544,7 @@ stages:
   - name: Try to delete API rule (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       method: DELETE
       params:
         rule_ids: 1
@@ -2560,7 +2560,7 @@ stages:
   - name: Try to get API policies (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2570,7 +2570,7 @@ stages:
   - name: Try to get API policy (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       method: GET
       params:
         policy_ids: 1
@@ -2586,7 +2586,7 @@ stages:
   - name: Try to delete API policy (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       method: DELETE
       params:
         policy_ids: all
@@ -2598,7 +2598,7 @@ stages:
   - name: Try to delete API policy (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       method: DELETE
       params:
         policy_ids: 1
@@ -2614,7 +2614,7 @@ stages:
   - name: Try to add API policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       method: POST
       json:
         name: "test_i2"
@@ -2638,7 +2638,7 @@ stages:
   - name: Try to update API policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/1"
       method: PUT
       json:
         name: "test_i3"
@@ -2662,7 +2662,7 @@ stages:
   - name: Try to add roles to user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/99/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/99/roles"
       method: POST
       params:
         role_ids: 1
@@ -2678,7 +2678,7 @@ stages:
   - name: Try to remove roles from user (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/99/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/99/roles"
       method: DELETE
       params:
         role_ids: all
@@ -2690,7 +2690,7 @@ stages:
   - name: Try to remove role from user (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/99/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/99/roles"
       method: DELETE
       params:
         role_ids: 1
@@ -2706,7 +2706,7 @@ stages:
   - name: Try to add policies to role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1/policies"
       method: POST
       params:
         policy_ids: 1
@@ -2722,7 +2722,7 @@ stages:
   - name: Try to add rules to role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1/rules"
       method: POST
       params:
         rule_ids: 1
@@ -2738,7 +2738,7 @@ stages:
   - name: Try to remove policies from role (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1/policies"
       method: DELETE
       params:
         policy_ids: all
@@ -2750,7 +2750,7 @@ stages:
   - name: Try to remove policy from role (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1/policies"
       method: DELETE
       params:
         policy_ids: 1
@@ -2766,7 +2766,7 @@ stages:
   - name: Try to remove rules from role (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1/rules"
       method: DELETE
       params:
         rule_ids: all
@@ -2778,7 +2778,7 @@ stages:
   - name: Try to remove rule from role (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/1/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/1/rules"
       method: DELETE
       params:
         rule_ids: 1
@@ -2794,7 +2794,7 @@ stages:
   - name: Try to get API security config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2808,7 +2808,7 @@ stages:
   - name: Try to update API security config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       method: PUT
       json:
         auth_token_exp_timeout: 700
@@ -2824,7 +2824,7 @@ stages:
   - name: Try to restore default API security config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2838,7 +2838,7 @@ stages:
   - name: Try to get SCA data
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2852,7 +2852,7 @@ stages:
   - name: Try to request policy checks for 000
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/000/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/000/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2866,7 +2866,7 @@ stages:
   - name: Try to run syscheck scan (generic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2876,7 +2876,7 @@ stages:
   - name: Try to run syscheck scan (specific)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       method: PUT
       params:
         agents_list: '001'
@@ -2892,7 +2892,7 @@ stages:
   - name: Try to get syscheck data
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2906,7 +2906,7 @@ stages:
   - name: Try to remove syscheck data
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/001"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2920,7 +2920,7 @@ stages:
   - name: Try to get syscheck last scan for agent 001
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/001/last_scan"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2934,7 +2934,7 @@ stages:
   - name: Try to get agent hardware (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2948,7 +2948,7 @@ stages:
   - name: Try to get agent hotfixes (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2962,7 +2962,7 @@ stages:
   - name: Try to get agent netaddr (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2976,7 +2976,7 @@ stages:
   - name: Try to get agent netiface (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2990,7 +2990,7 @@ stages:
   - name: Try to get agent netproto (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3004,7 +3004,7 @@ stages:
   - name: Try to get agent os (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3018,7 +3018,7 @@ stages:
   - name: Try to get agent packages (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3032,7 +3032,7 @@ stages:
   - name: Try to get agent ports (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3046,7 +3046,7 @@ stages:
   - name: Try to get agent processes (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3060,7 +3060,7 @@ stages:
   - name: Try to get agent users (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/users"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3074,7 +3074,7 @@ stages:
   - name: Try to get agent groups (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3088,7 +3088,7 @@ stages:
   - name: Try to get agent browser extensions (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/browser_extensions"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3102,7 +3102,7 @@ stages:
   - name: Try to get agent services (syscollector)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/services"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -3116,7 +3116,7 @@ stages:
   - name: Try to get tasks status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cdb_list_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Show the lists of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -29,7 +29,7 @@ stages:
   - name: Show an specified filename (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -51,7 +51,7 @@ stages:
   - name: Try to show an specified path (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -73,7 +73,7 @@ stages:
   - name: Show the lists files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -99,7 +99,7 @@ stages:
   - name: Show content from a list (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/aws-eventnames"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/aws-eventnames"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -116,7 +116,7 @@ stages:
   - name: Try to show content from a list (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/security-eventchannel"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -132,7 +132,7 @@ stages:
   - name: Try to overwrite security-eventchannel (indirectly denied deletion)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/security-eventchannel"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -155,7 +155,7 @@ stages:
   - name: Overwrite audit-keys list (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -175,7 +175,7 @@ stages:
   - name: Updload new list file (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/new_cdb_list"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/new_cdb_list"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -197,7 +197,7 @@ stages:
   - name: Delete a CDB list (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/audit-keys"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/audit-keys"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -215,7 +215,7 @@ stages:
   - name: Try to delete a CDB list (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/lists/files/security-eventchannel"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/lists/files/security-eventchannel"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE

--- a/api/test/integration/test_rbac_white_ciscat_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_ciscat_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get ciscat result for agent 001 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/001/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/001/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Get ciscat result for agent 002 (allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/002/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/002/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -40,7 +40,7 @@ stages:
   - name: Get ciscat result for agent 003 (denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/ciscat/003/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/ciscat/003/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get cluster config
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -37,7 +37,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -67,7 +67,7 @@ stages:
   - name: Get cluster healtcheck
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/healthcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/healthcheck"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -102,7 +102,7 @@ stages:
   - name: Get cluster ruleset synchronization status (partial response, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/ruleset/synchronization"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/ruleset/synchronization"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -128,7 +128,7 @@ stages:
   - name: Get cluster node
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/local/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/local/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -153,7 +153,7 @@ stages:
   - name: Get cluster nodes
     request: &get_cluster_nodes
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -236,7 +236,7 @@ stages:
   - name: Get cluster (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -250,7 +250,7 @@ stages:
   - name: Get cluster (worker2) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -271,7 +271,7 @@ stages:
   - name: Get cluster (master-node,worker1,worker2) (Allow, Deny, Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/nodes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/nodes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -303,7 +303,7 @@ stages:
   - name: Get cluster status
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -323,7 +323,7 @@ stages:
   - name: Request (master-node)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -356,7 +356,7 @@ stages:
   - name: Request (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -366,7 +366,7 @@ stages:
   - name: Filters -> section=alerts (worker2) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -393,7 +393,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -414,7 +414,7 @@ stages:
   - name: Request cluster validation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/configuration/validation"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -444,7 +444,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -454,7 +454,7 @@ stages:
   - name: Try to show the config of analisys/global through a worker
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration/analysis/global"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/configuration/analysis/global"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -469,7 +469,7 @@ stages:
   - name: Request (worker1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -479,7 +479,7 @@ stages:
   - name: Request (master-node)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/master-node/info"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/master-node/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -494,7 +494,7 @@ stages:
   - name: Request (worker2) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -504,7 +504,7 @@ stages:
   - name: Request (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -519,7 +519,7 @@ stages:
   - name: Request (worker2) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -529,7 +529,7 @@ stages:
   - name: Request (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/logs/summary"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -544,7 +544,7 @@ stages:
   - name: Request daemons statistics from worker1 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -554,7 +554,7 @@ stages:
   - name: Request daemons statistics from worker2 (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/daemons/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -569,7 +569,7 @@ stages:
   - name: Cluster stats (worker1) today (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -579,7 +579,7 @@ stages:
   - name: Cluster stats (worker2) today (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/stats"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -596,7 +596,7 @@ stages:
   - name: Request (worker2) (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -606,7 +606,7 @@ stages:
   - name: Request (worker1) (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -621,7 +621,7 @@ stages:
   - name: Request API config (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/api/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -651,7 +651,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -676,7 +676,7 @@ stages:
   - name: Restart cluster
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/restart"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -702,7 +702,7 @@ stages:
   - name: Reload cluster nodes ruleset (worker1, worker2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -734,7 +734,7 @@ stages:
   - name: Upload a valid configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker2/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker2/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -754,7 +754,7 @@ stages:
   - name: Try to upload a valid configuration (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/worker1/configuration"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/cluster/worker1/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:

--- a/api/test/integration/test_rbac_white_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_decoder_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Try to show the decoders of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -36,7 +36,7 @@ stages:
   - name: Try to show the decoders of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -55,7 +55,7 @@ stages:
   - name: Try to show the decoders of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -91,7 +91,7 @@ stages:
   - name: Try to show the decoders files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -114,7 +114,7 @@ stages:
   - name: Try to show the decoders files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -139,7 +139,7 @@ stages:
   - name: Try to show the decoders files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -161,7 +161,7 @@ stages:
   - name: Get one decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0005-wazuh_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0005-wazuh_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -171,7 +171,7 @@ stages:
   - name: Try to get one decoder file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/0064-cisco-asa_decoders.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/0064-cisco-asa_decoders.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -186,7 +186,7 @@ stages:
   - name: Update one decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -198,7 +198,7 @@ stages:
   - name: Try to update the same file without delete permissions (overwrite)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/new_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/new_decoder.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -224,7 +224,7 @@ stages:
   - name: Delete one decoder file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/local_decoder.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/local_decoder.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -234,7 +234,7 @@ stages:
   - name: Try to delete one decoder file that does not exist
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/files/not_exist.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/files/not_exist.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -249,7 +249,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/decoders/parents"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/decoders/parents"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_event_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_event_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Try to send webhook events (Denied)
     request:
       verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/events"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/events"
       method: POST
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_experimental_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -26,7 +26,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -39,7 +39,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -62,7 +62,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/rootcheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -94,7 +94,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscheck"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -147,7 +147,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -164,7 +164,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/ciscat/results"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/ciscat/results"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -193,7 +193,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -214,7 +214,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hardware"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -245,7 +245,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -266,7 +266,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netaddr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -297,7 +297,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -318,7 +318,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netiface"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -349,7 +349,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -370,7 +370,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/netproto"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -401,7 +401,7 @@ stages:
   - name: Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -422,7 +422,7 @@ stages:
   - name: Request a list of agents (Partially allowed, user aware)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -453,7 +453,7 @@ stages:
   - name:  Request all agents (Partially allowed, user agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages?wait_for_complete=true"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages?wait_for_complete=true"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -470,7 +470,7 @@ stages:
   - name:  Request all agents (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/packages"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -491,7 +491,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -528,7 +528,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/ports"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -557,7 +557,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -574,7 +574,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/processes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -603,7 +603,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -620,7 +620,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/experimental/syscollector/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/experimental/syscollector/hotfixes"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_logtest_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_logtest_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Run logtest without token (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -26,7 +26,7 @@ stages:
   - name: Run logtest without token in order to start session (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -47,7 +47,7 @@ stages:
   - name: End logtest session (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/logtest/sessions/{returned_token:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/logtest/sessions/{returned_token:s}"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_manager_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Request manager configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Request manager configuration validation (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/validation"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -38,7 +38,7 @@ stages:
   - name: Request manager component configuration (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/agentless/agentless"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration/agentless/agentless"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -53,7 +53,7 @@ stages:
   - name: Request manager info (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/info"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/info"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -68,7 +68,7 @@ stages:
   - name: Request manager logs (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -83,7 +83,7 @@ stages:
   - name: Request manager logs summary (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/logs/summary"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -98,7 +98,7 @@ stages:
   - name: Request daemons statistics (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/daemons/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/daemons/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -113,7 +113,7 @@ stages:
   - name: Request manager stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -130,7 +130,7 @@ stages:
   - name: Request manager analysisd stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/analysisd"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/analysisd"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -145,7 +145,7 @@ stages:
   - name: Request manager hourly stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/hourly"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/hourly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -160,7 +160,7 @@ stages:
   - name: Request manager remoted stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/remoted"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/remoted"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -175,7 +175,7 @@ stages:
   - name: Request manager weekly stats (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/stats/weekly"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/stats/weekly"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -190,7 +190,7 @@ stages:
   - name: Request manager status (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/status"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -205,7 +205,7 @@ stages:
   - name: Request API config (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/api/config"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/api/config"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -220,7 +220,7 @@ stages:
   - name: Upload a valid configuration (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/configuration"
       method: PUT
       data: "{valid_ossec_conf:s}"
       headers:
@@ -237,7 +237,7 @@ stages:
   - name: Restart manager (Denied) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/restart"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -252,7 +252,7 @@ stages:
   - name: Restart manager (Denied) (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/analysisd/reload"
+      url: "{protocol:s}://{host:s}:{master_port:d}/manager/analysisd/reload"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_mitre_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Request MITRE metadata (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/metadata"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/metadata"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -25,7 +25,7 @@ stages:
   - name: Request MITRE mitigations (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/mitigations"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/mitigations"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -41,7 +41,7 @@ stages:
   - name: Request MITRE references (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/references"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/references"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -57,7 +57,7 @@ stages:
   - name: Request MITRE techniques (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/techniques"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/techniques"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -73,7 +73,7 @@ stages:
   - name: Request MITRE tactics (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/tactics"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/tactics"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -89,7 +89,7 @@ stages:
   - name: Request MITRE groups (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -105,7 +105,7 @@ stages:
   - name: Request MITRE software (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/mitre/software"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/mitre/software"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_overview_endpoints.tavern.yaml
@@ -5,7 +5,7 @@ stages:
  - name: Get full agents overview
    request:
      verify: False
-     url: "{protocol:s}://{host:s}:{port:d}/overview/agents"
+     url: "{protocol:s}://{host:s}:{master_port:d}/overview/agents"
      method: GET
      headers:
        Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rootcheck_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/000"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -24,7 +24,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response: &permission_denied
@@ -44,7 +44,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -63,7 +63,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -78,7 +78,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -95,7 +95,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -119,7 +119,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -136,7 +136,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -153,7 +153,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_white_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_rule_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Try to show the rules of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -45,7 +45,7 @@ stages:
   - name: Try to show the rules of the system (try q parameter to bypass a denied resource)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -64,7 +64,7 @@ stages:
   - name: Try to show the rules of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -103,7 +103,7 @@ stages:
   - name: Try to show the rules files of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -126,7 +126,7 @@ stages:
   - name: Try to show the rules files of the system (list)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -149,7 +149,7 @@ stages:
   - name: Try to show the rules files of the system (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -171,7 +171,7 @@ stages:
   - name: Get one rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0015-ossec_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0015-ossec_rules.xml"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -185,7 +185,7 @@ stages:
   - name: Try to get one rule file (no permissions)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0011-ossec_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0011-ossec_rules.xml"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -200,7 +200,7 @@ stages:
   - name: Update one rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -212,7 +212,7 @@ stages:
   - name: Try to update the same file without delete permissions (overwrite)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -238,7 +238,7 @@ stages:
   - name: Delete one rule file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/local_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/local_rules.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -248,7 +248,7 @@ stages:
   - name: Try to delete one rule file that does not exist
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/not_exist.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/not_exist.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -263,7 +263,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -285,7 +285,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/pci_dss"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -307,7 +307,7 @@ stages:
   - name: Try to show the groups of rules in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/mitre"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_sca_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Request sca for agent 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/000"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/000"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -19,7 +19,7 @@ stages:
   - name: Request sca for agent 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -34,7 +34,7 @@ stages:
   - name: Request sca for agent 002 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/002"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -47,7 +47,7 @@ stages:
   - name: Request sca for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -57,7 +57,7 @@ stages:
   - name: Request sca for agent 003 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/003"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/003"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -67,7 +67,7 @@ stages:
   - name: Request sca for agent 005 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/005"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/005"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -85,7 +85,7 @@ stages:
   - name: Request policy checks for 000 (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/000/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/000/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -98,7 +98,7 @@ stages:
   - name: Request policy checks for 001 (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/cis_debian9_L1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/cis_debian9_L1"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -45,7 +45,7 @@ stages:
   - name: Get a specified user by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -71,7 +71,7 @@ stages:
   - name: Get a specified user by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -88,7 +88,7 @@ stages:
   - name: Get a list of users by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -116,7 +116,7 @@ stages:
   - name: Get a list of users by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -128,7 +128,7 @@ stages:
   - name: Get a list of users by its username (Both)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -178,7 +178,7 @@ stages:
   - name: Get all roles in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -223,7 +223,7 @@ stages:
   - name: Get a specified role by its id (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -244,7 +244,7 @@ stages:
   - name: Get a specified role by its id (It doesn't exist but we have all the permissions on the resource roles)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -267,7 +267,7 @@ stages:
   - name: Get a list of roles by its id (Existent and no existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -299,7 +299,7 @@ stages:
   - name: Get all rules in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -329,7 +329,7 @@ stages:
   - name: Get all policies in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -346,7 +346,7 @@ stages:
   - name: Get a specified policy by its id (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -363,7 +363,7 @@ stages:
   - name: Get current security config (allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -383,7 +383,7 @@ stages:
   - name: Update default security config (deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -400,7 +400,7 @@ stages:
   - name: Update one specified user in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/105"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/105"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -412,7 +412,7 @@ stages:
   - name: Update one specified user in the system (All denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/1"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -429,7 +429,7 @@ stages:
   - name: Update one specified user's allow_run_as flag (Allowed)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103/run_as"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -454,7 +454,7 @@ stages:
   - name: Update one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -475,7 +475,7 @@ stages:
   - name: Update one specified role in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/2"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -492,7 +492,7 @@ stages:
   - name: Update one specified rule in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -509,7 +509,7 @@ stages:
   - name: Update one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -546,7 +546,7 @@ stages:
   - name: Update one specified policy in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/106"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/106"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -569,7 +569,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -581,7 +581,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Allow and Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -598,7 +598,7 @@ stages:
   - name: Create one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -631,7 +631,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -643,7 +643,7 @@ stages:
   - name: Create one specified link between one user and a list of roles (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -660,7 +660,7 @@ stages:
   - name: Create one specified link between one role and a list of rules (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -672,7 +672,7 @@ stages:
   - name: Create one specified link between one role and a list of rules (Partially allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/105/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/105/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -704,7 +704,7 @@ stages:
   - name: Delete one specified link between one role and a list of rules (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/11/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/11/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -721,7 +721,7 @@ stages:
   - name: Delete one specified link between one user and a list of roles (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -733,7 +733,7 @@ stages:
   - name: Delete one specified link between one user and a list of roles (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/104/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/104/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -750,7 +750,7 @@ stages:
   - name: Delete one specified link between one role and a list of policies (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/11/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/11/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -767,7 +767,7 @@ stages:
   - name: Delete one specified user in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -789,7 +789,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -811,7 +811,7 @@ stages:
   - name: Delete all allowed user in the system (All)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -830,7 +830,7 @@ stages:
   - name: Delete a list of users in the system (Allow and deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -863,7 +863,7 @@ stages:
   - name: Delete all rules in the system (Deny) (User agnostic)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -882,7 +882,7 @@ stages:
   - name: Delete one specified rule in the system (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -899,7 +899,7 @@ stages:
   - name: Delete all roles in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -918,7 +918,7 @@ stages:
   - name: Delete one specified role in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -935,7 +935,7 @@ stages:
   - name: Delete one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -954,7 +954,7 @@ stages:
   - name: Delete one specified policy in the system (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -971,7 +971,7 @@ stages:
   - name: Create one specified user (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -989,7 +989,7 @@ stages:
   - name: Create one specified role (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1010,7 +1010,7 @@ stages:
   - name: Create one specified policy (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1050,7 +1050,7 @@ stages:
   - name: Revoke all tokens (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT

--- a/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscheck_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -24,7 +24,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response: &permission_denied
@@ -44,7 +44,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/000/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -63,7 +63,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -78,7 +78,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -95,7 +95,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -119,7 +119,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -136,7 +136,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -157,7 +157,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_syscollector_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get os from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -38,7 +38,7 @@ stages:
   - name: Get os from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/os"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -58,7 +58,7 @@ stages:
   - name: Get hardware from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -86,7 +86,7 @@ stages:
   - name: Get hardware from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -101,7 +101,7 @@ stages:
   - name: Get netaddr from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -123,7 +123,7 @@ stages:
   - name: Get netaddr from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -138,7 +138,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -171,7 +171,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -186,7 +186,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -207,7 +207,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -222,7 +222,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -253,7 +253,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -268,7 +268,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/006/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -299,7 +299,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -314,7 +314,7 @@ stages:
   - name: Get netiface from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/006/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/006/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -362,7 +362,7 @@ stages:
   - name: Get netiface from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -377,7 +377,7 @@ stages:
   - name: Get all hotfixes from an agent (Allow)
     request: &hotfix_request_allow
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -396,7 +396,7 @@ stages:
   - name: Get all hotfixes from an agent (Deny)
     request: &hotfix_request_deny
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -418,7 +418,7 @@ stages:
   - name: Get users from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -433,7 +433,7 @@ stages:
   - name: Get users from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -448,7 +448,7 @@ stages:
   - name: Get groups from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -463,7 +463,7 @@ stages:
   - name: Get groups from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -478,7 +478,7 @@ stages:
   - name: Get browser extensions from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/browser_extensions"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -493,7 +493,7 @@ stages:
   - name: Get browser extensions from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/browser_extensions"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -508,7 +508,7 @@ stages:
   - name: Get services from an agent (Allow)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/services"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -523,7 +523,7 @@ stages:
   - name: Get services from an agent (Deny)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/services"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_task_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all existent tasks (At this point there is no task created)
     request: &get_tasks
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Upgrade an agent
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -33,7 +33,7 @@ stages:
     request: &get_rootcheck_agent
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -465,7 +465,7 @@ stages:
   - name: Try to get 012 agent's rootcheck data (never connected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/012"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/012"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -484,7 +484,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -505,7 +505,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -532,7 +532,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -557,7 +557,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -588,7 +588,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -607,7 +607,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -627,7 +627,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/rootcheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rootcheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_rule_endpoints.tavern.yaml
+++ b/api/test/integration/test_rule_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Try to show the rules of the system
     request: &general_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -214,7 +214,7 @@ stages:
   - name: Search in rules
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -318,7 +318,7 @@ stages:
   - name: Try to show the rules of the system with a non-existent state
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -780,7 +780,7 @@ stages:
   - name: Try to show the rules by requirement pci_dss
     request: &pci_dss_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/pci_dss"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/pci_dss"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -888,7 +888,7 @@ stages:
   - name: Try to show the rules by requirement gdpr
     request: &gdpr_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/gdpr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/gdpr"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -997,7 +997,7 @@ stages:
   - name: Try to show the rules by requirement gpg13
     request: &gpg13_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/gpg13"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/gpg13"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1111,7 +1111,7 @@ stages:
   - name: Try to show the rules by requirement hipaa
     request: &hipaa_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/hipaa"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/hipaa"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1198,7 +1198,7 @@ stages:
   - name: Try to show the rules by requirement nist-800-53
     request: &nist-800-53_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/nist-800-53"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/nist-800-53"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1285,7 +1285,7 @@ stages:
   - name: Try to show the rules by requirement tsc
     request: &tsc_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/tsc"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/tsc"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1370,7 +1370,7 @@ stages:
   - name: Try to show the rules by requirement mitre
     request: &mitre_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/requirement/mitre"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/requirement/mitre"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1457,7 +1457,7 @@ stages:
   - name: Try to show the rules groups
     request: &groups_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/groups"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1559,7 +1559,7 @@ stages:
   - name: Get the rules files
     request: &files_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1728,7 +1728,7 @@ stages:
   - name: Download rule (JSON format)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0350-amazon_rules.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1745,7 +1745,7 @@ stages:
   - name: Download rule (raw format)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0350-amazon_rules.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1758,7 +1758,7 @@ stages:
   - name: Download rule (it does not exist)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/no_exists.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/no_exists.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1778,7 +1778,7 @@ stages:
   - name: Download rule (user ruleset, rule belongs to default ruleset)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0350-amazon_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0350-amazon_rules.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1800,7 +1800,7 @@ stages:
   - name: Download rule (invalid file 1)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/rulexml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/rulexml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1812,7 +1812,7 @@ stages:
   - name: Download rule (invalid file 2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/..%2F..%2Fetc%local_rules.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/..%2F..%2Fetc%local_rules.xml"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1829,7 +1829,7 @@ stages:
   - name: Upload new valid rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -1849,7 +1849,7 @@ stages:
   - name: Upload new valid rule in custom subdir
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -1871,7 +1871,7 @@ stages:
   - name: Upload same rule (overwrite=False)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -1894,7 +1894,7 @@ stages:
   - name: Upload same rule (overwrite=True)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -1908,7 +1908,7 @@ stages:
   - name: Upload rule with invalid name
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule"
       method: PUT
       data: "{new_rules:s}"
       headers:
@@ -1923,7 +1923,7 @@ stages:
   - name: Upload invalid rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/invalid_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/invalid_rule.xml"
       method: PUT
       data: "{new_rules_with_syntax_error:s}"
       headers:
@@ -1946,7 +1946,7 @@ stages:
   - name: Upload invalid rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/empty_file.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/empty_file.xml"
       method: PUT
       data: "{empty_file_xml:s}"
       headers:
@@ -1974,7 +1974,7 @@ stages:
   - name: Delete user rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1992,7 +1992,7 @@ stages:
   - name: Delete user rule in subdir
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2012,7 +2012,7 @@ stages:
   - name: Delete same user rule (it does not exist now)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new_rule.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/new_rule.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2033,7 +2033,7 @@ stages:
   - name: Delete ruleset rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/0010-rules_config.xml"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/0010-rules_config.xml"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2054,7 +2054,7 @@ stages:
   - name: Delete invalid rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/ossec.conf"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules/files/ossec.conf"
       method: DELETE
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2072,7 +2072,7 @@ stages:
   - name: Try to show a rule with a existent id
     request: &id_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -2199,7 +2199,7 @@ stages:
   - name: No rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_sca_endpoints.tavern.yaml
+++ b/api/test/integration/test_sca_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Request
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -19,7 +19,7 @@ stages:
   - name: Parameters -> limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -55,7 +55,7 @@ stages:
   - name: Parameters -> offset=1,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -75,7 +75,7 @@ stages:
   - name: Parameters -> search=cis,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -96,7 +96,7 @@ stages:
   - name: Parameters -> q=score>0,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -117,7 +117,7 @@ stages:
   - name: Parameters -> limit=999999
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -129,7 +129,7 @@ stages:
   - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -151,7 +151,7 @@ stages:
   - name: Parameters -> description,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -173,7 +173,7 @@ stages:
   - name: Parameters -> name=CIS Benchmark for Debian/Linux 9, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -195,7 +195,7 @@ stages:
   - name: Parameters -> sort=-score,limit=10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -214,7 +214,7 @@ stages:
   - name: Parameters -> limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -251,7 +251,7 @@ stages:
   - name: Parameters -> offset=1,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -272,7 +272,7 @@ stages:
   - name: Parameters -> search=cis,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -293,7 +293,7 @@ stages:
   - name: Parameters -> q=score>0,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -314,7 +314,7 @@ stages:
   - name: Parameters -> limit=999999
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -326,7 +326,7 @@ stages:
   - name: Parameters -> references=https://www.cisecurity.org/cis-benchmarks/, limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -348,7 +348,7 @@ stages:
   - name: Parameters -> description,limit=1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -370,7 +370,7 @@ stages:
   - name: Parameters -> sort=-score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -388,7 +388,7 @@ stages:
   - name: Parameters -> sort=+score,limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -405,7 +405,7 @@ stages:
   - name: Try to get 012 agent's SCA data (never connected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/012"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/012"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -417,7 +417,7 @@ stages:
   - name: Get distinct sca agent data
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/006"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/006"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -453,7 +453,7 @@ stages:
   - name: Get agent SCA data using select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -492,7 +492,7 @@ stages:
   - name: Get agent SCA data using select and distinct
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -516,7 +516,7 @@ stages:
   - name: Get policy ID
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -531,7 +531,7 @@ stages:
   - name: Get generic SCA check item
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -559,7 +559,7 @@ stages:
   - name: Get item with the command field (q="rules.type=command")
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -602,7 +602,7 @@ stages:
   - name: Get items with the condition 'all'
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -621,7 +621,7 @@ stages:
   - name: Get item with the file field (q="rules.type=file")
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -666,7 +666,7 @@ stages:
   - name: Get SCA checks using limit=4
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -697,7 +697,7 @@ stages:
   - name: Get SCA checks using limit=2, offset=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -723,7 +723,7 @@ stages:
   - name: Try to get SCA checks using limit=999999
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -737,7 +737,7 @@ stages:
   - name: Get SCA checks using sort=-id, limit=2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -757,7 +757,7 @@ stages:
   - name: Get SCA checks using sort=-title
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -782,7 +782,7 @@ stages:
   - name: Get SCA checks using sort=command
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -808,7 +808,7 @@ stages:
   - name: Get SCA checks using search=pci_dss
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -833,7 +833,7 @@ stages:
   - name: Get SCA check using query (command)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -863,7 +863,7 @@ stages:
   - name: Get SCA check using query (file)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -895,7 +895,7 @@ stages:
   - name: Get SCA checks filtering by rationale
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -915,7 +915,7 @@ stages:
   - name: Get SCA checks filtering by command
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -935,7 +935,7 @@ stages:
   - name: Get SCA checks filtering by condition
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -955,7 +955,7 @@ stages:
   - name: Get SCA checks filtering by description
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -975,7 +975,7 @@ stages:
   - name: Get SCA checks filtering by title
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -995,7 +995,7 @@ stages:
   - name: Get SCA checks filtering by file
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1015,7 +1015,7 @@ stages:
   - name: Get SCA checks filtering by remediation
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1035,7 +1035,7 @@ stages:
   - name: Get SCA checks filtering by rationale
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1084,7 +1084,7 @@ stages:
   - name: Get policy ID
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1097,7 +1097,7 @@ stages:
   - name: Get agent SCA data using select
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1115,7 +1115,7 @@ stages:
   - name: Get agent SCA data using select and distinct
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/sca/001/checks/{sca_policy_id:s}"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/sca/001/checks/{sca_policy_id:s}"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_DELETE_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Try to delete a existent role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -29,7 +29,7 @@ stages:
   - name: Try to delete the admin role of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -52,7 +52,7 @@ stages:
   - name: Try to delete a non-existent role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -72,7 +72,7 @@ stages:
   - name: Try to delete a existent role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -95,7 +95,7 @@ stages:
   - name: Try to delete a non-existent role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -110,7 +110,7 @@ stages:
   - name: Try to delete a non-existent role-policy (role non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -125,7 +125,7 @@ stages:
   - name: Try to delete a non-existent role-policy (default role, policy non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/3/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/3/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -149,7 +149,7 @@ stages:
   - name: Try to delete a non-existent role-policy from a role (policy non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/100/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/100/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -177,7 +177,7 @@ stages:
   - name: Try to delete a existent role-rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -200,7 +200,7 @@ stages:
   - name: Try to delete a non-existent role-rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -215,7 +215,7 @@ stages:
   - name: Try to delete a non-existent role-rule (role non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -230,7 +230,7 @@ stages:
   - name: Try to delete a non-existent role-rule (reserved role)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/3/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/3/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -252,7 +252,7 @@ stages:
   - name: Try to delete a non-existent role-rule (rule non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/100/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/100/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -279,7 +279,7 @@ stages:
   - name: Try to delete a existent user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/101/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/101/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -299,7 +299,7 @@ stages:
   - name: Try to delete a non-existent user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/987/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/987/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -314,7 +314,7 @@ stages:
   - name: Try to delete a non-existent user-role (role non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/105/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/105/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -343,7 +343,7 @@ stages:
   - name: Try to delete a existent policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -365,7 +365,7 @@ stages:
   - name: Try to delete the admin policy of the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -380,7 +380,7 @@ stages:
   - name: Try to delete an inexistent policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -399,7 +399,7 @@ stages:
   - name: Try to delete one existent role and no existent one
     request: &delete_roles_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -451,7 +451,7 @@ stages:
   - name: Try to delete roles (invalid role_ids)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -469,7 +469,7 @@ stages:
   - name: Try to delete two existent policies
     request: &delete_all_policies_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -518,7 +518,7 @@ stages:
   - name: Try to delete policies (invalid policy_ids)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -536,7 +536,7 @@ stages:
     delay_before: 10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -559,7 +559,7 @@ stages:
   - name: Delete the current user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -582,7 +582,7 @@ stages:
   - name: Delete an admin user (wazuh-wui)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -605,7 +605,7 @@ stages:
   - name: Delete an existent user (with body)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -623,7 +623,7 @@ stages:
   - name: Delete an existent user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -641,7 +641,7 @@ stages:
   - name: Delete all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -677,7 +677,7 @@ stages:
   - name: Delete all users in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -694,7 +694,7 @@ stages:
   - name: Delete a non-existent rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -717,7 +717,7 @@ stages:
   - name: Delete an admin rule (wui-admin)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -740,7 +740,7 @@ stages:
   - name: Delete an existent rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -759,7 +759,7 @@ stages:
     delay_after: 1
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -788,7 +788,7 @@ stages:
   - name: Delete all rules in the system (invalid)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -806,7 +806,7 @@ stages:
   - name: Change security configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -824,7 +824,7 @@ stages:
   - name: Restore default configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -839,7 +839,7 @@ stages:
   - name: Get security configuration to check if DELETE method worked correctly
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -860,7 +860,7 @@ stages:
     delay_before: 10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -878,7 +878,7 @@ stages:
   - name: Try to delete all roles
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:

--- a/api/test/integration/test_security_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_GET_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Try to show the roles of the system
     request: &all_roles_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -400,7 +400,7 @@ stages:
   - name: Try to show the policies of the system
     request: &all_policies_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -730,7 +730,7 @@ stages:
   - name: Try to show the rules of the system
     request: &all_rules_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -842,7 +842,7 @@ stages:
   - name: Search in rules
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -1097,7 +1097,7 @@ stages:
   - name: Get an API token in raw format
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate"
       headers:
         Authorization: "Basic {basic_auth:s}"
       params:
@@ -1114,7 +1114,7 @@ stages:
   - name: Test generated token
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/"
       headers:
         Authorization: "Bearer {login_token}"
       method: GET
@@ -1136,7 +1136,7 @@ stages:
   - name: Get all users in the system
     request: &all_users_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1599,7 +1599,7 @@ stages:
   - name: Get information about the current user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/me"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/me"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1629,7 +1629,7 @@ stages:
   - name: Get information about the current user processed policies
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/me/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/me/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1647,7 +1647,7 @@ stages:
   - name: Testing RBAC's actions catalog
     request: &rbac_actions_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/actions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/actions"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1701,7 +1701,7 @@ stages:
   - name: Testing RBAC's actions catalog
     request: &rbac_resources_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/resources"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/resources"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1755,7 +1755,7 @@ stages:
   - name: Get current security configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Add a role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -29,7 +29,7 @@ stages:
   - name: Add a role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -51,7 +51,7 @@ stages:
   - name: Add a role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -73,7 +73,7 @@ stages:
   - name: Add a too long named role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -86,7 +86,7 @@ stages:
   - name: Add an existent role (name) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -110,7 +110,7 @@ stages:
   - name: Add an existent role to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -138,7 +138,7 @@ stages:
   - name: Add a rule to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -164,7 +164,7 @@ stages:
   - name: Add a rule to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -190,7 +190,7 @@ stages:
   - name: Add a rule to the system (same rule but different name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -216,7 +216,7 @@ stages:
   - name: Add a too long named rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -237,7 +237,7 @@ stages:
   - name: Add a policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -276,7 +276,7 @@ stages:
   - name: Add a policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -313,7 +313,7 @@ stages:
   - name: Add a policy to the system (case insensitive)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -348,7 +348,7 @@ stages:
   - name: Add a policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -385,7 +385,7 @@ stages:
   - name: Add an existent policy (name) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -417,7 +417,7 @@ stages:
   - name: Add an existent policy (policy) to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -449,7 +449,7 @@ stages:
   - name: Add an invalid policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -481,7 +481,7 @@ stages:
   - name: Add an invalid policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -501,7 +501,7 @@ stages:
   - name: Add an invalid policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -520,7 +520,7 @@ stages:
   - name: Add an invalid policy to the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -539,7 +539,7 @@ stages:
   - name: Add a too long named policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -562,7 +562,7 @@ stages:
   - name: Create link role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -580,7 +580,7 @@ stages:
   - name: Create link role-policy
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/100/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/100/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -598,7 +598,7 @@ stages:
   - name: Create link role-policy (non-existent role)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -622,7 +622,7 @@ stages:
   - name: Create link role-policy (non-existent policy)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/101/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/101/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -647,7 +647,7 @@ stages:
   - name: Create link role-policy (Both non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/policies"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/policies"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -667,7 +667,7 @@ stages:
   - name: Create link role-rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -685,7 +685,7 @@ stages:
   - name: Create link role-rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/100/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/100/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -703,7 +703,7 @@ stages:
   - name: Create link role-rule (non-existent role)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -727,7 +727,7 @@ stages:
   - name: Create link role-rule (non-existent rule)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/101/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/101/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -752,7 +752,7 @@ stages:
   - name: Create link role-rule (Both non-existent)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999/rules"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999/rules"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -779,7 +779,7 @@ stages:
   - name: Create a new user (empty body)
     request: &post_users_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -799,7 +799,7 @@ stages:
   - name: Create a new user (secure password)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       json:
@@ -812,7 +812,7 @@ stages:
   - name: Create a new user (secure password 2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       json:
@@ -825,7 +825,7 @@ stages:
   - name: Add a too long named user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       json:
@@ -946,7 +946,7 @@ stages:
   - name: Create a new user (secure password)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users"
       headers:
         Authorization: "Bearer {test_login_token}"
       json:
@@ -960,7 +960,7 @@ stages:
   - name: Create link user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/106/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/106/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -978,7 +978,7 @@ stages:
   - name: Create link user-role
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/107/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/107/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -996,7 +996,7 @@ stages:
   - name: Create link user-role (non-existent roles)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/107/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/107/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1021,7 +1021,7 @@ stages:
   - name: Create link user-role (valid roles, already linked roles, non-existent roles)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/106/roles"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/106/roles"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: POST
@@ -1058,7 +1058,7 @@ stages:
   - name: Log in with wazuh-wui and default rules and expect admin permissions (1/2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
       headers:
         Authorization: "Basic {basic_auth_context:s}"
       method: POST
@@ -1074,7 +1074,7 @@ stages:
   - name: Log in with wazuh-wui and default rules and expect admin permissions (2/2)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
       headers:
         Authorization: "Basic {basic_auth_context:s}"
       method: POST
@@ -1090,7 +1090,7 @@ stages:
   - name: Log in with wazuh-wui and no matching rule
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
       headers:
         Authorization: "Basic {basic_auth_context:s}"
       method: POST
@@ -1106,7 +1106,7 @@ stages:
   - name: Try to user auth context with a user without run_as (Denied)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
       headers:
         Authorization: "Basic {basic_auth:s}"
       method: POST
@@ -1125,7 +1125,7 @@ stages:
   - name: Get an API token in raw format
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate"
       headers:
         Authorization: "Basic {basic_auth:s}"
       params:
@@ -1142,7 +1142,7 @@ stages:
   - name: Test generated token
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/"
       headers:
         Authorization: "Bearer {login_token}"
       method: GET

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
   - name: Modify a role in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -30,7 +30,7 @@ stages:
   - name: Modify a role in the system (using same name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -52,7 +52,7 @@ stages:
   - name: Modify a role in the system (using a very long name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -65,7 +65,7 @@ stages:
   - name: Modify a role in the system (using same name for a different ID)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -89,7 +89,7 @@ stages:
   - name: Modify a non-existent role in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/roles/999"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/roles/999"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -117,7 +117,7 @@ stages:
   - name: Modify a policy in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -154,7 +154,7 @@ stages:
   - name: Modify a policy in the system (without change policy definition)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -183,7 +183,7 @@ stages:
   - name: Modify a policy in the system (using a very long name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -196,7 +196,7 @@ stages:
   - name: Modify a policy in the system (without change name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -232,7 +232,7 @@ stages:
   - name: Modify a policy in the system (case insensitive)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -268,7 +268,7 @@ stages:
   - name: Modify a non-existent policy in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/999"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/999"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -300,7 +300,7 @@ stages:
   - name: Modify a policy in the system, bad policy definition
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/policies/104"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/policies/104"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -325,7 +325,7 @@ stages:
   - name: Modify a rule in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -351,7 +351,7 @@ stages:
   - name: Modify a rule in the system (using same name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -376,7 +376,7 @@ stages:
   - name: Modify a rule in the system (using a very long name)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/102"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/102"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -389,7 +389,7 @@ stages:
   - name: Modify a rule in the system (using same name for a different ID)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -413,7 +413,7 @@ stages:
   - name: Modify a rule in the system (using different name but same rule)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -442,7 +442,7 @@ stages:
   - name: Modify a non-existent rule in the system
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/rules/999"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/rules/999"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -473,7 +473,7 @@ stages:
   - name: Revoke all tokens
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -483,7 +483,7 @@ stages:
   - name: Revoke all tokens (Invalid token after previous call)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/revoke"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -499,7 +499,7 @@ stages:
     delay_after: 10
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/user/authenticate"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: DELETE
@@ -514,7 +514,7 @@ stages:
   - name: Update an existent user (empty body)
     request: &put_users_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -550,7 +550,7 @@ stages:
   - name: Update an non-existent user
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/200"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/200"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -604,7 +604,7 @@ stages:
   - name: Update user's allow_run_as flag
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/103/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/103/run_as"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -624,7 +624,7 @@ stages:
   - name: Update user's allow_run_as flag (invalid_user)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/INVALID/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/INVALID/run_as"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -636,7 +636,7 @@ stages:
   - name: Update user's allow_run_as flag (nonexistent user)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/999/run_as"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/999/run_as"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -664,7 +664,7 @@ stages:
   - name: Update security configuration
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -681,7 +681,7 @@ stages:
   - name: Get security configuration to check if PUT method worked correctly
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/config"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/config"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET

--- a/api/test/integration/test_syscheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscheck_endpoints.tavern.yaml
@@ -8,7 +8,7 @@ stages:
     request: &get_syscheck_agent
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/000"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -403,7 +403,7 @@ stages:
   - name: Try to get 012 agent's syscheck data (never connected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/012"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/012"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -482,7 +482,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/000/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/000/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -506,7 +506,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -526,7 +526,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -555,7 +555,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -581,7 +581,7 @@ stages:
     request:
       verify: False
       method: PUT
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -603,7 +603,7 @@ stages:
     request: &get_syscheck_agent_002
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1018,7 +1018,7 @@ stages:
     request:
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/002/last_scan"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/002/last_scan"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1042,7 +1042,7 @@ stages:
     request:
       verify: False
       method: DELETE
-      url: "{protocol:s}://{host:s}:{port:d}/syscheck/001"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscheck/001"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_syscollector_endpoints.tavern.yaml
+++ b/api/test/integration/test_syscollector_endpoints.tavern.yaml
@@ -7,7 +7,7 @@ stages:
     request: &os_request_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/os"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -55,7 +55,7 @@ stages:
   - name: Try to get 012 agent's syscollector OS data (never connected)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/012/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/012/os"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -109,7 +109,7 @@ stages:
   - name: Hardware of an agent
     request: &hardware_request_002
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -188,7 +188,7 @@ stages:
   - name: Packages of and agent
     request: &packages_request_003
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/003/packages"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/003/packages"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -589,7 +589,7 @@ stages:
   - name: Processes of an agent with limit = 1
     request: &processes_request_004
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/004/processes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/004/processes"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -1093,7 +1093,7 @@ stages:
     request: &port_request_005
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/005/ports"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/005/ports"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -1362,7 +1362,7 @@ stages:
     request: &netaddr_request_002
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -1762,7 +1762,7 @@ stages:
     request: &netproto_request_003
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/003/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/003/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -2101,7 +2101,7 @@ stages:
     request: &netiface_request_008
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/008/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/008/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -2777,7 +2777,7 @@ stages:
     request: &os_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/os"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/os"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -2863,7 +2863,7 @@ stages:
   - name: Hardware of an agent
     request: &hardware_request
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/hardware"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/hardware"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: GET
@@ -2939,7 +2939,7 @@ stages:
     request: &netaddr_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netaddr"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netaddr"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -3272,7 +3272,7 @@ stages:
     request: &netproto_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netproto"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netproto"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -3614,7 +3614,7 @@ stages:
     request: &netiface_request
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/002/netiface"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/002/netiface"
       headers:
         Authorization: "Bearer {test_login_token}"
       params:
@@ -4264,7 +4264,7 @@ stages:
     request: &hotfix_request_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/hotfixes"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/hotfixes"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -4315,7 +4315,7 @@ stages:
     request: &user_request_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/users"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/users"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -4348,7 +4348,7 @@ stages:
     request: &group_request_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/groups"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/groups"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -4381,7 +4381,7 @@ stages:
     request: &browser_extension_request_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/browser_extensions"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -4407,7 +4407,7 @@ stages:
 
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/browser_extensions"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/browser_extensions"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -4440,7 +4440,7 @@ stages:
     request: &service_request_001
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/services"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
@@ -4465,7 +4465,7 @@ stages:
         function: tavern_utils:test_distinct_key
       verify: False
       method: GET
-      url: "{protocol:s}://{host:s}:{port:d}/syscollector/001/services"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/syscollector/001/services"
       headers:
         Authorization: "Bearer {test_login_token}"
     response:

--- a/api/test/integration/test_task_endpoints.tavern.yaml
+++ b/api/test/integration/test_task_endpoints.tavern.yaml
@@ -6,7 +6,7 @@ stages:
   - name: Get all existent tasks (At this point there are no tasks created)
     request: &get_tasks
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -23,7 +23,7 @@ stages:
   - name: Upgrade old agents to create tasks
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -48,7 +48,7 @@ stages:
   - name: Upgrade agents to create tasks (Invalid version)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/agents/upgrade"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/agents/upgrade"
       method: PUT
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -275,7 +275,7 @@ stages:
   - name: Get specified tasks
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -304,7 +304,7 @@ stages:
   - name: Get specified tasks, agent_id (005)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -328,7 +328,7 @@ stages:
   - name: Get specified tasks, agent_id (000)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -347,7 +347,7 @@ stages:
   - name: Get all existent tasks with module=upgrade_module
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -378,7 +378,7 @@ stages:
   - name: Get all existent tasks with command=upgrade
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -391,7 +391,7 @@ stages:
   - name: Get all existent tasks with node=worker2
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"
@@ -409,7 +409,7 @@ stages:
   - name: Get all existent tasks with status=In progress
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/tasks/status"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/tasks/status"
       method: GET
       headers:
         Authorization: "Bearer {test_login_token}"

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -122,8 +122,8 @@ class InBuffer:
 
         # Command is the first 11 B of command without dashes (in case they were added)
         self.cmd = cmd[:-1].split(b' ')[0]
-        if self.total <= 0 or self.total > MAX_TOTAL_SIZE :
-            raise exception.WazuhClusterError(3050, extra_message=str(self.total))
+        if self.total > MAX_TOTAL_SIZE :
+            raise exception.WazuhClusterError(3050, extra_message=f"Header total size out of range: {self.total}")
         self.payload = bytearray(self.total)
         return header[header_size:]
 
@@ -793,7 +793,6 @@ class Handler(asyncio.Protocol):
             Received data.
         """
         self.in_buffer += message
-
         try:
             for command, counter, payload, flag_divided in self.get_messages():
                 # If the message is a divided one

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -141,11 +141,25 @@ def test_inbuffer_get_info_from_header(unpack_mock):
 
 
 @patch('struct.unpack')
+def test_inbuffer_get_info_from_header_zero_size_ok(unpack_mock):
+    """Validate that zero-size payloads in header are accepted."""
+    unpack_mock.return_value = (1, 0, b'echo')
+
+    remaining_data = in_buffer.get_info_from_header(b"header", "hhl", 1)
+
+    assert remaining_data == b"eader"
+    assert in_buffer.counter == 1
+    assert in_buffer.total == 0
+    assert in_buffer.payload == bytearray(0)
+
+
+@patch('struct.unpack')
 def test_inbuffer_get_info_from_header_ko(unpack_mock):
     """Test if the exception is being properly raised when 'total' exceeds MAX_CHUNK_SIZE in InBuffer class."""
     unpack_mock.return_value = (0, cluster_common.MAX_TOTAL_SIZE + 1, b'pwd')
 
-    with pytest.raises(exception.WazuhClusterError, match=r'.* 3050 .*'):
+    with pytest.raises(exception.WazuhClusterError,
+                       match=r'.*Header total size out of range.*'):
         in_buffer.get_info_from_header(b"header", "hhl", 1)
 
 
@@ -1218,8 +1232,9 @@ def test_handler_process_error_str():
     assert handler.in_str == {}
 
     # Test return inside loop and condition
-    handler.in_str = {b"string_id": in_buffer}
-    assert handler.process_error_str(b"2048") == (b'ok', b'string_id')
+    local_in_buffer = cluster_common.InBuffer()
+    handler.in_str = {b"string_id": local_in_buffer}
+    assert handler.process_error_str(b"0") == (b'ok', b'string_id')
     assert handler.in_str == {}
 
 


### PR DESCRIPTION
## Description

This PR fixes the active configuration endpoint behavior in clustered environments and aligns API integration tests with the new routing model.

It also fixes cluster message header handling to allow valid zero-length payloads and improves related error reporting.

Closes https://github.com/wazuh/internal-devel-requests/issues/4263 

## Proposed Changes

- Fixed cluster message parsing in `InBuffer`:
  - Accepts `total == 0` payloads.
  - Keeps rejection only for payloads above `MAX_TOTAL_SIZE`.
  - Improved error detail for out-of-range totals.
- Updated cluster unit tests in `framework/wazuh/core/cluster/tests/test_common.py`:
  - Added validation for zero-size payload headers.
  - Updated exception assertion to match the new message.
  - Adjusted `process_error_str` test to use an explicit local buffer and valid code path.
- Updated API integration test routing to support master-node and balanced-node paths:
  - Added `balanced_port` and `master_port` in `api/test/integration/common.yaml`.
  - Login now targets `master_port` in `api/test/integration/conftest.py`.
  - Updated Tavern test URLs across API integration suites to use the correct port depending on endpoint type.

### Results and Evidence
#### Test report

[archive.zip](https://github.com/user-attachments/files/26674273/archive.zip)

#### Test results

---
| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Issues Ref.** | **Status** |
|--|--|--|--|--|--|--|--|
| test_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_DELETE_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_GET_endpoints.tavern.yaml | 96 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_POST_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_PUT_endpoints.tavern.yaml | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cluster_endpoints.tavern.yaml | 50 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_decoder_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_default_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_event_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_manager_endpoints.tavern.yaml | 35 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_agent_endpoints.tavern.yaml | 43 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cluster_endpoints.tavern.yaml | 20 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_manager_endpoints.tavern.yaml | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscollector_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_agent_endpoints.tavern.yaml | 43 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_all_endpoints.tavern.yaml | 169 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cluster_endpoints.tavern.yaml | 19 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_manager_endpoints.tavern.yaml | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscollector_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rule_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_sca_endpoints.tavern.yaml | 45 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_DELETE_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_GET_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_POST_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_PUT_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscheck_endpoints.tavern.yaml | 34 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscollector_endpoints.tavern.yaml | 161 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_task_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |

https://jenkins-production.qa.wazuh.info/job/4.14.5/job/Test_integration_endpoints/11/
### Manual tests with their corresponding evidence

> curl -sk -X GET "$WAZUH_MANAGER/manager/configuration/com/cluster?pretty=true"
```json
{
   "data": {
      "affected_items": [
         {
            "name": "wazuh",
            "node_name": "master-node",
            "node_type": "master",
            "key": "9d273b53510fef702b54a92e9cffc82e",
            "port": 1516,
            "bind_addr": "0.0.0.0",
            "nodes": [
               "wazuh-master"
            ],
            "hidden": "no",
            "disabled": false
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Active configuration was successfully read in specified node",
   "error": 0
}
```


<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests *(pending execution in CI/local environment)*

Additional test evidence from code changes:
- Unit tests updated in:
  - `framework/wazuh/core/cluster/tests/test_common.py`
- API integration test suite definitions updated in:
  - `api/test/integration/*.tavern.yaml`

### Artifacts Affected

- Source code:
  - `framework/wazuh/core/cluster/common.py`
- Unit tests:
  - `framework/wazuh/core/cluster/tests/test_common.py`
- API integration test assets:
  - `api/test/integration/common.yaml`
  - `api/test/integration/conftest.py`
  - Multiple `api/test/integration/*.tavern.yaml` test specifications.
- Executables/packages/default runtime configuration: N/A.

### Configuration Changes

- Added test configuration variables in integration tests:
  - `balanced_port`
  - `master_port`
- Replaced previous single `port` usage in test definitions with endpoint-aware routing.
- Backward compatibility impact:
  - Runtime product configuration: N/A.
  - Test framework configuration: requires both ports to be present in test environment values.

### Tests Introduced

- New unit test added:
  - `test_inbuffer_get_info_from_header_zero_size_ok`.
  - Scope: validates that zero-size payload headers are accepted in cluster message parsing.
- Existing unit tests updated:
  - Header out-of-range error assertion updated for new error message.
  - `process_error_str` path adjusted to validate expected behavior with valid code and local buffer setup.
- Integration tests:
  - No brand-new Tavern suites added; existing suites were updated to match the new routing strategy.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

