### PR TITLE
(4x) Fix script injection vulnerabilities in CI workflows

### DIFF
--- a/.github/workflows/4_codeanalysis_coverity-image.yml
+++ b/.github/workflows/4_codeanalysis_coverity-image.yml
@@ -25,9 +25,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download Coverity tarball
+        env:
+          COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_WAZUH_TOKEN }}
         run: |
           wget -q https://scan.coverity.com/download/linux64 \
-            --post-data "token=${{ secrets.COVERITY_SCAN_WAZUH_TOKEN }}&project=${PROJECT//\//%2F}" \
+            --post-data "token=${COVERITY_TOKEN}&project=${PROJECT//\//%2F}" \
             -O tools/testing/coverity/coverity_tool.tgz
 
       - name: Log in to the Container registry

--- a/.github/workflows/4_codeanalysis_coverity.yml
+++ b/.github/workflows/4_codeanalysis_coverity.yml
@@ -35,17 +35,20 @@ jobs:
 
       - name: Set up project and build variables
         id: vars
+        env:
+          INPUT_PROJECT: ${{ github.event.inputs.project }}
+          INPUT_THREADS: ${{ github.event.inputs.threads }}
         run: |
-          if [[ "${{ github.event.inputs.project }}" == "wazuh" ]]; then
+          if [[ "$INPUT_PROJECT" == "wazuh" ]]; then
             echo "PROJECT=wazuh/wazuh" >> $GITHUB_OUTPUT
           else
             echo "PROJECT=wazuh/ossec-wazuh" >> $GITHUB_OUTPUT
           fi
 
-          if [[ ${{ github.event.inputs.threads }} -le 0 ]]; then
+          if [[ $INPUT_THREADS -le 0 ]]; then
             echo "JOBS=$(nproc)" >> $GITHUB_OUTPUT
           else
-            echo "JOBS=${{ github.event.inputs.threads }}" >> $GITHUB_OUTPUT
+            echo "JOBS=$INPUT_THREADS" >> $GITHUB_OUTPUT
           fi
 
           VERSION=$(jq -r '.version + "-" + .stage' VERSION.json)

--- a/.github/workflows/4_codeanalysis_python.yml
+++ b/.github/workflows/4_codeanalysis_python.yml
@@ -30,12 +30,16 @@ jobs:
           pip install bandit
 
       - name: Generate baseline from target branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}:baseline_branch
+          git fetch origin ${BASE_REF}:baseline_branch
           git checkout baseline_branch
           bandit -r ${{ env.PYTHON_DIRS }} -f json -o bandit_baseline.json -x '**/test/**,**/tests/**' --exit-zero
 
       - name: Run bandit scan on PR changes
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git checkout ${HEAD_REF}
           bandit -r ${{ env.PYTHON_DIRS }} -x '**/test/**,**/tests/**' --baseline bandit_baseline.json

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -92,13 +92,13 @@ jobs:
 
       - name: Set AWS credentials file
         run: |
-          sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile default
-          sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile default
+          sudo aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID} --profile default
+          sudo aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY} --profile default
           sudo aws configure set default.region ${AWS_DEFAULT_REGION} --profile default
       - name: Set AWS credentials file for inspector2 tests (us-east-2)
         run: |
-          sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile inspector_tests
-          sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile inspector_tests
+          sudo aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID} --profile inspector_tests
+          sudo aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY} --profile inspector_tests
           sudo aws configure set region us-east-2 --profile inspector_tests
 
       - name: "Install a compatible CMake"


### PR DESCRIPTION
## Description

Fixes script injection vulnerabilities and inline secret interpolation in 4.x CI/CD workflows, found during a broader audit of `${{ ... }}` expressions inside `run:` blocks.

`${{ ... }}` expressions interpolated directly into `run:` shell blocks are substituted at the workflow evaluation level — before bash runs — so a crafted value (user input, branch name) can break out of the intended command and execute arbitrary shell code. Secrets interpolated inline are also visible in process listings and shell error output regardless of injection risk.

This extends the fix applied to the 5.x branch in #35480.

## Proposed Changes

The fix in all cases: move secrets and user-controlled expressions to step-level `env:` variables before referencing them in shell commands. Shell variables are expanded as data, not as code.

### `4_codeanalysis_coverity.yml` — `prepare` job

- `github.event.inputs.project` — inside `[[ "..." ]]`, injectable by breaking out with `"`
- `github.event.inputs.threads` — unquoted in `[[ ... -le 0 ]]` and in `echo`, directly injectable

> **Note:** No secrets are currently referenced in the `prepare` job, so this is preemptive hardening — the vectors are not exploitable today but would become so the moment a secret is added to that job.

### Results and Evidence

Before (vulnerable):
```yaml
- run: |
    if [[ "${{ github.event.inputs.project }}" == "wazuh" ]]; then
    ...
    if [[ ${{ github.event.inputs.threads }} -le 0 ]]; then
    ...
    echo "JOBS=${{ github.event.inputs.threads }}" >> $GITHUB_OUTPUT
```

After (safe):
```yaml
- env:
    INPUT_PROJECT: ${{ github.event.inputs.project }}
    INPUT_THREADS: ${{ github.event.inputs.threads }}
  run: |
    if [[ "$INPUT_PROJECT" == "wazuh" ]]; then
    ...
    if [[ $INPUT_THREADS -le 0 ]]; then
    ...
    echo "JOBS=$INPUT_THREADS" >> $GITHUB_OUTPUT
```

---

### `4_codeanalysis_python.yml`

- `github.event.pull_request.base.ref` (Generate baseline step) — used directly in `git fetch origin <ref>:baseline_branch`. An attacker can open a fork PR from a branch named e.g. `main; <command>` to inject arbitrary commands on the self-hosted runner (`wz-linux-amd64`).
- `github.event.pull_request.head.ref` (Run bandit scan step) — same injection vector via `git checkout <ref>`.

**Trigger:** `pull_request` — exploitable by any external contributor opening a fork PR. **Runner:** self-hosted (`wz-linux-amd64`).

### `4_codeanalysis_coverity-image.yml`

- `COVERITY_SCAN_WAZUH_TOKEN` (Download Coverity tarball step) — interpolated inline into a `wget --post-data` argument, making the token visible in process listings and shell error output.

**Secrets at risk:** `COVERITY_SCAN_WAZUH_TOKEN`

### `4_testintegration_aws-tier-0-1.yml`

- `IT_AWS_KEY_ID` and `IT_AWS_SECRET_ACCESS_KEY` (Set AWS credentials file steps) — both secrets were already correctly defined in the job-level `env:` block but were re-interpolated inline in the `aws configure` commands. Replaced with references to the already-defined env vars.

**Secrets at risk:** `IT_AWS_KEY_ID`, `IT_AWS_SECRET_ACCESS_KEY`

---

### Artifacts Affected

- `.github/workflows/4_codeanalysis_coverity.yml`
- `.github/workflows/4_codeanalysis_python.yml`
- `.github/workflows/4_codeanalysis_coverity-image.yml`
- `.github/workflows/4_testintegration_aws-tier-0-1.yml`

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — CI workflow changes with no associated unit or integration tests.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
