### PR TITLE
Prevent agent.host.ip from being silently dropped when agent IP is empty

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -923,6 +923,12 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
 
     key_unlock();
 
+    /* Agents registered without a fixed address use "any"; fall back to the real connection IP. */
+    if (strcmp(agent_ip, "any") == 0 && srcip[0] != '\0') {
+        os_free(agent_ip);
+        os_strdup(srcip, agent_ip);
+    }
+
     if (sock_idle >= 0) {
         _close_sock(&keys, sock_idle);
     }

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -921,6 +921,13 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
     os_strdup(keys.keyentries[agentid]->name, agent_name);
     os_strdup(keys.keyentries[agentid]->ip->ip, agent_ip);
 
+    /* If the agent registered with "any" IP, use the actual source IP of the message
+     * so that downstream consumers (e.g. inventory harvester) can populate agent.host.ip */
+    if (strcmp(agent_ip, "any") == 0 && srcip[0] != '\0') {
+        os_free(agent_ip);
+        os_strdup(srcip, agent_ip);
+    }
+
     key_unlock();
 
     if (sock_idle >= 0) {

--- a/src/shared_modules/utils/tests/reflectiveJson_test.cpp
+++ b/src/shared_modules/utils/tests/reflectiveJson_test.cpp
@@ -390,4 +390,65 @@ TEST_F(ReflectiveJsonTest, NumericBufferZeroing)
     EXPECT_EQ(json.front(), '{');
     EXPECT_EQ(json.back(), '}');
 }
+
+TEST_F(ReflectiveJsonTest, IsEmptyReturnsFalseForPartiallyPopulatedNestedStruct)
+{
+    struct NestedData
+    {
+        std::string_view stringField;
+        int64_t intField;
+
+        REFLECTABLE(MAKE_FIELD("stringField", &NestedData::stringField),
+                    MAKE_FIELD("intField", &NestedData::intField));
+    };
+
+    NestedData obj;
+    obj.stringField = "someValue";
+    obj.intField    = DEFAULT_INT_VALUE;
+
+    EXPECT_FALSE(isEmpty(obj));
+}
+
+TEST_F(ReflectiveJsonTest, IsEmptyReturnsTrueWhenAllFieldsAreEmpty)
+{
+    struct NestedData
+    {
+        std::string_view stringField;
+        int64_t intField;
+
+        REFLECTABLE(MAKE_FIELD("stringField", &NestedData::stringField),
+                    MAKE_FIELD("intField", &NestedData::intField));
+    };
+
+    NestedData obj;
+    obj.stringField = "";
+    obj.intField    = DEFAULT_INT_VALUE;
+
+    EXPECT_TRUE(isEmpty(obj));
+}
+
+TEST_F(ReflectiveJsonTest, PartiallyPopulatedNestedStructIsNotOmittedFromOutput)
+{
+    struct NestedData
+    {
+        std::string_view stringField;
+        int64_t intField;
+
+        REFLECTABLE(MAKE_FIELD("stringField", &NestedData::stringField),
+                    MAKE_FIELD("intField", &NestedData::intField));
+    };
+
+    TestData<NestedData> obj;
+    obj.fieldOne              = "";
+    obj.fieldTwo              = DEFAULT_INT_VALUE;
+    obj.fieldThree.stringField = "someValue";
+    obj.fieldThree.intField   = DEFAULT_INT_VALUE;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_EQ(json.find(R"("fieldOne":)"), std::string::npos);
+    EXPECT_EQ(json.find(R"("fieldTwo":)"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldThree":{"stringField":"someValue"})"), std::string::npos);
+}
 #endif

--- a/src/shared_modules/utils/tests/reflectiveJson_test.cpp
+++ b/src/shared_modules/utils/tests/reflectiveJson_test.cpp
@@ -390,4 +390,78 @@ TEST_F(ReflectiveJsonTest, NumericBufferZeroing)
     EXPECT_EQ(json.front(), '{');
     EXPECT_EQ(json.back(), '}');
 }
+
+// Regression tests for wazuh/wazuh#35251: agent.host.ip missing when other Host
+// fields (architecture, hostname, os) are empty.
+// The isEmpty() function for reflectable structs must return false when at least
+// one field has a value, so that partially-populated nested objects are not
+// silently dropped from the serialized output.
+
+TEST_F(ReflectiveJsonTest, IsEmptyReturnsFalseForPartiallyPopulatedNestedStruct)
+{
+    struct NestedData
+    {
+        std::string_view stringField;
+        int64_t intField;
+
+        REFLECTABLE(MAKE_FIELD("stringField", &NestedData::stringField),
+                    MAKE_FIELD("intField", &NestedData::intField));
+    };
+
+    // Only stringField is set; intField is at its sentinel (empty) value.
+    NestedData obj;
+    obj.stringField = "someValue";
+    obj.intField    = DEFAULT_INT_VALUE;
+
+    EXPECT_FALSE(isEmpty(obj));
+}
+
+TEST_F(ReflectiveJsonTest, IsEmptyReturnsTrueWhenAllFieldsAreEmpty)
+{
+    struct NestedData
+    {
+        std::string_view stringField;
+        int64_t intField;
+
+        REFLECTABLE(MAKE_FIELD("stringField", &NestedData::stringField),
+                    MAKE_FIELD("intField", &NestedData::intField));
+    };
+
+    NestedData obj;
+    obj.stringField = "";
+    obj.intField    = DEFAULT_INT_VALUE;
+
+    EXPECT_TRUE(isEmpty(obj));
+}
+
+TEST_F(ReflectiveJsonTest, PartiallyPopulatedNestedStructIsNotOmittedFromOutput)
+{
+    // When a nested reflectable struct has only SOME fields populated,
+    // serializeToJSON must emit the object with only those non-empty fields.
+    struct NestedData
+    {
+        std::string_view stringField;
+        int64_t intField;
+
+        REFLECTABLE(MAKE_FIELD("stringField", &NestedData::stringField),
+                    MAKE_FIELD("intField", &NestedData::intField));
+    };
+
+    TestData<NestedData> obj;
+    obj.fieldOne              = "";
+    obj.fieldTwo              = DEFAULT_INT_VALUE;
+    obj.fieldThree.stringField = "someValue";
+    obj.fieldThree.intField   = DEFAULT_INT_VALUE;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    // Outer fields that are empty must be absent.
+    EXPECT_EQ(json.find(R"("fieldOne":)"), std::string::npos);
+    EXPECT_EQ(json.find(R"("fieldTwo":)"), std::string::npos);
+
+    // fieldThree is not empty (stringField has a value) and must appear, containing
+    // only its non-empty sub-field.
+    EXPECT_NE(json.find(R"("fieldThree":{"stringField":"someValue"})"), std::string::npos);
+}
 #endif

--- a/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/fileElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/fileElement.hpp
@@ -50,7 +50,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/registryKeyElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/registryKeyElement.hpp
@@ -50,7 +50,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/registryValueElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/registryValueElement.hpp
@@ -49,7 +49,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/browserExtensionElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/browserExtensionElement.hpp
@@ -68,7 +68,7 @@ public:
         element.data.agent.id = agentId;
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/groupElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/groupElement.hpp
@@ -82,7 +82,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hotfixElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hotfixElement.hpp
@@ -54,7 +54,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
@@ -53,7 +53,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netElement.hpp
@@ -52,7 +52,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netIfaceElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netIfaceElement.hpp
@@ -55,7 +55,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/networkProtocolElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/networkProtocolElement.hpp
@@ -55,7 +55,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/osElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/osElement.hpp
@@ -49,7 +49,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/packageElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/packageElement.hpp
@@ -53,7 +53,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/portElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/portElement.hpp
@@ -53,7 +53,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/processElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/processElement.hpp
@@ -55,7 +55,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/serviceElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/serviceElement.hpp
@@ -63,7 +63,7 @@ public:
         element.data.agent.id = agentId;
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/userElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/userElement.hpp
@@ -171,7 +171,7 @@ public:
         element.data.agent.name = data->agentName();
         element.data.agent.version = data->agentVersion();
 
-        if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)
+        if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
         {
             element.data.agent.host.ip = agentIp;
         }


### PR DESCRIPTION
## Summary

Two-layer fix for the missing `agent.host.ip` field confirmed in wazuh/external-devel-requests#6690.

### Layer 1 — `remoted/secure.c` (root cause)

When `HandleSecureMessage` forwards a syscollector/syscheck event to the router, it reads the agent IP from the keystore's registered IP (`keys.keyentries[agentid]->ip->ip`). For agents enrolled without a fixed address this value is the literal string `"any"`, which propagates through the FlatBuffer pipeline until inventory harvester's element builders discard it — leaving `agent.host.ip` absent from every indexed document for that agent.

The actual sender IP is already extracted into `srcip` from `message->addr` earlier in the same function. The fix uses it as a fallback when the registered IP is `"any"`:

```c
os_strdup(keys.keyentries[agentid]->ip->ip, agent_ip);

/* If the agent registered with "any" IP, use the actual source IP of the message */
if (strcmp(agent_ip, "any") == 0 && srcip[0] != '\0') {
    os_free(agent_ip);
    os_strdup(srcip, agent_ip);
}
```

The `srcmsg` used for the internal wazuh-db queue is intentionally left unchanged to preserve legacy routing behaviour.

### Layer 2 — inventory harvester element builders (defensive)

All 16 element builders (13 system-inventory types + 3 FIM types) previously set `host.ip = ""` when `agentIp()` returned an empty string, which then caused `isEmpty(host) == true` and silently dropped the entire `host` object from the serialized JSON. Added `!agentIp.empty()` guard to make the intent explicit:

```cpp
// before
if (auto agentIp = data->agentIp(); agentIp.compare("any") != 0)

// after
if (auto agentIp = data->agentIp(); !agentIp.empty() && agentIp.compare("any") != 0)
```

### Layer 3 — regression tests (`reflectiveJson_test.cpp`)

Three unit tests verify that `isEmpty()` and `serializeToJSON()` correctly handle a reflectable struct where only a subset of fields is populated (the `Host`-with-only-`ip` pattern), so any future regression in the serialization path is caught immediately.

## Root cause chain

```
Agent enrolled with no fixed IP
  → client.keys stores "any"
  → secure.c reads "any" from keystore  ← fix here (Layer 1)
  → router/schemaAdapter appends "any" to FlatBuffer JSON
  → systemContext::agentIp() returns "any"
  → element builder skips host.ip assignment  ← hardened (Layer 2)
  → isEmpty(host) == true
  → "host" key omitted from serialized document
  → agent.host.ip missing in index
```

## Evidences
- Using a full environment with 4.14.5, register an agent with any IP:
```
001 ubuntu24-2 any 543c32612a96d2399d7592d21e976a8802a14a8f5106aaee9e78e6d05ca40066
```
- No ip in dashboard:
<img width="1714" height="1145" alt="image" src="https://github.com/user-attachments/assets/677c37c7-89d9-4efa-bc6a-f89ab06db8a3" />


After updating manager with this branch changes:
- `/var/ossec/etc/client.keys`
```
004 ubuntu24-2 any f1a0195d6ce5b161b8394f1e30f61e04185bd1e9b11595a61a201a32b20566c6
```

<img width="1715" height="1147" alt="image" src="https://github.com/user-attachments/assets/155fe0ef-3363-4ad2-80be-d16a896da958" />



## Test plan

- [x] Agent enrolled with `"any"` IP: after fix, `agent.host.ip` is populated with the real connection IP in indexed documents.
- [x] Agent enrolled with explicit IP: behaviour unchanged.
- [x] `IsEmptyReturnsFalseForPartiallyPopulatedNestedStruct` passes.
- [x] `IsEmptyReturnsTrueWhenAllFieldsAreEmpty` passes.
- [x] `PartiallyPopulatedNestedStructIsNotOmittedFromOutput` passes.
- [x] All existing `remoted`, `reflectiveJson`, and `systemInventoryUpsertElement` unit tests pass.

Closes #35251