### PR TITLE
Update release date for v5.0.0 to 2026-06-24

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -2,7 +2,7 @@ wazuh-agent (5.0.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Sun, 12 Apr 2026 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 24 Jun 2026 00:00:00 +0000
 
 wazuh-agent (4.14.5-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-agent/debian/copyright
+++ b/packages/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Sun, 12 Apr 2026 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 24 Jun 2026 00:00:00 +0000
 
 It was downloaded from:
 

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -2,7 +2,7 @@ wazuh-manager (5.0.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Sun, 12 Apr 2026 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 24 Jun 2026 00:00:00 +0000
 
 wazuh-manager (4.14.5-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-manager/debian/copyright
+++ b/packages/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Sun, 12 Apr 2026 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 24 Jun 2026 00:00:00 +0000
 
 It was downloaded from:
 

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -784,7 +784,7 @@ rm -fr %{buildroot}
 %files -n wazuh-agent-debuginfo -f debugfiles.list
 
 %changelog
-* Sun Apr 12 2026 support <info@wazuh.com> - 5.0.0
+* Wed Jun 24 2026 support <info@wazuh.com> - 5.0.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 * Sat Apr 11 2026 support <info@wazuh.com> - 4.14.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-5.html

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -638,7 +638,7 @@ rm -fr %{buildroot}
 %files -n wazuh-manager-debuginfo -f debugfiles.list
 
 %changelog
-* Sun Apr 12 2026 support <info@wazuh.com> - 5.0.0
+* Wed Jun 24 2026 support <info@wazuh.com> - 5.0.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-5-0-0.html
 * Sat Apr 11 2026 support <info@wazuh.com> - 4.14.5
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-14-5.html


### PR DESCRIPTION
## Description

Updates the release date for v5.0.0 to `2026-06-24` across all packaging files.

| File | Change |
|---|---|
| `packages/debs/SPECS/wazuh-manager/debian/changelog` | `Sun, 12 Apr 2026` → `Wed, 24 Jun 2026` |
| `packages/debs/SPECS/wazuh-manager/debian/copyright` | `Sun, 12 Apr 2026` → `Wed, 24 Jun 2026` |
| `packages/debs/SPECS/wazuh-agent/debian/changelog` | `Sun, 12 Apr 2026` → `Wed, 24 Jun 2026` |
| `packages/debs/SPECS/wazuh-agent/debian/copyright` | `Sun, 12 Apr 2026` → `Wed, 24 Jun 2026` |
| `packages/rpms/SPECS/wazuh-manager.spec` | `Sun Apr 12 2026` → `Wed Jun 24 2026` |
| `packages/rpms/SPECS/wazuh-agent.spec` | `Sun Apr 12 2026` → `Wed Jun 24 2026` |

## Linked issue

Closes #35443