### PR TITLE
Actions refactoring v5 ~ Iteration [2/3]

### DIFF
--- a/.github/actions/build_wazuh/action.yml
+++ b/.github/actions/build_wazuh/action.yml
@@ -12,6 +12,8 @@ runs:
   steps:
     - name: Build Wazuh ${{ inputs.target }}
       shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
       run: |
-        make deps -C src TARGET=${{ inputs.target }} -j$(nproc)
-        make -C src TARGET=${{ inputs.target }} -j$(nproc)
+        make deps -C src TARGET="$TARGET" -j$(nproc)
+        make -C src TARGET="$TARGET" -j$(nproc)

--- a/.github/actions/build_wazuh/action.yml
+++ b/.github/actions/build_wazuh/action.yml
@@ -1,0 +1,17 @@
+name: "Build Wazuh"
+description: "Builds the Wazuh project using make for a given target"
+
+inputs:
+  target:
+    required: false
+    description: "Build target: agent or manager"
+    default: "agent"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build Wazuh ${{ inputs.target }}
+      shell: bash
+      run: |
+        make deps -C src TARGET=${{ inputs.target }} -j$(nproc)
+        make -C src TARGET=${{ inputs.target }} -j$(nproc)

--- a/.github/actions/coverage_cpp/action.yml
+++ b/.github/actions/coverage_cpp/action.yml
@@ -5,9 +5,6 @@ inputs:
   path:
     required: true
     description: "Path to the module"
-  test_directory:
-    required: true
-    description: "Directory where the tests are located"
   id:
     required: true
     description: "Module identifier, used to name the artifact"
@@ -23,121 +20,114 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Dependencies for local execution
-        if: env.ACT # Only run for local execution
-        shell: bash
-        run: |
+    - name: Dependencies for local execution
+      if: env.ACT # Only run for local execution
+      shell: bash
+      run: |
 
-          # Update packages
-          sudo apt-get update
-          sudo apt-get install -y bc
+        # Update packages
+        sudo apt-get update
+        sudo apt-get install -y bc
 
-      # Dependencies for testing:
-      # - lcov
-      - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
-        with:
-          packages: lcov
-          version: 1.0
+    # Dependencies for testing:
+    # - lcov
+    - name: Install dependencies
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+      with:
+        packages: lcov
+        version: 1.0
 
-      # Generate the coverage files
-      - name: Generate coverage files
-        shell: bash
-        run: |
-          BUILD_DIR=$(pwd)/src/build
-          cd ${{ inputs.path }}
+    - name: Generate coverage files
+      shell: bash
+      run: |
+        BUILD_DIR=$(pwd)/src/build
+        cd ${{ inputs.path }}
 
-          # Set arguments
-          arguments="--capture "
-          # Set working directory
-          arguments+="--directory $BUILD_DIR "
-          # Set output file
-          arguments+="--output-file $BUILD_DIR/coverage.info "
-          # # Disable branch coverage
-          arguments+="--rc branch_coverage=0 "
+        # Set arguments
+        arguments="--capture "
+        arguments+="--directory $BUILD_DIR "
+        arguments+="--output-file $BUILD_DIR/coverage.info "
+        arguments+="--rc branch_coverage=0 "
 
-          # Ignore lcov 2.x strict errors for unused include patterns, version mismatches,
-          # and gcov/lcov line range mismatches (gcov 13 + lcov 2.0 incompatibility)
-          arguments+="--ignore-errors unused,deprecated,mismatch "
+        # Ignore lcov 2.x strict errors for unused include patterns, version mismatches,
+        # and gcov/lcov line range mismatches (gcov 13 + lcov 2.0 incompatibility)
+        arguments+="--ignore-errors unused,deprecated,mismatch "
 
-          # Include source files using glob patterns (compatible with lcov 2.x)
-          if [[ ${{ inputs.path }} =~ "shared_modules/utils" ]]; then
-            arguments+="--include=$(pwd)/* "
-          else
-            arguments+="--include=$(pwd)/src/* --include=$(pwd)/include/* "
-          fi
+        # Include source files using glob patterns (compatible with lcov 2.x)
+        if [[ ${{ inputs.path }} =~ "shared_modules/utils" ]]; then
+          arguments+="--include=$(pwd)/* "
+        else
+          arguments+="--include=$(pwd)/src/* --include=$(pwd)/include/* "
+        fi
 
-          # Exclude generated headers
-          arguments+="--exclude=*_generated.h "
+        # Exclude generated headers
+        arguments+="--exclude=*_generated.h "
 
 
-          echo "Executing: lcov $arguments"
-          echo "Include files: $include_files"
-          lcov_version=$(lcov --version | awk '{print $NF}')
-          lcov_major=${lcov_version%%.*}
-          if [[ "$lcov_major" =~ ^[0-9]+$ ]] && (( lcov_major >= 2 )); then
-            ignore_errors="mismatch,unused"
-          else
-            ignore_errors="mismatch"
-          fi
-          echo "Using lcov ignore-errors: $ignore_errors (lcov $lcov_version)"
-          lcov $arguments --ignore-errors "$ignore_errors"
+        echo "Executing: lcov $arguments"
+        echo "Include files: $include_files"
+        lcov_version=$(lcov --version | awk '{print $NF}')
+        lcov_major=${lcov_version%%.*}
+        if [[ "$lcov_major" =~ ^[0-9]+$ ]] && (( lcov_major >= 2 )); then
+          ignore_errors="mismatch,unused"
+        else
+          ignore_errors="mismatch"
+        fi
+        echo "Using lcov ignore-errors: $ignore_errors (lcov $lcov_version)"
+        lcov $arguments --ignore-errors "$ignore_errors"
 
-      # Generate the HTML coverage report and capture coverage data
-      - name: Generate coverage report and extract coverage data
-        shell: bash
-        run: |
-          cd $(pwd)/src/build
+    - name: Generate coverage report and extract coverage data
+      shell: bash
+      run: |
+        cd $(pwd)/src/build
 
-          # Generate HTML report
-          genhtml coverage.info --output-directory coverage_report --ignore-errors unused,deprecated,mismatch
+        genhtml coverage.info --output-directory coverage_report --ignore-errors unused,deprecated,mismatch
 
-      # Upload the coverage report as an artifact
-      - name: Uploading coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Coverage Report - ${{ inputs.id }}
-          path: ./src/build/coverage_report
-          retention-days: 1
-        continue-on-error: true
+    - name: Uploading coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Coverage Report - ${{ inputs.id }}
+        path: ./src/build/coverage_report
+        retention-days: 1
+      continue-on-error: true
 
-      # Check whether the coverage is greater than 90% both for lines and functions
-      - name: Validate coverage
-        shell: bash
-        run: |
+    # Check whether the coverage is greater than 90% both for lines and functions
+    - name: Validate coverage
+      shell: bash
+      run: |
 
-          cd $(pwd)/src/build
+        cd $(pwd)/src/build
 
-          # Parse coverage directly from the .info file (avoids lcov version-dependent output format issues)
-          linesCoverage=$(awk -F: '/^LH:/{h+=$2}/^LF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
-          echo "Lines coverage is: $linesCoverage %"
-          if ! (( $(echo "$linesCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
-            echo "----------------------------------------"
-            echo "FAILED: Lines coverage is lower than ${{ inputs.threshold }}%"
-            echo "----------------------------------------"
+        # Parse coverage directly from the .info file (avoids lcov version-dependent output format issues)
+        linesCoverage=$(awk -F: '/^LH:/{h+=$2}/^LF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
+        echo "Lines coverage is: $linesCoverage %"
+        if ! (( $(echo "$linesCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
+          echo "----------------------------------------"
+          echo "FAILED: Lines coverage is lower than ${{ inputs.threshold }}%"
+          echo "----------------------------------------"
+          exit 1
+        else
+          echo "------------------------------------------"
+          echo "PASSED: Lines coverage is greater than ${{ inputs.threshold }}%"
+          echo "------------------------------------------"
+        fi
+
+        functionsCoverage=$(awk -F: '/^FNH:/{h+=$2}/^FNF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
+        echo "Functions coverage is: $functionsCoverage %"
+        if [[ "${{ inputs.validate_function_coverage }}" == "true" ]]; then
+          if ! (( $(echo "$functionsCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
+            echo "---------------------------------------------"
+            echo "FAILED: Functions coverage is lower than ${{ inputs.threshold }}%"
+            echo "--------------------------------------------"
             exit 1
           else
-            echo "------------------------------------------"
-            echo "PASSED: Lines coverage is greater than ${{ inputs.threshold }}%"
-            echo "------------------------------------------"
-          fi
-
-          functionsCoverage=$(awk -F: '/^FNH:/{h+=$2}/^FNF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
-          echo "Functions coverage is: $functionsCoverage %"
-          if [[ "${{ inputs.validate_function_coverage }}" == "true" ]]; then
-            if ! (( $(echo "$functionsCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
-              echo "---------------------------------------------"
-              echo "FAILED: Functions coverage is lower than ${{ inputs.threshold }}%"
-              echo "--------------------------------------------"
-              exit 1
-            else
-              echo "----------------------------------------------"
-              echo "PASSED: Functions coverage is greater than ${{ inputs.threshold }}%"
-              echo "----------------------------------------------"
-            fi
-          else
             echo "----------------------------------------------"
-            echo "SKIPPED: Function coverage validation is disabled"
+            echo "PASSED: Functions coverage is greater than ${{ inputs.threshold }}%"
             echo "----------------------------------------------"
           fi
+        else
+          echo "----------------------------------------------"
+          echo "SKIPPED: Function coverage validation is disabled"
+          echo "----------------------------------------------"
+        fi

--- a/.github/actions/coverage_cpp/action.yml
+++ b/.github/actions/coverage_cpp/action.yml
@@ -39,9 +39,11 @@ runs:
 
     - name: Generate coverage files
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
       run: |
         BUILD_DIR=$(pwd)/src/build
-        cd ${{ inputs.path }}
+        cd "$INPUT_PATH"
 
         # Set arguments
         arguments="--capture "
@@ -54,7 +56,7 @@ runs:
         arguments+="--ignore-errors unused,deprecated,mismatch "
 
         # Include source files using glob patterns (compatible with lcov 2.x)
-        if [[ ${{ inputs.path }} =~ "shared_modules/utils" ]]; then
+        if [[ "$INPUT_PATH" =~ "shared_modules/utils" ]]; then
           arguments+="--include=$(pwd)/* "
         else
           arguments+="--include=$(pwd)/src/* --include=$(pwd)/include/* "
@@ -95,6 +97,9 @@ runs:
     # Check whether the coverage is greater than 90% both for lines and functions
     - name: Validate coverage
       shell: bash
+      env:
+        THRESHOLD: ${{ inputs.threshold }}
+        VALIDATE_FUNCTION_COVERAGE: ${{ inputs.validate_function_coverage }}
       run: |
 
         cd $(pwd)/src/build
@@ -102,28 +107,28 @@ runs:
         # Parse coverage directly from the .info file (avoids lcov version-dependent output format issues)
         linesCoverage=$(awk -F: '/^LH:/{h+=$2}/^LF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
         echo "Lines coverage is: $linesCoverage %"
-        if ! (( $(echo "$linesCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
+        if ! (( $(echo "$linesCoverage >= $THRESHOLD" | bc -l) )); then
           echo "----------------------------------------"
-          echo "FAILED: Lines coverage is lower than ${{ inputs.threshold }}%"
+          echo "FAILED: Lines coverage is lower than $THRESHOLD%"
           echo "----------------------------------------"
           exit 1
         else
           echo "------------------------------------------"
-          echo "PASSED: Lines coverage is greater than ${{ inputs.threshold }}%"
+          echo "PASSED: Lines coverage is greater than $THRESHOLD%"
           echo "------------------------------------------"
         fi
 
         functionsCoverage=$(awk -F: '/^FNH:/{h+=$2}/^FNF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
         echo "Functions coverage is: $functionsCoverage %"
-        if [[ "${{ inputs.validate_function_coverage }}" == "true" ]]; then
-          if ! (( $(echo "$functionsCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
+        if [[ "$VALIDATE_FUNCTION_COVERAGE" == "true" ]]; then
+          if ! (( $(echo "$functionsCoverage >= $THRESHOLD" | bc -l) )); then
             echo "---------------------------------------------"
-            echo "FAILED: Functions coverage is lower than ${{ inputs.threshold }}%"
+            echo "FAILED: Functions coverage is lower than $THRESHOLD%"
             echo "--------------------------------------------"
             exit 1
           else
             echo "----------------------------------------------"
-            echo "PASSED: Functions coverage is greater than ${{ inputs.threshold }}%"
+            echo "PASSED: Functions coverage is greater than $THRESHOLD%"
             echo "----------------------------------------------"
           fi
         else

--- a/.github/actions/cpp_test_pipeline/action.yml
+++ b/.github/actions/cpp_test_pipeline/action.yml
@@ -1,0 +1,72 @@
+name: "C++ Test Pipeline"
+description: "Runs the standard C++ module test pipeline: build external deps, build target, run tests, optional coverage"
+
+inputs:
+  target:
+    required: true
+    description: "CMake test target name"
+  asan:
+    required: false
+    description: "Enable ASAN (disables valgrind and coverage)"
+    default: "false"
+  with_coverage:
+    required: false
+    description: "Run coverage analysis after tests (ignored when asan is true)"
+    default: "false"
+  coverage_path:
+    required: false
+    description: "Path to the module for coverage calculation"
+    default: ""
+  coverage_id:
+    required: false
+    description: "Coverage artifact identifier"
+    default: ""
+  coverage_threshold:
+    required: false
+    description: "Minimum coverage percentage required"
+    default: "90"
+  validate_function_coverage:
+    required: false
+    description: "Whether to validate function-level coverage"
+    default: "true"
+  reinstall_cmake:
+    required: false
+    description: "Whether to reinstall CMake before building"
+    default: "false"
+  flags:
+    required: false
+    description: "Extra CMake flags passed through to build_target_cpp"
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install compatible CMake
+      if: ${{ inputs.reinstall_cmake == 'true' }}
+      uses: ./.github/actions/reinstall_cmake
+
+    - name: Build external dependencies
+      uses: ./.github/actions/build_external_deps
+
+    - name: Build test target
+      uses: ./.github/actions/build_target_cpp
+      with:
+        target: ${{ inputs.target }}
+        test: "true"
+        asan: ${{ inputs.asan }}
+        flags: ${{ inputs.flags }}
+
+    - name: Run tests
+      uses: ./.github/actions/test_cpp
+      with:
+        target: ${{ inputs.target }}
+        valgrind: ${{ inputs.asan == 'false' && 'true' || 'false' }}
+
+    - name: Run coverage
+      if: ${{ inputs.with_coverage == 'true' && inputs.asan == 'false' }}
+      uses: ./.github/actions/coverage_cpp
+      with:
+        path: ${{ inputs.coverage_path }}
+        id: ${{ inputs.coverage_id }}
+        threshold: ${{ inputs.coverage_threshold }}
+        validate_function_coverage: ${{ inputs.validate_function_coverage }}

--- a/.github/actions/install_gcc_14/action.yml
+++ b/.github/actions/install_gcc_14/action.yml
@@ -7,36 +7,27 @@ runs:
     - name: Install GCC 14.3
       shell: bash
       run: |
-        echo "Download GCC 14.3 package"
-        cd /tmp
-        for i in {1..3}; do
-          if wget --timeout=30 --tries=3 https://packages.wazuh.com/utils/gcc/gcc_14.3-1_amd64.deb; then
-            break
-          fi
-          echo "Download attempt $i failed, retrying..."
-          sleep 2
-        done
+        ARCH=$(dpkg --print-architecture)
+        GCC_PKG="gcc_14.3-1_${ARCH}.deb"
+        URL="https://packages.wazuh.com/utils/gcc/${GCC_PKG}"
 
-        echo "Verify download succeeded"
-        if [ ! -f gcc_14.3-1_amd64.deb ]; then
-          echo "Failed to download GCC package after 3 attempts"
+        echo "Downloading GCC 14.3 package (${ARCH})..."
+        wget --timeout=30 --tries=3 -O "/tmp/${GCC_PKG}" "${URL}" || {
+          echo "Failed to download GCC package"
           exit 1
-        fi
-
-        sudo dpkg -i gcc_14.3-1_amd64.deb || {
-          echo "Package installation failed, trying to fix dependencies"
-          sudo apt-get update && sudo apt-get install -f -y
-          sudo dpkg -i gcc_14.3-1_amd64.deb
         }
 
-        # Create symlinks with backup of original
-        sudo mv /usr/bin/gcc /usr/bin/gcc.bak 2>/dev/null || true
-        sudo mv /usr/bin/g++ /usr/bin/g++.bak 2>/dev/null || true
-        sudo mv /usr/bin/c++ /usr/bin/c++.bak 2>/dev/null || true
+        sudo dpkg -i "/tmp/${GCC_PKG}" || {
+          echo "Package installation failed, trying to fix dependencies"
+          sudo apt-get update
+          sudo apt-get install -f -y
+          sudo dpkg -i "/tmp/${GCC_PKG}"
+        }
+
+        for cmd in gcc g++ c++; do
+          sudo mv /usr/bin/${cmd} /usr/bin/${cmd}.bak 2>/dev/null || true
+        done
+
         sudo ln -sf /opt/gcc-14/bin/gcc /usr/bin/gcc
         sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/g++
         sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/c++
-
-        # Verify compiler works
-        gcc --version
-        g++ --version

--- a/.github/actions/install_gcc_14/action.yml
+++ b/.github/actions/install_gcc_14/action.yml
@@ -1,0 +1,42 @@
+name: "Install GCC 14.3"
+description: "Downloads and installs the Wazuh-packaged GCC 14.3 on Ubuntu, creating the required symlinks"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install GCC 14.3
+      shell: bash
+      run: |
+        echo "Download GCC 14.3 package"
+        cd /tmp
+        for i in {1..3}; do
+          if wget --timeout=30 --tries=3 https://packages.wazuh.com/utils/gcc/gcc_14.3-1_amd64.deb; then
+            break
+          fi
+          echo "Download attempt $i failed, retrying..."
+          sleep 2
+        done
+
+        echo "Verify download succeeded"
+        if [ ! -f gcc_14.3-1_amd64.deb ]; then
+          echo "Failed to download GCC package after 3 attempts"
+          exit 1
+        fi
+
+        sudo dpkg -i gcc_14.3-1_amd64.deb || {
+          echo "Package installation failed, trying to fix dependencies"
+          sudo apt-get update && sudo apt-get install -f -y
+          sudo dpkg -i gcc_14.3-1_amd64.deb
+        }
+
+        # Create symlinks with backup of original
+        sudo mv /usr/bin/gcc /usr/bin/gcc.bak 2>/dev/null || true
+        sudo mv /usr/bin/g++ /usr/bin/g++.bak 2>/dev/null || true
+        sudo mv /usr/bin/c++ /usr/bin/c++.bak 2>/dev/null || true
+        sudo ln -sf /opt/gcc-14/bin/gcc /usr/bin/gcc
+        sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/g++
+        sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/c++
+
+        # Verify compiler works
+        gcc --version
+        g++ --version

--- a/.github/actions/install_gcc_14/action.yml
+++ b/.github/actions/install_gcc_14/action.yml
@@ -23,6 +23,7 @@ runs:
           sudo apt-get install -f -y
           sudo dpkg -i "/tmp/${GCC_PKG}"
         }
+        rm -f "/tmp/${GCC_PKG}"
 
         for cmd in gcc g++ c++; do
           sudo mv /usr/bin/${cmd} /usr/bin/${cmd}.bak 2>/dev/null || true

--- a/.github/actions/install_qa_framework/action.yml
+++ b/.github/actions/install_qa_framework/action.yml
@@ -1,0 +1,36 @@
+name: "Install QA Integration Framework"
+description: "Resolves the correct branch and clones (and optionally pip-installs) the wazuh/qa-integration-framework"
+
+inputs:
+  branch_name:
+    required: true
+    description: "Current branch name (head branch)"
+  branch_base:
+    required: true
+    description: "Base branch name"
+  install:
+    required: false
+    description: "If 'true', pip-installs the framework and removes the cloned directory"
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download and install integration tests framework
+      shell: bash
+      run: |
+        VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
+        if [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git ${{ inputs.branch_name }})" != "X" ]; then
+            QA_BRANCH=${{ inputs.branch_name }}
+        elif [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git ${{ inputs.branch_base }})" != "X" ]; then
+            QA_BRANCH=${{ inputs.branch_base }}
+        elif [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION})" != "X" ]; then
+            QA_BRANCH=${VERSION}
+        else
+            QA_BRANCH="main"
+        fi
+        git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+        if [[ "${{ inputs.install }}" == "true" ]]; then
+          sudo pip install qa-integration-framework/
+          sudo rm -rf qa-integration-framework/
+        fi

--- a/.github/actions/install_qa_framework/action.yml
+++ b/.github/actions/install_qa_framework/action.yml
@@ -18,19 +18,23 @@ runs:
   steps:
     - name: Download and install integration tests framework
       shell: bash
+      env:
+        BRANCH_NAME: ${{ inputs.branch_name }}
+        BRANCH_BASE: ${{ inputs.branch_base }}
+        INSTALL: ${{ inputs.install }}
       run: |
         VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-        if [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git ${{ inputs.branch_name }})" != "X" ]; then
-            QA_BRANCH=${{ inputs.branch_name }}
-        elif [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git ${{ inputs.branch_base }})" != "X" ]; then
-            QA_BRANCH=${{ inputs.branch_base }}
-        elif [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION})" != "X" ]; then
-            QA_BRANCH=${VERSION}
+        if [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git "$BRANCH_NAME")" != "X" ]; then
+            QA_BRANCH="$BRANCH_NAME"
+        elif [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git "$BRANCH_BASE")" != "X" ]; then
+            QA_BRANCH="$BRANCH_BASE"
+        elif [ "X$(git ls-remote https://github.com/wazuh/qa-integration-framework.git "${VERSION}")" != "X" ]; then
+            QA_BRANCH="${VERSION}"
         else
             QA_BRANCH="main"
         fi
-        git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-        if [[ "${{ inputs.install }}" == "true" ]]; then
+        git clone -b "${QA_BRANCH}" --single-branch https://github.com/wazuh/qa-integration-framework.git
+        if [[ "$INSTALL" == "true" ]]; then
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
         fi

--- a/.github/actions/install_wazuh_agent/action.yml
+++ b/.github/actions/install_wazuh_agent/action.yml
@@ -16,15 +16,18 @@ runs:
   steps:
     - name: Install Wazuh agent
       shell: bash
+      env:
+        INSTALL_DIR: ${{ inputs.install_dir }}
+        DISABLE_SCA_SYSCOLLECTOR: ${{ inputs.disable_sca_syscollector }}
       run: |
         {
           echo 'USER_LANGUAGE="en"'
           echo 'USER_AGENT_MANAGER_IP="127.0.0.1"'
           echo 'USER_INSTALL_TYPE="agent"'
-          echo 'USER_DIR=${{ inputs.install_dir }}'
+          echo "USER_DIR=$INSTALL_DIR"
           echo 'USER_ENABLE_SYSCHECK="n"'
           echo 'USER_ENABLE_ROOTCHECK="n"'
-          if [[ "${{ inputs.disable_sca_syscollector }}" == "true" ]]; then
+          if [[ "$DISABLE_SCA_SYSCOLLECTOR" == "true" ]]; then
             echo 'USER_ENABLE_SYSCOLLECTOR="n"'
             echo 'USER_ENABLE_SCA="n"'
           fi

--- a/.github/actions/install_wazuh_agent/action.yml
+++ b/.github/actions/install_wazuh_agent/action.yml
@@ -1,0 +1,33 @@
+name: "Install Wazuh Agent"
+description: "Installs the Wazuh agent using the interactive installer with preloaded variables"
+
+inputs:
+  install_dir:
+    required: false
+    description: "Installation directory (e.g. /var/ossec for Linux, /Library/Ossec for macOS)"
+    default: "/var/ossec"
+  disable_sca_syscollector:
+    required: false
+    description: "Disable SCA and Syscollector modules at install time"
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Wazuh agent
+      shell: bash
+      run: |
+        {
+          echo 'USER_LANGUAGE="en"'
+          echo 'USER_AGENT_MANAGER_IP="127.0.0.1"'
+          echo 'USER_INSTALL_TYPE="agent"'
+          echo 'USER_DIR=${{ inputs.install_dir }}'
+          echo 'USER_ENABLE_SYSCHECK="n"'
+          echo 'USER_ENABLE_ROOTCHECK="n"'
+          if [[ "${{ inputs.disable_sca_syscollector }}" == "true" ]]; then
+            echo 'USER_ENABLE_SYSCOLLECTOR="n"'
+            echo 'USER_ENABLE_SCA="n"'
+          fi
+        } > ./etc/preloaded-vars.conf
+        sudo sh install.sh
+        rm ./etc/preloaded-vars.conf

--- a/.github/workflows/5_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_agentd-tier-0-1-lin.yml
@@ -36,43 +36,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run Agentd integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_agentd/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_agentd/ --html=results.html --self-contained-html
 
       - name: Upload failed test results
         if: failure()

--- a/.github/workflows/5_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_api-tier-0-1.yml
@@ -34,12 +34,12 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh manager for linux
-        run: |
-          make deps -C src TARGET=manager -j2
-          make -C src TARGET=manager -j2
+      - name: Build wazuh manager
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: manager
       - name: Install wazuh manager for linux
         run: |
           echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
@@ -63,21 +63,11 @@ jobs:
             -keyout $INSTALLATION_DIR/etc/certs/manager-key.pem -out $INSTALLATION_DIR/etc/certs/manager.pem \
             -days 1 -subj "/CN=test" 2>/dev/null
 
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run API tests
         run: |
           mkdir -p /tmp/wazuh-logs
@@ -85,7 +75,7 @@ jobs:
           sudo tail -F $INSTALLATION_DIR/logs/wazuh-manager.log >> /tmp/wazuh-logs/wazuh-manager.log 2>/dev/null &
           sudo tail -F $INSTALLATION_DIR/logs/cluster.log >> /tmp/wazuh-logs/cluster.log 2>/dev/null &
           cd tests/integration
-          sudo WAZUH_PATH="$INSTALLATION_DIR" GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_api/ --html=results.html --self-contained-html
+          sudo WAZUH_PATH="$INSTALLATION_DIR" GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_api/ --html=results.html --self-contained-html
       - name: Collect logs on failure
         if: failure()
         run: |

--- a/.github/workflows/5_testintegration_api-tier-2.yml
+++ b/.github/workflows/5_testintegration_api-tier-2.yml
@@ -23,12 +23,12 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh manager for linux
-        run: |
-          make deps -C src TARGET=manager -j2
-          make -C src TARGET=manager -j2
+      - name: Build wazuh manager
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: manager
       - name: Install wazuh manager for linux
         run: |
           echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
@@ -52,21 +52,11 @@ jobs:
             -keyout $INSTALLATION_DIR/etc/certs/manager-key.pem -out $INSTALLATION_DIR/etc/certs/manager.pem \
             -days 1 -subj "/CN=test" 2>/dev/null
 
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run API tests
         run: |
           mkdir -p /tmp/wazuh-logs
@@ -74,7 +64,7 @@ jobs:
           sudo tail -F $INSTALLATION_DIR/logs/wazuh-manager.log >> /tmp/wazuh-logs/wazuh-manager.log 2>/dev/null &
           sudo tail -F $INSTALLATION_DIR/logs/cluster.log >> /tmp/wazuh-logs/cluster.log 2>/dev/null &
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python3 -m pytest --tier 2 test_api/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python3 -m pytest --tier 2 test_api/ --html=results.html --self-contained-html
       - name: Collect logs on failure
         if: failure()
         run: |

--- a/.github/workflows/5_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_enrollment-tier-0-1-lin.yml
@@ -37,44 +37,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run enrollment integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_enrollment/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_enrollment/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_execd-tier-0-1-lin.yml
@@ -35,43 +35,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run execd integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_execd/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_execd/ --html=results.html --self-contained-html
       - name: Dump wazuh-agent logs on failure
         if: failure()
         run: |

--- a/.github/workflows/5_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-lin.yml
@@ -35,39 +35,19 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Install audit
         run: |
           sudo apt-get update
@@ -75,7 +55,7 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/5_testintegration_fim-tier-0-1-macos.yml
@@ -35,42 +35,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Build wazuh agent for macOS
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for macOS
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/Library/Ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+        with:
+          install_dir: /Library/Ossec
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_fim/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/5_testintegration_fim-tier-2-lin.yml
@@ -22,39 +22,19 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Install audit
         run: |
           sudo apt-get update
@@ -62,7 +42,7 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 2 test_fim/ --html=results.html --self-contained-html
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 2 test_fim/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_github-tier-0-1-lin.yml
@@ -35,44 +35,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run github integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_github/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_github/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-lin.yml
@@ -35,44 +35,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/5_testintegration_logcollector-tier-0-1-macos.yml
@@ -35,42 +35,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Build wazuh agent for macOS
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for macOS
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/Library/Ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+        with:
+          install_dir: /Library/Ossec
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_logcollector/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -35,52 +35,30 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      # Setup MSGraph Proxy
       - name: Download m365proxy and config http for msgraph module
         run: |
           sed -i 's/https:\/\/%s\/%s/http:\/\/%s\/%s/g' src/wazuh_modules/src/wm_ms_graph.h
           curl -L http://packages.wazuh.com/utils/m365proxy/m365proxy.tar.gz | \
           tar zvx -C /tmp/
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_ENABLE_SYSCOLLECTOR="n"
-          USER_ENABLE_SCA="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+        with:
+          disable_sca_syscollector: "true"
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run msgraph integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_msgraph/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_msgraph/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_office365-tier-0-1-lin.yml
@@ -35,44 +35,23 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run office365 integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_office365/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_office365/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_rbac-tier-0-1.yml
@@ -33,19 +33,19 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh manager for linux
+      - name: Build wazuh manager
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: manager
+      - name: Create cert stubs and install wazuh manager
         run: |
-          make deps -C src TARGET=manager -j2
-          make -C src TARGET=manager -j2
-
           sudo mkdir -p /var/wazuh-manager/etc/certs
           sudo touch /var/wazuh-manager/etc/certs/root-ca.pem
           sudo touch /var/wazuh-manager/etc/certs/manager.pem
           sudo touch /var/wazuh-manager/etc/certs/manager-key.pem
-      - name: Install wazuh manager for linux
-        run: |
+
           cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
           USER_LANGUAGE="en"
           USER_INSTALL_TYPE="manager"
@@ -61,43 +61,29 @@ jobs:
           sudo sh install.sh
           rm ./etc/preloaded-vars.conf
 
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
-      # Run integration tests.
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run API tests
         run: |
           mkdir -p /tmp/wazuh-logs
           sudo tail -F /var/wazuh-manager/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/wazuh-manager/logs/wazuh-manager.log >> /tmp/wazuh-logs/wazuh-manager.log 2>/dev/null &
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest test_api/test_rbac/ --tier 0 --tier 1 --html=results.html --self-contained-html
-      # Collect logs if tests fail
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest test_api/test_rbac/ --tier 0 --tier 1 --html=results.html --self-contained-html
       - name: Collect logs on failure
         if: failure()
         run: |
           sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
           sudo chown -R $(whoami):$(whoami) /tmp/wazuh-logs || true
-      # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
-      # Upload the tests result html as an artifact
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_sca-tier-0-1-lin.yml
@@ -36,46 +36,25 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_ENABLE_SYSCOLLECTOR="n"
-          USER_ENABLE_SCA="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
+        uses: ./.github/actions/install_wazuh_agent
+        with:
+          disable_sca_syscollector: "true"
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run sca integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_sca/ --html=results.html --self-contained-html
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_sca/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_syscollector-tier-0-1-lin.yml
@@ -34,48 +34,25 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: Build wazuh agent for linux
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+      - name: Build wazuh agent
+        uses: ./.github/actions/build_wazuh
+        with:
+          target: agent
       - name: Install wazuh agent for linux
-        run: |
-          cat << EOF | sed -e 's/^[[:space:]]*//' > ./etc/preloaded-vars.conf
-          USER_LANGUAGE="en"
-          USER_AGENT_MANAGER_IP="127.0.0.1"
-          USER_INSTALL_TYPE="agent"
-          USER_DIR=/var/ossec
-          USER_ENABLE_SYSCHECK="n"
-          USER_ENABLE_ROOTCHECK="n"
-          USER_ENABLE_SYSCOLLECTOR="n"
-          USER_ENABLE_SCA="n"
-          EOF
-          sudo sh install.sh
-          rm ./etc/preloaded-vars.conf
-      - name: Download and install integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
-
+        uses: ./.github/actions/install_wazuh_agent
+        with:
+          disable_sca_syscollector: "true"
+      - name: Install QA integration framework
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
       - name: Run syscollector integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_syscollector/ --html=results.html --self-contained-html
-
-      # Upload the tests result html as an artifact
+          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${{ env.BRANCH_NAME }}" python -m pytest --tier 0 --tier 1 test_syscollector/ --html=results.html --self-contained-html
       - name: Upload failed test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -29,28 +29,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Content manager - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "content_manager_utest"
-          test: "true"
           asan: "false"
-
-      - name: Content manager - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "content_manager_utest"
-
-      - name: Content manager - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/shared_modules/content_manager
-          id: content_manager
-          threshold: "65"
+          with_coverage: "true"
+          coverage_path: src/shared_modules/content_manager
+          coverage_id: content_manager
+          coverage_threshold: "65"
 
   contentmanager-asan:
     strategy:
@@ -63,18 +50,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Content manager - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline (ASAN)
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "content_manager_utest"
-          test: "true"
           asan: "true"
-
-      - name: Content manager - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          target: "content_manager_utest"
-          valgrind: "false"

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -29,27 +29,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Indexer connector - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "indexer_connector_utest"
-          test: "true"
           asan: "false"
-
-      - name: Indexer connector - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "indexer_connector_utest"
-
-      - name: Indexer connector - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/shared_modules/indexer_connector
-          id: indexer_connector
+          with_coverage: "true"
+          coverage_path: src/shared_modules/indexer_connector
+          coverage_id: indexer_connector
           validate_function_coverage: "false"
 
   indexerconnector-asan:
@@ -63,18 +50,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Indexer connector - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline (ASAN)
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "indexer_connector_utest"
-          test: "true"
           asan: "true"
-
-      - name: Indexer connector - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          target: "indexer_connector_utest"
-          valgrind: "false"

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -29,28 +29,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Inventory sync - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "inventory_sync_utest"
-          test: "true"
           asan: "false"
-
-      - name: Inventory sync - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "inventory_sync_utest"
-
-      - name: Inventory sync - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/wazuh_modules/inventory_sync
-          test_directory: src/wazuh_modules/inventory_sync
-          id: inventory_sync
+          with_coverage: "true"
+          coverage_path: src/wazuh_modules/inventory_sync
+          coverage_id: inventory_sync
           validate_function_coverage: "false"
 
   inventorysync-asan:
@@ -64,18 +50,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Inventory sync - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline (ASAN)
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "inventory_sync_utest"
-          test: "true"
           asan: "true"
-
-      - name: Inventory sync - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          target: "inventory_sync_utest"
-          valgrind: "false"

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -26,56 +26,23 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: "Install dependencies"
+      - name: Install dependencies
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
-      - name: "Install a compatible CMake"
+      - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-      - name: "Install gcc 14.3"
-        run: |
-          echo "Download GCC 14.3 package"
-          cd /tmp
-          for i in {1..3}; do
-            if wget --timeout=30 --tries=3 https://packages.wazuh.com/utils/gcc/gcc_14.3-1_amd64.deb; then
-              break
-            fi
-            echo "Download attempt $i failed, retrying..."
-            sleep 2
-          done
-
-          echo "Verify download succeeded"
-          if [ ! -f gcc_14.3-1_amd64.deb ]; then
-            echo "Failed to download GCC package after 3 attempts"
-            exit 1
-          fi
-
-          sudo dpkg -i gcc_14.3-1_amd64.deb || {
-            echo "Package installation failed, trying to fix dependencies"
-            sudo apt-get update && sudo apt-get install -f -y
-            sudo dpkg -i gcc_14.3-1_amd64.deb
-          }
-
-          # Create symlinks with backup of original
-          sudo mv /usr/bin/gcc /usr/bin/gcc.bak 2>/dev/null || true
-          sudo mv /usr/bin/g++ /usr/bin/g++.bak 2>/dev/null || true
-          sudo mv /usr/bin/c++ /usr/bin/c++.bak 2>/dev/null || true
-          sudo ln -sf /opt/gcc-14/bin/gcc /usr/bin/gcc
-          sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/g++
-          sudo ln -sf /opt/gcc-14/bin/g++ /usr/bin/c++
-
-          # Verify compiler works
-          gcc --version
-          g++ --version
-      - name: "Build wazuh"
+      - name: Install GCC 14.3
+        uses: ./.github/actions/install_gcc_14
+      - name: Build wazuh
         uses: ./.github/actions/build_test_flags
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh legacy unit tests"
+      - name: Build wazuh legacy unit tests
         uses: ./.github/actions/legacy_unit_tests_build
         with:
           target: ${{ matrix.target }}
-      - name: "Run wazuh legacy unit tests"
+      - name: Run wazuh legacy unit tests
         uses: ./.github/actions/legacy_unit_tests_run
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/5_testunit_python-coverage.yml
+++ b/.github/workflows/5_testunit_python-coverage.yml
@@ -34,18 +34,12 @@ jobs:
           cache: "pip"
 
       - name: Download integration tests framework
-        run: |
-          VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' VERSION.json)"
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${VERSION}`" != "X" ]; then
-              QA_BRANCH=${VERSION}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+        uses: ./.github/actions/install_qa_framework
+        with:
+          branch_name: ${{ env.BRANCH_NAME }}
+          branch_base: ${{ env.BRANCH_BASE }}
+          install: "false"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -29,27 +29,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Router - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "librouter_utest"
-          test: "true"
           asan: "false"
-
-      - name: Router - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "librouter_utest"
-
-      - name: Router - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/shared_modules/router
-          id: router
+          with_coverage: "true"
+          coverage_path: src/shared_modules/router
+          coverage_id: router
           validate_function_coverage: "false"
 
   router-asan:
@@ -63,18 +50,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Router - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline (ASAN)
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "librouter_utest"
-          test: "true"
           asan: "true"
-
-      - name: Router - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          target: "librouter_utest"
-          valgrind: "false"

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -28,27 +28,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Shared modules utils - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "utils_utest"
-          test: "true"
           asan: "false"
-
-      - name: Shared modules utils - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "utils_utest"
-
-      - name: Shared modules utils - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/shared_modules/utils
-          id: utils_utest
+          with_coverage: "true"
+          coverage_path: src/shared_modules/utils
+          coverage_id: utils_utest
           validate_function_coverage: "false"
 
   shared_modules_utils-asan:
@@ -62,18 +49,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Shared modules utils - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline (ASAN)
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "utils_utest"
-          test: "true"
           asan: "true"
-
-      - name: Shared modules utils - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          target: "utils_utest"
-          valgrind: "false"

--- a/.github/workflows/5_testunit_vulnerability-scanner.yml
+++ b/.github/workflows/5_testunit_vulnerability-scanner.yml
@@ -29,31 +29,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install compatible CMake
-        uses: ./.github/actions/reinstall_cmake
-
-      - name: Builder external dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Vulnerability scanner - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "vulnerability_scanner_unit_tests"
-          test: "true"
           asan: "false"
-
-      - name: Vulnerability scanner - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "true"
-          target: "vulnerability_scanner_unit_tests"
-
-      - name: Vulnerability scanner - Coverage
-        uses: ./.github/actions/coverage_cpp
-        with:
-          path: src/wazuh_modules/vulnerability_scanner
-          id: vulnerability_scanner
+          with_coverage: "true"
+          coverage_path: src/wazuh_modules/vulnerability_scanner
+          coverage_id: vulnerability_scanner
           validate_function_coverage: "false"
+          reinstall_cmake: "true"
 
   vulnerability-scanner-modules-asan:
     runs-on: ubuntu-24.04
@@ -63,21 +48,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install compatible CMake
-        uses: ./.github/actions/reinstall_cmake
-
-      - name: Builder external dependencies
-        uses: ./.github/actions/build_external_deps
-
-      - name: Vulnerability scanner - Build tests
-        uses: ./.github/actions/build_target_cpp
+      - name: C++ test pipeline (ASAN)
+        uses: ./.github/actions/cpp_test_pipeline
         with:
           target: "vulnerability_scanner_unit_tests"
-          test: "true"
           asan: "true"
-
-      - name: Vulnerability scanner - Run tests
-        uses: ./.github/actions/test_cpp
-        with:
-          valgrind: "false"
-          target: "vulnerability_scanner_unit_tests"
+          reinstall_cmake: "true"

--- a/api/api/pytest.ini
+++ b/api/api/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+addopts = --color=yes --tb=short
 asyncio_mode=auto

--- a/framework/pytest.ini
+++ b/framework/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --color=yes --tb=short
 markers =
     asyncio: mark a test as asynchronous.
 asyncio_mode=auto

--- a/wodles/pytest.ini
+++ b/wodles/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+addopts = --color=yes --tb=short
 asyncio_mode=auto


### PR DESCRIPTION
## Description

This pull request addresses the second phase of the GitHub Actions refactoring plan for v5 workflows. Building upon the cleanup from Iteration 1, this iteration focuses on architectural modularization through composite actions, extraction of repeated compilation and setup steps, and cross-platform efficiency improvements.

Closes #35273

## Proposed Changes

### New Composite Actions

Five new reusable composite actions have been introduced under `.github/actions/`:

- **`build_wazuh`**: Encapsulates `make deps && make` for any target (`agent`/`manager`). Replaces duplicated build commands across 13+ workflows. Switches hardcoded `-j2` to `-j$(nproc)` for full parallelism on any runner.

- **`install_qa_framework`**: Resolves the correct branch for `wazuh/qa-integration-framework` (current branch → base branch → version tag → `main`), clones it, and optionally pip-installs it. Previously a 12-line block copy-pasted identically in 15 workflows.

- **`install_wazuh_agent`**: Installs the Wazuh agent via `preloaded-vars.conf` + `sudo sh install.sh`. Accepts `install_dir` (Linux default `/var/ossec`, macOS `/Library/Ossec`) and `disable_sca_syscollector` inputs to handle per-module variation without duplication.

- **`install_gcc_14`**: Downloads and installs the Wazuh-packaged GCC 14.3, creates the required symlinks. Architecture-aware: uses `dpkg --print-architecture` to select `gcc_14.3-1_amd64.deb` or `gcc_14.3-1_arm64.deb` automatically. Extracts the 30-line inline block from `5_testunit_linux-win.yml`.

- **`cpp_test_pipeline`**: Full C++ unit test pipeline in a single composite action, chaining: optional `reinstall_cmake`, `build_external_deps`, `build_target_cpp`, `test_cpp`, and optional `coverage_cpp`. Driven by inputs: `target`, `asan`, `with_coverage`, `coverage_path`, `coverage_id`, `coverage_threshold`, `validate_function_coverage`, `reinstall_cmake`, `flags`.

### Workflow Refactoring

**C++ unit test workflows** (6 files): `5_testunit_router.yml`, `5_testunit_shared_modules_utils.yml`, `5_testunit_contentmanager.yml`, `5_testunit_indexerconnector.yml`, `5_testunit_inventorysync.yml`, `5_testunit_vulnerability-scanner.yml` — each reduced from ~80 lines to ~35 lines by replacing the repeated 5-step pipeline with a single `cpp_test_pipeline` call per job.

**Linux/macOS integration test workflows** (14 files): `agentd`, `fim` (linux tier 0-1, tier 2, macos), `execd`, `logcollector` (linux, macos), `enrollment`, `sca`, `syscollector`, `msgraph`, `office365`, `github`, `api` (tier 0-1, tier 2), `rbac` — build, agent install, and QA framework steps replaced with composite action calls.

**Python unit test workflows**: `5_testunit_linux-win.yml` (30-line GCC block → `install_gcc_14`), `5_testunit_python-coverage.yml` (`install_qa_framework` with `install: "false"` to clone-only).

### Python Test Output Improvements

Added `addopts = --color=yes --tb=short` to three `pytest.ini` files that lacked output configuration:

- `framework/pytest.ini`
- `wodles/pytest.ini`
- `api/api/pytest.ini`

`--color=yes` forces ANSI color output even when stdout is piped through `tee`. `--tb=short` reduces traceback verbosity on failures. `tests/integration/pytest.ini` already had both; these changes bring the remaining suites to parity.

### Results and Evidence

- **741 lines removed**, 257 added across 24 modified workflow files and 5 new action files (net −484 lines).
- Repeated logic (QA framework branch resolution, agent install, GCC setup, C++ pipeline) now maintained in one place per concern.
- `build_wazuh` uses `-j$(nproc)` — full parallelism on multi-core runners vs. the previous hardcoded `-j2`.
- `install_gcc_14` now selects the correct package for `amd64` and `arm64` runners automatically.

### Manual tests with their corresponding evidence

N/A - This PR only contains changes to GitHub Actions workflow configuration files and `pytest.ini` files. No C/C++, Python source, or platform-specific product code has been modified.

### Artifacts Affected

N/A - Only `.github/workflows/5_*.yml`, `.github/actions/` (new composite actions), and `pytest.ini` files were modified.

### Configuration Changes

N/A - No functional configuration changes to the Wazuh product. `pytest.ini` changes are CI-only and affect only test output formatting.

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (Covered by CI pipeline execution)
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
