### PR TITLE
Skip vdFirst and polling for vdSync when a feedUpdate occurs

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -282,6 +282,15 @@ public:
     void registerNotify(std::function<void()> callback);
 
     /**
+     * @brief Force a refresh on one or more indices so recently indexed documents
+     * become immediately searchable.
+     *
+     * @param indexPattern Index name or wildcard pattern (e.g.
+     *                     "wazuh-states-inventory-packages").
+     */
+    void refresh(std::string_view indexPattern);
+
+    /**
      * @brief Check have a server available.
      *
      * @return true if have a server available, false otherwise.

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
@@ -109,6 +109,11 @@ public:
         m_impl.registerNotify(std::move(callback));
     }
 
+    void refresh(std::string_view indexPattern)
+    {
+        m_impl.refresh(indexPattern);
+    }
+
     bool isAvailable() const
     {
         return m_impl.isAvailable();
@@ -207,6 +212,11 @@ void IndexerConnectorSync::invokePendingCallbacks()
 void IndexerConnectorSync::registerNotify(std::function<void()> callback)
 {
     m_impl->registerNotify(std::move(callback));
+}
+
+void IndexerConnectorSync::refresh(std::string_view indexPattern)
+{
+    m_impl->refresh(indexPattern);
 }
 
 bool IndexerConnectorSync::isAvailable() const

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -1281,6 +1281,29 @@ public:
         m_notify.push_back(std::move(callback));
     }
 
+    void refresh(std::string_view indexPattern)
+    {
+        std::string url;
+        url += m_selector->getNext();
+        url += "/";
+        url += indexPattern;
+        url += "/_refresh";
+        logDebug2(IC_NAME, "Forcing index refresh: %s", url.c_str());
+
+        const auto onSuccess = [](const std::string& response)
+        {
+            logDebug2(IC_NAME, "Index refresh response: %s", response.c_str());
+        };
+        const auto onError = [](const std::string& error, const long statusCode, const std::string&)
+        {
+            logWarn(IC_NAME, "Index refresh failed: %s, status code: %ld", error.c_str(), statusCode);
+        };
+
+        m_httpRequest->post(RequestParameters {.url = HttpURL(url), .secureCommunication = m_secureCommunication},
+                            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
+                            {});
+    }
+
     bool isAvailable() const
     {
         return m_selector->isAvailable();

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1099,8 +1099,10 @@ public:
                                 // session thread until it completes (or the scanner is stopped).
                                 // The agent stays in Status_Processing — already sent at End-message
                                 // time — so it will not mark its VDFirst flag prematurely.
+                                bool waitedForFeed = false;
                                 if (!VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
+                                    waitedForFeed = true;
                                     logDebug1(LOGGER_DEFAULT_TAG,
                                               "InventorySyncFacade: CVE feed not yet loaded — agent %s waiting.",
                                               res.context->agentId.c_str());
@@ -1110,27 +1112,43 @@ public:
                                 // Run scan only if the scanner was not stopped during the wait.
                                 if (VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
-                                    logDebug2(LOGGER_DEFAULT_TAG,
-                                              "InventorySyncFacade: Running vulnerability scanner for agent %s...",
-                                              res.context->agentId.c_str());
-                                    try
+
+                                    const bool skipScan =
+                                        waitedForFeed && res.context->option == Wazuh::SyncSchema::Option_VDSync;
+
+                                    if (skipScan)
                                     {
-                                        VulnerabilityScannerFacade::instance().runScanner(*m_dataStore, *res.context);
+                                        logInfo(LOGGER_DEFAULT_TAG,
+                                                "InventorySyncFacade: Skipping VDSync scan for agent %s — "
+                                                "feed-update full scan will cover all packages.",
+                                                res.context->agentId.c_str());
                                     }
-                                    catch (const std::exception& e)
+                                    else
                                     {
-                                        logError(LOGGER_DEFAULT_TAG,
-                                                 "InventorySyncFacade: Vulnerability scanner exception for agent "
-                                                 "%s: %s",
-                                                 res.context->agentId.c_str(),
-                                                 e.what());
-                                        m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                                         res.context->agentId,
-                                                                         res.context->sessionId,
-                                                                         res.context->moduleName);
-                                        m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
-                                        m_agentSessions.erase(res.context->sessionId);
-                                        m_sessionCompletedCV.notify_all();
+                                        logDebug2(LOGGER_DEFAULT_TAG,
+                                                  "InventorySyncFacade: Running vulnerability scanner for agent "
+                                                  "%s...",
+                                                  res.context->agentId.c_str());
+                                        try
+                                        {
+                                            VulnerabilityScannerFacade::instance().runScanner(*m_dataStore,
+                                                                                              *res.context);
+                                        }
+                                        catch (const std::exception& e)
+                                        {
+                                            logError(LOGGER_DEFAULT_TAG,
+                                                     "InventorySyncFacade: Vulnerability scanner exception for "
+                                                     "agent %s: %s",
+                                                     res.context->agentId.c_str(),
+                                                     e.what());
+                                            m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
+                                                                             res.context->agentId,
+                                                                             res.context->sessionId,
+                                                                             res.context->moduleName);
+                                            m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
+                                            m_agentSessions.erase(res.context->sessionId);
+                                            m_sessionCompletedCV.notify_all();
+                                        }
                                     }
                                 }
                                 else

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -279,9 +279,16 @@ class InventorySyncFacadeImpl final
             auto agentId = startMsg->agentid() ? startMsg->agentid()->string_view() : std::string_view();
             auto moduleName = startMsg->module_() ? startMsg->module_()->string_view() : std::string_view();
 
-            // Check if agent is locked
+            // Check if agent is locked.
+            // syscollector_vd sessions (VDFirst/VDSync) are exempt from the feed-update lock:
+            // they read package data from their RocksDB session store, not from the OpenSearch
+            // package index, so they cannot produce dirty reads during a feed-update full scan.
+            // Per-agent serialisation with the feed-update scan is handled by the wait in
+            // hasActiveSessionForModule instead.
             std::string agentIdStr(agentId.data(), agentId.size());
-            if (isAgentLocked(agentIdStr))
+            const std::string moduleNameStr(moduleName.data(), moduleName.size());
+            const bool isVDModule = (moduleNameStr == "syscollector_vd");
+            if (!isVDModule && isAgentLocked(agentIdStr))
             {
                 logDebug2(LOGGER_DEFAULT_TAG,
                           "InventorySyncFacade::start: Agent %s is locked, rejecting new session",
@@ -1427,19 +1434,23 @@ public:
      *     feed-update scan (the first-scan itself will cover the updated feed).
      *   - VDSync session:  blocks until the session ends or the timeout expires, then
      *     returns false so the caller proceeds with the feed-update scan.
+     *     If the session does not finish within the timeout, the wait is retried up to
+     *     maxRetries additional times before giving up.
      *
      * When called without a timeout (default): behaves as a plain existence check and
      * returns true if any session matches, regardless of the session option.
      *
      * @param agentId    Agent ID to check
      * @param moduleName Module name to check (e.g., "syscollector_vd")
-     * @param timeout    How long to wait for a VDSync session to finish (0 = no wait)
+     * @param timeout    How long to wait per attempt for a VDSync session to finish (0 = no wait)
+     * @param maxRetries Maximum number of extra wait attempts after the first timeout (0 = no retry)
      * @return true if a VDFirst session is active (caller should skip the scan);
      *         false in all other cases (no session, or VDSync finished/timed out)
      */
     bool hasActiveSessionForModule(const std::string& agentId,
                                    const std::string& moduleName,
-                                   std::chrono::seconds timeout) const
+                                   std::chrono::seconds timeout,
+                                   uint32_t maxRetries) const
     {
         std::shared_lock lock(m_agentSessionsMutex);
 
@@ -1458,33 +1469,52 @@ public:
                     // VDSync: wait for the session to finish before the feed-update scan reads
                     // the indexer, so all packages are in a consistent state.
                     logInfo(LOGGER_DEFAULT_TAG,
-                            "Feed update scan waiting for VDSync session to complete for agent %s (timeout: %lds).",
+                            "Feed update scan waiting for VDSync session to complete for agent %s "
+                            "(timeout: %lds, max retries: %u).",
                             agentId.c_str(),
-                            static_cast<long>(timeout.count()));
+                            static_cast<long>(timeout.count()),
+                            maxRetries);
 
-                    const bool completed =
-                        m_sessionCompletedCV.wait_for(lock,
-                                                      timeout,
-                                                      [&]()
-                                                      {
-                                                          for (const auto& [sId, s] : m_agentSessions)
-                                                          {
-                                                              if (s.getContext()->agentId == agentId
-                                                                  && s.getContext()->moduleName == moduleName)
-                                                              {
-                                                                  return false; // still active
-                                                              }
-                                                          }
-                                                          return true; // session gone
-                                                      });
-
-                    if (!completed)
+                    const auto isSessionGone = [&]()
                     {
-                        logWarn(LOGGER_DEFAULT_TAG,
-                                "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
-                                "Proceeding with current indexer data.",
-                                agentId.c_str(),
-                                static_cast<long>(timeout.count()));
+                        for (const auto& [sId, s] : m_agentSessions)
+                        {
+                            if (s.getContext()->agentId == agentId && s.getContext()->moduleName == moduleName)
+                            {
+                                return false; // still active
+                            }
+                        }
+                        return true; // session gone
+                    };
+
+                    uint32_t attemptsLeft = maxRetries + 1;
+                    while (attemptsLeft > 0)
+                    {
+                        --attemptsLeft;
+                        const bool completed = m_sessionCompletedCV.wait_for(lock, timeout, isSessionGone);
+
+                        if (completed)
+                        {
+                            break;
+                        }
+
+                        if (attemptsLeft > 0)
+                        {
+                            logWarn(LOGGER_DEFAULT_TAG,
+                                    "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
+                                    "Retrying (%u retries left).",
+                                    agentId.c_str(),
+                                    static_cast<long>(timeout.count()),
+                                    attemptsLeft);
+                        }
+                        else
+                        {
+                            logWarn(LOGGER_DEFAULT_TAG,
+                                    "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
+                                    "Proceeding with current indexer data.",
+                                    agentId.c_str(),
+                                    static_cast<long>(timeout.count()));
+                        }
                     }
                 }
 
@@ -1548,6 +1578,7 @@ public:
 
         if (cleanedCount > 0)
         {
+            m_sessionCompletedCV.notify_all();
             logInfo(LOGGER_DEFAULT_TAG,
                     "Cleaned up %zu zombie session(s) for agent %s",
                     cleanedCount,
@@ -1747,6 +1778,7 @@ private:
 
                 // Remove session from map
                 m_agentSessions.erase(it);
+                m_sessionCompletedCV.notify_all();
             }
         }
     }

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -34,6 +34,7 @@
 #include <rocksdb/slice.h>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 constexpr int SINGLE_THREAD_COUNT = 1;
@@ -280,15 +281,14 @@ class InventorySyncFacadeImpl final
             auto moduleName = startMsg->module_() ? startMsg->module_()->string_view() : std::string_view();
 
             // Check if agent is locked.
-            // syscollector_vd sessions (VDFirst/VDSync) are exempt from the feed-update lock:
-            // they read package data from their RocksDB session store, not from the OpenSearch
-            // package index, so they cannot produce dirty reads during a feed-update full scan.
-            // Per-agent serialisation with the feed-update scan is handled by the wait in
-            // hasActiveSessionForModule instead.
+            // syscollector_vd sessions (VDFirst/VDSync) are only exempt from the
+            // global all-agents lock. Per-agent locks still reject them so SAFU can
+            // lock only the agent it is about to scan and avoid new concurrent
+            // inventory writes for that agent.
             std::string agentIdStr(agentId.data(), agentId.size());
             const std::string moduleNameStr(moduleName.data(), moduleName.size());
             const bool isVDModule = (moduleNameStr == "syscollector_vd");
-            if (!isVDModule && isAgentLocked(agentIdStr))
+            if (isAgentLocked(agentIdStr, isVDModule))
             {
                 logDebug2(LOGGER_DEFAULT_TAG,
                           "InventorySyncFacade::start: Agent %s is locked, rejecting new session",
@@ -1199,14 +1199,16 @@ public:
                                 // Run scan only if the scanner was not stopped during the wait.
                                 if (VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
-                                    // Skip VDSync delta scan when a feed-update full scan is already
-                                    // covering all packages — either because this session waited for the
-                                    // initial feed load (the feed-update scan fires right after) or
-                                    // because a feed-update full scan is currently in progress.
+                                    // Skip VDSync delta scan only when a feed-update full scan is
+                                    // actively in progress — SAFU will cover all packages for this
+                                    // agent.  Do NOT skip based on waitedForFeed alone: when the feed
+                                    // has no new CVEs (changed=false), prepareFeedUpdateScan() is never
+                                    // called, so isFeedUpdateScanInProgress() is false and the VDSync
+                                    // scan must run.
                                     const bool feedUpdateInProgress =
                                         VulnerabilityScannerFacade::instance().isFeedUpdateScanInProgress();
                                     const bool skipScan =
-                                        (waitedForFeed || feedUpdateInProgress) &&
+                                        feedUpdateInProgress &&
                                         res.context->option == Wazuh::SyncSchema::Option_VDSync;
 
                                     logWarn(LOGGER_DEFAULT_TAG,
@@ -1219,21 +1221,15 @@ public:
                                             waitedForFeed ? "true" : "false",
                                             feedUpdateInProgress ? "true" : "false",
                                             skipScan ? "true" : "false",
-                                            skipScan
-                                                ? (waitedForFeed
-                                                       ? "SKIPPED — waited for feed, feed-update full scan covers all packages"
-                                                       : "SKIPPED — feed-update full scan in progress, covers all packages")
-                                                : "RUN — executing delta vulnerability scan now");
+                                            skipScan ? "SKIPPED — feed-update full scan in progress, covers all packages"
+                                                     : "RUN — executing delta vulnerability scan now");
 
                                     if (skipScan)
                                     {
                                         logInfo(LOGGER_DEFAULT_TAG,
                                                 "InventorySyncFacade: Skipping VDSync scan for agent %s — "
-                                                "%s.",
-                                                res.context->agentId.c_str(),
-                                                waitedForFeed
-                                                    ? "feed-update full scan will cover all packages"
-                                                    : "feed-update full scan in progress, covers all packages");
+                                                "feed-update full scan in progress, covers all packages.",
+                                                res.context->agentId.c_str());
                                     }
                                     else
                                     {
@@ -1248,6 +1244,11 @@ public:
                                         {
                                             VulnerabilityScannerFacade::instance().runScanner(
                                                 *m_dataStore, *res.context);
+                                            if (res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                                            {
+                                                VulnerabilityScannerFacade::instance().registerFeedUpdateCoveredAgent(
+                                                    res.context->agentId);
+                                            }
                                             logWarn(LOGGER_DEFAULT_TAG,
                                                     "[VDSYNC] Scan RUN END: agent=%s sessionId=%llu option=%s — "
                                                     "runScanner() completed successfully.",
@@ -1584,10 +1585,17 @@ public:
      * @param agentId Agent ID to check
      * @return true if agent is locked (or all agents are locked)
      */
-    bool isAgentLocked(const std::string& agentId) const
+    bool isAgentLocked(const std::string& agentId, const bool allowVDGlobalExemption = false) const
     {
         std::shared_lock lock(m_blockedAgentsMutex);
-        return m_allAgentsLocked.load() || m_blockedAgents.contains(agentId);
+
+        if (m_blockedAgents.contains(agentId))
+        {
+            return true;
+        }
+
+        const bool allAgentsLocked = m_allAgentsLocked.load();
+        return allAgentsLocked && !allowVDGlobalExemption;
     }
 
     /**
@@ -1619,15 +1627,35 @@ public:
     }
 
     /**
+     * @brief Returns the agents that currently have an active session for the module/option pair.
+     *
+     * @param moduleName Module name to filter (e.g. "syscollector_vd").
+     * @param option Session option to filter.
+     * @return Set of agent IDs with a matching active session.
+     */
+    std::unordered_set<std::string> getAgentsWithActiveSessionForModule(const std::string& moduleName,
+                                                                        Wazuh::SyncSchema::Option option) const
+    {
+        std::unordered_set<std::string> agentIds;
+        std::shared_lock lock(m_agentSessionsMutex);
+
+        for (const auto& [sessionId, session] : m_agentSessions)
+        {
+            const auto& context = session.getContext();
+            if (context->moduleName == moduleName && context->option == option)
+            {
+                agentIds.insert(context->agentId);
+            }
+        }
+
+        return agentIds;
+    }
+
+    /**
      * @brief Wait until all active VDSync sessions across all agents have completed.
      *
-     * Called by the feed-update callback BEFORE it acquires m_internalMutex, avoiding
-     * the deadlock where feedUpdate holds that mutex while waiting for a VDSync session
-     * that is itself blocked trying to acquire the same mutex.
-     *
-     * Because VulnerabilityScannerFacade::m_feedUpdateScanInProgress is set before
-     * this is called, VDSync sessions in their scan-decision phase will skip their scan
-     * and end quickly, so each hasActiveSessionForModule call below returns fast.
+     * Called by the feed-update callback after the SAFU state flag is raised, so
+     * VDSync sessions in their scan-decision phase can self-skip and finish fast.
      *
      * @param timeout    Maximum wait time per attempt (forwarded to hasActiveSessionForModule).
      * @param maxRetries Retry count (forwarded to hasActiveSessionForModule).
@@ -1636,20 +1664,8 @@ public:
     {
         while (true)
         {
-            std::vector<std::string> vdSyncAgents;
-            {
-                std::shared_lock lock(m_agentSessionsMutex);
-                for (const auto& [id, session] : m_agentSessions)
-                {
-                    const auto& ctx = session.getContext();
-                    if (ctx->moduleName == "syscollector_vd" &&
-                        ctx->option == Wazuh::SyncSchema::Option_VDSync)
-                    {
-                        vdSyncAgents.push_back(ctx->agentId);
-                    }
-                }
-            }
-
+            const auto vdSyncAgents =
+                getAgentsWithActiveSessionForModule("syscollector_vd", Wazuh::SyncSchema::Option_VDSync);
             if (vdSyncAgents.empty())
             {
                 break;

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -280,11 +280,10 @@ class InventorySyncFacadeImpl final
             auto agentId = startMsg->agentid() ? startMsg->agentid()->string_view() : std::string_view();
             auto moduleName = startMsg->module_() ? startMsg->module_()->string_view() : std::string_view();
 
-            // Check if agent is locked.
-            // syscollector_vd sessions (VDFirst/VDSync) are only exempt from the
-            // global all-agents lock. Per-agent locks still reject them so SAFU can
-            // lock only the agent it is about to scan and avoid new concurrent
-            // inventory writes for that agent.
+            // VDFirst/VDSync sessions bypass the global all-agents lock (held during shutdown)
+            // but are still blocked by per-agent locks. The feed-update scan takes a per-agent
+            // lock before scanning to prevent new inventory sessions from writing data while
+            // the scan reads it.
             std::string agentIdStr(agentId.data(), agentId.size());
             const std::string moduleNameStr(moduleName.data(), moduleName.size());
             const bool isVDModule = (moduleNameStr == "syscollector_vd");
@@ -337,31 +336,6 @@ class InventorySyncFacadeImpl final
                     m_agentSessions.try_emplace(
                         sessionId, sessionId, startMsg, *m_dataStore, *m_indexerQueue, *m_responseDispatcher);
                     logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Session created %llu", sessionId);
-
-                    if (startMsg->option() == Wazuh::SyncSchema::Option_VDSync ||
-                        startMsg->option() == Wazuh::SyncSchema::Option_VDFirst)
-                    {
-                        const char* optStr =
-                            startMsg->option() == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst";
-                        const char* modeStr = [&]() -> const char*
-                        {
-                            switch (startMsg->mode())
-                            {
-                                case Wazuh::SyncSchema::Mode_ModuleFull: return "ModuleFull";
-                                case Wazuh::SyncSchema::Mode_ModuleDelta: return "ModuleDelta";
-                                default: return "Other";
-                            }
-                        }();
-                        logWarn(LOGGER_DEFAULT_TAG,
-                                "[VDSYNC] Session CREATED: agent=%s module=%s option=%s mode=%s "
-                                "size=%llu sessionId=%llu — Start ACK (Status_Ok) sent to agent.",
-                                agentIdStr.c_str(),
-                                moduleNameStr.c_str(),
-                                optStr,
-                                modeStr,
-                                static_cast<unsigned long long>(startMsg->size()),
-                                sessionId);
-                    }
                 }
             }
         }
@@ -408,17 +382,6 @@ class InventorySyncFacadeImpl final
             }
             else
             {
-                const auto& ctx = it->second.getContext();
-                if (ctx->option == Wazuh::SyncSchema::Option_VDSync || ctx->option == Wazuh::SyncSchema::Option_VDFirst)
-                {
-                    logWarn(LOGGER_DEFAULT_TAG,
-                            "[VDSYNC] End message RECEIVED: agent=%s sessionId=%llu option=%s — "
-                            "agent finished sending all packages; session queued for indexing "
-                            "(Status_Processing sent to agent).",
-                            ctx->agentId.c_str(),
-                            ctx->sessionId,
-                            ctx->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst");
-                }
                 // Handle end.
                 it->second.handleEnd(*m_responseDispatcher);
                 logDebug2(
@@ -674,26 +637,6 @@ public:
             [this](const Response& res)
             {
                 logDebug2(LOGGER_DEFAULT_TAG, "Indexer queue action...");
-                if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
-                    res.context->option == Wazuh::SyncSchema::Option_VDFirst)
-                {
-                    const char* modeStr = [&]() -> const char*
-                    {
-                        switch (res.context->mode)
-                        {
-                            case Wazuh::SyncSchema::Mode_ModuleFull: return "ModuleFull";
-                            case Wazuh::SyncSchema::Mode_ModuleDelta: return "ModuleDelta";
-                            default: return "Other";
-                        }
-                    }();
-                    logWarn(LOGGER_DEFAULT_TAG,
-                            "[VDSYNC] IndexerQueue PROCESSING: agent=%s sessionId=%llu option=%s mode=%s — "
-                            "all packages received; starting bulk indexing to OpenSearch.",
-                            res.context->agentId.c_str(),
-                            res.context->sessionId,
-                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
-                            modeStr);
-                }
                 {
                     std::shared_lock sessionLock(m_agentSessionsMutex);
                     if (m_agentSessions.find(res.context->sessionId) == m_agentSessions.end())
@@ -1152,79 +1095,27 @@ public:
                         if (res.context->option == Wazuh::SyncSchema::Option_VDFirst ||
                             res.context->option == Wazuh::SyncSchema::Option_VDSync)
                         {
-                            logWarn(LOGGER_DEFAULT_TAG,
-                                    "[VDSYNC] Packages INDEXED: agent=%s sessionId=%llu option=%s "
-                                    "hasBulkData=%s — packages queued for bulk send to OpenSearch "
-                                    "(notify-callback will fire when OpenSearch ACKs the bulk).",
-                                    res.context->agentId.c_str(),
-                                    res.context->sessionId,
-                                    res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
-                                    hasBulkData ? "true" : "false");
-
                             if (VulnerabilityScannerFacade::instance().isInitialized())
                             {
-                                // If the CVE feed initial load is still in progress, block this
-                                // session thread until it completes (or the scanner is stopped).
-                                // The agent stays in Status_Processing — already sent at End-message
-                                // time — so it will not mark its VDFirst flag prematurely.
-                                bool waitedForFeed = false;
-                                const bool feedReadyNow = VulnerabilityScannerFacade::instance().isFeedReady();
-                                logWarn(LOGGER_DEFAULT_TAG,
-                                        "[VDSYNC] Feed check: agent=%s sessionId=%llu option=%s "
-                                        "isFeedReady=%s — %s.",
-                                        res.context->agentId.c_str(),
-                                        res.context->sessionId,
-                                        res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
-                                        feedReadyNow ? "true" : "false",
-                                        feedReadyNow ? "proceeding directly to scan decision"
-                                                     : "CVE feed not ready, this thread will block");
-                                if (!feedReadyNow)
+                                // On the first manager startup the CVE feed may still be downloading.
+                                // Block here until it's ready so the scan doesn't run against empty data.
+                                // The agent stays in Status_Processing (sent at End-message time) and
+                                // gets Status_Ok once the scan finishes.
+                                if (!VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
-                                    waitedForFeed = true;
-                                    logWarn(LOGGER_DEFAULT_TAG,
-                                            "[VDSYNC] Wait START: agent=%s sessionId=%llu option=%s — "
-                                            "blocking IndexerQueue thread until CVE feed is ready.",
-                                            res.context->agentId.c_str(),
-                                            res.context->sessionId,
-                                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                    : "VDFirst");
                                     VulnerabilityScannerFacade::instance().waitForFeedReady();
-                                    logWarn(LOGGER_DEFAULT_TAG,
-                                            "[VDSYNC] Wait END: agent=%s sessionId=%llu option=%s — "
-                                            "CVE feed ready, resuming.",
-                                            res.context->agentId.c_str(),
-                                            res.context->sessionId,
-                                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                    : "VDFirst");
                                 }
 
-                                // Run scan only if the scanner was not stopped during the wait.
+                                // waitForFeedReady() also returns when stop() fires before the feed is ready.
                                 if (VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
-                                    // Skip VDSync delta scan only when a feed-update full scan is
-                                    // actively in progress — SAFU will cover all packages for this
-                                    // agent.  Do NOT skip based on waitedForFeed alone: when the feed
-                                    // has no new CVEs (changed=false), prepareFeedUpdateScan() is never
-                                    // called, so isFeedUpdateScanInProgress() is false and the VDSync
-                                    // scan must run.
+                                    // Skip the VDSync delta scan when feed-update scan is already running — it
+                                    // does a full package scan and covers this agent too. If the feed
+                                    // update had no new CVEs, feed-update scan never starts and we must scan here.
                                     const bool feedUpdateInProgress =
                                         VulnerabilityScannerFacade::instance().isFeedUpdateScanInProgress();
                                     const bool skipScan =
-                                        feedUpdateInProgress &&
-                                        res.context->option == Wazuh::SyncSchema::Option_VDSync;
-
-                                    logWarn(LOGGER_DEFAULT_TAG,
-                                            "[VDSYNC] Scan decision: agent=%s sessionId=%llu option=%s "
-                                            "waitedForFeed=%s feedUpdateInProgress=%s skipScan=%s — %s.",
-                                            res.context->agentId.c_str(),
-                                            res.context->sessionId,
-                                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                   : "VDFirst",
-                                            waitedForFeed ? "true" : "false",
-                                            feedUpdateInProgress ? "true" : "false",
-                                            skipScan ? "true" : "false",
-                                            skipScan ? "SKIPPED — feed-update full scan in progress, covers all packages"
-                                                     : "RUN — executing delta vulnerability scan now");
+                                        feedUpdateInProgress && res.context->option == Wazuh::SyncSchema::Option_VDSync;
 
                                     if (skipScan)
                                     {
@@ -1235,13 +1126,6 @@ public:
                                     }
                                     else
                                     {
-                                        logWarn(LOGGER_DEFAULT_TAG,
-                                                "[VDSYNC] Scan RUN START: agent=%s sessionId=%llu option=%s — "
-                                                "calling runScanner() with RocksDB delta packages.",
-                                                res.context->agentId.c_str(),
-                                                res.context->sessionId,
-                                                res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                        : "VDFirst");
                                         try
                                         {
                                             VulnerabilityScannerFacade::instance().runScanner(*m_dataStore,
@@ -1251,14 +1135,6 @@ public:
                                                 VulnerabilityScannerFacade::instance().registerFeedUpdateCoveredAgent(
                                                     res.context->agentId);
                                             }
-                                            logWarn(LOGGER_DEFAULT_TAG,
-                                                    "[VDSYNC] Scan RUN END: agent=%s sessionId=%llu option=%s — "
-                                                    "runScanner() completed successfully.",
-                                                    res.context->agentId.c_str(),
-                                                    res.context->sessionId,
-                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync
-                                                        ? "VDSync"
-                                                        : "VDFirst");
                                         }
                                         catch (const std::exception& e)
                                         {
@@ -1273,14 +1149,6 @@ public:
                                                                              res.context->moduleName);
                                             m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                                             eraseSession(res.context->sessionId);
-                                            logWarn(LOGGER_DEFAULT_TAG,
-                                                    "[VDSYNC] Session END (scanner-exception): agent=%s "
-                                                    "sessionId=%llu option=%s reason=%s",
-                                                    res.context->agentId.c_str(),
-                                                    res.context->sessionId,
-                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                            : "VDFirst",
-                                                    e.what());
                                             m_sessionCompletedCV.notify_all();
                                         }
                                     }
@@ -1322,17 +1190,6 @@ public:
                                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                                   ctx->sessionId);
                                     }
-                                    if (ctx->option == Wazuh::SyncSchema::Option_VDSync ||
-                                        ctx->option == Wazuh::SyncSchema::Option_VDFirst)
-                                    {
-                                        logWarn(LOGGER_DEFAULT_TAG,
-                                                "[VDSYNC] Session END (notify-callback): agent=%s sessionId=%llu "
-                                                "option=%s — OpenSearch ACKed the bulk; Status_Ok sent to agent; "
-                                                "RocksDB data deleted.",
-                                                ctx->agentId.c_str(),
-                                                ctx->sessionId,
-                                                ctx->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst");
-                                    }
                                     m_sessionCompletedCV.notify_all();
                                 });
                         }
@@ -1354,16 +1211,6 @@ public:
                                 logDebug2(LOGGER_DEFAULT_TAG,
                                           "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                           res.context->sessionId);
-                            }
-                            if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
-                                res.context->option == Wazuh::SyncSchema::Option_VDFirst)
-                            {
-                                logWarn(LOGGER_DEFAULT_TAG,
-                                        "[VDSYNC] Session END (immediate-response): agent=%s sessionId=%llu "
-                                        "option=%s — no bulk data; Status_Ok sent to agent immediately.",
-                                        res.context->agentId.c_str(),
-                                        res.context->sessionId,
-                                        res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst");
                             }
                             m_sessionCompletedCV.notify_all();
                         }
@@ -1399,17 +1246,6 @@ public:
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                   res.context->sessionId);
                     }
-                    if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
-                        res.context->option == Wazuh::SyncSchema::Option_VDFirst)
-                    {
-                        logWarn(LOGGER_DEFAULT_TAG,
-                                "[VDSYNC] Session END (InventorySyncException): agent=%s sessionId=%llu "
-                                "option=%s reason=%s",
-                                res.context->agentId.c_str(),
-                                res.context->sessionId,
-                                res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
-                                e.what());
-                    }
                     m_sessionCompletedCV.notify_all();
 
                     m_indexerConnector->invokePendingCallbacks();
@@ -1438,17 +1274,6 @@ public:
                         logDebug2(LOGGER_DEFAULT_TAG,
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                   res.context->sessionId);
-                    }
-                    if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
-                        res.context->option == Wazuh::SyncSchema::Option_VDFirst)
-                    {
-                        logWarn(LOGGER_DEFAULT_TAG,
-                                "[VDSYNC] Session END (exception): agent=%s sessionId=%llu "
-                                "option=%s reason=%s",
-                                res.context->agentId.c_str(),
-                                res.context->sessionId,
-                                res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
-                                e.what());
                     }
                     m_sessionCompletedCV.notify_all();
 
@@ -1654,14 +1479,16 @@ public:
     }
 
     /**
-     * @brief Wait until all active VDSync sessions across all agents have completed.
+     * @brief Wait for all in-progress VDSync sessions to finish before feed-update scan starts.
      *
-     * Called by the feed-update callback after the SAFU state flag is raised, so
-     * VDSync sessions in their scan-decision phase can self-skip and finish fast.
+     * Called from the feed-update callback after prepareFeedUpdateScan() sets the
+     * feed-update scan in-progress flag. VDSync sessions see that flag and self-skip, so they
+     * drain quickly. Iterates up to MAX_OUTER_ITERATIONS times in case new sessions
+     * started between loop iterations.
      *
-     * @param timeout    Maximum wait time per attempt (forwarded to hasActiveSessionForModule).
-     * @param maxRetries Retry count (forwarded to hasActiveSessionForModule).
-     * @return true  if at least one VDSync session was active.
+     * @param timeout    Per-agent wait timeout, forwarded to hasActiveSessionForModule.
+     * @param maxRetries Retry count, forwarded to hasActiveSessionForModule.
+     * @return true if at least one VDSync session was active (index refresh recommended).
      */
     bool waitForAllVDSyncSessions(std::chrono::seconds timeout, uint32_t maxRetries) const
     {
@@ -1686,14 +1513,19 @@ public:
     }
 
     /**
-     * @brief Check if a specific agent has an active session for a specific module.egardless of the session option.
+     * @brief Check whether an agent has an active session for the given module.
      *
-     * @param agentId    Agent ID to check
-     * @param moduleName Module name to check (e.g., "syscollector_vd")
-     * @param timeout    How long to wait per attempt for a VDSync session to finish (0 = no wait)
-     * @param maxRetries Maximum number of extra wait attempts after the first timeout (0 = no retry)
-     * @return true if a VDFirst session is active (caller should skip the scan);
-     *         false in all other cases (no session, or VDSync finished/timed out)
+     * VDFirst sessions return true immediately — feed-update scan should skip that agent
+     * because VDFirst already runs a full scan with the updated feed.
+     * VDSync sessions wait up to timeout × (maxRetries+1) seconds to finish,
+     * then return false so the scan proceeds with whatever data is available.
+     *
+     * @param agentId    Agent to check.
+     * @param moduleName Module to match (e.g. "syscollector_vd").
+     * @param timeout    Per-attempt wait timeout (zero = no wait).
+     * @param maxRetries Extra wait attempts after the first timeout.
+     * @return true  if a VDFirst session is live (feed-update scan should skip this agent);
+     *         false if no session exists or a VDSync session finished/timed out.
      */
     bool hasActiveSessionForModule(const std::string& agentId,
                                    const std::string& moduleName,
@@ -1709,7 +1541,7 @@ public:
             {
                 if (context->option == Wazuh::SyncSchema::Option_VDFirst)
                 {
-                    return true; // VDFirst: caller should skip
+                    return true; // VDFirst owns a full scan — feed-update scan should skip this agent
                 }
 
                 if (timeout > std::chrono::seconds(0))
@@ -1764,13 +1596,14 @@ public:
                     }
                 }
 
-                return false; // VDSync: proceed with the scan (waited or no-wait requested)
+                return false; // VDSync session finished (or timed out) — feed-update scan can proceed
             }
         }
 
-        return false; // no session
+        return false; // no matching session found
     }
 
+    // Always use this instead of erasing m_agentSessions directly — it holds the exclusive lock.
     size_t eraseSession(uint64_t sessionId)
     {
         std::unique_lock lock(m_agentSessionsMutex);
@@ -2038,7 +1871,7 @@ private:
     std::string m_clusterName;
     int m_maxSessions {1000}; // Maximum concurrent sessions (configured from internal_options)
     mutable std::shared_mutex m_agentSessionsMutex;
-    mutable std::condition_variable_any m_sessionCompletedCV; ///< Notified whenever a session is removed
+    mutable std::condition_variable_any m_sessionCompletedCV;
     std::mutex m_sessionTimeoutMutex;
     std::condition_variable m_sessionTimeoutCv;
     std::atomic<bool> m_stopping {false};

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -347,9 +347,9 @@ class InventorySyncFacadeImpl final
                         {
                             switch (startMsg->mode())
                             {
-                                case Wazuh::SyncSchema::Mode_ModuleFull:  return "ModuleFull";
+                                case Wazuh::SyncSchema::Mode_ModuleFull: return "ModuleFull";
                                 case Wazuh::SyncSchema::Mode_ModuleDelta: return "ModuleDelta";
-                                default:                                   return "Other";
+                                default: return "Other";
                             }
                         }();
                         logWarn(LOGGER_DEFAULT_TAG,
@@ -409,8 +409,7 @@ class InventorySyncFacadeImpl final
             else
             {
                 const auto& ctx = it->second.getContext();
-                if (ctx->option == Wazuh::SyncSchema::Option_VDSync ||
-                    ctx->option == Wazuh::SyncSchema::Option_VDFirst)
+                if (ctx->option == Wazuh::SyncSchema::Option_VDSync || ctx->option == Wazuh::SyncSchema::Option_VDFirst)
                 {
                     logWarn(LOGGER_DEFAULT_TAG,
                             "[VDSYNC] End message RECEIVED: agent=%s sessionId=%llu option=%s — "
@@ -682,9 +681,9 @@ public:
                     {
                         switch (res.context->mode)
                         {
-                            case Wazuh::SyncSchema::Mode_ModuleFull:  return "ModuleFull";
+                            case Wazuh::SyncSchema::Mode_ModuleFull: return "ModuleFull";
                             case Wazuh::SyncSchema::Mode_ModuleDelta: return "ModuleDelta";
-                            default:                                   return "Other";
+                            default: return "Other";
                         }
                     }();
                     logWarn(LOGGER_DEFAULT_TAG,
@@ -695,12 +694,15 @@ public:
                             res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
                             modeStr);
                 }
-                if (auto sessionIt = m_agentSessions.find(res.context->sessionId); sessionIt == m_agentSessions.end())
                 {
-                    logError(LOGGER_DEFAULT_TAG,
-                             "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                             res.context->sessionId);
-                    return;
+                    std::shared_lock sessionLock(m_agentSessionsMutex);
+                    if (m_agentSessions.find(res.context->sessionId) == m_agentSessions.end())
+                    {
+                        logError(LOGGER_DEFAULT_TAG,
+                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                 res.context->sessionId);
+                        return;
+                    }
                 }
 
                 try
@@ -772,7 +774,7 @@ public:
                                 m_responseDispatcher->sendEndAck(
                                     Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
                                 // Delete Session.
-                                if (m_agentSessions.erase(ctx->sessionId) == 0)
+                                if (eraseSession(ctx->sessionId) == 0)
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG,
                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -814,7 +816,7 @@ public:
                                 m_responseDispatcher->sendEndAck(
                                     Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
                                 // Delete Session.
-                                if (m_agentSessions.erase(ctx->sessionId) == 0)
+                                if (eraseSession(ctx->sessionId) == 0)
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG,
                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -847,7 +849,7 @@ public:
                                 m_responseDispatcher->sendEndAck(
                                     Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
                                 // Delete Session.
-                                if (m_agentSessions.erase(ctx->sessionId) == 0)
+                                if (eraseSession(ctx->sessionId) == 0)
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG,
                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -894,7 +896,7 @@ public:
                                 m_responseDispatcher->sendEndAck(
                                     Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
                                 // Delete Session.
-                                if (m_agentSessions.erase(ctx->sessionId) == 0)
+                                if (eraseSession(ctx->sessionId) == 0)
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG,
                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -1012,7 +1014,7 @@ public:
                                                              res.context->moduleName);
                         }
 
-                        if (m_agentSessions.erase(res.context->sessionId) == 0)
+                        if (eraseSession(res.context->sessionId) == 0)
                         {
                             logDebug2(LOGGER_DEFAULT_TAG,
                                       "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -1185,7 +1187,7 @@ public:
                                             res.context->agentId.c_str(),
                                             res.context->sessionId,
                                             res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                   : "VDFirst");
+                                                                                                    : "VDFirst");
                                     VulnerabilityScannerFacade::instance().waitForFeedReady();
                                     logWarn(LOGGER_DEFAULT_TAG,
                                             "[VDSYNC] Wait END: agent=%s sessionId=%llu option=%s — "
@@ -1193,7 +1195,7 @@ public:
                                             res.context->agentId.c_str(),
                                             res.context->sessionId,
                                             res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                   : "VDFirst");
+                                                                                                    : "VDFirst");
                                 }
 
                                 // Run scan only if the scanner was not stopped during the wait.
@@ -1239,11 +1241,11 @@ public:
                                                 res.context->agentId.c_str(),
                                                 res.context->sessionId,
                                                 res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                       : "VDFirst");
+                                                                                                        : "VDFirst");
                                         try
                                         {
-                                            VulnerabilityScannerFacade::instance().runScanner(
-                                                *m_dataStore, *res.context);
+                                            VulnerabilityScannerFacade::instance().runScanner(*m_dataStore,
+                                                                                              *res.context);
                                             if (res.context->option == Wazuh::SyncSchema::Option_VDFirst)
                                             {
                                                 VulnerabilityScannerFacade::instance().registerFeedUpdateCoveredAgent(
@@ -1254,8 +1256,9 @@ public:
                                                     "runScanner() completed successfully.",
                                                     res.context->agentId.c_str(),
                                                     res.context->sessionId,
-                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
-                                                                                                           : "VDFirst");
+                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync
+                                                        ? "VDSync"
+                                                        : "VDFirst");
                                         }
                                         catch (const std::exception& e)
                                         {
@@ -1269,15 +1272,14 @@ public:
                                                                              res.context->sessionId,
                                                                              res.context->moduleName);
                                             m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
-                                            m_agentSessions.erase(res.context->sessionId);
+                                            eraseSession(res.context->sessionId);
                                             logWarn(LOGGER_DEFAULT_TAG,
                                                     "[VDSYNC] Session END (scanner-exception): agent=%s "
                                                     "sessionId=%llu option=%s reason=%s",
                                                     res.context->agentId.c_str(),
                                                     res.context->sessionId,
-                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync
-                                                        ? "VDSync"
-                                                        : "VDFirst",
+                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
+                                                                                                            : "VDFirst",
                                                     e.what());
                                             m_sessionCompletedCV.notify_all();
                                         }
@@ -1314,7 +1316,7 @@ public:
                                     // Delete data from database.
                                     m_dataStore->deleteByPrefix(std::to_string(ctx->sessionId));
                                     // Delete Session.
-                                    if (m_agentSessions.erase(ctx->sessionId) == 0)
+                                    if (eraseSession(ctx->sessionId) == 0)
                                     {
                                         logDebug2(LOGGER_DEFAULT_TAG,
                                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -1347,7 +1349,7 @@ public:
                                                              res.context->sessionId,
                                                              res.context->moduleName);
                             m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
-                            if (m_agentSessions.erase(res.context->sessionId) == 0)
+                            if (eraseSession(res.context->sessionId) == 0)
                             {
                                 logDebug2(LOGGER_DEFAULT_TAG,
                                           "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -1391,7 +1393,7 @@ public:
                     // Delete data from database.
                     m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                     // Delete Session.
-                    if (m_agentSessions.erase(res.context->sessionId) == 0)
+                    if (eraseSession(res.context->sessionId) == 0)
                     {
                         logDebug2(LOGGER_DEFAULT_TAG,
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -1431,7 +1433,7 @@ public:
                     // Delete data from database.
                     m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                     // Delete Session.
-                    if (m_agentSessions.erase(res.context->sessionId) == 0)
+                    if (eraseSession(res.context->sessionId) == 0)
                     {
                         logDebug2(LOGGER_DEFAULT_TAG,
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
@@ -1659,10 +1661,13 @@ public:
      *
      * @param timeout    Maximum wait time per attempt (forwarded to hasActiveSessionForModule).
      * @param maxRetries Retry count (forwarded to hasActiveSessionForModule).
+     * @return true  if at least one VDSync session was active.
      */
-    void waitForAllVDSyncSessions(std::chrono::seconds timeout, uint32_t maxRetries) const
+    bool waitForAllVDSyncSessions(std::chrono::seconds timeout, uint32_t maxRetries) const
     {
-        while (true)
+        bool hadActiveSessions = false;
+        constexpr uint32_t MAX_OUTER_ITERATIONS = 3;
+        for (uint32_t i = 0; i < MAX_OUTER_ITERATIONS; ++i)
         {
             const auto vdSyncAgents =
                 getAgentsWithActiveSessionForModule("syscollector_vd", Wazuh::SyncSchema::Option_VDSync);
@@ -1671,11 +1676,13 @@ public:
                 break;
             }
 
+            hadActiveSessions = true;
             for (const auto& agentId : vdSyncAgents)
             {
                 hasActiveSessionForModule(agentId, "syscollector_vd", timeout, maxRetries);
             }
         }
+        return hadActiveSessions;
     }
 
     /**
@@ -1775,6 +1782,12 @@ public:
         }
 
         return false; // no session
+    }
+
+    size_t eraseSession(uint64_t sessionId)
+    {
+        std::unique_lock lock(m_agentSessionsMutex);
+        return m_agentSessions.erase(sessionId);
     }
 
     /**

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1123,6 +1123,7 @@ public:
                                                                          res.context->moduleName);
                                         m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                                         m_agentSessions.erase(res.context->sessionId);
+                                        m_sessionCompletedCV.notify_all();
                                     }
                                 }
                                 else
@@ -1162,6 +1163,7 @@ public:
                                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                                   ctx->sessionId);
                                     }
+                                    m_sessionCompletedCV.notify_all();
                                 });
                         }
                         else
@@ -1183,6 +1185,7 @@ public:
                                           "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                           res.context->sessionId);
                             }
+                            m_sessionCompletedCV.notify_all();
                         }
                     } // End of else block for non-MetadataDelta/GroupDelta modes
 
@@ -1216,6 +1219,7 @@ public:
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                   res.context->sessionId);
                     }
+                    m_sessionCompletedCV.notify_all();
 
                     m_indexerConnector->invokePendingCallbacks();
                 }
@@ -1244,6 +1248,7 @@ public:
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                   res.context->sessionId);
                     }
+                    m_sessionCompletedCV.notify_all();
 
                     m_indexerConnector->invokePendingCallbacks();
                 }
@@ -1295,6 +1300,7 @@ public:
                                       }
                                       return false;
                                   });
+                    m_sessionCompletedCV.notify_all();
                 }
             });
 
@@ -1432,6 +1438,71 @@ public:
             }
         }
         return false;
+    }
+
+    /**
+     * @brief Information about an active session for a given agent and module
+     */
+    struct ActiveSessionInfo
+    {
+        bool active {false};   ///< Whether a session exists
+        bool isVDFirst {false}; ///< Whether the session option is VDFirst
+    };
+
+    /**
+     * @brief Check if a specific agent has an active session for a specific module and return its type
+     * @param agentId Agent ID to check
+     * @param moduleName Module name to check (e.g., "syscollector_vd")
+     * @return ActiveSessionInfo with active=false when no session exists, or active=true with the session type
+     */
+    ActiveSessionInfo getActiveSessionInfoForModule(const std::string& agentId,
+                                                    const std::string& moduleName) const
+    {
+        std::shared_lock lock(m_agentSessionsMutex);
+
+        for (const auto& [sessionId, session] : m_agentSessions)
+        {
+            const auto& context = session.getContext();
+            if (context->agentId == agentId && context->moduleName == moduleName)
+            {
+                return {true, context->option == Wazuh::SyncSchema::Option_VDFirst};
+            }
+        }
+        return {false, false};
+    }
+
+    /**
+     * @brief Wait until the active syscollector_vd session for an agent finishes.
+     *
+     * Blocks the calling thread using a condition variable that is notified every time a
+     * session is removed from m_agentSessions. The wait returns as soon as the session
+     * for the given agent+module is gone, or when the timeout expires.
+     *
+     * @param agentId Agent ID to wait for
+     * @param moduleName Module name (e.g., "syscollector_vd")
+     * @param timeout Maximum time to wait
+     * @return true if the session completed before the timeout, false if timed out
+     */
+    bool waitForSessionCompletion(const std::string& agentId,
+                                  const std::string& moduleName,
+                                  std::chrono::seconds timeout) const
+    {
+        std::shared_lock lock(m_agentSessionsMutex);
+        return m_sessionCompletedCV.wait_for(lock,
+                                             timeout,
+                                             [&]()
+                                             {
+                                                 for (const auto& [sessionId, session] : m_agentSessions)
+                                                 {
+                                                     const auto& context = session.getContext();
+                                                     if (context->agentId == agentId
+                                                         && context->moduleName == moduleName)
+                                                     {
+                                                         return false; // still active
+                                                     }
+                                                 }
+                                                 return true; // session gone
+                                             });
     }
 
     /**
@@ -1693,6 +1764,7 @@ private:
     std::string m_clusterName;
     int m_maxSessions {1000}; // Maximum concurrent sessions (configured from internal_options)
     mutable std::shared_mutex m_agentSessionsMutex;
+    mutable std::condition_variable_any m_sessionCompletedCV; ///< Notified whenever a session is removed
     std::mutex m_sessionTimeoutMutex;
     std::condition_variable m_sessionTimeoutCv;
     std::atomic<bool> m_stopping {false};

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1420,12 +1420,26 @@ public:
     }
 
     /**
-     * @brief Check if a specific agent has an active session for a specific module
-     * @param agentId Agent ID to check
+     * @brief Check if a specific agent has an active session for a specific module.
+     *
+     * When called from a feed-update scan context (timeout > 0):
+     *   - VDFirst session: returns true immediately so the caller can skip the redundant
+     *     feed-update scan (the first-scan itself will cover the updated feed).
+     *   - VDSync session:  blocks until the session ends or the timeout expires, then
+     *     returns false so the caller proceeds with the feed-update scan.
+     *
+     * When called without a timeout (default): behaves as a plain existence check and
+     * returns true if any session matches, regardless of the session option.
+     *
+     * @param agentId    Agent ID to check
      * @param moduleName Module name to check (e.g., "syscollector_vd")
-     * @return true if the agent has an active session for the module, false otherwise
+     * @param timeout    How long to wait for a VDSync session to finish (0 = no wait)
+     * @return true if a VDFirst session is active (caller should skip the scan);
+     *         false in all other cases (no session, or VDSync finished/timed out)
      */
-    bool hasActiveSessionForModule(const std::string& agentId, const std::string& moduleName) const
+    bool hasActiveSessionForModule(const std::string& agentId,
+                                   const std::string& moduleName,
+                                   std::chrono::seconds timeout) const
     {
         std::shared_lock lock(m_agentSessionsMutex);
 
@@ -1434,75 +1448,51 @@ public:
             const auto& context = session.getContext();
             if (context->agentId == agentId && context->moduleName == moduleName)
             {
-                return true;
+                if (context->option == Wazuh::SyncSchema::Option_VDFirst)
+                {
+                    return true; // VDFirst: caller should skip
+                }
+
+                if (timeout > std::chrono::seconds(0))
+                {
+                    // VDSync: wait for the session to finish before the feed-update scan reads
+                    // the indexer, so all packages are in a consistent state.
+                    logInfo(LOGGER_DEFAULT_TAG,
+                            "Feed update scan waiting for VDSync session to complete for agent %s (timeout: %lds).",
+                            agentId.c_str(),
+                            static_cast<long>(timeout.count()));
+
+                    const bool completed =
+                        m_sessionCompletedCV.wait_for(lock,
+                                                      timeout,
+                                                      [&]()
+                                                      {
+                                                          for (const auto& [sId, s] : m_agentSessions)
+                                                          {
+                                                              if (s.getContext()->agentId == agentId
+                                                                  && s.getContext()->moduleName == moduleName)
+                                                              {
+                                                                  return false; // still active
+                                                              }
+                                                          }
+                                                          return true; // session gone
+                                                      });
+
+                    if (!completed)
+                    {
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
+                                "Proceeding with current indexer data.",
+                                agentId.c_str(),
+                                static_cast<long>(timeout.count()));
+                    }
+                }
+
+                return false; // VDSync: proceed with the scan (waited or no-wait requested)
             }
         }
-        return false;
-    }
 
-    /**
-     * @brief Information about an active session for a given agent and module
-     */
-    struct ActiveSessionInfo
-    {
-        bool active {false};   ///< Whether a session exists
-        bool isVDFirst {false}; ///< Whether the session option is VDFirst
-    };
-
-    /**
-     * @brief Check if a specific agent has an active session for a specific module and return its type
-     * @param agentId Agent ID to check
-     * @param moduleName Module name to check (e.g., "syscollector_vd")
-     * @return ActiveSessionInfo with active=false when no session exists, or active=true with the session type
-     */
-    ActiveSessionInfo getActiveSessionInfoForModule(const std::string& agentId,
-                                                    const std::string& moduleName) const
-    {
-        std::shared_lock lock(m_agentSessionsMutex);
-
-        for (const auto& [sessionId, session] : m_agentSessions)
-        {
-            const auto& context = session.getContext();
-            if (context->agentId == agentId && context->moduleName == moduleName)
-            {
-                return {true, context->option == Wazuh::SyncSchema::Option_VDFirst};
-            }
-        }
-        return {false, false};
-    }
-
-    /**
-     * @brief Wait until the active syscollector_vd session for an agent finishes.
-     *
-     * Blocks the calling thread using a condition variable that is notified every time a
-     * session is removed from m_agentSessions. The wait returns as soon as the session
-     * for the given agent+module is gone, or when the timeout expires.
-     *
-     * @param agentId Agent ID to wait for
-     * @param moduleName Module name (e.g., "syscollector_vd")
-     * @param timeout Maximum time to wait
-     * @return true if the session completed before the timeout, false if timed out
-     */
-    bool waitForSessionCompletion(const std::string& agentId,
-                                  const std::string& moduleName,
-                                  std::chrono::seconds timeout) const
-    {
-        std::shared_lock lock(m_agentSessionsMutex);
-        return m_sessionCompletedCV.wait_for(lock,
-                                             timeout,
-                                             [&]()
-                                             {
-                                                 for (const auto& [sessionId, session] : m_agentSessions)
-                                                 {
-                                                     const auto& context = session.getContext();
-                                                     if (context->agentId == agentId
-                                                         && context->moduleName == moduleName)
-                                                     {
-                                                         return false; // still active
-                                                     }
-                                                 }
-                                                 return true; // session gone
-                                             });
+        return false; // no session
     }
 
     /**

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1686,18 +1686,7 @@ public:
     }
 
     /**
-     * @brief Check if a specific agent has an active session for a specific module.
-     *
-     * When called from a feed-update scan context (timeout > 0):
-     *   - VDFirst session: returns true immediately so the caller can skip the redundant
-     *     feed-update scan (the first-scan itself will cover the updated feed).
-     *   - VDSync session:  blocks until the session ends or the timeout expires, then
-     *     returns false so the caller proceeds with the feed-update scan.
-     *     If the session does not finish within the timeout, the wait is retried up to
-     *     maxRetries additional times before giving up.
-     *
-     * When called without a timeout (default): behaves as a plain existence check and
-     * returns true if any session matches, regardless of the session option.
+     * @brief Check if a specific agent has an active session for a specific module.egardless of the session option.
      *
      * @param agentId    Agent ID to check
      * @param moduleName Module name to check (e.g., "syscollector_vd")
@@ -1725,8 +1714,6 @@ public:
 
                 if (timeout > std::chrono::seconds(0))
                 {
-                    // VDSync: wait for the session to finish before the feed-update scan reads
-                    // the indexer, so all packages are in a consistent state.
                     logInfo(LOGGER_DEFAULT_TAG,
                             "Feed update scan waiting for VDSync session to complete for agent %s "
                             "(timeout: %lds, max retries: %u).",

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -337,6 +337,31 @@ class InventorySyncFacadeImpl final
                     m_agentSessions.try_emplace(
                         sessionId, sessionId, startMsg, *m_dataStore, *m_indexerQueue, *m_responseDispatcher);
                     logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Session created %llu", sessionId);
+
+                    if (startMsg->option() == Wazuh::SyncSchema::Option_VDSync ||
+                        startMsg->option() == Wazuh::SyncSchema::Option_VDFirst)
+                    {
+                        const char* optStr =
+                            startMsg->option() == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst";
+                        const char* modeStr = [&]() -> const char*
+                        {
+                            switch (startMsg->mode())
+                            {
+                                case Wazuh::SyncSchema::Mode_ModuleFull:  return "ModuleFull";
+                                case Wazuh::SyncSchema::Mode_ModuleDelta: return "ModuleDelta";
+                                default:                                   return "Other";
+                            }
+                        }();
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "[VDSYNC] Session CREATED: agent=%s module=%s option=%s mode=%s "
+                                "size=%llu sessionId=%llu — Start ACK (Status_Ok) sent to agent.",
+                                agentIdStr.c_str(),
+                                moduleNameStr.c_str(),
+                                optStr,
+                                modeStr,
+                                static_cast<unsigned long long>(startMsg->size()),
+                                sessionId);
+                    }
                 }
             }
         }
@@ -383,6 +408,18 @@ class InventorySyncFacadeImpl final
             }
             else
             {
+                const auto& ctx = it->second.getContext();
+                if (ctx->option == Wazuh::SyncSchema::Option_VDSync ||
+                    ctx->option == Wazuh::SyncSchema::Option_VDFirst)
+                {
+                    logWarn(LOGGER_DEFAULT_TAG,
+                            "[VDSYNC] End message RECEIVED: agent=%s sessionId=%llu option=%s — "
+                            "agent finished sending all packages; session queued for indexing "
+                            "(Status_Processing sent to agent).",
+                            ctx->agentId.c_str(),
+                            ctx->sessionId,
+                            ctx->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst");
+                }
                 // Handle end.
                 it->second.handleEnd(*m_responseDispatcher);
                 logDebug2(
@@ -638,6 +675,26 @@ public:
             [this](const Response& res)
             {
                 logDebug2(LOGGER_DEFAULT_TAG, "Indexer queue action...");
+                if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
+                    res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                {
+                    const char* modeStr = [&]() -> const char*
+                    {
+                        switch (res.context->mode)
+                        {
+                            case Wazuh::SyncSchema::Mode_ModuleFull:  return "ModuleFull";
+                            case Wazuh::SyncSchema::Mode_ModuleDelta: return "ModuleDelta";
+                            default:                                   return "Other";
+                        }
+                    }();
+                    logWarn(LOGGER_DEFAULT_TAG,
+                            "[VDSYNC] IndexerQueue PROCESSING: agent=%s sessionId=%llu option=%s mode=%s — "
+                            "all packages received; starting bulk indexing to OpenSearch.",
+                            res.context->agentId.c_str(),
+                            res.context->sessionId,
+                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
+                            modeStr);
+                }
                 if (auto sessionIt = m_agentSessions.find(res.context->sessionId); sessionIt == m_agentSessions.end())
                 {
                     logError(LOGGER_DEFAULT_TAG,
@@ -1093,6 +1150,15 @@ public:
                         if (res.context->option == Wazuh::SyncSchema::Option_VDFirst ||
                             res.context->option == Wazuh::SyncSchema::Option_VDSync)
                         {
+                            logWarn(LOGGER_DEFAULT_TAG,
+                                    "[VDSYNC] Packages INDEXED: agent=%s sessionId=%llu option=%s "
+                                    "hasBulkData=%s — packages queued for bulk send to OpenSearch "
+                                    "(notify-callback will fire when OpenSearch ACKs the bulk).",
+                                    res.context->agentId.c_str(),
+                                    res.context->sessionId,
+                                    res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
+                                    hasBulkData ? "true" : "false");
+
                             if (VulnerabilityScannerFacade::instance().isInitialized())
                             {
                                 // If the CVE feed initial load is still in progress, block this
@@ -1100,39 +1166,95 @@ public:
                                 // The agent stays in Status_Processing — already sent at End-message
                                 // time — so it will not mark its VDFirst flag prematurely.
                                 bool waitedForFeed = false;
-                                if (!VulnerabilityScannerFacade::instance().isFeedReady())
+                                const bool feedReadyNow = VulnerabilityScannerFacade::instance().isFeedReady();
+                                logWarn(LOGGER_DEFAULT_TAG,
+                                        "[VDSYNC] Feed check: agent=%s sessionId=%llu option=%s "
+                                        "isFeedReady=%s — %s.",
+                                        res.context->agentId.c_str(),
+                                        res.context->sessionId,
+                                        res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
+                                        feedReadyNow ? "true" : "false",
+                                        feedReadyNow ? "proceeding directly to scan decision"
+                                                     : "CVE feed not ready, this thread will block");
+                                if (!feedReadyNow)
                                 {
                                     waitedForFeed = true;
-                                    logDebug1(LOGGER_DEFAULT_TAG,
-                                              "InventorySyncFacade: CVE feed not yet loaded — agent %s waiting.",
-                                              res.context->agentId.c_str());
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "[VDSYNC] Wait START: agent=%s sessionId=%llu option=%s — "
+                                            "blocking IndexerQueue thread until CVE feed is ready.",
+                                            res.context->agentId.c_str(),
+                                            res.context->sessionId,
+                                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
+                                                                                                   : "VDFirst");
                                     VulnerabilityScannerFacade::instance().waitForFeedReady();
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "[VDSYNC] Wait END: agent=%s sessionId=%llu option=%s — "
+                                            "CVE feed ready, resuming.",
+                                            res.context->agentId.c_str(),
+                                            res.context->sessionId,
+                                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
+                                                                                                   : "VDFirst");
                                 }
 
                                 // Run scan only if the scanner was not stopped during the wait.
                                 if (VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
-
+                                    // Skip VDSync delta scan when a feed-update full scan is already
+                                    // covering all packages — either because this session waited for the
+                                    // initial feed load (the feed-update scan fires right after) or
+                                    // because a feed-update full scan is currently in progress.
+                                    const bool feedUpdateInProgress =
+                                        VulnerabilityScannerFacade::instance().isFeedUpdateScanInProgress();
                                     const bool skipScan =
-                                        waitedForFeed && res.context->option == Wazuh::SyncSchema::Option_VDSync;
+                                        (waitedForFeed || feedUpdateInProgress) &&
+                                        res.context->option == Wazuh::SyncSchema::Option_VDSync;
+
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "[VDSYNC] Scan decision: agent=%s sessionId=%llu option=%s "
+                                            "waitedForFeed=%s feedUpdateInProgress=%s skipScan=%s — %s.",
+                                            res.context->agentId.c_str(),
+                                            res.context->sessionId,
+                                            res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
+                                                                                                   : "VDFirst",
+                                            waitedForFeed ? "true" : "false",
+                                            feedUpdateInProgress ? "true" : "false",
+                                            skipScan ? "true" : "false",
+                                            skipScan
+                                                ? (waitedForFeed
+                                                       ? "SKIPPED — waited for feed, feed-update full scan covers all packages"
+                                                       : "SKIPPED — feed-update full scan in progress, covers all packages")
+                                                : "RUN — executing delta vulnerability scan now");
 
                                     if (skipScan)
                                     {
                                         logInfo(LOGGER_DEFAULT_TAG,
                                                 "InventorySyncFacade: Skipping VDSync scan for agent %s — "
-                                                "feed-update full scan will cover all packages.",
-                                                res.context->agentId.c_str());
+                                                "%s.",
+                                                res.context->agentId.c_str(),
+                                                waitedForFeed
+                                                    ? "feed-update full scan will cover all packages"
+                                                    : "feed-update full scan in progress, covers all packages");
                                     }
                                     else
                                     {
-                                        logDebug2(LOGGER_DEFAULT_TAG,
-                                                  "InventorySyncFacade: Running vulnerability scanner for agent "
-                                                  "%s...",
-                                                  res.context->agentId.c_str());
+                                        logWarn(LOGGER_DEFAULT_TAG,
+                                                "[VDSYNC] Scan RUN START: agent=%s sessionId=%llu option=%s — "
+                                                "calling runScanner() with RocksDB delta packages.",
+                                                res.context->agentId.c_str(),
+                                                res.context->sessionId,
+                                                res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
+                                                                                                       : "VDFirst");
                                         try
                                         {
-                                            VulnerabilityScannerFacade::instance().runScanner(*m_dataStore,
-                                                                                              *res.context);
+                                            VulnerabilityScannerFacade::instance().runScanner(
+                                                *m_dataStore, *res.context);
+                                            logWarn(LOGGER_DEFAULT_TAG,
+                                                    "[VDSYNC] Scan RUN END: agent=%s sessionId=%llu option=%s — "
+                                                    "runScanner() completed successfully.",
+                                                    res.context->agentId.c_str(),
+                                                    res.context->sessionId,
+                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync"
+                                                                                                           : "VDFirst");
                                         }
                                         catch (const std::exception& e)
                                         {
@@ -1147,6 +1269,15 @@ public:
                                                                              res.context->moduleName);
                                             m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                                             m_agentSessions.erase(res.context->sessionId);
+                                            logWarn(LOGGER_DEFAULT_TAG,
+                                                    "[VDSYNC] Session END (scanner-exception): agent=%s "
+                                                    "sessionId=%llu option=%s reason=%s",
+                                                    res.context->agentId.c_str(),
+                                                    res.context->sessionId,
+                                                    res.context->option == Wazuh::SyncSchema::Option_VDSync
+                                                        ? "VDSync"
+                                                        : "VDFirst",
+                                                    e.what());
                                             m_sessionCompletedCV.notify_all();
                                         }
                                     }
@@ -1188,6 +1319,17 @@ public:
                                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                                   ctx->sessionId);
                                     }
+                                    if (ctx->option == Wazuh::SyncSchema::Option_VDSync ||
+                                        ctx->option == Wazuh::SyncSchema::Option_VDFirst)
+                                    {
+                                        logWarn(LOGGER_DEFAULT_TAG,
+                                                "[VDSYNC] Session END (notify-callback): agent=%s sessionId=%llu "
+                                                "option=%s — OpenSearch ACKed the bulk; Status_Ok sent to agent; "
+                                                "RocksDB data deleted.",
+                                                ctx->agentId.c_str(),
+                                                ctx->sessionId,
+                                                ctx->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst");
+                                    }
                                     m_sessionCompletedCV.notify_all();
                                 });
                         }
@@ -1209,6 +1351,16 @@ public:
                                 logDebug2(LOGGER_DEFAULT_TAG,
                                           "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                           res.context->sessionId);
+                            }
+                            if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
+                                res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                            {
+                                logWarn(LOGGER_DEFAULT_TAG,
+                                        "[VDSYNC] Session END (immediate-response): agent=%s sessionId=%llu "
+                                        "option=%s — no bulk data; Status_Ok sent to agent immediately.",
+                                        res.context->agentId.c_str(),
+                                        res.context->sessionId,
+                                        res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst");
                             }
                             m_sessionCompletedCV.notify_all();
                         }
@@ -1244,6 +1396,17 @@ public:
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                   res.context->sessionId);
                     }
+                    if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
+                        res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                    {
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "[VDSYNC] Session END (InventorySyncException): agent=%s sessionId=%llu "
+                                "option=%s reason=%s",
+                                res.context->agentId.c_str(),
+                                res.context->sessionId,
+                                res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
+                                e.what());
+                    }
                     m_sessionCompletedCV.notify_all();
 
                     m_indexerConnector->invokePendingCallbacks();
@@ -1272,6 +1435,17 @@ public:
                         logDebug2(LOGGER_DEFAULT_TAG,
                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                   res.context->sessionId);
+                    }
+                    if (res.context->option == Wazuh::SyncSchema::Option_VDSync ||
+                        res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                    {
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "[VDSYNC] Session END (exception): agent=%s sessionId=%llu "
+                                "option=%s reason=%s",
+                                res.context->agentId.c_str(),
+                                res.context->sessionId,
+                                res.context->option == Wazuh::SyncSchema::Option_VDSync ? "VDSync" : "VDFirst",
+                                e.what());
                     }
                     m_sessionCompletedCV.notify_all();
 
@@ -1442,6 +1616,50 @@ public:
             }
         }
         return count;
+    }
+
+    /**
+     * @brief Wait until all active VDSync sessions across all agents have completed.
+     *
+     * Called by the feed-update callback BEFORE it acquires m_internalMutex, avoiding
+     * the deadlock where feedUpdate holds that mutex while waiting for a VDSync session
+     * that is itself blocked trying to acquire the same mutex.
+     *
+     * Because VulnerabilityScannerFacade::m_feedUpdateScanInProgress is set before
+     * this is called, VDSync sessions in their scan-decision phase will skip their scan
+     * and end quickly, so each hasActiveSessionForModule call below returns fast.
+     *
+     * @param timeout    Maximum wait time per attempt (forwarded to hasActiveSessionForModule).
+     * @param maxRetries Retry count (forwarded to hasActiveSessionForModule).
+     */
+    void waitForAllVDSyncSessions(std::chrono::seconds timeout, uint32_t maxRetries) const
+    {
+        while (true)
+        {
+            std::vector<std::string> vdSyncAgents;
+            {
+                std::shared_lock lock(m_agentSessionsMutex);
+                for (const auto& [id, session] : m_agentSessions)
+                {
+                    const auto& ctx = session.getContext();
+                    if (ctx->moduleName == "syscollector_vd" &&
+                        ctx->option == Wazuh::SyncSchema::Option_VDSync)
+                    {
+                        vdSyncAgents.push_back(ctx->agentId);
+                    }
+                }
+            }
+
+            if (vdSyncAgents.empty())
+            {
+                break;
+            }
+
+            for (const auto& agentId : vdSyncAgents)
+            {
+                hasActiveSessionForModule(agentId, "syscollector_vd", timeout, maxRetries);
+            }
+        }
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -308,9 +308,6 @@ private:
             }
         } agentUnlockGuard {agent.id, agentLocked};
 
-        // If a VDFirst session is active, skip the feed-update scan — the first scan will
-        // cover the updated feed. For VDSync, wait for the session to finish so the indexer
-        // data is fully consistent before the feed-update full scan reads all packages.
         constexpr auto WAIT_TIMEOUT = std::chrono::seconds(60);
         constexpr uint32_t WAIT_MAX_RETRIES = 2;
         if (InventorySyncFacade::instance().hasActiveSessionForModule(

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -38,10 +38,12 @@ class TScanAgentList final : public AbstractHandler<std::shared_ptr<TScanContext
 {
 public:
     using ScanRunner = std::function<void(std::shared_ptr<TScanContext>)>;
+    using SkipAgentPredicate = std::function<bool(const std::string&)>;
 
 private:
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
     ScanRunner m_scanRunner;
+    SkipAgentPredicate m_shouldSkipAgent;
     static constexpr size_t DEFAULT_PAGE_SIZE = 1000;
 
     static nlohmann::json buildInventoryQuery(const std::string& agentId,
@@ -283,6 +285,29 @@ private:
 
     void scanAgent(const AgentContextData& agent, const bool noIndex) const
     {
+        if (m_shouldSkipAgent && m_shouldSkipAgent(agent.id))
+        {
+            logWarn(WM_VULNSCAN_LOGTAG,
+                    "Skipping feed update scan for agent %s: current SAFU cycle is already covered by VDFirst.",
+                    agent.id.c_str());
+            return;
+        }
+
+        const bool agentLocked =
+            InventorySyncFacade::instance().lockAgent(agent.id, "Feed update full scan in progress");
+        struct AgentUnlockGuard
+        {
+            std::string agentId;
+            bool locked {false};
+            ~AgentUnlockGuard()
+            {
+                if (locked)
+                {
+                    InventorySyncFacade::instance().unlockAgent(agentId);
+                }
+            }
+        } agentUnlockGuard {agent.id, agentLocked};
+
         // If a VDFirst session is active, skip the feed-update scan — the first scan will
         // cover the updated feed. For VDSync, wait for the session to finish so the indexer
         // data is fully consistent before the feed-update full scan reads all packages.
@@ -418,10 +443,14 @@ public:
      *
      * @param indexerConnector Indexer connector instance.
      * @param scanRunner Function that executes the scan for a prepared ScanContext.
+     * @param shouldSkipAgent Optional predicate to skip agents already covered by the current SAFU cycle.
      */
-    explicit TScanAgentList(std::shared_ptr<TIndexerConnector> indexerConnector, ScanRunner scanRunner)
+    explicit TScanAgentList(std::shared_ptr<TIndexerConnector> indexerConnector,
+                            ScanRunner scanRunner,
+                            SkipAgentPredicate shouldSkipAgent = {})
         : m_indexerConnector(std::move(indexerConnector))
         , m_scanRunner(std::move(scanRunner))
+        , m_shouldSkipAgent(std::move(shouldSkipAgent))
     {
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -286,9 +286,10 @@ private:
         // If a VDFirst session is active, skip the feed-update scan — the first scan will
         // cover the updated feed. For VDSync, wait for the session to finish so the indexer
         // data is fully consistent before the feed-update full scan reads all packages.
-        constexpr auto WAIT_TIMEOUT = std::chrono::seconds(300);
+        constexpr auto WAIT_TIMEOUT = std::chrono::seconds(60);
+        constexpr uint32_t WAIT_MAX_RETRIES = 2;
         if (InventorySyncFacade::instance().hasActiveSessionForModule(
-                agent.id, "syscollector_vd", WAIT_TIMEOUT))
+                agent.id, "syscollector_vd", WAIT_TIMEOUT, WAIT_MAX_RETRIES))
         {
             logWarn(WM_VULNSCAN_LOGTAG,
                     "Skipping feed update scan for agent %s: VDFirst session active. "

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -285,14 +285,17 @@ private:
 
     void scanAgent(const AgentContextData& agent, const bool noIndex) const
     {
+        // Skip agents already covered by a concurrent VDFirst session in this post feed update scan cycle.
         if (m_shouldSkipAgent && m_shouldSkipAgent(agent.id))
         {
-            logWarn(WM_VULNSCAN_LOGTAG,
-                    "Skipping feed update scan for agent %s: current SAFU cycle is already covered by VDFirst.",
+            logInfo(WM_VULNSCAN_LOGTAG,
+                    "Skipping feed update scan for agent %s: already covered by VDFirst.",
                     agent.id.c_str());
             return;
         }
 
+        // Lock the agent to block new inventory sessions while we scan.
+        // The lock is released via RAII when this function returns.
         const bool agentLocked =
             InventorySyncFacade::instance().lockAgent(agent.id, "Feed update full scan in progress");
         struct AgentUnlockGuard
@@ -308,14 +311,16 @@ private:
             }
         } agentUnlockGuard {agent.id, agentLocked};
 
+        // Wait for any active VDFirst/VDSync session to finish before scanning.
+        // VDFirst returns true immediately — it owns a full scan, so we skip.
+        // VDSync waits up to the timeout, then we proceed with current indexer data.
         constexpr auto WAIT_TIMEOUT = std::chrono::seconds(60);
         constexpr uint32_t WAIT_MAX_RETRIES = 2;
         if (InventorySyncFacade::instance().hasActiveSessionForModule(
                 agent.id, "syscollector_vd", WAIT_TIMEOUT, WAIT_MAX_RETRIES))
         {
-            logWarn(WM_VULNSCAN_LOGTAG,
-                    "Skipping feed update scan for agent %s: VDFirst session active. "
-                    "First scan will cover the updated feed.",
+            logInfo(WM_VULNSCAN_LOGTAG,
+                    "Skipping feed update scan for agent %s: VDFirst session active, it covers the updated feed.",
                     agent.id.c_str());
             return;
         }
@@ -440,7 +445,8 @@ public:
      *
      * @param indexerConnector Indexer connector instance.
      * @param scanRunner Function that executes the scan for a prepared ScanContext.
-     * @param shouldSkipAgent Optional predicate to skip agents already covered by the current SAFU cycle.
+     * @param shouldSkipAgent Optional predicate to skip agents already covered by the current post feed update scan
+     * cycle.
      */
     explicit TScanAgentList(std::shared_ptr<TIndexerConnector> indexerConnector,
                             ScanRunner scanRunner,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -20,6 +20,7 @@
 #include "loggerHelper.h"
 #include "scanContext.hpp"
 #include "stringHelper.h"
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -282,15 +283,44 @@ private:
 
     void scanAgent(const AgentContextData& agent, const bool noIndex) const
     {
-        // Skip if agent has active syscollector_vd session to avoid race condition.
-        // VDFirst/VDSync may still be indexing inventory data while feed update scan queries it.
-        if (InventorySyncFacade::instance().hasActiveSessionForModule(agent.id, "syscollector_vd"))
+        // If a syscollector_vd session is active the agent is still indexing inventory data.
+        // Behaviour depends on the session type:
+        //   - VDFirst: skip entirely — it will perform a full scan once indexing is done,
+        //              so a redundant feed-update scan would produce identical results.
+        //   - VDSync:  wait for the session to finish before scanning. A VDSync delta only
+        //              covers changed packages; running the feed-update full scan afterwards
+        //              ensures that unchanged packages are also checked against new CVEs.
+        const auto sessionInfo =
+            InventorySyncFacade::instance().getActiveSessionInfoForModule(agent.id, "syscollector_vd");
+        if (sessionInfo.active)
         {
-            logWarn(WM_VULNSCAN_LOGTAG,
-                    "Skipping vulnerability scan for agent %s: syscollector_vd session active. Agent inventory may "
-                    "still be indexing.",
+            if (sessionInfo.isVDFirst)
+            {
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Skipping feed update scan for agent %s: VDFirst session active. "
+                        "First scan will cover the updated feed.",
+                        agent.id.c_str());
+                return;
+            }
+
+            // VDSync session active: wait for it to complete so the indexer data is
+            // fully consistent before the feed-update full scan reads it.
+            logInfo(WM_VULNSCAN_LOGTAG,
+                    "Waiting for VDSync session to complete for agent %s before running feed update scan.",
                     agent.id.c_str());
-            return;
+
+            constexpr auto WAIT_TIMEOUT = std::chrono::seconds(300);
+            const bool completed = InventorySyncFacade::instance().waitForSessionCompletion(
+                agent.id, "syscollector_vd", WAIT_TIMEOUT);
+
+            if (!completed)
+            {
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Timeout waiting for VDSync session for agent %s (%lds). "
+                        "Running feed update scan with current indexer data.",
+                        agent.id.c_str(),
+                        static_cast<long>(WAIT_TIMEOUT.count()));
+            }
         }
 
         OsContextData osData;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -283,44 +283,18 @@ private:
 
     void scanAgent(const AgentContextData& agent, const bool noIndex) const
     {
-        // If a syscollector_vd session is active the agent is still indexing inventory data.
-        // Behaviour depends on the session type:
-        //   - VDFirst: skip entirely — it will perform a full scan once indexing is done,
-        //              so a redundant feed-update scan would produce identical results.
-        //   - VDSync:  wait for the session to finish before scanning. A VDSync delta only
-        //              covers changed packages; running the feed-update full scan afterwards
-        //              ensures that unchanged packages are also checked against new CVEs.
-        const auto sessionInfo =
-            InventorySyncFacade::instance().getActiveSessionInfoForModule(agent.id, "syscollector_vd");
-        if (sessionInfo.active)
+        // If a VDFirst session is active, skip the feed-update scan — the first scan will
+        // cover the updated feed. For VDSync, wait for the session to finish so the indexer
+        // data is fully consistent before the feed-update full scan reads all packages.
+        constexpr auto WAIT_TIMEOUT = std::chrono::seconds(300);
+        if (InventorySyncFacade::instance().hasActiveSessionForModule(
+                agent.id, "syscollector_vd", WAIT_TIMEOUT))
         {
-            if (sessionInfo.isVDFirst)
-            {
-                logWarn(WM_VULNSCAN_LOGTAG,
-                        "Skipping feed update scan for agent %s: VDFirst session active. "
-                        "First scan will cover the updated feed.",
-                        agent.id.c_str());
-                return;
-            }
-
-            // VDSync session active: wait for it to complete so the indexer data is
-            // fully consistent before the feed-update full scan reads it.
-            logInfo(WM_VULNSCAN_LOGTAG,
-                    "Waiting for VDSync session to complete for agent %s before running feed update scan.",
+            logWarn(WM_VULNSCAN_LOGTAG,
+                    "Skipping feed update scan for agent %s: VDFirst session active. "
+                    "First scan will cover the updated feed.",
                     agent.id.c_str());
-
-            constexpr auto WAIT_TIMEOUT = std::chrono::seconds(300);
-            const bool completed = InventorySyncFacade::instance().waitForSessionCompletion(
-                agent.id, "syscollector_vd", WAIT_TIMEOUT);
-
-            if (!completed)
-            {
-                logWarn(WM_VULNSCAN_LOGTAG,
-                        "Timeout waiting for VDSync session for agent %s (%lds). "
-                        "Running feed update scan with current indexer data.",
-                        agent.id.c_str(),
-                        static_cast<long>(WAIT_TIMEOUT.count()));
-            }
+            return;
         }
 
         OsContextData osData;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -216,7 +216,13 @@ public:
         std::unique_lock<std::shared_mutex> lock(m_mutex, std::defer_lock);
         if (lockScan)
         {
-            lock.lock();
+            if (!lock.try_lock())
+            {
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Feed update scan waiting for VD lock: agent='%s'",
+                          scanContext->agentId().data());
+                lock.lock();
+            }
         }
 
         logInfo(WM_VULNSCAN_LOGTAG,

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -65,8 +65,6 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
         return;
     }
 
-    logInfo(WM_VULNSCAN_LOGTAG, "Vulnerability scan started after feed update: full scan for all agents.");
-
     std::unique_lock<std::shared_mutex> scanLock(m_internalMutex, std::defer_lock);
     if (!scanLock.try_lock())
     {
@@ -87,6 +85,8 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
                                         });
 
     buildAllAgents->setLast(scanAgents);
+
+    logInfo(WM_VULNSCAN_LOGTAG, "Vulnerability scan started after feed update: full scan for all agents.");
 
     bool scanCompleted = true;
     try

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -21,6 +21,7 @@
 #include "schemaValidator.hpp"
 #include "socketDBWrapper.hpp"
 #include "stringHelper.h"
+#include <chrono>
 #include <atomic>
 #include <mutex>
 #include <string>
@@ -65,14 +66,6 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
         return;
     }
 
-    std::unique_lock<std::shared_mutex> scanLock(m_internalMutex, std::defer_lock);
-    if (!scanLock.try_lock())
-    {
-        logDebug2(WM_VULNSCAN_LOGTAG, "Feed update scan waiting for VD lock.");
-        scanLock.lock();
-    }
-    logDebug2(WM_VULNSCAN_LOGTAG, "VD lock acquired by FeedUpdate thread");
-
     auto scanContext = std::make_shared<ScanContext>();
 
     auto buildAllAgents = std::make_shared<BuildAllAgentListContext>();
@@ -81,7 +74,11 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
                                         [this](std::shared_ptr<ScanContext> agentContext)
                                         {
                                             auto context = std::move(agentContext);
-                                            m_scanOrchestrator->runScanAfterFeedUpdate(std::move(context), false);
+                                            m_scanOrchestrator->runScanAfterFeedUpdate(std::move(context));
+                                        },
+                                        [this](const std::string& agentId)
+                                        {
+                                            return shouldSkipFeedUpdateScanForAgent(agentId);
                                         });
 
     buildAllAgents->setLast(scanAgents);
@@ -106,7 +103,6 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
         scanCompleted = false;
     }
 
-    logDebug2(WM_VULNSCAN_LOGTAG, "Releasing VD lock, full scan completed");
     logInfo(WM_VULNSCAN_LOGTAG,
             "Vulnerability scan finished after feed update: full scan for all agents (agents=%zu, status=%s).",
             scanContext ? scanContext->m_agents.size() : 0u,
@@ -362,6 +358,16 @@ void VulnerabilityScannerFacade::start(
             initContentUpdater,
             [this](bool changed)
             {
+                constexpr auto VD_SYNC_WAIT_TIMEOUT = std::chrono::seconds(60);
+                constexpr uint32_t VD_SYNC_WAIT_MAX_RETRIES = 2;
+
+                const bool skipPostUpdateScan = shouldSkipPostUpdateScan();
+                if (changed && !skipPostUpdateScan)
+                {
+                    beginFeedUpdateScan(InventorySyncFacade::instance().getAgentsWithActiveSessionForModule(
+                        "syscollector_vd", Wazuh::SyncSchema::Option_VDFirst));
+                }
+
                 // Mark feed as ready and wake any inventory-sync session threads that
                 // are blocked in waitForFeedReady() waiting for the initial load.
                 m_feedReady.store(true, std::memory_order_release);
@@ -379,31 +385,23 @@ void VulnerabilityScannerFacade::start(
                 }
 
                 // Re-scan all agents after content update, only if this instance handles vulnerability scanning.
-                if (shouldSkipPostUpdateScan())
+                if (skipPostUpdateScan)
                 {
                     logDebug1(WM_VULNSCAN_LOGTAG, "Feed update scan skipped: testtool override enabled.");
                     return;
                 }
 
-                const bool lockAcquired =
-                    InventorySyncFacade::instance().lockAgent("", "Feed update full scan in progress");
-
-                struct AgentUnlockGuard
+                struct FeedUpdateScanGuard
                 {
-                    bool locked {false};
-                    ~AgentUnlockGuard()
+                    VulnerabilityScannerFacade& facade;
+                    ~FeedUpdateScanGuard()
                     {
-                        if (locked)
-                        {
-                            InventorySyncFacade::instance().unlockAgent("");
-                        }
+                        facade.endFeedUpdateScan();
                     }
-                } unlockGuard {lockAcquired};
+                } feedUpdateScanGuard {*this};
 
-                if (!lockAcquired)
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG, "Feed update scan proceeding with existing agent lock.");
-                }
+                InventorySyncFacade::instance().waitForAllVDSyncSessions(VD_SYNC_WAIT_TIMEOUT,
+                                                                         VD_SYNC_WAIT_MAX_RETRIES);
 
                 runScanAfterFeedUpdate();
             });
@@ -442,6 +440,8 @@ void VulnerabilityScannerFacade::start(
 
 void VulnerabilityScannerFacade::stop()
 {
+    endFeedUpdateScan();
+
     // Atomic flag section
     if (m_noWaitToStop)
     {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -21,8 +21,8 @@
 #include "schemaValidator.hpp"
 #include "socketDBWrapper.hpp"
 #include "stringHelper.h"
-#include <chrono>
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -69,17 +69,14 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
     auto scanContext = std::make_shared<ScanContext>();
 
     auto buildAllAgents = std::make_shared<BuildAllAgentListContext>();
-    auto scanAgents =
-        std::make_shared<ScanAgentList>(m_indexerConnector,
-                                        [this](std::shared_ptr<ScanContext> agentContext)
-                                        {
-                                            auto context = std::move(agentContext);
-                                            m_scanOrchestrator->runScanAfterFeedUpdate(std::move(context));
-                                        },
-                                        [this](const std::string& agentId)
-                                        {
-                                            return shouldSkipFeedUpdateScanForAgent(agentId);
-                                        });
+    auto scanAgents = std::make_shared<ScanAgentList>(
+        m_indexerConnector,
+        [this](std::shared_ptr<ScanContext> agentContext)
+        {
+            auto context = std::move(agentContext);
+            m_scanOrchestrator->runScanAfterFeedUpdate(std::move(context));
+        },
+        [this](const std::string& agentId) { return shouldSkipFeedUpdateScanForAgent(agentId); });
 
     buildAllAgents->setLast(scanAgents);
 
@@ -400,8 +397,17 @@ void VulnerabilityScannerFacade::start(
                     }
                 } feedUpdateScanGuard {*this};
 
-                InventorySyncFacade::instance().waitForAllVDSyncSessions(VD_SYNC_WAIT_TIMEOUT,
-                                                                         VD_SYNC_WAIT_MAX_RETRIES);
+                const bool hadVDSyncSessions = InventorySyncFacade::instance().waitForAllVDSyncSessions(
+                    VD_SYNC_WAIT_TIMEOUT, VD_SYNC_WAIT_MAX_RETRIES);
+
+                if (hadVDSyncSessions && !m_shouldStop.load(std::memory_order_acquire) && m_indexerConnector)
+                {
+                    logInfo(WM_VULNSCAN_LOGTAG,
+                            "VDSync session(s) completed during feed update — forcing index refresh on '%s' "
+                            "to ensure delta packages are searchable before feed-update scan.",
+                            PACKAGE_INDEX.data());
+                    m_indexerConnector->refresh(PACKAGE_INDEX);
+                }
 
                 runScanAfterFeedUpdate();
             });
@@ -442,12 +448,17 @@ void VulnerabilityScannerFacade::stop()
 {
     endFeedUpdateScan();
 
-    // Atomic flag section
+    // Always signal stop before releasing shared resources. Setting the flag under
+    // the mutex prevents waitForFeedReady() from missing the wakeup; memory_order_release
+    // pairs with the acquire load in the feed-update callback so it sees m_shouldStop=true
+    // before m_indexerConnector is reset below.
+    {
+        std::lock_guard lk(m_feedReadyMutex);
+        m_shouldStop.store(true, std::memory_order_release);
+    }
     if (m_noWaitToStop)
     {
-        m_shouldStop.store(true);
-        // Wake any session threads blocked in waitForFeedReady() so shutdown is not
-        // delayed by sessions waiting for the initial CVE feed load to complete.
+        // Wake session threads blocked in waitForFeedReady().
         m_feedReadyCV.notify_all();
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -356,12 +356,13 @@ void VulnerabilityScannerFacade::start(
             [this](bool changed)
             {
                 constexpr auto VD_SYNC_WAIT_TIMEOUT = std::chrono::seconds(60);
-                constexpr uint32_t VD_SYNC_WAIT_MAX_RETRIES = 2;
+                constexpr uint32_t VD_SYNC_WAIT_MAX_RETRIES = 5;
 
                 const bool skipPostUpdateScan = shouldSkipPostUpdateScan();
                 if (changed && !skipPostUpdateScan)
                 {
-                    beginFeedUpdateScan(InventorySyncFacade::instance().getAgentsWithActiveSessionForModule(
+                    // Must be called before m_feedReady is set to true — see prepareFeedUpdateScan().
+                    prepareFeedUpdateScan(InventorySyncFacade::instance().getAgentsWithActiveSessionForModule(
                         "syscollector_vd", Wazuh::SyncSchema::Option_VDFirst));
                 }
 
@@ -448,21 +449,18 @@ void VulnerabilityScannerFacade::stop()
 {
     endFeedUpdateScan();
 
-    // Always signal stop before releasing shared resources. Setting the flag under
-    // the mutex prevents waitForFeedReady() from missing the wakeup; memory_order_release
-    // pairs with the acquire load in the feed-update callback so it sees m_shouldStop=true
-    // before m_indexerConnector is reset below.
+    // Signal stop under the mutex so waitForFeedReady() cannot miss the subsequent
+    // notify_all(). The release store ensures the feed-update callback thread
+    // sees m_shouldStop=true before m_indexerConnector is reset below.
     {
         std::lock_guard lk(m_feedReadyMutex);
         m_shouldStop.store(true, std::memory_order_release);
     }
     if (m_noWaitToStop)
     {
-        // Wake session threads blocked in waitForFeedReady().
         m_feedReadyCV.notify_all();
     }
 
-    // Reset shared pointers
     m_indexerConnector.reset();
     if (m_databaseFeedManager)
     {
@@ -472,6 +470,5 @@ void VulnerabilityScannerFacade::stop()
 
     m_scanOrchestrator.reset();
 
-    // Destroy socketDbWrapper
     SocketDBWrapper::instance().teardown();
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -86,7 +86,7 @@ public:
      */
     bool isFeedReady() const
     {
-        return m_feedReady.load(std::memory_order_relaxed);
+        return m_feedReady.load(std::memory_order_acquire);
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -141,22 +141,27 @@ public:
      * runs normally and Status_Ok is sent.
      *
      * Returns immediately if the feed is already ready.  Also returns (without scan)
-     * when m_shouldStop is set so shutdown is not blocked by waiting sessions.
      */
     void waitForFeedReady()
     {
+        constexpr auto FEED_READY_TIMEOUT = std::chrono::seconds(1800);
+
         if (m_feedReady.load(std::memory_order_acquire))
         {
             return;
         }
         std::unique_lock<std::mutex> lock(m_feedReadyMutex);
         // clang-format off
-        m_feedReadyCV.wait(lock, [this]
-        {
-            return m_feedReady.load(std::memory_order_relaxed) ||
-                   m_shouldStop.load(std::memory_order_relaxed);
-        });
+        const bool ready = m_feedReadyCV.wait_for(
+            lock,
+            FEED_READY_TIMEOUT,
+            [this]
+            { return m_feedReady.load(std::memory_order_relaxed) || m_shouldStop.load(std::memory_order_relaxed); });
         // clang-format on
+        if (!ready)
+        {
+            logWarn(WM_VULNSCAN_LOGTAG, "CVE feed not ready after timeout — proceeding without feed.");
+        }
     }
 
 private:
@@ -173,7 +178,14 @@ private:
      */
     void runScanAfterFeedUpdate();
 
-    void beginFeedUpdateScan(std::unordered_set<std::string> coveredAgents)
+    // prepareFeedUpdateScan() MUST be called before m_feedReady=true.
+    // Any session blocked in waitForFeedReady() will read isFeedUpdateScanInProgress()
+    // immediately upon waking the flag must be active at that moment.
+    /**
+     * @brief Arm the feed-update scan flag before signalling feed readiness.
+     *
+     */
+    void prepareFeedUpdateScan(std::unordered_set<std::string> coveredAgents)
     {
         {
             std::unique_lock lock(m_feedUpdateCoveredAgentsMutex);

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -18,6 +18,7 @@
 #include "scanOrchestrator/scanOrchestrator.hpp"
 #include "singleton.hpp"
 #include "socketClient.hpp"
+#include "vulnerabilityScannerFacade_defs.hpp"
 #include <atomic>
 #include <condition_variable>
 #include <functional>
@@ -90,11 +91,11 @@ public:
     }
 
     /**
-     * @brief Returns true while a feed-update scan is pending or running.
+     * @brief True while the feed-update scan (full rescan of all agents after a CVE update) is running.
      *
-     * The flag is raised before the initial-feed waiters are released so that
-     * concurrent VDSync sessions can self-skip their VD scan and let the SAFU
-     * path cover them instead.
+     * Set to true before waking waitForFeedReady() callers so that any VDSync
+     * session that unblocks sees the flag and skips its own scan — the feed-update
+     * scan already covers those packages in its full pass.
      */
     bool isFeedUpdateScanInProgress() const
     {
@@ -102,10 +103,10 @@ public:
     }
 
     /**
-     * @brief Returns true when the current SAFU cycle must skip the agent.
+     * @brief Returns true if feed-update scan should skip this agent in the current cycle.
      *
-     * The skip set is used to avoid duplicating the first scan when a VDFirst
-     * session is already covering the same feed generation.
+     * Agents are added to the skip set when a concurrent VDFirst session already
+     * scanned them with the updated feed, making a second feed-update scan redundant.
      */
     bool shouldSkipFeedUpdateScanForAgent(const std::string& agentId) const
     {
@@ -114,11 +115,11 @@ public:
     }
 
     /**
-     * @brief Marks an agent as already covered by the current SAFU cycle.
+     * @brief Records that a VDFirst session already scanned this agent with the current feed.
      *
-     * Used when a VDFirst session successfully runs while the feed-update cycle
-     * is still active, so SAFU can skip that agent even if the session finishes
-     * before the full-scan path reaches it.
+     * Call after a successful VDFirst scan while the feed-update scan is active. The
+     * feed-update scan checks this set and skips covered agents, even if the VDFirst
+     * session has already finished by the time the feed-update scan reaches that agent.
      */
     void registerFeedUpdateCoveredAgent(const std::string& agentId)
     {
@@ -132,15 +133,15 @@ public:
     }
 
     /**
-     * @brief Blocks the calling thread until the CVE feed is fully loaded or the
-     *        scanner is stopped.
+     * @brief Blocks until the CVE feed is fully loaded or the scanner is stopped.
      *
-     * Called by inventory-sync session threads for VDFirst/VDSync sessions when the
-     * feed is not yet available.  The session keeps the agent in Status_Processing
-     * (already sent at End-message time) until this returns, at which point the scan
-     * runs normally and Status_Ok is sent.
+     * VDFirst/VDSync session threads call this when the feed is not yet available.
+     * The agent stays in Status_Processing (sent at End-message time) while waiting;
+     * once this returns the caller checks isFeedReady() again before scanning.
      *
-     * Returns immediately if the feed is already ready.  Also returns (without scan)
+     * Returns immediately if the feed is already ready or if stop() was called.
+     * After a 30-minute timeout it logs a warning and returns so the session
+     * does not block indefinitely.
      */
     void waitForFeedReady()
     {
@@ -156,15 +157,17 @@ public:
             lock,
             FEED_READY_TIMEOUT,
             [this]
-            { return m_feedReady.load(std::memory_order_relaxed) || m_shouldStop.load(std::memory_order_relaxed); });
+            { return m_feedReady.load(std::memory_order_acquire) || m_shouldStop.load(std::memory_order_relaxed); });
         // clang-format on
         if (!ready)
         {
-            logWarn(WM_VULNSCAN_LOGTAG, "CVE feed not ready after timeout — proceeding without feed.");
+            logWarn(WM_VULNSCAN_LOGTAG, "CVE feed not ready after timeout — aborting wait, scan will be skipped.");
         }
     }
 
 private:
+    VULNERABILITY_SCANNER_FACADE_FRIEND_TEST_DECLARATIONS;
+
     /**
      * @brief Decompress database content.
      *
@@ -178,12 +181,13 @@ private:
      */
     void runScanAfterFeedUpdate();
 
-    // prepareFeedUpdateScan() MUST be called before m_feedReady=true.
-    // Any session blocked in waitForFeedReady() will read isFeedUpdateScanInProgress()
-    // immediately upon waking the flag must be active at that moment.
     /**
-     * @brief Arm the feed-update scan flag before signalling feed readiness.
+     * @brief Arms the feed-update scan state before the feed-ready signal is sent.
      *
+     * Must be called before storing true to m_feedReady. Sessions blocked
+     * in waitForFeedReady() check isFeedUpdateScanInProgress() as soon as
+     * they wake — the flag must already be set at that point or they will
+     * run a redundant scan.
      */
     void prepareFeedUpdateScan(std::unordered_set<std::string> coveredAgents)
     {
@@ -194,6 +198,8 @@ private:
         m_feedUpdateScanInProgress.store(true, std::memory_order_release);
     }
 
+    // Clears the feed-update scan in-progress flag and the covered-agents skip list.
+    // Called when the full rescan finishes or when stop() tears down the facade.
     void endFeedUpdateScan()
     {
         m_feedUpdateScanInProgress.store(false, std::memory_order_release);

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 
 /**
  * @brief VulnerabilityScannerFacade class.
@@ -89,6 +90,48 @@ public:
     }
 
     /**
+     * @brief Returns true while a feed-update scan is pending or running.
+     *
+     * The flag is raised before the initial-feed waiters are released so that
+     * concurrent VDSync sessions can self-skip their VD scan and let the SAFU
+     * path cover them instead.
+     */
+    bool isFeedUpdateScanInProgress() const
+    {
+        return m_feedUpdateScanInProgress.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Returns true when the current SAFU cycle must skip the agent.
+     *
+     * The skip set is used to avoid duplicating the first scan when a VDFirst
+     * session is already covering the same feed generation.
+     */
+    bool shouldSkipFeedUpdateScanForAgent(const std::string& agentId) const
+    {
+        std::shared_lock lock(m_feedUpdateCoveredAgentsMutex);
+        return m_feedUpdateCoveredAgents.contains(agentId);
+    }
+
+    /**
+     * @brief Marks an agent as already covered by the current SAFU cycle.
+     *
+     * Used when a VDFirst session successfully runs while the feed-update cycle
+     * is still active, so SAFU can skip that agent even if the session finishes
+     * before the full-scan path reaches it.
+     */
+    void registerFeedUpdateCoveredAgent(const std::string& agentId)
+    {
+        if (agentId.empty() || !isFeedUpdateScanInProgress())
+        {
+            return;
+        }
+
+        std::unique_lock lock(m_feedUpdateCoveredAgentsMutex);
+        m_feedUpdateCoveredAgents.insert(agentId);
+    }
+
+    /**
      * @brief Blocks the calling thread until the CVE feed is fully loaded or the
      *        scanner is stopped.
      *
@@ -130,6 +173,23 @@ private:
      */
     void runScanAfterFeedUpdate();
 
+    void beginFeedUpdateScan(std::unordered_set<std::string> coveredAgents)
+    {
+        {
+            std::unique_lock lock(m_feedUpdateCoveredAgentsMutex);
+            m_feedUpdateCoveredAgents = std::move(coveredAgents);
+        }
+        m_feedUpdateScanInProgress.store(true, std::memory_order_release);
+    }
+
+    void endFeedUpdateScan()
+    {
+        m_feedUpdateScanInProgress.store(false, std::memory_order_release);
+
+        std::unique_lock lock(m_feedUpdateCoveredAgentsMutex);
+        m_feedUpdateCoveredAgents.clear();
+    }
+
     /**
      * @brief Get seconds from epoch.
      * This method is used to get the seconds from epoch.
@@ -148,8 +208,11 @@ private:
     std::shared_mutex m_internalMutex;
     std::atomic<bool> m_initialized {false};
     std::atomic<bool> m_feedReady {false};
+    std::atomic<bool> m_feedUpdateScanInProgress {false};
     std::condition_variable m_feedReadyCV;
     std::mutex m_feedReadyMutex;
+    mutable std::shared_mutex m_feedUpdateCoveredAgentsMutex;
+    std::unordered_set<std::string> m_feedUpdateCoveredAgents;
     std::shared_ptr<ScanOrchestrator> m_scanOrchestrator;
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade_defs.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade_defs.hpp
@@ -1,0 +1,24 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _VULNERABILITY_SCANNER_FACADE_DEFS_HPP
+#define _VULNERABILITY_SCANNER_FACADE_DEFS_HPP
+
+#ifdef WAZUH_UNIT_TESTING
+#define VULNERABILITY_SCANNER_FACADE_FRIEND_TEST_DECLARATIONS                                                          \
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, PrepareFeedUpdateScan_ArmsFlagAndPopulatesCoveredSet);                 \
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, EndFeedUpdateScan_ClearsFlagAndCoveredSet);                            \
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, RegisterFeedUpdateCoveredAgent_AddsAgentDuringActiveScan);             \
+    FRIEND_TEST(VulnerabilityScannerFacadeTest, RegisterFeedUpdateCoveredAgent_RejectsEmptyAgentIdDuringActiveScan)
+#else
+#define VULNERABILITY_SCANNER_FACADE_FRIEND_TEST_DECLARATIONS
+#endif // WAZUH_UNIT_TESTING
+
+#endif // _VULNERABILITY_SCANNER_FACADE_DEFS_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
@@ -611,3 +611,69 @@ TEST_F(VulnerabilityScannerFacadeTest, Stop_NoWaitToStopFalse_SkipsNotify)
     EXPECT_NO_THROW(facade.stop());
     EXPECT_FALSE(facade.isFeedReady());
 }
+
+TEST_F(VulnerabilityScannerFacadeTest, IsFeedUpdateScanInProgress_FalseBeforeFeedUpdateCycle)
+{
+    auto& facade = VulnerabilityScannerFacade::instance();
+    EXPECT_FALSE(facade.isFeedUpdateScanInProgress());
+}
+
+TEST_F(VulnerabilityScannerFacadeTest, ShouldSkipFeedUpdateScanForAgent_FalseWhenCoveredSetEmpty)
+{
+    auto& facade = VulnerabilityScannerFacade::instance();
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_001"));
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent(""));
+}
+
+TEST_F(VulnerabilityScannerFacadeTest, RegisterFeedUpdateCoveredAgent_NoOpWhenScanNotInProgress)
+{
+    auto& facade = VulnerabilityScannerFacade::instance();
+    ASSERT_FALSE(facade.isFeedUpdateScanInProgress());
+
+    EXPECT_NO_THROW(facade.registerFeedUpdateCoveredAgent("agent_001"));
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_001"));
+}
+
+TEST_F(VulnerabilityScannerFacadeTest, PrepareFeedUpdateScan_ArmsFlagAndPopulatesCoveredSet)
+{
+    auto& facade = VulnerabilityScannerFacade::instance();
+    facade.endFeedUpdateScan();
+
+    facade.prepareFeedUpdateScan({"agent_001", "agent_002"});
+
+    EXPECT_TRUE(facade.isFeedUpdateScanInProgress());
+    EXPECT_TRUE(facade.shouldSkipFeedUpdateScanForAgent("agent_001"));
+    EXPECT_TRUE(facade.shouldSkipFeedUpdateScanForAgent("agent_002"));
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_999"));
+
+    facade.endFeedUpdateScan();
+}
+
+TEST_F(VulnerabilityScannerFacadeTest, EndFeedUpdateScan_ClearsFlagAndCoveredSet)
+{
+    auto& facade = VulnerabilityScannerFacade::instance();
+    facade.prepareFeedUpdateScan({"agent_001", "agent_002"});
+    ASSERT_TRUE(facade.isFeedUpdateScanInProgress());
+    ASSERT_TRUE(facade.shouldSkipFeedUpdateScanForAgent("agent_001"));
+
+    facade.endFeedUpdateScan();
+
+    EXPECT_FALSE(facade.isFeedUpdateScanInProgress());
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_001"));
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_002"));
+}
+
+TEST_F(VulnerabilityScannerFacadeTest, RegisterFeedUpdateCoveredAgent_AddsAgentDuringActiveScan)
+{
+    auto& facade = VulnerabilityScannerFacade::instance();
+    facade.prepareFeedUpdateScan({});
+    ASSERT_TRUE(facade.isFeedUpdateScanInProgress());
+    ASSERT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_007"));
+
+    facade.registerFeedUpdateCoveredAgent("agent_007");
+
+    EXPECT_TRUE(facade.shouldSkipFeedUpdateScanForAgent("agent_007"));
+    EXPECT_FALSE(facade.shouldSkipFeedUpdateScanForAgent("agent_008"));
+
+    facade.endFeedUpdateScan();
+}


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

The Vulnerability Detector performs a full scan for all agents after every CVE feed update. The previous fix (PR #35363) introduced a guard in `scanAgent()` that skipped any agent with an active `syscollector_vd` session to avoid reading partially-indexed inventory data. However, this guard was applied to all session types. Introducing a new bug:

- **VDFirst** sessions perform a full scan on their own once indexing completes, so skipping the feed-update scan is correct.
- **VDSync** sessions that result in a **package delta** scan only process the packages that changed. If the feed-update scan is skipped for these agents, packages not in the delta are never evaluated against the new CVEs, leaving vulnerabilities undetected.

This PR fixes the bug by differentiating between VDFirst and VDSync sessions and applying the correct skip/wait logic for each case.

## Proposed Changes

- **inventorySyncFacade.hpp**:
  - Added `mutable std::condition_variable_any m_sessionCompletedCV`, notified every time a session is removed from `m_agentSessions`.
  - Added `m_sessionCompletedCV.notify_all()` at all session removal points (normal completion, error paths, session timeout, `cleanupStaleSessionForAgentModule`, and `cleanupZombieSessions`). The two cleanup functions require explicit notification because, with `syscollector_vd` exempt from the feed-update lock, a new VDSync session can arrive while the feed-update is waiting on an existing one; without the notification, the wait would sleep for the full timeout before waking up.
  - Extended `hasActiveSessionForModule()` with optional `timeout` and `maxRetries` parameters. When a timeout is provided:
    - If the active session is **VDFirst**: returns `true` immediately so the caller can skip the redundant scan.
    - If the active session is **VDSync**: blocks efficiently using the condition variable until the session finishes or the timeout expires. If it times out and `maxRetries > 0`, the wait is retried up to `maxRetries` additional times before giving up and proceeding with the scan.
    - If no session is active: returns `false` immediately.
- Added `eraseSession()` helper that always acquires a `unique_lock` before erasing from `m_agentSessions`. Replaced all unprotected `m_agentSessions.erase()` calls with `eraseSession()`.
- VDSync delta scan is skipped when a scan post-feed update occurs.
- If a VDFirst scan occurs while a feed download is in progress, the post-feed update scan is skipped

- **scanAgentList.hpp**:
  - skip with a single call to `hasActiveSessionForModule()` passing a 60s timeout and 2 max retries.

- **IndexerConnector**
- Added a `refresh` method. It sends a query to OpenSearch using the `_refresh` field to enable searching of the indexed packages following a VDSync for the post-feed-update scan

### Results and Evidence

- VDFirst while feed update

<details>

```
2026/04/29 15:11:31 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/04/29 15:11:31 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/04/29 15:23:58 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 169299 docs in 747137ms
2026/04/29 15:23:59 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 169035 docs in 747876ms
2026/04/29 15:23:59 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 338334 documents, cursor: '386887'
2026/04/29 15:24:14 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/04/29 15:24:14 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/04/29 15:24:14 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/04/29 15:24:14 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/04/29 15:24:14 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 001: current SAFU cycle is already covered by VDFirst.
2026/04/29 15:24:14 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=1, status=ok).
2026/04/29 15:24:15 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 1504 ms: 603 packages scanned, 0 skipped, 126 vulnerable packages
2026/04/29 15:24:17 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 3468 new, 0 solved
2026/04/29 15:24:17 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/04/29 15:24:17 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=first_scan option=VDFirst

```

</details>

- VDSync while feed update

<details>

```
2026/04/29 15:37:12 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 169299 docs in 582723ms
2026/04/29 15:37:12 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 169035 docs in 582898ms
2026/04/29 15:37:12 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 338334 documents, cursor: '386887'
2026/04/29 15:37:34 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/04/29 15:37:34 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/04/29 15:37:34 logger-helper: INFO: Feed update scan waiting for VDSync session to complete for agent 001 (timeout: 60s, max retries: 2).
2026/04/29 15:37:34 logger-helper: INFO: InventorySyncFacade: Skipping VDSync scan for agent 001 — feed-update full scan will cover all packages.
2026/04/29 15:37:34 wazuh-manager-modulesd:vulnerability-scanner: INFO: VDSync session(s) completed during feed update — forcing index refresh on 'wazuh-states-inventory-packages' to ensure delta packages are searchable before feed-update scan.
2026/04/29 15:37:34 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/04/29 15:37:34 logger-helper: INFO: Locked agent 001 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 15:37:34 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=feed_update
2026/04/29 15:37:38 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 1791 ms: 700 packages scanned, 0 skipped, 148 vulnerable packages
2026/04/29 15:37:38 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 157 new, 0 solved
2026/04/29 15:37:39 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
2026/04/29 15:37:39 logger-helper: INFO: Unlocked agent 001 for new sessions
2026/04/29 15:37:39 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=1, status=ok).
```

</details>

- VDFirst with multiple agents

<details>

```
2026/04/29 15:39:01 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/04/29 15:39:01 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/04/29 15:39:02 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/04/29 15:39:11 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/04/29 15:47:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 169299 docs in 521802ms
2026/04/29 15:47:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 169035 docs in 521933ms
2026/04/29 15:47:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 338334 documents, cursor: '386887'
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/04/29 15:47:52 logger-helper: INFO: Locked agent 001 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='003' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '003' - Packages scan completed in 17 ms: 111 packages scanned, 0 skipped, 21 vulnerable packages
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '003' - Vulnerability scan completed: 33 new, 0 solved
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '003' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='003' type=full reason=first_scan option=VDFirst
2026/04/29 15:47:52 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=feed_update
2026/04/29 15:47:53 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 110 ms: 700 packages scanned, 0 skipped, 148 vulnerable packages
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 0 new, 0 solved
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
2026/04/29 15:47:54 logger-helper: INFO: Unlocked agent 001 for new sessions
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 002: current SAFU cycle is already covered by VDFirst.
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 003: current SAFU cycle is already covered by VDFirst.
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 004: current SAFU cycle is already covered by VDFirst.
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 005: current SAFU cycle is already covered by VDFirst.
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 006: current SAFU cycle is already covered by VDFirst.
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=6, status=ok).
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='006' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '006' - Packages scan completed in 2 ms: 111 packages scanned, 0 skipped, 21 vulnerable packages
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '006' - Vulnerability scan completed: 33 new, 0 solved
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '006' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='006' type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='004' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '004' - Packages scan completed in 3 ms: 111 packages scanned, 0 skipped, 21 vulnerable packages
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '004' - Vulnerability scan completed: 33 new, 0 solved
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '004' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='004' type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='002' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Packages scan completed in 2 ms: 111 packages scanned, 0 skipped, 21 vulnerable packages
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Vulnerability scan completed: 33 new, 0 solved
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='002' type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='005' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '005' - Packages scan completed in 2 ms: 111 packages scanned, 0 skipped, 21 vulnerable packages
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '005' - Vulnerability scan completed: 33 new, 0 solved
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '005' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/04/29 15:47:54 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='005' type=full reason=first_scan option=VDFirst

```

</details>

- VDSync with multiples agent

<details>

```
2026/04/29 16:01:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 169299 docs in 567085ms
2026/04/29 16:01:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 169035 docs in 567241ms
2026/04/29 16:01:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 338334 documents, cursor: '386887'
2026/04/29 16:01:55 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/04/29 16:01:55 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/04/29 16:01:55 logger-helper: INFO: InventorySyncFacade: Skipping VDSync scan for agent 006 — feed-update full scan will cover all packages.
2026/04/29 16:01:55 logger-helper: INFO: Feed update scan waiting for VDSync session to complete for agent 003 (timeout: 60s, max retries: 2).
2026/04/29 16:01:55 logger-helper: INFO: InventorySyncFacade: Skipping VDSync scan for agent 002 — feed-update full scan in progress, covers all packages.
2026/04/29 16:01:55 logger-helper: INFO: InventorySyncFacade: Skipping VDSync scan for agent 003 — feed-update full scan in progress, covers all packages.
2026/04/29 16:01:55 logger-helper: INFO: InventorySyncFacade: Skipping VDSync scan for agent 004 — feed-update full scan in progress, covers all packages.
2026/04/29 16:01:55 logger-helper: INFO: InventorySyncFacade: Skipping VDSync scan for agent 005 — feed-update full scan in progress, covers all packages.
2026/04/29 16:01:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: VDSync session(s) completed during feed update — forcing index refresh on 'wazuh-states-inventory-packages' to ensure delta packages are searchable before feed-update scan.
2026/04/29 16:01:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/04/29 16:01:57 logger-helper: INFO: Locked agent 001 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 16:01:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=feed_update
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 512 ms: 700 packages scanned, 0 skipped, 148 vulnerable packages
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 0 new, 0 solved
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
2026/04/29 16:01:58 logger-helper: INFO: Unlocked agent 001 for new sessions
2026/04/29 16:01:58 logger-helper: INFO: Locked agent 002 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='002' (v5.0.0) type=full reason=feed_update
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Packages scan completed in 13 ms: 448 packages scanned, 6 skipped, 51 vulnerable packages
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Vulnerability scan completed: 119 new, 17 solved
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='002' type=full reason=feed_update
2026/04/29 16:01:58 logger-helper: INFO: Unlocked agent 002 for new sessions
2026/04/29 16:01:58 logger-helper: INFO: Locked agent 003 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='003' (v5.0.0) type=full reason=feed_update
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '003' - Packages scan completed in 7 ms: 448 packages scanned, 6 skipped, 51 vulnerable packages
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '003' - Vulnerability scan completed: 119 new, 17 solved
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='003' type=full reason=feed_update
2026/04/29 16:01:58 logger-helper: INFO: Unlocked agent 003 for new sessions
2026/04/29 16:01:58 logger-helper: INFO: Locked agent 004 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='004' (v5.0.0) type=full reason=feed_update
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '004' - Packages scan completed in 8 ms: 448 packages scanned, 6 skipped, 51 vulnerable packages
2026/04/29 16:01:58 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '004' - Vulnerability scan completed: 119 new, 17 solved
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='004' type=full reason=feed_update
2026/04/29 16:01:59 logger-helper: INFO: Unlocked agent 004 for new sessions
2026/04/29 16:01:59 logger-helper: INFO: Locked agent 005 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='005' (v5.0.0) type=full reason=feed_update
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '005' - Packages scan completed in 7 ms: 448 packages scanned, 6 skipped, 51 vulnerable packages
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '005' - Vulnerability scan completed: 119 new, 17 solved
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='005' type=full reason=feed_update
2026/04/29 16:01:59 logger-helper: INFO: Unlocked agent 005 for new sessions
2026/04/29 16:01:59 logger-helper: INFO: Locked agent 006 from creating new sessions - Reason: Feed update full scan in progress
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='006' (v5.0.0) type=full reason=feed_update
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '006' - Packages scan completed in 8 ms: 448 packages scanned, 6 skipped, 51 vulnerable packages
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '006' - Vulnerability scan completed: 119 new, 17 solved
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='006' type=full reason=feed_update
2026/04/29 16:01:59 logger-helper: INFO: Unlocked agent 006 for new sessions
2026/04/29 16:01:59 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=6, status=ok).
```

</details>

<details>
<summary> E2E </summary>
<img width="1849" height="967" alt="image" src="https://github.com/user-attachments/assets/5c3e7ea7-671f-4a88-a18b-9c43042ec495" />

<img width="1849" height="967" alt="image" src="https://github.com/user-attachments/assets/bdcb7e88-cd1d-447c-a70f-58ba908b7275" />

</details>

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues