### PR TITLE
Fix spec.yaml blob URLs to reference v5.0.0-beta1 tag

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -44,7 +44,7 @@ info:
   title: 'Wazuh API REST'
   license:
     name: 'GPL 2.0'
-    url: 'https://github.com/wazuh/wazuh/blob/v5.0.0/LICENSE'
+    url: 'https://github.com/wazuh/wazuh/blob/v5.0.0-beta1/LICENSE'
 
 servers:
   - url: '{protocol}://{host}:{port}'
@@ -3974,7 +3974,7 @@ paths:
                 api_version: "v4.5.0"
                 revision: 'beta1'
                 license_name: "GPL 2.0"
-                license_url: "https://github.com/wazuh/wazuh/blob/v5.0.0/LICENSE"
+                license_url: "https://github.com/wazuh/wazuh/blob/v5.0.0-beta1/LICENSE"
                 hostname: "wazuh"
                 timestamp: "2019-04-02T08:08:11Z"
 


### PR DESCRIPTION
## Description

The `api/api/spec/spec.yaml` blob URL references were pointing to \`blob/v5.0.0/\` (the unreleased final version) instead of the actual pre-release tag \`v5.0.0-beta1\`.

| File | Change |
|---|---|
| \`api/api/spec/spec.yaml\` | \`blob/v5.0.0/LICENSE\` → \`blob/v5.0.0-beta1/LICENSE\` (2 refs) |

After this PR is merged, the \`v5.0.0-beta1\` tag will be moved to point to the resulting commit.

## Linked issue

Related to #35443