### PR TITLE
SCA: fix 'occured' -> 'occurred' in sca_policy_check debug log messages

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -170,7 +170,7 @@ RuleResult FileRuleEvaluator::CheckFileExistence()
     }
     else
     {
-        LoggingHelper::getInstance().log(LOG_DEBUG, "An error occured and file rule '" + m_ctx.rule + "' could not be resolved");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "An error occurred and file rule '" + m_ctx.rule + "' could not be resolved");
         m_lastInvalidReason = "File system access error for '" + m_ctx.rule + "'";
         return RuleResult::Invalid; // File system access error
     }
@@ -535,7 +535,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryExistence()
     }
     else
     {
-        LoggingHelper::getInstance().log(LOG_DEBUG, "An error occured and file rule " + m_ctx.rule + " could not be resolved");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "An error occurred and file rule " + m_ctx.rule + " could not be resolved");
         m_lastInvalidReason = "Directory access error for '" + m_ctx.rule + "'";
         return RuleResult::Invalid;
     }


### PR DESCRIPTION
Two debug log messages in `src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp` (lines 173, 538) read 'An error occured'. Fixed to 'occurred'. String-literal-only change.