### PR TITLE
Avoid using keyentries counter as index

### DIFF
--- a/src/os_auth/src/main-server.c
+++ b/src/os_auth/src/main-server.c
@@ -838,14 +838,19 @@ void enqueue_pending_key(int ret, uint32_t index_client) {
                 merror("Agent key not saved for %s", g_client_pool[index_client]->agentname);
                 ERR_print_errors_fp(stderr);
                 w_mutex_lock(&mutex_keys);
-                OS_DeleteKey(&keys, keys.keyentries[keys.keysize - 1]->id, 1);
+                if (g_client_pool[index_client]->new_id) {
+                    OS_DeleteKey(&keys, g_client_pool[index_client]->new_id, 1);
+                }
                 w_mutex_unlock(&mutex_keys);
             } else {
                 /* Add pending key to write */
                 w_mutex_lock(&mutex_keys);
-                add_insert(keys.keyentries[keys.keysize - 1], g_client_pool[index_client]->centralized_group);
-                write_pending = 1;
-                w_cond_signal(&cond_pending);
+                int key_index = OS_IsAllowedID(&keys, g_client_pool[index_client]->new_id);
+                if (key_index >= 0) {
+                    add_insert(keys.keyentries[key_index], g_client_pool[index_client]->centralized_group);
+                    write_pending = 1;
+                    w_cond_signal(&cond_pending);
+                }
                 w_mutex_unlock(&mutex_keys);
             }
         }


### PR DESCRIPTION
## Description

# Update 04/15 

There's a race condition while filling the authd queue after SSL handshake using the keyentries internal counter.

--- 

- Client.keys file 

> [!NOTE]
> 50 agents are successfully dumped to the disk 

<details><summary>Expand</summary>

```console
001 57d9fa433a5c any 68f644214b7476db9e9e87b4213e3da28b7c722df70f5f8e943b0e836dcbadb8
002 b85579ba4d7d any dbf74220c433fea6ed6dd1c622978ac1736fe00e8b6c885576f4228ba9dbd9cc
003 dfb6a897f57c any b5c57543cd43aab678034467249f01637a1336d005327e80fba9bd492800bbfa
004 9465a6635220 any e8a8a3f5032c3d1155be1b0015487b5076f47c2887a33f47388849d8ad6afaa8
005 d4280307bb88 any 2d88a68dfa10a0a8aec2118c44a32d97e9dad4a2500593f766d071118f445b8e
006 8f09d8ba059d any 0d3ef042eb74fdb3afb8a61d744a604aa55635ee040b3a2c6865c2c3c51498a4
007 961594c97622 any 48159324104f239cf0118ff09a0dd3c67c9bfdeddf2037f6d1d0c0d142e9076d
008 bda6dd5721a2 any 62df1bde0ab63299c177451e8078c5ff629297b8eefd88de4ceeb5bd0eb8fe79
009 d692a7d50872 any cfa02f1488dd01b813017b751d88586fc1f6d3c169642b68f2490effd6dbd9ed
010 6b8a8f3f4edf any 3c29e7dcaf8f9425174823651f4ffbb9e205da5b0d801cd89065daae4d06563b
011 c5e8dad90d0a any 68d9d2297a85acdfc9c7249e83f81040c29385aad29fd38e9dbaf1e564243b5a
012 da2c6f21dece any e1be2b073a31adb9436bc1586d24b2f127a4bb5a40a139789568bb80bc40d48a
013 0c3b0f9123d8 any 6cccaf81a12102901a324ae56e58f1d6e84da76f07682850fe3b61fbfc1f8bea
014 123af99c44f4 any c920612ac7e5e8a5dc0dd61141ea5c32eec4028862ddaed438a36995f375575f
015 c9abc465a84d any 2af2c62791e0c68ea01f4f1a85ef7bfd24aeba514a4bccc4e007c2ff6ee087c5
016 b20716025011 any 4cd01557ef1bb4e8a6bc32894273364e4051db1fcca69b64e1c1b0e2412f98fe
017 2a42d15f54c5 any 91d32387aeaecd59ce55192a9e33d257561f204f0159605a035dc2d67f27ab8a
018 4dfcc7ed54c7 any bfbe46768875fbc9de0f23996c33055bd15576990227bef3d36dd6c739c826ef
019 8c0d2e0b1b38 any 9b260af1a0508dae79db5e2bf6df4fca94f6d8bf3475e0df89a322af989267ef
020 dfb29948150a any bed0997ce7d53e5c85f1a37cca7e9fa145536df0231a658236d1eaa4ce9c6d0f
021 e19f7f625952 any 9dc8a0d831c23a664dc1d53d380b550dacb0741ab1053dcb6dadea21f0b719a8
022 82b51d257043 any 0530e8eaa10db1ce5b19e8b345c7711fad67547577088e38ac98165da5a810ae
023 c06f21c090f8 any e40a07cd8f2b30545cb49bc96183a4eb711dee23b153ebe29320f8756f85383b
024 0c23c12e8275 any 7f964870fdd7f583886feb1363594b8cb442446eaa9b8ecdcd213e8a714ac82d
025 a387eae071cf any 01001caffb0c17b8945ba3a18d5e80106079f70877d4b59bb6005138bd9d13a4
026 d9869ae03834 any 2219910b48d0149304eb1c218070133801cd02ff2e6572fd98e37495ff2c2e0e
027 13f8fc6e5f67 any c6d7fd9dc08cb49fcbf1a9862a2b4a25422fdd92f8908423fa971cd15c6cd690
028 f01a0877c927 any 92e60b5f6cc7eca60db51da77bf0cc195cb61ce69e7ec92fc86f18c6565a8e48
029 7e9dd98ca9bf any f73c4fa32875a8e29bef3dbb96058683025a0ac3a517e8d0ac812283c5983bab
030 2d4b680fb80d any f303128aed7e6579f4e5732886bcf758218b8f6ce8bbba33c812dcef05110de7
031 93d4d61b6a01 any f368ec754b20bfacfce6f30042668eca96e023d3576c358fbf5f4e150e04972e
032 9d6dde33fea3 any 1770ad93805174fe190ee0e72882a0a98cb1e76cb36f2b1e0454dc2edba48122
033 5004fa3e4cb8 any 7a9f1cc167d10f05e0d3265a7c632f93771d7098ff7bd25d5fc398f403518ef4
034 bfce3aa66609 any 256e152d232465af757407e9b7214a1b8f9a897f22ab3e48a57ffa634a88ead8
035 e7074094d465 any 9fddabab0230635cb2041ec1dbff5fea96a2fb95166ce812d2b57f0b1a1e56b7
036 0583218ce39b any 41fc1582e1e26e4030420267791f958ea967ab31a00c05f49880ab0ff193e01f
037 064ea870e423 any 66536c81621e84238c3d6492f9f526d6caf3916ffe3d3cf23e3b7c068b3f84d9
038 2df360fe5083 any 54ee36d730ce218e2ff8f2b48d9098721de7459f79740a7c46675a5a9f697ae0
039 5f527206252d any 668dd7956a5aaae7b64cdadec7312432074ff7ef51eb6acb4a3042330c9ed331
040 f477ce85d42a any 7477961057ab2636ca3555851ed83b331f29c070e4059886336eea915cc1a39d
041 a20e1a47830a any 4ff7f547335f191ab06d32421fd2dafb4fe6b2fb374735fb85b08ddae76fe7b2
042 921e7ac4110b any ebd4048fd0af8322da16600288e962411e4ee3200936d316321ef697ac1f67b9
043 8930f13cdead any c42606bd7fd8ebb4f5e0c8f2e742d6cb9f1b4515df41d8f90ce35e6aaa52f868
044 011ebb73b117 any 6c233e609cd733b07c58b36ba813cbff941fbea2f6c1e150cfbff7cd1010f0e6
045 3141a362d07a any ea890b32a7dbbbc27a885168035eee47ac9696bcb9a48291885a6777a56d3509
046 551a9c5beda4 any 8e39d257974310bbfbaa985eee9c259d9fb62f5eb3cbd8c1068db5bb9ac57e89
047 578316cfcf3f any e6d135e258380c875f4f976e456d11af861abe3a59113987c87698faf9116c6b
048 101ccb9c9a95 any c791a819c5688c8a007265c81727d28b22c8b1fc9b0c4130a1e63bd25b7200c8
049 e710da4e1921 any 439015659acaee847610bcf9301764be998823d410b3eeae57e9a6d5aadddbc8
050 eb6ae7738f12 any 0cd523898bd88752e5d1c2db00fbf829b823147954cce9bf94b09fa12bdf1e28
```

</details>

---

- Registered agents 
 
> [!NOTE]
> Only 49 agents registered. The missing agent is 3141a362d07a id 45 

<details><summary>Expand</summary> 

```json
{
  "data": {
    "affected_items": [
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "001",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:58+00:00",
        "dateAdd": "2026-04-15T14:43:38+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "57d9fa433a5c",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "002",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "b85579ba4d7d",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "003",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "dfb6a897f57c",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "004",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "9465a6635220",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "005",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "d4280307bb88",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "006",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "8f09d8ba059d",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "007",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:39+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "961594c97622",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "008",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "bda6dd5721a2",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "009",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "d692a7d50872",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "010",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:39+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "6b8a8f3f4edf",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "011",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "c5e8dad90d0a",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "012",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "da2c6f21dece",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "013",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "0c3b0f9123d8",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "014",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "123af99c44f4",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "015",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:39+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "c9abc465a84d",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "016",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "b20716025011",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "017",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "2a42d15f54c5",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "018",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "4dfcc7ed54c7",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "019",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "8c0d2e0b1b38",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "020",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "dfb29948150a",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "021",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "e19f7f625952",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "022",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "82b51d257043",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "023",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "c06f21c090f8",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "024",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "0c23c12e8275",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "025",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "a387eae071cf",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "026",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "d9869ae03834",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "027",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "13f8fc6e5f67",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "028",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "f01a0877c927",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "029",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "7e9dd98ca9bf",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "030",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "2d4b680fb80d",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "031",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "93d4d61b6a01",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "032",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "9d6dde33fea3",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "033",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:39+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "5004fa3e4cb8",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "034",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "bfce3aa66609",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "035",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "e7074094d465",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "036",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "0583218ce39b",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "037",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:39+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "064ea870e423",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "038",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "2df360fe5083",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "039",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "5f527206252d",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "040",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:59+00:00",
        "dateAdd": "2026-04-15T14:43:39+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "f477ce85d42a",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "041",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "a20e1a47830a",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "042",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "921e7ac4110b",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "043",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "8930f13cdead",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "044",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "011ebb73b117",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "046",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "551a9c5beda4",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "047",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "578316cfcf3f",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "048",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "101ccb9c9a95",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "049",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "e710da4e1921",
        "status": "active"
      },
      {
        "os": {
          "arch": "x86_64",
          "major": "9",
          "name": "CentOS Stream",
          "platform": "centos",
          "version": "9"
        },
        "ip": "any",
        "status_code": 0,
        "version": "v5.0.0",
        "id": "050",
        "group_config_status": "synced",
        "group": [
          "default"
        ],
        "registerIP": "any",
        "lastKeepAlive": "2026-04-15T14:44:40+00:00",
        "dateAdd": "2026-04-15T14:43:40+00:00",
        "node_name": "node01",
        "mergedSum": "ca35f9148a3273413eccb79f149f4757",
        "name": "eb6ae7738f12",
        "status": "active"
      }
    ],
    "total_affected_items": 49,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details> 

--- 

- Logs file 

> [!NOTE]
> Successfully receive the request for all agents, but it tried to add to the global database the agent 46 twice.  

```console
grep "Received request" wazuh-manager.log | wc -l
50
```

```console
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:1143 at run_writer(): DEBUG: [Writer] Performing insert([046] 551a9c5beda4).
2026/04/15 11:43:40 wazuh-manager-db[181533] wdb_parser.c:105 at wdb_parse(): DEBUG: Global query: insert-agent {"id":46,"name":"551a9c5beda4","register_ip":"any","internal_key":"8e39d257974310bbfbaa985eee9c259d9fb62f5eb3cbd8c1068db5bb9ac57e89","date_add":1776264220}
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:1155 at run_writer(): DEBUG: [Writer] wdb_insert_agent(): 437 µs.
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:1170 at run_writer(): DEBUG: [Writer] wdb_set_agent_groups_csv(): 0 µs.
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:1143 at run_writer(): DEBUG: [Writer] Performing insert([046] 551a9c5beda4).
2026/04/15 11:43:40 wazuh-manager-db[181533] wdb_parser.c:105 at wdb_parse(): DEBUG: Global query: insert-agent {"id":46,"name":"551a9c5beda4","register_ip":"any","internal_key":"8e39d257974310bbfbaa985eee9c259d9fb62f5eb3cbd8c1068db5bb9ac57e89","date_add":1776264220}
2026/04/15 11:43:40 wazuh-manager-db[181533] wdb.c:786 at wdb_exec_stmt_silent(): DEBUG: SQL statement execution failed
2026/04/15 11:43:40 wazuh-manager-db[181533] wdb_parser.c:1005 at wdb_parse_global_insert_agent(): DEBUG: Global DB Cannot execute SQL query; err database queue/db/global.db: UNIQUE constraint failed: agent.id
2026/04/15 11:43:40 wazuh-manager-authd[181527] wazuhdb_queries_op.c:95 at wdb_insert_agent(): DEBUG: Global DB Error reported in the result of the query
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:1152 at run_writer(): INFO: The agent 046 '551a9c5beda4' already exists in the database.
```

> [!NOTE]
> The information to be added to the global, is popped from an internal queue, and that queue has one entry missing because the race condition in the enqueue_pending_key() function tried to enqueue the same agent twice. We could verify this with a simple log

```console
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:846 at enqueue_pending_key(): INFO: Enqueue using agent id '046'. Instead of '045'.
2026/04/15 11:43:40 wazuh-manager-authd[181527] main-server.c:846 at enqueue_pending_key(): INFO: Enqueue using agent id '046'. Instead of '046'.
```

## Proposed Changes

Use the ID immediately assigned to the client structure and avoid using the keyentries counter. 

### Manual tests with their corresponding evidence

Deploying 125 agents 

Agents successfully registered 

[agents.json](https://github.com/user-attachments/files/26757943/agents.json)

```json
    "total_affected_items": 125,
    "total_failed_items": 0,
    "failed_items": []
```

Logs 

No warning or error messages during registration. 

```console
grep -E "ERR|CRIT|WARN" wazuh-manager.log
2026/04/15 13:16:06 wazuh-manager-modulesd: WARNING: (1230): Invalid element in the configuration: 'cti-url'.
2026/04/15 13:16:07 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/04/15 13:16:19 wazuh-manager-modulesd: WARNING: (1230): Invalid element in the configuration: 'cti-url'.
2026/04/15 13:16:19 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/04/15 13:17:02 wazuh-manager-modulesd: WARNING: (1230): Invalid element in the configuration: 'cti-url'.
2026/04/15 13:17:06 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/04/15 13:17:06 wazuh-manager-analysisd: WARNING: Router: router/tester/0 table is empty
2026/04/15 13:17:18 wazuh-manager-modulesd: WARNING: (1230): Invalid element in the configuration: 'cti-url'.
2026/04/15 13:17:18 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/04/15 13:17:18 wazuh-manager-modulesd:vulnerability-scanner: WARNING: The local feed database is incomplete at startup: required global maps are missing. Clearing updater state to force a clean rebuild.
2026/04/15 13:19:32 logger-helper: WARNING: Queue is full (size: 30000, max: 30000). Starting to discard events. Periodic summaries will be logged every 30 seconds.
2026/04/15 13:20:02 logger-helper: WARNING: Queue overflow continues: 15100 events discarded in the last 30 seconds (queue size: 30000, max: 30000, total discarded: 15100).
```

[wazuh-manager.log](https://github.com/user-attachments/files/26757975/wazuh-manager.log)
