### PR TITLE
Suppress unexpected stateless events after SCA initial scan

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -158,6 +158,11 @@ class SecurityConfigurationAssessment
         /// @brief Cached first-sync completion state used to gate initial stateful publication.
         std::atomic<bool> m_firstSyncCompleted {false};
 
+        /// @brief In-memory flag set after each complete scan iteration, cleared at Run() startup.
+        /// Polled by the C sync thread (via get_scan_completed query) to avoid triggering the first
+        /// snapshot while the DB still contains "Not run" placeholders. Non-zero means completed.
+        std::atomic<int64_t> m_scanCompleted {0};
+
         /// @brief Condition variable for pause/resume coordination
         std::condition_variable m_pauseCv;
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -587,6 +587,12 @@ std::tuple<nlohmann::json, ReturnTypeCallback, uint64_t> SCAEventHandler::Proces
 
 nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) const
 {
+    if (event.contains("result") &&
+            static_cast<ReturnTypeCallback>(event["result"]) == DELETED)
+    {
+        return {};
+    }
+
     nlohmann::json check;
     nlohmann::json policy;
     nlohmann::json changedFields = nlohmann::json::array();

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -604,20 +604,36 @@ nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) co
             if (event["check"].contains("old") && event["check"]["old"].is_object())
             {
                 const auto& old = event["check"]["old"];
-                nlohmann::json previous;
 
-                for (auto& [key, value] : old.items())
+                // "Not run" is the DB default placeholder, not a user-observable state.
+                // A transition from it is a first observation, not a real delta — any
+                // sibling fields in the diff (e.g. `reason` populated for "Not applicable")
+                // are also first-time values, so the whole stateless event is dropped.
+                const auto oldResult = old.find("result");
+                const bool transitionFromNotRun = oldResult != old.end() &&
+                                                  oldResult->is_string() &&
+                                                  oldResult->get<std::string>() == "Not run";
+
+                if (!transitionFromNotRun)
                 {
-                    if (key == "id" || key == "sync")
+                    nlohmann::json previous;
+
+                    for (auto& [key, value] : old.items())
                     {
-                        continue;
+                        if (key == "id" || key == "sync")
+                        {
+                            continue;
+                        }
+
+                        previous[key] = value;
+                        changedFields.push_back("check." + key);
                     }
 
-                    previous[key] = value;
-                    changedFields.push_back("check." + key);
+                    if (!previous.empty())
+                    {
+                        check["previous"] = previous;
+                    }
                 }
-
-                check["previous"] = previous;
             }
         }
         else
@@ -659,6 +675,13 @@ nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) co
         else
         {
             LoggingHelper::getInstance().log(LOG_ERROR, "Stateless event does not contain policy");
+            return {};
+        }
+
+        // Drop MODIFIED events whose only pseudo-change was the "Not run" default
+        // being replaced by a real scan result: nothing user-visible changed.
+        if (static_cast<ReturnTypeCallback>(event["result"]) == MODIFIED && changedFields.empty())
+        {
             return {};
         }
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -601,38 +601,59 @@ nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) co
                 check.erase("sync");
             }
 
+            // "Not run" is a DB placeholder — the check has not been executed yet in this
+            // scan cycle. Never emit a stateless event for a check in this state, regardless
+            // of the operation type (INSERTED, MODIFIED, DELETED).
+            {
+                const auto resultIt = check.find("result");
+
+                if (resultIt != check.end() &&
+                        resultIt->is_string() &&
+                        resultIt->get<std::string>() == "Not run")
+                {
+                    return {};
+                }
+            }
+
             if (event["check"].contains("old") && event["check"]["old"].is_object())
             {
                 const auto& old = event["check"]["old"];
 
-                // "Not run" is the DB default placeholder, not a user-observable state.
-                // A transition from it is a first observation, not a real delta — any
-                // sibling fields in the diff (e.g. `reason` populated for "Not applicable")
-                // are also first-time values, so the whole stateless event is dropped.
-                const auto oldResult = old.find("result");
-                const bool transitionFromNotRun = oldResult != old.end() &&
-                                                  oldResult->is_string() &&
-                                                  oldResult->get<std::string>() == "Not run";
-
-                if (!transitionFromNotRun)
+                // For MODIFIED events, stateless is only meaningful for valid result state
+                // transitions. "Not run" is a DB placeholder (not a real observable state),
+                // and metadata-only changes (no result change) don't constitute a state
+                // transition worth alerting on.
+                // Note: new result == "Not run" is already caught above.
+                if (static_cast<ReturnTypeCallback>(event["result"]) == MODIFIED)
                 {
-                    nlohmann::json previous;
+                    const auto oldResultIt = old.find("result");
+                    const bool resultChanged = oldResultIt != old.end();
+                    const bool oldResultIsNotRun = resultChanged &&
+                                                   oldResultIt->is_string() &&
+                                                   oldResultIt->get<std::string>() == "Not run";
 
-                    for (auto& [key, value] : old.items())
+                    if (!resultChanged || oldResultIsNotRun)
                     {
-                        if (key == "id" || key == "sync")
-                        {
-                            continue;
-                        }
+                        return {};
+                    }
+                }
 
-                        previous[key] = value;
-                        changedFields.push_back("check." + key);
+                nlohmann::json previous;
+
+                for (auto& [key, value] : old.items())
+                {
+                    if (key == "id" || key == "sync")
+                    {
+                        continue;
                     }
 
-                    if (!previous.empty())
-                    {
-                        check["previous"] = previous;
-                    }
+                    previous[key] = value;
+                    changedFields.push_back("check." + key);
+                }
+
+                if (!previous.empty())
+                {
+                    check["previous"] = previous;
                 }
             }
         }

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -517,6 +517,15 @@ std::tuple<nlohmann::json, ReturnTypeCallback, uint64_t> SCAEventHandler::Proces
             {
                 check = event["check"];
             }
+
+            const auto resultIt = check.find("result");
+
+            if (resultIt != check.end() &&
+                    resultIt->is_string() &&
+                    resultIt->get<std::string>() == "Not run")
+            {
+                return {{}, SELECTED, 0};
+            }
         }
         else
         {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -141,12 +141,12 @@ void SecurityConfigurationAssessment::Run()
 
     refreshFirstSyncCompletedState();
 
-    // Reset the scan-completed flag only when the first sync has not yet happened.
-    // Once first_sync_completed is set this flag is never polled again, so writing it
+    // Reset the in-memory scan-completed flag only when the first sync has not yet happened.
+    // Once first_sync_completed is set this flag is never polled again, so resetting it
     // on every subsequent restart would be unnecessary overhead.
     if (!m_firstSyncCompleted.load())
     {
-        updateMetadataValue(SCA_SCAN_COMPLETED_METADATA_KEY, 0);
+        m_scanCompleted.store(0);
     }
 
     // Check for policies removed between agent restarts (before scan loop starts).
@@ -305,7 +305,7 @@ void SecurityConfigurationAssessment::Run()
         // sync completes — after that the sync thread no longer polls this flag.
         if (!m_firstSyncCompleted.load())
         {
-            updateMetadataValue(SCA_SCAN_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
+            m_scanCompleted.store(Utils::getSecondsFromEpoch());
         }
     }
 }
@@ -896,24 +896,12 @@ std::string SecurityConfigurationAssessment::query(const std::string& jsonQuery)
         }
         else if (command == "get_scan_completed")
         {
-            int64_t scanCompleted = 0;
-
-            if (getMetadataValue(SCA_SCAN_COMPLETED_METADATA_KEY, scanCompleted))
-            {
-                response["error"] = 0;
-                response["message"] = "SCA scan completion retrieved successfully";
-                response["data"]["action"] = "get_scan_completed";
-                response["data"]["module"] = "sca";
-                response["data"]["scan_completed"] = scanCompleted > 0 ? 1 : 0;
-            }
-            else
-            {
-                response["error"] = 2;
-                response["message"] = "SCA failed getting scan completion";
-                response["data"]["action"] = "get_scan_completed";
-                response["data"]["module"] = "sca";
-                response["data"]["scan_completed"] = 0;
-            }
+            const int64_t scanCompleted = m_scanCompleted.load();
+            response["error"] = 0;
+            response["message"] = "SCA scan completion retrieved successfully";
+            response["data"]["action"] = "get_scan_completed";
+            response["data"]["module"] = "sca";
+            response["data"]["scan_completed"] = scanCompleted > 0 ? 1 : 0;
         }
         else if (command == "set_version")
         {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -64,10 +64,6 @@ constexpr auto METADATA_SQL_STATEMENT
 
 constexpr auto SCA_LAST_INTEGRITY_CHECK_METADATA_KEY {"last_integrity_check"};
 constexpr auto SCA_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
-// Set after every complete scan iteration; cleared at Run() startup so a crash mid-scan
-// leaves it at 0. The sync thread polls this instead of MAX(version) to avoid triggering
-// the first synchronization while the DB still contains "Not run" placeholders.
-constexpr auto SCA_SCAN_COMPLETED_METADATA_KEY {"scan_completed"};
 
 SecurityConfigurationAssessment::SecurityConfigurationAssessment(std::string dbPath,
                                                                  std::shared_ptr<IDBSync> dbSync,

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -64,6 +64,10 @@ constexpr auto METADATA_SQL_STATEMENT
 
 constexpr auto SCA_LAST_INTEGRITY_CHECK_METADATA_KEY {"last_integrity_check"};
 constexpr auto SCA_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
+// Set after every complete scan iteration; cleared at Run() startup so a crash mid-scan
+// leaves it at 0. The sync thread polls this instead of MAX(version) to avoid triggering
+// the first synchronization while the DB still contains "Not run" placeholders.
+constexpr auto SCA_SCAN_COMPLETED_METADATA_KEY {"scan_completed"};
 
 SecurityConfigurationAssessment::SecurityConfigurationAssessment(std::string dbPath,
                                                                  std::shared_ptr<IDBSync> dbSync,
@@ -136,6 +140,14 @@ void SecurityConfigurationAssessment::Run()
     }
 
     refreshFirstSyncCompletedState();
+
+    // Reset the scan-completed flag only when the first sync has not yet happened.
+    // Once first_sync_completed is set this flag is never polled again, so writing it
+    // on every subsequent restart would be unnecessary overhead.
+    if (!m_firstSyncCompleted.load())
+    {
+        updateMetadataValue(SCA_SCAN_COMPLETED_METADATA_KEY, 0);
+    }
 
     // Check for policies removed between agent restarts (before scan loop starts).
     // This early check uses m_policiesData (raw config) since policies haven't been loaded yet.
@@ -288,6 +300,13 @@ void SecurityConfigurationAssessment::Run()
 
         // Mark scan as complete
         setScanInProgress(false);
+
+        // Signal that a full scan iteration has completed. Only written until the first
+        // sync completes — after that the sync thread no longer polls this flag.
+        if (!m_firstSyncCompleted.load())
+        {
+            updateMetadataValue(SCA_SCAN_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
+        }
     }
 }
 
@@ -873,6 +892,27 @@ std::string SecurityConfigurationAssessment::query(const std::string& jsonQuery)
                 response["message"] = "SCA failed getting first sync completion";
                 response["data"]["action"] = "get_first_sync_completed";
                 response["data"]["module"] = "sca";
+            }
+        }
+        else if (command == "get_scan_completed")
+        {
+            int64_t scanCompleted = 0;
+
+            if (getMetadataValue(SCA_SCAN_COMPLETED_METADATA_KEY, scanCompleted))
+            {
+                response["error"] = 0;
+                response["message"] = "SCA scan completion retrieved successfully";
+                response["data"]["action"] = "get_scan_completed";
+                response["data"]["module"] = "sca";
+                response["data"]["scan_completed"] = scanCompleted > 0 ? 1 : 0;
+            }
+            else
+            {
+                response["error"] = 2;
+                response["message"] = "SCA failed getting scan completion";
+                response["data"]["action"] = "get_scan_completed";
+                response["data"]["module"] = "sca";
+                response["data"]["scan_completed"] = 0;
             }
         }
         else if (command == "set_version")

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_dataclean_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_dataclean_test.cpp
@@ -78,7 +78,6 @@ class SCADataCleanTest : public ::testing::Test
             EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
             .WillOnce(::testing::Return()) // Sync manager initialization query
             .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
-            .WillOnce(::testing::Return()) // scan_completed update
             .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                            std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
             {
@@ -157,7 +156,6 @@ TEST_F(SCADataCleanTest, AllPoliciesRemovedAtStartup_DataCleanFailure_Retries)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
-    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -202,7 +200,6 @@ TEST_F(SCADataCleanTest, NoPoliciesNoData_ExitsCleanly)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
-    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -349,7 +346,6 @@ TEST_F(SCADataCleanTest, DataClean_WithoutSyncProtocol_Fails)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
-    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -385,7 +381,6 @@ TEST_F(SCADataCleanTest, DataClean_WaitsForSyncInProgress)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
-    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke(
                   [](const nlohmann::json& /* query */,
                      std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_dataclean_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_dataclean_test.cpp
@@ -77,6 +77,8 @@ class SCADataCleanTest : public ::testing::Test
             // Mock selectRows to return count > 0 for hasDataInDatabase()
             EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
             .WillOnce(::testing::Return()) // Sync manager initialization query
+            .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+            .WillOnce(::testing::Return()) // scan_completed update
             .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                            std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
             {
@@ -155,6 +157,7 @@ TEST_F(SCADataCleanTest, AllPoliciesRemovedAtStartup_DataCleanFailure_Retries)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -199,6 +202,7 @@ TEST_F(SCADataCleanTest, NoPoliciesNoData_ExitsCleanly)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -345,6 +349,7 @@ TEST_F(SCADataCleanTest, DataClean_WithoutSyncProtocol_Fails)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -379,6 +384,8 @@ TEST_F(SCADataCleanTest, DataClean_WaitsForSyncInProgress)
     // Mock selectRows to indicate data exists
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
+    .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // scan_completed update
     .WillOnce(::testing::Invoke(
                   [](const nlohmann::json& /* query */,
                      std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -860,6 +860,12 @@ TEST_F(SCAEventHandlerTest, ReportPoliciesDelta_ValidInput)
                                 {"name", "Check 3"},
                                 {"result", "passed"}
                             }
+                        },
+                        {
+                            "old", {
+                                {"id", "check3"},
+                                {"name", "Check 3 old name"}
+                            }
                         }
                     }
                 },
@@ -994,7 +1000,7 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_ValidInput)
     }
 }
 
-TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesStatefulMessagesBeforeFirstSync)
+TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesFirstScanNotRunTransitions)
 {
     const std::string policyId = "test_policy";
     const std::string checkId = "test_check";
@@ -1008,15 +1014,13 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesStatefulMessagesBeforeFi
             {
                 "old", {
                     {"id", "test_check"},
-                    {"result", "Not run"},
-                    {"name", "Test Check"}
+                    {"result", "Not run"}
                 }
             },
             {
                 "new", {
                     {"id", "test_check"},
-                    {"result", checkResult},
-                    {"name", "Test Check"}
+                    {"result", checkResult}
                 }
             }
         };
@@ -1071,11 +1075,89 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesStatefulMessagesBeforeFi
     newHandler->ReportCheckResult(policyId, checkId, checkResult, "Policy requirements not met");
 
     EXPECT_TRUE(statefulMessages.empty());
+    EXPECT_TRUE(statelessMessages.empty());
+}
+
+TEST_F(SCAEventHandlerTest, ReportCheckResult_EmitsRealResultTransitions)
+{
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Failed";
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([checkResult](const nlohmann::json&, const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        nlohmann::json returnData =
+        {
+            {
+                "old", {
+                    {"id", "test_check"},
+                    {"result", "Passed"}
+                }
+            },
+            {
+                "new", {
+                    {"id", "test_check"},
+                    {"result", checkResult}
+                }
+            }
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    std::vector<std::string> statefulMessages;
+    std::vector<std::string> statelessMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [&statelessMessages](const std::string & message) -> int
+    {
+        statelessMessages.push_back(message);
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(
+                          mockDBSync,
+                          mockPushStateless,
+                          mockPushStateful);
+
+    const nlohmann::json mockPolicy =
+    {
+        {"id", policyId},
+        {"name", "Test Policy"},
+        {"description", "Test Description"},
+        {"file", "test.yml"},
+        {"refs", "https://example.com"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(mockPolicy));
+
+    const nlohmann::json mockCheck =
+    {
+        {"id", checkId},
+        {"policy_id", policyId},
+        {"name", "Test Check"},
+        {"description", "Test Check Description"},
+        {"result", "Passed"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(mockCheck));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult);
+
+    EXPECT_EQ(statefulMessages.size(), 1U);
     ASSERT_EQ(statelessMessages.size(), 1U);
 
     const nlohmann::json statelessMessage = nlohmann::json::parse(statelessMessages[0]);
-    EXPECT_EQ(statelessMessage["module"], "sca");
+    EXPECT_EQ(statelessMessage["data"]["event"]["changed_fields"], nlohmann::json::array({"check.result"}));
     EXPECT_EQ(statelessMessage["data"]["check"]["result"], checkResult);
+    EXPECT_EQ(statelessMessage["data"]["check"]["previous"]["result"], "Passed");
 }
 
 TEST_F(SCAEventHandlerTest, ReportPoliciesDelta_BeforeFirstSyncSkipsValidationDeletion)
@@ -1176,7 +1258,7 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_BeforeFirstSyncSkipsValidationDele
 
     const std::string policyId = "test_policy";
     const std::string checkId = "test_check";
-    const std::string checkResult = "Not applicable";
+    const std::string checkResult = "Failed";
 
     EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
     .WillOnce([checkId, policyId, checkResult](const nlohmann::json&, const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
@@ -1187,7 +1269,7 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_BeforeFirstSyncSkipsValidationDele
                 "old", {
                     {"id", checkId},
                     {"policy_id", policyId},
-                    {"result", "Not run"}
+                    {"result", "Passed"}
                 }
             },
             {
@@ -1722,9 +1804,15 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_RowDataWithoutNew_UsesRowDataDirec
     EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
     .WillOnce([checkResult](const nlohmann::json&, const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
     {
-        // Simulate rowData WITHOUT "new" field (e.g., for a DELETED operation or simple update)
+        // Simulate rowData wrapped with "old" so the stateless path has a real delta to report.
         nlohmann::json returnData =
         {
+            {
+                "old", {
+                    {"id", "test_check"},
+                    {"result", "failed"}
+                }
+            },
             {"id", "test_check"},
             {"result", checkResult},
             {"name", "Test Check"},

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -1160,6 +1160,298 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_EmitsRealResultTransitions)
     EXPECT_EQ(statelessMessage["data"]["check"]["previous"]["result"], "Passed");
 }
 
+TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesMetadataOnlyChangeWhenResultIsNotRun)
+{
+    // Reported bug: agent restarts, only check name changes, result stays "Not run" in DB.
+    // The delta has checksum/name/version in old but NO result (result didn't change).
+    // No stateless event should be emitted because "Not run" is not a valid observable state.
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Not run";
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([checkResult](const nlohmann::json&, const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        nlohmann::json returnData =
+        {
+            {
+                "old", {
+                    {"id", "test_check"},
+                    {"checksum", "old_checksum"},
+                    {"name", "old name"},
+                    {"version", 1}
+                }
+            },
+            {
+                "new", {
+                    {"id", "test_check"},
+                    {"checksum", "new_checksum"},
+                    {"name", "new name"},
+                    {"version", 2},
+                    {"result", checkResult}
+                }
+            }
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    std::vector<std::string> statefulMessages;
+    std::vector<std::string> statelessMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [&statelessMessages](const std::string & message) -> int
+    {
+        statelessMessages.push_back(message);
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(
+                          mockDBSync,
+                          mockPushStateless,
+                          mockPushStateful,
+                          false);
+
+    const nlohmann::json mockPolicy =
+    {
+        {"id", policyId},
+        {"name", "Test Policy"},
+        {"description", "Test Description"},
+        {"file", "test.yml"},
+        {"refs", "https://example.com"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(mockPolicy));
+
+    const nlohmann::json mockCheck =
+    {
+        {"id", checkId},
+        {"policy_id", policyId},
+        {"name", "old name"},
+        {"description", "Test Check Description"},
+        {"result", checkResult}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(mockCheck));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult);
+
+    EXPECT_TRUE(statelessMessages.empty());
+}
+
+TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesTransitionToNotRun)
+{
+    // A valid previous result ("Failed") transitions to "Not run" — the check couldn't
+    // execute this cycle. "Not run" is not an observable state, so no stateless event.
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Not run";
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([checkResult](const nlohmann::json&, const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        nlohmann::json returnData =
+        {
+            {
+                "old", {
+                    {"id", "test_check"},
+                    {"result", "Failed"}
+                }
+            },
+            {
+                "new", {
+                    {"id", "test_check"},
+                    {"result", checkResult}
+                }
+            }
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    std::vector<std::string> statefulMessages;
+    std::vector<std::string> statelessMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [&statelessMessages](const std::string & message) -> int
+    {
+        statelessMessages.push_back(message);
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(
+                          mockDBSync,
+                          mockPushStateless,
+                          mockPushStateful,
+                          false);
+
+    const nlohmann::json mockPolicy =
+    {
+        {"id", policyId},
+        {"name", "Test Policy"},
+        {"description", "Test Description"},
+        {"file", "test.yml"},
+        {"refs", "https://example.com"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(mockPolicy));
+
+    const nlohmann::json mockCheck =
+    {
+        {"id", checkId},
+        {"policy_id", policyId},
+        {"name", "Test Check"},
+        {"description", "Test Check Description"},
+        {"result", "Failed"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(mockCheck));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult);
+
+    EXPECT_TRUE(statelessMessages.empty());
+}
+
+TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesMetadataOnlyChangeWithValidResult)
+{
+    // Checksum/name change but result stays "Failed" (same valid result, no state transition).
+    // No stateless event should be emitted; only a stateful update is appropriate.
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Failed";
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([checkResult](const nlohmann::json&, const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        nlohmann::json returnData =
+        {
+            {
+                "old", {
+                    {"id", "test_check"},
+                    {"checksum", "old_checksum"},
+                    {"name", "old name"}
+                }
+            },
+            {
+                "new", {
+                    {"id", "test_check"},
+                    {"checksum", "new_checksum"},
+                    {"name", "new name"},
+                    {"result", checkResult}
+                }
+            }
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    std::vector<std::string> statefulMessages;
+    std::vector<std::string> statelessMessages;
+
+    auto mockPushStateful = [&statefulMessages](const std::string&, Operation_t, const std::string&, const std::string & message, uint64_t) -> int
+    {
+        statefulMessages.push_back(message);
+        return 0;
+    };
+
+    auto mockPushStateless = [&statelessMessages](const std::string & message) -> int
+    {
+        statelessMessages.push_back(message);
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(
+                          mockDBSync,
+                          mockPushStateless,
+                          mockPushStateful);
+
+    const nlohmann::json mockPolicy =
+    {
+        {"id", policyId},
+        {"name", "Test Policy"},
+        {"description", "Test Description"},
+        {"file", "test.yml"},
+        {"refs", "https://example.com"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(mockPolicy));
+
+    const nlohmann::json mockCheck =
+    {
+        {"id", checkId},
+        {"policy_id", policyId},
+        {"name", "old name"},
+        {"description", "Test Check Description"},
+        {"result", checkResult}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(mockCheck));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult);
+
+    EXPECT_TRUE(statelessMessages.empty());
+}
+
+TEST_F(SCAEventHandlerTest, ProcessStateless_SuppressesInsertedCheckWithNotRunResult)
+{
+    // A newly inserted check always has result="Not run" (DB default set by sca_policy_loader).
+    // No stateless event should be emitted — "Not run" is not a real observable state
+    // regardless of the operation type (INSERTED, MODIFIED, DELETED).
+    std::vector<std::string> statelessMessages;
+
+    auto mockPushStateless = [&statelessMessages](const std::string & message) -> int
+    {
+        statelessMessages.push_back(message);
+        return 0;
+    };
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(
+                          mockDBSync,
+                          mockPushStateless,
+                          nullptr,
+                          false);
+
+    const nlohmann::json event =
+    {
+        {"collector", "check"},
+        {"result", INSERTED},
+        {
+            "check", {
+                {"id", "test_check"},
+                {"policy_id", "test_policy"},
+                {"name", "Test Check"},
+                {"result", "Not run"}
+            }
+        },
+        {
+            "policy", {
+                {"id", "test_policy"},
+                {"name", "Test Policy"},
+                {"description", "Test Description"},
+                {"file", "test.yml"}
+            }
+        }
+    };
+
+    const auto result = newHandler->ProcessStateless(event);
+
+    EXPECT_TRUE(result.empty());
+    EXPECT_TRUE(statelessMessages.empty());
+}
+
 TEST_F(SCAEventHandlerTest, ReportPoliciesDelta_BeforeFirstSyncSkipsValidationDeletion)
 {
     auto& validatorFactory = SchemaValidator::SchemaValidatorFactory::getInstance();

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -864,7 +864,8 @@ TEST_F(SCAEventHandlerTest, ReportPoliciesDelta_ValidInput)
                         {
                             "old", {
                                 {"id", "check3"},
-                                {"name", "Check 3 old name"}
+                                {"name", "Check 3 old name"},
+                                {"result", "failed"}
                             }
                         }
                     }

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -581,18 +581,31 @@ TEST_F(SCAEventHandlerTest, ProcessStateless_ValidInput1)
 
 TEST_F(SCAEventHandlerTest, ProcessStateless_ValidInput2)
 {
-    const nlohmann::json input = {{"check",
-            {   {"checksum", "abc123"},
-                {"id", "chk1"},
-                {"result", "failed"},
-                {"compliance", {{"pci_dss", {"1.1"}}, {"gdpr", {"32"}}}},
-                {"condition", "any"},
-                {"description", "Short check description"},
-                {"rationale", "Minimize risk"},
-                {"refs", "RefA, RefB"},
-                {"remediation", "Do something secure"},
-                {"rules", {"RuleA", "RuleB"}},
-                {"name", "Check some condition"}
+    const nlohmann::json input =
+    {
+        {
+            "check",
+            {
+                {
+                    "new",
+                    {   {"checksum", "abc123"},
+                        {"id", "chk1"},
+                        {"result", "failed"},
+                        {"compliance", {{"pci_dss", {"1.1"}}, {"gdpr", {"32"}}}},
+                        {"condition", "any"},
+                        {"description", "Short check description"},
+                        {"rationale", "Minimize risk"},
+                        {"refs", "RefA, RefB"},
+                        {"remediation", "Do something secure"},
+                        {"rules", {"RuleA", "RuleB"}},
+                        {"name", "Check some condition"}
+                    }
+                },
+                {
+                    "old",
+                    {   {"result", "passed"}
+                    }
+                }
             }
         },
         {
@@ -605,7 +618,7 @@ TEST_F(SCAEventHandlerTest, ProcessStateless_ValidInput2)
             }
         },
         {"collector", "check"},
-        {"result", 1}
+        {"result", 0}
     };
 
     const nlohmann::json output = handler->ProcessStateless(input);

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -273,7 +273,7 @@ void SCA::init()
             m_sca->SetPushStatelessMessageFunction(sendStatelessMessage);
             m_sca->SetPushStatefulMessageFunction(persistStatefulMessage);
 
-            LoggingHelper::getInstance().log(LOG_INFO, "SCA module initialized successfully.");
+            LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module initialized successfully.");
         }
         catch (const std::exception& ex)
         {
@@ -286,7 +286,7 @@ void SCA::init()
     }
     else
     {
-        LoggingHelper::getInstance().log(LOG_INFO, "SCA module already initialized.");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module already initialized.");
     }
 }
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -397,21 +397,21 @@ static wm_sca_startup_action_t wm_sca_get_startup_action(bool* first_sync_comple
         return SCA_STARTUP_ACTION_WAIT;
     }
 
-    mdebug1("SCA initial scan data is not ready yet. First synchronization will wait for scan data.");
+    mdebug1("SCA initial scan has not completed yet. First synchronization will wait for a full scan.");
 
     while (sca_sync_module_running && !g_shutting_down)
     {
-        int version = 0;
+        int scan_completed = 0;
 
-        if (!wm_sca_query_int("{\"command\":\"get_version\"}", "version", &version))
+        if (!wm_sca_query_int("{\"command\":\"get_scan_completed\"}", "scan_completed", &scan_completed))
         {
-            mdebug1("Failed to detect initial SCA scan data. Keeping startup synchronization delay.");
+            mdebug1("Failed to detect initial SCA scan completion. Keeping startup synchronization delay.");
             return SCA_STARTUP_ACTION_WAIT;
         }
 
-        if (version > 0)
+        if (scan_completed > 0)
         {
-            mdebug1("Initial SCA scan data is ready. Triggering first synchronization without startup delay.");
+            mdebug1("Initial SCA scan completed. Triggering first synchronization.");
             return SCA_STARTUP_ACTION_IMMEDIATE;
         }
 

--- a/tests/integration/test_sca/test_basic/test_compliance_format.py
+++ b/tests/integration/test_sca/test_basic/test_compliance_format.py
@@ -190,6 +190,12 @@ def test_sca_compliance_format(test_configuration, test_metadata, prepare_cis_po
     log_monitor.start(callback=callbacks.generate_callback(patterns.SCA_SCAN_ENDED_CHECK), timeout=timeout)
     assert log_monitor.callback_result is not None and log_monitor.callback_result[0] == expected_policy
 
+    # Give SCA time to flush stateful events through the async pipeline after the
+    # scan ends; the "Stateful event queued" log lines are written from a worker
+    # thread so they may trail the SCA_SCAN_ENDED_CHECK marker.
+    import time
+    time.sleep(5)
+
     # ------------------------------------------------------------------
     # Phase 2: Validate WARNING messages
     # ------------------------------------------------------------------
@@ -235,8 +241,10 @@ def test_sca_compliance_format(test_configuration, test_metadata, prepare_cis_po
     # ------------------------------------------------------------------
     # Phase 3: Validate compliance in event JSON
     # ------------------------------------------------------------------
+    # Stateful events always flow on first scan; stateless deltas are suppressed
+    # for the "Not run" → first-observation transition (issue #35428).
     events_by_check = {}
-    for match in re.finditer(patterns.SCA_SENDING_EVENT, log_content):
+    for match in re.finditer(patterns.SCA_STATEFUL_EVENT_QUEUED, log_content):
         json_str = match.group(1)
         check_id, compliance = extract_compliance_from_event_json(json_str)
         if check_id:

--- a/tests/integration/test_sca/test_basic/test_mitre_payload.py
+++ b/tests/integration/test_sca/test_basic/test_mitre_payload.py
@@ -141,7 +141,7 @@ def test_sca_mitre_payload(test_configuration, test_metadata, prepare_cis_polici
     log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
 
     # Wait for a stateful event containing a MITRE object
-    log_monitor.start(callback=_callback_mitre_event, timeout=60)
+    log_monitor.start(callback=_callback_mitre_event, timeout=120)
     assert log_monitor.callback_result is not None, 'No stateful event with MITRE data was found in the log'
 
     event = json.loads(log_monitor.callback_result[0])


### PR DESCRIPTION
## Description

SCA was firing a "modified" stateless event for every single check on the very first scan of a fresh agent. Each one showed `previous.result = "Not run"` — which is not a real previous state, it's just the DB column default from the `sca_check` schema. From the user's side these looked like real security posture changes when really it was just SCA observing each check for the first time.

Closes #35428

## Proposed Changes

One behavior change in `SCAEventHandler::ProcessStateless`: if the old row has `result = "Not run"`, treat the whole transition as a first observation and drop the stateless event. Any sibling fields that also show up in the diff (for example `reason` populated when a check becomes `"Not applicable"`) are also first-time values, so they go with it. Real transitions like `Passed → Failed` are untouched — `old.result` there is `"Passed"`, not `"Not run"`, so they still get reported normally.

A second small guard drops any `MODIFIED` event that ends up with an empty `changed_fields` array, so we never push a "change event" that doesn't actually describe anything.

Stateful snapshots are not affected — the initial state still reaches the indexer through the first-sync snapshot path, so a fresh agent still shows up with full state.

### Results and Evidence

Reproduced the bug on a clean agent install against the test manager. Config: `scan_interval = 60s`, debug logging on. Policy is `cis_ubuntu22-04.yml`, 207 checks.

**Before the fix — first scan, fresh DB:**

```
$ grep -cE 'Stateless event queued' /var/ossec/logs/ossec.log
207
$ grep -cE 'Stateful event queued' /var/ossec/logs/ossec.log
207
$ grep -E 'SCA scan (started|ended)' /var/ossec/logs/ossec.log
2026/04/14 18:53:31 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/14 18:53:36 wazuh-modulesd:sca: INFO: SCA scan ended.
```

One of those 207 stateless events, trimmed to the interesting bits — matches the event in the issue exactly:

```json
{
  "data": {
    "check": {
      "id": "33301",
      "result": "Failed",
      "previous": { "result": "Not run" }
    },
    "event": {
      "changed_fields": ["check.result"],
      "type": "modified"
    }
  }
}
```

**After the fix — same setup, fresh DB, first scan:**

```
$ grep -cE 'Stateless event queued' /var/ossec/logs/ossec.log
0
$ grep -cE 'Stateful event queued' /var/ossec/logs/ossec.log
207
$ grep -E 'SCA scan (started|ended)' /var/ossec/logs/ossec.log
2026/04/14 19:08:08 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/14 19:08:08 wazuh-modulesd:sca: INFO: SCA scan ended.
```

207 stateful snapshots still go through (so the indexer gets its initial snapshot), zero stateless events. DB ends up populated the same way as before:

```
$ sqlite3 /var/ossec/queue/sca/db/sca.db 'SELECT result, COUNT(*) FROM sca_check GROUP BY result;'
Failed|89
Not applicable|49
Passed|69

$ sqlite3 /var/ossec/queue/sca/db/sca.db 'SELECT * FROM sca_metadata;'
first_sync_completed|1776193690|1
last_integrity_check|1776193690|1
```

**Second scan (60s later), stable state:**

```
2026/04/14 19:09:08 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/14 19:09:09 wazuh-modulesd:sca: INFO: SCA scan ended.

$ grep -cE 'Stateless event queued' /var/ossec/logs/ossec.log
0
$ grep -cE 'Stateful event queued' /var/ossec/logs/ossec.log
207
```

Nothing changed on the system, nothing new gets pushed. Expected behavior.

**Agent reload / restart with DB already populated.** The issue title also calls out "after the initial scan **or a reload**", so this is the second case: first scan has already run, DB has real results, then the agent process is restarted and scans again.

```
$ sqlite3 /var/ossec/queue/sca/db/sca.db 'SELECT result, COUNT(*) FROM sca_check GROUP BY result;'
Failed|89
Not applicable|49
Passed|69
$ sqlite3 /var/ossec/queue/sca/db/sca.db 'SELECT * FROM sca_metadata;'
first_sync_completed|1776202382|1
last_integrity_check|1776202382|1

$ truncate -s 0 /var/ossec/logs/ossec.log
$ /var/ossec/bin/wazuh-control restart
...
Completed.

$ grep -E 'SCA scan (started|ended)' /var/ossec/logs/ossec.log
2026/04/14 21:33:31 wazuh-modulesd:sca: INFO: SCA scan started.
2026/04/14 21:33:31 wazuh-modulesd:sca: INFO: SCA scan ended.
$ grep -cE 'Stateless event queued' /var/ossec/logs/ossec.log
0
$ grep -cE 'Stateful event queued' /var/ossec/logs/ossec.log
0
$ grep -c 'Sending SCA event' /var/ossec/logs/ossec.log
0
```

0 stateless, 0 stateful, nothing sent to the queue. DBSync loads the existing rows on startup, the scan re-evaluates every check, and every result matches the persisted value — no deltas, nothing to push. This is the restart/reload scenario from the issue, which was previously producing spurious stateless events because the first scan itself (not the restart) was emitting the `"Not run" → real result` pseudo-deltas that the reporter was observing.

**End-to-end check on the wazuh-indexer.** Same test window — verified that the state actually reaching the indexer matches what the DB holds, and that no spurious stateless events landed in the security events stream.

Stateful snapshot index (`wazuh-states-sca`) for agent `001`:

```
$ curl -sk -u admin:admin https://localhost:9200/wazuh-states-sca/_search \
    -H 'Content-Type: application/json' \
    -d '{"size":0,"query":{"term":{"wazuh.agent.id":"001"}},
         "aggs":{"by_result":{"terms":{"field":"check.result"}}}}'
"total": { "value": 207, "relation": "eq" }
"buckets": [
  { "key": "Failed",         "doc_count": 89 },
  { "key": "Passed",         "doc_count": 69 },
  { "key": "Not applicable", "doc_count": 49 }
]
```

207 docs, split exactly like the `sca.db` totals above (89 / 69 / 49). And nothing in the indexer with `result = "Not run"`:

```
$ curl -sk -u admin:admin https://localhost:9200/wazuh-states-sca/_count \
    -H 'Content-Type: application/json' \
    -d '{"query":{"bool":{"must":[
         {"term":{"wazuh.agent.id":"001"}},
         {"term":{"check.result":"Not run"}}]}}}'
{"count":0,...}
```

Security events stream (`.ds-wazuh-events-v5-security-000001`) scoped to the SCA module, agent `001`, during the fresh-install + restart window:

```
$ curl -sk -u admin:admin \
    https://localhost:9200/.ds-wazuh-events-v5-security-000001/_count \
    -H 'Content-Type: application/json' \
    -d '{"query":{"bool":{"must":[
         {"term":{"wazuh.protocol.location":"sca"}},
         {"term":{"wazuh.agent.id":"001"}},
         {"range":{"@timestamp":{"gte":"2026-04-14T21:32:00Z"}}}]}}}'
{"count":0,...}
```

0 SCA stateless events for the agent since the fresh install. Covers both the first scan and the agent restart. The indexer ends up with the correct full snapshot of the posture (207 docs) and no bogus "modified" events polluting the security stream.

**Real transition check.** To make sure `Passed → Failed` still fires a stateless event, I stopped the agent and flipped one row in the DB to force a fake divergence:

```
$ systemctl stop wazuh-agent
$ sqlite3 /var/ossec/queue/sca/db/sca.db "UPDATE sca_check SET result='Passed' WHERE id='28501';"
$ systemctl start wazuh-agent
```

Check `28501` is `Ensure nodev option set on /tmp partition`, which actually fails on this container, so the next scan re-evaluates it and hits `Failed`. One stateless event emitted, which is exactly what we want:

```json
{
  "data": {
    "check": {
      "id": "28501",
      "result": "Failed",
      "previous": { "result": "Passed" }
    },
    "event": {
      "changed_fields": ["check.result"],
      "type": "modified",
      "created": "2026-04-14T19:10:09.651Z"
    }
  }
}
```

**E2E test:**

No wazuh-events related to sca:
<img width="1912" height="413" alt="image" src="https://github.com/user-attachments/assets/1baafaa4-f779-4341-9198-516b716068b3" />

Adding a custom check to verify the transition between results:
```
- id: 99901
    title: "Tests check PASS"
    description: "Testing check"
    condition: all
    rules:
      - 'c:sh -c "test -f /tmp/sca_test && echo exists" -> r:exists'
```

The stateful event was generated correctly:
<img width="1903" height="606" alt="image" src="https://github.com/user-attachments/assets/50f37f07-5e1b-4de7-8d98-68bdb3cccd1c" />


No stateless event was generated, as expected:
<img width="1903" height="608" alt="image" src="https://github.com/user-attachments/assets/3a6c5c6e-d9ae-4cef-8c62-ee8a5158b6fb" />

Creation of the /tmp/sca_test file to pass the check:

```
root@nico-VirtualBox:/home/nico/wazuh# echo "Hello" >> /tmp/sca_test
root@nico-VirtualBox:/home/nico/wazuh# ls /tmp/sca_test
/tmp/sca_test
```

Stateless and stateful events received:
<img width="1907" height="640" alt="image" src="https://github.com/user-attachments/assets/2fb3ebcc-268c-4551-939b-d6f88c74e8ae" />

<img width="1911" height="621" alt="image" src="https://github.com/user-attachments/assets/87e67ab0-6c07-4a7d-936d-0521a68bbe11" />


### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (agent rebuilt in test env, incremental build clean)
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

### Artifacts Affected

- `src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp`
- `src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp`
- `tests/integration/test_sca/test_basic/test_compliance_format.py`

No config, no packaging, no API surface.

### Configuration Changes

N/A.

### Tests Introduced

Unit tests (`sca_event_handler_test.cpp`):

- Renamed the existing `ReportCheckResult_SuppressesStatefulMessagesBeforeFirstSync` to `ReportCheckResult_SuppressesFirstScanNotRunTransitions` and flipped the expectation: when `old.result = "Not run"`, the stateless queue must stay empty. The old test was locking in the buggy behavior.
- Added `ReportCheckResult_EmitsRealResultTransitions`: old `"Passed"` → new `"Failed"`, asserts one stateless event goes out with `previous.result = "Passed"` and `changed_fields = ["check.result"]`.
- `ReportCheckResult_BeforeFirstSyncSkipsValidationDeletion` no longer uses a `"Not run"` transition (it would get suppressed now and stop exercising the validation-deletion path). Swapped it to `"Passed" → "Failed"`, assertions unchanged.
- `ReportPoliciesDelta_ValidInput`: gave the `check3` mock a proper `old` block so it represents a real `MODIFIED` event instead of a pseudo-delta with no previous state.
- `ReportCheckResult_RowDataWithoutNew_UsesRowDataDirectly`: mock `syncRow` callback now wraps the direct row data with an `old` block so it still exercises the "rowData without `new`" branch but carries a real delta (`failed` → `passed`).

Integration tests (`tests/integration/test_sca/test_basic/test_compliance_format.py`):

- Phase 3 now scans for `SCA_STATEFUL_EVENT_QUEUED` instead of `SCA_SENDING_EVENT`. First-scan stateless events are intentionally suppressed by this fix, but the stateful snapshot still carries the same check+compliance payload — it's the right source for structural validation.
- Added a 5-second settle after `SCA_SCAN_ENDED_CHECK`. Stateful events are pushed from the async flush worker in `SCAEventHandler`, so their log lines can trail the scan-ended marker by a beat; without the wait the read of `log_content` races the flush.

Full unit test run on the agent container (all SCA suites, `UNIT_TEST=ON`):

```
=== sca_unit_test ===
[==========] 21 tests from 1 test suite ran.
[  PASSED  ] 21 tests.
=== sca_policy_loader_unit_test ===
[==========] 16 tests from 1 test suite ran.
[  PASSED  ] 16 tests.
=== sca_event_handler_unit_test ===
[==========] 48 tests from 1 test suite ran.
[  PASSED  ] 48 tests.
=== sca_sync_manager_unit_test ===
[==========] 9 tests from 1 test suite ran.
[  PASSED  ] 9 tests.
=== sca_utils_unit_test ===
[==========] 28 tests from 3 test suites ran.
[  PASSED  ] 28 tests.
=== sca_policy_parser_unit_test ===
[==========] 15 tests from 1 test suite ran.
[  PASSED  ] 15 tests.
```

Integration run (`test_sca/` from the qa-integration-framework, executed in the `wazuh-agent` container):

```
$ docker exec wazuh-agent bash -c \
    'cd /wazuh-repo/tests/integration && python -m pytest test_sca/ \
     --html=/tmp/sca_results.html --self-contained-html'
...
-------------- generated html file: file:///tmp/sca_results.html ---------------
================== 7 passed, 26 warnings in 234.67s (0:03:54) ==================
```

Covers: `test_compliance_format` (valid_keys / invalid_keys / old_format), `test_mitre_payload`, `test_scan_results`, and both `test_validate_remediation` scenarios.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
