### PR TITLE
Ms-graph - handle relationships that contain '/'

### DIFF
--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -2224,7 +2224,76 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     will_return(__wrap_wm_state_io, -1);
 
     expect_string(__wrap__mterror, tag, WM_MS_GRAPH_LOGTAG);
-    expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
+    expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state for resource 'security' and relationship 'alerts_v2'. State file: 'var/wodles/ms-graph-example_tenant-security-alerts_v2'.");
+
+    wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
+}
+
+void test_wm_ms_graph_scan_relationships_slash_in_relationship_name(void **state) {
+    /*
+    Verifies that a relationship name containing '/' (e.g. "cases/eDiscoveryCases")
+    has its slash replaced with '-' when constructing the state file name, preventing
+    invalid subdirectory paths from being created.
+
+    <resource>
+      <name>security</name>
+      <relationship>cases/eDiscoveryCases</relationship>
+    </resource>
+    */
+    wm_ms_graph* module_data = (wm_ms_graph *)*state;
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config);
+    os_calloc(1, sizeof(wm_ms_graph_auth), module_data->auth_config[0]);
+    module_data->enabled = true;
+    module_data->only_future_events = true;
+    module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
+    module_data->time_delay = 10;
+    module_data->run_on_start = true;
+    module_data->scan_config.interval = 60;
+    os_strdup("v1.0", module_data->version);
+    os_strdup("example_client", module_data->auth_config[0]->client_id);
+    os_strdup("example_tenant", module_data->auth_config[0]->tenant_id);
+    os_strdup("example_secret", module_data->auth_config[0]->secret_value);
+    os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, module_data->auth_config[0]->login_fqdn);
+    os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, module_data->auth_config[0]->query_fqdn);
+    os_malloc(sizeof(wm_ms_graph_resource), module_data->resources);
+    os_strdup("security", module_data->resources[0].name);
+    module_data->num_resources = 1;
+    os_malloc(sizeof(char*), module_data->resources[0].relationships);
+    os_strdup("cases/eDiscoveryCases", module_data->resources[0].relationships[0]);
+    module_data->resources[0].num_relationships = 1;
+    bool initial = true;
+
+#ifdef TEST_WINAGENT
+    will_return_count(__wrap_os_random, 12345, 2);
+#else
+    will_return(__wrap_os_random, 12345);
+#endif
+
+    // The '/' in "cases/eDiscoveryCases" must be replaced with '-' in the state file name,
+    // while the original relationship name is preserved in the bookmark log message.
+    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-cases-eDiscoveryCases");
+    expect_value(__wrap_wm_state_io, op, WM_IO_READ);
+    expect_any(__wrap_wm_state_io, state);
+    expect_any(__wrap_wm_state_io, size);
+    will_return(__wrap_wm_state_io, -1);
+
+    will_return(__wrap_isDebug, 1);
+
+#ifndef WIN32
+    will_return(__wrap_gmtime_r, 1);
+#endif
+    will_return(__wrap_strftime, "2023-02-08T12:24:56Z");
+    will_return(__wrap_strftime, 20);
+
+    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-cases-eDiscoveryCases");
+    expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
+    expect_any(__wrap_wm_state_io, state);
+    expect_any(__wrap_wm_state_io, size);
+    will_return(__wrap_wm_state_io, 1);
+
+    expect_string(__wrap__mtdebug1, tag, WM_MS_GRAPH_LOGTAG);
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:24:56Z' for tenant 'example_tenant' resource 'security' and relationship 'cases/eDiscoveryCases', waiting '60' seconds to run first scan.");
 
     wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
@@ -3414,7 +3483,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_wm_state_io, -1);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state.");
+    expect_string(__wrap__mterror, formatted_msg, "Couldn't save running state for resource 'deviceManagement' and relationship 'auditEvents'. State file: 'var/wodles/ms-graph-example_tenant-deviceManagement-auditEvents'.");
 
     wm_ms_graph_scan_relationships(module_data, module_data->auth_config[0], initial);
 }
@@ -4431,6 +4500,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_get_access_token_no_expire_time, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_initial_only_no, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write, setup_conf, teardown_conf),
+        cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_slash_in_relationship_name, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_response, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp, setup_conf, teardown_conf),
         cmocka_unit_test_setup_teardown(test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code, setup_conf, teardown_conf),

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -290,6 +290,13 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
             if (!inventory) {
                 snprintf(relationship_state_name, OS_SIZE_1024 -1, "%s-%s-%s-%s", WM_MS_GRAPH_CONTEXT.name,
                     auth_config->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num]);
+                // Replace '/' with '-' so relationship names like "cases/eDiscoveryCases"
+                // don't create invalid subdirectory paths in the state file location.
+                for (char *p = relationship_state_name; *p; p++) {
+                    if (*p == '/') {
+                        *p = '-';
+                    }
+                }
 
                 memset(&relationship_state_struc, 0, sizeof(relationship_state_struc));
 
@@ -304,7 +311,9 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
                     (!initial_scan && !relationship_state_struc.next_time)) {
                     relationship_state_struc.next_time = scan_time;
                     if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
-                        mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                        mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state for resource '%s' and relationship '%s'. State file: '" WM_STATE_DIR "/%s'.",
+                            ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num],
+                            relationship_state_name);
                     } else if (isDebug()) {
                         gmtime_r(&scan_time, &tm_aux);
                         strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%dT%H:%M:%SZ", &tm_aux);
@@ -448,7 +457,9 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
             if (!inventory && !fail) {
                 relationship_state_struc.next_time = scan_time;
                 if (wm_state_io(relationship_state_name, WM_IO_WRITE, &relationship_state_struc, sizeof(relationship_state_struc)) < 0) {
-                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state.");
+                    mterror(WM_MS_GRAPH_LOGTAG, "Couldn't save running state for resource '%s' and relationship '%s'. State file: '" WM_STATE_DIR "/%s'.",
+                        ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num],
+                        relationship_state_name);
                 } else {
                     mtdebug1(WM_MS_GRAPH_LOGTAG, "Bookmark updated to '%s' for tenant '%s' resource '%s' and relationship '%s', waiting '%d' seconds to run next scan.",
                         end_time_str, auth_config->tenant_id, ms_graph->resources[resource_num].name, ms_graph->resources[resource_num].relationships[relationship_num], ms_graph->scan_config.interval);

--- a/tests/integration/test_msgraph/test_API/data/response_samples/responses.json
+++ b/tests/integration/test_msgraph/test_API/data/response_samples/responses.json
@@ -50,16 +50,6 @@
       }
     },
     {
-      "url": "http://graph.microsoft.com/v1.0/security/cases/eDiscoveryCases?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
-      "method": "GET",
-      "responseCode": 200,
-      "responseBody": {
-        "value": [
-          "microsoft.graph.security.ediscoveryCase"
-        ]
-      }
-    },
-    {
       "url": "http://graph.microsoft.com/v1.0/auditLogs/signIns?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 429,

--- a/tests/integration/test_msgraph/test_API/data/response_samples/responses.json
+++ b/tests/integration/test_msgraph/test_API/data/response_samples/responses.json
@@ -50,6 +50,16 @@
       }
     },
     {
+      "url": "http://graph.microsoft.com/v1.0/security/cases/eDiscoveryCases?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
+      "method": "GET",
+      "responseCode": 200,
+      "responseBody": {
+        "value": [
+          "microsoft.graph.security.ediscoveryCase"
+        ]
+      }
+    },
+    {
       "url": "http://graph.microsoft.com/v1.0/auditLogs/signIns?$top=*&$filter=createdDateTime+ge+*+and+createdDateTime+lt+*",
       "method": "GET",
       "responseCode": 429,


### PR DESCRIPTION
## Description

The MS-Graph module fails to retrieve logs for relationships whose names contain a forward slash (e.g., `cases/eDiscoveryCases`). When building the state file path, the `/` is treated as a directory separator, pointing to a non-existent subdirectory. This causes state file read/write operations to silently fail, leaving `next_time` at 0 and triggering initialization logic on every scan cycle — effectively skipping all API calls for the affected relationship indefinitely.

Closes #35058

## Proposed Changes

- **Sanitize relationship names in state file paths**: after building the state file name from the relationship name, replace any `/` with `-`. This ensures names like `cases/eDiscoveryCases` produce a flat path (`ms-graph-<tenant>-security-cases-eDiscoveryCases`) while the `/` is preserved in the API URL where it belongs.
- **Improve "Couldn't save running state" error message**: the original message gave no context. It now includes the resource name, relationship name, and full state file path to make failures immediately actionable.

### Results and Evidence

Manual test with `cases/eDiscoveryCases` configured as a relationship. The improved error message now surfaces the exact state file path, making the root cause immediately visible:

``` log
2026/04/14 15:51:11 wazuh-modulesd:ms-graph[130049] wm_ms_graph.c:314 at wm_ms_graph_scan_relationships(): ERROR: Couldn't save running state for resource 'security' and relationship 'cases/eDiscoveryCases'. State file: 'var/wodles/ms-graph-tenant_id-security-cases/eDiscoveryCases'.
```

The path `cases/eDiscoveryCases` in the error above confirms the pre-fix behaviour (path treated as subdirectory). With the sanitization applied and the module recompiled, the state file path becomes `var/wodles/ms-graph-tenant_id-security-cases-eDiscoveryCases` (flat, valid path) and the module correctly scans and bookmarks the relationship.

### Artifacts Affected

- `wazuh-modulesd` (Linux, macOS, Windows)

### Tests Introduced

- **Unit test** `test_wm_ms_graph_scan_relationships_slash_in_relationship_name` (`src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c`): verifies that a relationship name containing `/` produces a sanitized (dash-separated) state file tag passed to `wm_state_io`, while the original relationship name (with slash) is preserved in the bookmark debug message.                                         

- Updated `test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write` and `test_wm_ms_graph_scan_relationships_single_success_two_resources` to expect the new enriched error message format.
- Integration test mock response added for `security/cases/eDiscoveryCases`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
