### PR TITLE
Fixing CIS 28730 and 28731 rules false negative for dictcheck and enforcing

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -3701,10 +3701,10 @@ checks:
       tactic: ["TA0006", "TA0003"]
       technique: ["T1078", "T1098", "T1110", "T1136", "T1556"]
       subtechnique: ["T1556.001", "T1550.001", "T1550.002"]
-    condition: all
+    condition: any
     rules:
       - 'd:/etc/security/pwquality.conf.d -> r:.*\.conf -> !r:^# && r:^\s*\t*dictcheck && n:\s*\t*=\s*\t*(\d+) compare != 0'
-      - 'f:/etc/pam.d/common-password -> !r:^# && r:^\s*\t*dictcheck && n:\s*\t*=\s*\t*(\d+) compare != 0'
+      - 'f:/etc/security/pwquality.conf -> !r:^# && r:^\s*\t*dictcheck && n:\s*\t*=\s*\t*(\d+) compare != 0'
 
   # 5.3.3.2.7 Ensure password quality checking is enforced. (Automated)
   - id: 28731
@@ -3727,10 +3727,10 @@ checks:
       tactic: ["TA0006", "TA0003"]
       technique: ["T1078", "T1098", "T1110", "T1136", "T1556"]
       subtechnique: ["T1556.001", "T1550.001", "T1550.002"]
-    condition: all
+    condition: any
     rules:
       - 'd:/etc/security/pwquality.conf.d -> r:.*\.conf -> !r:^# && r:^\s*\t*enforcing && n:\s*\t*=\s*\t*(\d+) compare != 0'
-      - 'f:/etc/pam.d/common-password -> !r:^# && r:^\s*\t*enforcing && n:\s*\t*=\s*\t*(\d+) compare != 0'
+      - 'f:/etc/security/pwquality.conf -> !r:^# && r:^\s*\t*enforcing && n:\s*\t*=\s*\t*(\d+) compare != 0'
 
   # 5.3.3.2.8 Ensure password quality is enforced for the root user. (Automated)
   - id: 28732


### PR DESCRIPTION
## Description

As described in #34259, CIS SCA checks **28730** (Ensure password dictionary check is enabled) and **28731** (Ensure password quality checking is enforced) are failing on correctly configured Ubuntu 22.04 systems. The rules use `condition: all` and include a second rule that looks for `dictcheck` and `enforcing` as standalone lines in `/etc/pam.d/common-password`, which is not valid PAM syntax. These options belong in `/etc/security/pwquality.conf` or `/etc/security/pwquality.conf.d/*.conf` — not in PAM configuration files.

## Proposed Changes

Replace the invalid `/etc/pam.d/common-password` rule with a check against `/etc/security/pwquality.conf`, and change the condition from `all` to `any` so the check passes when either the `conf.d` directory or the main `pwquality.conf` file has the relevant setting configured to a non-zero value.

**Check 28730 (dictcheck):**

```yaml
condition: any
rules:
  - 'd:/etc/security/pwquality.conf.d -> r:.*\.conf -> !r:^# && r:^\s*\t*dictcheck && n:\s*\t*=\s*\t*(\d+) compare != 0'
  - 'f:/etc/security/pwquality.conf -> !r:^# && r:^\s*\t*dictcheck && n:\s*\t*=\s*\t*(\d+) compare != 0'
```

**Check 28731 (enforcing):**

```yaml
condition: any
rules:
  - 'd:/etc/security/pwquality.conf.d -> r:.*\.conf -> !r:^# && r:^\s*\t*enforcing && n:\s*\t*=\s*\t*(\d+) compare != 0'
  - 'f:/etc/security/pwquality.conf -> !r:^# && r:^\s*\t*enforcing && n:\s*\t*=\s*\t*(\d+) compare != 0'
```

## Results and Evidence

On Ubuntu 22.04, `dictcheck` and `enforcing` are `pam_pwquality` settings that must be configured in `/etc/security/pwquality.conf` or `/etc/security/pwquality.conf.d/*.conf`. The previous rule expected them as standalone lines in `/etc/pam.d/common-password`, which is not valid PAM file syntax — in PAM files these would only appear as module arguments on a `pam_pwquality.so` line (e.g., `password requisite pam_pwquality.so retry=3 dictcheck=1`), not as top-level key-value pairs.

### Before fix

System configuration (correctly set):

```
root@ubuntu22:~# cat /etc/security/pwquality.conf
# pwquality configuration
dictcheck = 1
enforcing = 1

root@ubuntu22:~# cat /etc/pam.d/common-password | grep -v '^#'
password	[success=1 default=ignore]	pam_unix.so obscure yescrypt
password	requisite			pam_deny.so
password	required			pam_permit.so
```

SCA results with the old rules — checks **fail** despite correct configuration:

```
28730|Ensure password dictionary check is enabled.|failed
28731|Ensure password quality checking is enforced.|failed
```

### After fix

After updating the rules and restarting the agent, the checks correctly **pass**:

```
28730|Ensure password dictionary check is enabled.|passed
28731|Ensure password quality checking is enforced.|passed
```

Agent log confirming successful scan completion:

```
2026/04/20 08:30:15 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2026/04/20 08:30:15 sca: INFO: Starting Security Configuration Assessment scan.
2026/04/20 08:30:15 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2026/04/20 08:30:18 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2026/04/20 08:30:18 sca: INFO: Security Configuration Assessment scan finished. Duration: 3 seconds.
```

**Test environment:**
- Wazuh v4.14.4
- Ubuntu 22.04.5 LTS
- SCA Policy: CIS Ubuntu Linux 22.04 LTS Benchmark v2.0.0

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues