### PR TITLE
Fix workflow input name: set-as-main → set_as_main in bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -23,7 +23,7 @@ on:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
         type: string
-      set-as-main:
+      set_as_main:
         description: 'Update version values only, preserving main branch references in URLs'
         default: false
         required: false
@@ -87,7 +87,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
           DATE: ${{ inputs.date }}
-          SET_AS_MAIN: ${{ inputs.set-as-main }}
+          SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}


### PR DESCRIPTION
Fixes #35591

The `set-as-main` workflow input was declared with a hyphen, while the bumper orchestrator dispatches it with an underscore (`set_as_main`). GitHub Actions requires an exact match, so dispatches were failing with HTTP 422.

This renames the input and its internal reference to `set_as_main`, consistent with every other repository in the bumper ecosystem.