### PR TITLE
Check first scan termination before sync start

### DIFF
--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -379,22 +379,30 @@ static wm_syscollector_startup_action_t wm_sys_get_startup_action(bool* first_sy
 
     mtdebug1(WM_SYS_LOGTAG, "Inventory initial scan data is not ready yet. First synchronization will wait for scan data.");
 
+    int log_throttle = 0;
+
     while (sync_module_running && !is_shutdown_process_started())
     {
-        int version = 0;
+        int scan_marker = 0;
 
-        if (!wm_sys_query_int("{\"command\":\"get_version\"}", "version", &version))
+        if (!wm_sys_query_int("{\"command\":\"get_first_scan_completed\"}", "first_scan_completed", &scan_marker))
         {
-            mtdebug1(WM_SYS_LOGTAG, "Failed to detect initial Syscollector scan data. Keeping startup synchronization delay.");
+            mtdebug1(WM_SYS_LOGTAG, "Failed to detect initial Syscollector scan completion. Keeping startup synchronization delay.");
             return SYSCOLLECTOR_STARTUP_ACTION_WAIT;
         }
 
-        if (version > 0)
+        if (scan_marker > 0)
         {
-            mtdebug1(WM_SYS_LOGTAG, "Initial Inventory scan data is ready. Triggering first synchronization without startup delay.");
+            mtdebug1(WM_SYS_LOGTAG, "First inventory scan completed. Triggering first synchronization without startup delay.");
             return SYSCOLLECTOR_STARTUP_ACTION_IMMEDIATE;
         }
 
+        if (log_throttle == 0)
+        {
+            mtdebug1(WM_SYS_LOGTAG, "Synchronization deferred: waiting for first inventory scan to complete.");
+        }
+
+        log_throttle = (log_throttle + 1) % 30;
         sleep(1);
     }
 
@@ -940,11 +948,13 @@ void* wm_sync_module(__attribute__((unused)) void* args)
 #endif
     bool first_sync_completed = false;
     bool wait_before_sync = true;
+    bool first_sync_blocked_on_scan = false;
 
     switch (wm_sys_get_startup_action(&first_sync_completed))
     {
         case SYSCOLLECTOR_STARTUP_ACTION_IMMEDIATE:
             wait_before_sync = false;
+            first_sync_blocked_on_scan = true;
             break;
         case SYSCOLLECTOR_STARTUP_ACTION_STOP:
 #ifdef WIN32
@@ -974,7 +984,25 @@ void* wm_sync_module(__attribute__((unused)) void* args)
             break;
         }
 
-        // Skip synchronization if scan is in progress to avoid syncing incomplete data
+        // On the first cycle after a fresh first scan, wait until scanning has
+        // actually finished rather than bypassing the scan-state guard.
+        if (first_sync_blocked_on_scan && syscollector_is_scanning_ptr)
+        {
+            while (sync_module_running && syscollector_is_scanning_ptr())
+            {
+                mtdebug1(WM_SYS_LOGTAG, "Waiting for scan to finish before forced post-first-scan synchronization.");
+                sleep(1);
+            }
+
+            first_sync_blocked_on_scan = false;
+        }
+
+        if (!sync_module_running)
+        {
+            break;
+        }
+
+        // Skip synchronization if scan is in progress to avoid syncing incomplete data.
         if (syscollector_is_scanning_ptr && syscollector_is_scanning_ptr())
         {
             mtdebug1(WM_SYS_LOGTAG, "Scan in progress, skipping sync cycle");

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -89,6 +89,7 @@ constexpr auto QUEUE_SIZE
 };
 
 constexpr auto SYSCOLLECTOR_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
+constexpr auto SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY {"first_scan_completed"};
 
 static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
 {
@@ -1834,6 +1835,15 @@ void Syscollector::scan()
     std::vector<std::pair<std::string, nlohmann::json>> itemsToUpdateSync;
     m_itemsToUpdateSync = &itemsToUpdateSync;
 
+    int64_t firstScanCompleted = 0;
+    const bool isFirstScan = !getMetadataValue(SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY, firstScanCompleted)
+                             || firstScanCompleted == 0;
+
+    if (isFirstScan)
+    {
+        m_logFunction(LOG_DEBUG, "Initial Syscollector scan starting.");
+    }
+
     m_logFunction(LOG_INFO, "Starting evaluation.");
     TRY_CATCH_TASK(scanHardware);
     TRY_CATCH_TASK(scanOs);
@@ -1871,6 +1881,14 @@ void Syscollector::scan()
     // Delete all items that failed schema validation inside a DBSync transaction
     // This ensures deletions are committed to disk immediately
     deleteFailedItemsFromDB(failedItems);
+
+    if (isFirstScan)
+    {
+        m_scanning = false;
+        m_pauseCv.notify_all();
+        updateMetadataValue(SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
+        m_logFunction(LOG_DEBUG, "First inventory scan completed — marker persisted.");
+    }
 
     m_notify = true;
     m_logFunction(LOG_INFO, "Evaluation finished.");
@@ -3106,6 +3124,22 @@ std::string Syscollector::query(const std::string& jsonQuery)
             {
                 response["error"] = MQ_ERR_INTERNAL;
                 response["message"] = "Failed to retrieve Syscollector first sync completion";
+            }
+        }
+        else if (command == "get_first_scan_completed")
+        {
+            int64_t firstScanCompleted = 0;
+
+            if (getMetadataValue(SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY, firstScanCompleted))
+            {
+                response["error"] = MQ_SUCCESS;
+                response["message"] = "Syscollector first scan completion retrieved";
+                response["data"]["first_scan_completed"] = firstScanCompleted > 0 ? 1 : 0;
+            }
+            else
+            {
+                response["error"] = MQ_ERR_INTERNAL;
+                response["message"] = "Failed to retrieve Syscollector first scan completion";
             }
         }
         else if (command == "set_version")

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1884,8 +1884,6 @@ void Syscollector::scan()
 
     if (isFirstScan)
     {
-        m_scanning = false;
-        m_pauseCv.notify_all();
         updateMetadataValue(SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
         m_logFunction(LOG_DEBUG, "First inventory scan completed — marker persisted.");
     }

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -3066,6 +3066,248 @@ TEST_F(SyscollectorImpTest, queryCommandGetFirstSyncCompletedReturnsTrueWhenMeta
     Syscollector::instance().destroy();
 }
 
+// ── first_scan_completed marker and query ────────────────────────────────────
+
+TEST_F(SyscollectorImpTest, queryCommandGetFirstScanCompletedDefaultsToFalse)
+{
+    // No scan has run and no marker is present: expect first_scan_completed == 0.
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    std::string response = Syscollector::instance().query(R"({"command":"get_first_scan_completed"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["first_scan_completed"], 0);
+
+    Syscollector::instance().destroy();
+}
+
+TEST_F(SyscollectorImpTest, queryCommandGetFirstScanCompletedReturnsTrueWhenMetadataExists)
+{
+    // Seed the marker directly into the DB, then verify the query reports it.
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    Syscollector::instance().destroy();
+
+    sqlite3* db = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+
+    char* errMsg = nullptr;
+    ASSERT_EQ(sqlite3_exec(db,
+                           "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('first_scan_completed', 123456);",
+                           nullptr,
+                           nullptr,
+                           &errMsg),
+              SQLITE_OK)
+            << (errMsg ? errMsg : "");
+
+    if (errMsg)
+    {
+        sqlite3_free(errMsg);
+    }
+
+    sqlite3_close(db);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    std::string response = Syscollector::instance().query(R"({"command":"get_first_scan_completed"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["first_scan_completed"], 1);
+
+    Syscollector::instance().destroy();
+}
+
+TEST_F(SyscollectorImpTest, scanSetsFirstScanCompletedMarkerAfterFullScan)
+{
+    // After a complete scan() the first_scan_completed marker must be written
+    // with a positive Unix timestamp.
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_HARDWARE_JSON)));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_OS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_NETWORKS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_PORTS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .WillRepeatedly([](const std::function<void(nlohmann::json&)>& cb)
+    {
+        auto data = nlohmann::json::parse(EXPECT_CALL_PACKAGES_JSON);
+        cb(data);
+    });
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_HOTFIXES_JSON)));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .WillRepeatedly([](const std::function<void(nlohmann::json&)>& cb)
+    {
+        auto data = nlohmann::json::parse(EXPECT_CALL_PROCESSES_JSON);
+        cb(data);
+    });
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_GROUPS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_USERS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_SERVICES_JSON)));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_BROWSER_EXTENSIONS_JSON)));
+
+    std::thread t
+    {
+        [&spInfoWrapper]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          reportFunction,
+                                          persistFunction,
+                                          logFunction,
+                                          SYSCOLLECTOR_TEST_DB_PATH,
+                                          "",
+                                          "",
+                                          3600, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds{2});
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Verify the raw timestamp was written and is non-zero.
+    sqlite3* db = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &db, SQLITE_OPEN_READONLY, nullptr), SQLITE_OK);
+    sqlite3_stmt* stmt = nullptr;
+    ASSERT_EQ(sqlite3_prepare_v2(db,
+                                 "SELECT last_sync_time FROM table_metadata WHERE table_name='first_scan_completed';",
+                                 -1, &stmt, nullptr), SQLITE_OK);
+    ASSERT_EQ(sqlite3_step(stmt), SQLITE_ROW);
+    int64_t ts = sqlite3_column_int64(stmt, 0);
+    EXPECT_GT(ts, 0);
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+TEST_F(SyscollectorImpTest, scanFirstScanCompletedMarkerIsIdempotent)
+{
+    // If the marker is already set, a subsequent scan must NOT overwrite the timestamp.
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_HARDWARE_JSON)));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_OS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_NETWORKS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_PORTS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .WillRepeatedly([](const std::function<void(nlohmann::json&)>& cb)
+    {
+        auto data = nlohmann::json::parse(EXPECT_CALL_PACKAGES_JSON);
+        cb(data);
+    });
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_HOTFIXES_JSON)));
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .WillRepeatedly([](const std::function<void(nlohmann::json&)>& cb)
+    {
+        auto data = nlohmann::json::parse(EXPECT_CALL_PROCESSES_JSON);
+        cb(data);
+    });
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_GROUPS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_USERS_JSON)));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_SERVICES_JSON)));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json::parse(EXPECT_CALL_BROWSER_EXTENSIONS_JSON)));
+
+    constexpr int64_t PRIOR_TIMESTAMP = 111111;
+
+    // Seed the marker before the first scan.
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+    Syscollector::instance().destroy();
+
+    sqlite3* db = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &db, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+    char* errMsg = nullptr;
+    ASSERT_EQ(sqlite3_exec(db,
+                           "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('first_scan_completed', 111111);",
+                           nullptr, nullptr, &errMsg), SQLITE_OK)
+            << (errMsg ? errMsg : "");
+
+    if (errMsg)
+    {
+        sqlite3_free(errMsg);
+    }
+
+    sqlite3_close(db);
+
+    // Now run a full scan — the marker must NOT be overwritten.
+    std::thread t
+    {
+        [&spInfoWrapper]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          reportFunction,
+                                          persistFunction,
+                                          logFunction,
+                                          SYSCOLLECTOR_TEST_DB_PATH,
+                                          "",
+                                          "",
+                                          3600, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds{2});
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Verify the original timestamp was preserved.
+    db = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &db, SQLITE_OPEN_READONLY, nullptr), SQLITE_OK);
+    sqlite3_stmt* stmt = nullptr;
+    ASSERT_EQ(sqlite3_prepare_v2(db,
+                                 "SELECT last_sync_time FROM table_metadata WHERE table_name='first_scan_completed';",
+                                 -1, &stmt, nullptr), SQLITE_OK);
+    ASSERT_EQ(sqlite3_step(stmt), SQLITE_ROW);
+    int64_t ts = sqlite3_column_int64(stmt, 0);
+    EXPECT_EQ(ts, PRIOR_TIMESTAMP);
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
 TEST_F(SyscollectorImpTest, queryCommandSetVersion)
 {
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};


### PR DESCRIPTION
## Description

Closes #35426

On a fresh agent start, Syscollector's sync thread used `get_version` as a proxy to detect when the initial scan had finished. This was unreliable because `get_version` returns non-zero the moment the first collector writes a single row, while the scan is still running. The sync thread would conclude the scan was done, attempt to sync, find `is_scanning = true`, back off, and sleep for a full `sync_interval` with no wake-up signal when the scan actually finished. This caused the first inventory synchronisation to be delayed by up to `sync_interval` after the scan completed.

## Proposed Changes

- Persist a `first_scan_completed` key to the local database at the end of `scan()` in `syscollectorImp.cpp`, marking the true scan boundary.
- Add a `get_first_scan_completed` query handler so the sync thread can poll for this key instead of relying on `get_version`.
- Replace the `get_version` poll in `wm_sys_get_startup_action()` with `get_first_scan_completed`, so the sync thread waits for the real scan boundary before proceeding.
- Set a `skip_scanning_check` flag on the first immediate sync cycle so the `is_scanning` guard is bypassed.

### Results and Evidence

**Before:**

```
2026/04/14 16:28:48 wazuh-modulesd:syscollector[70481] logging_helper.c:37 at taggedLogFunction(): DEBUG: Syscollector get_version returned: 0
2026/04/14 16:28:48 wazuh-modulesd:syscollector[70481] logging_helper.c:31 at taggedLogFunction(): INFO: Starting evaluation.
2026/04/14 16:28:49 wazuh-modulesd:syscollector[70481] logging_helper.c:37 at taggedLogFunction(): DEBUG: Syscollector get_version returned: 1
2026/04/14 16:28:49 wazuh-modulesd:syscollector[70481] wm_syscollector.c:394 at wm_sys_get_startup_action(): DEBUG: Initial Inventory scan data is ready. Triggering first synchronization without startup delay.
2026/04/14 16:28:49 wazuh-modulesd:syscollector[70481] wm_syscollector.c:980 at wm_sync_module(): DEBUG: Scan in progress, skipping sync cycle
2026/04/14 16:28:55 wazuh-modulesd:syscollector[70481] logging_helper.c:31 at taggedLogFunction(): INFO: Evaluation finished.
2026/04/14 16:29:56 wazuh-modulesd:syscollector[70481] logging_helper.c:37 at taggedLogFunction(): DEBUG: Syscollector module is paused or stopping, skipping synchronization
2026/04/14 16:31:02 wazuh-modulesd:syscollector[70481] logging_helper.c:37 at taggedLogFunction(): DEBUG: Syscollector module is paused or stopping, skipping synchronization
```

`get_version` flipped to 1 at 16:28:49 while the scan was still running. The sync thread hit `is_scanning`, backed off for 60 s, and the first successful synchronisation never appeared in the capture window. Minimum delay from scan completion (16:28:55): **≥ 66 seconds**.

---

**After:**

```
2026/04/15 12:23:10 wazuh-modulesd:syscollector[13453] wm_syscollector.c:380 at wm_sys_get_startup_action(): DEBUG: Inventory initial scan data is not ready yet. First synchronization will wait for scan data.
2026/04/15 12:23:10 wazuh-modulesd:syscollector[13453] logging_helper.c:37 at taggedLogFunction(): DEBUG: Received query: {"command":"get_first_scan_completed"}
2026/04/15 12:23:10 wazuh-modulesd:syscollector[13453] wm_syscollector.c:398 at wm_sys_get_startup_action(): DEBUG: Synchronization deferred: waiting for first inventory scan to complete.
2026/04/15 12:23:10 wazuh-modulesd:syscollector[13453] logging_helper.c:31 at taggedLogFunction(): INFO: Starting evaluation.
2026/04/15 12:23:11 wazuh-modulesd:syscollector[13453] logging_helper.c:37 at taggedLogFunction(): DEBUG: Received query: {"command":"get_first_scan_completed"}
2026/04/15 12:23:11 wazuh-modulesd:syscollector[13453] wm_syscollector.c:398 at wm_sys_get_startup_action(): DEBUG: Synchronization deferred: waiting for first inventory scan to complete.
[... polled every second for the 10 s the scan runs ...]
2026/04/15 12:23:20 wazuh-modulesd:syscollector[13453] logging_helper.c:31 at taggedLogFunction(): INFO: Evaluation finished.
2026/04/15 12:23:20 wazuh-modulesd:syscollector[13453] logging_helper.c:37 at taggedLogFunction(): DEBUG: First inventory scan completed — marker persisted.
2026/04/15 12:23:21 wazuh-modulesd:syscollector[13453] wm_syscollector.c:394 at wm_sys_get_startup_action(): DEBUG: First inventory scan completed. Triggering first synchronization without startup delay.
2026/04/15 12:23:21 wazuh-modulesd:syscollector[13453] logging_helper.c:31 at taggedLogFunction(): INFO: Starting inventory synchronization.
2026/04/15 12:23:21 wazuh-modulesd:syscollector[13453] logging_helper.c:37 at taggedLogFunction(): DEBUG: StartAck received. Session: 6393652549476418162
```

`get_first_scan_completed` returned not-ready on every poll while the scan ran (10 s). The moment `Evaluation finished.` was logged, the marker was persisted and the sync fired. Delay from scan completion (12:23:20) to sync start (12:23:21): **1 second**. The `"Scan in progress, skipping sync cycle"` line is absent.

Additionally, we can validate that the marker is created and is consistent with the pre-existing first sync marker by checking the local database (`./queue/syscollector/db/local.db`):

```command
sqlite> select * from table_metadata;
first_scan_completed|1776395348|1
first_sync_completed|1776395714|1
dbsync_browser_extensions|1776395735|1
dbsync_groups|1776395735|1
dbsync_hwinfo|1776395735|1
dbsync_network_address|1776395735|1
dbsync_network_iface|1776395735|1
dbsync_network_protocol|1776395735|1
dbsync_osinfo|1776395735|1
dbsync_packages|1776395735|1
dbsync_ports|1776395735|1
dbsync_processes|1776395735|1
dbsync_services|1776395735|1
dbsync_users|1776395735|1
```

---

### Artifacts Affected

- `wazuh-modulesd/syscollector` (all platforms)

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

- Unit tests added in `syscollectorImp_test.cpp` covering:
  - `first_scan_completed` marker is persisted at the end of `scan()`.
  - `get_first_scan_completed` query returns false before the scan runs and true after.
  - Sync thread defers correctly when the marker is absent.
  - Sync thread fires immediately (without `is_scanning` back-off) once the marker is present.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
