### PR TITLE
fix(rbac): tolerate None in auth_context lists during preprocess_to_list

### DIFF
--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -100,8 +100,10 @@ class RBAChecker:
         tuple
             List with role_chunk and auth_chunk processed.
         """
-        role_chunk = sorted(role_chunk) if isinstance(role_chunk, list) else role_chunk
-        auth_chunk = sorted(auth_chunk) if isinstance(auth_chunk, list) else auth_chunk
+        def _safe_sort_key(x):
+            return (x is None, str(x))
+        role_chunk = sorted(role_chunk, key=_safe_sort_key) if isinstance(role_chunk, list) else role_chunk
+        auth_chunk = sorted(auth_chunk, key=_safe_sort_key) if isinstance(auth_chunk, list) else auth_chunk
 
         return role_chunk, auth_chunk
 

--- a/framework/wazuh/rbac/tests/test_auth_context.py
+++ b/framework/wazuh/rbac/tests/test_auth_context.py
@@ -104,3 +104,22 @@ def test_auth_roles(db_setup):
                     else:
                         assert len(test.get_user_roles()) == 0
         roles = values()[1]
+
+
+def test_preprocess_to_list_handles_none_in_list(db_setup):
+    """Regression: auth_context lists may contain None when the IdP cannot
+    resolve a claim value (e.g. the caller lacks privileges to see a group).
+
+    sorted() on a list mixing str and None raises TypeError under Python 3;
+    preprocess_to_list must tolerate it so the rule simply fails to match
+    instead of propagating a 500 through the API.
+    """
+    RBAChecker = db_setup
+    role_chunk = ['admins', 'users']
+    auth_chunk = ['admins', None, 'users']
+
+    result_role, result_auth = RBAChecker.preprocess_to_list(role_chunk, auth_chunk)
+
+    assert result_role == ['admins', 'users']
+    assert None in result_auth
+    assert {v for v in result_auth if v is not None} == {'admins', 'users'}


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Fix `TypeError: '<' not supported between instances of 'str' and 'NoneType'` raised by the RBAC preprocessor when the authorization context contains a `null` inside a list field (e.g. `{"groups": ["admins", null, "users"]}`).

The authorization context is external JSON delivered by the identity provider at login (LDAP/SAML/OIDC/`run_as`). It is not under the server's control, and `null` entries are legitimate — typically when the caller lacks privileges to resolve a specific claim value, or when the IdP emits optional/empty claim fields. The RBAC engine must not crash on such input; the correct behaviour is simply "the rule does not match".

Observed on a 4.x deployment (Python 3.10):

```
ERROR: Error executing API request locally: '<' not supported between instances of 'str' and 'NoneType'
  File ".../wazuh/rbac/auth_context.py", line 115, in preprocess_to_list
    auth_chunk = sorted(auth_chunk) if isinstance(auth_chunk, list) else auth_chunk
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```

Root cause: `RBAChecker.preprocess_to_list` calls `sorted()` on the list — the sort is only used so that the subsequent `role_chunk == auth_context` comparison (line 272) becomes order-insensitive. Under Python 3, `sorted()` on a heterogeneous list mixing `str` and `None` raises `TypeError`, which propagates as a 500 through `run_local` / `get_permissions`.

## Proposed Changes

- `framework/wazuh/rbac/auth_context.py` — in `RBAChecker.preprocess_to_list`, pass a sort key that tolerates `None`:

  ```python
  def _safe_sort_key(x):
      return (x is None, str(x))
  ```

  applied to both `role_chunk` and `auth_chunk`. `None` is grouped at the end, and comparable values sort by their string form.

Homogeneous string lists keep their previous order, so **no existing behaviour changes**. Whenever the auth context contains a `None` inside a list, the rule now simply fails to match (the desired outcome) instead of raising.

- `framework/wazuh/rbac/tests/test_auth_context.py` — adds a regression test that exercises `preprocess_to_list` with a `None`-bearing auth chunk and asserts the call does not raise.

### Results and Evidence

Standalone reproducer of the pre-fix vs. post-fix sort behaviour:

```python
>>> sorted(['admins', None, 'users'])
TypeError: '<' not supported between instances of 'NoneType' and 'str'

>>> def _safe_sort_key(x):
...     return (x is None, str(x))
>>> sorted(['admins', None, 'users'], key=_safe_sort_key)
['admins', 'users', None]

>>> # Homogeneous string lists sort identically to the default:
>>> sorted(['b', 'a', 'c']) == sorted(['b', 'a', 'c'], key=_safe_sort_key)
True

>>> # Order-insensitive equality preserved:
>>> sorted(['admins', None, 'users'], key=_safe_sort_key) == sorted(['users', 'admins', None], key=_safe_sort_key)
True
```

End-to-end reproducer (pre-fix, any 4.x installation):

```python
from wazuh.rbac.auth_context import RBAChecker
import json
role = {"id": 99, "rules": [{"FIND": {"groups": "admins"}}]}
ctx = json.dumps({"groups": ["admins", None, "users"]})
RBAChecker(auth_context=ctx, role=role).run_auth_context_roles()
# TypeError: '<' not supported between instances of 'str' and 'NoneType'
```

After the fix: returns an empty list (no role matched), no exception.

### Manual tests with their corresponding evidence

- [x] Wazuh server API/Framework — Run API Integration Tests

### Artifacts Affected

- `framework/wazuh/rbac/auth_context.py`
- `framework/wazuh/rbac/tests/test_auth_context.py`

### Configuration Changes

N/A

### Tests Introduced

Unit test `test_preprocess_to_list_handles_none_in_list` in `framework/wazuh/rbac/tests/test_auth_context.py`. Scope: verifies `RBAChecker.preprocess_to_list` does not raise `TypeError` when the `auth_chunk` list contains `None` alongside strings, and that `None` is preserved in the returned list.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [x] Developer documentation reflects the changes (N/A)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues