### PR TITLE
Validate IP address format in host_ip field for Windows

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -1180,9 +1180,26 @@ nlohmann::json SysInfo::getUsers() const
 
                 if (!hostStr.empty())
                 {
-                    userItem["host_ip"] = userItem["host_ip"].get<std::string>() == UNKNOWN_VALUE
-                                          ? hostStr
-                                          : (userItem["host_ip"].get<std::string>() + primaryArraySeparator + hostStr);
+                    // Validate IP address before assigning to host_ip field
+                    static auto pfnInetPton { Utils::getInetPtonFunctionAddress() };
+
+                    bool isValidIp = false;
+
+                    if (pfnInetPton)
+                    {
+                        struct in_addr ipv4;
+                        struct in6_addr ipv6;
+                        isValidIp = (pfnInetPton(AF_INET, hostStr.c_str(), &ipv4) == 1) ||
+                                    (pfnInetPton(AF_INET6, hostStr.c_str(), &ipv6) == 1);
+                    }
+
+                    // Only assign if valid IP, otherwise keep UNKNOWN_VALUE
+                    if (isValidIp)
+                    {
+                        userItem["host_ip"] = userItem["host_ip"].get<std::string>() == UNKNOWN_VALUE
+                                              ? hostStr
+                                              : (userItem["host_ip"].get<std::string>() + primaryArraySeparator + hostStr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

  This PR fixes a schema validation error in Syscollector on Windows agents where the `host.ip` field was incorrectly populated with hostnames instead of valid IP addresses. The issue occurred when Remote Desktop (RDP) sessions used AF_UNSPEC (undefined address family), causing the Windows Terminal Services API to return client hostnames instead of IP addresses.

  Closes #35411

  ## Proposed Changes

  ### Bugs Fixed
  - Added IP address validation in `sysInfoWin.cpp` (data_provider/src/sysInfoWin.cpp:1181-1203) to filter out invalid IP addresses before assigning them to the `host.ip` field in the logged users inventory
  - Reused existing `Utils::getInetPtonFunctionAddress()` function from `windowsHelper.h` to validate IPv4 and IPv6 addresses
  - Non-IP values (such as hostnames) now default to `UNKNOWN_VALUE` (" ") instead of being sent and failing schema validation

  ### Technical Details
  - The fix validates IP addresses using `inet_pton` for both AF_INET (IPv4) and AF_INET6 (IPv6)
  - Only valid IP addresses are now assigned to the `host.ip` field
  - When the Windows Terminal Services API returns a hostname (when `ClientAddressFamily == AF_UNSPEC`), the field is left as `UNKNOWN_VALUE` instead of causing a schema validation error

  ### Results and Evidence

  **Before the fix:**
  - Schema validation errors occurred when RDP sessions with AF_UNSPEC returned hostnames
  - Error message: `Invalid field type: host.ip = "msizojmgn" expected type: ip`
  - Events were rejected by the engine due to invalid IP format

Opening a Remote Desktop (RDP) session on the agent endpoint:

<details><summary>Agent ossec.log</summary>

```log
2026/04/15 19:46:37 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/04/15 19:46:39 wazuh-modulesd:syscollector: ERROR: Schema validation failed for Syscollector message (table: dbsync_users, index: wazuh-states-inventory-users). Errors:   - host.ip[0]: Invalid IP address format: nbertoldo-X570-
2026/04/15 19:46:39 wazuh-modulesd:syscollector: ERROR: Raw event that failed validation: {"checksum":{"hash":{"sha1":"237a84f55c41fc0b15894e775b38fa1167f617ae"}},"host":{"ip":["nbertoldo-X570-"]},"login":{"status":true,"tty":"RDP-Tcp#0","type":"active"},"process":{"pid":-1},"state":{"document_version":2,"modified_at":"2026-04-15T19:46:39.587Z"},"user":{"auth_failures":{"count":0,"timestamp":null},"created":null,"full_name":"Vagrant","group":{"id":544,"id_signed":544},"groups":["Administrators:Users"],"home":"C:\\Users\\vagrant","id":"1000","is_hidden":false,"is_remote":false,"last_login":"2026-04-15T19:44:25.000Z","name":"vagrant","password":{"expiration_date":null,"hash_algorithm":null,"inactive_days":0,"last_change":0,"max_days_between_changes":0,"min_days_between_changes":0,"status":null,"warning_days_before_expiration":0},"roles":null,"shell":"C:\\Windows\\system32\\cmd.exe","type":"local","uid_signed":1000,"uuid":"S-1-5-21-1673099515-2324581457-255951991-1000"}}
2026/04/15 19:46:39 wazuh-modulesd:syscollector: ERROR: Discarding invalid Syscollector message (table: dbsync_users)
2026/04/15 19:46:43 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

</details> 


  **After the fix:**
  - Hostnames are filtered out and not assigned to `host.ip`
  - Only valid IPv4/IPv6 addresses are assigned to the field
  - Invalid values default to `UNKNOWN_VALUE` (" ")
  - Schema validation succeeds
  - Code compiled successfully for Windows agent target without errors

Opening a Remote Desktop (RDP) session on the agent endpoint:

<details><summary>Agent ossec.log</summary>

```log
2026/04/15 20:08:46 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/04/15 20:08:54 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

</details> 

<details><summary>Dashboard event</summary>

```json
{
  "_index": "wazuh-states-inventory-users",
  "_id": "wazuh_002_ffb2eb2fe05b15856640e45d37f8d1fb2618af9a",
  "_score": 0,
  "_source": {
    "wazuh": {
      "agent": {
        "groups": [
          "default"
        ],
        "host": {
          "architecture": "x86_64",
          "hostname": "VM-WIN2022",
          "os": {
            "name": "Microsoft Windows Server 2022 Standard",
            "platform": "windows",
            "type": "windows",
            "version": "10.0.20348.1906"
          }
        },
        "id": "002",
        "name": "vm-win2022",
        "version": "v5.0.0"
      },
      "cluster": {
        "name": "wazuh"
      }
    },
    "checksum": {
      "hash": {
        "sha1": "d75afa780058f4173f999ae78795df43bfe18ace"
      }
    },
    "host": {
      "ip": null
    },
    "login": {
      "status": true,
      "tty": "RDP-Tcp#0",
      "type": "active"
    },
    "process": {
      "pid": -1
    },
    "state": {
      "document_version": 3,
      "modified_at": "2026-04-15T20:08:50.169Z"
    },
    "user": {
      "auth_failures": {
        "count": 0,
        "timestamp": null
      },
      "created": null,
      "full_name": "Vagrant",
      "group": {
        "id": 544,
        "id_signed": 544
      },
      "groups": [
        "Administrators:Users"
      ],
      "home": "C:\\Users\\vagrant",
      "id": "1000",
      "is_hidden": false,
      "is_remote": false,
      "last_login": "2026-04-15T20:07:37.000Z",
      "name": "vagrant",
      "password": {
        "expiration_date": null,
        "hash_algorithm": null,
        "inactive_days": 0,
        "last_change": 0,
        "max_days_between_changes": 0,
        "min_days_between_changes": 0,
        "status": null,
        "warning_days_before_expiration": 0
      },
      "roles": null,
      "shell": "C:\\Windows\\system32\\cmd.exe",
      "type": "local",
      "uid_signed": 1000,
      "uuid": "S-1-5-21-1673099515-2324581457-255951991-1000"
    }
  },
  "fields": {
    "state.modified_at": [
      "2026-04-15T20:08:50.169Z"
    ],
    "user.last_login": [
      "2026-04-15T20:07:37.000Z"
    ]
  }
}
```

<img width="564" height="908" alt="Captura desde 2026-04-15 17-20-04" src="https://github.com/user-attachments/assets/03a0b4e1-ac88-4e35-b160-819e42198bfb" />

</details> 

  ### Manual tests with their corresponding evidence

  - Compilation without warnings on every supported platform
    - [ ] Linux
    - [x] Windows (compiled successfully with TARGET=winagent DEBUG=1)
    - [ ] MAC OS X
  - [x] Log syntax and correct language review

  - Memory tests for Windows
    - [ ] Coverity
    - [ ] UMDH

  ### Artifacts Affected

  - **Windows Agent Executables**:
    - `wazuh-agent.exe` (Syscollector module)
    - `sysinfo.dll` (data provider library)

  ### Configuration Changes

  N/A - No configuration changes required. The fix is transparent to users.

  ### Tests Introduced

  No new automated tests were added. Existing unit tests in `src/unit_tests/data_provider/sysInfoWin/sysInfoWin_test.cpp` continue to pass as they already use valid IP addresses in test
  data.

  Manual testing should verify:
  1. Windows agents with RDP sessions using AF_UNSPEC no longer generate schema validation errors
  2. Valid IP addresses from RDP sessions are still correctly captured
  3. Logged user events are successfully indexed without validation errors

  ## Review Checklist

  - [ ] Code changes reviewed
  - [ ] Relevant evidence provided (compilation success)
  - [ ] Tests cover the new functionality
  - [ ] Configuration changes documented (N/A)
  - [ ] Developer documentation reflects the changes
  - [ ] Meets requirements and/or definition of done
  - [ ] No unresolved dependencies with other issues