### PR TITLE
Preserve manager files during package upgrades

### DIFF
--- a/.github/actions/5_builderpackage_manager-upgrade-rules-test/action.yml
+++ b/.github/actions/5_builderpackage_manager-upgrade-rules-test/action.yml
@@ -1,0 +1,86 @@
+name: 'Test Wazuh upgrade preservation rules'
+description: 'Prepare and validate file preserve/overwrite rules around Wazuh upgrades'
+inputs:
+  mode:
+    description: 'Execution mode: prepare, validate, or run'
+    required: true
+  component:
+    description: 'Wazuh component: manager or agent'
+    required: false
+    default: manager
+  system:
+    description: 'Package system: deb or rpm'
+    required: true
+  container:
+    description: 'Docker container name or ID where the component is installed'
+    required: false
+    default: ''
+  package_path:
+    description: 'Path to the target package inside the container'
+    required: true
+  tested_docker:
+    description: 'image:tag used for full run mode'
+    required: false
+    default: ''
+  package_mount:
+    description: 'Host path to mount as /packages in full run mode'
+    required: false
+    default: /tmp
+  old_package_url:
+    description: 'URL of the baseline package in full run mode'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Run upgrade rules test
+      shell: bash
+      run: |
+        DOCKER=(docker)
+        if ! docker ps >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1; then
+          DOCKER=(sudo docker)
+        fi
+
+        if [ "${{ inputs.mode }}" = "run" ]; then
+          if [ -z "${{ inputs.tested_docker }}" ]; then
+            echo "tested_docker is required for run mode" >&2
+            exit 1
+          fi
+          if [ -z "${{ inputs.old_package_url }}" ]; then
+            echo "old_package_url is required for run mode" >&2
+            exit 1
+          fi
+
+          CONTAINER_NAME="wazuh_${{ inputs.component }}_upgrade_rules_${{ inputs.system }}_${GITHUB_RUN_ID:-local}_${GITHUB_RUN_ATTEMPT:-0}_${RANDOM}"
+          cleanup_container() {
+            "${DOCKER[@]}" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          }
+          "${DOCKER[@]}" run \
+            --name "$CONTAINER_NAME" \
+            -d \
+            -v "${{ inputs.package_mount }}:/packages" \
+            --entrypoint /bin/bash \
+            "${{ inputs.tested_docker }}" \
+            -lc 'tail -f /dev/null'
+          trap cleanup_container EXIT
+
+          "${DOCKER[@]}" cp "${{ github.action_path }}/upgrade_rules_test.sh" "$CONTAINER_NAME:/tmp/upgrade_rules_test.sh"
+          "${DOCKER[@]}" exec "$CONTAINER_NAME" bash -lc 'chmod +x /tmp/upgrade_rules_test.sh && /tmp/upgrade_rules_test.sh "$1" "$2" "$3" "$4" "$5"' -- \
+            "${{ inputs.mode }}" \
+            "${{ inputs.system }}" \
+            "${{ inputs.package_path }}" \
+            "${{ inputs.component }}" \
+            "${{ inputs.old_package_url }}"
+        else
+          if [ -z "${{ inputs.container }}" ]; then
+            echo "container is required for ${{ inputs.mode }} mode" >&2
+            exit 1
+          fi
+
+          "${DOCKER[@]}" cp "${{ github.action_path }}/upgrade_rules_test.sh" "${{ inputs.container }}:/tmp/upgrade_rules_test.sh"
+          "${DOCKER[@]}" exec "${{ inputs.container }}" bash -lc 'chmod +x /tmp/upgrade_rules_test.sh && /tmp/upgrade_rules_test.sh "$1" "$2" "$3" "$4"' -- \
+            "${{ inputs.mode }}" \
+            "${{ inputs.system }}" \
+            "${{ inputs.package_path }}" \
+            "${{ inputs.component }}"
+        fi

--- a/.github/actions/5_builderpackage_manager-upgrade-rules-test/upgrade_rules_test.sh
+++ b/.github/actions/5_builderpackage_manager-upgrade-rules-test/upgrade_rules_test.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+SYSTEM="${2:-}"
+PACKAGE_PATH="${3:-}"
+COMPONENT="${4:-manager}"
+OLD_PACKAGE_URL="${5:-}"
+EXTRACT_DIR=""
+INSTALL_DIR=""
+MARKER=""
+MARKED_FILES_LIST=""
+DELETED_ETC_REL=""
+DELETED_DATA_REL=""
+BINARY_REL=""
+
+COMMENT_MARKERS=()
+CUSTOM_ETC_MARKERS=()
+DATA_MARKERS=()
+
+log() {
+    echo "[upgrade-rules] $*"
+}
+
+fail() {
+    echo "[upgrade-rules] ERROR: $*" >&2
+    exit 1
+}
+
+configure_component() {
+    case "$COMPONENT" in
+        manager)
+            INSTALL_DIR="/var/wazuh-manager"
+            MARKER="WAZUH_UPGRADE_RULES_MARKER"
+            MARKED_FILES_LIST="/tmp/wazuh-manager-upgrade-rules-marked-files.list"
+            DELETED_ETC_REL="etc/outputs/default/indexer.yml"
+            DELETED_DATA_REL="data/store/schema/engine-schema/0"
+            BINARY_REL="bin/wazuh-manager-analysisd"
+            COMMENT_MARKERS=(
+                "etc/wazuh-manager.conf|wazuh-manager.conf|<!-- | -->"
+                "etc/shared/agent-template.conf|agent-template|<!-- | -->"
+                "etc/shared/default/agent.conf|shared-default-agent|<!-- | -->"
+                "etc/wazuh-manager-internal-options.conf|internal-options|# |"
+                "etc/client.keys|client-keys|# |"
+            )
+            CUSTOM_ETC_MARKERS=(
+                "etc/custom-upgrade-rules-marker|custom-etc"
+            )
+            DATA_MARKERS=(
+                "data/mmdb/GeoLite2-ASN.mmdb|mmdb-asn"
+                "data/mmdb/GeoLite2-City.mmdb|mmdb-city"
+                "data/store/enrichment/geo/0|store-enrichment-geo"
+                "data/store/enrichment/ioc/0|store-enrichment-ioc"
+                "data/store/geo/mmdb/0|store-geo-mmdb"
+                "data/store/schema/allowed-fields/0|store-allowed-fields"
+                "data/store/schema/wazuh-logpar-overrides/0|store-logpar-overrides"
+                "data/custom-upgrade-rules-marker|custom-data"
+            )
+            ;;
+        agent)
+            INSTALL_DIR="/var/ossec"
+            MARKER="WAZUH_AGENT_UPGRADE_RULES_MARKER"
+            DELETED_ETC_REL="etc/internal_options.conf"
+            DELETED_DATA_REL=""
+            BINARY_REL="bin/wazuh-agentd"
+            COMMENT_MARKERS=(
+                "etc/ossec.conf|ossec-conf|<!-- | -->"
+                "etc/local_internal_options.conf|local-internal-options|# |"
+                "etc/client.keys|client-keys|# |"
+            )
+            CUSTOM_ETC_MARKERS=(
+                "etc/custom-upgrade-rules-marker|custom-etc"
+                "etc/shared/custom-upgrade-rules-marker|custom-shared"
+            )
+            ;;
+        *)
+            fail "Unsupported component: $COMPONENT"
+            ;;
+    esac
+}
+
+cleanup_extract() {
+    if [ -n "$EXTRACT_DIR" ] && [ -d "$EXTRACT_DIR" ]; then
+        rm -rf "$EXTRACT_DIR"
+        EXTRACT_DIR=""
+    fi
+}
+
+require_file() {
+    local path="$1"
+    [ -f "$path" ] || fail "Missing file: $path"
+}
+
+path_for() {
+    local relative_path="$1"
+    printf '%s/%s' "$INSTALL_DIR" "$relative_path"
+}
+
+stop_component_if_running() {
+    case "$COMPONENT" in
+        manager)
+            command -v systemctl >/dev/null 2>&1 && systemctl stop wazuh-manager >/dev/null 2>&1 || true
+            command -v service >/dev/null 2>&1 && service wazuh-manager stop >/dev/null 2>&1 || true
+            [ -x "${INSTALL_DIR}/bin/wazuh-manager-control" ] && "${INSTALL_DIR}/bin/wazuh-manager-control" stop >/dev/null 2>&1 || true
+            ;;
+        agent)
+            command -v systemctl >/dev/null 2>&1 && systemctl stop wazuh-agent >/dev/null 2>&1 || true
+            command -v service >/dev/null 2>&1 && service wazuh-agent stop >/dev/null 2>&1 || true
+            [ -x "${INSTALL_DIR}/bin/wazuh-control" ] && "${INSTALL_DIR}/bin/wazuh-control" stop >/dev/null 2>&1 || true
+            ;;
+    esac
+}
+
+write_marker() {
+    local path="$1"
+    local label="$2"
+
+    mkdir -p "$(dirname "$path")"
+    printf '%s:%s\n' "$MARKER" "$label" > "$path"
+}
+
+write_marker_rel() {
+    local relative_path="$1"
+    local label="$2"
+
+    write_marker "$(path_for "$relative_path")" "$label"
+}
+
+# Append the marker as a syntactically valid comment for the file's format,
+# so config parsers do not error out if services are started around the test.
+append_marker_commented() {
+    local path="$1"
+    local label="$2"
+    local prefix="$3"
+    local suffix="$4"
+
+    require_file "$path"
+    printf '\n%s%s:%s%s\n' "$prefix" "$MARKER" "$label" "$suffix" >> "$path"
+}
+
+assert_contains_marker() {
+    local path="$1"
+
+    require_file "$path"
+    grep -q "$MARKER" "$path" || fail "Marker was not preserved in $path"
+}
+
+assert_not_contains_marker() {
+    local path="$1"
+
+    require_file "$path"
+    if grep -q "$MARKER" "$path"; then
+        fail "Marker unexpectedly preserved in $path"
+    fi
+}
+
+package_root_path() {
+    local relative_path="$1"
+
+    printf '%s%s/%s' "$EXTRACT_DIR" "$INSTALL_DIR" "$relative_path"
+}
+
+assert_matches_package() {
+    local relative_path="$1"
+    local installed_path
+    local packaged_path
+
+    installed_path="$(path_for "$relative_path")"
+    packaged_path="$(package_root_path "$relative_path")"
+    require_file "$installed_path"
+    require_file "$packaged_path"
+
+    cmp -s "$installed_path" "$packaged_path" || fail "$installed_path does not match target package"
+}
+
+ensure_cpio() {
+    command -v cpio >/dev/null 2>&1 && return 0
+
+    if command -v yum >/dev/null 2>&1; then
+        yum install -y cpio
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf install -y cpio
+    elif command -v microdnf >/dev/null 2>&1; then
+        microdnf install -y cpio
+    else
+        fail "cpio is required"
+    fi
+}
+
+extract_package() {
+    cleanup_extract
+    [ -n "$PACKAGE_PATH" ] || fail "Missing package path"
+    require_file "$PACKAGE_PATH"
+
+    EXTRACT_DIR="$(mktemp -d)"
+
+    case "$SYSTEM" in
+        deb)
+            command -v dpkg-deb >/dev/null 2>&1 || fail "dpkg-deb is required"
+            dpkg-deb -x "$PACKAGE_PATH" "$EXTRACT_DIR"
+            ;;
+        rpm)
+            command -v rpm2cpio >/dev/null 2>&1 || fail "rpm2cpio is required"
+            ensure_cpio
+            (cd "$EXTRACT_DIR" && rpm2cpio "$PACKAGE_PATH" | cpio -idm --quiet)
+            ;;
+        *)
+            fail "Unsupported package system: $SYSTEM"
+            ;;
+    esac
+}
+
+assert_target_package_contains() {
+    local relative_path="$1"
+
+    extract_package
+    require_file "$(package_root_path "$relative_path")"
+    cleanup_extract
+}
+
+download_old_package() {
+    [ -n "$OLD_PACKAGE_URL" ] || fail "Missing old package URL"
+    mkdir -p /old_package
+    curl -fL -o "/old_package/$(basename "$OLD_PACKAGE_URL")" "$OLD_PACKAGE_URL"
+}
+
+package_operation() {
+    local package_path="$1"
+    local operation="$2"
+
+    require_file "$package_path"
+
+    case "$SYSTEM:$operation" in
+        deb:install)
+            dpkg --install "$package_path"
+            ;;
+        deb:upgrade)
+            dpkg --install --force-confnew "$package_path"
+            ;;
+        rpm:install)
+            rpm -ivh --ignorearch "$package_path"
+            ;;
+        rpm:upgrade)
+            rpm -Uvh --ignorearch "$package_path"
+            ;;
+        *)
+            fail "Unsupported package operation: $SYSTEM $operation"
+            ;;
+    esac
+}
+
+prepare_common_markers() {
+    local marker_entry
+    local relative_path
+    local label
+    local prefix
+    local suffix
+
+    for marker_entry in "${COMMENT_MARKERS[@]}"; do
+        IFS='|' read -r relative_path label prefix suffix <<< "$marker_entry"
+        append_marker_commented "$(path_for "$relative_path")" "$label" "$prefix" "$suffix"
+    done
+
+    for marker_entry in "${CUSTOM_ETC_MARKERS[@]}"; do
+        IFS='|' read -r relative_path label <<< "$marker_entry"
+        write_marker_rel "$relative_path" "$label"
+    done
+
+    for marker_entry in "${DATA_MARKERS[@]+"${DATA_MARKERS[@]}"}"; do
+        IFS='|' read -r relative_path label <<< "$marker_entry"
+        write_marker_rel "$relative_path" "$label"
+    done
+}
+
+prepare_manager_outputs() {
+    local output_file
+    local outputs_found="no"
+    local deleted_etc_file
+
+    deleted_etc_file="$(path_for "$DELETED_ETC_REL")"
+    : > "$MARKED_FILES_LIST"
+
+    if [ -d "${INSTALL_DIR}/etc/outputs/default" ]; then
+        while IFS= read -r output_file; do
+            [ "$output_file" = "$deleted_etc_file" ] && continue
+            append_marker_commented "$output_file" "outputs" "# " ""
+            printf '%s\n' "$output_file" >> "$MARKED_FILES_LIST"
+            outputs_found="yes"
+        done < <(find "${INSTALL_DIR}/etc/outputs/default" -maxdepth 1 -type f -name '*.yml' | sort)
+    fi
+
+    [ "$outputs_found" = "yes" ] || fail "No output .yml files found to mark"
+
+    assert_target_package_contains "data/tzdb/iana/version"
+    write_marker_rel "data/tzdb/iana/version" "tzdb"
+}
+
+prepare() {
+    [ -d "$INSTALL_DIR" ] || fail "$INSTALL_DIR is not installed"
+
+    stop_component_if_running
+
+    prepare_common_markers
+
+    if [ "$COMPONENT" = "manager" ]; then
+        prepare_manager_outputs
+    fi
+
+    if [ -n "$DELETED_ETC_REL" ]; then
+        require_file "$(path_for "$DELETED_ETC_REL")"
+        rm -f "$(path_for "$DELETED_ETC_REL")"
+    fi
+
+    if [ -n "$DELETED_DATA_REL" ]; then
+        require_file "$(path_for "$DELETED_DATA_REL")"
+        rm -f "$(path_for "$DELETED_DATA_REL")"
+    fi
+
+    write_marker_rel "$BINARY_REL" "binary"
+    chmod 0750 "$(path_for "$BINARY_REL")"
+
+    log "Prepared $COMPONENT upgrade rule markers"
+    log "Marker locations before upgrade:"
+    if [ "$COMPONENT" = "manager" ]; then
+        grep -RHn "$MARKER" "${INSTALL_DIR}/etc" "${INSTALL_DIR}/data" 2>/dev/null || true
+    else
+        grep -RHn "$MARKER" "${INSTALL_DIR}/etc" 2>/dev/null || true
+    fi
+    log "Files staged as 'should be reinstalled by package':"
+    [ -n "$DELETED_ETC_REL" ] && printf '  %s\n' "$(path_for "$DELETED_ETC_REL")"
+    [ -n "$DELETED_DATA_REL" ] && printf '  %s\n' "$(path_for "$DELETED_DATA_REL")"
+
+    return 0
+}
+
+validate_common_markers() {
+    local marker_entry
+    local relative_path
+    local label
+
+    for marker_entry in "${COMMENT_MARKERS[@]}"; do
+        IFS='|' read -r relative_path label _ <<< "$marker_entry"
+        assert_contains_marker "$(path_for "$relative_path")"
+    done
+
+    for marker_entry in "${CUSTOM_ETC_MARKERS[@]}"; do
+        IFS='|' read -r relative_path label <<< "$marker_entry"
+        assert_contains_marker "$(path_for "$relative_path")"
+    done
+
+    for marker_entry in "${DATA_MARKERS[@]+"${DATA_MARKERS[@]}"}"; do
+        IFS='|' read -r relative_path label <<< "$marker_entry"
+        assert_contains_marker "$(path_for "$relative_path")"
+    done
+}
+
+validate_manager_outputs() {
+    local output_file
+
+    [ -s "$MARKED_FILES_LIST" ] || fail "Marked files list missing or empty: $MARKED_FILES_LIST"
+    while IFS= read -r output_file; do
+        [ -n "$output_file" ] || continue
+        assert_contains_marker "$output_file"
+    done < "$MARKED_FILES_LIST"
+
+    assert_not_contains_marker "$(path_for "data/tzdb/iana/version")"
+    assert_matches_package "data/tzdb/iana/version"
+}
+
+validate() {
+    extract_package
+    trap 'cleanup_extract' EXIT
+
+    log "Post-upgrade etc/ contents:"
+    ls -laR "${INSTALL_DIR}/etc" 2>/dev/null | head -120 || true
+    if [ "$COMPONENT" = "manager" ]; then
+        log "Post-upgrade data/ top-level contents:"
+        ls -la "${INSTALL_DIR}/data" 2>/dev/null || true
+        log "Post-upgrade marker matches under etc/ and data/:"
+        grep -RHn "$MARKER" "${INSTALL_DIR}/etc" "${INSTALL_DIR}/data" 2>/dev/null || true
+    else
+        log "Post-upgrade marker matches under etc/:"
+        grep -RHn "$MARKER" "${INSTALL_DIR}/etc" 2>/dev/null || true
+    fi
+
+    validate_common_markers
+
+    if [ "$COMPONENT" = "manager" ]; then
+        validate_manager_outputs
+    fi
+
+    if [ -n "$DELETED_ETC_REL" ]; then
+        assert_not_contains_marker "$(path_for "$DELETED_ETC_REL")"
+        assert_matches_package "$DELETED_ETC_REL"
+    fi
+
+    if [ -n "$DELETED_DATA_REL" ]; then
+        assert_not_contains_marker "$(path_for "$DELETED_DATA_REL")"
+        assert_matches_package "$DELETED_DATA_REL"
+    fi
+
+    assert_not_contains_marker "$(path_for "$BINARY_REL")"
+    assert_matches_package "$BINARY_REL"
+
+    log "All assertions passed."
+    log "Validated $COMPONENT upgrade rule markers"
+}
+
+run_full_upgrade() {
+    local old_package_path
+
+    download_old_package
+    old_package_path="/old_package/$(basename "$OLD_PACKAGE_URL")"
+    package_operation "$old_package_path" "install"
+
+    if [ "$COMPONENT" = "agent" ] && [ -f "${INSTALL_DIR}/etc/ossec.conf" ]; then
+        sed -i 's/MANAGER_IP/1.1.1.1/g' "${INSTALL_DIR}/etc/ossec.conf"
+    fi
+
+    prepare
+    package_operation "$PACKAGE_PATH" "upgrade"
+    validate
+}
+
+configure_component
+
+case "$MODE" in
+    prepare)
+        prepare
+        ;;
+    validate)
+        validate
+        ;;
+    run)
+        run_full_upgrade
+        ;;
+    *)
+        fail "Unsupported mode: $MODE"
+        ;;
+esac

--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -222,6 +222,17 @@ jobs:
           expected_upgrade_version: ${{ env.VERSION }}
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
 
+      - name: Test agent upgrade rule checks
+        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
+        with:
+          mode: run
+          component: agent
+          system: ${{ env.SYSTEM }}
+          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
+          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
+          package_mount: /tmp
+          package_path: /packages/${{ env.PACKAGE_NAME }}
+
   upload-deb-arm64-to-s3:
     needs: [build-deb-arm64, test-deb-arm64]
     if: success()
@@ -471,6 +482,17 @@ jobs:
           old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
           expected_upgrade_version: ${{ env.VERSION }}
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
+
+      - name: Test agent upgrade rule checks
+        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
+        with:
+          mode: run
+          component: agent
+          system: ${{ env.SYSTEM }}
+          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
+          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
+          package_mount: /tmp
+          package_path: /packages/${{ env.PACKAGE_NAME }}
 
   upload-rpm-arm64-to-s3:
     needs: [build-rpm-arm64, test-rpm-arm64]

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -263,6 +263,17 @@ jobs:
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
           package_path: /tmp/upgrade_test
 
+      - name: Test agent upgrade rule checks
+        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
+        with:
+          mode: run
+          component: agent
+          system: ${{ env.SYSTEM }}
+          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
+          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
+          package_mount: /tmp/upgrade_test
+          package_path: /packages/${{ env.PACKAGE_NAME }}
+
   upload-deb-to-s3:
     needs: [build-deb, test-deb]
     if: success()
@@ -547,6 +558,17 @@ jobs:
           expected_upgrade_version: ${{ env.VERSION }}
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
           package_path: /tmp/upgrade_test
+
+      - name: Test agent upgrade rule checks
+        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
+        with:
+          mode: run
+          component: agent
+          system: ${{ env.SYSTEM }}
+          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
+          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
+          package_mount: /tmp/upgrade_test
+          package_path: /packages/${{ env.PACKAGE_NAME }}
 
   upload-rpm-to-s3:
     needs: [build-rpm, test-rpm]

--- a/.github/workflows/5_builderpackage_manager.yml
+++ b/.github/workflows/5_builderpackage_manager.yml
@@ -333,40 +333,51 @@ jobs:
             curl -fL --connect-timeout 20 --max-time 300 -o "/tmp/$FILE_NAME_PUBLIC" "$PACKAGE_URL"
           echo "PUBLIC_PACKAGE_NAME=$FILE_NAME_PUBLIC" >> $GITHUB_ENV
 
-      - name: Run container and install public wazuh-manager
-        if: env.HAS_PREVIOUS_RELEASE == 'true'
+      - name: Run container and install upgrade baseline
         timeout-minutes: 20
         run: |
-          FILE_NAME=${{ env.PUBLIC_PACKAGE_NAME }}
           SYSTEM=${{ inputs.system }}
+          if [ "${{ env.HAS_PREVIOUS_RELEASE }}" = "true" ]; then
+            FILE_NAME=${{ env.PUBLIC_PACKAGE_NAME }}
+          else
+            FILE_NAME=${{ env.PACKAGE_NAME }}
+          fi
 
           if [ "$SYSTEM" = "deb" ]; then
             BASE_IMAGE="ubuntu:22.04"
             INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 -f install -y"
             UPDATE_CMD="apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update"
-            docker run --name wazuh_previous -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
+            docker run --name wazuh_upgrade_rules -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
             sleep 5
           else
             BASE_IMAGE="centos:8"
             INSTALL_CMD="yum --setopt=retries=5 --setopt=timeout=30 localinstall -y /packages/$FILE_NAME"
-            UPDATE_CMD="yum --setopt=retries=5 --setopt=timeout=30 update -y"
-            docker run --name wazuh_previous -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
+            UPDATE_CMD="yum --setopt=retries=5 --setopt=timeout=30 install -y cpio && yum --setopt=retries=5 --setopt=timeout=30 update -y"
+            docker run --name wazuh_upgrade_rules -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
             # Configuring CentOS 8 repositories
-            docker exec wazuh_previous bash -c "sed -i.bak 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*"
-            docker exec wazuh_previous bash -c "sed -i.bak 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
+            docker exec wazuh_upgrade_rules bash -c "sed -i.bak 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*"
+            docker exec wazuh_upgrade_rules bash -c "sed -i.bak 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
             sleep 5
           fi
 
           "$RETRY_SCRIPT" --attempts 4 --delay 10 --backoff 2 --max-delay 45 --timeout 600 \
             --label "Refresh package repositories in upgrade test container" -- \
-            docker exec wazuh_previous bash -lc "$UPDATE_CMD"
+            docker exec wazuh_upgrade_rules bash -lc "$UPDATE_CMD"
           "$RETRY_SCRIPT" --attempts 3 --delay 15 --backoff 2 --max-delay 45 --timeout 900 \
-            --label "Install previous public manager package" -- \
-            docker exec wazuh_previous bash -lc "$INSTALL_CMD"
-          docker exec wazuh_previous bash -c "/var/wazuh-manager/bin/wazuh-manager-control info || echo 'Manager not started yet'"
+            --label "Install manager package for upgrade baseline" -- \
+            docker exec wazuh_upgrade_rules bash -lc "$INSTALL_CMD"
+          docker exec wazuh_upgrade_rules bash -c "/var/wazuh-manager/bin/wazuh-manager-control info || echo 'Manager not started yet'"
+          echo "UPGRADE_CONTAINER=wazuh_upgrade_rules" >> $GITHUB_ENV
+
+      - name: Prepare manager upgrade rule checks
+        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
+        with:
+          mode: prepare
+          system: ${{ inputs.system }}
+          container: ${{ env.UPGRADE_CONTAINER }}
+          package_path: /packages/${{ env.PACKAGE_NAME }}
 
       - name: Upgrade to current Wazuh version
-        if: env.HAS_PREVIOUS_RELEASE == 'true'
         timeout-minutes: 20
         run: |
           SYSTEM=${{ inputs.system }}
@@ -374,16 +385,26 @@ jobs:
 
           if [ "$SYSTEM" = "deb" ]; then
             INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=60 -f install -y"
-          else
+          elif [ "${{ env.HAS_PREVIOUS_RELEASE }}" = "true" ]; then
             INSTALL_CMD="yum --setopt=retries=5 --setopt=timeout=30 localinstall -y /packages/$FILE_NAME"
+          else
+            INSTALL_CMD="rpm -Uvh --replacepkgs /packages/$FILE_NAME"
           fi
 
           echo "Upgrading to current version with package: $FILE_NAME"
-          docker cp /tmp/$FILE_NAME wazuh_previous:/packages/$FILE_NAME
+          docker cp /tmp/$FILE_NAME $UPGRADE_CONTAINER:/packages/$FILE_NAME
           "$RETRY_SCRIPT" --attempts 3 --delay 15 --backoff 2 --max-delay 45 --timeout 900 \
             --label "Upgrade manager package in test container" -- \
-            docker exec wazuh_previous bash -lc "$INSTALL_CMD"
-          docker exec wazuh_previous bash -c "/var/wazuh-manager/bin/wazuh-manager-control info || echo 'Manager not started yet after upgrade'"
+            docker exec $UPGRADE_CONTAINER bash -lc "$INSTALL_CMD"
+          docker exec $UPGRADE_CONTAINER bash -c "/var/wazuh-manager/bin/wazuh-manager-control info || echo 'Manager not started yet after upgrade'"
+
+      - name: Validate manager upgrade rule checks
+        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
+        with:
+          mode: validate
+          system: ${{ inputs.system }}
+          container: ${{ env.UPGRADE_CONTAINER }}
+          package_path: /packages/${{ env.PACKAGE_NAME }}
 
       - name: Upload package to GitHub
         if: always()

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2914,6 +2914,9 @@ components:
                   platform:
                     type: string
                     format: alphanumeric_symbols
+                  type:
+                    type: string
+                    format: alphanumeric_symbols
                   version:
                     type: string
                     format: alphanumeric_symbols

--- a/docs/ref/upgrade.md
+++ b/docs/ref/upgrade.md
@@ -1,6 +1,6 @@
 # Upgrade
 
-This guide provides instructions for upgrading Wazuh server and agent components from a previous version. The upgrade process preserves your existing configuration and only updates the package binaries. The service is automatically restarted during the upgrade.
+This guide provides instructions for upgrading Wazuh server and agent components from a previous version. The upgrade process preserves the documented configuration and runtime paths while replacing package-managed files with the new version. The service is automatically restarted during the upgrade.
 
 **Important**: Upgrading the Wazuh **manager** from version 4.x to 5.x is **not supported**. For manager major version upgrades, a fresh installation is required. However, Wazuh **agents** support upgrades from 4.x to 5.x and can connect to a 5.x manager.
 
@@ -60,9 +60,36 @@ sudo rpm -Uvh wazuh-manager-*.rpm
 
 The package manager will automatically:
 - Stop the current service
-- Preserve your configuration files
+- Preserve your configuration and runtime data (see [File preservation](#file-preservation))
 - Install the new binaries
 - Start the service
+
+### File preservation
+
+During a 5.x to 5.x upgrade, the package and source upgrade scripts apply a **preserve / restore** mechanism that guarantees the following behavior:
+
+| Path | Result after upgrade |
+|---|---|
+| `etc/` | Preserved from the previous installation, including `localtime`. |
+| `data/*` (except `data/tzdb`) | Preserved from the previous installation. |
+| `data/tzdb` | Not preserved by the upgrade backup/restore flow; updated from the new package or source timezone database. |
+| `bin/`, libraries, assets | Replaced by the new package. |
+
+This applies to `.deb`, `.rpm`, and source-based upgrades.
+
+File contents, permissions, and ownership are preserved for the paths listed above. The upgrade does not normalize or reset any permissions or ownership set by the administrator.
+
+**Seeing new defaults.** Because `etc/` is fully preserved, new default values shipped by the package are not automatically applied to existing files. On DEB manager upgrades a `wazuh-manager.conf.new` side-file is written alongside the live config so you can compare changes manually. On RPM no equivalent side-file is generated for the preserved paths; compare against the package defaults manually if needed.
+
+**If the upgrade fails.** Source-based upgrades attempt to restore preserved files automatically when the upgrade fails or is interrupted after the preserve step. If automatic restore fails, or if a package-based upgrade fails before restoration completes, the preserve directory is left in place for manual recovery:
+
+| Stack | Preserve directory |
+|---|---|
+| DEB | `/var/wazuh-manager/packages_files/manager_upgrade_preserve` |
+| RPM | `/var/wazuh-manager/tmp/manager_upgrade_preserve` |
+| Source | `${TMPDIR:-/tmp}/wazuh-manager-upgrade-preserve.*` |
+
+Once you have recovered the data, remove the preserve directory before retrying. DEB and RPM upgrades abort if they find an existing preserve backup. Source upgrades create a new temporary preserve directory for each attempt, so an older source preserve directory does not block a retry, but it should still be removed after manual recovery.
 
 ### Verify upgrade
 
@@ -270,12 +297,34 @@ This section covers agent upgrades across all supported platforms.
 
 Before upgrading agents:
 
-1. Backup agent configuration (`ossec.conf` and `client.keys`)
+1. Back up agent configuration as a precaution (`ossec.conf` and `client.keys` are preserved automatically, but an external backup is still recommended)
 2. Plan upgrades in batches to avoid upgrading all agents simultaneously
 3. Test on non-production agents first
 4. Verify manager compatibility with the new agent version
 
 **Note:** Wazuh agents version 4.x and later support upgrades to version 5.x.
+
+### File preservation
+
+During a 5.x to 5.x agent upgrade the package scripts apply a **preserve / restore** mechanism for agent configuration files:
+
+| Path | Result after upgrade |
+|---|---|
+| `etc/` (`ossec.conf`, `client.keys`, `local_internal_options.conf`, `localtime`, ...) | Preserved from the previous installation. |
+| `bin/`, libraries | Replaced by the new package. |
+
+
+On DEB upgrades a `ossec.conf.new` side-file is written with the new default config for comparison.
+
+As with server upgrades, file contents, permissions, and ownership are preserved for the paths listed above. The upgrade does not normalize or reset any permissions or ownership set by the administrator.
+
+Preserve directory locations for recovery:
+
+| Stack | Preserve directory |
+|---|---|
+| DEB | `/var/ossec/packages_files/agent_upgrade_preserve` |
+| RPM | `/var/ossec/tmp/agent_upgrade_preserve` |
+| Source | `${TMPDIR:-/tmp}/wazuh-agent-upgrade-preserve.*` |
 
 ### Download package
 
@@ -533,6 +582,21 @@ sudo systemctl stop wazuh-manager
 sudo cp $BACKUP_DIR/db/global.db /var/wazuh-manager/var/db/global.db
 sudo chown wazuh-manager:wazuh-manager /var/wazuh-manager/var/db/global.db
 sudo systemctl start wazuh-manager
+```
+
+### Upgrade aborted: existing preserve directory
+
+If a previous package-based upgrade was interrupted, a preserve directory may still be present. DEB and RPM upgrades abort with a message like `Existing upgrade preserve backup found`. Source upgrades use a new temporary preserve directory for each attempt, so older source preserve directories do not block retries. To recover:
+
+1. Inspect the preserve directory contents.
+2. Copy any needed files back to `etc/` or, for manager upgrades, `data/`.
+3. Remove the preserve directory, then retry the upgrade.
+
+```bash
+# Example for manager DEB
+ls /var/wazuh-manager/packages_files/manager_upgrade_preserve/
+# Recover if needed, then:
+sudo rm -rf /var/wazuh-manager/packages_files/manager_upgrade_preserve
 ```
 
 ### Agent issues

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1557,7 +1557,7 @@ def get_full_overview() -> WazuhResult:
     stats_distinct_node = get_distinct_agents(fields=['node_name'], q=q).affected_items
     groups = get_agent_groups().affected_items
     stats_distinct_os = get_distinct_agents(fields=['os.name',
-                                                    'os.platform', 'os.version'], q=q).affected_items
+                                                    'os.platform', 'os.type', 'os.version'], q=q).affected_items
     stats_version = get_distinct_agents(fields=['version'], q=q).affected_items
     agent_summary_status = get_agents_summary_status()
     summary = agent_summary_status['data'] if 'data' in agent_summary_status else dict()

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,127 @@ setBuildCextra()
     mv "$tmp_config_os" "$config_os"
 }
 
+UPGRADE_PRESERVE_DIR=""
+
+UPGRADE_PRESERVE_CP="cp -Rp"
+__cp_test_dir=$(mktemp -d 2>/dev/null)
+if [ -n "${__cp_test_dir}" ] && [ -d "${__cp_test_dir}" ]; then
+    : > "${__cp_test_dir}/src" 2>/dev/null
+    if cp -a "${__cp_test_dir}/src" "${__cp_test_dir}/dst" 2>/dev/null; then
+        UPGRADE_PRESERVE_CP="cp -a"
+    fi
+    rm -rf "${__cp_test_dir}"
+fi
+unset __cp_test_dir
+
+# Keep backup metadata for manual recovery, but restore without -p/-a so
+# source upgrades keep the ownership and modes assigned by the installer.
+UPGRADE_PRESERVE_RESTORE_CP="cp -R"
+
+PrepareUpgradePreserve()
+{
+    UPGRADE_PRESERVE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/wazuh-${INSTYPE}-upgrade-preserve.XXXXXX" 2>/dev/null) || return 1
+    [ -n "${UPGRADE_PRESERVE_DIR}" ] && [ -d "${UPGRADE_PRESERVE_DIR}" ] || return 1
+
+    if [ -d "${INSTALLDIR}/etc" ]; then
+        ${UPGRADE_PRESERVE_CP} "${INSTALLDIR}/etc" "${UPGRADE_PRESERVE_DIR}/" || return 1
+    fi
+
+    if [ "X${INSTYPE}" = "Xmanager" ] && [ -d "${INSTALLDIR}/data" ]; then
+        mkdir -p "${UPGRADE_PRESERVE_DIR}/data" || return 1
+
+        for DATA_ENTRY in "${INSTALLDIR}/data/"* "${INSTALLDIR}/data/."[!.]* "${INSTALLDIR}/data/"..?*; do
+            [ -e "${DATA_ENTRY}" ] || continue
+            DATA_NAME=$(basename "${DATA_ENTRY}")
+            [ "${DATA_NAME}" = "tzdb" ] && continue
+            ${UPGRADE_PRESERVE_CP} "${DATA_ENTRY}" "${UPGRADE_PRESERVE_DIR}/data/" || return 1
+        done
+    fi
+}
+
+RestoreUpgradePreserve()
+{
+    [ -n "${UPGRADE_PRESERVE_DIR}" ] || return 0
+
+    if [ -d "${UPGRADE_PRESERVE_DIR}/etc" ]; then
+        mkdir -p "${INSTALLDIR}/etc" || return 1
+        ${UPGRADE_PRESERVE_RESTORE_CP} "${UPGRADE_PRESERVE_DIR}/etc/." "${INSTALLDIR}/etc/" || return 1
+    fi
+
+    if [ "X${INSTYPE}" = "Xmanager" ] && [ -d "${UPGRADE_PRESERVE_DIR}/data" ]; then
+        mkdir -p "${INSTALLDIR}/data" || return 1
+
+        for DATA_ENTRY in "${UPGRADE_PRESERVE_DIR}/data/"* "${UPGRADE_PRESERVE_DIR}/data/."[!.]* "${UPGRADE_PRESERVE_DIR}/data/"..?*; do
+            [ -e "${DATA_ENTRY}" ] || continue
+            ${UPGRADE_PRESERVE_RESTORE_CP} "${DATA_ENTRY}" "${INSTALLDIR}/data/" || return 1
+        done
+    fi
+
+    rm -rf "${UPGRADE_PRESERVE_DIR}" || return 1
+    UPGRADE_PRESERVE_DIR=""
+}
+
+CleanupUpgradePreserve()
+{
+    if [ -n "${UPGRADE_PRESERVE_DIR}" ] && [ -d "${UPGRADE_PRESERVE_DIR}" ]; then
+        rm -rf "${UPGRADE_PRESERVE_DIR}"
+    fi
+}
+
+PrepareErrorExit()
+{
+    echo "ERROR: $1"
+    CleanupUpgradePreserve
+    exit 1
+}
+
+RestoreErrorExit()
+{
+    echo "ERROR: $1"
+    if [ -n "${UPGRADE_PRESERVE_DIR}" ] && [ -d "${UPGRADE_PRESERVE_DIR}" ]; then
+        echo "Preserved files left at ${UPGRADE_PRESERVE_DIR} for manual recovery."
+    fi
+    exit 1
+}
+
+AttemptUpgradePreserveRestore()
+{
+    RESTORE_REASON=$1
+
+    [ -n "${UPGRADE_PRESERVE_DIR}" ] && [ -d "${UPGRADE_PRESERVE_DIR}" ] || return 0
+
+    echo ""
+    echo "${RESTORE_REASON}; attempting to restore preserved files..."
+    if RestoreUpgradePreserve; then
+        echo "Preserved files restored successfully."
+        return 0
+    fi
+
+    echo "ERROR: Could not restore preserved files automatically."
+    if [ -n "${UPGRADE_PRESERVE_DIR}" ] && [ -d "${UPGRADE_PRESERVE_DIR}" ]; then
+        echo "Manual recovery: contents are at ${UPGRADE_PRESERVE_DIR}"
+    fi
+    return 1
+}
+
+HandleUpgradeExit()
+{
+    EXIT_STATUS=$?
+    trap - 0
+
+    [ "${EXIT_STATUS}" = "0" ] && exit 0
+
+    AttemptUpgradePreserveRestore "ERROR: Upgrade failed"
+    exit "${EXIT_STATUS}"
+}
+
+HandleUpgradeInterrupt()
+{
+    trap - HUP INT TERM 0
+    AttemptUpgradePreserveRestore "WARNING: Upgrade interrupted"
+    exit 1
+}
+
 isPFFirewall()
 {
     UNAME=$(uname)
@@ -136,8 +257,28 @@ Install()
         UpdateStopWAZUH
     fi
 
+    if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ] || [ "X${INSTYPE}" = "Xagent" ]; }; then
+        PrepareUpgradePreserve || PrepareErrorExit "Could not prepare ${INSTYPE} upgrade preserve backup."
+        trap 'HandleUpgradeInterrupt' HUP INT TERM
+        trap 'HandleUpgradeExit' 0
+    fi
+
     # Install selected components.
     InstallWazuh
+    INSTALL_STATUS=$?
+
+    if [ "${INSTALL_STATUS}" != "0" ]; then
+        if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ] || [ "X${INSTYPE}" = "Xagent" ]; }; then
+            trap - HUP INT TERM 0
+            AttemptUpgradePreserveRestore "ERROR: Upgrade failed"
+        fi
+        exit "${INSTALL_STATUS}"
+    fi
+
+    if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ] || [ "X${INSTYPE}" = "Xagent" ]; }; then
+        trap - HUP INT TERM 0
+        RestoreUpgradePreserve || RestoreErrorExit "Could not restore ${INSTYPE} upgrade preserve backup."
+    fi
 
     cd ../
 

--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -14,10 +14,22 @@ case "$1" in
     GROUP="wazuh"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
+    WAZUH_PRESERVE_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_upgrade_preserve"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_installation_scripts"
     SCA_BASE_DIR="${SCRIPTS_DIR}/sca"
 
     OSMYSHELL="/sbin/nologin"
+
+    restore_upgrade_preserve() {
+        if [ -d "${WAZUH_PRESERVE_DIR}/etc" ]; then
+            mkdir -p "${DIR}/etc"
+            cp -a "${WAZUH_PRESERVE_DIR}/etc/." "${DIR}/etc/"
+        fi
+
+        if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
+            rm -rf "${WAZUH_PRESERVE_DIR}"
+        fi
+    }
 
     if [ -d /run/systemd/system ]; then
         rm -f /etc/init.d/wazuh-agent
@@ -46,30 +58,18 @@ case "$1" in
         chmod 640 ${DIR}/etc/ossec.conf.new
     fi
 
-    # For the etc dir
-    if [ -f /etc/localtime ]; then
-        cp -pL /etc/localtime ${DIR}/etc/;
-        chmod 640 ${DIR}/etc/localtime
-        chown root:${GROUP} ${DIR}/etc/localtime
+    if [ -z "$2" ]; then
+        # For the etc dir
+        if [ -f /etc/localtime ]; then
+            cp -pL /etc/localtime ${DIR}/etc/;
+            chmod 640 ${DIR}/etc/localtime
+            chown root:${GROUP} ${DIR}/etc/localtime
+        fi
     fi
 
     # Remove deprecated binaries
     if [ -f ${DIR}/bin/agent-auth ]; then
         rm -f ${DIR}/bin/agent-auth
-    fi
-
-    # Restore the local rules, client.keys and local_decoder
-    if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
-        cp ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys
-    fi
-    # Restore ossec.conf configuration
-    if [ -f ${WAZUH_TMP_DIR}/ossec.conf ]; then
-        mv ${WAZUH_TMP_DIR}/ossec.conf ${DIR}/etc/ossec.conf
-        chmod 640 ${DIR}/etc/ossec.conf
-    fi
-    # Restore internal options configuration
-    if [ -f ${WAZUH_TMP_DIR}/local_internal_options.conf ]; then
-        mv ${WAZUH_TMP_DIR}/local_internal_options.conf ${DIR}/etc/local_internal_options.conf
     fi
 
     # Install the SCA files
@@ -112,12 +112,6 @@ case "$1" in
 
     fi
 
-    # Restore group files
-    if [ -d ${WAZUH_TMP_DIR}/group ]; then
-        cp -rfp ${WAZUH_TMP_DIR}/group/* ${DIR}/etc/shared
-        rm -rf ${WAZUH_TMP_DIR}/group
-    fi
-
     touch ${DIR}/logs/active-responses.log
     chown wazuh:wazuh ${DIR}/logs/active-responses.log
     chmod 0660 ${DIR}/logs/active-responses.log
@@ -134,6 +128,12 @@ case "$1" in
     if [ -z "$2" ] ; then
         ${SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
     fi
+
+    # Restore preserved etc/ as the last content-restore/overwrite
+    # step for that tree, matching the RPM %posttrans ordering and the
+    # strict "etc/ MUST NOT be overwritten" contract from the upgrade rules.
+    # Permission normalization may still follow afterwards.
+    restore_upgrade_preserve
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -6,13 +6,29 @@ set -e
 
 DIR="/var/ossec"
 WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
+WAZUH_PRESERVE_DIR="${DIR}/packages_files/agent_upgrade_preserve"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
 
-        if [ -d ${WAZUH_TMP_DIR} ]; then
-            rm -rf ${WAZUH_TMP_DIR}
-        fi
+        case "$1" in
+            failed-upgrade|abort-upgrade)
+                if [ -d "${WAZUH_TMP_DIR}" ]; then
+                    echo "Wazuh upgrade recovery files were preserved at ${WAZUH_TMP_DIR}. Restore them manually if needed." >&2
+                fi
+                if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
+                    echo "Wazuh upgrade recovery files were preserved at ${WAZUH_PRESERVE_DIR}. Restore them manually if needed." >&2
+                fi
+                ;;
+            *)
+                if [ -d ${WAZUH_TMP_DIR} ]; then
+                    rm -rf ${WAZUH_TMP_DIR}
+                fi
+                if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
+                    rm -rf "${WAZUH_PRESERVE_DIR}"
+                fi
+                ;;
+        esac
 
         # Back up the old configuration files as .save
         if [ ! -d ${DIR}/etc ]; then

--- a/packages/debs/SPECS/wazuh-agent/debian/preinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/preinst
@@ -6,9 +6,23 @@ set -e
 # configuration variables
 DIR="/var/ossec"
 WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
+WAZUH_PRESERVE_DIR="${DIR}/packages_files/agent_upgrade_preserve"
 
 # environment configuration
 mkdir -p ${WAZUH_TMP_DIR}
+
+backup_upgrade_preserve() {
+    if [ -e "${WAZUH_PRESERVE_DIR}" ]; then
+        echo "ERROR: Existing agent upgrade preserve backup found at ${WAZUH_PRESERVE_DIR}." >&2
+        echo "ERROR: Recover or move this directory before retrying the upgrade." >&2
+        exit 1
+    fi
+    mkdir -p "${WAZUH_PRESERVE_DIR}"
+
+    if [ -d "${DIR}/etc" ]; then
+        cp -a "${DIR}/etc" "${WAZUH_PRESERVE_DIR}/"
+    fi
+}
 
 case "$1" in
     install|upgrade)
@@ -80,6 +94,8 @@ EOF
             fi
             ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 
+            backup_upgrade_preserve
+
             # Remove old databases if upgrading from pre 5.X to 5.X
             if [ $MAJOR -lt 5 ]; then
                 if [ -f ${DIR}/queue/syscollector/db/local.db ]; then
@@ -118,32 +134,6 @@ EOF
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
-        # Delete old service
-        if [ -f /etc/init.d/ossec ]; then
-            rm /etc/init.d/ossec
-        fi
-
-        # back up the current user rules
-        if [ -f ${DIR}/etc/client.keys ]; then
-            cp ${DIR}/etc/client.keys ${WAZUH_TMP_DIR}/client.keys
-        fi
-        if [ -f ${DIR}/etc/local_internal_options.conf ]; then
-            cp -p ${DIR}/etc/local_internal_options.conf ${WAZUH_TMP_DIR}/local_internal_options.conf
-        fi
-        if [ -f ${DIR}/etc/ossec.conf ]; then
-            cp -p ${DIR}/etc/ossec.conf ${WAZUH_TMP_DIR}/ossec.conf
-        fi
-
-        if [ -d "${DIR}/etc/shared" ]; then
-            if [ "$(ls -A "${DIR}/etc/shared")" ]; then
-                files="$(ls -A ${DIR}/etc/shared/*)"
-            fi
-        fi
-
-        if [ ! -z "$files" ]; then
-            mkdir -p ${WAZUH_TMP_DIR}/group
-            cp -rp ${DIR}/etc/shared/* ${WAZUH_TMP_DIR}/group/
-        fi
     ;;
 
     abort-upgrade)

--- a/packages/debs/SPECS/wazuh-manager/debian/postinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/postinst
@@ -21,8 +21,29 @@ case "$1" in
     GROUP="wazuh-manager"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
+    WAZUH_PRESERVE_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_upgrade_preserve"
     OSMYSHELL="/sbin/nologin"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_installation_scripts"
+
+    restore_upgrade_preserve() {
+        if [ -d "${WAZUH_PRESERVE_DIR}/etc" ]; then
+            mkdir -p "${DIR}/etc"
+            cp -a "${WAZUH_PRESERVE_DIR}/etc/." "${DIR}/etc/"
+        fi
+
+        if [ -d "${WAZUH_PRESERVE_DIR}/data" ]; then
+            mkdir -p "${DIR}/data"
+
+            for DATA_ENTRY in "${WAZUH_PRESERVE_DIR}/data/"* "${WAZUH_PRESERVE_DIR}/data/."[!.]* "${WAZUH_PRESERVE_DIR}/data/"..?*; do
+                [ -e "${DATA_ENTRY}" ] || continue
+                cp -a "${DATA_ENTRY}" "${DIR}/data/"
+            done
+        fi
+
+        if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
+            rm -rf "${WAZUH_PRESERVE_DIR}"
+        fi
+    }
 
     if [ -d /run/systemd/system ]; then
         rm -f /etc/init.d/wazuh-manager
@@ -104,31 +125,19 @@ case "$1" in
 
     chmod 640 ${DIR}/etc/sslmanager.cert ${DIR}/etc/sslmanager.key > /dev/null 2>&1 || true
 
-    # For the etc dir
-    if [ -f /etc/localtime ]; then
-        cp -pL /etc/localtime ${DIR}/etc/;
-        chmod 640 ${DIR}/etc/localtime
-        chown root:${GROUP} ${DIR}/etc/localtime
-    fi
+    if [ -z "$2" ]; then
+        # For the etc dir
+        if [ -f /etc/localtime ]; then
+            cp -pL /etc/localtime ${DIR}/etc/;
+            chmod 640 ${DIR}/etc/localtime
+            chown root:${GROUP} ${DIR}/etc/localtime
+        fi
 
-    if [ -f /etc/TIMEZONE ]; then
-        cp -p /etc/TIMEZONE ${DIR}/etc/;
-        chmod 640 ${DIR}/etc/TIMEZONE
-        chown root:root ${DIR}/etc/TIMEZONE
-    fi
-
-    # Restore client.keys configuration
-    if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
-        mv ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys
-    fi
-    # Restore manager internal options configuration
-    if [ -f ${WAZUH_TMP_DIR}/wazuh-manager-internal-options.conf ]; then
-        mv ${WAZUH_TMP_DIR}/wazuh-manager-internal-options.conf ${DIR}/etc/wazuh-manager-internal-options.conf
-    fi
-
-    # Restore wazuh-manager.conf configuration
-    if [ -f ${WAZUH_TMP_DIR}/wazuh-manager.conf ]; then
-        mv ${WAZUH_TMP_DIR}/wazuh-manager.conf ${DIR}/etc/wazuh-manager.conf
+        if [ -f /etc/TIMEZONE ]; then
+            cp -p /etc/TIMEZONE ${DIR}/etc/;
+            chmod 640 ${DIR}/etc/TIMEZONE
+            chown root:root ${DIR}/etc/TIMEZONE
+        fi
     fi
 
     for BIN in agent_groups agent_upgrade cluster_control rbac_control \
@@ -156,16 +165,6 @@ case "$1" in
     chmod 660 ${DIR}/etc/wazuh-manager.conf > /dev/null 2>&1 || true
     chown root:${GROUP} ${DIR}/etc/wazuh-manager-internal-options.conf > /dev/null 2>&1 || true
     chmod 640 ${DIR}/etc/wazuh-manager-internal-options.conf > /dev/null 2>&1 || true
-    # Restore group files
-    if [ -d ${WAZUH_TMP_DIR}/group ]; then
-        cp -rfp ${WAZUH_TMP_DIR}/group/* ${DIR}/etc/shared
-        rm -rf ${WAZUH_TMP_DIR}/group/
-    fi
-
-    # Restore agent-groups files
-    if [ -d ${WAZUH_TMP_DIR}/agent-groups ]; then
-        mv ${WAZUH_TMP_DIR}/agent-groups ${DIR}/queue/
-    fi
 
     # Restore RBAC database
     if [ -f ${WAZUH_TMP_DIR}/rbac.db ]; then
@@ -190,8 +189,10 @@ case "$1" in
     chown ${USER}:${GROUP} ${DIR}/logs/wazuh-manager.json
     chmod 0660 ${DIR}/logs/wazuh-manager.json
 
-    # Set merged.mg permissions to new ones
-    find ${DIR}/etc/shared/ -type f -name 'merged.mg' -exec chmod 644 {} \;
+    # Restore preserved etc/ and data/ as the last content-restore/overwrite
+    # step for those trees, matching the RPM %posttrans ordering and the
+    # strict "etc/ MUST NOT be overwritten" contract from the upgrade rules.
+    restore_upgrade_preserve
 
     # Check if SELinux is installed and enabled
     if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then

--- a/packages/debs/SPECS/wazuh-manager/debian/postrm
+++ b/packages/debs/SPECS/wazuh-manager/debian/postrm
@@ -15,6 +15,7 @@ if [ "$1" = "abort-upgrade" ] || [ "$1" = "failed-upgrade" ]; then
 fi
 
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
+WAZUH_PRESERVE_DIR="${DIR}/packages_files/manager_upgrade_preserve"
 ROLLBACK_MARKER="${WAZUH_TMP_DIR}/rollback_prepared"
 
 # If preinst did not prepare rollback state, abort safely.
@@ -27,9 +28,24 @@ fi
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
 
-        if [ -d ${WAZUH_TMP_DIR} ]; then
-            rm -rf ${WAZUH_TMP_DIR}
-        fi
+        case "$1" in
+            failed-upgrade|abort-upgrade)
+                if [ -d "${WAZUH_TMP_DIR}" ]; then
+                    echo "Wazuh upgrade recovery files were preserved at ${WAZUH_TMP_DIR}. Restore them manually if needed." >&2
+                fi
+                if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
+                    echo "Wazuh upgrade recovery files were preserved at ${WAZUH_PRESERVE_DIR}. Restore them manually if needed." >&2
+                fi
+                ;;
+            *)
+                if [ -d ${WAZUH_TMP_DIR} ]; then
+                    rm -rf ${WAZUH_TMP_DIR}
+                fi
+                if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
+                    rm -rf "${WAZUH_PRESERVE_DIR}"
+                fi
+                ;;
+        esac
 
         # Back up the old configuration files as .save
         if [ ! -d ${DIR}/etc/shared/default ]; then

--- a/packages/debs/SPECS/wazuh-manager/debian/preinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/preinst
@@ -5,14 +5,35 @@ set -e
 # configuration variables
 DIR="/var/wazuh-manager"
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
-VERSION="$2"
-MAJOR=$(echo "$VERSION" | cut -dv -f2 | cut -d. -f1)
-
+WAZUH_PRESERVE_DIR="${DIR}/packages_files/manager_upgrade_preserve"
 prepare_tmp_dir() {
     if [ -d "${WAZUH_TMP_DIR}" ]; then
         rm -rf "${WAZUH_TMP_DIR}"
     fi
     mkdir -p "${WAZUH_TMP_DIR}"
+}
+
+backup_upgrade_preserve() {
+    if [ -e "${WAZUH_PRESERVE_DIR}" ]; then
+        echo "ERROR: Existing manager upgrade preserve backup found at ${WAZUH_PRESERVE_DIR}." >&2
+        echo "ERROR: Recover or move this directory before retrying the upgrade." >&2
+        exit 1
+    fi
+    mkdir -p "${WAZUH_PRESERVE_DIR}"
+
+    if [ -d "${DIR}/etc" ]; then
+        cp -a "${DIR}/etc" "${WAZUH_PRESERVE_DIR}/"
+    fi
+
+    if [ -d "${DIR}/data" ]; then
+        mkdir -p "${WAZUH_PRESERVE_DIR}/data"
+        for DATA_ENTRY in "${DIR}/data/"* "${DIR}/data/."[!.]* "${DIR}/data/"..?*; do
+            [ -e "${DATA_ENTRY}" ] || continue
+            DATA_NAME=$(basename "${DATA_ENTRY}")
+            [ "${DATA_NAME}" = "tzdb" ] && continue
+            cp -a "${DATA_ENTRY}" "${WAZUH_PRESERVE_DIR}/data/"
+        done
+    fi
 }
 
 case "$1" in
@@ -110,6 +131,8 @@ EOF
                 kill -15 $(pgrep -f wazuh-manager-authd)
             fi
 
+            backup_upgrade_preserve
+
             if [ -d ${DIR}/logs/ossec ]; then
                 mv ${DIR}/logs/ossec ${DIR}/logs/wazuh
             fi
@@ -149,10 +172,6 @@ EOF
                 cp -fp ${DIR}/api/configuration/api.yaml ${WAZUH_TMP_DIR}/api.yaml
             fi
 
-            # Agent-groups files
-            if [ -d ${DIR}/queue/agent-groups ]; then
-                mv -f ${DIR}/queue/agent-groups ${WAZUH_TMP_DIR}/
-            fi
         else
             # environment configuration (original behavior for install)
             prepare_tmp_dir
@@ -160,27 +179,6 @@ EOF
 
         if [ ! -z "$2" ] && [ ! -f ${DIR}/etc/wazuh-manager.conf ] ; then
             touch ${WAZUH_TMP_DIR}/create_conf
-        fi
-
-        # Delete old service
-        if [ -f /etc/init.d/ossec ]; then
-          rm /etc/init.d/ossec
-        fi
-
-        if [ -f ${DIR}/etc/client.keys ]; then
-            cp -p ${DIR}/etc/client.keys ${WAZUH_TMP_DIR}/client.keys
-        fi
-
-        if [ -f ${DIR}/etc/wazuh-manager-internal-options.conf ]; then
-            cp -p ${DIR}/etc/wazuh-manager-internal-options.conf ${WAZUH_TMP_DIR}/wazuh-manager-internal-options.conf
-        fi
-
-        if [ -f ${DIR}/etc/wazuh-manager.conf ]; then
-            cp -p ${DIR}/etc/wazuh-manager.conf ${WAZUH_TMP_DIR}/wazuh-manager.conf
-        fi
-
-        if [ -d ${DIR}/etc/shared ]; then
-            cp -rp ${DIR}/etc/shared ${WAZUH_TMP_DIR}/group
         fi
 
         if [ -d ${DIR}/var/db/agents ]; then

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -209,7 +209,7 @@ elif [ -f %{_localstatedir}/VERSION.json ]; then
 fi
 
 # Validate upgrade constraints for Agent (only during upgrade)
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   ERROR_TYPE=""
 
   # Determine if upgrade should be blocked
@@ -249,7 +249,7 @@ EOF
 fi
 
 # Stop the services to upgrade the package
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   if [ ! -d "%{_localstatedir}" ]; then
     echo "Error: Directory %{_localstatedir} does not exist. Cannot perform upgrade" >&2
     exit 1
@@ -266,6 +266,24 @@ if [ $1 = 2 ]; then
     touch %{_localstatedir}/tmp/wazuh.restart
   fi
   %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
+
+  UPGRADE_PRESERVE_DIR="%{_localstatedir}/tmp/agent_upgrade_preserve"
+  (
+    set -e
+    if [ -e "${UPGRADE_PRESERVE_DIR}" ]; then
+      echo "ERROR: Existing agent upgrade preserve backup found at ${UPGRADE_PRESERVE_DIR}." >&2
+      echo "ERROR: Recover or move this directory before retrying the upgrade." >&2
+      exit 1
+    fi
+    mkdir -p "${UPGRADE_PRESERVE_DIR}"
+
+    if [ -d "%{_localstatedir}/etc" ]; then
+      cp -a "%{_localstatedir}/etc" "${UPGRADE_PRESERVE_DIR}/"
+    fi
+  ) || {
+    echo "ERROR: Could not prepare agent upgrade preserve backup at ${UPGRADE_PRESERVE_DIR}." >&2
+    exit 1
+  }
 fi
 
 # Remove old databases if upgrading from pre 5.X to 5.X
@@ -280,7 +298,7 @@ fi
 
 %post
 
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
     rm -rf %{_localstatedir}/logs/wazuh
     cp -rp %{_localstatedir}/logs/ossec %{_localstatedir}/logs/wazuh
@@ -292,7 +310,7 @@ if [ $1 = 2 ]; then
   fi
 fi
 # If the package is being installed
-if [ $1 = 1 ]; then
+if [ "$1" -eq 1 ]; then
 
   touch %{_localstatedir}/logs/active-responses.log
   chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
@@ -323,9 +341,6 @@ fi
 
 # Delete the installation files used to configure the agent
 rm -rf %{_localstatedir}/packages_files
-
-# Remove unnecessary files from shared directory
-rm -f %{_localstatedir}/etc/shared/*.rpmnew
 
 #AlmaLinux
 if [ -r "/etc/almalinux-release" ]; then
@@ -594,16 +609,6 @@ fi
 
 DELETE_WAZUH_USER_AND_GROUP=0
 
-if [ $1 = 1 ]; then
-  if [ ! -f %{_localstatedir}/etc/client.keys ]; then
-    if [ -f %{_localstatedir}/etc/client.keys.rpmsave ]; then
-      mv %{_localstatedir}/etc/client.keys.rpmsave %{_localstatedir}/etc/client.keys
-    elif [ -f %{_localstatedir}/etc/client.keys.rpmnew ]; then
-      mv %{_localstatedir}/etc/client.keys.rpmnew %{_localstatedir}/etc/client.keys
-    fi
-  fi
-fi
-
 # If the package is been uninstalled or we want to delete wazuh user and group
 if [ $1 = 0 ] || [ $DELETE_WAZUH_USER_AND_GROUP = 1 ]; then
   # Remove the wazuh user if it exists
@@ -632,6 +637,22 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
+UPGRADE_PRESERVE_DIR="%{_localstatedir}/tmp/agent_upgrade_preserve"
+
+if [ -d "${UPGRADE_PRESERVE_DIR}" ]; then
+  (
+    set -e
+    if [ -d "${UPGRADE_PRESERVE_DIR}/etc" ]; then
+      mkdir -p "%{_localstatedir}/etc"
+      cp -a "${UPGRADE_PRESERVE_DIR}/etc/." "%{_localstatedir}/etc/"
+    fi
+  ) || {
+    echo "ERROR: Could not restore agent upgrade preserve backup; contents left at ${UPGRADE_PRESERVE_DIR}." >&2
+    exit 1
+  }
+  rm -rf "${UPGRADE_PRESERVE_DIR}"
+fi
+
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service
   systemctl daemon-reload > /dev/null 2>&1
@@ -685,10 +706,10 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/backup
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
-%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %{_localstatedir}/etc/client.keys
 %attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
 %attr(640, root, wazuh) %{_localstatedir}/etc/localtime
-%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
+%attr(640, root, wazuh) %{_localstatedir}/etc/local_internal_options.conf
 %attr(640, root, wazuh) %ghost %{_localstatedir}/etc/ossec.conf
 %attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -122,7 +122,7 @@ exit 0
 # ============================================================
 # HARD BLOCK: Prevent upgrade from 4.X to 5.X
 # ============================================================
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   # Check if this is an upgrade from 4.X
   if [ -f %{_sysconfdir}/ossec-init.conf ]; then
     . %{_sysconfdir}/ossec-init.conf
@@ -159,7 +159,7 @@ if ! getent passwd wazuh-manager > /dev/null 2>&1; then
 fi
 
 # Validate upgrade constraints for Manager (only during upgrade)
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   # Get version information
   if [ -f "%{_localstatedir}/bin/wazuh-manager-control" ]; then
     OLD_VERSION=`%{_localstatedir}/bin/wazuh-manager-control info -v 2>/dev/null`
@@ -209,7 +209,7 @@ EOF
 fi
 
 # Stop the services to upgrade the package
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-manager > /dev/null 2>&1; then
     systemctl stop wazuh-manager.service > /dev/null 2>&1
     touch %{_localstatedir}/tmp/wazuh.restart
@@ -225,9 +225,37 @@ if [ $1 = 2 ]; then
   elif [ -x %{_localstatedir}/bin/wazuh-control ]; then
     %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
   fi
-fi
-if pgrep -f wazuh-manager-authd > /dev/null 2>&1; then
+  if pgrep -f wazuh-manager-authd > /dev/null 2>&1; then
     kill -15 $(pgrep -f wazuh-manager-authd)
+  fi
+
+  UPGRADE_PRESERVE_DIR="%{_localstatedir}/tmp/manager_upgrade_preserve"
+  (
+    set -e
+    if [ -e "${UPGRADE_PRESERVE_DIR}" ]; then
+      echo "ERROR: Existing manager upgrade preserve backup found at ${UPGRADE_PRESERVE_DIR}." >&2
+      echo "ERROR: Recover or move this directory before retrying the upgrade." >&2
+      exit 1
+    fi
+    mkdir -p "${UPGRADE_PRESERVE_DIR}"
+
+    if [ -d "%{_localstatedir}/etc" ]; then
+      cp -a "%{_localstatedir}/etc" "${UPGRADE_PRESERVE_DIR}/"
+    fi
+
+    if [ -d "%{_localstatedir}/data" ]; then
+      mkdir -p "${UPGRADE_PRESERVE_DIR}/data"
+      for DATA_ENTRY in "%{_localstatedir}/data/"* "%{_localstatedir}/data/."[!.]* "%{_localstatedir}/data/"..?*; do
+        [ -e "${DATA_ENTRY}" ] || continue
+        DATA_NAME=$(basename "${DATA_ENTRY}")
+        [ "${DATA_NAME}" = "tzdb" ] && continue
+        cp -a "${DATA_ENTRY}" "${UPGRADE_PRESERVE_DIR}/data/"
+      done
+    fi
+  ) || {
+    echo "ERROR: Could not prepare manager upgrade preserve backup at ${UPGRADE_PRESERVE_DIR}." >&2
+    exit 1
+  }
 fi
 
 # Remove/relocate existing SQLite databases
@@ -255,7 +283,7 @@ if [ -d %{_localstatedir}/queue/agent-info ]; then
 fi
 
 # Delete old API backups
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   if [ -d %{_localstatedir}/~api ]; then
     rm -rf %{_localstatedir}/~api
   fi
@@ -291,7 +319,7 @@ fi
 %post
 
 # Upgrade install code block
-if [ $1 = 2 ]; then
+if [ "$1" -eq 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
     rm -rf %{_localstatedir}/logs/wazuh
     cp -rp %{_localstatedir}/logs/ossec %{_localstatedir}/logs/wazuh
@@ -305,7 +333,7 @@ if [ $1 = 2 ]; then
 fi
 
 # Fresh install code block
-if [ $1 = 1 ]; then
+if [ "$1" -eq 1 ]; then
 
   . %{_localstatedir}/packages_files/manager_installation_scripts/src/init/dist-detect.sh
 
@@ -353,9 +381,6 @@ chmod 0660 %{_localstatedir}/etc/wazuh-manager.conf
 
 # Delete the installation files used to configure the manager
 rm -rf %{_localstatedir}/packages_files
-
-# Remove unnecessary files from default group
-rm -f %{_localstatedir}/etc/shared/default/*.rpmnew
 
 # Remove old ossec user and group if exists and change ownwership of files
 
@@ -454,6 +479,31 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
+UPGRADE_PRESERVE_DIR="%{_localstatedir}/tmp/manager_upgrade_preserve"
+
+if [ -d "${UPGRADE_PRESERVE_DIR}" ]; then
+  (
+    set -e
+    if [ -d "${UPGRADE_PRESERVE_DIR}/etc" ]; then
+      mkdir -p "%{_localstatedir}/etc"
+      cp -a "${UPGRADE_PRESERVE_DIR}/etc/." "%{_localstatedir}/etc/"
+    fi
+
+    if [ -d "${UPGRADE_PRESERVE_DIR}/data" ]; then
+      mkdir -p "%{_localstatedir}/data"
+
+      for DATA_ENTRY in "${UPGRADE_PRESERVE_DIR}/data/"* "${UPGRADE_PRESERVE_DIR}/data/."[!.]* "${UPGRADE_PRESERVE_DIR}/data/"..?*; do
+        [ -e "${DATA_ENTRY}" ] || continue
+        cp -a "${DATA_ENTRY}" "%{_localstatedir}/data/"
+      done
+    fi
+  ) || {
+    echo "ERROR: Could not restore manager upgrade preserve backup; contents left at ${UPGRADE_PRESERVE_DIR}." >&2
+    exit 1
+  }
+  rm -rf "${UPGRADE_PRESERVE_DIR}"
+fi
+
 if [ -f %{_sysconfdir}/systemd/system/wazuh-manager.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-manager.service
   systemctl daemon-reload > /dev/null 2>&1
@@ -522,13 +572,13 @@ rm -fr %{buildroot}
 %attr(660, root, wazuh-manager) %ghost %{_localstatedir}/etc/wazuh-manager.conf
 %attr(640, root, root) %ghost %{_localstatedir}/etc/sslmanager.cert
 %attr(640, root, root) %ghost %{_localstatedir}/etc/sslmanager.key
-%attr(660, wazuh-manager, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/client.keys
-%attr(640, root, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/wazuh-manager-internal-options.conf
+%attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh-manager) %{_localstatedir}/etc/wazuh-manager-internal-options.conf
 %attr(640, root, wazuh-manager) %{_localstatedir}/etc/localtime
 %dir %attr(770, root, wazuh-manager) %{_localstatedir}/etc/shared
 %dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/default
 %attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/agent-template.conf
-%attr(660, wazuh-manager, wazuh-manager) %config(noreplace) %{_localstatedir}/etc/shared/default/*
+%attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/shared/default/*
 %dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/outputs
 %dir %attr(750, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/outputs/default
 %attr(640, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/outputs/default/*.yml


### PR DESCRIPTION
## Description

Implements a unified preserve / restore mechanism around Wazuh 5.x -> 5.x upgrades for the three packaging stacks (`.deb`, `.rpm`, and source via `install.sh`), so that the rules for what is preserved and what is overwritten stay consistent across methods.

Preservation rules applied during upgrades:

| Component | Path | Action |
|---|---|---|
| Manager | `etc/` | Preserve |
| Manager | `data/*` except `data/tzdb` | Preserve |
| Manager | `data/tzdb` | Overwrite |
| Agent | `etc/` | Preserve |
| Both | `bin/`, libraries, assets | Overwrite |

## Proposed Changes

### Common mechanism

The flow is the same in every stack:

1. **Before unpack** (preinst / `%pre` / `PrepareUpgradePreserve`): recursive copy of the component-specific preserved trees to a temporary preserve directory.
   - Manager: preserves `etc/` and `data/*` except `data/tzdb`.
   - Agent: preserves `etc/` only.
2. The package manager / `InstallWazuh` unpacks files and overwrites the install tree.
3. **As the last content-restore/overwrite step for the preserved trees** (postinst / `%posttrans` / `RestoreUpgradePreserve`): the preserved content is copied back over the install tree. Permission normalization may still run afterwards.

File contents are preserved for the paths listed above. Permissions and ownership are normalized back to the installation baseline after restore, the exact mechanism differs per stack (see the stack-specific sections below).

### `.deb`  preinst / postinst

`packages/debs/SPECS/wazuh-{manager,agent}/debian/preinst`
- New `backup_upgrade_preserve` function that creates `${DIR}/packages_files/{manager,agent}_upgrade_preserve`.
- Manager copies `etc/` and `data/*` except `data/tzdb` with `cp -a`.
- Agent copies `etc/` only with `cp -a`.
- If a previous preserve directory still exists, the upgrade aborts instead of overwriting possible recovery data.
- Removed the per-file ad-hoc backups (`client.keys`, `ossec.conf`, `wazuh-manager-internal-options.conf`, `etc/shared/group/*`) covered by the full `etc/` backup.
- Removed dead backup/restore of `queue/agent-groups` from the manager preinst/postinst: the directory is not created by any component in 5.x, so the `if [ -d ... ]` block never entered.

`packages/debs/SPECS/wazuh-{manager,agent}/debian/postinst`
- New `restore_upgrade_preserve` function that restores the preserved content.
- **The call is made at the end of postinst**, just before `merged.mg` chmod / `restore-permissions.sh`, to match the ordering of `%posttrans` in RPM and to honor the strict "etc/ MUST NOT be overwritten" contract.
- Removed the corresponding per-file restores that matched the backups removed in preinst.

`packages/debs/SPECS/wazuh-{manager,agent}/debian/postrm`
- Defensive cleanup of the preserve directory on remove/deconfigure.
- On `failed-upgrade` / `abort-upgrade`, the preserve directory is kept and its path is printed for manual recovery.

### `.rpm`  wazuh-{manager,agent}.spec

`%pre` (when `$1 = 2`)
- Creates `%{_localstatedir}/tmp/{manager,agent}_upgrade_preserve`.
- Manager backs up `etc/` + `data/*` except `data/tzdb`.
- Agent backs up `etc/` only.
- If a previous preserve directory still exists, the transaction aborts instead of overwriting possible recovery data.
- The block is wrapped in a subshell with `set -e` and `|| { echo ERROR; exit 1; }` so that the transaction aborts if a critical operation fails, instead of silently continuing with a partial backup.

`%posttrans`
- Restores preserved `etc/` and, for manager only, preserved `data/*` from the preserve. Same `set -e` protection as `%pre`. If restore fails, the script exits with an error and the preserve directory is left in place for manual recovery.
- After restore, applies chown/chmod to `wazuh-manager.conf`, `wazuh-manager-internal-options.conf`, `client.keys` (manager) / `ossec.conf`, `local_internal_options.conf`, `client.keys` (agent), and normalizes `merged.mg` to 0644 in the manager.

`%files`
- Removed `%config(noreplace)` from the files now handled by the preserve mechanism (`client.keys`, `wazuh-manager-internal-options.conf`, `etc/shared/default/*`, `local_internal_options.conf`).
- Removed the `client.keys.rpmsave/.rpmnew` recovery in the agent `%post` and the `*.rpmnew` cleanup in the manager `%post`  no longer relevant without `%config`.

### Source  `install.sh`

- New functions `PrepareUpgradePreserve`, `RestoreUpgradePreserve`, `CleanupUpgradePreserve`, `PrepareErrorExit`, `RestoreErrorExit`, `HandleUpgradeInterrupt`.
- In `Install()`, when `update_only=yes` and `INSTYPE` is `manager` or `agent`, `PrepareUpgradePreserve` runs before `InstallWazuh` and `RestoreUpgradePreserve` runs after.
- `PrepareUpgradePreserve` creates the preserve directory with `mktemp -d` under `${TMPDIR:-/tmp}` using the pattern `wazuh-${INSTYPE}-upgrade-preserve.XXXXXX`.
- Manager source upgrades preserve `etc/` and `data/*` except `data/tzdb`; agent source upgrades preserve `etc/` only.
- A trap on `HUP/INT/TERM` is installed pointing at `HandleUpgradeInterrupt`  if the user interrupts the script with `Ctrl+C` during `InstallWazuh`, the trap attempts to restore from preserve before exiting; if the restore fails, the preserve directory is left on disk and its path is printed for manual recovery.
- The trap is cleared right before the explicit call to `RestoreUpgradePreserve` to avoid recursion if the restore itself fails.
- The backup uses `cp -a` when available (detected at startup via a test using two distinct paths created with `mktemp -d`), falling back to `cp -Rp`. The supported source-upgrade platforms provide `mktemp`; the previous predictable `/tmp` fallback was removed to avoid unsafe root writes/removals.
- The restore uses `cp -R` (without `-p`): for files that `InstallWazuh` already created in the install tree, `cp -R` overwrites only the content and leaves the permissions and ownership set by the installer untouched. For custom files present only in the backup (not installed by the package), they are created with default permissions (backup mode minus umask) owned by root.
- DEB and RPM abort if they find an existing preserve backup from a previous attempt. Source upgrades create a new temporary preserve directory for each attempt, so an older source preserve directory does not block a retry, but it should still be removed after manual recovery.

### CI  End-to-end tests

`.github/actions/5_builderpackage_manager-upgrade-rules-test/`  new reusable composite action with `prepare`, `validate`, and `run` modes, plus a `component` input (`manager` or `agent`):
- **`prepare`**: appends markers to the component-specific preserved files, writes custom files, deletes selected package-managed files, and alters the contents of a binary. For manager it also marks preserved `data/*` paths and `data/tzdb/iana/version`. For agent it only marks `etc/`, because the agent does not install `data/` or `data/tzdb`.
- **`validate`**: after the upgrade checks that markers are preserved in the expected preserved trees, that `tzdb` (manager only) and the binary match the target package, and that deleted package-managed files are reinstalled from the package.
- **`run`**: starts a test container, installs the old package, prepares markers, upgrades to the target package, and validates the result. This mode is used by the agent workflows after the smoke upgrade test.
- The composite action passes mode/system/package path as positional shell parameters to avoid re-parsing action inputs inside the `bash -lc` command string.

`.github/workflows/5_builderpackage_manager.yml`
- The upgrade test step now runs unconditionally, not only when a previous public release exists. When it doesn't, the package itself is used as baseline (`rpm -Uvh --replacepkgs` to force `$1=2` in RPM).
- The container is renamed from `wazuh_previous` to `wazuh_upgrade_rules` and exposed as the `UPGRADE_CONTAINER` env var.
- Added the steps `Prepare manager upgrade rule checks` and `Validate manager upgrade rule checks` before and after the upgrade.

`.github/workflows/5_builderpackage_agent-linux.yml` and `.github/workflows/5_builderpackage_agent-linux-arm64.yml`
- Added `Test agent upgrade rule checks` after the smoke upgrade test, reusing the same composite action in `run` mode with `component: agent`.
- The agent upgrade-rule test validates `etc/` preservation plus binary/package-managed file overwrite behavior, without creating or checking `data/` markers.

### Results and Evidence


Manual validation focused on the upgrade preservation contract:

| Stack | Component | Result |
|---|---|---|
| DEB package | Manager / Agent | CI & Manual validation. |
| RPM package | Manager / Agent | CI & Manual validation. |
| Source install | Manager / Agent | Manual validation. |

Expected behavior:

- Preserve `etc/`.
- Preserve `data/*`, except `data/tzdb`.
- Replace `data/tzdb`.
- Replace binaries and package/source-managed assets.
- Leave no temporary preserve directories after a successful upgrade.


<details>
<summary>Manual DEB manager upgrade evidence</summary>

### MANAGER

Fresh install:

```console
/var/wazuh-manager/etc/
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── localtime
├── outputs
│   └── default
│       ├── file-output-integrations.yml
│       └── indexer.yml
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf

6 directories, 14 files
```
Create markers: and delete directory: 

```console

sudo sh -c "printf '\n# DEB_MGR_ETC_MARKER\n' >> /var/wazuh-manager/etc/wazuh-manager.conf"
sudo sh -c "printf 'DEB_MGR_ETC_CUSTOM\n' > /var/wazuh-manager/etc/custom-deb-marker"
sudo sh -c "printf 'DEB_MGR_DATA_MARKER\n' > /var/wazuh-manager/data/custom-deb-marker"
sudo sh -c "printf 'DEB_MGR_TZDB_MARKER\n' > /var/wazuh-manager/data/tzdb/iana/version"
rm -rf /var/wazuh-manager
```
```console
/var/wazuh-manager/etc/
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── custom-deb-marker
├── localtime
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf

4 directories, 13 files
```
Upgrade:

```console
root@manager:~# dpkg -i wazuh-manager_5.0.0-latest_amd64.deb
(Reading database ... 161024 files and directories currently installed.)
Preparing to unpack wazuh-manager_5.0.0-latest_amd64.deb ...
Unpacking wazuh-manager (5.0.0-0) over (5.0.0-0) ...
Setting up wazuh-manager (5.0.0-0) ...

```
Verify results:

```console

grep -q 'DEB_MGR_ETC_MARKER' /var/wazuh-manager/etc/wazuh-manager.conf \
  && echo "OK manager etc conf preserved" || echo "ERROR manager etc conf lost"

grep -q 'DEB_MGR_ETC_CUSTOM' /var/wazuh-manager/etc/custom-deb-marker \
  && echo "OK manager custom etc preserved" || echo "ERROR manager custom etc lost"

grep -q 'DEB_MGR_DATA_MARKER' /var/wazuh-manager/data/custom-deb-marker \
  && echo "OK manager data preserved" || echo "ERROR manager data lost"

grep -q 'DEB_MGR_TZDB_MARKER' /var/wazuh-manager/data/tzdb/iana/version \
  && echo "ERROR manager tzdb preserved" || echo "OK manager tzdb overwritten"
```

```text
OK manager etc conf preserved
OK manager custom etc preserved
OK manager data preserved
OK manager tzdb overwritten
```
```console
/var/wazuh-manager/etc/
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── custom-deb-marker
├── localtime
├── outputs
│   └── default
│       ├── file-output-integrations.yml
│       └── indexer.yml
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
├── wazuh-manager.conf.new
└── wazuh-manager-internal-options.conf

6 directories, 16 files
```


### AGENT
Fresh install:

```console
/var/ossec/etc/
├── client.keys
├── internal_options.conf
├── local_internal_options.conf
├── localtime
├── ossec.conf
├── shared
│   ├── agent.conf
│   └── merged.mg
└── wpk_root.pem

2 directories, 8 files
```
Create markers
```console
sudo sh -c "printf '\n# DEB_AGENT_ETC_MARKER\n' >> /var/ossec/etc/ossec.conf"
sudo sh -c "printf 'DEB_AGENT_ETC_CUSTOM\n' > /var/ossec/etc/custom-deb-marker"
sudo sh -c "printf 'DEB_AGENT_SHARED_CUSTOM\n' > /var/ossec/etc/shared/custom-deb-marker"
```
```console
var/ossec/etc/
├── client.keys
├── custom-deb-marker
├── internal_options.conf
├── local_internal_options.conf
├── localtime
├── ossec.conf
├── shared
│   ├── agent.conf
│   ├── custom-deb-marker
│   └── merged.mg
└── wpk_root.pem

2 directories, 10 files
```
Upgrade:

```console
dpkg -i wazuh-agent_5.0.0-0_amd64_12bbbc8.deb
(Reading database ... 161410 files and directories currently installed.)
Preparing to unpack wazuh-agent_5.0.0-0_amd64_12bbbc8.deb ...
Unpacking wazuh-agent (5.0.0-0) over (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
```
```console
/var/ossec/etc/
├── client.keys
├── custom-deb-marker
├── internal_options.conf
├── local_internal_options.conf
├── localtime
├── ossec.conf
├── ossec.conf.new
├── shared
│   ├── agent.conf
│   ├── custom-deb-marker
│   └── merged.mg
└── wpk_root.pem

2 directories, 11 files
```
Verify results:

```console
grep -q 'DEB_AGENT_ETC_MARKER' /var/ossec/etc/ossec.conf \
  && echo "OK agent ossec.conf preserved" || echo "ERROR agent ossec.conf lost"

grep -q 'DEB_AGENT_ETC_CUSTOM' /var/ossec/etc/custom-deb-marker \
  && echo "OK agent custom etc preserved" || echo "ERROR agent custom etc lost"

grep -q 'DEB_AGENT_SHARED_CUSTOM' /var/ossec/etc/shared/custom-deb-marker \
  && echo "OK agent shared preserved" || echo "ERROR agent shared lost"
```

```text
OK agent ossec.conf preserved
OK agent custom etc preserved
OK agent shared preserved
```

### E2E

Comman executed in order to create 20 findings:

```console
sudo apt install --only-upgrade openssl -y
```

Functional E2E:

<img width="1911" height="997" alt="image" src="https://github.com/user-attachments/assets/ecb11dc7-304f-48f9-8b57-bdc11948cb8d" />


</details>


<details>
<summary>RPM package upgrade evidence</summary>


### MANAGER

Fresh install:

```console
/var/wazuh-manager/etc
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── localtime
├── outputs
│   └── default
│       ├── file-output-integrations.yml
│       └── indexer.yml
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf

5 directories, 14 files

```
Create markers: and delete directory: 

```console
sudo sh -c "printf '\n# RPM_MGR_ETC_MARKER\n' >> /var/wazuh-manager/etc/wazuh-manager.conf"
sudo sh -c "printf 'RPM_MGR_ETC_CUSTOM\n' > /var/wazuh-manager/etc/custom-rpm-marker"
sudo sh -c "printf 'RPM_MGR_DATA_MARKER\n' > /var/wazuh-manager/data/custom-rpm-marker"
sudo sh -c "printf 'RPM_MGR_TZDB_MARKER\n' > /var/wazuh-manager/data/tzdb/iana/version"

rm -rf /var/wazuh-manager/etc/outputs
```
```console
/var/wazuh-manager/etc
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── custom-rpm-marker
├── localtime
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf

3 directories, 13 files

```
Upgrade:

```console
[root@rpmManager ~]# sudo rpm -Uvh --replacepkgs ./wazuh-manager-5.0.0-latest.x86_64.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-manager-5.0.0-0            ################################# [ 50%]
Cleaning up / removing...
   2:wazuh-manager-5.0.0-0            ################################# [100%]

```
Verify results:

```console

grep -q 'RPM_MGR_ETC_MARKER' /var/wazuh-manager/etc/wazuh-manager.conf \
  && echo "OK manager etc conf preserved" || echo "ERROR manager etc conf lost"

grep -q 'RPM_MGR_ETC_CUSTOM' /var/wazuh-manager/etc/custom-rpm-marker \
  && echo "OK manager custom etc preserved" || echo "ERROR manager custom etc lost"

grep -q 'RPM_MGR_DATA_MARKER' /var/wazuh-manager/data/custom-rpm-marker \
  && echo "OK manager data preserved" || echo "ERROR manager data lost"

grep -q 'RPM_MGR_TZDB_MARKER' /var/wazuh-manager/data/tzdb/iana/version \
  && echo "ERROR manager tzdb preserved" || echo "OK manager tzdb overwritten"
```

```text
OK manager etc conf preserved
OK manager custom etc preserved
OK manager data preserved
OK manager tzdb overwritten
```
```console
/var/wazuh-manager/etc
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── custom-rpm-marker
├── localtime
├── outputs
│   └── default
│       ├── file-output-integrations.yml
│       └── indexer.yml
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf

5 directories, 15 files

```


### AGENT
Fresh install:

```console
/var/ossec/etc/
├── client.keys
├── internal_options.conf
├── local_internal_options.conf
├── localtime
├── ossec.conf
├── shared
└── wpk_root.pem

1 directory, 6 files

```
Create markers
```console
sudo sh -c "printf '\n# RPM_AGENT_ETC_MARKER\n' >> /var/ossec/etc/ossec.conf"
sudo sh -c "printf 'RPM_AGENT_ETC_CUSTOM\n' > /var/ossec/etc/custom-rpm-marker"
sudo sh -c "printf 'RPM_AGENT_SHARED_CUSTOM\n' > /var/ossec/etc/shared/custom-rpm-marker"
```
```console
/var/ossec/etc/
├── client.keys
├── custom-rpm-marker
├── internal_options.conf
├── local_internal_options.conf
├── localtime
├── ossec.conf
├── shared
│   └── custom-rpm-marker
└── wpk_root.pem

1 directory, 8 files

```
Upgrade:

```console
[root@rpmManager ~]# sudo rpm -Uvh --replacepkgs ./wazuh-agent_5.0.0-0_x86_64_12bbbc8.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-5.0.0-0              ################################# [ 50%]
Cleaning up / removing...
   2:wazuh-agent-5.0.0-0              ################################# [100%]
```
```console
/var/ossec/etc/
├── client.keys
├── custom-rpm-marker
├── internal_options.conf
├── local_internal_options.conf
├── localtime
├── ossec.conf
├── shared
│   └── custom-rpm-marker
└── wpk_root.pem

1 directory, 8 files

```
Verify results:

```console
grep -q 'RPM_AGENT_ETC_MARKER' /var/ossec/etc/ossec.conf \
  && echo "OK agent ossec.conf preserved" || echo "ERROR agent ossec.conf lost"

grep -q 'RPM_AGENT_ETC_CUSTOM' /var/ossec/etc/custom-rpm-marker \
  && echo "OK agent custom etc preserved" || echo "ERROR agent custom etc lost"

grep -q 'RPM_AGENT_SHARED_CUSTOM' /var/ossec/etc/shared/custom-rpm-marker \
  && echo "OK agent shared preserved" || echo "ERROR agent shared lost"
```

```text
OK agent ossec.conf preserved
OK agent custom etc preserved
OK agent shared preserved
```


</details>

</details>

<details>
<summary>Source manager and agent upgrade evidence</summary>

### Manager

The manager was able to start after installing the required certificates:

```text
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/etc/systemd/system/wazuh-manager.service; enabled; preset: enabled)
     Active: active (running)
```
Before :

```console
/var/wazuh-manager/etc/
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── localtime
├── outputs
│   └── default
│       ├── file-output-integrations.yml
│       └── indexer.yml
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf
```

Markers were added to preserved paths, overwritten paths, and `data/tzdb`. A package/source-managed `etc/outputs` directory was also removed before the upgrade to verify it is installed again by the source installer.

```bash
/var/wazuh-manager/bin/wazuh-manager-control stop || true
systemctl stop wazuh-manager || true

printf '\n# SRC_ETC_MARKER\n' >> /var/wazuh-manager/etc/wazuh-manager.conf
printf 'SRC_ETC_CUSTOM_MARKER\n' > /var/wazuh-manager/etc/custom-src-marker
printf 'SRC_DATA_MARKER\n' > /var/wazuh-manager/data/custom-src-marker
printf 'SRC_TZDB_MARKER\n' > /var/wazuh-manager/data/tzdb/iana/version
printf 'SRC_BINARY_MARKER\n' > /var/wazuh-manager/bin/wazuh-manager-analysisd
chmod 750 /var/wazuh-manager/bin/wazuh-manager-analysisd

rm -rf /var/wazuh-manager/etc/outputs
```

The `etc/outputs` directory was removed before the upgrade to verify that source-managed directories are recreated by the installer:



Command:
`rm -rf /var/wazuh-manager/etc/outputs`

After:  deletion + markers:

```console
/var/wazuh-manager/etc/
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── custom-src-marker
├── localtime
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf
```

The source upgrade was executed through the normal installer flow and `Update existing installation` was selected:

```text
1- Installation type:
   1) manager
   2) agent
   Select an option [1-2]: 1

2- Existing manager installation detected at:
   /var/wazuh-manager
   1) Update existing installation
   2) Clean install in same directory (existing data will be removed)
   3) Exit
   Select an option [1-3]: 1
```

Validation after upgrade:

```text
OK manager etc
OK manager data
OK manager tzdb overwritten
OK manager binary overwritten
```

The deleted `etc/outputs` directory was installed again, while the custom `etc/` marker remained present:

```console
/var/wazuh-manager/etc/
├── certs
│   ├── manager-key.pem
│   ├── manager.pem
│   └── root-ca.pem
├── client.keys
├── custom-src-marker
├── localtime
├── outputs
│   └── default
│       ├── file-output-integrations.yml
│       └── indexer.yml
├── shared
│   ├── agent-template.conf
│   └── default
│       ├── agent.conf
│       ├── agent-template.conf
│       └── merged.mg
├── sslmanager.cert
├── sslmanager.key
├── wazuh-manager.conf
└── wazuh-manager-internal-options.conf
```

### Agent

Markers were added to preserved `etc/` paths and to an overwritten binary:

```bash
/var/ossec/bin/wazuh-control stop || true
systemctl stop wazuh-agent || true

printf '\n# SRC_ETC_MARKER\n' >> /var/ossec/etc/ossec.conf
printf 'SRC_ETC_CUSTOM_MARKER\n' > /var/ossec/etc/custom-src-marker
printf 'SRC_SHARED_CUSTOM_MARKER\n' > /var/ossec/etc/shared/custom-src-marker
printf 'SRC_BINARY_MARKER\n' > /var/ossec/bin/wazuh-agentd
chmod 750 /var/ossec/bin/wazuh-agentd
```

The source upgrade was executed through the normal installer flow and `Update existing installation` was selected:

```text
1- Installation type:
   1) manager
   2) agent
   Select an option [1-2]: 2

2- Existing agent installation detected at:
   /var/ossec
   1) Update existing installation
   2) Clean install in same directory (existing data will be removed)
   3) Exit
   Select an option [1-3]: 1
```

Validation after upgrade:

```text
OK agent etc
OK agent custom etc
OK agent shared
OK agent binary overwritten
```

### Clean install note

`Clean install in same directory` is intentionally outside the upgrade-preservation contract. If that option is selected, losing the `etc/` and `data/` markers is expected because the existing installation is removed/recreated.

Clean install was also exercised as a sanity check to ensure the new upgrade-preserve logic does not affect the clean-install path or introduce log/startup errors.

```text
2- Existing manager installation detected at:
   /var/wazuh-manager
   1) Update existing installation
   2) Clean install in same directory (existing data will be removed)
   3) Exit
   Select an option [1-3]: 2

 - Configuration finished properly.
```

Expected clean-install result:

```text
Custom markers under etc/ and data/ are removed.
Managed binaries are installed from the source tree.
No upgrade preserve directory is created or restored.
No log-related installation error is emitted.
```

</details>



### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Manager `.deb` package (`wazuh-manager`)
- Agent `.deb` package (`wazuh-agent`)
- Manager `.rpm` package (`wazuh-manager`)
- Agent `.rpm` package (`wazuh-agent`)
- Source-based install / upgrade (`install.sh` with `update_only=yes`)


### Configuration Changes

Behavior changes vs. previous version.

- During upgrades, files under `etc/` are **always** preserved, including `localtime` and `TIMEZONE`. Previously, the DEB postinst overwrote these two with the host's copy on every upgrade. They are now kept as the user's, in line with the "etc/ MUST NOT be overwritten" contract.
- On RPM, files that used to be `%config(noreplace)` (`client.keys`, `wazuh-manager-internal-options.conf`, `etc/shared/default/*`, `local_internal_options.conf`) are no longer treated that way by RPM. Preservation is performed by the preserve mechanism. Consequence: users who **did not** modify these files keep the old default rather than adopting the new one shipped by the package. If a new version introduces improvements in default values, they must be adopted manually.
- Temporary disk space requirement during the upgrade: for manager, approximately the current size of `etc/` + `data/` excluding `tzdb`; for agent, approximately the current size of `etc/`. The preserve directory lives under `${INSTALLDIR}/packages_files/` (DEB), `${INSTALLDIR}/tmp/` (RPM), or `${TMPDIR:-/tmp}/wazuh-${INSTYPE}-upgrade-preserve.*` (source).

### Tests Introduced

- Composite action `5_builderpackage_manager-upgrade-rules-test` with `prepare` / `validate` / `run` modes, integrated into the manager build workflow and reused by the agent workflows.
- The same composite action is reused for the agent workflows in `run` mode after the existing smoke upgrade test.
- Manager coverage: `wazuh-manager.conf`, `wazuh-manager-internal-options.conf`, `client.keys`, `shared/agent-template.conf`, `shared/default/agent.conf`, `etc/outputs/default/*.yml`, `etc/custom-*`, `data/mmdb/*`, `data/store/{enrichment,geo,schema}/*`, `data/custom-*`, `data/tzdb/iana/version`, `bin/wazuh-manager-analysisd`, plus a deleted file that gets reinstalled from the package.
- Agent coverage: `etc/ossec.conf`, `etc/local_internal_options.conf`, `etc/client.keys`, `etc/custom-*`, `etc/shared/custom-*`, `etc/internal_options.conf` (deleted and reinstalled), `bin/wazuh-agentd`. The agent test intentionally does not include `data/` or `data/tzdb` because those paths are not installed by the agent.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
