### PR TITLE
Persist VD first-sync state in table_metadata

### DIFF
--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -149,11 +149,14 @@ class EXPORTED Syscollector final
         std::vector<std::string> getDataContextTables(Operation operation, const std::string& index);
 
         /**
-         * @brief Checks if the first VD sync has been completed
+         * @brief Checks if the first VD sync has been completed.
+         * @details The state is persisted in @c table_metadata under the
+         *          @c vd_first_sync_completed key as an epoch-seconds timestamp;
+         *          any value > 0 means the first VD sync already completed.
          * @return true if first VD sync is done, false if this is the first scan (VDFIRST)
          */
-        bool isVDFirstSyncDone() const;
-        void createVDFirstSyncFlagIfNeeded(const bool vdResult, const bool firstSyncDone) const;
+        bool isVDFirstSyncDone();
+        void persistVDFirstSyncIfNeeded(const bool vdResult, const bool firstSyncDone);
         /**
          * @brief Processes VD DataContext after scan completes
          * @details Queries the VD sync protocol database for pending DataValue items,

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -16,7 +16,6 @@
 #include "timeHelper.h"
 #include <cstdint>
 #include <iostream>
-#include <fstream>
 #include <stack>
 #include <set>
 #include <chrono>
@@ -90,6 +89,7 @@ constexpr auto QUEUE_SIZE
 
 constexpr auto SYSCOLLECTOR_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
 constexpr auto SYSCOLLECTOR_FIRST_SCAN_COMPLETED_METADATA_KEY {"first_scan_completed"};
+constexpr auto SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY {"vd_first_sync_completed"};
 
 static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
 {
@@ -148,10 +148,6 @@ static const std::map<std::string, std::string> AGENTD_TO_INDEX_MAP
     {"browser_extensions", SYSCOLLECTOR_SYNC_INDEX_BROWSER_EXTENSIONS},
     // LCOV_EXCL_STOP
 };
-
-// VD (Vulnerability Detection) flag file path
-// This file is created after the first successful VD sync to distinguish VDFIRST from VDSYNC
-static constexpr auto VD_FIRST_SYNC_FLAG_FILE = "queue/syscollector/db/.vd_first_sync_done";
 
 static void sanitizeJsonValue(nlohmann::json& input)
 {
@@ -2287,7 +2283,7 @@ bool Syscollector::syncModule(Mode mode)
 
         bool vdSuccess = m_spSyncProtocolVD->synchronizeModule(mode, vdOption);
 
-        createVDFirstSyncFlagIfNeeded(vdSuccess, firstSyncDone);
+        persistVDFirstSyncIfNeeded(vdSuccess, firstSyncDone);
 
         success = vdSuccess && success;
     }
@@ -2511,51 +2507,36 @@ std::vector<std::string> Syscollector::getDataContextTables(Operation operation,
     return tables;
 }
 
-bool Syscollector::isVDFirstSyncDone() const
+bool Syscollector::isVDFirstSyncDone()
 {
-    std::ifstream flagCheck(VD_FIRST_SYNC_FLAG_FILE);
-    bool firstSyncDone = flagCheck.good();
-    flagCheck.close();
-    return firstSyncDone;
+    int64_t vdFirstSyncCompleted = 0;
+    return getMetadataValue(SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY, vdFirstSyncCompleted)
+           && vdFirstSyncCompleted > 0;
 }
 
-void Syscollector::createVDFirstSyncFlagIfNeeded(const bool vdResult, const bool firstSyncDone) const
+void Syscollector::persistVDFirstSyncIfNeeded(const bool vdResult, const bool firstSyncDone)
 {
-    // Create the VD first-sync flag after a successful first VD flush.
     if (vdResult && !firstSyncDone && !m_stopping.load())
     {
-        if (m_logFunction)
-        {
-            m_logFunction(LOG_DEBUG, "VD first flush successful, attempting to create flag file: " + std::string(VD_FIRST_SYNC_FLAG_FILE));
-        }
-
-        std::ofstream flagFile(VD_FIRST_SYNC_FLAG_FILE);
-
-        if (flagFile.is_open())
-        {
-            flagFile << "1";
-            flagFile.close();
-
-            if (m_logFunction)
-            {
-                m_logFunction(LOG_INFO, "VD first sync completed (via flush), flag file created");
-            }
-        }
-        else
+        if (updateMetadataValue(SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch()))
         {
             if (m_logFunction)
             {
-                m_logFunction(LOG_ERROR, "Failed to create VD flag file: " + std::string(VD_FIRST_SYNC_FLAG_FILE));
+                m_logFunction(LOG_INFO, "VD first sync completed, metadata marker persisted.");
             }
+        }
+        else if (m_logFunction)
+        {
+            m_logFunction(LOG_ERROR, "Failed to persist VD first sync metadata marker.");
         }
     }
     else if (m_stopping.load() && vdResult && !firstSyncDone)
     {
-        m_logFunction(LOG_DEBUG, "VD first sync successful but module is stopping, flag file not created");
+        m_logFunction(LOG_DEBUG, "VD first sync successful but module is stopping, metadata marker not persisted.");
     }
     else if (!vdResult)
     {
-        m_logFunction(LOG_DEBUG, "VD sync was not successful, flag file not created");
+        m_logFunction(LOG_DEBUG, "VD sync was not successful, metadata marker not persisted.");
     }
 }
 
@@ -2846,7 +2827,7 @@ int Syscollector::executeFlushSync()
 
         vdResult = m_spSyncProtocolVD->synchronizeModule(Mode::DELTA, vdOption);
 
-        createVDFirstSyncFlagIfNeeded(vdResult, firstSyncDone);
+        persistVDFirstSyncIfNeeded(vdResult, firstSyncDone);
     }
 
     const bool overallSuccess = result && vdResult;
@@ -3190,6 +3171,22 @@ std::string Syscollector::query(const std::string& jsonQuery)
             {
                 response["error"] = MQ_ERR_INTERNAL;
                 response["message"] = "Failed to retrieve Syscollector first scan completion";
+            }
+        }
+        else if (command == "get_vd_first_sync_completed")
+        {
+            int64_t vdFirstSyncCompleted = 0;
+
+            if (getMetadataValue(SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY, vdFirstSyncCompleted))
+            {
+                response["error"] = MQ_SUCCESS;
+                response["message"] = "Syscollector VD first sync completion retrieved";
+                response["data"]["vd_first_sync_completed"] = vdFirstSyncCompleted > 0 ? 1 : 0;
+            }
+            else
+            {
+                response["error"] = MQ_ERR_INTERNAL;
+                response["message"] = "Failed to retrieve Syscollector VD first sync completion";
             }
         }
         else if (command == "set_version")

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -11,10 +11,9 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
-#include <filesystem>
 #include <functional>
 #include <future>
-#include <fstream>
+#include <memory>
 #include <sqlite3.h>
 #include <thread>
 
@@ -28,7 +27,6 @@
 
 constexpr auto SYSCOLLECTOR_DB_PATH {":memory:"};
 constexpr auto SYSCOLLECTOR_TEST_DB_PATH {"syscollector_test.db"};
-constexpr auto VD_FIRST_SYNC_FLAG_FILE {"queue/syscollector/db/.vd_first_sync_done"};
 
 // Mock SchemaValidatorEngine for dependency injection in tests
 class MockSchemaValidatorEngine : public SchemaValidator::ISchemaValidatorEngine
@@ -193,7 +191,6 @@ const auto expected_dbsync_browser_extensions
 void SyscollectorImpTest::SetUp()
 {
     std::remove(SYSCOLLECTOR_TEST_DB_PATH);
-    std::remove(VD_FIRST_SYNC_FLAG_FILE);
 
     // Initialize SchemaValidatorFactory with mocks to prevent issues in Wine/Windows tests
     // This ensures all tests use mock validators instead of loading real embedded schemas
@@ -230,7 +227,6 @@ void SyscollectorImpTest::SetUp()
 void SyscollectorImpTest::TearDown()
 {
     std::remove(SYSCOLLECTOR_TEST_DB_PATH);
-    std::remove(VD_FIRST_SYNC_FLAG_FILE);
 
     // Ensure Syscollector singleton is destroyed after each test
     // This prevents stale function pointer issues between tests
@@ -2984,21 +2980,56 @@ TEST_F(SyscollectorImpTest, executeFlushSync_VDEnabled_FirstSyncNotDone_FlushSuc
 
 TEST_F(SyscollectorImpTest, executeFlushSync_VDEnabled_FirstSyncAlreadyDone_FlushSucceeds)
 {
-    std::filesystem::create_directories("queue/syscollector/db");
-    {
-        std::ofstream flag(VD_FIRST_SYNC_FLAG_FILE);
-        ASSERT_TRUE(flag.is_open()) << "Could not create VD first-sync flag file for test setup";
-    }
-
     const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
     EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    // Initialize once to create the schema (including table_metadata), then destroy to
+    // release the DB so we can seed the VD first-sync marker directly.
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600,
+                                  false,    // scanOnStart
+                                  false,    // hardware
+                                  true,     // os
+                                  false,    // network
+                                  true,     // packages
+                                  false,    // ports
+                                  false,    // portsAll
+                                  false,    // processes
+                                  false,    // hotfixes
+                                  false,    // groups
+                                  false,    // users
+                                  false,    // services
+                                  false,    // browserExtensions
+                                  false);   // notifyOnFirstScan
+    Syscollector::instance().destroy();
+
+    {
+        sqlite3* rawDb = nullptr;
+        ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &rawDb, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+        std::unique_ptr<sqlite3, decltype(&sqlite3_close)> db {rawDb, &sqlite3_close};
+
+        char* rawErrMsg = nullptr;
+        const int execResult = sqlite3_exec(db.get(),
+                                            "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('vd_first_sync_completed', 123456);",
+                                            nullptr,
+                                            nullptr,
+                                            &rawErrMsg);
+        std::unique_ptr<char, decltype(&sqlite3_free)> errMsg {rawErrMsg, &sqlite3_free};
+        ASSERT_EQ(execResult, SQLITE_OK) << (errMsg ? errMsg.get() : "");
+    }
 
     Syscollector::instance().init(spInfoWrapper,
                                   reportFunction,
                                   persistFunction,
                                   logFunction,
-                                  SYSCOLLECTOR_DB_PATH,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
                                   "",
                                   "",
                                   3600,
@@ -5721,4 +5752,131 @@ TEST_F(SyscollectorImpTest, destroyWaitsForOngoingFlush)
     destroyThread.join();
 
     EXPECT_TRUE(destroyDone);
+}
+
+TEST_F(SyscollectorImpTest, queryCommandGetVDFirstSyncCompletedDefaultsToFalse)
+{
+    // No VD sync has run and no marker is present: expect vd_first_sync_completed == 0.
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    std::string response = Syscollector::instance().query(R"({"command":"get_vd_first_sync_completed"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["vd_first_sync_completed"], 0);
+
+    Syscollector::instance().destroy();
+}
+
+TEST_F(SyscollectorImpTest, queryCommandGetVDFirstSyncCompletedReturnsTrueWhenMetadataExists)
+{
+    // Seed the marker directly into the DB, then verify the query reports it.
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    Syscollector::instance().destroy();
+
+    {
+        sqlite3* rawDb = nullptr;
+        ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &rawDb, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+        std::unique_ptr<sqlite3, decltype(&sqlite3_close)> db {rawDb, &sqlite3_close};
+
+        char* rawErrMsg = nullptr;
+        const int execResult = sqlite3_exec(db.get(),
+                                            "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('vd_first_sync_completed', 123456);",
+                                            nullptr,
+                                            nullptr,
+                                            &rawErrMsg);
+        std::unique_ptr<char, decltype(&sqlite3_free)> errMsg {rawErrMsg, &sqlite3_free};
+        ASSERT_EQ(execResult, SQLITE_OK) << (errMsg ? errMsg.get() : "");
+    }
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    std::string response = Syscollector::instance().query(R"({"command":"get_vd_first_sync_completed"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["vd_first_sync_completed"], 1);
+
+    Syscollector::instance().destroy();
+}
+
+TEST_F(SyscollectorImpTest, queryCommandGetVDFirstSyncCompletedIgnoresZeroTimestamp)
+{
+    // A row with last_sync_time=0 must NOT be reported as completed (boolean is "> 0").
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    Syscollector::instance().destroy();
+
+    {
+        sqlite3* rawDb = nullptr;
+        ASSERT_EQ(sqlite3_open_v2(SYSCOLLECTOR_TEST_DB_PATH, &rawDb, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+        std::unique_ptr<sqlite3, decltype(&sqlite3_close)> db {rawDb, &sqlite3_close};
+
+        char* rawErrMsg = nullptr;
+        const int execResult = sqlite3_exec(db.get(),
+                                            "INSERT OR REPLACE INTO table_metadata (table_name, last_sync_time) VALUES ('vd_first_sync_completed', 0);",
+                                            nullptr,
+                                            nullptr,
+                                            &rawErrMsg);
+        std::unique_ptr<char, decltype(&sqlite3_free)> errMsg {rawErrMsg, &sqlite3_free};
+        ASSERT_EQ(execResult, SQLITE_OK) << (errMsg ? errMsg.get() : "");
+    }
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_TEST_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false, false, false, false, false, false, false, false, false);
+
+    std::string response = Syscollector::instance().query(R"({"command":"get_vd_first_sync_completed"})");
+    auto responseJson = nlohmann::json::parse(response);
+
+    EXPECT_EQ(responseJson["error"], MQ_SUCCESS);
+    EXPECT_EQ(responseJson["data"]["vd_first_sync_completed"], 0);
+
+    Syscollector::instance().destroy();
 }


### PR DESCRIPTION
## Description

Closes #35582

Syscollector was persisting the VD first-sync state in a flag file (`queue/syscollector/db/.vd_first_sync_done`) that stored only a boolean `"1"` value, while all other synchronization markers already lived in the `table_metadata` database with epoch-second timestamps. This PR replaces the flag-file mechanism with a metadata row (`vd_first_sync_completed`),
aligns VD state persistence with the existing `first_sync_completed` / `first_scan_completed` pattern, and adds a one-shot cleanup of any orphan flag file from a pre-fix 5.0 beta install.

## Proposed Changes

- Add `SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY` (`"vd_first_sync_completed"`) constant in `syscollectorImp.cpp`.
- Replace `isVDFirstSyncDone()` file-existence check with `getMetadataValue("vd_first_sync_completed", v) && v > 0`, making `table_metadata` the single source of truth for the `VDFIRST` / `VDSYNC` decision.
- After a successful `VDFIRST` run, call `updateMetadataValue(SYSCOLLECTOR_VD_FIRST_SYNC_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch())` to persist the exact completion timestamp instead of creating a boolean flag file.
- Add `get_vd_first_sync_completed` query command for external callers (parity with `get_first_scan_completed` / `get_first_sync_completed`).

### Results and Evidence

**Before**

```log
2026/04/20 20:54:40 syscollector: DEBUG: VD first sync successful, attempting to create flag file: queue/syscollector/db/.vd_first_sync_done
2026/04/20 20:54:40 syscollector: INFO: VD first sync completed, flag file created
```

1. The flag file `.vd_first_sync_done` exists after initialization. 

```console
$ ls -la /var/ossec/queue/syscollector/db/.vd_first_sync_done
-rw-r--r-- 1 root wazuh 1 Apr 20 20:54 /var/ossec/queue/syscollector/db/.vd_first_sync_done
$ cat /var/ossec/queue/syscollector/db/.vd_first_sync_done
1
```

2. The `first_scan_completed` and `first_sync_completed` marks are present, but no mark for VD.

```sql
# sqlite> select * from table_metadata;
first_scan_completed|1776778793|1
first_sync_completed|1776778802|1
dbsync_browser_extensions|1776778822|1
dbsync_groups|1776778822|1
dbsync_hwinfo|1776778822|1
dbsync_network_address|1776778822|1
dbsync_network_iface|1776778822|1
dbsync_network_protocol|1776778822|1
dbsync_osinfo|1776778822|1
dbsync_packages|1776778822|1
dbsync_ports|1776778822|1
dbsync_processes|1776778822|1
dbsync_services|1776778822|1
dbsync_users|1776778822|1
```

---

**After:**

```log
2026/04/20 19:45:40 syscollector: INFO: VD first sync completed, metadata marker persisted.
```

1. The flag file `.vd_first_sync_done` does not exist. 

```console
$ ls /var/ossec/queue/syscollector/db/.vd_first_sync_done
ls: cannot access '/var/ossec/queue/syscollector/db/.vd_first_sync_done': No such file or directory
```

2. `vd_first_sync_completed` marker present with epoch timestamp, matching the log exactly.

```sql
# sqlite> select * from table_metadata;
first_scan_completed|1776792655|1
first_sync_completed|1776792663|1
vd_first_sync_completed|1776792683|1
dbsync_browser_extensions|1776792683|1
dbsync_groups|1776792683|1
dbsync_hwinfo|1776792683|1
dbsync_network_address|1776792683|1
dbsync_network_iface|1776792683|1
dbsync_network_protocol|1776792683|1
dbsync_osinfo|1776792683|1
dbsync_packages|1776792683|1
dbsync_ports|1776792683|1
dbsync_processes|1776792683|1
dbsync_services|1776792683|1
dbsync_users|1776792683|1
```

### Artifacts Affected

- `syscollector`

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- New unit tests in `syscollectorImp_test.cpp`:

| Test | Scope |
|---|---|
| `queryCommandGetVDFirstSyncCompletedDefaultsToFalse` | `get_vd_first_sync_completed` returns `0` when no marker exists |
| `queryCommandGetVDFirstSyncCompletedReturnsTrueWhenMetadataExists` | returns `1` when a positive timestamp is present in `table_metadata` |
| `queryCommandGetVDFirstSyncCompletedIgnoresZeroTimestamp` | returns `0` when the stored timestamp is `0` (incomplete run) |

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
