### PR TITLE
Remove legacy unclassified category

### DIFF
--- a/src/engine/ruleset/outputs/indexer.yml
+++ b/src/engine/ruleset/outputs/indexer.yml
@@ -7,5 +7,13 @@ metadata:
   description: Output integrations events to wazuh-indexer
 
 outputs:
-  - wazuh-indexer:
-      index: "wazuh-events-v5-${wazuh.integration.category}"
+  - first_of:
+    - check: index_unclassified_events($wazuh.integration.decoders)
+      then:
+        - wazuh-indexer:
+            index: "wazuh-events-v5-unclassified"
+
+    - check: NOT array_length_eq($wazuh.integration.decoders, 1)
+      then:
+        - wazuh-indexer:
+            index: "wazuh-events-v5-${wazuh.integration.category}"

--- a/src/engine/ruleset/outputs/indexer.yml
+++ b/src/engine/ruleset/outputs/indexer.yml
@@ -7,13 +7,5 @@ metadata:
   description: Output integrations events to wazuh-indexer
 
 outputs:
-  - first_of:
-    - check: index_unclassified_events($wazuh.integration.decoders)
-      then:
-        - wazuh-indexer:
-            index: "wazuh-events-v5-unclassified"
-
-    - check: NOT array_length_eq($wazuh.integration.decoders, 1)
-      then:
-        - wazuh-indexer:
-            index: "wazuh-events-v5-${wazuh.integration.category}"
+  - wazuh-indexer:
+      index: "wazuh-events-v5-${wazuh.integration.category}"

--- a/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
+++ b/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
@@ -5,10 +5,11 @@
 
 #include <fastmetrics/registry.hpp>
 
+#include "syntax.hpp"
+
 namespace
 {
-constexpr std::string_view JPATH_ORIGIN_SPACE = "/wazuh/space/name";                   ///< wazuh.space.name
-constexpr std::string_view JPATH_INTEGRATION_DECODERS = "/wazuh/integration/decoders"; ///< wazuh.integration.decoders
+constexpr std::string_view JPATH_ORIGIN_SPACE = "/wazuh/space/name"; ///< wazuh.space.name
 const std::string ENRICHMENT_SPACE_TRACEABLE_NAME = "enrichment/OriginSpace";
 const std::string DISCARDED_EVENTS_FILTER_TRACEABLE_NAME = "filter/DiscardedEvents";
 const std::string CLEANUP_DECODER_VARIABLES_TRACEABLE_NAME = "cleanup/DecoderTemporaryVariables";
@@ -98,7 +99,7 @@ base::Expression postOutputUnclassifiedCounter(const std::string& spaceName,
         {
             try
             {
-                if (event->size(JPATH_INTEGRATION_DECODERS) == 1)
+                if (event->size(syntax::asset::DECODERS_PATH) == 1)
                 {
                     unclassifiedCounter->add(1);
                 }

--- a/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
+++ b/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
@@ -3,16 +3,13 @@
 #include <exception>
 #include <fmt/format.h>
 
-#include <cmstore/categories.hpp>
 #include <fastmetrics/registry.hpp>
 
 namespace
 {
 constexpr std::string_view JPATH_ORIGIN_SPACE = "/wazuh/space/name";                   ///< wazuh.space.name
-const json::PointerPath PP_INTEGRATION_CATEGORY {"/wazuh/integration/category"};       ///< wazuh.integration.category
 constexpr std::string_view JPATH_INTEGRATION_DECODERS = "/wazuh/integration/decoders"; ///< wazuh.integration.decoders
 const std::string ENRICHMENT_SPACE_TRACEABLE_NAME = "enrichment/OriginSpace";
-const std::string UNCLASSIFIED_FILTER_TRACEABLE_NAME = "filter/UnclassifiedEvents";
 const std::string DISCARDED_EVENTS_FILTER_TRACEABLE_NAME = "filter/DiscardedEvents";
 const std::string CLEANUP_DECODER_VARIABLES_TRACEABLE_NAME = "cleanup/DecoderTemporaryVariables";
 
@@ -45,54 +42,6 @@ std::pair<base::Expression, std::string> getSpaceEnrichment(const cm::store::dat
         });
 
     return std::make_pair(makeTraceableSuccessExpression(op, isTestMode), ENRICHMENT_SPACE_TRACEABLE_NAME);
-}
-
-std::pair<base::Expression, std::string> getUnclassifiedFilter(const cm::store::dataType::Policy& policy, bool isTestMode)
-{
-    // Filter unclassified events based on policy configuration
-    const bool shouldIndex = policy.shouldIndexUnclassifiedEvents();
-
-    auto op = base::Term<base::EngineOp>::create(
-        UNCLASSIFIED_FILTER_TRACEABLE_NAME,
-        [shouldIndex, isTestMode](base::Event event) -> base::result::Result<base::Event>
-        {
-            if (shouldIndex && !isTestMode)
-            {
-                // If indexing unclassified events is enabled and tracing is disabled, allow the event without
-                // modification
-                return base::result::makeSuccess<decltype(event)>(event);
-            }
-
-            // Get the integration category
-            const auto isUnclassified = [&]() -> bool
-            {
-                std::string_view categoryStr;
-                return event->getString(categoryStr, PP_INTEGRATION_CATEGORY) == json::RetGet::Success
-                       && categoryStr == cm::store::categories::UNCLASSIFIED_CATEGORY;
-            }();
-
-            // If category is unclassified and indexing is disabled, drop the event
-            if (isUnclassified && !shouldIndex)
-            {
-                if (isTestMode)
-                {
-                    return base::result::makeFailure<decltype(event)>(
-                        event,
-                        "dropUnclassifiedEvent() -> Event dropped because it is unclassified and policy "
-                        "index_unclassified_events=false");
-                }
-                return base::result::makeFailure<decltype(event)>(event);
-            }
-
-            // Otherwise, allow the event to continue
-            return base::result::makeSuccess<decltype(event)>(
-                event,
-                isUnclassified ? "dropUnclassifiedEvent() -> Event is unclassified but policy "
-                                 "index_unclassified_events=true, allowing event"
-                               : "dropUnclassifiedEvent() -> Event is classified, allowing event");
-        });
-
-    return std::make_pair(makeTraceableSuccessExpression(op, isTestMode), UNCLASSIFIED_FILTER_TRACEABLE_NAME);
 }
 
 std::pair<base::Expression, std::string>

--- a/src/engine/source/builder/src/builders/enrichment/enrichment.hpp
+++ b/src/engine/source/builder/src/builders/enrichment/enrichment.hpp
@@ -51,18 +51,6 @@ base::Expression postOutputUnclassifiedCounter(const std::string& spaceName,
 std::pair<base::Expression, std::string> getSpaceEnrichment(const cm::store::dataType::Policy& policy, bool isTestMode);
 
 /**
- * @brief Get the filter expression to handle unclassified events according to policy configuration.
- *
- * This filter checks if wazuh.integration.category is "unclassified" and drops the event
- * if the policy's index_unclassified_events flag is false.
- *
- * @param policy Policy data.
- * @param isTestMode Enable tracing in the filter expression.
- * @return std::pair<base::Expression, std::string> The built filter expression and its traceable name.
- */
-std::pair<base::Expression, std::string> getUnclassifiedFilter(const cm::store::dataType::Policy& policy, bool isTestMode);
-
-/**
  * @brief Get the Geo Enrichment Builder
  *
  * @param geoManager Geo manager instance, used to create 1 locator per enrichment.

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
@@ -1900,6 +1900,12 @@ FilterOp opBuilderHelperIndexUnclassifiedEvents(const Reference& targetField,
                                                 const std::vector<OpArg>& opArgs,
                                                 const std::shared_ptr<const IBuildCtx>& buildCtx)
 {
+    if (targetField.jsonPath() != syntax::asset::DECODERS_PATH)
+    {
+        throw std::runtime_error(fmt::format("index_unclassified_events: target field must be 'wazuh.integration.decoders', got '{}'",
+                                             targetField.dotPath()));
+    }
+
     // Assert expected number of parameters
     utils::assertSize(opArgs, 0);
 

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -759,11 +759,11 @@ FilterOp opBuilderHelperArrayLength(const Reference& targetField,
  *
  * This helper returns true if:
  * - The policy has indexUnclassifiedEvents flag set to true AND
- * - The target array has exactly 1 element
+ * - $wazuh.integration.decoders has exactly 1 element
  *
  * Otherwise, it returns false.
  *
- * @param targetField Reference to the array field to check (typically wazuh.integration.decoders)
+ * @param targetField Reference to $wazuh.integration.decoders. Any other field is rejected at build-time.
  * @param opArgs Vector of operation arguments (empty for this helper)
  * @param buildCtx Build context containing policy configuration
  * @return FilterOp The filter operation

--- a/src/engine/source/builder/src/policy/factory.hpp
+++ b/src/engine/source/builder/src/policy/factory.hpp
@@ -228,10 +228,7 @@ base::Expression buildSubgraphExpression(const Graph<base::Name, Asset>& subgrap
  * 3. Pre-Enrichment:
  *    - This stage performs initial enrichment operations before IOCs:
  *      a) Origin Space Mapping: Maps the event to its origin space based on policy configuration.
- *      b) Unclassified Events Filter: Evaluates events with "unclassified" category:
- *         - If policy.index_unclassified_events is true, the event continues normally.
- *         - If policy.index_unclassified_events is false, the event is dropped and pipeline stops.
- *      c) Discarded Events Filter: Evaluates events based on discard criteria defined in the policy:
+ *      b) Discarded Events Filter: Evaluates events based on discard criteria defined in the policy:
  *         - If policy.index_discarded_events is true, the event continues normally despite being discarded.
  *         - If policy.index_discarded_events is false and wazuh.space.event_discarded is true, the event is
  *         dropped and pipeline stops.
@@ -255,7 +252,7 @@ base::Expression buildSubgraphExpression(const Graph<base::Name, Asset>& subgrap
  *    - If no outputs are configured, the pipeline ends after the last filter.
  *
  * @param graph Policy graph containing decoder, filter, and output trees.
- * @param preEnrichmentExpression Expression for pre-enrichment stage (space mapping + unclassified filter).
+ * @param preEnrichmentExpression Expression for pre-enrichment stage.
  * @param enrichmentExpression Expression for enrichment stage (geo, IOCs, etc.).
  *
  * @return base::Expression Complete policy expression with all pipeline stages.

--- a/src/engine/source/builder/src/policy/policy.cpp
+++ b/src/engine/source/builder/src/policy/policy.cpp
@@ -73,13 +73,6 @@ Policy::Policy(const cm::store::NamespaceId& namespaceId,
             m_assets.insert(base::Name(traceable));
         }
 
-        // Unclassified events filter (DISABLED - moved to output stage)
-        // {
-        //     auto [exp, traceable] = builders::enrichment::getUnclassifiedFilter(policyData, trace);
-        //     preEnrichmentOps.push_back(exp);
-        //     m_assets.insert(base::Name(traceable));
-        // }
-
         // Discarded events filter (based on policy configuration)
         {
             auto discardedCounter = fastmetrics::manager().getOrCreateCounter(

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/indexUnclassifiedEvents_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/indexUnclassifiedEvents_test.cpp
@@ -1,6 +1,7 @@
 #include "builders/baseBuilders_test.hpp"
 
 #include "builders/opfilter/opBuilderHelperFilter.hpp"
+#include "syntax.hpp"
 
 namespace
 {
@@ -24,14 +25,42 @@ auto contextExpected(bool indexUnclassified)
 
 namespace filterbuildtest
 {
-INSTANTIATE_TEST_SUITE_P(Builders,
-                         FilterBuilderTest,
-                         testing::Values(
-                             /*** Index Unclassified Events ***/
-                             FilterT({}, opfilter::opBuilderHelperIndexUnclassifiedEvents, SUCCESS()),
-                             FilterT({makeValue(R"(1)")}, opfilter::opBuilderHelperIndexUnclassifiedEvents, FAILURE()),
-                             FilterT({makeRef("ref")}, opfilter::opBuilderHelperIndexUnclassifiedEvents, FAILURE())),
-                         testNameFormatter<FilterBuilderTest>("IndexUnclassifiedEvents"));
+class IndexUnclassifiedEventsBuildTest : public BaseBuilderTest
+{
+};
+
+TEST_F(IndexUnclassifiedEventsBuildTest, BuildsWithDecodersField)
+{
+    Reference targetField {"wazuh.integration.decoders"};
+
+    contextExpected(true)(*mocks);
+    expectBuildSuccess();
+
+    ASSERT_NO_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {}, mocks->ctx));
+}
+
+TEST_F(IndexUnclassifiedEventsBuildTest, RejectsUnexpectedTargetField)
+{
+    Reference targetField {"targetField"};
+
+    ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {}, mocks->ctx), std::exception);
+}
+
+TEST_F(IndexUnclassifiedEventsBuildTest, RejectsValueArgument)
+{
+    Reference targetField {"wazuh.integration.decoders"};
+
+    ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {makeValue(R"(1)")}, mocks->ctx),
+                 std::exception);
+}
+
+TEST_F(IndexUnclassifiedEventsBuildTest, RejectsReferenceArgument)
+{
+    Reference targetField {"wazuh.integration.decoders"};
+
+    ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {makeRef("ref")}, mocks->ctx),
+                 std::exception);
+}
 } // namespace filterbuildtest
 
 namespace filteroperatestest
@@ -41,59 +70,59 @@ INSTANTIATE_TEST_SUITE_P(Builders,
                          testing::Values(
                              /*** Index Unclassified Events - Tests with policy disabled (default) ***/
                              // Policy disabled, array size 1 - should fail
-                             FilterT(R"({"target": ["decoder1"]})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1"]}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(false))),
                              // Policy disabled, array size 2 - should fail
-                             FilterT(R"({"target": ["decoder1", "decoder2"]})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1", "decoder2"]}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(false))),
                              // Policy disabled, empty array - should fail
-                             FilterT(R"({"target": []})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": []}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(false))),
                              /*** Index Unclassified Events - Tests with policy enabled ***/
                              // Policy enabled, array size 1 - should succeed
-                             FilterT(R"({"target": ["decoder1"]})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1"]}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      SUCCESS(contextExpected(true))),
                              // Policy enabled, array size 2 - should fail
-                             FilterT(R"({"target": ["decoder1", "decoder2"]})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1", "decoder2"]}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(true))),
                              // Policy enabled, empty array - should fail
-                             FilterT(R"({"target": []})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": []}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(true))),
                              // Policy enabled, array size 3 - should fail
-                             FilterT(R"({"target": ["d1", "d2", "d3"]})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": ["d1", "d2", "d3"]}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(true))),
                              /*** Index Unclassified Events - Error cases ***/
                              // Test with non-existent field (policy enabled)
                              FilterT(R"({"other": ["decoder"]})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(true))),
                              // Test with non-array field (policy enabled)
-                             FilterT(R"({"target": "decoder"})",
+                             FilterT(R"({"wazuh": {"integration": {"decoders": "decoder"}}})",
                                      opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "target",
+                                     "wazuh.integration.decoders",
                                      {},
                                      FAILURE(contextExpected(true)))),
                          testNameFormatter<FilterOperationTest>("IndexUnclassifiedEvents"));

--- a/src/engine/source/builder/test/src/unit/policy/factory_test.cpp
+++ b/src/engine/source/builder/test/src/unit/policy/factory_test.cpp
@@ -27,10 +27,9 @@ base::Expression createDummyEnrichment()
 base::Expression createDummyPreEnrichment()
 {
     auto originSpaceExp = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-    auto unclassifiedExp = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
     auto discardedExp = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
     auto cleanupVarsExp = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-    return base::And::create("preEnrichment", {originSpaceExp, unclassifiedExp, discardedExp, cleanupVarsExp});
+    return base::And::create("preEnrichment", {originSpaceExp, discardedExp, cleanupVarsExp});
 }
 } // namespace
 namespace buildgraphtest
@@ -181,10 +180,9 @@ INSTANTIATE_TEST_SUITE_P(
                        auto decoder = Or::create("DecodersTree/Input", {assetExpr("decoder/asset/0")});
                        auto phase1 = Chain::create("Phase1_Decoders", {decoder});
                        auto originSpace = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-                       auto unclassified = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
                        auto discarded = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
                        auto cleanupVars = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-                       auto phase2 = And::create("preEnrichment", {originSpace, unclassified, discarded, cleanupVars});
+                       auto phase2 = And::create("preEnrichment", {originSpace, discarded, cleanupVars});
                        auto enrichment = base::Term<base::EngineOp>::create("enrichment/geo", nullptr);
                        return And::create("test", {phase1, phase2, enrichment});
                    })),
@@ -197,10 +195,9 @@ INSTANTIATE_TEST_SUITE_P(
                        auto decoder = Or::create("DecodersTree/Input", {assetExpr("decoder/root/0")});
                        auto phase1 = Chain::create("Phase1_Decoders", {decoder});
                        auto originSpace = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-                       auto unclassified = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
                        auto discarded = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
                        auto cleanupVars = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-                       auto phase2 = And::create("preEnrichment", {originSpace, unclassified, discarded, cleanupVars});
+                       auto phase2 = And::create("preEnrichment", {originSpace, discarded, cleanupVars});
                        auto enrichment = base::Term<base::EngineOp>::create("enrichment/geo", nullptr);
                        auto output = Broadcast::create("OutputsTree/Input", {assetExpr("output/asset/0")});
                        return And::create("test", {phase1, phase2, enrichment, output});
@@ -218,10 +215,9 @@ INSTANTIATE_TEST_SUITE_P(
                        auto decoder = Or::create("DecodersTree/Input", {parentExpr});
                        auto phase1 = Chain::create("Phase1_Decoders", {decoder});
                        auto originSpace = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-                       auto unclassified = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
                        auto discarded = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
                        auto cleanupVars = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-                       auto phase2 = And::create("preEnrichment", {originSpace, unclassified, discarded, cleanupVars});
+                       auto phase2 = And::create("preEnrichment", {originSpace, discarded, cleanupVars});
                        auto enrichment = base::Term<base::EngineOp>::create("enrichment/geo", nullptr);
                        return And::create("test", {phase1, phase2, enrichment});
                    })),
@@ -234,10 +230,9 @@ INSTANTIATE_TEST_SUITE_P(
                        auto decoder = Or::create("DecodersTree/Input", {assetExpr("decoder/root/0")});
                        auto phase1 = Chain::create("Phase1_Decoders", {decoder});
                        auto originSpace = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-                       auto unclassified = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
                        auto discarded = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
                        auto cleanupVars = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-                       auto phase2 = And::create("preEnrichment", {originSpace, unclassified, discarded, cleanupVars});
+                       auto phase2 = And::create("preEnrichment", {originSpace, discarded, cleanupVars});
                        auto enrichment = base::Term<base::EngineOp>::create("enrichment/geo", nullptr);
                        auto childExpr = assetExpr("output/child/0");
                        auto childrenOp = Broadcast::create("output/parent/0/Children", {childExpr});
@@ -261,10 +256,9 @@ INSTANTIATE_TEST_SUITE_P(
                        auto decoder = Or::create("DecodersTree/Input", {parentExpr});
                        auto phase1 = Chain::create("Phase1_Decoders", {decoder});
                        auto originSpace = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-                       auto unclassified = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
                        auto discarded = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
                        auto cleanupVars = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-                       auto phase2 = And::create("preEnrichment", {originSpace, unclassified, discarded, cleanupVars});
+                       auto phase2 = And::create("preEnrichment", {originSpace, discarded, cleanupVars});
                        auto enrichment = base::Term<base::EngineOp>::create("enrichment/geo", nullptr);
                        return And::create("test", {phase1, phase2, enrichment});
                    })),
@@ -285,10 +279,9 @@ INSTANTIATE_TEST_SUITE_P(
 
                        // Phase 2: Enrichment/IOCs
                        auto originSpace = base::Term<base::EngineOp>::create("enrichment/OriginSpace", nullptr);
-                       auto unclassified = base::Term<base::EngineOp>::create("filter/UnclassifiedEvents", nullptr);
                        auto discarded = base::Term<base::EngineOp>::create("filter/DiscardedEvents", nullptr);
                        auto cleanupVars = base::Term<base::EngineOp>::create("CleanupDecoderVariables", nullptr);
-                       auto phase2 = And::create("preEnrichment", {originSpace, unclassified, discarded, cleanupVars});
+                       auto phase2 = And::create("preEnrichment", {originSpace, discarded, cleanupVars});
                        auto enrichment = base::Term<base::EngineOp>::create("enrichment/geo", nullptr);
 
                        // Phase 3: Outputs
@@ -1229,11 +1222,10 @@ TEST(OrderPreservation, PreEnrichmentCleanupIsLast)
     auto preEnrichmentOp = preEnrichment->getPtr<base::And>();
     const auto& ops = preEnrichmentOp->getOperands();
 
-    ASSERT_EQ(ops.size(), 4);
+    ASSERT_EQ(ops.size(), 3);
     EXPECT_EQ(ops[0]->getName(), "enrichment/OriginSpace");
-    EXPECT_EQ(ops[1]->getName(), "filter/UnclassifiedEvents");
-    EXPECT_EQ(ops[2]->getName(), "filter/DiscardedEvents");
-    EXPECT_EQ(ops[3]->getName(), "CleanupDecoderVariables");
+    EXPECT_EQ(ops[1]->getName(), "filter/DiscardedEvents");
+    EXPECT_EQ(ops[2]->getName(), "CleanupDecoderVariables");
 }
 
 // Test order preservation with parent-child relationships

--- a/src/engine/source/cmstore/interface/cmstore/categories.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/categories.hpp
@@ -8,21 +8,13 @@ namespace cm::store::categories
 {
 
 /**
- * @brief Special category for unclassified events
- * 
- * Events with this category are assigned by the root decoder (according to CTI integrations).
- * Pipeline behavior for these events depends on policy.index_unclassified_events configuration.
- */
-inline constexpr std::string_view UNCLASSIFIED_CATEGORY = "unclassified";
-
-/**
  * @brief Available Categories and their Indexes
  *
  * This map defines the available categories
  * in the CMStore system. Any integration or asset should belong to one of these categories.
  */
-inline constexpr std::array<std::string_view, 8> AVAILABLE_CATEGORIES = {
-    "access-management", "applications", "cloud-services", "network-activity", "other", "security", "system-activity", UNCLASSIFIED_CATEGORY};
+inline constexpr std::array<std::string_view, 7> AVAILABLE_CATEGORIES = {
+    "access-management", "applications", "cloud-services", "network-activity", "other", "security", "system-activity"};
 
 /**
  * @brief Get all available categories and their indexes in the namespace

--- a/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
+++ b/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
@@ -319,7 +319,6 @@ TEST(CategoriesTest, ExistingCategoriesFound)
 {
     EXPECT_TRUE(cm::store::categories::exists("security"));
     EXPECT_TRUE(cm::store::categories::exists("network-activity"));
-    EXPECT_TRUE(cm::store::categories::exists("unclassified"));
 }
 
 TEST(CategoriesTest, UnknownCategoryNotFound)
@@ -331,7 +330,7 @@ TEST(CategoriesTest, UnknownCategoryNotFound)
 TEST(CategoriesTest, GetAvailableCategoriesNonEmpty)
 {
     const auto& cats = cm::store::categories::getAvailableCategories();
-    EXPECT_EQ(cats.size(), 8U);
+    EXPECT_EQ(cats.size(), 7U);
 }
 
 // ======================================================================

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/documentation.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/documentation.py
@@ -34,7 +34,7 @@ def parse_yaml_to_documentation(parser: Parser):
 
     if parser.get_helper_type() != "map":
         target_field = TargetField(
-            parser.get_target_field_type(), parser.get_target_field_subset())
+            parser.get_target_field_type(), parser.get_target_field_subset(), parser.get_target_field_path())
 
     tests = parser.get_tests() or []
     examples = [

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/mark_down_generator.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/mark_down_generator.py
@@ -100,6 +100,8 @@ class MarkdownGenerator(IExporter):
 
         rows = []
         row = []
+        if getattr(output, "path", None):
+            row.append(output.path)
         if isinstance(output.type_, list):
             row.append(f"[{', '.join(output.type_)}]")
             row.append("-")
@@ -176,17 +178,19 @@ class MarkdownGenerator(IExporter):
                             args_values.append(self._format_call_arg(arg))
 
             if getattr(example, "target_field", None):
-                event_data["target_field"] = example.target_field
+                target_field_name = getattr(doc.target_field, "path", None) or "target_field"
+                event_data[target_field_name] = example.target_field
 
             call_str = f"{doc.name}({', '.join(args_values)})" if args_values else f"{doc.name}()"
+            target_field_name = getattr(doc.target_field, "path", None) or "target_field"
 
             self.content.append(f"{description}\n")
             self.content.append(f"#### Asset\n")
 
             if helper_type == "filter":
-                self.content.append("```yaml\ncheck:\n  - target_field: " + call_str + "\n```\n")
+                self.content.append("```yaml\ncheck:\n  - " + target_field_name + ": " + call_str + "\n```\n")
             else:
-                self.content.append("```yaml\nnormalize:\n  - map:\n      - target_field: " + call_str + "\n```\n")
+                self.content.append("```yaml\nnormalize:\n  - map:\n      - " + target_field_name + ": " + call_str + "\n```\n")
 
             self.content.append("#### Input Event\n")
             self.content.append("```json\n" + json.dumps(event_data, indent=2) + "\n```\n")
@@ -198,7 +202,7 @@ class MarkdownGenerator(IExporter):
                 final_event = dict(event_data)
                 if example.expected is not None:
                     if example.should_pass or doc.helper_type == "transformation":
-                        final_event["target_field"] = example.expected
+                        final_event[target_field_name] = example.expected
 
                 if all(v is None for v in final_event.values()):
                     final_event = {}
@@ -237,7 +241,7 @@ class MarkdownGenerator(IExporter):
 
         if doc.target_field:
             self.content.append(f"## Target Field\n")
-            headers = ["Type", "Possible values"]
+            headers = ["Path", "Type", "Possible values"] if getattr(doc.target_field, "path", None) else ["Type", "Possible values"]
             self.create_output_table(doc.target_field, headers)
 
         if doc.output:

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/types.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/types.py
@@ -19,9 +19,10 @@ class Output:
 
 
 class TargetField:
-    def __init__(self, type_: str, subset: str):
+    def __init__(self, type_: str, subset: str, path: str = None):
         self.type_ = type_
         self.subset = subset
+        self.path = path
 
 
 class Restriction:

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/test_cases_generator/parser.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/test_cases_generator/parser.py
@@ -252,7 +252,7 @@ class Parser:
         Returns:
             str: The type of the target field, or None if not present.
         """
-        if self.has_target_field:
+        if self.has_target_field():
             return self.yaml_data["target_field"]["type"]
         return None
 
@@ -263,8 +263,13 @@ class Parser:
         Returns:
             str: The subset of the target field, or an empty string if not present.
         """
-        if self.has_target_field:
+        if self.has_target_field():
             return self.yaml_data["target_field"].get("generate", "")
+        return None
+
+    def get_target_field_path(self):
+        if self.has_target_field():
+            return self.yaml_data["target_field"].get("path")
         return None
 
     def get_tests(self):

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/test_cases_generator/test_data.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/test_cases_generator/test_data.py
@@ -32,6 +32,10 @@ class TestData:
         self.tests = {"build_test": [], "run_test": []}
         self.asset_definition = {}
 
+    def get_target_field_name(self):
+        target_field_path = self.parser.get_target_field_path()
+        return target_field_path if target_field_path else "_target_field"
+
     def set_helper_type(self, helper_type: str):
         """
         Sets the helper type.
@@ -59,14 +63,15 @@ class TestData:
             target_field_value (optional): The target field value. Defaults to None.
         """
         helper = f"{self.parser.get_name()}({', '.join(str(v) for v in arguments)})"
+        target_field_name = self.get_target_field_name()
         if self.helper_type == "map":
             normalize_list = [{"map": [{"_helper": helper}]}]
         elif self.helper_type == "filter":
-            normalize_list = [{"map": [{"_target_field": target_field_value}]}, {"check": [{"_target_field": helper}], "map": [
+            normalize_list = [{"map": [{target_field_name: target_field_value}]}, {"check": [{target_field_name: helper}], "map": [
                 {"_verification_field": "It is used to verify if the check passed correctly"}]}]
         else:
             normalize_list = [
-                {"map": [{"_target_field": target_field_value}, {"_target_field": helper}]}]
+                {"map": [{target_field_name: target_field_value}, {target_field_name: helper}]}]
         self.asset_definition = {
             "name": "decoder/test/0", "normalize": normalize_list}
 
@@ -97,19 +102,20 @@ class TestData:
             target_field_value (optional): The target field value. Defaults to None.
         """
         helper = f"{self.parser.get_name()}({', '.join(str(v) for v in arguments)})"
+        target_field_name = self.get_target_field_name()
         if self.helper_type == "map":
             normalize_list = [{"map": [{"_eventJson": "parse_json($event.original)"}, {
                 "_helper": helper}]}]
         elif self.helper_type == "filter":
             normalize_list = [
                 {"map": [{"_eventJson": "parse_json($event.original)"}, {
-                    "_target_field": target_field_value}]},
-                {"check": [{"_target_field": helper}], "map": [
+                    target_field_name: target_field_value}]},
+                {"check": [{target_field_name: helper}], "map": [
                     {"_verification_field": "It is used to verify if the check passed correctly"}]}
             ]
         else:
-            normalize_list = [{"map": [{"_eventJson": "parse_json($event.original)"}, {"_target_field": target_field_value}, {
-                "_target_field": helper}]}]
+            normalize_list = [{"map": [{"_eventJson": "parse_json($event.original)"}, {target_field_name: target_field_value}, {
+                target_field_name: helper}]}]
         self.asset_definition = {
             "name": "decoder/test/0", "normalize": normalize_list}
 

--- a/src/engine/test/helper_tests/helpers_description/filter/index_unclassified_events.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/index_unclassified_events.yml
@@ -6,14 +6,15 @@ metadata:
     Determines whether unclassified events should be indexed based on policy configuration.
     This filter returns true if and only if:
     1. The policy flag 'indexUnclassifiedEvents' is enabled (configured at build time)
-    2. The target field is an array containing exactly 1 element
+    2. The target field is exactly 'wazuh.integration.decoders'
+    3. 'wazuh.integration.decoders' is an array containing exactly 1 element
 
     This helper is used in output routing to decide whether to index events that have only
     one decoder (unclassified events) when the policy allows it. If the policy flag is
     disabled or the array has a different size, the validation fails.
 
-    Note: This helper does not accept any arguments and depends on the policy context
-    configured at build time.
+    Note: This helper does not accept any arguments, rejects any target field other than
+    'wazuh.integration.decoders', and depends on the policy context configured at build time.
   keywords:
     - array
     - policy
@@ -29,6 +30,7 @@ arguments: {}
 target_field:
   type: array
   generate: all
+  path: wazuh.integration.decoders
 
 # Note: These tests assume the policy flag 'indexUnclassifiedEvents' is enabled in the test environment.
 # In production, this flag is configured per policy and evaluated at build time.

--- a/src/engine/test/integration_tests/engine-it/src/integration_test/initial_state.py
+++ b/src/engine/test/integration_tests/engine-it/src/integration_test/initial_state.py
@@ -310,7 +310,7 @@ def init_cm_resources(api_client: APIClient):
         integ_uuid=INTEG_WAZUH_CORE_UUID,
         integ_title="wazuh-core-test",
         default_parent=DECODER_TEST_UUID,
-        category="unclassified",
+        category="other",
         decoder_uuid=DECODER_TEST_UUID,
     )
 


### PR DESCRIPTION
## Description

The previous implementation of unclassified events relied on a dedicated `"unclassified"` integration category and a pipeline filtering stage between the decoder tree and IOC enrichment. This approach is replaced by a decoder-count-based definition: an event is unclassified if it was processed by **exactly one decoder** (`wazuh.integration.decoders` has exactly 1 element).


Closes [#35123](https://github.com/wazuh/wazuh/issues/35123)

## Proposed changes

- Removed `"unclassified"` as a valid integration category. Any integration declaring it is now rejected at validation time.
- Removed the category-based filter (`getUnclassifiedFilter`) from the pre-enrichment pipeline stage. The pipeline is now clean: `pre-filters → decoders → IOCs → post-filters → outputs` with no special unclassified handling between decoders and enrichment.
- Restricted `index_unclassified_events` helper to only accept `$wazuh.integration.decoders` as target field. Any other field is rejected at policy build time.
- Kept `index_unclassified_events` and `index_discarded_events` policy fields and the unclassified metric counter (`postOutputUnclassifiedCounter`), which already uses the new decoder-count definition.

## Results and Evidence

### Build & Install

```bash

General settings:
    TARGET:             manager
    V:                  
    DEBUG:              yes
    INSTALLDIR:         
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh-manager
    WAZUH_USER:         wazuh-manager
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                gcc
    MAKE              /usr/bin/make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building manager


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# service wazuh-manager status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-private ns list                               

- cmsync_standard_896e

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-router list

- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_896e
  priority: 1
  uptime: 12520

```
``` console

2026/04/21 15:35:56 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/04/21 15:35:56 wazuh-manager-analysisd: INFO: Engine started and ready to process events.

```

### Testing

<details><summary>1. Base pipeline flow</summary>
<p>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-router list

- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_896e
  priority: 1
  uptime: 65

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-private ns list
- cmsync_standard_896e

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test -s test -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:wazuhtest:hello world


---
traces:
[🟢] decoder/core-wazuh-message/0 -> success
  ↳ _tmp_json: parse_json($event.original) -> Parser parser failed at: hello world
[🔴] decoder/wazuh-inventory-module/0 -> failed
  ↳ event.module: filter("inventory") -> Target field 'event.module' not found
[🔴] decoder/wazuh-fim/0 -> failed
  ↳ [check: $_tmp_json.module == "fim"] -> Failure
[🔴] decoder/wazuh-sca/0 -> failed
  ↳ [check: string_equal($_tmp_json.module, "sca")] -> Failure
[🔴] decoder/wazuh-remoted/0 -> failed
  ↳ [check: regex_match($event.original, '^[0-9]{4}/[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} wazuh-manager-(remoted|monitord): [A-Z]+: wazuh: ')] -> Failure
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🔴] enrichment/Geo -> failed
  ↳ Geo()|AS() -> Failure: IP not found at field 'client.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'destination.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'host.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'observer.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'server.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'source.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'threat.enrichments.indicator.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'threat.indicator.ip'
  ↳ Geo()|AS() -> Failure: IP not found at field 'wazuh.agent.host.ip'

output:
  event:
    original: hello world
  wazuh:
    integration:
      category: security
      decoders:
      - decoder/core-wazuh-message/0
      name: wazuh-core
    protocol:
      location: wazuhtest
      queue: 49
    space:
      name: standard
```

</p>
</details>

<details><summary>2. Reject unclassified category</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
  "metadata": {
    "title": "manual-test-unclassified"
  },
  "enabled": true,
  "category": "unclassified",
  "decoders": [],
  "kvdbs": []
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-public cm validate integration < /tmp/test2-unclassified-integration.json

Error validating resource: Failed to validate resource of type 'integration': Integration category is not valid: unclassified
```

</p>
</details>

<details><summary>3. Reject invalid helper target</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "policy": {
    "title": "manual-test-invalid-index-unclassified",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [
      "33333333-3333-4333-8333-333333333333"
    ],
    "origin_space": "standard",
    "index_unclassified_events": true,
    "index_discarded_events": false
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [
      {
        "id": "33333333-3333-4333-8333-333333333333",
        "name": "output/indexer/0",
        "enabled": true,
        "outputs": [
          {
            "first_of": [
              {
                "check": "index_unclassified_events($wazuh.integration.category)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-other"
                    }
                  }
                ]
              }
            ]
          }
        ]
      }
    ],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test3/0",
        "enabled": true,
        "check": "exists($event.original)"
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test3"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-public cm policy-validate -n standard < /tmp/test3-invalid-index-unclassified-policy.json

Error validating policy: Failed to create the testing environment: Error building Output output/indexer/0: Stage 'outputs' failed to build output 'first_of': Stage 'first_of' failed to process item 0: first_of.item-0: failed to build check: Stage 'check' failed to build expression 'index_unclassified_events($wazuh.integration.category)': Failed to build operation 'wazuh.integration.category: index_unclassified_events': index_unclassified_events: target field must be 'wazuh.integration.decoders', got 'wazuh.integration.category'
```

</p>
</details>

<details><summary>4. Accept other category</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "policy": {
    "title": "manual-test4-category-other-single-decoder",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [],
    "origin_space": "standard",
    "index_unclassified_events": true,
    "index_discarded_events": false
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test4/0",
        "enabled": true,
        "check": "exists($event.original)",
        "normalize": [
          {
            "map": [
              {
                "event.category": "array_append(test)"
              },
              {
                "event.kind": "metric"
              },
              {
                "event.type": "array_append(info)"
              }
            ]
          }
        ]
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test4"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-private ns import test4_other_single -c "$(cat /tmp/test4-category-other-single-decoder.json)" --force

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test session add test4 test4_other_single

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test add -i test4 -c single-line -q 1 -o "test4"
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test4 -s test4 -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test4:hello world


---
traces:
[🟢] decoder/manual-test4/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ event.category: array_append("test") -> Success
  ↳ event.kind: map("metric") -> Success
  ↳ event.type: array_append("info") -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'

output:
  event:
    category:
    - test
    kind: metric
    original: hello world
    type:
    - info
  wazuh:
    integration:
      category: other
      decoders:
      - decoder/manual-test4/0
      name: manual-test4
    protocol:
      location: test4
      queue: 49
    space:
      name: standard
```

</p>
</details>

<details><summary>5. Helper matches single decoder</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "policy": {
    "title": "manual-test5-single-decoder-flag-on",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [
      "33333333-3333-4333-8333-333333333333"
    ],
    "origin_space": "standard",
    "index_unclassified_events": true,
    "index_discarded_events": false
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [
      {
        "id": "33333333-3333-4333-8333-333333333333",
        "name": "output/manual-test5/0",
        "enabled": true,
        "outputs": [
          {
            "first_of": [
              {
                "check": "index_unclassified_events($wazuh.integration.decoders)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-manual-test5-unclassified"
                    }
                  }
                ]
              },
              {
                "check": "NOT array_length_eq($wazuh.integration.decoders, 1)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-manual-test5-fallback"
                    }
                  }
                ]
              }
            ]
          }
        ]
      }
    ],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test5/0",
        "enabled": true,
        "check": "exists($event.original)",
        "normalize": [
          {
            "map": [
              {
                "event.category": "array_append(test)"
              },
              {
                "event.kind": "metric"
              },
              {
                "event.type": "array_append(info)"
              }
            ]
          }
        ]
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test5"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-private ns import test5_single_on -c "$(cat /tmp/test5-single-decoder-flag-on.json)"

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test session add test5 test5_single_on

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test add -i test5 -c single-line -q 1 -o "test5"
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test5 -s test5 -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test5:hello world


---
traces:
[🟢] decoder/manual-test5/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ event.category: array_append("test") -> Success
  ↳ event.kind: map("metric") -> Success
  ↳ event.type: array_append("info") -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🟢] output/manual-test5/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.decoders)] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-manual-test5-unclassified) -> Success

output:
  event:
    category:
    - test
    kind: metric
    original: hello world
    type:
    - info
  wazuh:
    integration:
      category: other
      decoders:
      - decoder/manual-test5/0
      name: manual-test5
    protocol:
      location: test5
      queue: 49
    space:
      name: standard
```

</p>
</details>

<details><summary>6. Helper skips multi decoder</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "policy": {
    "title": "manual-test6-multi-decoder-flag-on",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [
      "33333333-3333-4333-8333-333333333333"
    ],
    "origin_space": "standard",
    "index_unclassified_events": true,
    "index_discarded_events": false
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [
      {
        "id": "33333333-3333-4333-8333-333333333333",
        "name": "output/manual-test6/0",
        "enabled": true,
        "outputs": [
          {
            "first_of": [
              {
                "check": "index_unclassified_events($wazuh.integration.decoders)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-manual-test6-unclassified"
                    }
                  }
                ]
              },
              {
                "check": "NOT array_length_eq($wazuh.integration.decoders, 1)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-manual-test6-fallback"
                    }
                  }
                ]
              }
            ]
          }
        ]
      }
    ],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test6-root/0",
        "enabled": true,
        "check": "exists($event.original)",
        "normalize": [
          {
            "map": [
              {
                "event.category": "array_append(test)"
              },
              {
                "event.kind": "metric"
              },
              {
                "event.type": "array_append(info)"
              }
            ]
          }
        ]
      },
      {
        "id": "44444444-4444-4444-8444-444444444444",
        "name": "decoder/manual-test6-child/0",
        "enabled": true,
        "parents": [
          "decoder/manual-test6-root/0"
        ],
        "check": "exists($event.original)"
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test6"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111",
          "44444444-4444-4444-8444-444444444444"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-private ns import test6_multi_on -c "$(cat /tmp/test6-multi-decoder-flag-on.json)"

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test session add test6 test6_multi_on

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test add -i test6 -c single-line -q 1 -o "test6"
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test6 -s test6 -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test6:hello world


---
traces:
[🟢] decoder/manual-test6-root/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ event.category: array_append("test") -> Success
  ↳ event.kind: map("metric") -> Success
  ↳ event.type: array_append("info") -> Success
[🟢] decoder/manual-test6-child/0 -> success
  ↳ [check: exists($event.original)] -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🟢] output/manual-test6/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.decoders)] -> Failure
  ↳ [check: NOT array_length_eq($wazuh.integration.decoders, 1)] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-manual-test6-fallback) -> Success

output:
  event:
    category:
    - test
    kind: metric
    original: hello world
    type:
    - info
  wazuh:
    integration:
      category: other
      decoders:
      - decoder/manual-test6-root/0
      - decoder/manual-test6-child/0
      name: manual-test6
    protocol:
      location: test6
      queue: 49
    space:
      name: standard
```

</p>
</details>

<details><summary>7. Helper disabled with single decoder</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "policy": {
    "title": "manual-test7-single-decoder-flag-off",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [
      "33333333-3333-4333-8333-333333333333"
    ],
    "origin_space": "standard",
    "index_unclassified_events": false,
    "index_discarded_events": false
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [
      {
        "id": "33333333-3333-4333-8333-333333333333",
        "name": "output/manual-test7/0",
        "enabled": true,
        "outputs": [
          {
            "first_of": [
              {
                "check": "index_unclassified_events($wazuh.integration.decoders)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-manual-test7-unclassified"
                    }
                  }
                ]
              },
              {
                "check": "array_length_eq($wazuh.integration.decoders, 1)",
                "then": [
                  {
                    "wazuh-indexer": {
                      "index": "wazuh-events-v5-manual-test7-single-decoder"
                    }
                  }
                ]
              }
            ]
          }
        ]
      }
    ],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test7/0",
        "enabled": true,
        "check": "exists($event.original)",
        "normalize": [
          {
            "map": [
              {
                "event.category": "array_append(test)"
              },
              {
                "event.kind": "metric"
              },
              {
                "event.type": "array_append(info)"
              }
            ]
          }
        ]
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test7"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-private ns import test7_single_off -c "$(cat /tmp/test7-single-decoder-flag-off.json)"

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test session add test7 test7_single_off

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test add -i test7 -c single-line -q 1 -o "test7"
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test7 -s test7 -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test7:hello world


---
traces:
[🟢] decoder/manual-test7/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ event.category: array_append("test") -> Success
  ↳ event.kind: map("metric") -> Success
  ↳ event.type: array_append("info") -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🟢] output/manual-test7/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.decoders)] -> Failure
  ↳ [check: array_length_eq($wazuh.integration.decoders, 1)] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-manual-test7-single-decoder) -> Success

output:
  event:
    category:
    - test
    kind: metric
    original: hello world
    type:
    - info
  wazuh:
    integration:
      category: other
      decoders:
      - decoder/manual-test7/0
      name: manual-test7
    protocol:
      location: test7
      queue: 49
    space:
      name: standard
```

</p>
</details>

<details><summary>8. Flat indexer output</summary>
<p>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# sed -n '1,120p' /var/wazuh-manager/etc/outputs/default/indexer.yml

name: output/indexer/0
enabled: true

metadata:
  module: wazuh
  title: Indexer data stream outputs
  description: Output integrations events to wazuh-indexer

outputs:
  - first_of:
      - check: index_unclassified_events($wazuh.integration.decoders)
        then:
          - wazuh-indexer:
              index: "wazuh-events-v5-unclassified"
      - check: NOT array_length_eq($wazuh.integration.decoders, 1)
        then:
          - wazuh-indexer:
              index: "wazuh-events-v5-${wazuh.integration.category}"
```

</p>
</details>

<details><summary>9. Discarded event handling</summary>
<p>

<details><summary>details</summary>
<p>

```json
{
  "policy": {
    "title": "manual-test9a-discard-off",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [
      "33333333-3333-4333-8333-333333333333"
    ],
    "origin_space": "standard",
    "index_unclassified_events": false,
    "index_discarded_events": false
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [
      {
        "id": "33333333-3333-4333-8333-333333333333",
        "name": "output/manual-test9a/0",
        "enabled": true,
        "outputs": [
          {
            "wazuh-indexer": {
              "index": "wazuh-events-v5-manual-test9a"
            }
          }
        ]
      }
    ],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test9a/0",
        "enabled": true,
        "check": "exists($event.original)",
        "normalize": [
          {
            "map": [
              {
                "event.category": "array_append(test)"
              },
              {
                "event.kind": "metric"
              },
              {
                "event.type": "array_append(info)"
              },
              {
                "wazuh.space.event_discarded": "map(true)"
              }
            ]
          }
        ]
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test9a"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

```json
{
  "policy": {
    "title": "manual-test9b-discard-on",
    "enabled": true,
    "root_decoder": "11111111-1111-4111-8111-111111111111",
    "integrations": [
      "22222222-2222-4222-8222-222222222222"
    ],
    "filters": [],
    "enrichments": [],
    "outputs": [
      "33333333-3333-4333-8333-333333333333"
    ],
    "origin_space": "standard",
    "index_unclassified_events": false,
    "index_discarded_events": true
  },
  "resources": {
    "kvdbs": [],
    "filters": [],
    "outputs": [
      {
        "id": "33333333-3333-4333-8333-333333333333",
        "name": "output/manual-test9b/0",
        "enabled": true,
        "outputs": [
          {
            "wazuh-indexer": {
              "index": "wazuh-events-v5-manual-test9b"
            }
          }
        ]
      }
    ],
    "decoders": [
      {
        "id": "11111111-1111-4111-8111-111111111111",
        "name": "decoder/manual-test9b/0",
        "enabled": true,
        "check": "exists($event.original)",
        "normalize": [
          {
            "map": [
              {
                "event.category": "array_append(test)"
              },
              {
                "event.kind": "metric"
              },
              {
                "event.type": "array_append(info)"
              },
              {
                "wazuh.space.event_discarded": "map(true)"
              }
            ]
          }
        ]
      }
    ],
    "integrations": [
      {
        "id": "22222222-2222-4222-8222-222222222222",
        "metadata": {
          "title": "manual-test9b"
        },
        "enabled": true,
        "category": "other",
        "decoders": [
          "11111111-1111-4111-8111-111111111111"
        ],
        "kvdbs": []
      }
    ]
  }
}
```

</p>
</details>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-private ns import test9a_discard_off -c "$(cat /tmp/test9a-discard-off.json)"

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test session add test9a test9a_discard_off

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test add -i test9a -c single-line -q 1 -o "test9a"
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test9a -s test9a -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test9a:hello world


---
traces:
[🟢] decoder/manual-test9a/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ event.category: array_append("test") -> Success
  ↳ event.kind: map("metric") -> Success
  ↳ event.type: array_append("info") -> Success
  ↳ wazuh.space.event_discarded: map(true) -> Success
[🔴] filter/DiscardedEvents -> failed
  ↳ Discard_event() -> Failure: Event won't be indexed (wazuh.space.event_discarded=true and index_discarded_events=false)

output:
  event:
    category:
    - test
    kind: metric
    original: hello world
    type:
    - info
  wazuh:
    integration:
      category: other
      decoders:
      - decoder/manual-test9a/0
      name: manual-test9a
    protocol:
      location: test9a
      queue: 49
    space:
      event_discarded: true
      name: standard
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-private ns import test9b_discard_on -c "$(cat /tmp/test9b-discard-on.json)"

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test session add test9b test9b_discard_on

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●›
╰─# engine-test add -i test9b -c single-line -q 1 -o "test9b"
```

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test9b -s test9b -dd


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test9b:hello world


---
traces:
[🟢] decoder/manual-test9b/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ event.category: array_append("test") -> Success
  ↳ event.kind: map("metric") -> Success
  ↳ event.type: array_append("info") -> Success
  ↳ wazuh.space.event_discarded: map(true) -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (index_discarded_events=true)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'
[🟢] output/manual-test9b/0 -> success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-manual-test9b) -> Success

output:
  event:
    category:
    - test
    kind: metric
    original: hello world
    type:
    - info
  wazuh:
    integration:
      category: other
      decoders:
      - decoder/manual-test9b/0
      name: manual-test9b
    protocol:
      location: test9b
      queue: 49
    space:
      event_discarded: true
      name: standard
```

</p>
</details>

<details><summary>10. Unclassified metric counter</summary>
<p>

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-metrics get space.standard.events.unclassified

space.standard.events.unclassified: 8.0  (type=counter, enabled)

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test5 -s test5


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test5:hello world


---
event:
  category:
  - test
  kind: metric
  original: hello world
  type:
  - info
wazuh:
  integration:
    category: other
    decoders:
    - decoder/manual-test5/0
    name: manual-test5
  protocol:
    location: test5
    queue: 49
  space:
    name: standard



Enter any events [ENTER to send event, CTRL+C to finish]:

^C#
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-metrics get space.standard.events.unclassified

space.standard.events.unclassified: 9.0  (type=counter, enabled)

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-test run-raw test6 -s test6


Enter any events [ENTER to send event, CTRL+C to finish]:

1:test6:hello world


---
event:
  category:
  - test
  kind: metric
  original: hello world
  type:
  - info
wazuh:
  integration:
    category: other
    decoders:
    - decoder/manual-test6-root/0
    - decoder/manual-test6-child/0
    name: manual-test6
  protocol:
    location: test6
    queue: 49
  space:
    name: standard



Enter any events [ENTER to send event, CTRL+C to finish]:

^C#
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35123-Remove-Old-Unclassified-Category●› 
╰─# engine-metrics get space.standard.events.unclassified

space.standard.events.unclassified: 9.0  (type=counter, enabled)
```

</p>
</details>

