### PR TITLE
Backport: Fix FIM flaky integration tests

### DIFF
--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers
+addopts = --strict-markers --color=yes --tb=short
 markers =
     tier(level)
     darwin

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -3,18 +3,31 @@ Copyright (C) 2015-2024, Wazuh Inc.
 Created by Wazuh, Inc. <info@wazuh.com>.
 This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
+
+from time import sleep
+
 import pytest
 
-from wazuh_testing.constants.paths.logs import WAZUH_API_LOG_FILE_PATH, WAZUH_API_JSON_LOG_FILE_PATH
+from wazuh_testing.constants.paths.logs import (
+    WAZUH_API_LOG_FILE_PATH,
+    WAZUH_API_JSON_LOG_FILE_PATH,
+)
 from wazuh_testing.constants.api import WAZUH_API_PORT, CONFIGURATION_TYPES
-from wazuh_testing.modules.api.configuration import get_configuration, append_configuration, delete_configuration_file
+from wazuh_testing.modules.api.configuration import (
+    get_configuration,
+    append_configuration,
+    delete_configuration_file,
+)
+from wazuh_testing.modules.api.utils import login
 from wazuh_testing.modules.api.patterns import API_STARTED_MSG
 from wazuh_testing.tools.monitors import file_monitor
 from wazuh_testing.utils.callbacks import generate_callback
 
 
 @pytest.fixture
-def add_configuration(test_configuration: list[dict], request: pytest.FixtureRequest) -> None:
+def add_configuration(
+    test_configuration: list[dict], request: pytest.FixtureRequest
+) -> None:
     """Add configuration to the Wazuh API configuration files.
 
     Args:
@@ -27,7 +40,7 @@ def add_configuration(test_configuration: list[dict], request: pytest.FixtureReq
     # Save current configuration
     backup = get_configuration(configuration_type=test_target_type)
     # Set new configuration at the end of the configuration file
-    append_configuration(test_configuration['blocks'], test_target_type)
+    append_configuration(test_configuration["blocks"], test_target_type)
 
     yield
 
@@ -49,27 +62,75 @@ def wait_for_api_start(test_configuration: dict) -> None:
         RuntimeError: When the log was not found.
     """
     # Set the default values
-    logs_format = 'plain'
-    host = ['0.0.0.0', '::']
+    logs_format = "plain"
+    host = ["0.0.0.0", "::"]
     port = WAZUH_API_PORT
+    protocol = "https"
+    skip_login_probe = False
 
     # Check if specific values were set or set the defaults
     if test_configuration is not None:
-        if test_configuration.get('blocks') is not None:
-            logs_configuration = test_configuration['blocks'].get('logs')
+        if test_configuration.get("blocks") is not None:
+            logs_configuration = test_configuration["blocks"].get("logs")
             # Set the default value if `format`` is not set
-            logs_format = 'plain' if logs_configuration is None else logs_configuration.get('format', 'plain')
-            host = test_configuration['blocks'].get('host', ['0.0.0.0', '::'])
-            port = test_configuration['blocks'].get('port', WAZUH_API_PORT)
+            logs_format = (
+                "plain"
+                if logs_configuration is None
+                else logs_configuration.get("format", "plain")
+            )
+            host = test_configuration["blocks"].get("host", ["0.0.0.0", "::"])
+            port = test_configuration["blocks"].get("port", WAZUH_API_PORT)
+            https_configuration = test_configuration["blocks"].get("https")
+            if (
+                https_configuration is not None
+                and https_configuration.get("enabled") is False
+            ):
+                protocol = "http"
+            intervals_configuration = test_configuration["blocks"].get("intervals")
+            if intervals_configuration is not None:
+                request_timeout = intervals_configuration.get("request_timeout")
+                skip_login_probe = request_timeout in (0, "0")
 
-    file_to_monitor = WAZUH_API_JSON_LOG_FILE_PATH if logs_format == 'json' else WAZUH_API_LOG_FILE_PATH
+    file_to_monitor = (
+        WAZUH_API_JSON_LOG_FILE_PATH
+        if logs_format == "json"
+        else WAZUH_API_LOG_FILE_PATH
+    )
     monitor_start_message = file_monitor.FileMonitor(file_to_monitor)
     monitor_start_message.start(
-        callback=generate_callback(API_STARTED_MSG, {
-            'host': str(host),
-            'port': str(port)
-        })
+        callback=generate_callback(
+            API_STARTED_MSG, {"host": str(host), "port": str(port)}
+        )
     )
 
     if monitor_start_message.callback_result is None:
-        raise RuntimeError('The API was not started as expected.')
+        raise RuntimeError("The API was not started as expected.")
+
+    if skip_login_probe:
+        return
+
+    configured_hosts = host if isinstance(host, list) else [host]
+    local_hosts = {"0.0.0.0", "::", "127.0.0.1", "::1", "localhost"}
+    if not any(configured_host in local_hosts for configured_host in configured_hosts):
+        return
+
+    last_exception = None
+    for _ in range(15):
+        try:
+            login(
+                host="localhost",
+                port=str(port),
+                protocol=protocol,
+                timeout=2,
+                login_attempts=1,
+                backoff_factor=0,
+            )
+            return
+        except Exception as exception:
+            last_exception = exception
+            sleep(1)
+
+    if last_exception is not None:
+        raise last_exception
+
+    raise RuntimeError("The API was not ready to accept logins.")

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_delete_hardlink_symlink.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_delete_hardlink_symlink.py
@@ -1,4 +1,4 @@
-'''
+"""
 copyright: Copyright (C) 2015-2024, Wazuh Inc.
 
            Created by Wazuh, Inc. <info@wazuh.com>.
@@ -55,7 +55,8 @@ pytest_args:
 
 tags:
     - fim
-'''
+"""
+
 import sys
 import pytest
 
@@ -63,14 +64,20 @@ from pathlib import Path
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
-from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG
+from wazuh_testing.modules.agentd.configuration import (
+    AGENTD_DEBUG,
+    AGENTD_WINDOWS_DEBUG,
+)
 from wazuh_testing.modules.fim.patterns import INODE_ENTRIES_PATH_COUNT
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.modules.fim.configuration import SYSCHECK_DEBUG
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils import file
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+from wazuh_testing.utils.configuration import (
+    get_test_cases_data,
+    load_configuration_template,
+)
 
 from . import TEST_CASES_PATH, CONFIGS_PATH
 
@@ -79,21 +86,36 @@ from . import TEST_CASES_PATH, CONFIGS_PATH
 pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
 
 # Test metadata, configuration and ids.
-cases_path = Path(TEST_CASES_PATH, 'cases_delete_hardlink_symlink.yaml')
-config_path = Path(CONFIGS_PATH, 'configuration_basic.yaml')
+cases_path = Path(TEST_CASES_PATH, "cases_delete_hardlink_symlink.yaml")
+config_path = Path(CONFIGS_PATH, "configuration_basic.yaml")
 test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
-test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
+test_configuration = load_configuration_template(
+    config_path, test_configuration, test_metadata
+)
 
 # Set configurations required by the fixtures.
 local_internal_options = {SYSCHECK_DEBUG: 2, AGENTD_DEBUG: 2, MONITORD_ROTATE_LOG: 0}
-if sys.platform == WINDOWS: local_internal_options.update({AGENTD_WINDOWS_DEBUG: 2})
+if sys.platform == WINDOWS:
+    local_internal_options.update({AGENTD_WINDOWS_DEBUG: 2})
 
 
-@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=cases_ids)
-def test_delete_hardlink_symlink(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
-                                 configure_local_internal_options, folder_to_monitor, create_links_to_file,
-                                 daemons_handler, start_monitoring):
-    '''
+@pytest.mark.parametrize(
+    "test_configuration, test_metadata",
+    zip(test_configuration, test_metadata),
+    ids=cases_ids,
+)
+def test_delete_hardlink_symlink(
+    test_configuration,
+    test_metadata,
+    set_wazuh_configuration,
+    truncate_monitored_files,
+    configure_local_internal_options,
+    folder_to_monitor,
+    create_links_to_file,
+    daemons_handler,
+    start_monitoring,
+):
+    """
     description: Check if FIM events contain the correct number of file paths when 'hard'
                  and 'symbolic' links are used. For this purpose, the test will monitor
                  a testing folder and create regular files, also 'symlink' and 'hard link'
@@ -148,10 +170,10 @@ def test_delete_hardlink_symlink(test_configuration, test_metadata, set_wazuh_co
     tags:
         - scheduled
         - realtime
-    '''
+    """
     wazuh_log_monitor = FileMonitor(WAZUH_LOG_PATH)
-    hardlink_amount = test_metadata.get('hardlink_amount')
-    symlink_amount = test_metadata.get('symlink_amount')
+    hardlink_amount = test_metadata.get("hardlink_amount")
+    symlink_amount = test_metadata.get("symlink_amount")
 
     file.delete_files_in_folder(folder_to_monitor)
     wazuh_log_monitor.start(generate_callback(INODE_ENTRIES_PATH_COUNT))

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_delete_hardlink_symlink.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_delete_hardlink_symlink.py
@@ -175,9 +175,10 @@ def test_delete_hardlink_symlink(
     hardlink_amount = test_metadata.get("hardlink_amount")
     symlink_amount = test_metadata.get("symlink_amount")
 
-    file.delete_files_in_folder(folder_to_monitor)
     wazuh_log_monitor.start(generate_callback(INODE_ENTRIES_PATH_COUNT))
     inode_entries, path_count = wazuh_log_monitor.callback_result
 
-    assert int(inode_entries) == 1 + hardlink_amount
+    assert int(inode_entries) == 1 + symlink_amount
     assert int(path_count) == 1 + hardlink_amount + symlink_amount
+
+    file.delete_files_in_folder(folder_to_monitor)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_delete_multiple_files.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_delete_multiple_files.py
@@ -153,13 +153,13 @@ def test_delete_multiple_files(test_configuration, test_metadata, set_wazuh_conf
     fim_mode = test_metadata.get('fim_mode')
     files_amount = test_metadata.get('files_amount')
 
-    file.delete_files_in_folder(folder_to_monitor)
-
     # Assert
     wazuh_log_monitor.start(generate_callback(INODE_ENTRIES_PATH_COUNT))
     inode_entries, path_count = wazuh_log_monitor.callback_result
     assert inode_entries == path_count
     assert int(path_count) == files_amount
+
+    file.delete_files_in_folder(folder_to_monitor)
 
     wazuh_log_monitor.start(generate_callback(EVENT_TYPE_DELETED))
     assert get_fim_event_data(wazuh_log_monitor.callback_result)['mode'] == fim_mode

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/data/test_cases/cases_cud.yaml
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/data/test_cases/cases_cud.yaml
@@ -55,7 +55,7 @@
               args: [!!python/object/apply:os.getcwd [], symlink]
     FREQUENCY: 43200 # As default 12 hs
     FIM_MODE:
-      whodata: 'yes'
+      realtime: 'yes'
   metadata:
     symlink:  !!python/object/apply:os.path.join
               args: [!!python/object/apply:os.getcwd [], symlink]

--- a/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_audit_rules_with_symlink.py
+++ b/tests/integration/test_fim/test_files/test_follow_symbolic_link/test_audit_rules_with_symlink.py
@@ -149,7 +149,7 @@ def test_audit_rules_with_symlink(test_configuration, test_metadata, set_wazuh_c
 
     expected_output:
         - r'.*Links check finalized.*'
-        - r'.*Audit rules reloaded\. Rules loaded: (.+)'
+        - r'.*Audit rules reloaded. Rules loaded: (.+)'
         - r'.*"type":"modified".*'
 
     tags:


### PR DESCRIPTION
## Description

FIM integration tests, specifically `test_delete_hardlink_symlink` and `test_delete_multiple_files`, were experiencing flaky failures in the CI environment. The root cause was twofold:
1.  **Race Condition:** The tests were deleting monitored files before the `wazuh-syscheckd` daemon had finished its baseline scan and written the corresponding `INODE_ENTRIES_PATH_COUNT` log. This led to inconsistent inode and path counts being read by the test's log monitor.
2.  **Incorrect Inode Logic:** The `test_delete_hardlink_symlink` test incorrectly assumed that creating a hardlink increments the inode count. In Linux, a hardlink shares the same inode as the original file, so only symbolic links (symlinks) should increase the expected total inode count.

Additionally, the `pytest` output in GitHub Actions was extremely verbose and lacked color formatting, making it difficult to pinpoint the exact cause of test failures quickly.

This PR addresses these issues to ensure consistent FIM integration test executions and improves the readability of CI test reports.

> [!NOTE]
> Backport the changes from #35354 to the 4.14.5 branch to fix the FIM in the 4.14.5 release line.
> Also backport the commit that fixes the test_cud (https://github.com/wazuh/wazuh/pull/35060/changes/0ee02b54daf8e66d770a662b8da4010c45d4dfc1)

Closes #35583 

## Proposed Changes

- Fixed the race condition in `test_delete_hardlink_symlink.py` and `test_delete_multiple_files.py` by ensuring the log monitor verifies the baseline scan completion (`INODE_ENTRIES_PATH_COUNT`) **before** triggering the file deletion events.
- Corrected the mathematical assertion in `test_delete_hardlink_symlink.py` to accurately reflect that only symlinks contribute to new inodes (`assert int(inode_entries) == 1 + symlink_amount`).
- Updated `tests/integration/pytest.ini` by adding `--color=yes` and `--tb=short` to `addopts`. This forces colorized output in the CI and reduces traceback verbosity, hiding massive docstrings and focusing directly on the failing assertions.

### Results and Evidence

-  https://github.com/wazuh/wazuh/actions/runs/24572310895/job/71864761464?pr=35535

### Artifacts Affected

-   `tests/integration/test_fim/test_files/test_basic_usage/test_delete_hardlink_symlink.py`
-   `tests/integration/test_fim/test_files/test_basic_usage/test_delete_multiple_files.py`
-   `tests/integration/pytest.ini`

### Configuration Changes

-   Modified `tests/integration/pytest.ini` to include `--color=yes` and `--tb=short` by default.

### Tests Introduced

N/A — Existing tests were corrected.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
