### PR TITLE
Add udp socket support in logcollector

### DIFF
--- a/docs/ref/modules/logcollector/README.md
+++ b/docs/ref/modules/logcollector/README.md
@@ -14,3 +14,5 @@ Wazuh collects, analyzes, and stores logs from endpoints, network devices, and a
 ## How it works
 
 Wazuh uses the Logcollector module to collect logs from monitored endpoints, applications, and network devices. The Wazuh server then analyzes the collected logs in real-time using decoders and rules, and extracts relevant information from the logs and maps them to appropriate fields , generating alerts when the logs meets certain criteria.
+
+On UNIX platforms, Logcollector can also receive UTF-8 log messages on UNIX datagram sockets by configuring a `localfile` block with `log_format` set to `socket`. Logcollector binds the socket and external processes send datagrams to it.

--- a/docs/ref/modules/logcollector/configuration.md
+++ b/docs/ref/modules/logcollector/configuration.md
@@ -164,6 +164,59 @@ Restart the agent after applying the configuration.
 
 ---
 
+## Streaming logs from an HTTP endpoint over a UNIX stream socket
+
+On UNIX platforms, Logcollector can act as an HTTP/1.1 client over a UNIX **stream** socket (`SOCK_STREAM`) and treat each newline-delimited line of the response body as a log event. Use `log_format` set to `http-unix`. Unlike `log_format=socket` (which binds and waits for datagrams), this mode **connects to a socket owned by another process**, issues a `GET`, and consumes the streamed response.
+
+```xml
+<localfile>
+  <location>/var/run/example.sock</location>
+  <log_format>http-unix</log_format>
+  <endpoint>/events</endpoint>
+  <reconnect_interval>5</reconnect_interval>
+  <target>agent</target>
+</localfile>
+```
+
+The `location` value is the UNIX stream socket path of the producing service. A dedicated worker thread per `<localfile>` issues the configured HTTP request, parses the response (supports `Transfer-Encoding: chunked`, `Content-Length`, and read-until-close), and forwards each non-empty UTF-8 line to the output queue. If the connection is closed by the peer or fails, the worker waits `reconnect_interval` seconds and retries indefinitely.
+
+### http-unix-specific options
+
+| Option               | Default | Description                                                                  |
+|----------------------|---------|------------------------------------------------------------------------------|
+| `endpoint`           | `/`     | HTTP path to request. Must start with `/`.                                   |
+| `reconnect_interval` | `5`     | Seconds to wait between reconnect attempts. Allowed range: `1`–`3600`.       |
+
+### Streaming Docker events
+
+The Docker daemon exposes a streaming `/events` endpoint over `/var/run/docker.sock`. Logcollector can consume it directly:
+
+```xml
+<localfile>
+  <location>/var/run/docker.sock</location>
+  <log_format>http-unix</log_format>
+  <endpoint>/events</endpoint>
+  <reconnect_interval>5</reconnect_interval>
+</localfile>
+```
+
+The Wazuh user must have read access to `/var/run/docker.sock` (typically by joining the `docker` group).
+
+!!! note
+    This is **not** a drop-in replacement for the existing Docker Listener wodle (`wodles/docker-listener/DockerListener.py`). The wodle wraps each event in `{"integration":"docker","docker":<event>}` and sends with the `Wazuh-Docker` queue header so the bundled Docker rules match. `log_format=http-unix` forwards each line of the Docker stream verbatim — rules consuming raw Docker events would need to be adjusted accordingly. The wodle remains supported; choose the path that matches your decoder/rule pipeline.
+
+!!! note
+    - This log format is available only on UNIX platforms.
+    - The unix socket file must be a **stream** socket owned by the producer; Logcollector connects but does not bind or unlink.
+    - Lines must be valid UTF-8 text. Binary payloads and invalid UTF-8 are dropped.
+    - Each `<localfile>` of this type creates one dedicated worker thread that owns the connection lifecycle (connect, parse, reconnect).
+    - Lines exceeding `OS_MAXSTR` bytes are dropped with a warning.
+    - The `age`, `ignore_binaries`, and `only-future-events` options are ignored for `log_format=http-unix`.
+
+Restart the agent after applying the configuration.
+
+---
+
 ## Monitoring log files with environment variables
 
 !!! note

--- a/docs/ref/modules/logcollector/configuration.md
+++ b/docs/ref/modules/logcollector/configuration.md
@@ -92,6 +92,78 @@ Restart the agent to apply the configuration.
 
 ---
 
+## Monitoring UNIX datagram sockets
+
+On UNIX platforms, Logcollector can bind a UNIX datagram socket and receive log messages sent to it by external processes, by using `log_format` set to `socket`.
+
+```xml
+<localfile>
+  <location>/var/run/app.sock</location>
+  <log_format>socket</log_format>
+  <target>agent</target>
+  <out_format target="agent">$(timestamp) $(log)</out_format>
+  <label key="source">app</label>
+  <ignore>healthcheck</ignore>
+  <restrict>ERROR|WARN</restrict>
+</localfile>
+```
+
+The `location` value is a UNIX socket path where Logcollector will create a datagram socket. External processes send log messages as datagrams using `SOCK_DGRAM`. Each datagram is treated as a single log message. If the socket file is removed, Logcollector will detect this and re-create it. Date-based paths and wildcard expansion follow the same resolution flow used by file-backed `localfile` entries.
+
+### Socket-specific options
+
+| Option         | Default       | Description                                                         |
+|----------------|---------------|---------------------------------------------------------------------|
+| `socket_mode`  | `0660`        | Octal permission bits for the socket file.                          |
+| `socket_group` | Process group | Group name for the socket file, resolved at creation time.          |
+| `recv_buffer`  | `65536` (64K) | Minimum kernel receive buffer size (`SO_RCVBUF`). Accepts K/M/G suffixes. Maximum 16M. |
+
+!!! note
+    `recv_buffer` sets a minimum value for `SO_RCVBUF`. If the kernel default is already larger, no change is made. For high-volume sources, increase this to absorb bursts (e.g. `1M`). The value must be between 65536 (the maximum datagram size) and 16M.
+
+### rsyslog integration example
+
+A common use case is forwarding syslog messages from rsyslog to Logcollector via a local UNIX socket. Logcollector creates and owns the socket; rsyslog writes to it.
+
+**Wazuh agent** (`ossec.conf`):
+
+```xml
+<localfile>
+  <location>/var/run/wazuh-rsyslog.sock</location>
+  <log_format>socket</log_format>
+  <socket_mode>0660</socket_mode>
+  <socket_group>syslog</socket_group>
+  <recv_buffer>1M</recv_buffer>
+</localfile>
+```
+
+**rsyslog** (`/etc/rsyslog.d/wazuh.conf`):
+
+```
+# rsyslog v8.24+ (RainerScript)
+module(load="omuxsock")
+action(type="omuxsock" socket="/var/run/wazuh-rsyslog.sock"
+       template="RSYSLOG_TraditionalFileFormat")
+
+# rsyslog legacy syntax (v8.21 and earlier)
+# $ModLoad omuxsock
+# $OMUxSockSocket /var/run/wazuh-rsyslog.sock
+# *.* :omuxsock:
+```
+
+Ensure the rsyslog user belongs to the configured `socket_group`, or set `socket_mode` to `0666`.
+
+!!! note
+    - This log format is available only on UNIX platforms.
+    - Messages must be valid UTF-8 text. Binary payloads and invalid UTF-8 are dropped.
+    - Logcollector creates and owns the socket file — it is removed when the source is closed.
+    - The `age` option is accepted for compatibility but ignored for `log_format=socket`.
+    - Socket readers do not use `file_status.json`, bookmarks, or file rotation and truncation semantics.
+
+Restart the agent after applying the configuration.
+
+---
+
 ## Monitoring log files with environment variables
 
 !!! note

--- a/src/config/include/localfile-config.h
+++ b/src/config/include/localfile-config.h
@@ -15,6 +15,11 @@
 #define EVENTCHANNEL "eventchannel"
 #define MACOS        "macos"
 #define SOCKET_LOG   "socket"
+#define HTTP_UNIX_LOG                 "http-unix"
+#define HTTP_UNIX_DEFAULT_ENDPOINT    "/"
+#define HTTP_UNIX_DEFAULT_RECONNECT   5
+#define HTTP_UNIX_MIN_RECONNECT       1
+#define HTTP_UNIX_MAX_RECONNECT       3600
 #define JOURNALD_LOG                  "journald"
 #define MULTI_LINE_REGEX              "multi-line-regex"
 #define MULTI_LINE_REGEX_TIMEOUT      5
@@ -43,6 +48,7 @@
 #define MACOS_LOG_TIMEOUT               5
 
 #include <pthread.h>
+#include <signal.h>
 
 /* For ino_t */
 #include <sys/types.h>
@@ -258,6 +264,13 @@ typedef struct _logreader {
     char *socket_group;
     mode_t socket_mode;
     int socket_recv_buffer;
+
+    /* HTTP-over-UNIX-stream (log_format=http-unix) */
+    char *http_endpoint;
+    int http_reconnect_interval;
+    pthread_t http_thread;
+    volatile sig_atomic_t http_thread_started;
+    volatile sig_atomic_t http_stop;
 #endif
 } logreader;
 

--- a/src/config/include/localfile-config.h
+++ b/src/config/include/localfile-config.h
@@ -14,6 +14,7 @@
 #define EVENTLOG     "eventlog"
 #define EVENTCHANNEL "eventchannel"
 #define MACOS        "macos"
+#define SOCKET_LOG   "socket"
 #define JOURNALD_LOG                  "journald"
 #define MULTI_LINE_REGEX              "multi-line-regex"
 #define MULTI_LINE_REGEX_TIMEOUT      5
@@ -23,6 +24,7 @@
 #define DIFF_DEFAULT_SIZE (10 * 1024 * 1024)
 #define DEFAULT_FREQUENCY_SECS  360
 #define DIFF_MAX_SIZE (2 * 1024 * 1024 * 1024LL)
+#define SOCKET_RECV_BUFFER_MAX (16 * 1024 * 1024)  /* 16 MB — hard cap for SO_RCVBUF */
 
 /* macOS log command configurations */
 
@@ -249,6 +251,14 @@ typedef struct _logreader {
 
     FILE *fp;
     fpos_t position; // Pointer offset when closed
+
+#ifndef WIN32
+    int socket_fd;
+    char *socket_path;
+    char *socket_group;
+    mode_t socket_mode;
+    int socket_recv_buffer;
+#endif
 } logreader;
 
 typedef struct _logreader_glob {

--- a/src/config/src/localfile-config.c
+++ b/src/config/src/localfile-config.c
@@ -11,6 +11,7 @@
 #include "shared.h"
 #include "localfile-config.h"
 #include "config.h"
+#include "os_net.h"
 
 #ifdef WAZUH_UNIT_TESTING
 // Remove STATIC qualifier from tests
@@ -42,6 +43,13 @@ STATIC int w_logcollector_get_macos_log_type(const char * content);
  */
 w_exp_type_t w_check_regex_type(xml_node * node, const char * element);
 
+STATIC void w_logcollector_socket_release(logreader *logf);
+STATIC void w_logreader_release_runtime_entry(logreader *logf);
+STATIC void w_logcollector_validate_socket(logreader *logf,
+                                           const char *xml_localfile_age,
+                                           const char *xml_localfile_future,
+                                           const char *xml_localfile_binaries);
+
 int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
     unsigned int pl = 0;
@@ -70,6 +78,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_restrict = "restrict";
     const char *xml_localfile_multiline_regex =  "multiline_regex";
     const char *xml_localfile_filter = "filter";
+    const char *xml_localfile_socket_mode = "socket_mode";
+    const char *xml_localfile_socket_group = "socket_group";
+    const char *xml_localfile_recv_buffer = "recv_buffer";
 
     logreader *logf;
     logreader_config *log_config;
@@ -115,6 +126,9 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     logf[pl].exists = 1;
     logf[pl].future = 1;
     logf[pl].reconnect_time = DEFAULT_EVENTCHANNEL_REC_TIME;
+#ifndef WIN32
+    logf[pl].socket_fd = -1;
+#endif
     logf[pl].regex_ignore = NULL;
     logf[pl].regex_restrict = NULL;
 
@@ -406,6 +420,11 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 }
 #endif
             } else if (strcmp(logf[pl].logformat, JOURNALD_LOG) == 0) {
+            } else if (strcmp(logf[pl].logformat, SOCKET_LOG) == 0) {
+#ifdef WIN32
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+#endif
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
@@ -556,6 +575,34 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 w_clean_logreader(&logf[pl]);
                 return (0);
             }
+        } else if (strcmp(node[i]->element, xml_localfile_socket_mode) == 0) {
+#ifndef WIN32
+            char *endptr;
+            unsigned long mode_val = strtoul(node[i]->content, &endptr, 0);
+            if (endptr == node[i]->content || *endptr != '\0' || mode_val > 07777) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            logf[pl].socket_mode = (mode_t)mode_val;
+#endif
+        } else if (strcmp(node[i]->element, xml_localfile_socket_group) == 0) {
+#ifndef WIN32
+            if (strlen(node[i]->content) == 0) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            os_free(logf[pl].socket_group);
+            os_strdup(node[i]->content, logf[pl].socket_group);
+#endif
+        } else if (strcmp(node[i]->element, xml_localfile_recv_buffer) == 0) {
+#ifndef WIN32
+            long long value = w_validate_bytes(node[i]->content);
+            if (value <= 0 || value > SOCKET_RECV_BUFFER_MAX) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            logf[pl].socket_recv_buffer = (int)value;
+#endif
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);
@@ -677,6 +724,32 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             mwarn(LOGCOLLECTOR_OPTION_IGNORED, MACOS, xml_localfile_alias);
         }
     }
+
+    if (strcmp(logf[pl].logformat, SOCKET_LOG) == 0) {
+        w_logcollector_validate_socket(&logf[pl],
+                                       xml_localfile_age,
+                                       xml_localfile_future,
+                                       xml_localfile_binaries);
+    }
+
+#ifndef WIN32
+    /* Warn if socket-specific options are used on non-socket log formats */
+    if (strcmp(logf[pl].logformat, SOCKET_LOG) != 0) {
+        if (logf[pl].socket_mode != 0) {
+            mwarn(LOGCOLLECTOR_OPTION_IGNORED, logf[pl].logformat, xml_localfile_socket_mode);
+            logf[pl].socket_mode = 0;
+        }
+        if (logf[pl].socket_group != NULL) {
+            mwarn(LOGCOLLECTOR_OPTION_IGNORED, logf[pl].logformat, xml_localfile_socket_group);
+            os_free(logf[pl].socket_group);
+        }
+        if (logf[pl].socket_recv_buffer != 0) {
+            mwarn(LOGCOLLECTOR_OPTION_IGNORED, logf[pl].logformat, xml_localfile_recv_buffer);
+            logf[pl].socket_recv_buffer = 0;
+        }
+    }
+#endif
+
     /* Verify Multiline Regex Config */
     if (strcmp(logf[pl].logformat, MULTI_LINE_REGEX) == 0) {
 
@@ -883,7 +956,7 @@ void Free_Localfile(logreader_config * config){
                 if (config->globs[i].gfiles->file) {
                     Free_Logreader(config->globs[i].gfiles);
                     for (j = 1; config->globs[i].gfiles[j].file; j++) {
-                        free(config->globs[i].gfiles[j].file);
+                        w_logreader_release_runtime_entry(&config->globs[i].gfiles[j]);
                     }
                 }
                 free(config->globs[i].gfiles);
@@ -899,7 +972,79 @@ void w_clean_logreader(logreader * logf) {
     if (logf != NULL) {
         Free_Logreader(logf);
         memset(logf, 0, sizeof(logreader));
+#ifndef WIN32
+        logf->socket_fd = -1;
+#endif
     }
+}
+
+STATIC void w_logcollector_socket_release(logreader *logf) {
+#ifndef WIN32
+    if (logf == NULL) {
+        return;
+    }
+
+    if (logf->socket_path != NULL) {
+        OS_CloseSocket(logf->socket_fd);
+        unlink(logf->socket_path);
+        os_free(logf->socket_path);
+        logf->socket_fd = -1;
+    }
+#else
+    (void)logf;
+#endif
+}
+
+STATIC void w_logreader_release_runtime_entry(logreader *logf) {
+    if (logf == NULL) {
+        return;
+    }
+
+    os_free(logf->file);
+    w_multiline_log_config_free(&(logf->multiline));
+
+    if (logf->fp) {
+        fclose(logf->fp);
+        logf->fp = NULL;
+    }
+
+    w_logcollector_socket_release(logf);
+}
+
+STATIC void w_logcollector_validate_socket(logreader *logf,
+                                           const char *xml_localfile_age,
+                                           const char *xml_localfile_future,
+                                           const char *xml_localfile_binaries) {
+    if (logf == NULL) {
+        return;
+    }
+
+    if (logf->age != 0) {
+        mwarn(LOGCOLLECTOR_OPTION_IGNORED, SOCKET_LOG, xml_localfile_age);
+        logf->age = 0;
+        os_free(logf->age_str);
+    }
+
+    if (logf->filter_binary != 0) {
+        mwarn(LOGCOLLECTOR_OPTION_IGNORED, SOCKET_LOG, xml_localfile_binaries);
+        logf->filter_binary = 0;
+    }
+
+    /* diff_max_size is only set when <only-future-events> is explicitly parsed,
+     * so a nonzero value means the user configured it. */
+    if (logf->diff_max_size != 0) {
+        mwarn(LOGCOLLECTOR_OPTION_IGNORED, SOCKET_LOG, xml_localfile_future);
+    }
+    logf->future = 1;
+    logf->diff_max_size = DIFF_DEFAULT_SIZE;
+
+#ifndef WIN32
+    if (logf->socket_recv_buffer != 0 && logf->socket_recv_buffer < OS_MAXSTR) {
+        mwarn("recv_buffer value '%d' is below the minimum (%d). Default will be used.",
+              logf->socket_recv_buffer, OS_MAXSTR);
+        logf->socket_recv_buffer = 0;
+    }
+#endif
 }
 
 void Free_Logreader(logreader * logf) {
@@ -944,6 +1089,11 @@ void Free_Logreader(logreader * logf) {
             fclose(logf->fp);
         }
 
+        w_logcollector_socket_release(logf);
+#ifndef WIN32
+        os_free(logf->socket_group);
+#endif
+
         if (logf->out_format) {
             for (i = 0; logf->out_format[i]; ++i) {
                 free(logf->out_format[i]->target);
@@ -968,12 +1118,7 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
             if (fr) {
                 Free_Logreader(&(*logf)[i]);
             } else {
-                free((*logf)[i].file);
-                // If is a glob entry and multiline is set, we need to free the multiline config
-                w_multiline_log_config_free(&(*logf)[i].multiline);
-                if((*logf)[i].fp) {
-                    fclose((*logf)[i].fp);
-                }
+                w_logreader_release_runtime_entry(&(*logf)[i]);
             #ifdef WIN32
                 pthread_mutex_destroy(&(*logf)[i].mutex);
             #endif

--- a/src/config/src/localfile-config.c
+++ b/src/config/src/localfile-config.c
@@ -44,11 +44,21 @@ STATIC int w_logcollector_get_macos_log_type(const char * content);
 w_exp_type_t w_check_regex_type(xml_node * node, const char * element);
 
 STATIC void w_logcollector_socket_release(logreader *logf);
+STATIC void w_logcollector_http_unix_release(logreader *logf);
 STATIC void w_logreader_release_runtime_entry(logreader *logf);
+STATIC void w_logcollector_warn_file_only_options(logreader *logf,
+                                                  const char *log_format,
+                                                  const char *xml_localfile_age,
+                                                  const char *xml_localfile_future,
+                                                  const char *xml_localfile_binaries);
 STATIC void w_logcollector_validate_socket(logreader *logf,
                                            const char *xml_localfile_age,
                                            const char *xml_localfile_future,
                                            const char *xml_localfile_binaries);
+STATIC void w_logcollector_validate_http_unix(logreader *logf,
+                                              const char *xml_localfile_age,
+                                              const char *xml_localfile_future,
+                                              const char *xml_localfile_binaries);
 
 int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
@@ -81,6 +91,8 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
     const char *xml_localfile_socket_mode = "socket_mode";
     const char *xml_localfile_socket_group = "socket_group";
     const char *xml_localfile_recv_buffer = "recv_buffer";
+    const char *xml_localfile_endpoint = "endpoint";
+    const char *xml_localfile_reconnect_interval = "reconnect_interval";
 
     logreader *logf;
     logreader_config *log_config;
@@ -425,6 +437,11 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
 #endif
+            } else if (strcmp(logf[pl].logformat, HTTP_UNIX_LOG) == 0) {
+#ifdef WIN32
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+#endif
             } else {
                 merror(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
@@ -603,6 +620,26 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
             logf[pl].socket_recv_buffer = (int)value;
 #endif
+        } else if (strcmp(node[i]->element, xml_localfile_endpoint) == 0) {
+#ifndef WIN32
+            if (strlen(node[i]->content) == 0 || node[i]->content[0] != '/') {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            os_free(logf[pl].http_endpoint);
+            os_strdup(node[i]->content, logf[pl].http_endpoint);
+#endif
+        } else if (strcmp(node[i]->element, xml_localfile_reconnect_interval) == 0) {
+#ifndef WIN32
+            char *endptr;
+            long value = strtol(node[i]->content, &endptr, 10);
+            if (endptr == node[i]->content || *endptr != '\0' ||
+                value < HTTP_UNIX_MIN_RECONNECT || value > HTTP_UNIX_MAX_RECONNECT) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+            logf[pl].http_reconnect_interval = (int)value;
+#endif
         } else {
             merror(XML_INVELEM, node[i]->element);
             return (OS_INVALID);
@@ -732,6 +769,13 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                                        xml_localfile_binaries);
     }
 
+    if (strcmp(logf[pl].logformat, HTTP_UNIX_LOG) == 0) {
+        w_logcollector_validate_http_unix(&logf[pl],
+                                          xml_localfile_age,
+                                          xml_localfile_future,
+                                          xml_localfile_binaries);
+    }
+
 #ifndef WIN32
     /* Warn if socket-specific options are used on non-socket log formats */
     if (strcmp(logf[pl].logformat, SOCKET_LOG) != 0) {
@@ -746,6 +790,18 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         if (logf[pl].socket_recv_buffer != 0) {
             mwarn(LOGCOLLECTOR_OPTION_IGNORED, logf[pl].logformat, xml_localfile_recv_buffer);
             logf[pl].socket_recv_buffer = 0;
+        }
+    }
+
+    /* Warn if http-unix-specific options are used on non-http-unix log formats */
+    if (strcmp(logf[pl].logformat, HTTP_UNIX_LOG) != 0) {
+        if (logf[pl].http_endpoint != NULL) {
+            mwarn(LOGCOLLECTOR_OPTION_IGNORED, logf[pl].logformat, xml_localfile_endpoint);
+            os_free(logf[pl].http_endpoint);
+        }
+        if (logf[pl].http_reconnect_interval != 0) {
+            mwarn(LOGCOLLECTOR_OPTION_IGNORED, logf[pl].logformat, xml_localfile_reconnect_interval);
+            logf[pl].http_reconnect_interval = 0;
         }
     }
 #endif
@@ -995,6 +1051,27 @@ STATIC void w_logcollector_socket_release(logreader *logf) {
 #endif
 }
 
+STATIC void w_logcollector_http_unix_release(logreader *logf) {
+#ifndef WIN32
+    if (logf == NULL) {
+        return;
+    }
+
+    /* Signal worker to exit; thread polls http_stop at safe points */
+    if (logf->http_thread_started) {
+        logf->http_stop = 1;
+        pthread_join(logf->http_thread, NULL);
+        logf->http_thread_started = 0;
+    }
+
+    os_free(logf->http_endpoint);
+    logf->http_reconnect_interval = 0;
+    logf->http_stop = 0;
+#else
+    (void)logf;
+#endif
+}
+
 STATIC void w_logreader_release_runtime_entry(logreader *logf) {
     if (logf == NULL) {
         return;
@@ -1009,6 +1086,32 @@ STATIC void w_logreader_release_runtime_entry(logreader *logf) {
     }
 
     w_logcollector_socket_release(logf);
+    w_logcollector_http_unix_release(logf);
+}
+
+STATIC void w_logcollector_warn_file_only_options(logreader *logf,
+                                                  const char *log_format,
+                                                  const char *xml_localfile_age,
+                                                  const char *xml_localfile_future,
+                                                  const char *xml_localfile_binaries) {
+    if (logf->age != 0) {
+        mwarn(LOGCOLLECTOR_OPTION_IGNORED, log_format, xml_localfile_age);
+        logf->age = 0;
+        os_free(logf->age_str);
+    }
+
+    if (logf->filter_binary != 0) {
+        mwarn(LOGCOLLECTOR_OPTION_IGNORED, log_format, xml_localfile_binaries);
+        logf->filter_binary = 0;
+    }
+
+    /* diff_max_size is only set when <only-future-events> is explicitly parsed,
+     * so a nonzero value means the user configured it. */
+    if (logf->diff_max_size != 0) {
+        mwarn(LOGCOLLECTOR_OPTION_IGNORED, log_format, xml_localfile_future);
+    }
+    logf->future = 1;
+    logf->diff_max_size = DIFF_DEFAULT_SIZE;
 }
 
 STATIC void w_logcollector_validate_socket(logreader *logf,
@@ -1019,30 +1122,39 @@ STATIC void w_logcollector_validate_socket(logreader *logf,
         return;
     }
 
-    if (logf->age != 0) {
-        mwarn(LOGCOLLECTOR_OPTION_IGNORED, SOCKET_LOG, xml_localfile_age);
-        logf->age = 0;
-        os_free(logf->age_str);
-    }
-
-    if (logf->filter_binary != 0) {
-        mwarn(LOGCOLLECTOR_OPTION_IGNORED, SOCKET_LOG, xml_localfile_binaries);
-        logf->filter_binary = 0;
-    }
-
-    /* diff_max_size is only set when <only-future-events> is explicitly parsed,
-     * so a nonzero value means the user configured it. */
-    if (logf->diff_max_size != 0) {
-        mwarn(LOGCOLLECTOR_OPTION_IGNORED, SOCKET_LOG, xml_localfile_future);
-    }
-    logf->future = 1;
-    logf->diff_max_size = DIFF_DEFAULT_SIZE;
+    w_logcollector_warn_file_only_options(logf, SOCKET_LOG,
+                                          xml_localfile_age,
+                                          xml_localfile_future,
+                                          xml_localfile_binaries);
 
 #ifndef WIN32
     if (logf->socket_recv_buffer != 0 && logf->socket_recv_buffer < OS_MAXSTR) {
         mwarn("recv_buffer value '%d' is below the minimum (%d). Default will be used.",
               logf->socket_recv_buffer, OS_MAXSTR);
         logf->socket_recv_buffer = 0;
+    }
+#endif
+}
+
+STATIC void w_logcollector_validate_http_unix(logreader *logf,
+                                              const char *xml_localfile_age,
+                                              const char *xml_localfile_future,
+                                              const char *xml_localfile_binaries) {
+    if (logf == NULL) {
+        return;
+    }
+
+    w_logcollector_warn_file_only_options(logf, HTTP_UNIX_LOG,
+                                          xml_localfile_age,
+                                          xml_localfile_future,
+                                          xml_localfile_binaries);
+
+#ifndef WIN32
+    if (logf->http_endpoint == NULL) {
+        os_strdup(HTTP_UNIX_DEFAULT_ENDPOINT, logf->http_endpoint);
+    }
+    if (logf->http_reconnect_interval == 0) {
+        logf->http_reconnect_interval = HTTP_UNIX_DEFAULT_RECONNECT;
     }
 #endif
 }
@@ -1090,6 +1202,7 @@ void Free_Logreader(logreader * logf) {
         }
 
         w_logcollector_socket_release(logf);
+        w_logcollector_http_unix_release(logf);
 #ifndef WIN32
         os_free(logf->socket_group);
 #endif

--- a/src/logcollector/include/logcollector.h
+++ b/src/logcollector/include/logcollector.h
@@ -186,7 +186,31 @@ void* read_fullcommand(logreader* lf, int* rc, int drop_it);
 #ifndef WIN32
 /* Read datagrams from a UNIX datagram socket */
 void* read_socket(logreader* lf, int* rc, int drop_it);
+
+/**
+ * @brief Open an HTTP-over-UNIX-stream source: starts the worker thread.
+ *
+ * @param lf logreader configured with file (socket path), http_endpoint, http_reconnect_interval.
+ * @return 0 on success, -1 on failure (thread already running, missing config, pthread_create failure).
+ */
+int w_logcollector_http_unix_open(logreader* lf);
 #endif
+
+/**
+ * @brief Strip a single trailing '\n', reject embedded NUL bytes, validate UTF-8.
+ *
+ * Operates in-place on the buffer. After return, *len reflects the message length
+ * excluding any stripped newline. Empty messages (or messages that become empty
+ * after the strip) are reported as invalid.
+ *
+ * @param[in,out] buf         Null-terminated text buffer.
+ * @param[in,out] len         In: current buffer content length. Out: updated length.
+ * @param[in]     source_kind Short label for the source class (e.g. "socket", "http-unix"),
+ *                            used in the rejection debug message.
+ * @param[in]     source      Source identifier (file/socket path) for debug log context.
+ * @return true if the message is non-empty, NUL-free, and valid UTF-8; false to drop.
+ */
+bool w_logcollector_validate_text_line(char* buf, size_t* len, const char* source_kind, const char* source);
 
 /* Read auditd events */
 void* read_audit(logreader* lf, int* rc, int drop_it);

--- a/src/logcollector/include/logcollector.h
+++ b/src/logcollector/include/logcollector.h
@@ -183,6 +183,11 @@ void* read_djbmultilog(logreader* lf, int* rc, int drop_it);
 void* read_command(logreader* lf, int* rc, int drop_it);
 void* read_fullcommand(logreader* lf, int* rc, int drop_it);
 
+#ifndef WIN32
+/* Read datagrams from a UNIX datagram socket */
+void* read_socket(logreader* lf, int* rc, int drop_it);
+#endif
+
 /* Read auditd events */
 void* read_audit(logreader* lf, int* rc, int drop_it);
 

--- a/src/logcollector/src/config.c
+++ b/src/logcollector/src/config.c
@@ -150,18 +150,18 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath)
         cJSON_AddItemToObject(file, "query", query);
     }
     // Invalid configuration for journal logs
-    if (reader->journal_log == NULL)
+    if (reader->journal_log == NULL && (!reader->logformat || strcmp(reader->logformat, SOCKET_LOG) != 0))
     {
         cJSON_AddStringToObject(file, "ignore_binaries", reader->filter_binary ? "yes" : "no");
     }
 
-    if (reader->age_str)
+    if (reader->age_str && (!reader->logformat || strcmp(reader->logformat, SOCKET_LOG) != 0))
         cJSON_AddStringToObject(file, "age", reader->age_str);
     if (reader->exclude)
         cJSON_AddStringToObject(file, "exclude", reader->exclude);
 
     if (reader->logformat != NULL && strcmp(reader->logformat, EVENTLOG) != 0 && strcmp(reader->logformat, "command") != 0 &&
-        strcmp(reader->logformat, "full_command") != 0)
+        strcmp(reader->logformat, "full_command") != 0 && strcmp(reader->logformat, SOCKET_LOG) != 0)
     {
 
         if (reader->future == 1)

--- a/src/logcollector/src/config.c
+++ b/src/logcollector/src/config.c
@@ -149,19 +149,23 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath)
         }
         cJSON_AddItemToObject(file, "query", query);
     }
+    bool is_socket_like = reader->logformat != NULL &&
+                          (strcmp(reader->logformat, SOCKET_LOG) == 0 ||
+                           strcmp(reader->logformat, HTTP_UNIX_LOG) == 0);
+
     // Invalid configuration for journal logs
-    if (reader->journal_log == NULL && (!reader->logformat || strcmp(reader->logformat, SOCKET_LOG) != 0))
+    if (reader->journal_log == NULL && !is_socket_like)
     {
         cJSON_AddStringToObject(file, "ignore_binaries", reader->filter_binary ? "yes" : "no");
     }
 
-    if (reader->age_str && (!reader->logformat || strcmp(reader->logformat, SOCKET_LOG) != 0))
+    if (reader->age_str && !is_socket_like)
         cJSON_AddStringToObject(file, "age", reader->age_str);
     if (reader->exclude)
         cJSON_AddStringToObject(file, "exclude", reader->exclude);
 
     if (reader->logformat != NULL && strcmp(reader->logformat, EVENTLOG) != 0 && strcmp(reader->logformat, "command") != 0 &&
-        strcmp(reader->logformat, "full_command") != 0 && strcmp(reader->logformat, SOCKET_LOG) != 0)
+        strcmp(reader->logformat, "full_command") != 0 && !is_socket_like)
     {
 
         if (reader->future == 1)
@@ -226,6 +230,15 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath)
         cJSON_AddNumberToObject(multiline, "timeout", reader->multiline->timeout);
         cJSON_AddItemToObject(file, "multiline_regex", multiline);
     }
+#ifndef WIN32
+    if (reader->logformat != NULL && strcmp(reader->logformat, HTTP_UNIX_LOG) == 0)
+    {
+        if (reader->http_endpoint)
+            cJSON_AddStringToObject(file, "endpoint", reader->http_endpoint);
+        if (reader->http_reconnect_interval)
+            cJSON_AddNumberToObject(file, "reconnect_interval", reader->http_reconnect_interval);
+    }
+#endif
     if (reader->journal_log != NULL && reader->journal_log->filters != NULL)
     {
 

--- a/src/logcollector/src/logcollector.c
+++ b/src/logcollector/src/logcollector.c
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <pthread.h>
 #include "sysinfo_utils.h"
+#include "os_net.h"
 #include <openssl/evp.h>
 
 // Remove STATIC qualifier from tests
@@ -37,6 +38,11 @@ static int update_current(logreader **current, int *i, int *j);
 static void set_read(logreader *current, int i, int j);
 static IT_control remove_duplicates(logreader *current, int i, int j);
 static int find_duplicate_inode(logreader * lf);
+static bool source_is_socket(const logreader *lf);
+static bool source_is_open(const logreader *lf);
+static int open_source(int i, int j, int do_fseek, int do_log);
+static int reload_source(logreader *lf);
+static void close_source(logreader *lf);
 static void set_sockets();
 static void files_lock_init(void);
 static void check_text_only();
@@ -542,8 +548,8 @@ void LogCollectorStart()
                         }
                     }
 
-                    if (current->file && current->fp) {
-                        close_file(current);
+                    if (current->file && source_is_open(current)) {
+                        close_source(current);
                     }
                 }
 
@@ -571,7 +577,12 @@ void LogCollectorStart()
                     }
 
                     if (current->file && current->exists) {
-                        if (reload_file(current) == -1) {
+                        if (reload_source(current) == -1) {
+                            if (source_is_socket(current)) {
+                                current->exists = 0;
+                                continue;
+                            }
+
                             minfo(FORGET_FILE, current->file);
                             os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
                             free_files_status_data(old_file_status);
@@ -617,25 +628,51 @@ void LogCollectorStart()
                 /* Files with date -- check for day change */
                 if (current->ffile) {
                     if (update_fname(i, j)) {
-                        if (current->fp) {
-                            fclose(current->fp);
+                        if (source_is_open(current)) {
+                            close_source(current);
                         }
-                        current->fp = NULL;
                         current->exists = 1;
 
-                        handle_file(i, j, 0, 1);
+                        open_source(i, j, 0, 1);
                         continue;
                     }
 
                     /* Variable file name */
-                    else if (!current->fp && open_file_attempts - current->ign > 0) {
-                        handle_file(i, j, 1, 1);
+                    else if (!source_is_open(current) && (source_is_socket(current) || open_file_attempts - current->ign > 0)) {
+                        open_source(i, j, 1, 1);
                         continue;
                     }
                 }
 
                 /* Check for file change -- if the file is open already */
-                if (current->fp) {
+                if (source_is_open(current)) {
+#ifndef WIN32
+                    if (source_is_socket(current)) {
+                        struct stat stat_fd = { .st_mode = 0 };
+                        const char *socket_path = current->socket_path ? current->socket_path : current->file;
+
+                        if (w_stat(socket_path, &stat_fd) == -1 || (stat_fd.st_mode & S_IFMT) != S_IFSOCK) {
+                            if (current->exists == 1) {
+                                minfo(FORGET_FILE, current->file);
+                                w_logcollector_state_delete_file(current->file);
+                                current->exists = 0;
+                            }
+
+                            close_source(current);
+                            current->ign++;
+
+                            if (open_file_attempts) {
+                                mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
+                            } else {
+                                mdebug1(OPEN_UNABLE, current->file);
+                            }
+                        } else {
+                            current->exists = 1;
+                        }
+
+                        continue;
+                    }
+#endif
 #ifndef WIN32
 
                     /* To help detect a file rollover, temporarily open the file a second time.
@@ -759,7 +796,7 @@ void LogCollectorStart()
 #endif
 
                         current->fp = NULL;
-                        handle_file(i, j, 0, 1);
+                        open_source(i, j, 0, 1);
                         continue;
                     }
 #ifdef WIN32
@@ -792,7 +829,7 @@ void LogCollectorStart()
                         CloseHandle(h1);
 #endif
                         current->fp = NULL;
-                        handle_file(i, j, 0, 1);
+                        open_source(i, j, 0, 1);
                     } else {
 #ifdef WIN32
                         CloseHandle(h1);
@@ -847,11 +884,11 @@ void LogCollectorStart()
                 }
 
                 /* If open_file_attempts is at 0 the files aren't forgotted ever*/
-                if(open_file_attempts == 0){
+                if(open_file_attempts == 0 && !source_is_socket(current)){
                     current->ign = -1;
                 }
                 /* Too many errors for the file */
-                if (current->ign >= open_file_attempts) {
+                if (!source_is_socket(current) && current->ign >= open_file_attempts) {
                     /* 999 Maximum ignore */
                     if (current->ign == 999) {
                         continue;
@@ -897,12 +934,17 @@ void LogCollectorStart()
                 }
 
                 /* File not open */
-                if (!current->fp) {
+                if (!source_is_open(current)) {
+                    if (source_is_socket(current)) {
+                        open_source(i, j, 1, 1);
+                        continue;
+                    }
+
                     if (current->ign >= 999) {
                         continue;
                     } else {
                         /* Try for a few times to open the file */
-                        handle_file(i, j, 1, 1);
+                        open_source(i, j, 1, 1);
                         continue;
                     }
                 }
@@ -1000,6 +1042,139 @@ int update_fname(int i, int j)
 
     _cday = tm_result.tm_mday;
     return (0);
+}
+
+static bool source_is_socket(const logreader *lf) {
+    return lf != NULL && lf->logformat != NULL && strcmp(lf->logformat, SOCKET_LOG) == 0;
+}
+
+static bool source_is_open(const logreader *lf) {
+    if (lf == NULL) {
+        return false;
+    }
+
+    if (source_is_socket(lf)) {
+#ifndef WIN32
+        return lf->socket_path != NULL;
+#else
+        return false;
+#endif
+    }
+
+    return lf->fp != NULL;
+}
+
+#ifndef WIN32
+STATIC int open_socket_source(logreader *lf, int do_log) {
+    int fd = -1;
+    int flags = 0;
+
+    if (lf->socket_path != NULL) {
+        OS_CloseSocket(lf->socket_fd);
+        unlink(lf->socket_path);
+        os_free(lf->socket_path);
+        lf->socket_fd = -1;
+    }
+
+    {
+        gid_t sock_gid = getgid();
+        mode_t sock_mode = lf->socket_mode ? lf->socket_mode : 0660;
+        int recv_buf = lf->socket_recv_buffer ? lf->socket_recv_buffer : OS_MAXSTR;
+
+        if (lf->socket_group != NULL) {
+            sock_gid = Privsep_GetGroup(lf->socket_group);
+            if (sock_gid == (gid_t)-1) {
+                if (do_log == 1 && lf->exists == 1) {
+                    merror("Unable to resolve group '%s' for socket '%s'",
+                           lf->socket_group, lf->file);
+                    lf->exists = 0;
+                }
+                goto error;
+            }
+        }
+
+        fd = OS_BindUnixDomainWithPerms(lf->file, SOCK_DGRAM, recv_buf,
+                                         getuid(), sock_gid, sock_mode);
+    }
+    if (fd < 0) {
+        if (do_log == 1 && lf->exists == 1) {
+            merror("Unable to bind datagram socket '%s' (%d): %s", lf->file, errno, strerror(errno));
+            lf->exists = 0;
+        }
+        goto error;
+    }
+
+    if ((flags = fcntl(fd, F_GETFL, 0)) < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        merror("Unable to configure socket '%s' as non-blocking (%d): %s", lf->file, errno, strerror(errno));
+        OS_CloseSocket(fd);
+        goto error;
+    }
+
+    os_strdup(lf->file, lf->socket_path);
+    lf->socket_fd = fd;
+    lf->ign = 0;
+    lf->exists = 1;
+    return 0;
+
+error:
+    lf->ign++;
+
+    if (open_file_attempts) {
+        mdebug1(OPEN_ATTEMPT, lf->file, open_file_attempts - lf->ign);
+    } else {
+        mdebug1(OPEN_UNABLE, lf->file);
+    }
+
+    return -1;
+}
+#endif
+
+static int open_source(int i, int j, int do_fseek, int do_log) {
+    logreader *lf = j < 0 ? &logff[i] : &globs[j].gfiles[i];
+
+    if (source_is_socket(lf)) {
+#ifndef WIN32
+        return open_socket_source(lf, do_log);
+#else
+        return -1;
+#endif
+    }
+
+    return handle_file(i, j, do_fseek, do_log);
+}
+
+static int reload_source(logreader *lf) {
+    if (source_is_socket(lf)) {
+#ifndef WIN32
+        return open_socket_source(lf, 1);
+#else
+        return -1;
+#endif
+    }
+
+    return reload_file(lf);
+}
+
+static void close_source(logreader *lf) {
+    if (lf == NULL) {
+        return;
+    }
+
+    if (source_is_socket(lf)) {
+#ifndef WIN32
+        if (lf->socket_path == NULL) {
+            return;
+        }
+
+        OS_CloseSocket(lf->socket_fd);
+        unlink(lf->socket_path);
+        os_free(lf->socket_path);
+        lf->socket_fd = -1;
+#endif
+        return;
+    }
+
+    close_file(lf);
 }
 
 /* Open, get the fileno, seek to the end and update mtime */
@@ -1213,13 +1388,13 @@ void set_read(logreader *current, int i, int j) {
         /* Day must be zero for all files to be initialized */
         _cday = 0;
         if (update_fname(i, j)) {
-            handle_file(i, j, 1, 1);
+            open_source(i, j, 1, 1);
         } else {
             merror_exit(PARSE_ERROR, current->ffile);
         }
 
     } else {
-        handle_file(i, j, 1, 1);
+        open_source(i, j, 1, 1);
     }
 
     tg = 0;
@@ -1236,7 +1411,9 @@ void set_read(logreader *current, int i, int j) {
         current->read = read_snortfull;
     }
 #ifndef WIN32
-    if (strcmp("wazuhalert", current->logformat) == 0) {
+    if (strcmp(SOCKET_LOG, current->logformat) == 0) {
+        current->read = read_socket;
+    } else if (strcmp("wazuhalert", current->logformat) == 0) {
         current->read = read_wazuhalert;
     }
 #endif
@@ -1334,8 +1511,9 @@ int check_pattern_expand(int do_seek) {
                     continue;
                 }
 
-                if ((statbuf.st_mode & S_IFMT) != S_IFREG) {
-                    mdebug1("File %s is not a regular file. Skipping it.", g.gl_pathv[glob_offset]);
+                if ((!source_is_socket(globs[j].gfiles) && (statbuf.st_mode & S_IFMT) != S_IFREG) ||
+                    (source_is_socket(globs[j].gfiles) && (statbuf.st_mode & S_IFMT) != S_IFSOCK)) {
+                    mdebug1("Path %s does not match the expected source type. Skipping it.", g.gl_pathv[glob_offset]);
                     glob_offset++;
                     continue;
                 }
@@ -1374,7 +1552,7 @@ int check_pattern_expand(int do_seek) {
                         if  (!globs[j].gfiles[i].read) {
                             set_read(&globs[j].gfiles[i], i, j);
                         } else {
-                            handle_file(i, j, do_seek, 1);
+                            open_source(i, j, do_seek, 1);
                         }
 
                         added = 1;
@@ -1403,7 +1581,7 @@ int check_pattern_expand(int do_seek) {
                         if  (!globs[j].gfiles[i].read) {
                             set_read(&globs[j].gfiles[i], i, j);
                         } else {
-                            handle_file(i, j, do_seek, 1);
+                            open_source(i, j, do_seek, 1);
                         }
                     }
                 }
@@ -1565,7 +1743,7 @@ int check_pattern_expand(int do_seek) {
                             if (!globs[j].gfiles[i].read) {
                                 set_read(&globs[j].gfiles[i], i, j);
                             } else {
-                                handle_file(i, j, do_seek, 1);
+                                open_source(i, j, do_seek, 1);
                             }
 
                             added = 1;
@@ -1595,7 +1773,7 @@ int check_pattern_expand(int do_seek) {
                             if (!globs[j].gfiles[i].read) {
                                 set_read(&globs[j].gfiles[i], i, j);
                             } else {
-                                handle_file(i, j, do_seek, 1);
+                                open_source(i, j, do_seek, 1);
                             }
                         }
                     }
@@ -2069,7 +2247,7 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
 
             if (pthread_mutex_trylock(&current->mutex) == 0){
 
-                if (!current->fp) {
+                if (!source_is_open(current)) {
                     /* Run the command */
                     if (current->command) {
                         curr_time = time(0);
@@ -2094,6 +2272,28 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                         }
                     }
 #endif
+                    w_mutex_unlock(&current->mutex);
+                    rwlock_unlock(&files_update_rwlock);
+                    continue;
+                }
+
+                if (source_is_socket(current)) {
+                    current->read(current, &r, 0);
+
+                    if (r != 0) {
+                        mdebug1("Read error on socket '%s', will attempt to re-bind.", current->file);
+                        w_logcollector_state_delete_file(current->file);
+                        close_source(current);
+
+                        current->ign++;
+
+                        if (open_file_attempts && j < 0) {
+                            mdebug1(OPEN_ATTEMPT, current->file, open_file_attempts - current->ign);
+                        } else {
+                            mdebug1(OPEN_UNABLE, current->file);
+                        }
+                    }
+
                     w_mutex_unlock(&current->mutex);
                     rwlock_unlock(&files_update_rwlock);
                     continue;
@@ -2250,11 +2450,10 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
     #endif
 
                         /* Close the file */
-                        fclose(current->fp);
-                        current->fp = NULL;
+                        close_source(current);
 
                         /* Try to open it again */
-                        if (handle_file(i, j, 0, 1)) {
+                        if (open_source(i, j, 0, 1)) {
                             w_mutex_unlock(&current->mutex);
                             rwlock_unlock(&files_update_rwlock);
                             continue;
@@ -2345,7 +2544,7 @@ static void check_text_only() {
         }
 
         /* Check for files to exclude */
-        if(current->file && !current->command && current->filter_binary) {
+        if(current->file && !current->command && current->filter_binary && !source_is_socket(current)) {
             snprintf(file_name, PATH_MAX, "%s", current->file);
 
             char *file_excluded = OSHash_Get(excluded_files,file_name);

--- a/src/logcollector/src/logcollector.c
+++ b/src/logcollector/src/logcollector.c
@@ -39,6 +39,7 @@ static void set_read(logreader *current, int i, int j);
 static IT_control remove_duplicates(logreader *current, int i, int j);
 static int find_duplicate_inode(logreader * lf);
 static bool source_is_socket(const logreader *lf);
+static bool source_is_http_unix(const logreader *lf);
 static bool source_is_open(const logreader *lf);
 static int open_source(int i, int j, int do_fseek, int do_log);
 static int reload_source(logreader *lf);
@@ -151,6 +152,35 @@ STATIC atomic_int_t _startup_completed = ATOMIC_INT_INITIALIZER(0);
 STATIC w_macos_log_procceses_t * macos_processes = NULL;
 
 #endif
+
+bool w_logcollector_validate_text_line(char *buf, size_t *len, const char *source_kind, const char *source) {
+    if (buf == NULL || len == NULL) {
+        return false;
+    }
+
+    const char *kind = source_kind ? source_kind : "source";
+    const char *src = source ? source : "(null)";
+
+    if (*len > 0 && buf[*len - 1] == '\n') {
+        buf[--(*len)] = '\0';
+    }
+
+    if (*len == 0) {
+        return false;
+    }
+
+    if (strlen(buf) != *len) {
+        mdebug2("Message from %s '%s' contains zero-bytes. Dropping.", kind, src);
+        return false;
+    }
+
+    if (!w_utf8_valid(buf)) {
+        mdebug2("Message from %s '%s' is not valid UTF-8. Dropping.", kind, src);
+        return false;
+    }
+
+    return true;
+}
 
 int check_ignore_and_restrict(OSList * ignore_exp_list, OSList * restrict_exp_list, const char *log_line) {
     OSListNode *node_it;
@@ -578,7 +608,7 @@ void LogCollectorStart()
 
                     if (current->file && current->exists) {
                         if (reload_source(current) == -1) {
-                            if (source_is_socket(current)) {
+                            if (source_is_socket(current) || source_is_http_unix(current)) {
                                 current->exists = 0;
                                 continue;
                             }
@@ -638,7 +668,7 @@ void LogCollectorStart()
                     }
 
                     /* Variable file name */
-                    else if (!source_is_open(current) && (source_is_socket(current) || open_file_attempts - current->ign > 0)) {
+                    else if (!source_is_open(current) && (source_is_socket(current) || source_is_http_unix(current) || open_file_attempts - current->ign > 0)) {
                         open_source(i, j, 1, 1);
                         continue;
                     }
@@ -647,6 +677,10 @@ void LogCollectorStart()
                 /* Check for file change -- if the file is open already */
                 if (source_is_open(current)) {
 #ifndef WIN32
+                    if (source_is_http_unix(current)) {
+                        /* Worker thread manages connection liveness; nothing to verify here. */
+                        continue;
+                    }
                     if (source_is_socket(current)) {
                         struct stat stat_fd = { .st_mode = 0 };
                         const char *socket_path = current->socket_path ? current->socket_path : current->file;
@@ -888,7 +922,7 @@ void LogCollectorStart()
                     current->ign = -1;
                 }
                 /* Too many errors for the file */
-                if (!source_is_socket(current) && current->ign >= open_file_attempts) {
+                if (!source_is_socket(current) && !source_is_http_unix(current) && current->ign >= open_file_attempts) {
                     /* 999 Maximum ignore */
                     if (current->ign == 999) {
                         continue;
@@ -935,7 +969,7 @@ void LogCollectorStart()
 
                 /* File not open */
                 if (!source_is_open(current)) {
-                    if (source_is_socket(current)) {
+                    if (source_is_socket(current) || source_is_http_unix(current)) {
                         open_source(i, j, 1, 1);
                         continue;
                     }
@@ -1048,6 +1082,10 @@ static bool source_is_socket(const logreader *lf) {
     return lf != NULL && lf->logformat != NULL && strcmp(lf->logformat, SOCKET_LOG) == 0;
 }
 
+static bool source_is_http_unix(const logreader *lf) {
+    return lf != NULL && lf->logformat != NULL && strcmp(lf->logformat, HTTP_UNIX_LOG) == 0;
+}
+
 static bool source_is_open(const logreader *lf) {
     if (lf == NULL) {
         return false;
@@ -1061,53 +1099,99 @@ static bool source_is_open(const logreader *lf) {
 #endif
     }
 
+    if (source_is_http_unix(lf)) {
+#ifndef WIN32
+        return lf->http_thread_started != 0;
+#else
+        return false;
+#endif
+    }
+
     return lf->fp != NULL;
 }
 
 #ifndef WIN32
-STATIC int open_socket_source(logreader *lf, int do_log) {
-    int fd = -1;
-    int flags = 0;
+/* Release a previously-bound socket so the path can be re-bound. */
+static void release_bound_socket(logreader *lf) {
+    if (lf->socket_path == NULL) {
+        return;
+    }
+    OS_CloseSocket(lf->socket_fd);
+    unlink(lf->socket_path);
+    os_free(lf->socket_path);
+    lf->socket_fd = -1;
+}
 
-    if (lf->socket_path != NULL) {
-        OS_CloseSocket(lf->socket_fd);
-        unlink(lf->socket_path);
-        os_free(lf->socket_path);
-        lf->socket_fd = -1;
+/* Resolve the socket's owning group; falls back to the process group if
+ * <socket_group> is unset. Returns 0 on success, -1 on lookup failure. */
+static int resolve_socket_group(const logreader *lf, gid_t *out, int do_log, int *exists_out) {
+    if (lf->socket_group == NULL) {
+        *out = getgid();
+        return 0;
     }
 
-    {
-        gid_t sock_gid = getgid();
-        mode_t sock_mode = lf->socket_mode ? lf->socket_mode : 0660;
-        int recv_buf = lf->socket_recv_buffer ? lf->socket_recv_buffer : OS_MAXSTR;
-
-        if (lf->socket_group != NULL) {
-            sock_gid = Privsep_GetGroup(lf->socket_group);
-            if (sock_gid == (gid_t)-1) {
-                if (do_log == 1 && lf->exists == 1) {
-                    merror("Unable to resolve group '%s' for socket '%s'",
-                           lf->socket_group, lf->file);
-                    lf->exists = 0;
-                }
-                goto error;
-            }
+    gid_t gid = Privsep_GetGroup(lf->socket_group);
+    if (gid == (gid_t)-1) {
+        if (do_log == 1 && lf->exists == 1) {
+            merror("Unable to resolve group '%s' for socket '%s'",
+                   lf->socket_group, lf->file);
+            *exists_out = 0;
         }
-
-        fd = OS_BindUnixDomainWithPerms(lf->file, SOCK_DGRAM, recv_buf,
-                                         getuid(), sock_gid, sock_mode);
+        return -1;
     }
+    *out = gid;
+    return 0;
+}
+
+/* Make a socket non-blocking. Returns 0 on success, -1 on failure (and closes fd). */
+static int set_socket_nonblocking(int fd, const char *path) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        merror("Unable to configure socket '%s' as non-blocking (%d): %s", path, errno, strerror(errno));
+        OS_CloseSocket(fd);
+        return -1;
+    }
+    return 0;
+}
+
+/* Log open-attempt accounting after a failed open. */
+static void log_open_failure(const logreader *lf) {
+    if (open_file_attempts) {
+        mdebug1(OPEN_ATTEMPT, lf->file, open_file_attempts - lf->ign);
+    } else {
+        mdebug1(OPEN_UNABLE, lf->file);
+    }
+}
+
+STATIC int open_socket_source(logreader *lf, int do_log) {
+    release_bound_socket(lf);
+
+    mode_t sock_mode = lf->socket_mode ? lf->socket_mode : 0660;
+    int recv_buf = lf->socket_recv_buffer ? lf->socket_recv_buffer : OS_MAXSTR;
+    gid_t sock_gid;
+
+    if (resolve_socket_group(lf, &sock_gid, do_log, &lf->exists) < 0) {
+        lf->ign++;
+        log_open_failure(lf);
+        return -1;
+    }
+
+    int fd = OS_BindUnixDomainWithPerms(lf->file, SOCK_DGRAM, recv_buf,
+                                        getuid(), sock_gid, sock_mode);
     if (fd < 0) {
         if (do_log == 1 && lf->exists == 1) {
             merror("Unable to bind datagram socket '%s' (%d): %s", lf->file, errno, strerror(errno));
             lf->exists = 0;
         }
-        goto error;
+        lf->ign++;
+        log_open_failure(lf);
+        return -1;
     }
 
-    if ((flags = fcntl(fd, F_GETFL, 0)) < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-        merror("Unable to configure socket '%s' as non-blocking (%d): %s", lf->file, errno, strerror(errno));
-        OS_CloseSocket(fd);
-        goto error;
+    if (set_socket_nonblocking(fd, lf->file) < 0) {
+        lf->ign++;
+        log_open_failure(lf);
+        return -1;
     }
 
     os_strdup(lf->file, lf->socket_path);
@@ -1115,17 +1199,27 @@ STATIC int open_socket_source(logreader *lf, int do_log) {
     lf->ign = 0;
     lf->exists = 1;
     return 0;
+}
+#endif
 
-error:
-    lf->ign++;
-
-    if (open_file_attempts) {
-        mdebug1(OPEN_ATTEMPT, lf->file, open_file_attempts - lf->ign);
-    } else {
-        mdebug1(OPEN_UNABLE, lf->file);
+#ifndef WIN32
+static int open_http_unix_source(logreader *lf) {
+    int rc = w_logcollector_http_unix_open(lf);
+    if (rc == 0) {
+        lf->ign = 0;
+        lf->exists = 1;
     }
+    return rc;
+}
 
-    return -1;
+static void close_http_unix_source(logreader *lf) {
+    if (!lf->http_thread_started) {
+        return;
+    }
+    lf->http_stop = 1;
+    pthread_join(lf->http_thread, NULL);
+    lf->http_thread_started = 0;
+    lf->http_stop = 0;
 }
 #endif
 
@@ -1135,6 +1229,14 @@ static int open_source(int i, int j, int do_fseek, int do_log) {
     if (source_is_socket(lf)) {
 #ifndef WIN32
         return open_socket_source(lf, do_log);
+#else
+        return -1;
+#endif
+    }
+
+    if (source_is_http_unix(lf)) {
+#ifndef WIN32
+        return open_http_unix_source(lf);
 #else
         return -1;
 #endif
@@ -1152,6 +1254,15 @@ static int reload_source(logreader *lf) {
 #endif
     }
 
+    if (source_is_http_unix(lf)) {
+#ifndef WIN32
+        close_http_unix_source(lf);
+        return open_http_unix_source(lf);
+#else
+        return -1;
+#endif
+    }
+
     return reload_file(lf);
 }
 
@@ -1162,14 +1273,14 @@ static void close_source(logreader *lf) {
 
     if (source_is_socket(lf)) {
 #ifndef WIN32
-        if (lf->socket_path == NULL) {
-            return;
-        }
+        release_bound_socket(lf);
+#endif
+        return;
+    }
 
-        OS_CloseSocket(lf->socket_fd);
-        unlink(lf->socket_path);
-        os_free(lf->socket_path);
-        lf->socket_fd = -1;
+    if (source_is_http_unix(lf)) {
+#ifndef WIN32
+        close_http_unix_source(lf);
 #endif
         return;
     }
@@ -1413,6 +1524,9 @@ void set_read(logreader *current, int i, int j) {
 #ifndef WIN32
     if (strcmp(SOCKET_LOG, current->logformat) == 0) {
         current->read = read_socket;
+    } else if (strcmp(HTTP_UNIX_LOG, current->logformat) == 0) {
+        /* Worker thread handles I/O directly; no synchronous read callback. */
+        current->read = NULL;
     } else if (strcmp("wazuhalert", current->logformat) == 0) {
         current->read = read_wazuhalert;
     }
@@ -1511,11 +1625,15 @@ int check_pattern_expand(int do_seek) {
                     continue;
                 }
 
-                if ((!source_is_socket(globs[j].gfiles) && (statbuf.st_mode & S_IFMT) != S_IFREG) ||
-                    (source_is_socket(globs[j].gfiles) && (statbuf.st_mode & S_IFMT) != S_IFSOCK)) {
-                    mdebug1("Path %s does not match the expected source type. Skipping it.", g.gl_pathv[glob_offset]);
-                    glob_offset++;
-                    continue;
+                {
+                    bool expects_socket = source_is_socket(globs[j].gfiles) || source_is_http_unix(globs[j].gfiles);
+                    mode_t st_type = statbuf.st_mode & S_IFMT;
+                    if ((expects_socket && st_type != S_IFSOCK) ||
+                        (!expects_socket && st_type != S_IFREG)) {
+                        mdebug1("Path %s does not match the expected source type. Skipping it.", g.gl_pathv[glob_offset]);
+                        glob_offset++;
+                        continue;
+                    }
                 }
 
                 found = 0;
@@ -2299,6 +2417,13 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                     continue;
                 }
 
+                if (source_is_http_unix(current)) {
+                    /* Worker thread owns I/O and reconnect; nothing to do in the main loop. */
+                    w_mutex_unlock(&current->mutex);
+                    rwlock_unlock(&files_update_rwlock);
+                    continue;
+                }
+
                 /* Windows with IIS logs is very strange.
                 * For some reason it always returns 0 (not EOF)
                 * the fgetc. To solve this problem, we always
@@ -2544,7 +2669,7 @@ static void check_text_only() {
         }
 
         /* Check for files to exclude */
-        if(current->file && !current->command && current->filter_binary && !source_is_socket(current)) {
+        if(current->file && !current->command && current->filter_binary && !source_is_socket(current) && !source_is_http_unix(current)) {
             snprintf(file_name, PATH_MAX, "%s", current->file);
 
             char *file_excluded = OSHash_Get(excluded_files,file_name);

--- a/src/logcollector/src/read_http_unix.c
+++ b/src/logcollector/src/read_http_unix.c
@@ -1,0 +1,524 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef WIN32
+
+#include "shared.h"
+#include "logcollector.h"
+#include "os_net.h"
+#include <poll.h>
+#include <sys/socket.h>
+
+#define HTTP_RECV_CHUNK   8192
+#define HTTP_REQ_TEMPLATE "GET %s HTTP/1.1\r\n" \
+                          "Host: localhost\r\n" \
+                          "User-Agent: wazuh-logcollector\r\n" \
+                          "Accept: */*\r\n" \
+                          "Connection: keep-alive\r\n" \
+                          "\r\n"
+
+typedef enum {
+    BODY_CHUNKED,
+    BODY_LENGTH,
+    BODY_UNTIL_CLOSE
+} body_mode_t;
+
+typedef struct {
+    /* Raw bytes pending inspection (header parsing or chunk-size parsing). */
+    char *header_buf;
+    size_t header_len;
+    size_t header_cap;
+
+    /* Line accumulator: a partial trailing line carried across reads/chunks. */
+    char *line_buf;
+    size_t line_len;
+    size_t line_cap;
+
+    body_mode_t mode;
+    size_t bytes_remaining;   /* For BODY_CHUNKED (current chunk) and BODY_LENGTH (whole body). */
+} http_parse_ctx_t;
+
+/* ------------------------------------------------------------------------- */
+/* Stop-aware helpers                                                        */
+/* ------------------------------------------------------------------------- */
+
+static void http_unix_sleep_interruptible(const logreader *lf, int seconds) {
+    for (int s = 0; s < seconds && !lf->http_stop; s++) {
+        sleep(1);
+    }
+}
+
+/* Poll fd for input with stop-flag awareness. Returns:
+ *   1 = data ready
+ *   0 = stop requested
+ *  -1 = error or remote closed
+ */
+static int http_unix_wait_readable(int fd, const logreader *lf) {
+    while (!lf->http_stop) {
+        struct pollfd pfd = {.fd = fd, .events = POLLIN, .revents = 0};
+        int r = poll(&pfd, 1, 1000);
+
+        if (r < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            mdebug1("http-unix '%s': poll failed: %s", lf->file, strerror(errno));
+            return -1;
+        }
+        if (r == 0) {
+            continue;  /* timeout — re-check stop flag */
+        }
+        if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            return -1;
+        }
+        if (pfd.revents & POLLIN) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Buffer helpers                                                            */
+/* ------------------------------------------------------------------------- */
+
+static void http_buf_append(char **buf, size_t *len, size_t *cap, const char *src, size_t n) {
+    if (*len + n + 1 > *cap) {
+        size_t new_cap = (*cap == 0) ? 1024 : *cap;
+        while (new_cap < *len + n + 1) {
+            new_cap *= 2;
+        }
+        os_realloc(*buf, new_cap, *buf);
+        *cap = new_cap;
+    }
+    memcpy(*buf + *len, src, n);
+    *len += n;
+    (*buf)[*len] = '\0';
+}
+
+static void http_ctx_reset(http_parse_ctx_t *ctx) {
+    if (ctx->header_buf) {
+        ctx->header_buf[0] = '\0';
+    }
+    ctx->header_len = 0;
+    if (ctx->line_buf) {
+        ctx->line_buf[0] = '\0';
+    }
+    ctx->line_len = 0;
+    ctx->mode = BODY_UNTIL_CLOSE;
+    ctx->bytes_remaining = 0;
+}
+
+static void http_ctx_free(http_parse_ctx_t *ctx) {
+    os_free(ctx->header_buf);
+    os_free(ctx->line_buf);
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+/* ------------------------------------------------------------------------- */
+/* Connection setup                                                          */
+/* ------------------------------------------------------------------------- */
+
+static int http_unix_connect(const logreader *lf) {
+    int fd = OS_ConnectUnixDomain(lf->file, SOCK_STREAM, OS_MAXSTR);
+    if (fd < 0) {
+        return -1;
+    }
+    return fd;
+}
+
+static int http_unix_send_request(int fd, const logreader *lf) {
+    char req[OS_SIZE_1024];
+    int req_len = snprintf(req, sizeof(req), HTTP_REQ_TEMPLATE, lf->http_endpoint);
+    if (req_len <= 0 || (size_t)req_len >= sizeof(req)) {
+        merror("http-unix '%s': request line too long for endpoint '%s'", lf->file, lf->http_endpoint);
+        return -1;
+    }
+
+    ssize_t off = 0;
+    while (off < req_len) {
+        ssize_t n = send(fd, req + off, (size_t)(req_len - off), 0);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            mdebug1("http-unix '%s': send failed: %s", lf->file, strerror(errno));
+            return -1;
+        }
+        off += n;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Line emission                                                             */
+/* ------------------------------------------------------------------------- */
+
+/* Push a single accumulated line through the standard validation+queue path. */
+static void http_unix_emit_line(logreader *lf, char *line, size_t len) {
+    size_t msg_len = len;
+
+    if (!w_logcollector_validate_text_line(line, &msg_len, "http-unix", lf->file)) {
+        return;
+    }
+
+    mdebug2("Reading http-unix message: '%.*s'%s", sample_log_length, line,
+            (int)msg_len > sample_log_length ? "..." : "");
+
+    if (!check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, line)) {
+        w_msg_hash_queues_push(line, lf->file, msg_len + 1, lf->log_target, LOCALFILE_MQ);
+    }
+}
+
+/* Feed body bytes to the line splitter; emit complete lines, retain partial tail. */
+static void http_unix_feed_body(logreader *lf, http_parse_ctx_t *ctx, const char *data, size_t n) {
+    size_t start = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (data[i] == '\n') {
+            if (i > start) {
+                http_buf_append(&ctx->line_buf, &ctx->line_len, &ctx->line_cap, data + start, i - start);
+            }
+            if (ctx->line_len > 0) {
+                http_unix_emit_line(lf, ctx->line_buf, ctx->line_len);
+                ctx->line_len = 0;
+                if (ctx->line_buf) {
+                    ctx->line_buf[0] = '\0';
+                }
+            }
+            start = i + 1;
+        }
+    }
+    if (start < n) {
+        if (ctx->line_len + (n - start) >= OS_MAXSTR) {
+            mwarn("http-unix '%s': line exceeds %d bytes; dropping accumulated content.", lf->file, OS_MAXSTR);
+            ctx->line_len = 0;
+            if (ctx->line_buf) {
+                ctx->line_buf[0] = '\0';
+            }
+        } else {
+            http_buf_append(&ctx->line_buf, &ctx->line_len, &ctx->line_cap, data + start, n - start);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+/* Header / status / chunk parsing                                           */
+/* ------------------------------------------------------------------------- */
+
+/* Returns 0 on parse-incomplete (need more data), 1 on success, -1 on error. */
+static int http_unix_parse_headers(logreader *lf, http_parse_ctx_t *ctx) {
+    char *end = strstr(ctx->header_buf, "\r\n\r\n");
+    if (end == NULL) {
+        return 0;
+    }
+
+    /* Status line: "HTTP/1.1 200 OK\r\n" */
+    char *status_end = strstr(ctx->header_buf, "\r\n");
+    if (status_end == NULL || status_end >= end) {
+        return -1;
+    }
+
+    int status_code = 0;
+    if (sscanf(ctx->header_buf, "HTTP/1.%*d %d", &status_code) != 1) {
+        merror("http-unix '%s': malformed status line.", lf->file);
+        return -1;
+    }
+    if (status_code < 200 || status_code >= 300) {
+        merror("http-unix '%s': server returned HTTP %d.", lf->file, status_code);
+        return -1;
+    }
+
+    /* Default: read body until close, no length known */
+    ctx->mode = BODY_UNTIL_CLOSE;
+    ctx->bytes_remaining = 0;
+
+    /* Inspect headers: case-insensitive search for Transfer-Encoding and Content-Length */
+    char *line = status_end + 2;
+    while (line < end) {
+        char *eol = strstr(line, "\r\n");
+        if (eol == NULL || eol > end) {
+            break;
+        }
+        size_t line_len = (size_t)(eol - line);
+
+        if (line_len > 18 && strncasecmp(line, "Transfer-Encoding:", 18) == 0) {
+            /* Look for "chunked" anywhere in the value */
+            char *value = line + 18;
+            while (value < eol && (*value == ' ' || *value == '\t')) {
+                value++;
+            }
+            if ((size_t)(eol - value) >= 7 && strncasecmp(value, "chunked", 7) == 0) {
+                ctx->mode = BODY_CHUNKED;
+            }
+        } else if (line_len > 15 && strncasecmp(line, "Content-Length:", 15) == 0 && ctx->mode != BODY_CHUNKED) {
+            char *value = line + 15;
+            while (value < eol && (*value == ' ' || *value == '\t')) {
+                value++;
+            }
+            char tmp[32] = {0};
+            size_t tl = (size_t)(eol - value);
+            if (tl == 0 || tl >= sizeof(tmp)) {
+                return -1;
+            }
+            memcpy(tmp, value, tl);
+            char *endp;
+            long long cl = strtoll(tmp, &endp, 10);
+            if (*endp != '\0' || cl < 0) {
+                return -1;
+            }
+            ctx->mode = BODY_LENGTH;
+            ctx->bytes_remaining = (size_t)cl;
+        }
+
+        line = eol + 2;
+    }
+
+    /* Shift any post-header bytes already in header_buf to be re-fed as body. */
+    size_t header_total = (size_t)(end - ctx->header_buf) + 4;  /* include \r\n\r\n */
+    size_t leftover = ctx->header_len - header_total;
+    if (leftover > 0) {
+        memmove(ctx->header_buf, ctx->header_buf + header_total, leftover);
+    }
+    ctx->header_len = leftover;
+    if (ctx->header_buf) {
+        ctx->header_buf[ctx->header_len] = '\0';
+    }
+    return 1;
+}
+
+/* Process body bytes according to ctx->mode.
+ * Returns 0 on success (more data may be needed), -1 on parse error or end-of-body. */
+static int http_unix_consume_body_bytes(logreader *lf, http_parse_ctx_t *ctx, const char *data, size_t n) {
+    if (ctx->mode == BODY_LENGTH) {
+        size_t take = n < ctx->bytes_remaining ? n : ctx->bytes_remaining;
+        http_unix_feed_body(lf, ctx, data, take);
+        ctx->bytes_remaining -= take;
+        if (ctx->bytes_remaining == 0) {
+            /* Flush any trailing partial line as a final message. */
+            if (ctx->line_len > 0) {
+                http_unix_emit_line(lf, ctx->line_buf, ctx->line_len);
+                ctx->line_len = 0;
+            }
+            return -1;  /* signal: connection should be closed and re-established */
+        }
+        return 0;
+    }
+
+    if (ctx->mode == BODY_UNTIL_CLOSE) {
+        http_unix_feed_body(lf, ctx, data, n);
+        return 0;
+    }
+
+    /* BODY_CHUNKED: append to header_buf as the chunk-size scratch area, then drain. */
+    http_buf_append(&ctx->header_buf, &ctx->header_len, &ctx->header_cap, data, n);
+
+    while (ctx->header_len > 0) {
+        if (ctx->bytes_remaining == 0) {
+            /* Need to read a chunk size line: "<hex>[;ext]\r\n" */
+            char *eol = NULL;
+            for (size_t k = 0; k + 1 < ctx->header_len; k++) {
+                if (ctx->header_buf[k] == '\r' && ctx->header_buf[k + 1] == '\n') {
+                    eol = ctx->header_buf + k;
+                    break;
+                }
+            }
+            if (eol == NULL) {
+                return 0;
+            }
+            char size_line[64] = {0};
+            size_t sl = (size_t)(eol - ctx->header_buf);
+            if (sl >= sizeof(size_line)) {
+                merror("http-unix '%s': chunk size line too long.", lf->file);
+                return -1;
+            }
+            memcpy(size_line, ctx->header_buf, sl);
+            char *endp;
+            long long cs = strtoll(size_line, &endp, 16);
+            if (cs < 0 || (*endp != '\0' && *endp != ';')) {
+                merror("http-unix '%s': malformed chunk size '%s'.", lf->file, size_line);
+                return -1;
+            }
+            size_t consumed = sl + 2;
+            memmove(ctx->header_buf, ctx->header_buf + consumed, ctx->header_len - consumed);
+            ctx->header_len -= consumed;
+            ctx->header_buf[ctx->header_len] = '\0';
+
+            if (cs == 0) {
+                /* Last chunk — flush any partial line and signal EOF. */
+                if (ctx->line_len > 0) {
+                    http_unix_emit_line(lf, ctx->line_buf, ctx->line_len);
+                    ctx->line_len = 0;
+                }
+                return -1;
+            }
+            ctx->bytes_remaining = (size_t)cs + 2;  /* +2 for trailing \r\n */
+        }
+
+        /* Drain available chunk bytes. The trailing 2 bytes belong to \r\n delimiter. */
+        size_t avail = ctx->header_len;
+        size_t want = ctx->bytes_remaining;
+        size_t take = avail < want ? avail : want;
+
+        /* Of `take` bytes, the first (want - 2) are payload, the last belong to the trailing \r\n. */
+        size_t payload_remaining = ctx->bytes_remaining > 2 ? ctx->bytes_remaining - 2 : 0;
+        size_t payload_take = take < payload_remaining ? take : payload_remaining;
+        if (payload_take > 0) {
+            http_unix_feed_body(lf, ctx, ctx->header_buf, payload_take);
+        }
+
+        memmove(ctx->header_buf, ctx->header_buf + take, ctx->header_len - take);
+        ctx->header_len -= take;
+        ctx->header_buf[ctx->header_len] = '\0';
+        ctx->bytes_remaining -= take;
+
+        if (ctx->bytes_remaining > 0) {
+            return 0;  /* need more bytes to finish this chunk */
+        }
+        /* chunk fully consumed; loop back to read next chunk size */
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Per-connection consumer                                                   */
+/* ------------------------------------------------------------------------- */
+
+static void http_unix_consume(logreader *lf, int fd, http_parse_ctx_t *ctx) {
+    char buf[HTTP_RECV_CHUNK];
+    bool headers_parsed = false;
+
+    while (!lf->http_stop) {
+        int wr = http_unix_wait_readable(fd, lf);
+        if (wr <= 0) {
+            return;  /* stopped or socket-level error */
+        }
+
+        ssize_t n = recv(fd, buf, sizeof(buf), 0);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            mdebug1("http-unix '%s': recv failed: %s", lf->file, strerror(errno));
+            return;
+        }
+        if (n == 0) {
+            mdebug1("http-unix '%s': peer closed connection.", lf->file);
+            if (headers_parsed && ctx->mode == BODY_UNTIL_CLOSE && ctx->line_len > 0) {
+                http_unix_emit_line(lf, ctx->line_buf, ctx->line_len);
+                ctx->line_len = 0;
+            }
+            return;
+        }
+
+        if (!headers_parsed) {
+            http_buf_append(&ctx->header_buf, &ctx->header_len, &ctx->header_cap, buf, (size_t)n);
+            int hr = http_unix_parse_headers(lf, ctx);
+            if (hr < 0) {
+                return;
+            }
+            if (hr == 0) {
+                continue;  /* need more bytes for headers */
+            }
+            headers_parsed = true;
+
+            /* Feed any post-header bytes already in header_buf as body. */
+            if (ctx->header_len > 0) {
+                size_t carry = ctx->header_len;
+                /* Copy into a temp buffer because consume_body may reuse header_buf for chunks. */
+                char *tmp;
+                os_malloc(carry, tmp);
+                memcpy(tmp, ctx->header_buf, carry);
+                ctx->header_len = 0;
+                ctx->header_buf[0] = '\0';
+                int br = http_unix_consume_body_bytes(lf, ctx, tmp, carry);
+                os_free(tmp);
+                if (br < 0) {
+                    return;
+                }
+            }
+            continue;
+        }
+
+        if (http_unix_consume_body_bytes(lf, ctx, buf, (size_t)n) < 0) {
+            return;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+/* Worker thread                                                             */
+/* ------------------------------------------------------------------------- */
+
+static void *http_unix_worker(void *arg) {
+    logreader *lf = (logreader *)arg;
+    http_parse_ctx_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    bool first_failure_logged = false;
+
+    while (!lf->http_stop) {
+        int fd = http_unix_connect(lf);
+        if (fd < 0) {
+            if (!first_failure_logged) {
+                mwarn("http-unix '%s': unable to connect (%s); will keep retrying every %ds.",
+                      lf->file, strerror(errno), lf->http_reconnect_interval);
+                first_failure_logged = true;
+            } else {
+                mdebug2("http-unix '%s': connect failed: %s", lf->file, strerror(errno));
+            }
+            http_unix_sleep_interruptible(lf, lf->http_reconnect_interval);
+            continue;
+        }
+
+        if (first_failure_logged) {
+            minfo("http-unix '%s': connection established.", lf->file);
+            first_failure_logged = false;
+        } else {
+            mdebug1("http-unix '%s': connected.", lf->file);
+        }
+
+        if (http_unix_send_request(fd, lf) == 0) {
+            http_ctx_reset(&ctx);
+            http_unix_consume(lf, fd, &ctx);
+        }
+
+        OS_CloseSocket(fd);
+
+        if (!lf->http_stop) {
+            http_unix_sleep_interruptible(lf, lf->http_reconnect_interval);
+        }
+    }
+
+    http_ctx_free(&ctx);
+    return NULL;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Public entry                                                              */
+/* ------------------------------------------------------------------------- */
+
+int w_logcollector_http_unix_open(logreader *lf) {
+    if (lf == NULL || lf->file == NULL || lf->http_endpoint == NULL) {
+        return -1;
+    }
+    if (lf->http_thread_started) {
+        return 0;
+    }
+
+    lf->http_stop = 0;
+
+    if (CreateThreadJoinable(&lf->http_thread, http_unix_worker, lf) != 0) {
+        merror("http-unix '%s': failed to spawn worker thread.", lf->file);
+        return -1;
+    }
+
+    lf->http_thread_started = 1;
+    return 0;
+}
+
+#endif

--- a/src/logcollector/src/read_socket.c
+++ b/src/logcollector/src/read_socket.c
@@ -1,0 +1,81 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef WIN32
+
+#include "shared.h"
+#include "logcollector.h"
+
+/* Read datagrams from a UNIX datagram socket */
+void *read_socket(logreader *lf, int *rc, int drop_it) {
+    int lines = 0;
+    char buf[OS_MAXSTR + 1];
+
+    *rc = 0;
+
+    while (can_read() && (!maximum_lines || lines < maximum_lines)) {
+        ssize_t rbytes = recv(lf->socket_fd, buf, OS_MAXSTR, 0);
+
+        if (rbytes < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            mdebug1("Error reading from socket '%s': %s", lf->file, strerror(errno));
+            *rc = -1;
+            break;
+        }
+
+        if (rbytes == 0) {
+            /* Empty datagram — skip but keep reading queued messages */
+            continue;
+        }
+
+        buf[rbytes] = '\0';
+        size_t msg_len = (size_t)rbytes;
+
+        /* Strip trailing newline if present */
+        if (msg_len > 0 && buf[msg_len - 1] == '\n') {
+            buf[--msg_len] = '\0';
+        }
+
+        if (msg_len == 0) {
+            continue;
+        }
+
+        if (strlen(buf) != msg_len) {
+            mdebug2("Message from socket '%s' contains zero-bytes. Dropping.", lf->file);
+            continue;
+        }
+
+        if (!w_utf8_valid(buf)) {
+            mdebug2("Message from socket '%s' is not valid UTF-8. Dropping.", lf->file);
+            continue;
+        }
+
+        lines++;
+
+        if ((int)msg_len >= OS_MAXSTR - 1) {
+            mwarn("Datagram from socket '%s' may have been truncated (length = %zu): '%.*s'...",
+                  lf->file, msg_len, sample_log_length, buf);
+        } else {
+            mdebug2("Reading socket message: '%.*s'%s", sample_log_length, buf,
+                    (int)msg_len > sample_log_length ? "..." : "");
+        }
+
+        if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, buf)) {
+            w_msg_hash_queues_push(buf, lf->file, msg_len + 1, lf->log_target, LOCALFILE_MQ);
+        }
+    }
+
+    mdebug2("Read %d lines from %s", lines, lf->file);
+    return NULL;
+}
+
+#endif

--- a/src/logcollector/src/read_socket.c
+++ b/src/logcollector/src/read_socket.c
@@ -40,22 +40,7 @@ void *read_socket(logreader *lf, int *rc, int drop_it) {
         buf[rbytes] = '\0';
         size_t msg_len = (size_t)rbytes;
 
-        /* Strip trailing newline if present */
-        if (msg_len > 0 && buf[msg_len - 1] == '\n') {
-            buf[--msg_len] = '\0';
-        }
-
-        if (msg_len == 0) {
-            continue;
-        }
-
-        if (strlen(buf) != msg_len) {
-            mdebug2("Message from socket '%s' contains zero-bytes. Dropping.", lf->file);
-            continue;
-        }
-
-        if (!w_utf8_valid(buf)) {
-            mdebug2("Message from socket '%s' is not valid UTF-8. Dropping.", lf->file);
+        if (!w_logcollector_validate_text_line(buf, &msg_len, "socket", lf->file)) {
             continue;
         }
 

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -40,6 +40,8 @@ else()
     list(APPEND logcollector_flags "-Wl,--wrap,OS_SHA1_Stream -Wl,--wrap,merror_exit \
                                     -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek \
                                     -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetpos \
+                                    -Wl,--wrap,OS_CloseSocket -Wl,--wrap,unlink -Wl,--wrap,getpid \
+                                    -Wl,--wrap,OS_BindUnixDomainWithPerms -Wl,--wrap,Privsep_GetGroup -Wl,--wrap,fcntl \
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
                                     -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock \
                                     -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete -Wl,--wrap,fopen -Wl,--wrap,clearerr \
@@ -152,6 +154,10 @@ else()
                                     -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \
                                     -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
                                     -Wl,--wrap=w_fseek -Wl,--wrap,wfopen")
+
+    list(APPEND logcollector_names "test_read_socket")
+    list(APPEND logcollector_flags "-Wl,--wrap,recv -Wl,--wrap,can_read \
+                                    -Wl,--wrap,w_msg_hash_queues_push ${DEBUG_OP_WRAPPERS}")
 
 endif()
 

--- a/src/unit_tests/logcollector/test_localfile-config.c
+++ b/src/unit_tests/logcollector/test_localfile-config.c
@@ -951,6 +951,98 @@ void test_Read_Localfile_socket_defaults(void ** state) {
     Free_Localfile(&config);
 }
 
+void test_Read_Localfile_http_unix_defaults(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/run/docker.sock" };
+    xml_node log_format = { .element = "log_format", .content = HTTP_UNIX_LOG };
+    xml_node *nodes[] = { &location, &log_format, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].logformat, HTTP_UNIX_LOG);
+    assert_string_equal(config.config[0].http_endpoint, HTTP_UNIX_DEFAULT_ENDPOINT);
+    assert_int_equal(config.config[0].http_reconnect_interval, HTTP_UNIX_DEFAULT_RECONNECT);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_http_unix_endpoint_valid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/run/docker.sock" };
+    xml_node log_format = { .element = "log_format", .content = HTTP_UNIX_LOG };
+    xml_node endpoint = { .element = "endpoint", .content = "/events" };
+    xml_node *nodes[] = { &location, &log_format, &endpoint, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].http_endpoint, "/events");
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_http_unix_endpoint_invalid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/run/docker.sock" };
+    xml_node log_format = { .element = "log_format", .content = HTTP_UNIX_LOG };
+    xml_node endpoint = { .element = "endpoint", .content = "events" };
+    xml_node *nodes[] = { &location, &log_format, &endpoint, NULL };
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'endpoint': events.");
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), OS_INVALID);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_http_unix_reconnect_interval_valid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/run/docker.sock" };
+    xml_node log_format = { .element = "log_format", .content = HTTP_UNIX_LOG };
+    xml_node interval = { .element = "reconnect_interval", .content = "30" };
+    xml_node *nodes[] = { &location, &log_format, &interval, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_int_equal(config.config[0].http_reconnect_interval, 30);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_http_unix_reconnect_interval_invalid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/run/docker.sock" };
+    xml_node log_format = { .element = "log_format", .content = HTTP_UNIX_LOG };
+    xml_node interval = { .element = "reconnect_interval", .content = "0" };
+    xml_node *nodes[] = { &location, &log_format, &interval, NULL };
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'reconnect_interval': 0.");
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), OS_INVALID);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_http_unix_opts_on_non_http_unix(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/log/syslog" };
+    xml_node log_format = { .element = "log_format", .content = "syslog" };
+    xml_node endpoint = { .element = "endpoint", .content = "/events" };
+    xml_node interval = { .element = "reconnect_interval", .content = "10" };
+    xml_node *nodes[] = { &location, &log_format, &endpoint, &interval, NULL };
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(8004): log_format 'syslog' does not support 'endpoint' option. Option will be ignored.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(8004): log_format 'syslog' does not support 'reconnect_interval' option. Option will be ignored.");
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_null(config.config[0].http_endpoint);
+    assert_int_equal(config.config[0].http_reconnect_interval, 0);
+
+    Free_Localfile(&config);
+}
+
 // ------------------------------------------------
 /* journald_add_condition_to_filter */
 void test_journald_add_condition_to_filter_invalid_params(void ** state) {
@@ -1464,6 +1556,13 @@ int main(void) {
         cmocka_unit_test(test_Read_Localfile_recv_buffer_too_small),
         cmocka_unit_test(test_Read_Localfile_socket_opts_on_non_socket),
         cmocka_unit_test(test_Read_Localfile_socket_defaults),
+        // Test Read_Localfile http-unix configuration
+        cmocka_unit_test(test_Read_Localfile_http_unix_defaults),
+        cmocka_unit_test(test_Read_Localfile_http_unix_endpoint_valid),
+        cmocka_unit_test(test_Read_Localfile_http_unix_endpoint_invalid),
+        cmocka_unit_test(test_Read_Localfile_http_unix_reconnect_interval_valid),
+        cmocka_unit_test(test_Read_Localfile_http_unix_reconnect_interval_invalid),
+        cmocka_unit_test(test_Read_Localfile_http_unix_opts_on_non_http_unix),
         // Test journald_add_condition_to_filter
         cmocka_unit_test(test_journald_add_condition_to_filter_invalid_params),
         cmocka_unit_test(test_journald_add_condition_to_filter_non_field),

--- a/src/unit_tests/logcollector/test_localfile-config.c
+++ b/src/unit_tests/logcollector/test_localfile-config.c
@@ -759,6 +759,199 @@ void test_w_journal_filter_list_as_json_success(void ** state) {
 }
 
 // ------------------------------------------------
+/* Read_Localfile socket */
+void test_Read_Localfile_socket_age_ignored(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node age = { .element = "age", .content = "5m" };
+    xml_node *nodes[] = { &location, &log_format, &age, NULL };
+
+    expect_string(__wrap__mwarn,
+                  formatted_msg,
+                  "(8004): log_format 'socket' does not support 'age' option. Option will be ignored.");
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].logformat, SOCKET_LOG);
+    assert_string_equal(config.config[0].file, "/tmp/socket.sock");
+    assert_int_equal(config.config[0].age, 0);
+    assert_null(config.config[0].age_str);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_target_and_filters(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node target = { .element = "target", .content = "custom-target" };
+    xml_node ignore = { .element = "ignore", .content = "drop me" };
+    xml_node restrict_node = { .element = "restrict", .content = "keep me" };
+    xml_node *nodes[] = { &location, &log_format, &target, &ignore, &restrict_node, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].logformat, SOCKET_LOG);
+    assert_non_null(config.config[0].target);
+    assert_string_equal(config.config[0].target[0], "custom-target");
+    assert_null(config.config[0].target[1]);
+    assert_non_null(config.config[0].regex_ignore);
+    assert_non_null(config.config[0].regex_restrict);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_date_location(void ** state) {
+    logreader_config config = {0};
+    char expected_file[OS_FLSIZE + 1] = {0};
+    time_t now = time(NULL);
+    struct tm tm_result = { .tm_sec = 0 };
+    xml_node location = { .element = "location", .content = "/tmp/socket-%Y-%m-%d.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node *nodes[] = { &location, &log_format, NULL };
+
+    localtime_r(&now, &tm_result);
+    assert_true(strftime(expected_file, sizeof(expected_file), location.content, &tm_result) > 0);
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].logformat, SOCKET_LOG);
+    assert_string_equal(config.config[0].ffile, location.content);
+    assert_string_equal(config.config[0].file, location.content);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_mode_valid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node socket_mode = { .element = "socket_mode", .content = "0640" };
+    xml_node *nodes[] = { &location, &log_format, &socket_mode, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].logformat, SOCKET_LOG);
+    assert_int_equal(config.config[0].socket_mode, 0640);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_mode_invalid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node socket_mode = { .element = "socket_mode", .content = "99999" };
+    xml_node *nodes[] = { &location, &log_format, &socket_mode, NULL };
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'socket_mode': 99999.");
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), OS_INVALID);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_group_valid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node socket_group = { .element = "socket_group", .content = "syslog" };
+    xml_node *nodes[] = { &location, &log_format, &socket_group, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_string_equal(config.config[0].socket_group, "syslog");
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_group_empty(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node socket_group = { .element = "socket_group", .content = "" };
+    xml_node *nodes[] = { &location, &log_format, &socket_group, NULL };
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'socket_group': .");
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), OS_INVALID);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_recv_buffer_valid(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node recv_buffer = { .element = "recv_buffer", .content = "1M" };
+    xml_node *nodes[] = { &location, &log_format, &recv_buffer, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_int_equal(config.config[0].socket_recv_buffer, 1048576);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_recv_buffer_too_small(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node recv_buffer = { .element = "recv_buffer", .content = "1024" };
+    xml_node *nodes[] = { &location, &log_format, &recv_buffer, NULL };
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "recv_buffer value '1024' is below the minimum (65536). Default will be used.");
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_int_equal(config.config[0].socket_recv_buffer, 0);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_opts_on_non_socket(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/var/log/syslog" };
+    xml_node log_format = { .element = "log_format", .content = "syslog" };
+    xml_node socket_mode = { .element = "socket_mode", .content = "0640" };
+    xml_node socket_group = { .element = "socket_group", .content = "syslog" };
+    xml_node recv_buffer = { .element = "recv_buffer", .content = "1M" };
+    xml_node *nodes[] = { &location, &log_format, &socket_mode, &socket_group, &recv_buffer, NULL };
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(8004): log_format 'syslog' does not support 'socket_mode' option. Option will be ignored.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(8004): log_format 'syslog' does not support 'socket_group' option. Option will be ignored.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(8004): log_format 'syslog' does not support 'recv_buffer' option. Option will be ignored.");
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_int_equal(config.config[0].socket_mode, 0);
+    assert_null(config.config[0].socket_group);
+    assert_int_equal(config.config[0].socket_recv_buffer, 0);
+
+    Free_Localfile(&config);
+}
+
+void test_Read_Localfile_socket_defaults(void ** state) {
+    logreader_config config = {0};
+    xml_node location = { .element = "location", .content = "/tmp/socket.sock" };
+    xml_node log_format = { .element = "log_format", .content = SOCKET_LOG };
+    xml_node *nodes[] = { &location, &log_format, NULL };
+
+    assert_int_equal(Read_Localfile(nodes, &config, NULL), 0);
+    assert_non_null(config.config);
+    assert_int_equal(config.config[0].socket_mode, 0);
+    assert_null(config.config[0].socket_group);
+    assert_int_equal(config.config[0].socket_recv_buffer, 0);
+
+    Free_Localfile(&config);
+}
+
+// ------------------------------------------------
 /* journald_add_condition_to_filter */
 void test_journald_add_condition_to_filter_invalid_params(void ** state) {
 
@@ -1259,6 +1452,18 @@ int main(void) {
         cmocka_unit_test(test_w_journal_filter_list_as_json_null_params),
         cmocka_unit_test(test_w_journal_filter_list_as_json_fail_array),
         cmocka_unit_test(test_w_journal_filter_list_as_json_success),
+        // Test Read_Localfile socket configuration
+        cmocka_unit_test(test_Read_Localfile_socket_age_ignored),
+        cmocka_unit_test(test_Read_Localfile_socket_target_and_filters),
+        cmocka_unit_test(test_Read_Localfile_socket_date_location),
+        cmocka_unit_test(test_Read_Localfile_socket_mode_valid),
+        cmocka_unit_test(test_Read_Localfile_socket_mode_invalid),
+        cmocka_unit_test(test_Read_Localfile_socket_group_valid),
+        cmocka_unit_test(test_Read_Localfile_socket_group_empty),
+        cmocka_unit_test(test_Read_Localfile_recv_buffer_valid),
+        cmocka_unit_test(test_Read_Localfile_recv_buffer_too_small),
+        cmocka_unit_test(test_Read_Localfile_socket_opts_on_non_socket),
+        cmocka_unit_test(test_Read_Localfile_socket_defaults),
         // Test journald_add_condition_to_filter
         cmocka_unit_test(test_journald_add_condition_to_filter_invalid_params),
         cmocka_unit_test(test_journald_add_condition_to_filter_non_field),

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -227,6 +227,18 @@ void test_Free_Logreader_socket_runtime(void **state) {
     Free_Logreader(&lf);
 }
 
+void test_Free_Logreader_http_unix_endpoint(void **state) {
+    logreader lf = {0};
+
+    lf.file = strdup("/var/run/docker.sock");
+    lf.logformat = strdup(HTTP_UNIX_LOG);
+    lf.http_endpoint = strdup("/events");
+    lf.http_reconnect_interval = 5;
+    /* http_thread_started == 0: no pthread_join expected */
+
+    Free_Logreader(&lf);
+}
+
 void test_Remove_Localfile_socket_runtime(void **state) {
     logreader_glob glob = {0};
     logreader *entries = calloc(2, sizeof(logreader));
@@ -3057,6 +3069,7 @@ int main(void) {
 
         // Test socket runtime cleanup
         cmocka_unit_test(test_Free_Logreader_socket_runtime),
+        cmocka_unit_test(test_Free_Logreader_http_unix_endpoint),
         cmocka_unit_test(test_Remove_Localfile_socket_runtime),
         cmocka_unit_test(test_open_socket_source_custom_perms),
         cmocka_unit_test(test_open_socket_source_default_perms),

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -26,6 +26,10 @@
 #include "../wrappers/externals/cJSON/cJSON_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../wrappers/wazuh/os_crypto/sha1_op_wrappers.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+#include "../wrappers/wazuh/shared/privsep_op_wrappers.h"
+#include "../wrappers/linux/socket_wrappers.h"
+#include "../wrappers/posix/unistd_wrappers.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/posix/signal_wrappers.h"
 
@@ -42,6 +46,7 @@ void w_initialize_file_status();
 int w_update_hash_node(char * path, int64_t pos);
 int w_set_to_last_line_read(logreader *lf);
 void free_files_status_data(os_file_status_t *data);
+int open_socket_source(logreader *lf, int do_log);
 
 // Auxiliar structs
 typedef struct test_logcollector_s {
@@ -206,6 +211,143 @@ static int teardown_regex(void **state) {
 /* wraps */
 
 /* tests */
+
+void test_Free_Logreader_socket_runtime(void **state) {
+    logreader lf = {0};
+
+    lf.file = strdup("/tmp/test-free.sock");
+    lf.socket_path = strdup("/tmp/test-free.sock");
+    lf.socket_fd = 21;
+
+    expect_value(__wrap_OS_CloseSocket, sock, lf.socket_fd);
+    will_return(__wrap_OS_CloseSocket, 0);
+    expect_string(__wrap_unlink, file, "/tmp/test-free.sock");
+    will_return(__wrap_unlink, 0);
+
+    Free_Logreader(&lf);
+}
+
+void test_Remove_Localfile_socket_runtime(void **state) {
+    logreader_glob glob = {0};
+    logreader *entries = calloc(2, sizeof(logreader));
+
+    assert_non_null(entries);
+
+    entries[0].file = strdup("/tmp/test-remove.sock");
+    entries[0].socket_path = strdup("/tmp/test-remove.sock");
+    entries[0].socket_fd = 22;
+
+    glob.gfiles = entries;
+    glob.num_files = 1;
+    current_files = 1;
+
+    expect_value(__wrap_OS_CloseSocket, sock, entries[0].socket_fd);
+    will_return(__wrap_OS_CloseSocket, 0);
+    expect_string(__wrap_unlink, file, "/tmp/test-remove.sock");
+    will_return(__wrap_unlink, 0);
+
+    assert_int_equal(Remove_Localfile(&entries, 0, 1, 0, &glob), 0);
+    assert_int_equal(glob.num_files, 0);
+    assert_int_equal(current_files, 0);
+
+    free(entries);
+}
+
+void test_open_socket_source_custom_perms(void **state) {
+    logreader lf = {0};
+
+    lf.file = "/tmp/test-custom.sock";
+    lf.socket_path = NULL;
+    lf.socket_fd = -1;
+    lf.socket_mode = 0640;
+    lf.socket_group = strdup("syslog");
+    lf.socket_recv_buffer = 1048576;
+    lf.exists = 1;
+
+    /* Privsep_GetGroup resolves "syslog" to gid 110 */
+    expect_string(__wrap_Privsep_GetGroup, name, "syslog");
+    will_return(__wrap_Privsep_GetGroup, 110);
+
+    /* OS_BindUnixDomainWithPerms called with custom values */
+    expect_string(__wrap_OS_BindUnixDomainWithPerms, path, "/tmp/test-custom.sock");
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, max_msg_size, 1048576);
+    expect_any(__wrap_OS_BindUnixDomainWithPerms, uid);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, gid, 110);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0640);
+    will_return(__wrap_OS_BindUnixDomainWithPerms, 10);
+
+    /* fcntl for non-blocking */
+    will_return(__wrap_fcntl, 0);   /* F_GETFL returns 0 */
+    will_return(__wrap_fcntl, 0);   /* F_SETFL returns 0 */
+
+    assert_int_equal(open_socket_source(&lf, 1), 0);
+    assert_int_equal(lf.socket_fd, 10);
+    assert_string_equal(lf.socket_path, "/tmp/test-custom.sock");
+    assert_int_equal(lf.exists, 1);
+
+    os_free(lf.socket_path);
+    os_free(lf.socket_group);
+}
+
+void test_open_socket_source_default_perms(void **state) {
+    logreader lf = {0};
+
+    lf.file = "/tmp/test-default.sock";
+    lf.socket_path = NULL;
+    lf.socket_fd = -1;
+    lf.socket_mode = 0;
+    lf.socket_group = NULL;
+    lf.socket_recv_buffer = 0;
+    lf.exists = 1;
+
+    /* No Privsep_GetGroup call — socket_group is NULL */
+
+    /* OS_BindUnixDomainWithPerms called with defaults */
+    expect_string(__wrap_OS_BindUnixDomainWithPerms, path, "/tmp/test-default.sock");
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, max_msg_size, OS_MAXSTR);
+    expect_any(__wrap_OS_BindUnixDomainWithPerms, uid);
+    expect_any(__wrap_OS_BindUnixDomainWithPerms, gid);
+    expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
+    will_return(__wrap_OS_BindUnixDomainWithPerms, 11);
+
+    /* fcntl for non-blocking */
+    will_return(__wrap_fcntl, 0);
+    will_return(__wrap_fcntl, 0);
+
+    assert_int_equal(open_socket_source(&lf, 1), 0);
+    assert_int_equal(lf.socket_fd, 11);
+
+    os_free(lf.socket_path);
+}
+
+void test_open_socket_source_group_resolve_fail(void **state) {
+    logreader lf = {0};
+
+    lf.file = "/tmp/test-bagroup.sock";
+    lf.socket_path = NULL;
+    lf.socket_fd = -1;
+    lf.socket_mode = 0;
+    lf.socket_group = strdup("nonexistent");
+    lf.socket_recv_buffer = 0;
+    lf.exists = 1;
+
+    expect_string(__wrap_Privsep_GetGroup, name, "nonexistent");
+    will_return(__wrap_Privsep_GetGroup, (gid_t)-1);
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "Unable to resolve group 'nonexistent' for socket '/tmp/test-bagroup.sock'");
+
+    /* Error path calls mdebug1(OPEN_UNABLE, ...) since open_file_attempts == 0 */
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "(1963): Unable to open file '/tmp/test-bagroup.sock'.");
+
+    assert_int_equal(open_socket_source(&lf, 1), -1);
+    assert_int_equal(lf.exists, 0);
+
+    os_free(lf.socket_group);
+}
 
 /* w_get_hash_context */
 
@@ -2912,6 +3054,13 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_w_set_to_last_line_read_same_file, setup_local_hashmap, teardown_local_hashmap),
         cmocka_unit_test_setup_teardown(test_w_set_to_last_line_read_same_file_rotate, setup_local_hashmap, teardown_local_hashmap),
         cmocka_unit_test_setup_teardown(test_w_set_to_last_line_read_update_hash_node_error, setup_local_hashmap, teardown_local_hashmap),
+
+        // Test socket runtime cleanup
+        cmocka_unit_test(test_Free_Logreader_socket_runtime),
+        cmocka_unit_test(test_Remove_Localfile_socket_runtime),
+        cmocka_unit_test(test_open_socket_source_custom_perms),
+        cmocka_unit_test(test_open_socket_source_default_perms),
+        cmocka_unit_test(test_open_socket_source_group_resolve_fail),
 
         // Test w_macos_release_log_show
         cmocka_unit_test_setup_teardown(test_w_macos_release_log_show_not_launched, setup_process, teardown_process),

--- a/src/unit_tests/logcollector/test_read_socket.c
+++ b/src/unit_tests/logcollector/test_read_socket.c
@@ -1,0 +1,251 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include "logcollector.h"
+#include "shared.h"
+#include "../wrappers/common.h"
+
+extern int maximum_lines;
+
+static int group_setup(void **state) {
+    test_mode = 1;
+    maximum_lines = 0;
+    return 0;
+}
+
+static int group_teardown(void **state) {
+    test_mode = 0;
+    maximum_lines = 0;
+    return 0;
+}
+
+int __wrap_can_read() {
+    return mock_type(int);
+}
+
+int __wrap_w_msg_hash_queues_push(
+    const char *str, char *file, unsigned long size, logtarget *targets, char queue_mq) {
+    check_expected(str);
+    check_expected(file);
+    check_expected(size);
+    return mock_type(int);
+}
+
+/* Mock for recv() used by datagram reader */
+ssize_t __wrap_recv(int __fd, void *__buf, size_t __n, int __flags) {
+    const char *data = mock_ptr_type(const char *);
+    ssize_t retval = mock_type(ssize_t);
+    int err = mock_type(int);
+
+    if (retval > 0 && data != NULL) {
+        size_t copy_len = (size_t)retval < __n ? (size_t)retval : __n;
+        memcpy(__buf, data, copy_len);
+    }
+
+    if (retval < 0) {
+        errno = err;
+    }
+
+    return retval;
+}
+
+void test_read_socket_no_data(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, NULL);
+    will_return(__wrap_recv, -1);
+    will_return(__wrap_recv, EAGAIN);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 0 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+void test_read_socket_single_message(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, "socket event");
+    will_return(__wrap_recv, 12);
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Reading socket message: ''...");
+    expect_string(__wrap_w_msg_hash_queues_push, str, "socket event");
+    expect_string(__wrap_w_msg_hash_queues_push, file, lf.file);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen("socket event") + 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, NULL);
+    will_return(__wrap_recv, -1);
+    will_return(__wrap_recv, EAGAIN);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 1 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+void test_read_socket_message_with_newline(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+
+    /* Datagram with trailing newline — should be stripped */
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, "socket event\n");
+    will_return(__wrap_recv, 13);
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Reading socket message: ''...");
+    expect_string(__wrap_w_msg_hash_queues_push, str, "socket event");
+    expect_string(__wrap_w_msg_hash_queues_push, file, lf.file);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen("socket event") + 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, NULL);
+    will_return(__wrap_recv, -1);
+    will_return(__wrap_recv, EAGAIN);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 1 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+void test_read_socket_multiple_datagrams(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+
+    /* First datagram */
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, "line 1");
+    will_return(__wrap_recv, 6);
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Reading socket message: ''...");
+    expect_string(__wrap_w_msg_hash_queues_push, str, "line 1");
+    expect_string(__wrap_w_msg_hash_queues_push, file, lf.file);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen("line 1") + 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    /* Second datagram */
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, "line 2");
+    will_return(__wrap_recv, 6);
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Reading socket message: ''...");
+    expect_string(__wrap_w_msg_hash_queues_push, str, "line 2");
+    expect_string(__wrap_w_msg_hash_queues_push, file, lf.file);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen("line 2") + 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    /* No more data */
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, NULL);
+    will_return(__wrap_recv, -1);
+    will_return(__wrap_recv, EAGAIN);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 2 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+void test_read_socket_binary_rejected(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+    char payload[] = "a\0b";
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, payload);
+    will_return(__wrap_recv, 3);
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Message from socket '/tmp/socket.sock' contains zero-bytes. Dropping.");
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, NULL);
+    will_return(__wrap_recv, -1);
+    will_return(__wrap_recv, EAGAIN);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 0 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+void test_read_socket_invalid_utf8_rejected(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+    /* 0xFF is never valid in UTF-8 */
+    char payload[] = "hello\xFFworld";
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, payload);
+    will_return(__wrap_recv, (ssize_t)(sizeof(payload) - 1));
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Message from socket '/tmp/socket.sock' is not valid UTF-8. Dropping.");
+
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, NULL);
+    will_return(__wrap_recv, -1);
+    will_return(__wrap_recv, EAGAIN);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 0 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+void test_read_socket_maximum_lines(void **state) {
+    logreader lf = { .file = "/tmp/socket.sock", .socket_fd = 7 };
+    int rc = -1;
+    maximum_lines = 1;
+
+    /* First datagram — should be processed */
+    will_return(__wrap_can_read, 1);
+    will_return(__wrap_recv, "line 1");
+    will_return(__wrap_recv, 6);
+    will_return(__wrap_recv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Reading socket message: ''...");
+    expect_string(__wrap_w_msg_hash_queues_push, str, "line 1");
+    expect_string(__wrap_w_msg_hash_queues_push, file, lf.file);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen("line 1") + 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    /* Loop should stop because maximum_lines == 1 */
+    will_return(__wrap_can_read, 1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Read 1 lines from /tmp/socket.sock");
+
+    assert_null(read_socket(&lf, &rc, 0));
+    assert_int_equal(rc, 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_read_socket_no_data),
+        cmocka_unit_test(test_read_socket_single_message),
+        cmocka_unit_test(test_read_socket_message_with_newline),
+        cmocka_unit_test(test_read_socket_multiple_datagrams),
+        cmocka_unit_test(test_read_socket_binary_rejected),
+        cmocka_unit_test(test_read_socket_invalid_utf8_rejected),
+        cmocka_unit_test(test_read_socket_maximum_lines),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_http_unix.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_http_unix.py
@@ -1,0 +1,94 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Validate the runtime configuration exposed by Logcollector when an http-unix localfile is configured.
+
+components:
+    - logcollector
+
+suite: configuration
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-logcollector
+    - wazuh-manager-apid
+
+os_platform:
+    - linux
+
+tags:
+    - logcollector_configuration
+'''
+
+import os
+import tempfile
+import pytest
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.modules.logcollector import utils as logcollector_utils
+from wazuh_testing.tools.monitors import file_monitor
+from wazuh_testing.utils import callbacks
+
+from utils import build_tc_config
+
+
+pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
+
+socket_path = os.path.join(tempfile.gettempdir(), 'wazuh-itest-http-unix-cfg.sock')
+
+test_configuration = build_tc_config([
+    [
+        [
+            {'location': {'value': socket_path}},
+            {'log_format': {'value': 'http-unix'}},
+            {'endpoint': {'value': '/events'}},
+            {'reconnect_interval': {'value': '15'}},
+            {'target': {'value': 'agent'}},
+            {'age': {'value': '5m'}}
+        ]
+    ]
+])
+
+test_metadata = [{'socket_path': socket_path}]
+
+local_internal_options = {
+    'logcollector.debug': '2',
+    'logcollector.vcheck_files': '1'
+}
+
+daemons_handler_configuration = {'all_daemons': True}
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=['http-unix-runtime-config'])
+def test_configuration_http_unix(test_configuration, test_metadata, truncate_monitored_files, configure_local_internal_options,
+                                 remove_all_localfiles_wazuh_config, set_wazuh_configuration, daemons_handler,
+                                 wait_for_logcollector_start):
+    '''Verify the http-unix log_format is parsed, defaults applied, incompatible options ignored,
+    and the runtime configuration exposes the http-unix-specific fields.'''
+    logcollector_utils.check_logcollector_socket()
+
+    monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    monitor.start(
+        callback=callbacks.generate_callback(r".*log_format 'http-unix' does not support 'age' option."),
+        timeout=10
+    )
+    assert monitor.callback_result is not None, 'The ignored age warning was not generated.'
+
+    localfile_list = logcollector_utils.get_localfile_runtime_configuration()
+
+    assert len(localfile_list) == 1
+    assert localfile_list[0]['logformat'] == 'http-unix'
+    assert localfile_list[0]['file'] == test_metadata['socket_path']
+    assert localfile_list[0]['target'] == ['agent']
+    assert localfile_list[0]['endpoint'] == '/events'
+    assert localfile_list[0]['reconnect_interval'] == 15
+    assert 'age' not in localfile_list[0]
+    assert 'only-future-events' not in localfile_list[0]

--- a/tests/integration/test_logcollector/test_configuration/test_basic_configuration_socket.py
+++ b/tests/integration/test_logcollector/test_configuration/test_basic_configuration_socket.py
@@ -1,0 +1,88 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Validate the runtime configuration exposed by Logcollector when a UNIX socket localfile is configured.
+
+components:
+    - logcollector
+
+suite: configuration
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-logcollector
+    - wazuh-manager-apid
+
+os_platform:
+    - linux
+
+tags:
+    - logcollector_configuration
+'''
+
+import os
+import tempfile
+import pytest
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.modules.logcollector import utils as logcollector_utils
+from wazuh_testing.tools.monitors import file_monitor
+from wazuh_testing.utils import callbacks
+
+from utils import build_tc_config, wait_for_path_state
+
+
+pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
+
+socket_path = os.path.join(tempfile.gettempdir(), 'wazuh-itest-config.sock')
+
+test_configuration = build_tc_config([
+    [
+        [
+            {'location': {'value': socket_path}},
+            {'log_format': {'value': 'socket'}},
+            {'age': {'value': '5m'}},
+            {'target': {'value': 'agent'}}
+        ]
+    ]
+])
+
+test_metadata = [{'socket_path': socket_path}]
+
+local_internal_options = {
+    'logcollector.debug': '2',
+    'logcollector.vcheck_files': '1'
+}
+
+daemons_handler_configuration = {'all_daemons': True}
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=['socket-runtime-config'])
+def test_configuration_socket(test_configuration, test_metadata, truncate_monitored_files, configure_local_internal_options,
+                              remove_all_localfiles_wazuh_config, set_wazuh_configuration, daemons_handler,
+                              wait_for_logcollector_start):
+    logcollector_utils.check_logcollector_socket()
+
+    monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+    monitor.start(
+        callback=callbacks.generate_callback(r".*log_format 'socket' does not support 'age' option."),
+        timeout=10
+    )
+    assert monitor.callback_result is not None, 'The ignored age warning was not generated.'
+
+    localfile_list = logcollector_utils.get_localfile_runtime_configuration()
+
+    assert len(localfile_list) == 1
+    assert localfile_list[0]['logformat'] == 'socket'
+    assert localfile_list[0]['file'] == test_metadata['socket_path']
+    assert localfile_list[0]['target'] == ['agent']
+    assert 'age' not in localfile_list[0]
+    assert 'only-future-events' not in localfile_list[0]

--- a/tests/integration/test_logcollector/test_read/test_read_http_unix_basic.py
+++ b/tests/integration/test_logcollector/test_read/test_read_http_unix_basic.py
@@ -1,0 +1,233 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Validate HTTP-over-UNIX-stream log collection: logcollector connects to a UNIX stream socket,
+       issues an HTTP GET, and streams chunked response lines as log events. Also exercises the
+       reconnect path when the server closes the connection.
+
+components:
+    - logcollector
+
+suite: read
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-logcollector
+
+os_platform:
+    - linux
+
+tags:
+    - logcollector_read
+'''
+
+import os
+import socket
+import tempfile
+import threading
+import time
+import pytest
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.modules.logcollector import utils as logcollector_utils
+from wazuh_testing.tools.monitors import file_monitor
+from wazuh_testing.utils import callbacks
+
+from utils import build_tc_config, wait_for_path_state
+
+
+pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
+
+socket_path = os.path.join(tempfile.gettempdir(), 'wazuh-itest-http-unix.sock')
+
+test_configuration = build_tc_config([
+    [
+        [
+            {'location': {'value': socket_path}},
+            {'log_format': {'value': 'http-unix'}},
+            {'endpoint': {'value': '/events'}},
+            {'reconnect_interval': {'value': '2'}}
+        ]
+    ]
+])
+
+test_metadata = [{'socket_path': socket_path}]
+
+local_internal_options = {
+    'logcollector.debug': '2',
+    'logcollector.vcheck_files': '1'
+}
+
+daemons_handler_configuration = {'all_daemons': True}
+
+
+class HTTPUnixServer:
+    '''Minimal HTTP/1.1 chunked-response server bound to a UNIX stream socket.
+
+    Each call to publish_line() emits one chunk = one line + newline.
+    close_connection() forces the active client to receive EOF, exercising
+    the logcollector reconnect path.
+    '''
+
+    def __init__(self, path: str):
+        self.path = path
+        self._lines: list[str] = []
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._server: socket.socket | None = None
+        self._client: socket.socket | None = None
+        self._thread: threading.Thread | None = None
+        self._stop = False
+        self._kill_active = False
+
+    def start(self) -> None:
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(self.path)
+        self._server.listen(1)
+        self._server.settimeout(0.5)
+        os.chmod(self.path, 0o666)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop = True
+        with self._cond:
+            self._cond.notify_all()
+        if self._thread:
+            self._thread.join(timeout=5)
+        try:
+            if self._server:
+                self._server.close()
+        except OSError:
+            pass
+        try:
+            if os.path.exists(self.path):
+                os.unlink(self.path)
+        except OSError:
+            pass
+
+    def publish_line(self, line: str) -> None:
+        with self._cond:
+            self._lines.append(line)
+            self._cond.notify_all()
+
+    def close_connection(self) -> None:
+        '''Force the current client connection closed so the next reconnect cycle exercises the loop.'''
+        with self._cond:
+            self._kill_active = True
+            self._cond.notify_all()
+
+    def _run(self) -> None:
+        while not self._stop:
+            try:
+                client, _ = self._server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+
+            self._client = client
+            try:
+                self._serve(client)
+            finally:
+                try:
+                    client.close()
+                except OSError:
+                    pass
+                self._client = None
+
+    def _serve(self, client: socket.socket) -> None:
+        client.settimeout(2.0)
+        # Drain the request line + headers (read until \r\n\r\n)
+        buf = b''
+        try:
+            while b'\r\n\r\n' not in buf:
+                chunk = client.recv(1024)
+                if not chunk:
+                    return
+                buf += chunk
+        except socket.timeout:
+            return
+
+        # Send response status + chunked-encoding headers
+        try:
+            client.sendall(
+                b'HTTP/1.1 200 OK\r\n'
+                b'Content-Type: application/json\r\n'
+                b'Transfer-Encoding: chunked\r\n'
+                b'\r\n'
+            )
+        except OSError:
+            return
+
+        client.settimeout(None)
+        # Stream chunks until stopped or asked to close
+        while not self._stop:
+            with self._cond:
+                while not self._lines and not self._stop and not self._kill_active:
+                    self._cond.wait(timeout=1.0)
+                if self._kill_active:
+                    self._kill_active = False
+                    return
+                if self._stop:
+                    return
+                pending = self._lines[:]
+                self._lines.clear()
+
+            for line in pending:
+                payload = (line + '\n').encode()
+                size_line = f'{len(payload):x}\r\n'.encode()
+                try:
+                    client.sendall(size_line + payload + b'\r\n')
+                except OSError:
+                    return
+
+
+@pytest.fixture
+def http_unix_server(test_metadata):
+    '''Start the mock HTTP server BEFORE logcollector starts so the connect succeeds on first try.'''
+    server = HTTPUnixServer(test_metadata['socket_path'])
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=['http-unix-read-basic'])
+def test_read_http_unix_basic(test_configuration, test_metadata, http_unix_server, truncate_monitored_files,
+                              configure_local_internal_options, remove_all_localfiles_wazuh_config,
+                              set_wazuh_configuration, daemons_handler, wait_for_logcollector_start):
+    '''End-to-end: lines published over chunked HTTP arrive as log events, reconnect works after server-side close.'''
+    logcollector_utils.check_logcollector_socket()
+
+    wait_for_path_state(test_metadata['socket_path'])
+
+    monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+
+    # Stream one event and verify it gets read
+    http_unix_server.publish_line('first http-unix event')
+    monitor.start(
+        callback=callbacks.generate_callback(r".*Reading http-unix message: 'first http-unix event'"),
+        timeout=15
+    )
+    assert monitor.callback_result is not None, 'The first http-unix message was not processed.'
+
+    # Force the server-side connection closed; logcollector should reconnect after reconnect_interval
+    http_unix_server.close_connection()
+    time.sleep(3)  # ~reconnect_interval + small margin so the worker re-establishes the connection
+
+    http_unix_server.publish_line('after reconnect event')
+    monitor.start(
+        callback=callbacks.generate_callback(r".*Reading http-unix message: 'after reconnect event'"),
+        timeout=15
+    )
+    assert monitor.callback_result is not None, 'The reader did not recover after server-side close.'

--- a/tests/integration/test_logcollector/test_read/test_read_socket_basic.py
+++ b/tests/integration/test_logcollector/test_read/test_read_socket_basic.py
@@ -1,0 +1,93 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Validate UNIX datagram socket log collection in server mode: logcollector binds a datagram socket,
+       receives messages sent by external processes, and processes them as log events.
+
+components:
+    - logcollector
+
+suite: read
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-logcollector
+
+os_platform:
+    - linux
+
+tags:
+    - logcollector_read
+'''
+
+import os
+import tempfile
+import pytest
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.modules.logcollector import utils as logcollector_utils
+from wazuh_testing.tools.monitors import file_monitor
+from wazuh_testing.utils import callbacks
+
+from utils import build_tc_config, wait_for_path_state, send_log_to_unix_socket
+
+
+pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
+
+socket_path = os.path.join(tempfile.gettempdir(), 'wazuh-itest-read.sock')
+
+test_configuration = build_tc_config([
+    [
+        [
+            {'location': {'value': socket_path}},
+            {'log_format': {'value': 'socket'}}
+        ]
+    ]
+])
+
+test_metadata = [{'socket_path': socket_path}]
+
+local_internal_options = {
+    'logcollector.debug': '2',
+    'logcollector.vcheck_files': '1'
+}
+
+daemons_handler_configuration = {'all_daemons': True}
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=['socket-read-basic'])
+def test_read_socket_basic(test_configuration, test_metadata, truncate_monitored_files, configure_local_internal_options,
+                           remove_all_localfiles_wazuh_config, set_wazuh_configuration, daemons_handler,
+                           wait_for_logcollector_start):
+    '''Test server mode: logcollector binds a datagram socket and receives messages.'''
+    logcollector_utils.check_logcollector_socket()
+
+    # Wait for logcollector to create the socket file
+    wait_for_path_state(test_metadata['socket_path'])
+
+    monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+
+    # Send a datagram and verify it's read
+    send_log_to_unix_socket(test_metadata['socket_path'], 'first socket event')
+    monitor.start(
+        callback=callbacks.generate_callback(r".*Reading socket message: 'first socket event'"),
+        timeout=10
+    )
+    assert monitor.callback_result is not None, 'The first datagram message was not processed.'
+
+    # Send binary data (should be rejected) followed by valid data
+    send_log_to_unix_socket(test_metadata['socket_path'], b'a\x00b')
+    send_log_to_unix_socket(test_metadata['socket_path'], 'after binary')
+    monitor.start(
+        callback=callbacks.generate_callback(r".*Reading socket message: 'after binary'"),
+        timeout=10
+    )
+    assert monitor.callback_result is not None, 'The reader did not recover after a rejected binary datagram.'

--- a/tests/integration/test_logcollector/utils.py
+++ b/tests/integration/test_logcollector/utils.py
@@ -4,6 +4,9 @@ Created by Wazuh, Inc. <info@wazuh.com>.
 This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 from os.path import join as path_join
+from pathlib import Path
+import socket
+import time
 
 
 from wazuh_testing.tools.monitors import file_monitor
@@ -119,3 +122,38 @@ def send_log_to_journal(conf_message: dict):
         sp.run(['logger', '-t', tag, '-p', priority, message], check=True)
     except sp.CalledProcessError as e:
         raise Exception(f"Error sending log message to journal: {e}")
+
+
+def send_log_to_unix_socket(socket_path: str, message):
+    '''
+    Send a datagram to a UNIX socket path (for server mode).
+
+    Args:
+        socket_path (str): Destination socket path.
+        message (str | bytes): Payload to send.
+    '''
+
+    payload = message.encode() if isinstance(message, str) else message
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+        sock.sendto(payload, socket_path)
+
+
+def wait_for_path_state(path: str, exists: bool = True, timeout: int = 10):
+    '''
+    Wait until a filesystem path reaches the expected existence state.
+
+    Args:
+        path (str): Path to monitor.
+        exists (bool): Expected path existence.
+        timeout (int): Maximum wait time in seconds.
+    '''
+
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if Path(path).exists() == exists:
+            return
+        time.sleep(0.2)
+
+    raise TimeoutError(f"Path '{path}' did not reach exists={exists} in {timeout}s")


### PR DESCRIPTION
## Description

Closes #35134 (scope-extending follow-up).

The original wording of #35134 ("attempt to **open** the configured socket **if it exists**") and Marcel's comment ("UDP client (assuming the socket already exists)") describe a **client** that *connects to* an externally-owned socket. The previous PR on this branch implemented a UNIX datagram **server** (`log_format=socket`), which is the only way to *read* from a `SOCK_DGRAM` socket but does not match the original "Docker socket" use case the issue references — `DockerListener.py` does not consume datagrams; it speaks **HTTP/1.1 over `/var/run/docker.sock`** (`SOCK_STREAM`) and consumes Docker's chunked `/events` stream.

This PR closes that gap by adding a **generic HTTP-over-UNIX-stream client** to Logcollector via a new `log_format=http-unix`. A dedicated worker thread per `<localfile>` connects to the configured UNIX stream socket, issues a `GET <endpoint>`, parses the response (chunked / content-length / read-until-close), and forwards each newline-delimited line as a log event. The client transparently reconnects when the peer closes the connection or the producer is restarted.

This sits alongside `log_format=socket` (server mode) — the two cover complementary scenarios:

| Mode                   | Direction                          | Socket type   | Typical producer            |
|------------------------|------------------------------------|---------------|-----------------------------|
| `log_format=socket`    | Logcollector binds + receives      | `SOCK_DGRAM`  | rsyslog/syslog-ng/scripts   |
| `log_format=http-unix` | Logcollector connects + consumes   | `SOCK_STREAM` | Docker daemon, sidecars     |

The pre-existing `wodles/docker-listener/DockerListener.py` Python wodle is left in place — it wraps each event in `{"integration":"docker","docker":<event>}` so the bundled Docker rules match. `log_format=http-unix` forwards events verbatim and is intentionally generic; rules consuming raw Docker events would need to be adjusted.

## Proposed Changes

- **New reader** (`src/logcollector/src/read_http_unix.c`, 524 LoC): one worker thread per `<localfile>`. Connects with `OS_ConnectUnixDomain(..., SOCK_STREAM, ...)`, sends a minimal HTTP/1.1 request, and runs a small response parser that supports:
  - `Transfer-Encoding: chunked`
  - `Content-Length: N`
  - read-until-close fallback when neither header is present
  - newline-delimited line splitting with partial-line carry across reads/chunks
  - `OS_MAXSTR` line-length guard (oversize lines are dropped with a warning)
  - UTF-8 + NUL-byte rejection via the shared `w_logcollector_validate_text_line` helper
  - Stop-aware `poll()`/sleep loops so `pthread_join` returns within ~1 s on shutdown
  - Connect failure → mwarn once, then mdebug; reconnect every `<reconnect_interval>` seconds forever

- **Configuration support** (`src/config/src/localfile-config.c`, `src/config/include/localfile-config.h`): accepts `log_format=http-unix` (UNIX-only) with two new options:
  - `<endpoint>` — HTTP path to request (default `/`, must start with `/`)
  - `<reconnect_interval>` — seconds between reconnect attempts (default `5`, range `1`–`3600`)

  Standard incompatible-option warnings (`age`, `ignore_binaries`, `only-future-events`) and a symmetric warning when http-unix-only options appear on a non-http-unix `<localfile>`. New cleanup helper `w_logcollector_http_unix_release` joins the worker thread on `Free_Logreader` / config reload.

- **Logcollector integration** (`src/logcollector/src/logcollector.c`): adds `source_is_http_unix()` and extends the `source_is_open` / `open_source` / `reload_source` / `close_source` abstractions to dispatch to the new reader. The main read loop short-circuits http-unix sources (the worker owns I/O); file-disappearance / open-attempts / forget-file paths skip http-unix the same way they already skip socket sources.

- **JSON config generator** (`src/logcollector/src/config.c`): excludes `age` / `ignore_binaries` / `only-future-events` for http-unix sources (parity with socket); serialises `endpoint` and `reconnect_interval` for http-unix sources.

- **Boy-scout SRP improvements** to neighbouring code (kept minimal, behaviour-preserving):
  - Extracted `w_logcollector_validate_text_line(buf, len, source_kind, source)` in `logcollector.c` and used it from both `read_socket.c` and the new `read_http_unix.c` (~14 lines of duplicated newline-strip / NUL / UTF-8 logic removed from `read_socket.c`).
  - Split `open_socket_source` (~70 LoC, two nested blocks + `goto`) into four single-purpose helpers: `release_bound_socket`, `resolve_socket_group`, `set_socket_nonblocking`, `log_open_failure`. The orchestrator is now linear and `goto`-free. `close_source` now reuses `release_bound_socket` instead of inlining the same close+unlink+free.
  - Extracted `w_logcollector_warn_file_only_options` shared by both `w_logcollector_validate_socket` and the new `w_logcollector_validate_http_unix`.
  - Introduced an `is_socket_like` predicate in `config.c` so the same exclusion rule (`age`/`ignore_binaries`/`only-future-events`) is expressed once for both `SOCKET_LOG` and `HTTP_UNIX_LOG`.

- **Documentation**: new section in `docs/ref/modules/logcollector/configuration.md` with options table, a Docker `/events` example, and a clear note that this is **not** a drop-in DockerListener.py replacement.

- **Unit tests**: 6 new cases in `test_localfile-config.c` (http-unix defaults, endpoint valid/invalid, reconnect_interval valid/invalid, cross-format option warning) + 1 case in `test_logcollector.c` (`Free_Logreader` cleans up `http_endpoint` when no thread is running).

- **Integration tests**: two new files exercising the live reader end-to-end on the test harness.

### Results and Evidence

Validation performed on the Docker-based test environment (Ubuntu 22.04 agent + Wazuh v5.0.0 manager). The agent binary built from this branch contains the new symbols:

```
$ docker exec wazuh-agent strings /var/ossec/bin/wazuh-logcollector | grep -E "http-unix|Reading http-unix" | head
http-unix
http-unix '%s': request line too long for endpoint '%s'
http-unix '%s': send failed: %s
Reading http-unix message: '%.*s'%s
http-unix '%s': line exceeds %d bytes; dropping accumulated content.
```

<details>
<summary>End-to-end smoke test: chunked HTTP server on a UNIX stream socket → logcollector reads three events</summary>

A minimal Python HTTP server bound to `/tmp/wazuh-smoke-http-unix.sock` accepts the connection from logcollector, sends `HTTP/1.1 200 OK` with `Transfer-Encoding: chunked`, and emits three chunked events of the form `<size>\r\n<line>\n\r\n`. Each line surfaces in `ossec.log`:

```
2026/04/18 03:11:41 wazuh-logcollector[37926] logcollector.c:1514 at set_read(): DEBUG: Socket target for '/tmp/wazuh-smoke-http-unix.sock' -> agent
2026/04/18 03:11:41 wazuh-logcollector[37926] read_http_unix.c:482 at http_unix_worker(): DEBUG: http-unix '/tmp/wazuh-smoke-http-unix.sock': connected.
2026/04/18 03:11:41 wazuh-logcollector[37926] read_http_unix.c:171 at http_unix_emit_line(): DEBUG: Reading http-unix message: 'smoke-event-0'
2026/04/18 03:11:42 wazuh-logcollector[37926] read_http_unix.c:171 at http_unix_emit_line(): DEBUG: Reading http-unix message: 'smoke-event-1'
2026/04/18 03:11:42 wazuh-logcollector[37926] read_http_unix.c:171 at http_unix_emit_line(): DEBUG: Reading http-unix message: 'smoke-event-2'
```

</details>

<details>
<summary>Reconnect cycle on server-side close (configured <code>&lt;reconnect_interval&gt;2&lt;/reconnect_interval&gt;</code>)</summary>

The mock server delivers two events, then closes the connection. The worker reconnects ~3 s later (interval + small margin) and consumes the next event:

```
2026/04/18 03:17:55 read_http_unix.c at http_unix_worker(): DEBUG: http-unix '/tmp/wazuh-pr-evidence.sock': connected.
2026/04/18 03:17:55 read_http_unix.c at http_unix_emit_line(): DEBUG: Reading http-unix message: 'pr-evidence-event-1'
2026/04/18 03:17:56 read_http_unix.c at http_unix_emit_line(): DEBUG: Reading http-unix message: 'pr-evidence-event-2'
2026/04/18 03:17:58 read_http_unix.c at http_unix_worker(): DEBUG: http-unix '/tmp/wazuh-pr-evidence.sock': connected.
2026/04/18 03:17:58 read_http_unix.c at http_unix_emit_line(): DEBUG: Reading http-unix message: 'pr-evidence-after-reconnect'
```

</details>

<details>
<summary>Incompatible options ignored with warning (<code>age</code>, <code>socket_mode</code>) when used on <code>log_format=http-unix</code></summary>

Configured `<localfile>` with `<age>5m</age>` and `<socket_mode>0666</socket_mode>` on an `http-unix` source — both are warned and dropped:

```
2026/04/18 03:17:54 wazuh-logcollector localfile-config.c at w_logcollector_warn_file_only_options(): WARNING: (8004): log_format 'http-unix' does not support 'age' option. Option will be ignored.
2026/04/18 03:17:54 wazuh-logcollector localfile-config.c at Read_Localfile(): WARNING: (8004): log_format 'http-unix' does not support 'socket_mode' option. Option will be ignored.
```

</details>

<details>
<summary>Runtime configuration JSON exposes the http-unix-specific fields</summary>

```
$ python3 -c 'from wazuh_testing.modules.logcollector import utils; print(utils.get_localfile_runtime_configuration())'

{
  "file": "/tmp/wazuh-pr-evidence.sock",
  "logformat": "http-unix",
  "target": ["agent"],
  "endpoint": "/events",
  "reconnect_interval": 2
}
```

`age`, `ignore_binaries`, and `only-future-events` are correctly absent (file-only options).

</details>

<details>
<summary>Integration tests pass</summary>

```
$ python3 -m pytest test_logcollector/test_configuration/test_basic_configuration_http_unix.py -v
test_logcollector/test_configuration/test_basic_configuration_http_unix.py::test_configuration_http_unix[http-unix-runtime-config] PASSED [100%]
======================== 1 passed in 28.38s ========================

$ python3 -m pytest test_logcollector/test_read/test_read_http_unix_basic.py -v
test_logcollector/test_read/test_read_http_unix_basic.py::test_read_http_unix_basic[http-unix-read-basic] PASSED [100%]
======================== 1 passed in 26.38s ========================
```

</details>

<details>
<summary>No regression in pre-existing socket tests (covers boy-scout refactors of <code>open_socket_source</code> and the extracted <code>w_logcollector_validate_text_line</code> helper)</summary>

```
$ python3 -m pytest test_logcollector/test_configuration/test_basic_configuration_socket.py \
                    test_logcollector/test_read/test_read_socket_basic.py -v
test_logcollector/test_configuration/test_basic_configuration_socket.py::test_configuration_socket[socket-runtime-config] PASSED
test_logcollector/test_read/test_read_socket_basic.py::test_read_socket_basic[socket-read-basic] PASSED
======================== 2 passed in 52.55s ========================
```

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (Ubuntu 22.04 agent build via test environment)
  - [ ] Windows (feature is `#ifndef WIN32`-guarded; no Windows code path to compile)
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] N/A — feature is UNIX-only
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

- `wazuh-logcollector` (Linux/macOS — agent and manager)
- `ossec.conf` / `wazuh-manager.conf` (new `log_format=http-unix` value with `<endpoint>` and `<reconnect_interval>` options on `<localfile>`)

### Configuration Changes

- New `log_format` value: `http-unix` — Logcollector connects to a UNIX **stream** socket at the path given by `<location>` and consumes the HTTP response body of `GET <endpoint>` as newline-delimited log events.
- New http-unix-specific options:
  - `endpoint` — HTTP path to request (default `/`). Must start with `/`. Validated at parse time.
  - `reconnect_interval` — seconds to wait between reconnect attempts (default `5`, range `1`–`3600`).
- `age`, `ignore_binaries`, and `only-future-events` are accepted but ignored (with a warning) for this log format.
- `endpoint` / `reconnect_interval` used on a non-http-unix log format emit a warning and are reset.
- No changes to existing default values; new options only take effect when `log_format=http-unix` is explicitly chosen.
- The existing Python wodle `wodles/docker-listener/DockerListener.py` is **untouched** — it remains the supported drop-in path for users relying on the bundled Docker rules.

### Tests Introduced

- **Unit tests:**
  - `src/unit_tests/logcollector/test_localfile-config.c` — 6 new cases:
    - `test_Read_Localfile_http_unix_defaults` (defaults applied: `/`, 5 s)
    - `test_Read_Localfile_http_unix_endpoint_valid` / `_invalid` (`/events` accepted, `events` rejected)
    - `test_Read_Localfile_http_unix_reconnect_interval_valid` / `_invalid` (30 accepted, 0 rejected)
    - `test_Read_Localfile_http_unix_opts_on_non_http_unix` (cross-format warnings)
  - `src/unit_tests/logcollector/test_logcollector.c` — 1 new case:
    - `test_Free_Logreader_http_unix_endpoint` (cleanup frees `http_endpoint` and is a no-op when no worker thread is running)

- **Integration tests:**
  - `tests/integration/test_logcollector/test_configuration/test_basic_configuration_http_unix.py` — verifies `log_format=http-unix` is accepted, `<endpoint>` and `<reconnect_interval>` round-trip through the runtime configuration, and the `age` warning is emitted.
  - `tests/integration/test_logcollector/test_read/test_read_http_unix_basic.py` — spins up a Python `SOCK_STREAM` HTTP server, configures Logcollector against it, asserts that streamed chunked events arrive, then closes the server-side connection and asserts the worker reconnects and resumes consuming.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
