### PR TITLE
Backport: Validate current user in update-user endpoint to 4.10.4

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -377,7 +377,7 @@ async def update_user(user_id: str, pretty: bool = False, wait_for_complete: boo
     f_kwargs = await UpdateUserModel.get_kwargs(request,
                                                 additional_kwargs=
                                                 {'user_id': user_id,
-                                                  'current_user': request.get("user")})
+                                                  'current_user': request.context['token_info']['sub']})
 
     dapi = DistributedAPI(f=security.update_user,
                           f_kwargs=remove_nones_to_dict(f_kwargs),

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -298,9 +298,17 @@ async def test_create_user(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_re
 async def test_update_user(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
     """Verify 'update_user' endpoint is working as expected."""
     with patch('api.controllers.security_controller.Body.validate_content_type'):
-        with patch('api.controllers.security_controller.CreateUserModel.get_kwargs',
+        with patch('api.controllers.security_controller.UpdateUserModel.get_kwargs',
                    return_value=AsyncMock()) as mock_getkwargs:
             result = await update_user(user_id='001')
+
+            # Verify that current_user is correctly passed from token_info
+            mock_getkwargs.assert_called_once()
+            call_kwargs = mock_getkwargs.call_args[1]
+            assert 'additional_kwargs' in call_kwargs
+            assert call_kwargs['additional_kwargs']['user_id'] == '001'
+            assert call_kwargs['additional_kwargs']['current_user'] == mock_request.context['token_info']['sub']
+
             mock_dapi.assert_called_once_with(
                 f=security.update_user,
                 f_kwargs=mock_remove.return_value,

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -595,6 +595,44 @@ stages:
               allow_run_as: false
           total_affected_items: 1
 
+  - name: Update admin user password (should fail - error 5011)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/1"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        password: "HackedAdmin1!"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: 1
+              username: wazuh
+          total_affected_items: 1
+
+  - name: Update wazuh-wui admin user password
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/security/users/2"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+      json:
+        password: "NewWazuhWui1!"
+    response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          affected_items:
+            - id: 2
+              username: wazuh-wui
+          total_affected_items: 1
+
 
 ---
 test_name: PUT /security/users/{user_id}/run_as

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -229,7 +229,10 @@ def update_user(user_id: str = None, password: str = None, current_user: str = N
         elif not _user_password.match(password):
             raise WazuhError(5007)
 
-        if int(user_id[0]) <= MAX_ID_RESERVED and current_user is not None:
+        if int(user_id[0]) <= MAX_ID_RESERVED:
+            if current_user is None:
+                raise WazuhError(5011)
+
             with AuthenticationManager() as auth_manager:
                 current_user_id = auth_manager.get_user(current_user)['id']
 

--- a/framework/wazuh/tests/data/security/users_roles_test_cases.yml
+++ b/framework/wazuh/tests/data/security/users_roles_test_cases.yml
@@ -154,6 +154,16 @@ update_user:
       failed_items:
         "5009":
           - 106
+  - params:
+      user_id:
+        - 1
+      password: HackedPassword1!
+      current_user: normal
+    result:
+      affected_items: []
+      failed_items:
+        "5011":
+          - 1
 remove_users:
   - params:
       user_ids:


### PR DESCRIPTION
## Description

This PR corrects the user context retrieval in the `PUT /security/users/{user_id}` API endpoint. The endpoint was using `request.get("user")` instead of `request.context['token_info']['sub']` to identify the authenticated user, causing the existing admin-protection logic in the framework to not execute as intended.

This fix aligns the `update_user` endpoint with all other security endpoints in the same controller, which correctly use `request.context['token_info']['sub']`.

> [!NOTE]
> Backport the changes from #35442 to the 4.10.4 branch to keep the update-user flow consistent in the 4.10.4 release line.

Kudos to @jeroengui for reporting this issue.

## Proposed Changes

### Code Changes

**1. API Controller** ([api/api/controllers/security_controller.py:380](api/api/controllers/security_controller.py#L380))
- Changed `request.get("user")` → `request.context['token_info']['sub']`
- Aligns with other security endpoints: `get_user_me`, `logout_user`, `edit_run_as`, `delete_users`
**2. Framework Guard Enhancement** ([framework/wazuh/security.py:231-238](framework/wazuh/security.py#L231-L238))
- Added explicit validation: if `current_user is None` when updating admin users → raise `WazuhError(5011)`
- Ensures fail-closed behavior for edge cases

### Results and Evidence

**After the fix:**
```bash
# Attempting to update admin user (ID 1) with non-admin credentials
curl -sk -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -X PUT "https://localhost:55000/security/users/1" \
  -d '{"password":"NewPassword1!"}'
```

**Response:**
```json
{
  "title": "Bad Request",
  "detail": "Administrator users can only be modified by themselves",
  "remediation": "Log in as administrator and try again",
  "dapi_errors": {
    "unknown-node": {
      "error": "Administrator users can only be modified by themselves"
    }
  },
  "error": 5011
}
```

The admin-protection guard now executes correctly, returning error 5011 as designed.

### Artifacts Affected

- **wazuh-apid (manager)**: API endpoint behavior for admin user updates

### Configuration Changes

None required.

### Documentation Updates

None required. The intended behavior was already documented.

### Tests Introduced

**1. Framework Unit Tests** ([framework/wazuh/tests/data/security/users_roles_test_cases.yml](framework/wazuh/tests/data/security/users_roles_test_cases.yml#L157-L179))
- Non-admin user attempting to update admin user → expects error 5011
- Admin user updating another admin user → expects success
**2. Integration Tests** ([api/test/integration/test_security_PUT_endpoints.tavern.yaml](api/test/integration/test_security_PUT_endpoints.tavern.yaml#L599-L630))
- Update admin user password as admin
- Update wazuh-wui admin user password
**3. Controller Unit Tests** ([api/api/controllers/test/test_security_controller.py](api/api/controllers/test/test_security_controller.py#L298-L331))
- Fixed incorrect model reference: `CreateUserModel` → `UpdateUserModel`
- Validate `current_user` parameter is correctly passed from `token_info['sub']`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
