### PR TITLE
Bump stage from alpha0 to beta1 for v5.0.0

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
     "version": "5.0.0",
-    "stage": "alpha0"
+    "stage": "beta1"
 }

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -40,7 +40,7 @@ info:
     <SecurityDefinitions />
 
   version: '5.0.0'
-  x-revision: 'alpha0'
+  x-revision: 'beta1'
   title: 'Wazuh API REST'
   license:
     name: 'GPL 2.0'

--- a/docs/ref/modules/server-api/api-reference.md
+++ b/docs/ref/modules/server-api/api-reference.md
@@ -78,7 +78,7 @@ curl -k -X GET "https://localhost:55000/?pretty=true" \
   "data": {
     "title": "Wazuh API REST",
     "api_version": "5.0.0",
-    "revision": "alpha0",
+    "revision": "beta1",
     "license_name": "GPL 2.0",
     "hostname": "wazuh-manager",
     "timestamp": "2026-02-20T12:00:00Z"

--- a/framework/wazuh/core/cluster/__init__.py
+++ b/framework/wazuh/core/cluster/__init__.py
@@ -5,7 +5,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 __version__ = '5.0.0'
-__revision__ = 'alpha0'
+__revision__ = 'beta1'
 __author__ = "Wazuh Inc"
 __wazuh_name__ = "Wazuh"
 __licence__ = "\

--- a/src/Doxyfile
+++ b/src/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "WAZUH"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "v5.0.0-alpha0"
+PROJECT_NUMBER         = "v5.0.0-beta1"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -15,7 +15,7 @@ export LD_LIBRARY_PATH="${DIR}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # Installation info
 VERSION="v5.0.0"
-REVISION="alpha0"
+REVISION="beta1"
 TYPE="agent"
 
 ###  Do not modify below here ###

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -18,7 +18,7 @@ export LD_LIBRARY_PATH="${DIR}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # Installation info
 VERSION="v5.0.0"
-REVISION="alpha0"
+REVISION="beta1"
 TYPE="manager"
 WAZUH_ENGINE_GROUP="${WAZUH_ENGINE_GROUP:-wazuh-manager}"
 export WAZUH_ENGINE_GROUP


### PR DESCRIPTION
## Description

Bumps all `alpha0` stage/revision references to `beta1` across the codebase in preparation for the `v5.0.0-beta1` release.

### Files updated

| File | Change |
|---|---|
| `VERSION.json` | `"stage": "alpha0"` → `"stage": "beta1"` |
| `src/Doxyfile` | `PROJECT_NUMBER = "v5.0.0-alpha0"` → `"v5.0.0-beta1"` |
| `src/init/wazuh-server.sh` | `REVISION="alpha0"` → `REVISION="beta1"` |
| `src/init/wazuh-client.sh` | `REVISION="alpha0"` → `REVISION="beta1"` |
| `framework/wazuh/core/cluster/__init__.py` | `__revision__ = 'alpha0'` → `'beta1'` |
| `api/api/spec/spec.yaml` | `x-revision: 'alpha0'` → `x-revision: 'beta1'` |
| `docs/ref/modules/server-api/api-reference.md` | `"revision": "alpha0"` → `"revision": "beta1"` |

> **Note:** `src/Doxyfile` will be reverted to `"main"` in a follow-up commit after the `v5.0.0-beta1` tag is created.

## Linked issue

Closes #35443