### PR TITLE
wazuh-engine: `Json::SetString` strip trailing null bytes

### DIFF
--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -987,7 +987,13 @@ void Json::setString(std::string_view value, std::string_view path)
     if (pp.IsValid())
     {
         const auto* data = value.data() ? value.data() : "";
-        rapidjson::Value v(data, static_cast<rapidjson::SizeType>(value.size()), m_document.GetAllocator());
+        auto len = value.size();
+        // Strip trailing null bytes: a JSON string must not contain embedded \0.
+        while (len > 0 && data[len - 1] == '\0')
+        {
+            --len;
+        }
+        rapidjson::Value v(data, static_cast<rapidjson::SizeType>(len), m_document.GetAllocator());
         pp.Set(m_document, v);
         return;
     }

--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -1702,6 +1702,64 @@ TEST_F(JsonSettersTest, SetString)
     ASSERT_THROW(jObjString.setString("newValue", "object/key"), std::runtime_error);
 }
 
+TEST_F(JsonSettersTest, SetStringStripsTrailingNullBytes)
+{
+    Json doc {};
+    std::string tmp;
+
+    // Single trailing \0 (the most common case: OS_SendUnix sends strlen+1 bytes)
+    {
+        std::string_view withNull {"hello\0", 6}; // size=6, includes the \0
+        doc.setString(withNull, "/field");
+        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field"));
+        ASSERT_EQ("hello", tmp);
+        ASSERT_EQ(5u, tmp.size()); // no null byte stored
+        // Serialised JSON must not contain \u0000
+        ASSERT_EQ(std::string::npos, doc.str().find("\\u0000"));
+    }
+
+    // Multiple trailing \0 bytes (e.g. padded buffer)
+    {
+        std::string_view multiNull {"abc\0\0\0", 6};
+        doc.setString(multiNull, "/field2");
+        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field2"));
+        ASSERT_EQ("abc", tmp);
+        ASSERT_EQ(3u, tmp.size());
+    }
+
+    // String that is all null bytes must become an empty string
+    {
+        std::string_view allNull {"\0\0", 2};
+        doc.setString(allNull, "/field3");
+        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field3"));
+        ASSERT_TRUE(tmp.empty());
+    }
+
+    // Normal string without any \0 must be stored unchanged
+    {
+        doc.setString("normal", "/field4");
+        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field4"));
+        ASSERT_EQ("normal", tmp);
+    }
+
+    // Empty string must remain empty
+    {
+        doc.setString("", "/field5");
+        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field5"));
+        ASSERT_TRUE(tmp.empty());
+    }
+
+    // \0 embedded in the MIDDLE is not stripped (only trailing ones are)
+    {
+        std::string_view embeddedNull {"a\0b", 3}; // \0 is in the middle
+        doc.setString(embeddedNull, "/field6");
+        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field6"));
+        // Only the trailing-strip loop runs; the mid-string \0 followed by 'b' means
+        // no trailing \0 is stripped — the full 3-byte string is stored.
+        ASSERT_EQ(3u, tmp.size());
+    }
+}
+
 TEST_F(JsonSettersTest, SetInt)
 {
     Json jObjInt {R"({


### PR DESCRIPTION
## Description

`Json::setString` was refactored to accept `std::string_view` and pass its length explicitly to RapidJSON. This introduced a regression: when the `string_view` carried a trailing null byte (e.g. originating from a legacy Unix socket that sends `strlen + 1` bytes), RapidJSON would faithfully store the `\0` as part of the JSON string value, serialising it as `\u0000` in the output.

This caused `event.original` and any other field written through `setString` with a socket-derived buffer to contain a `\u0000` suffix, breaking all downstream decoders that perform string matching or JSON parsing on that field.

## Proposed Changes

### Bugs fixed

- **`Json::setString` — strip trailing null bytes before storing** (`src/engine/source/base/src/json.cpp`):
  Added a loop that removes any trailing `\0` bytes from the `string_view` length before constructing the RapidJSON value. This restores the behaviour of the previous implementation, which achieved the same effect implicitly by converting to `std::string` and using `.c_str()` (causing RapidJSON to call `strlen` internally and stop at the first `\0`).

- **Unit tests added** (`src/engine/source/base/test/src/unit/json_test.cpp`):
  New test `SetStringStripsTrailingNullBytes` covering:
  - Single trailing `\0` (the real-world socket case)
  - Multiple trailing `\0` bytes
  - String composed entirely of `\0` bytes (becomes empty)
  - Normal string without `\0` (unchanged)
  - Empty string (unchanged)
  - `\0` embedded in the middle (not stripped — only trailing nulls are removed)

### Root cause

`OS_SendUnix` (in `src/shared/os_net/os_net.c`) uses `strlen(msg) + 1` when `size == 0`, so every message dispatched through the legacy Unix socket includes its null terminator in the byte count. After decryption in remoted, `msg_length` reflects this and the `\0` is preserved through `memcpy` into `evt_item_t`, through the HTTP POST bulk body, and finally into `parseLegacyEvent` as a `string_view` whose `.size()` includes the extra byte. The old `setString` implementation neutralised this by chance; the new one exposed it.

### Results and Evidence

Before fix in archived events (standard-wazuh-events-v5.json):
```
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu17/thermal_throttle\u0000"},"@timestamp":"2026-04-14T10:37:30.435Z"}
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu19/thermal_throttle\u0000"},"@timestamp":"2026-04-14T10:37:30.473Z"}
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu18/thermal_throttle\u0000"},"@timestamp":"2026-04-14T10:37:30.473Z"}
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu20/thermal_throttle\u0000"},"@timestamp":"2026-04-14T10:37:30.474Z"}
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu21/thermal_throttle\u0000"},"@timestamp":"2026-04-14T10:37:30.474Z"}
```

After fix — in archived events:
```
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu7/thermal_throttle"},"@timestamp":"2026-04-14T11:14:00.490Z"}
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu8/thermal_throttle"},"@timestamp":"2026-04-14T11:14:00.490Z"}
{"wazuh":{"protocol":{"queue":49,"location":"df -P"},"agent":{"host":{"os":{"name":"Rocky Linux","version":"8.10","platform":"rocky","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-50-rocky8"},"id":"002","name":"wazuh-agent-50-rocky8","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"ossec: output: 'df -P': tmpfs             24391524         0  24391524       0% /sys/devices/system/cpu/cpu9/thermal_throttle"},"@timestamp":"2026-04-14T11:14:00.490Z"}
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-manager` (Linux)

### Configuration Changes

N/A

### Tests Introduced

New test `JsonSettersTest/SetStringStripsTrailingNullBytes` in `src/engine/source/base/test/src/unit/json_test.cpp`.

Covers 6 cases: single trailing `\0`, multiple trailing `\0`, all-null string, normal string, empty string, and mid-string `\0` (not stripped). Tests use `std::string_view{"value\0", N}` syntax to explicitly simulate the socket-buffer scenario that was previously untested.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
