### PR TITLE
wazuh-engine: `/logtest` endpoint cleanup temporary fields

### DIFF
--- a/docs/ref/modules/engine/spec.yaml
+++ b/docs/ref/modules/engine/spec.yaml
@@ -274,10 +274,11 @@ paths:
           (e.g. `"event.severity"`, `"tags[1]"`, `"hits[0].id"`).
         - `kind` — one of:
           - `unknown_field` — field is not defined in WCS and is not a temporary field.
-          - `temporary_field_not_allowed` — field is a pipeline-internal field (root starts with `_`).
           - `invalid_type` — value does not match the WCS type for that field.
         - `expected` / `actual` — present only for `invalid_type` errors; both are type strings
           (e.g. `"keyword"`, `"object"`, `"number"`).
+
+        Pipeline-internal temporary fields (root key starts with `_`) are cleaned before validation.
 
         Any WCS field can hold either a single value or an array of values of the same type.
         Arrays are always unrolled: each element is validated individually using the field's
@@ -473,8 +474,6 @@ paths:
                       validation:
                         valid: false
                         errors:
-                          - path: "_tmp"
-                            kind: "temporary_field_not_allowed"
                           - path: "event.severity"
                             kind: "invalid_type"
                             expected: "keyword"

--- a/src/engine/source/api/tester/src/handlers.cpp
+++ b/src/engine/source/api/tester/src/handlers.cpp
@@ -902,16 +902,24 @@ adapter::RouteHandler publicRunPost(const std::shared_ptr<::router::ITesterAPI>&
         }
 
         ResponseType eResponse {};
-        auto eResult = fromOutput(base::getResponse(response));
 
-        // Validate the final output event against WCS schema (informational, non-blocking).
-        // Temporary fields (_...) are cleaned before validation.
-        if (auto schemaValidatorLocked = wSchemaValidator.lock())
+        // Temporary fields (_...) are cleaned before building the response and validation.
         {
             const auto& outputEvent = base::getResponse(response).event();
             if (outputEvent)
             {
                 outputEvent->eraseRootKeysByPrefix("_");
+            }
+        }
+
+        auto eResult = fromOutput(base::getResponse(response));
+
+        // Validate the final output event against WCS schema (informational, non-blocking).
+        if (auto schemaValidatorLocked = wSchemaValidator.lock())
+        {
+            const auto& outputEvent = base::getResponse(response).event();
+            if (outputEvent)
+            {
                 *eResult.mutable_validation() = validateOutputEvent(*outputEvent, *schemaValidatorLocked);
             }
         }

--- a/src/engine/source/api/tester/src/handlers.cpp
+++ b/src/engine/source/api/tester/src/handlers.cpp
@@ -904,12 +904,14 @@ adapter::RouteHandler publicRunPost(const std::shared_ptr<::router::ITesterAPI>&
         ResponseType eResponse {};
         auto eResult = fromOutput(base::getResponse(response));
 
-        // Validate the final output event against WCS schema (informational, non-blocking)
+        // Validate the final output event against WCS schema (informational, non-blocking).
+        // Temporary fields (_...) are cleaned before validation.
         if (auto schemaValidatorLocked = wSchemaValidator.lock())
         {
             const auto& outputEvent = base::getResponse(response).event();
             if (outputEvent)
             {
+                outputEvent->eraseRootKeysByPrefix("_");
                 *eResult.mutable_validation() = validateOutputEvent(*outputEvent, *schemaValidatorLocked);
             }
         }

--- a/src/engine/source/api/tester/test/src/unit/handlers_test.cpp
+++ b/src/engine/source/api/tester/test/src/unit/handlers_test.cpp
@@ -797,7 +797,7 @@ INSTANTIATE_TEST_SUITE_P(
                 EXPECT_EQ(v.errors(0).kind(), "unknown_field");
             },
         },
-        // 7 ─ unknown empty object (subtree pruned at the parent)
+        // 7 ─ unknown empty object (subtree skipped at the parent)
         OutputValidationCase {
             "UnknownEmptyObject",
             R"({"foo":{}})",
@@ -810,7 +810,7 @@ INSTANTIATE_TEST_SUITE_P(
                 EXPECT_EQ(v.errors(0).kind(), "unknown_field");
             },
         },
-        // 8 ─ unknown empty array (subtree pruned at the parent)
+        // 8 ─ unknown empty array (subtree skipped at the parent)
         OutputValidationCase {
             "UnknownEmptyArray",
             R"({"foo":[]})",
@@ -823,17 +823,15 @@ INSTANTIATE_TEST_SUITE_P(
                 EXPECT_EQ(v.errors(0).kind(), "unknown_field");
             },
         },
-        // 9 ─ _tmp.* (entire subtree reported as one error at the _ root)
+        // 9 ─ _tmp.* (entire subtree excluded from validation report)
         OutputValidationCase {
             "TemporaryField",
             R"({"_tmp":{"stage1":"data","stage2":42}})",
             []() -> std::shared_ptr<schemf::IValidator> { return makeSchemaMock({}); },
             [](const eEngine::tester::Result_Validation& v)
             {
-                ASSERT_FALSE(v.valid());
-                ASSERT_EQ(v.errors_size(), 1);
-                EXPECT_EQ(v.errors(0).path(), "_tmp");
-                EXPECT_EQ(v.errors(0).kind(), "temporary_field_not_allowed");
+                EXPECT_TRUE(v.valid());
+                EXPECT_EQ(v.errors_size(), 0);
             },
         },
         // 10 ─ object where the schema expects a scalar
@@ -898,7 +896,7 @@ INSTANTIATE_TEST_SUITE_P(
                 EXPECT_EQ(v.errors_size(), 0);
             },
         },
-        // 13 ─ deterministic error ordering
+        // 13 ─ deterministic error ordering (temporaries excluded from report)
         // The final validateOutputEvent sort is the only ordering guarantee;
         // object children are visited in getObject() order (not sorted).
         OutputValidationCase {
@@ -908,18 +906,207 @@ INSTANTIATE_TEST_SUITE_P(
             [](const eEngine::tester::Result_Validation& v)
             {
                 ASSERT_FALSE(v.valid());
-                ASSERT_EQ(v.errors_size(), 4);
-                EXPECT_EQ(v.errors(0).path(), "_a");
-                EXPECT_EQ(v.errors(0).kind(), "temporary_field_not_allowed");
-                EXPECT_EQ(v.errors(1).path(), "_b");
-                EXPECT_EQ(v.errors(1).kind(), "temporary_field_not_allowed");
-                EXPECT_EQ(v.errors(2).path(), "aaa");
-                EXPECT_EQ(v.errors(2).kind(), "unknown_field");
-                EXPECT_EQ(v.errors(3).path(), "zzz");
-                EXPECT_EQ(v.errors(3).kind(), "unknown_field");
+                ASSERT_EQ(v.errors_size(), 2);
+                EXPECT_EQ(v.errors(0).path(), "aaa");
+                EXPECT_EQ(v.errors(0).kind(), "unknown_field");
+                EXPECT_EQ(v.errors(1).path(), "zzz");
+                EXPECT_EQ(v.errors(1).kind(), "unknown_field");
             },
         }),
     [](const testing::TestParamInfo<OutputValidationCase>& info) { return info.param.name; });
+
+// Additional tests: /logtest excludes temporary fields from validation (issue #35416)
+//
+// These verify that temporary fields (_...) are ignored by
+// /logtest WCS validation, while real schema errors are still reported.
+
+struct LogtestTemporaryExclusionCase
+{
+    std::string name;
+    std::string outputJson;
+    std::function<std::shared_ptr<schemf::IValidator>()> makeSchema;
+    std::function<void(const eEngine::tester::Result_Validation&)> check;
+};
+
+class LogtestTemporaryExclusionTest : public ::testing::TestWithParam<LogtestTemporaryExclusionCase>
+{
+};
+
+TEST_P(LogtestTemporaryExclusionTest, Handler)
+{
+    const auto& tc = GetParam();
+    auto schema = tc.makeSchema();
+    auto v = runOutputValidation(tc.outputJson, schema);
+    tc.check(v);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Api,
+    LogtestTemporaryExclusionTest,
+    ::testing::Values(
+        // 1 ─ only temporaries + valid WCS fields → valid, no errors
+        LogtestTemporaryExclusionCase {
+            "TemporaryPlusValidWcsFields",
+            R"({"_tmp":{"stage":"data"},"code":"42"})",
+            []() -> std::shared_ptr<schemf::IValidator> { return makeSchemaMock({{"code", schemf::Type::KEYWORD}}); },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                EXPECT_TRUE(v.valid());
+                EXPECT_EQ(v.errors_size(), 0);
+            },
+        },
+        // 2 ─ temporaries + real type error → only invalid_type reported
+        LogtestTemporaryExclusionCase {
+            "TemporaryPlusTypeMismatch",
+            R"({"_tmp":{"x":1},"severity":"bad"})",
+            []() -> std::shared_ptr<schemf::IValidator>
+            {
+                return makeSchemaMock(
+                    {{"severity", schemf::Type::LONG}},
+                    [](const DotPath& name, const json::Json& value) -> base::RespOrError<schemf::ValidationResult>
+                    {
+                        if (name.str() == "severity" && value.isString())
+                            return base::Error {"expected long"};
+                        return schemf::ValidationResult {};
+                    });
+            },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                ASSERT_FALSE(v.valid());
+                ASSERT_EQ(v.errors_size(), 1);
+                EXPECT_EQ(v.errors(0).path(), "severity");
+                EXPECT_EQ(v.errors(0).kind(), "invalid_type");
+            },
+        },
+        // 3 ─ unknown real field + temporaries → only unknown_field for the real field
+        LogtestTemporaryExclusionCase {
+            "UnknownFieldPlusTemporary",
+            R"({"custom_foo":"val","_decoder_vars":{"a":1}})",
+            []() -> std::shared_ptr<schemf::IValidator> { return makeSchemaMock({}); },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                ASSERT_FALSE(v.valid());
+                ASSERT_EQ(v.errors_size(), 1);
+                EXPECT_EQ(v.errors(0).path(), "custom_foo");
+                EXPECT_EQ(v.errors(0).kind(), "unknown_field");
+            },
+        },
+        // 4 ─ temporary as nested subtree/object with children → excluded entirely
+        LogtestTemporaryExclusionCase {
+            "TemporarySubtreeObject",
+            R"({"_internal":{"deep":{"nested":"value"},"list":[1,2,3]}})",
+            []() -> std::shared_ptr<schemf::IValidator> { return makeSchemaMock({}); },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                EXPECT_TRUE(v.valid());
+                EXPECT_EQ(v.errors_size(), 0);
+            },
+        },
+        // 5 ─ multiple temporaries in an otherwise valid event
+        LogtestTemporaryExclusionCase {
+            "MultipleTemporariesValid",
+            R"({"_a":"x","_b":{"nested":true},"_c":[1,2],"code":"42"})",
+            []() -> std::shared_ptr<schemf::IValidator> { return makeSchemaMock({{"code", schemf::Type::KEYWORD}}); },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                EXPECT_TRUE(v.valid());
+                EXPECT_EQ(v.errors_size(), 0);
+            },
+        },
+        // 6 ─ empty event (no fields at all) → valid
+        LogtestTemporaryExclusionCase {
+            "EmptyEvent",
+            R"({})",
+            []() -> std::shared_ptr<schemf::IValidator> { return makeSchemaMock({}); },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                EXPECT_TRUE(v.valid());
+                EXPECT_EQ(v.errors_size(), 0);
+            },
+        }),
+    [](const testing::TestParamInfo<LogtestTemporaryExclusionCase>& info) { return info.param.name; });
+
+/***********************************************************************
+ * /tester/run/post: verify that temporary fields ARE reported
+ *
+ * Unlike /logtest, the private endpoint preserves temporary_field_not_allowed
+ * in the validation report. This test drives runPost() directly.
+ **********************************************************************/
+
+/// Helper: run runPost with a canned output event and return validation.
+namespace
+{
+eEngine::tester::Result_Validation runPrivateOutputValidation(const std::string& outputJson,
+                                                              const std::shared_ptr<schemf::IValidator>& schema)
+{
+    auto tester = std::make_shared<MockTesterAPI>();
+    EXPECT_CALL(*tester, ingestTest(testing::_, testing::_))
+        .WillOnce(
+            [outputJson](auto&&, auto&&)
+            {
+                std::promise<base::RespOrError<::router::test::Output>> p;
+                p.set_value(makeOutput(outputJson));
+                return p.get_future();
+            });
+
+    eEngine::tester::RunPost_Request protoReq;
+    protoReq.set_name("test-session");
+    protoReq.set_event("1:/var/log/test:some event");
+    protoReq.set_trace_level(eEngine::tester::TraceLevel::NONE);
+
+    httplib::Response res;
+    runPost(tester, base::eventParsers::parseLegacyEvent, schema)(
+        createRequest<eEngine::tester::RunPost_Request>(protoReq), res);
+
+    EXPECT_EQ(res.status, 200);
+
+    auto parsed = eMessage::eMessageFromJson<eEngine::tester::RunPost_Response>(res.body);
+    if (!std::holds_alternative<eEngine::tester::RunPost_Response>(parsed))
+    {
+        ADD_FAILURE() << "Failed to parse RunPost_Response";
+        return {};
+    }
+
+    const auto& r = std::get<eEngine::tester::RunPost_Response>(parsed);
+    EXPECT_EQ(r.status(), eEngine::ReturnStatus::OK);
+    EXPECT_TRUE(r.has_result());
+    EXPECT_TRUE(r.result().has_validation());
+    return r.result().validation();
+}
+} // namespace
+
+TEST(RunPostTemporaryValidation, TemporaryFieldReportsError)
+{
+    auto schema = makeSchemaMock({});
+    auto v = runPrivateOutputValidation(R"({"_tmp":{"stage":"data"}})", schema);
+
+    ASSERT_FALSE(v.valid());
+    ASSERT_EQ(v.errors_size(), 1);
+    EXPECT_EQ(v.errors(0).path(), "_tmp");
+    EXPECT_EQ(v.errors(0).kind(), "temporary_field_not_allowed");
+}
+
+TEST(RunPostTemporaryValidation, TemporaryPlusUnknownReportsBoth)
+{
+    auto schema = makeSchemaMock({});
+    auto v = runPrivateOutputValidation(R"({"_tmp":"x","custom":"y"})", schema);
+
+    ASSERT_FALSE(v.valid());
+    ASSERT_EQ(v.errors_size(), 2);
+    EXPECT_EQ(v.errors(0).path(), "_tmp");
+    EXPECT_EQ(v.errors(0).kind(), "temporary_field_not_allowed");
+    EXPECT_EQ(v.errors(1).path(), "custom");
+    EXPECT_EQ(v.errors(1).kind(), "unknown_field");
+}
+
+TEST(RunPostTemporaryValidation, ValidFieldsNoTemporariesNoErrors)
+{
+    auto schema = makeSchemaMock({{"code", schemf::Type::KEYWORD}});
+    auto v = runPrivateOutputValidation(R"({"code":"42"})", schema);
+
+    EXPECT_TRUE(v.valid());
+    EXPECT_EQ(v.errors_size(), 0);
+}
 
 class LogtestDeleteTest : public ::testing::TestWithParam<LogtestDeleteCase>
 {


### PR DESCRIPTION

## Description

The WCS output validation introduced in #35314 reports `temporary_field_not_allowed` errors for every pipeline-internal field (those prefixed with `_`) found in the final output event. This is correct for `/tester/run/post`, where the developer inspects the full pipeline output. However, for the public `/logtest` endpoint, events that exit the pipeline early because `discard_event()` fired with `index_discarded_events=true` legitimately retain their temporary variables — the pipeline never reached the decoder cleanup stage. Flagging those fields in `/logtest` produces misleading validation noise for end users.

Closes #35416

## Proposed Changes

### Bugs fixed

**Pre-validation sanitization in `/logtest`** (`handlers.cpp`)

In `publicRunPost` (`/logtest`), before calling `validateOutputEvent`, `eraseRootKeysByPrefix("_")` is called in-place on the output event to remove all temporary fields. This is safe because `fromOutput()` already serialized the event into the protobuf response above, so the mutation does not affect the output returned to the caller.

- `publicRunPost` (`/logtest`) — validates a copy with all `_*` root keys removed. Temporary fields never reach the validator, so they are excluded from the report. `unknown_field` and `invalid_type` errors on WCS fields are still reported normally.
- `runPost` (`/tester/run/post`) — validates the raw output event unchanged. `temporary_field_not_allowed` is still emitted as before. **No behavioral change for this endpoint.**
- `validateOutputEvent`, `collectOutputErrors`, `classifyField` — **no changes**. All logic is the same as the original implementation from #35314.

**API spec** (`docs/ref/modules/engine/spec.yaml`)

- `/logtest` description: removed `temporary_field_not_allowed` from the `kind` enum list; added a note explaining that temporary fields are excluded from the validation report.
- `/logtest` response example `ok_with_validation_errors`: removed the `_tmp` / `temporary_field_not_allowed` entry to match the new behavior.
- `Result_ValidationError.kind` schema description: clarified that `temporary_field_not_allowed` is emitted exclusively by `/tester/run/post`, and explains why `/logtest` excludes it.

### Results and Evidence

**Tests with `cleanup_decoder_variables` in `false`:**

- `/logtest`:
```console
python test_logtest.py --event '{"code":"http","proto":"HTTP","host":"web-01","src_ip":"10.0.0.10","dst_ip":"10.0.0.20","user":"Alice","url":"https://example.local/path?a=1&b=2","reason":"integration test","env":"dev","version":"1.2.3","msg":"test event"}'
[request payload]
{
  "queue": 1,
  "location": "test",
  "metadata": {
    "wazuh": {
      "agent": {
        "id": "001"
      }
    }
  },
  "event": "{\"code\":\"http\",\"proto\":\"HTTP\",\"host\":\"web-01\",\"src_ip\":\"10.0.0.10\",\"dst_ip\":\"10.0.0.20\",\"user\":\"Alice\",\"url\":\"https://example.local/path?a=1&b=2\",\"reason\":\"integration test\",\"env\":\"dev\",\"version\":\"1.2.3\",\"msg\":\"test event\"}",
  "trace_level": "NONE",
  "space": "custom"
}

[http] status=200

[raw response]
{"status":"OK","result":{"output":{"_tmp_tags":["http","alice"],"network":{"protocol":"http"},"_raw":{"user":"Alice","src_ip":"10.0.0.10","host":"web-01","reason":"integration test","code":"http","env":"dev","proto":"HTTP","version":"1.2.3","msg":"test event","url":"https://example.local/path?a=1&b=2","dst_ip":"10.0.0.20"},"_tmp_user":"alice","event":{"severity":"should-be-a-long","reason":"integration test","kind":"event","category":["network","web",42],"type":["protocol","access"],"code":"http"},"source":{"ip":"10.0.0.10"},"@timestamp":"2026-04-13T21:10:48Z","_tmp_proto":"http","_event":{"code":100},"_tmp_code":"http","_tmp_url":"https://example.local/path?a=1&b=2","destination":{"ip":"10.0.0.20"},"host":{"name":"web-01"},"_tmp_arr":["http","web-01","alice"],"wazuh":{"protocol":{"location":"test","queue":1},"space":{"name":"custom"},"agent":{"id":"001"},"integration":{"category":"security","name":"integration/test-temporals/0","decoders":["decoder/core-root/0","decoder/integration-parent/0","decoder/child-uses-parent-temporals/0","decoder/grandchild-multiple-temporals/0"]}},"message":"test event","url":{"query":"a=1&b=2","original":"https://example.local/path?a=1&b=2","path":"https://example.local/path"},"_tmp_host":"web-01","_tmp_meta":{"version":"1.2.3","env":"dev"},"_tmp_defs":{"dns":{"network":{"protocol":"dns"},"event":{"kind":"event","category":["network"]}},"alert":{"network":{"protocol":"tcp"},"event":{"category":["network","intrusion_detection"],"kind":"alert"}},"http":{"network":{"protocol":"http"},"event":{"kind":"event","category":["network","web"]}}},"_tmp_split_url":["https://example.local/path","a=1&b=2"],"related":{"ip":["10.0.0.10","10.0.0.20"]}},"asset_traces":[],"validation":{"valid":false,"errors":[{"path":"event.category[2]","kind":"invalid_type","expected":"keyword","actual":"number"},{"path":"event.severity","kind":"invalid_type","expected":"long","actual":"string"}]}}}
```

Validation works ok:
```
[validation]
valid: False
errors: 2
  1. path='event.category[2]' kind='invalid_type' expected='keyword' actual='number'
  2. path='event.severity' kind='invalid_type' expected='long' actual='string'
```

- same event with engine-test (`/tester/run/post`):
```console
engine-test -c /workspaces/wazuh-5.x/engine-test.json run test -s custom  -dd              

Enter any events [ENTER to send event, CTRL+C to finish]:

{"code":"http","proto":"HTTP","host":"web-01","src_ip":"10.0.0.10","dst_ip":"10.0.0.20","user":"Alice","url":"https://example.local/path?a=1&b=2","reason":"integration test","env":"dev","version":"1.2.3","msg":"test event"}


---
traces:
[🟢] decoder/core-root/0 -> success
  ↳ @timestamp: get_date -> Success
[🟢] decoder/integration-parent/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ _raw: parse_json($event.original) -> Success
  ↳ _event.code: map(100) -> Success
  ↳ [_tmp_proto: downcase($_raw.proto)] -> Success
  ↳ _tmp_host: map($_raw.host) -> Success
  ↳ [_tmp_code: downcase($_raw.code)] -> Success
  ↳ _tmp_url: map($_raw.url) -> Success
  ↳ event.code: map($_tmp_code) -> Success
  ↳ source.ip: map($_raw.src_ip) -> Success
  ↳ destination.ip: map($_raw.dst_ip) -> Success
  ↳ host.name: map($_tmp_host) -> Success
  ↳ _tmp_payload_ok.network.protocol: map("udp") -> Success
  ↳ .: merge($_tmp_payload_ok) -> Success
  ↳ _tmp_bad_types.event.severity: map("should-be-a-long") -> Success
  ↳ .: merge($_tmp_bad_types) -> Success
  ↳ _tmp_payload_recursive.event.type: array_append("protocol", "access") -> Success
  ↳ _tmp_payload_recursive.network.transport: map("tcp") -> Success
  ↳ .: merge_recursive($_tmp_payload_recursive) -> Success
  ↳ _tmp_defs.alert.event.kind: map("alert") -> Success
  ↳ _tmp_defs.alert.event.category: array_append("network", "intrusion_detection") -> Success
  ↳ _tmp_defs.alert.network.protocol: map("tcp") -> Success
  ↳ _tmp_defs.dns.event.kind: map("event") -> Success
  ↳ _tmp_defs.dns.event.category: array_append("network") -> Success
  ↳ _tmp_defs.dns.network.protocol: map("dns") -> Success
  ↳ _tmp_defs.http.event.kind: map("event") -> Success
  ↳ _tmp_defs.http.event.category: array_append("network", "web") -> Success
  ↳ _tmp_defs.http.network.protocol: map("http") -> Success
  ↳ .: merge_key_in($_tmp_defs, $_tmp_code) -> Success
  ↳ .: merge_recursive_key_in($_tmp_defs, $_tmp_code) -> Success
  ↳ .: kvdb_get_merge("event_defaults_by_code", $_tmp_code) -> Success
  ↳ .: kvdb_get_merge_recursive("event_defaults_by_code", $_tmp_code) -> Success
  ↳ .: kvdb_get_merge_recursive("event_bad_array_test", $_tmp_code) -> Success
  ↳ event.code: map($_tmp_code) -> Success
  ↳ _tmp_bad_types.event.severity: map("should-be-a-long") -> Success
  ↳ .: merge_recursive($_tmp_bad_types) -> Success
[🟢] decoder/child-uses-parent-temporals/0 -> success
  ↳ [check: exists($_tmp_proto) AND exists($_tmp_host)] -> Success
  ↳ [_tmp_user: downcase($_raw.user)] -> Success
  ↳ _tmp_tags: array_append($_tmp_proto, $_tmp_user) -> Success
  ↳ network.protocol: map($_tmp_proto) -> Success
  ↳ event.reason: map($_raw.reason) -> Success
  ↳ related.ip: array_append($source.ip, $destination.ip) -> Success
[🟢] decoder/grandchild-multiple-temporals/0 -> success
  ↳ [check: (($_tmp_proto == http OR $_tmp_proto == dns OR $_tmp_proto == alert) OR $_tmp_code == alert) AND exists($_tmp_url)] -> Success
  ↳ _tmp_split_url: split($_tmp_url, "?") -> Success
  ↳ _tmp_meta.env: map($_raw.env) -> Success
  ↳ _tmp_meta.version: map($_raw.version) -> Success
  ↳ _tmp_arr: array_append($_tmp_proto, $_tmp_host, $_tmp_user) -> Success
  ↳ url.original: map($_tmp_url) -> Success
  ↳ url.path: map($_tmp_split_url.0) -> Success
  ↳ url.query: map($_tmp_split_url.1) -> Success
  ↳ message: map($_raw.msg) -> Success
  ↳ event.category: array_append("network") -> Failure: Value is not a string
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (index_discarded_events=true)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Skipped: Cleanup disabled by policy
[🟢] output/indexer/0 -> success
  ↳ [check: $wazuh.integration.category != "cloud-services" OR (NOT starts_with($wazuh.integration.name, "aws") AND NOT starts_with($wazuh.integration.name, "azure") AND NOT starts_with($wazuh.integration.name, "gcp"))] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-${wazuh.integration.category}) -> Success
[🟢] output/file-output-integrations/0 -> success
  ↳ write.output(file/custom-wazuh-events-v5) -> Success

output:
  '@timestamp': '2026-04-13T21:12:20Z'
  _event:
    code: 100
  _raw:
    code: http
    dst_ip: 10.0.0.20
    env: dev
    host: web-01
    msg: test event
    proto: HTTP
    reason: integration test
    src_ip: 10.0.0.10
    url: https://example.local/path?a=1&b=2
    user: Alice
    version: 1.2.3
  _tmp_arr:
  - http
  - web-01
  - alice
  _tmp_code: http
  _tmp_defs:
    alert:
      event:
        category:
        - network
        - intrusion_detection
        kind: alert
      network:
        protocol: tcp
    dns:
      event:
        category:
        - network
        kind: event
      network:
        protocol: dns
    http:
      event:
        category:
        - network
        - web
        kind: event
      network:
        protocol: http
  _tmp_host: web-01
  _tmp_meta:
    env: dev
    version: 1.2.3
  _tmp_proto: http
  _tmp_split_url:
  - https://example.local/path
  - a=1&b=2
  _tmp_tags:
  - http
  - alice
  _tmp_url: https://example.local/path?a=1&b=2
  _tmp_user: alice
  destination:
    ip: 10.0.0.20
  event:
    category:
    - network
    - web
    - 42
    code: http
    kind: event
    reason: integration test
    severity: should-be-a-long
    type:
    - protocol
    - access
  host:
    name: web-01
  message: test event
  network:
    protocol: http
  related:
    ip:
    - 10.0.0.10
    - 10.0.0.20
  source:
    ip: 10.0.0.10
  url:
    original: https://example.local/path?a=1&b=2
    path: https://example.local/path
    query: a=1&b=2
  wazuh:
    integration:
      category: security
      decoders:
      - decoder/core-root/0
      - decoder/integration-parent/0
      - decoder/child-uses-parent-temporals/0
      - decoder/grandchild-multiple-temporals/0
      name: integration/test-temporals/0
    protocol:
      location: /tmp/json
      queue: 49
    space:
      name: custom
```

- **From the dashboard before the pipeline failure fix `Discard_event() -> Failure: Event won't be indexed (wazuh.space.event_discarded=true and index_discarded_events=false)`:**

<img width="739" height="770" alt="image" src="https://github.com/user-attachments/assets/c1ede27f-54ac-4f1f-abcb-4d6c2fad984a" />

It is observed that temporary fields appear in the output and these same fields are reported in the validation.

- **From the dashboard after fix with the same test (same policy and event):**
<img width="761" height="830" alt="image" src="https://github.com/user-attachments/assets/a1b5ff63-0166-4b07-813f-db09d29a2c07" />

With the same event and using the same policy, it is observed that using `/logtest` the temporary fields are removed from the output, but using the private endpoint `/tester/run/post` the temporary fields are preserved.


### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [x] Added unit testing files ".ini" — N/A
  - [x] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `src/engine/source/api/tester/src/handlers.cpp`
- `src/engine/source/api/tester/test/src/unit/handlers_test.cpp`
- `docs/ref/modules/engine/spec.yaml`
- `src/engine/source/proto/src/tester.proto` (comment update only)

### Configuration Changes

N/A

### Tests Introduced

**`LogtestTemporaryExclusionTest`** — 6 parameterized cases driven through `publicRunPost` to verify `/logtest` behavior:

| # | Name | Scenario | Expected |
|---|------|----------|----------|
| 1 | `TemporaryPlusValidWcsFields` | `_tmp.*` + valid WCS field | `valid=true`, 0 errors |
| 2 | `TemporaryPlusTypeMismatch` | `_tmp.*` + WCS type mismatch | 1 `invalid_type` error only |
| 3 | `UnknownFieldPlusTemporary` | Unknown real field + temporary | 1 `unknown_field` error only |
| 4 | `TemporarySubtreeObject` | Temporary as deep nested object | `valid=true`, 0 errors |
| 5 | `MultipleTemporariesValid` | Multiple temporaries + valid fields | `valid=true`, 0 errors |
| 6 | `EmptyEvent` | Empty output event | `valid=true`, 0 errors |

**`RunPostTemporaryValidation`** — 3 standalone tests driven through `runPost` to pin the private endpoint's unchanged behavior:

| Name | Scenario | Expected |
|------|----------|----------|
| `TemporaryFieldReportsError` | `_tmp` in output | `valid=false`, 1 `temporary_field_not_allowed` |
| `TemporaryPlusUnknownReportsBoth` | `_tmp` + unknown field | Both errors reported |
| `ValidFieldsNoTemporariesNoErrors` | Valid WCS-only event | `valid=true`, 0 errors |

Existing `OutputValidationTest` cases updated:
- Test 9 (`TemporaryField`) — now expects `valid=true`, 0 errors (tests the `/logtest` path).
- Test 13 (`DeterministicErrorOrdering`) — now expects 2 errors (only the `unknown_field` entries; temporaries excluded).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
