### PR TITLE
Update integration/component weekly template

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration-component-test-manager.md
+++ b/.github/ISSUE_TEMPLATE/integration-component-test-manager.md
@@ -1,25 +1,41 @@
 ---
 name: Weekly Integration/Component test task (manager)
-about: Template for weekly integration and component testing tasks in the manager
-title: 'Week [number_week] - Integration/Component test manager'
+about: Weekly operational task to review the scheduled manager integration and component test executions and report their status.
+title: '[Week AA] Integration/Component test manager'
 labels: 'level/task, request/operational, type/test'
 assignees: ''
 
 ---
 
+## Previous week issue
+
+| Week | Issue |
+|---|---|
+| Previous | Add the link to the previous weekly issue here. |
+
 ## Description
-This issue aims to establish a **scheduled** task to run the integration tests every Wednesday. The purpose is to ensure code stability and prevent regressions on a regular basis.
+Use this issue to review the scheduled manager integration and component test executions, confirm the result of each workflow for every branch or tag under review, and document failures or anomalies that need follow-up.
+
+## What needs to be done
+
+1. Identify the version, branch, or tag under review for the current week.
+2. Open the latest execution for each workflow listed below.
+3. Record the result of every workflow and add the run link.
+4. If a workflow fails, summarize the error and the most likely cause.
+5. Open follow-up issues when a failure requires product or CI changes.
 
 All test results must have one of the following statuses:
 |Color| Details |
 |:--:|:--|
 | :green_circle: | The **pipeline** has been executed successfully |
+| :yellow_circle: | The **pipeline** is unstable or needs manual review |
 | :red_circle: | The **pipeline** has failed or it has errors |
 
 Any failed test should be reported, detailing the error and possible cause.
 
-## Test
-The scheduled task will execute the following integration tests every Wednesday:
+## Workflows to review
+
+The scheduled task executes the following workflows every Wednesday:
 
 | Test                                    | Link                                                                                        |
 |-----------------------------------------|---------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## What
- update the weekly integration/component manager issue template
- add a previous-week reference section
- clarify the review instructions and expected reporting structure

## Why
- align the manager weekly test issue with the updated operational workflow
- make the issue easier to create and fill consistently each week

## Validation
- no automated checks; markdown issue-template changes only
