### PR TITLE
Fix script injection vulnerabilities in CI workflows

### DIFF
--- a/.github/workflows/5_builderpackage_binutils.yml
+++ b/.github/workflows/5_builderpackage_binutils.yml
@@ -20,10 +20,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          BINUTILS_MAJOR_VERSION: ${{ github.event.inputs.binutils_major_version }}
+          BINUTILS_MINOR_VERSION: ${{ github.event.inputs.binutils_minor_version }}
         run: |
           docker build -t binutils-deb -f packages/debs/amd64/binutils/Dockerfile \
-            --build-arg BINUTILS_MAJOR_VERSION=${{ github.event.inputs.binutils_major_version }} \
-            --build-arg BINUTILS_MINOR_VERSION=${{ github.event.inputs.binutils_minor_version }} .
+            --build-arg BINUTILS_MAJOR_VERSION="$BINUTILS_MAJOR_VERSION" \
+            --build-arg BINUTILS_MINOR_VERSION="$BINUTILS_MINOR_VERSION" .
           docker run -v /tmp:/tmp binutils-deb /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .deb artifact
@@ -39,10 +42,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          BINUTILS_MAJOR_VERSION: ${{ github.event.inputs.binutils_major_version }}
+          BINUTILS_MINOR_VERSION: ${{ github.event.inputs.binutils_minor_version }}
         run: |
           docker build -t binutils-rpm -f packages/rpms/amd64/binutils/Dockerfile \
-            --build-arg BINUTILS_MAJOR_VERSION=${{ github.event.inputs.binutils_major_version }} \
-            --build-arg BINUTILS_MINOR_VERSION=${{ github.event.inputs.binutils_minor_version }} .
+            --build-arg BINUTILS_MAJOR_VERSION="$BINUTILS_MAJOR_VERSION" \
+            --build-arg BINUTILS_MINOR_VERSION="$BINUTILS_MINOR_VERSION" .
           docker run -v /tmp:/tmp binutils-rpm /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .rpm artifact
@@ -58,10 +64,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          BINUTILS_MAJOR_VERSION: ${{ github.event.inputs.binutils_major_version }}
+          BINUTILS_MINOR_VERSION: ${{ github.event.inputs.binutils_minor_version }}
         run: |
           docker build -t binutils-deb-arm64 -f packages/debs/arm64/binutils/Dockerfile \
-            --build-arg BINUTILS_MAJOR_VERSION=${{ github.event.inputs.binutils_major_version }} \
-            --build-arg BINUTILS_MINOR_VERSION=${{ github.event.inputs.binutils_minor_version }} .
+            --build-arg BINUTILS_MAJOR_VERSION="$BINUTILS_MAJOR_VERSION" \
+            --build-arg BINUTILS_MINOR_VERSION="$BINUTILS_MINOR_VERSION" .
           docker run -v /tmp:/tmp binutils-deb-arm64 /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .deb artifact
@@ -77,10 +86,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          BINUTILS_MAJOR_VERSION: ${{ github.event.inputs.binutils_major_version }}
+          BINUTILS_MINOR_VERSION: ${{ github.event.inputs.binutils_minor_version }}
         run: |
           docker build -t binutils-rpm-arm64 -f packages/rpms/arm64/binutils/Dockerfile \
-            --build-arg BINUTILS_MAJOR_VERSION=${{ github.event.inputs.binutils_major_version }} \
-            --build-arg BINUTILS_MINOR_VERSION=${{ github.event.inputs.binutils_minor_version }} .
+            --build-arg BINUTILS_MAJOR_VERSION="$BINUTILS_MAJOR_VERSION" \
+            --build-arg BINUTILS_MINOR_VERSION="$BINUTILS_MINOR_VERSION" .
           docker run -v /tmp:/tmp binutils-rpm-arm64 /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .rpm artifact

--- a/.github/workflows/5_builderpackage_gcc.yml
+++ b/.github/workflows/5_builderpackage_gcc.yml
@@ -20,10 +20,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          GCC_MAJOR_VERSION: ${{ github.event.inputs.gcc_major_version }}
+          GCC_MINOR_VERSION: ${{ github.event.inputs.gcc_minor_version }}
         run: |
           docker build -t gcc-deb -f packages/debs/amd64/gcc/Dockerfile \
-            --build-arg GCC_MAJOR_VERSION=${{ github.event.inputs.gcc_major_version }} \
-            --build-arg GCC_MINOR_VERSION=${{ github.event.inputs.gcc_minor_version }} .
+            --build-arg GCC_MAJOR_VERSION="$GCC_MAJOR_VERSION" \
+            --build-arg GCC_MINOR_VERSION="$GCC_MINOR_VERSION" .
           docker run -v /tmp:/tmp gcc-deb /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .deb artifact
@@ -39,10 +42,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          GCC_MAJOR_VERSION: ${{ github.event.inputs.gcc_major_version }}
+          GCC_MINOR_VERSION: ${{ github.event.inputs.gcc_minor_version }}
         run: |
           docker build -t gcc-rpm -f packages/rpms/amd64/gcc/Dockerfile \
-            --build-arg GCC_MAJOR_VERSION=${{ github.event.inputs.gcc_major_version }} \
-            --build-arg GCC_MINOR_VERSION=${{ github.event.inputs.gcc_minor_version }} .
+            --build-arg GCC_MAJOR_VERSION="$GCC_MAJOR_VERSION" \
+            --build-arg GCC_MINOR_VERSION="$GCC_MINOR_VERSION" .
           docker run -v /tmp:/tmp gcc-rpm /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .rpm artifact
@@ -58,10 +64,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          GCC_MAJOR_VERSION: ${{ github.event.inputs.gcc_major_version }}
+          GCC_MINOR_VERSION: ${{ github.event.inputs.gcc_minor_version }}
         run: |
           docker build -t gcc-deb-arm64 -f packages/debs/arm64/gcc/Dockerfile \
-            --build-arg GCC_MAJOR_VERSION=${{ github.event.inputs.gcc_major_version }} \
-            --build-arg GCC_MINOR_VERSION=${{ github.event.inputs.gcc_minor_version }} .
+            --build-arg GCC_MAJOR_VERSION="$GCC_MAJOR_VERSION" \
+            --build-arg GCC_MINOR_VERSION="$GCC_MINOR_VERSION" .
           docker run -v /tmp:/tmp gcc-deb-arm64 /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .deb artifact
@@ -77,10 +86,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker build
+        env:
+          GCC_MAJOR_VERSION: ${{ github.event.inputs.gcc_major_version }}
+          GCC_MINOR_VERSION: ${{ github.event.inputs.gcc_minor_version }}
         run: |
           docker build -t gcc-rpm-arm64 -f packages/rpms/arm64/gcc/Dockerfile \
-            --build-arg GCC_MAJOR_VERSION=${{ github.event.inputs.gcc_major_version }} \
-            --build-arg GCC_MINOR_VERSION=${{ github.event.inputs.gcc_minor_version }} .
+            --build-arg GCC_MAJOR_VERSION="$GCC_MAJOR_VERSION" \
+            --build-arg GCC_MINOR_VERSION="$GCC_MINOR_VERSION" .
           docker run -v /tmp:/tmp gcc-rpm-arm64 /bin/bash -c "cp /packages/* /tmp/"
 
       - name: Upload .rpm artifact

--- a/.github/workflows/5_builderpackage_gcc.yml
+++ b/.github/workflows/5_builderpackage_gcc.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           name: gcc-deb-arm64
           path: /tmp/*.deb
-  
+
   build-rpm-arm64:
     runs-on: ubuntu-24.04-arm
     steps:

--- a/.github/workflows/5_codeanalysis_coverity-image.yml
+++ b/.github/workflows/5_codeanalysis_coverity-image.yml
@@ -33,9 +33,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download Coverity tarball
+        env:
+          COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_WAZUH_TOKEN }}
         run: |
           wget -q https://scan.coverity.com/download/linux64 \
-            --post-data "token=${{ secrets.COVERITY_SCAN_WAZUH_TOKEN }}&project=${PROJECT//\//%2F}" \
+            --post-data "token=${COVERITY_TOKEN}&project=${PROJECT//\//%2F}" \
             -O tools/testing/coverity/coverity_tool.tgz
 
       - name: Log in to the Container registry

--- a/.github/workflows/5_codeanalysis_coverity.yml
+++ b/.github/workflows/5_codeanalysis_coverity.yml
@@ -42,17 +42,20 @@ jobs:
 
       - name: Set up project and build variables
         id: vars
+        env:
+          INPUT_PROJECT: ${{ github.event.inputs.project }}
+          INPUT_THREADS: ${{ github.event.inputs.threads }}
         run: |
-          if [[ "${{ github.event.inputs.project }}" == "wazuh" ]]; then
+          if [[ "$INPUT_PROJECT" == "wazuh" ]]; then
             echo "PROJECT=wazuh/wazuh" >> $GITHUB_OUTPUT
           else
             echo "PROJECT=wazuh/ossec-wazuh" >> $GITHUB_OUTPUT
           fi
 
-          if [[ ${{ github.event.inputs.threads }} -le 0 ]]; then
+          if [[ $INPUT_THREADS -le 0 ]]; then
             echo "JOBS=$(nproc)" >> $GITHUB_OUTPUT
           else
-            echo "JOBS=${{ github.event.inputs.threads }}" >> $GITHUB_OUTPUT
+            echo "JOBS=$INPUT_THREADS" >> $GITHUB_OUTPUT
           fi
 
           VERSION=$(jq -r '.version + "-" + .stage' VERSION.json)
@@ -83,9 +86,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print variables
+        env:
+          DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
         run: |
           echo Description: ${{ needs.prepare.outputs.description }}
-          echo Docker Image Tag: ${{ github.event.inputs.docker_image_tag }}
+          echo Docker Image Tag: $DOCKER_IMAGE_TAG
 
       - name: Build Coverity artifact
         uses: ./.github/actions/coverity/build

--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -298,6 +298,8 @@ jobs:
 
       - name: Run inventory sync integration tests
         working-directory: src/wazuh_modules/inventory_sync/qa
+        env:
+          TEST_MANAGER: ${{ github.event.inputs.test_manager || '127.0.0.1' }}
         run: |
           echo "[>] Running inventory sync integration tests..."
           source venv/bin/activate
@@ -308,8 +310,6 @@ jobs:
 
           # Run all tests
           echo "[>] Running all integration tests..."
-          TEST_MANAGER="${{ github.event.inputs.test_manager || '127.0.0.1' }}"
-
           python3 run_tests.py --manager "$TEST_MANAGER" --verbose
 
       - name: Cleanup and collect logs


### PR DESCRIPTION
## Description

Fixes script injection vulnerabilities in CI/CD workflows, found during a broader audit of `${{ ... }}` interpolations inside `run:` blocks.

In all cases, secrets or user-controlled expressions were interpolated directly into `run:` shell blocks. GitHub Actions substitutes these at the workflow evaluation level — before bash runs — so a crafted value can break out of the intended command and execute arbitrary shell code with secrets in scope.

Closes wazuh/internal-devel-requests#4534

## Proposed Changes

The fix in all cases: move secrets and inputs to step-level `env:` variables before referencing them in shell commands. Shell variables are expanded as data, not as code, so metacharacters in the value are never interpreted by bash.

### `5_codeanalysis_coverity.yml`

- `github.event.inputs.docker_image_tag` (Print variables step) — unquoted in `echo`, injectable via `;`

**Secrets at risk:** `GITHUB_TOKEN` (stored on disk via `docker/login-action` in a prior step)

### `5_testintegration_inventory-sync.yml`

- `github.event.inputs.test_manager` (Run inventory sync integration tests step) — inside a `""` shell assignment, injectable by breaking out with `"`

**Secrets at risk:** `GITHUB_TOKEN`

### Results and Evidence

Before (vulnerable):
```yaml
- run: |
    echo Docker Image Tag: ${{ github.event.inputs.docker_image_tag }}
```

After (safe):
```yaml
- env:
    DOCKER_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }}
  run: |
    echo Docker Image Tag: $DOCKER_IMAGE_TAG
```

---

### Preemptive hardening (no secrets exposed today)

During the audit we identified additional injection vectors in the same class. These workflows currently have no secrets in scope, so they are **not exploitable today** — but they become attack vectors the moment a secret is added to those jobs. Applied the same env-variable fix preemptively.

#### `5_codeanalysis_coverity.yml` — `prepare` job

- `github.event.inputs.project` — inside `[[ "..." ]]`, injectable by breaking out with `"`
- `github.event.inputs.threads` — unquoted in `[[ ... -le 0 ]]`, directly injectable

No secrets are referenced in the `prepare` job. The Coverity tokens only appear in the `upload` job.

#### `5_builderpackage_binutils.yml` / `5_builderpackage_gcc.yml`

- `github.event.inputs.binutils_major_version` / `binutils_minor_version`
- `github.event.inputs.gcc_major_version` / `gcc_minor_version`

All four inputs are passed unquoted as `--build-arg` values in `docker build` commands. No secrets are currently referenced in either workflow.

---

### `5_codeanalysis_coverity-image.yml`

- `COVERITY_SCAN_WAZUH_TOKEN` (Download Coverity tarball step) — interpolated inline into a `wget --post-data` argument. The token value is substituted directly into the shell command string, making it visible in process listings and shell error output.

**Secrets at risk:** `COVERITY_SCAN_WAZUH_TOKEN`

---

### Artifacts Affected

- `.github/workflows/5_codeanalysis_coverity.yml`
- `.github/workflows/5_testintegration_inventory-sync.yml`
- `.github/workflows/5_builderpackage_binutils.yml` *(preemptive)*
- `.github/workflows/5_builderpackage_gcc.yml` *(preemptive)*
- `.github/workflows/5_codeanalysis_coverity-image.yml`

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — these are CI workflow changes with no associated unit or integration tests.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
