### PR TITLE
Engine - Add Filter Sync

### DIFF
--- a/src/engine/source/cmcrud/include/cmcrud/cmcrudservice.hpp
+++ b/src/engine/source/cmcrud/include/cmcrud/cmcrudservice.hpp
@@ -38,6 +38,7 @@ public:
     void importNamespace(const cm::store::NamespaceId& nsId,
                          const std::vector<json::Json>& kvdbs,
                          const std::vector<json::Json>& decoders,
+                         const std::vector<json::Json>& filters,
                          const std::vector<json::Json>& integrations,
                          const json::Json& policy,
                          bool softValidation) override;

--- a/src/engine/source/cmcrud/interface/cmcrud/icmcrudservice.hpp
+++ b/src/engine/source/cmcrud/interface/cmcrud/icmcrudservice.hpp
@@ -113,6 +113,7 @@ public:
      * @param nsName Namespace identifier, to store the imported data.
      * @param kvdbs list of KVDB definitions in json format
      * @param decoders list of decoder definitions in json format
+     * @param filters list of filter definitions in json format
      * @param integrations list of integration definitions in json format
      * @param policy policy definition in json format
      * @param softValidation if true, only check the most critical validations.
@@ -121,6 +122,7 @@ public:
     virtual void importNamespace(const cm::store::NamespaceId& nsId,
                                  const std::vector<json::Json>& kvdbs,
                                  const std::vector<json::Json>& decoders,
+                                 const std::vector<json::Json>& filters,
                                  const std::vector<json::Json>& integrations,
                                  const json::Json& policy,
                                  bool softValidation) = 0;

--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -345,6 +345,7 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
 void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
                                   const std::vector<json::Json>& kvdbs,
                                   const std::vector<json::Json>& decoders,
+                                  const std::vector<json::Json>& filters,
                                   const std::vector<json::Json>& integrations,
                                   const json::Json& policy,
                                   bool softValidation)
@@ -385,6 +386,25 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
             validator->validateAsset(nsReader, assetJson);
         }
         ns->createResource(name.toStr(), cm::store::ResourceType::DECODER, assetJson);
+    }
+
+    for (const auto& jfilt : filters)
+    {
+        auto assetJson = store::detail::adaptFilter(jfilt);
+        auto name = assetNameFromJson(assetJson);
+        const auto resourceStr = cm::store::resourceTypeToString(cm::store::ResourceType::FILTER);
+
+        if (resourceStr != name.parts().front())
+        {
+            throw std::runtime_error(
+                fmt::format("Asset name '{}' does not match resource type '{}'", name.toStr(), resourceStr));
+        }
+
+        if (!softValidation)
+        {
+            validator->validateAsset(nsReader, assetJson);
+        }
+        ns->createResource(name.toStr(), cm::store::ResourceType::FILTER, assetJson);
     }
 
     for (const auto& jinteg : integrations)

--- a/src/engine/source/cmcrud/test/mocks/cmcrud/mockcmcrud.hpp
+++ b/src/engine/source/cmcrud/test/mocks/cmcrud/mockcmcrud.hpp
@@ -22,6 +22,7 @@ public:
                 (const cm::store::NamespaceId& nsId,
                  const std::vector<json::Json>& kvdbs,
                  const std::vector<json::Json>& decoders,
+                 const std::vector<json::Json>& filters,
                  const std::vector<json::Json>& integrations,
                  const json::Json& policy,
                  bool softValidation),

--- a/src/engine/source/cmcrud/test/src/unit/cmcrudservice_test.cpp
+++ b/src/engine/source/cmcrud/test/src/unit/cmcrudservice_test.cpp
@@ -116,6 +116,18 @@ static constexpr const char* kDecoderJson = R"({
   ]
 })";
 
+// Minimal filter asset example (JSON)
+static constexpr const char* kFilterJson = R"({
+  "name": "filter/pre-filter/0",
+  "id": "f1111111-1111-4111-a111-111111111111",
+  "enabled": true,
+  "type": "pre-filter",
+  "metadata": {
+    "title": "Test Pre-Filter"
+  },
+  "check": "$host.os.platform == 'ubuntu'"
+})";
+
 json::Json makeJsonPayload(const char* raw)
 {
     return json::Json {raw};
@@ -714,12 +726,13 @@ TEST(CrudService_Unit, UpsertIntegration_AcceptsJsonPayloadAndPassesJsonToStore)
     EXPECT_CALL(*nsPtr,
                 createResource("windows",
                                ResourceType::INTEGRATION,
-                               Truly([](const json::Json& content)
-                                     {
-                                         return content.isObject() && content.isBool("/enabled")
-                                                && content.isString("/metadata/title")
-                                                && getStringOrEmpty(content, "/metadata/title") == "windows";
-                                     })))
+                               Truly(
+                                   [](const json::Json& content)
+                                   {
+                                       return content.isObject() && content.isBool("/enabled")
+                                              && content.isString("/metadata/title")
+                                              && getStringOrEmpty(content, "/metadata/title") == "windows";
+                                   })))
         .Times(1);
     EXPECT_CALL(*nsPtr, updateResourceByUUID(_, _)).Times(0);
 
@@ -1154,6 +1167,43 @@ TEST(CrudService_Unit, ValidateResource_Integration_InvalidCategory_Throws)
         EXPECT_THAT(std::string {e.what()}, ::testing::HasSubstr("category"));
         EXPECT_THAT(std::string {e.what()}, ::testing::HasSubstr("not valid"));
     }
+}
+
+// ---------------------------------------------------------------------
+// importNamespace (component-based)
+// ---------------------------------------------------------------------
+
+TEST(CrudService_Unit, ImportNamespace_Success_WithFilters)
+{
+    auto store = std::make_shared<NiceMock<MockICMstore>>();
+    auto validator = std::make_shared<NiceMock<MockValidator>>();
+    CrudService service {store, validator};
+
+    const NamespaceId nsId {"imported"};
+    auto nsPtr = std::make_shared<NiceMock<MockICMstoreNS>>();
+    auto nsReader = std::static_pointer_cast<cm::store::ICMStoreNSReader>(nsPtr);
+
+    EXPECT_CALL(*store, existsNamespace(Truly([&nsId](const NamespaceId& id) { return id.toStr() == nsId.toStr(); })))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*store, createNamespace(Truly([&nsId](const NamespaceId& id) { return id.toStr() == nsId.toStr(); })))
+        .WillOnce(Return(nsPtr));
+
+    std::vector<json::Json> kvdbs;
+    std::vector<json::Json> decoders;
+    std::vector<json::Json> integrations;
+    std::vector<json::Json> filters;
+
+    // Add a filter
+    filters.emplace_back(makeJsonPayload(kFilterJson));
+
+    // Expect filter creation
+    EXPECT_CALL(*nsPtr, createResource("filter/pre-filter/0", ResourceType::FILTER, _)).Times(1);
+
+    // Expect policy upsert
+    EXPECT_CALL(*nsPtr, upsertPolicy(_)).Times(1);
+
+    EXPECT_NO_THROW(
+        service.importNamespace(nsId, kvdbs, decoders, filters, integrations, makeJsonPayload(kPolicyJson), true));
 }
 
 } // namespace cm::crud::test

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -190,6 +190,7 @@ void CMSync::downloadNamespace(std::string_view originSpace, const cm::store::Na
         cmcrudPtr->importNamespace(dstNamespace,
                                    policyResource.kvdbs,
                                    policyResource.decoders,
+                                   policyResource.filters,
                                    policyResource.integration,
                                    policyResource.policy,
                                    /*softValidation=*/true);

--- a/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
+++ b/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
@@ -345,7 +345,9 @@ TEST_F(CMSyncSynchronizeTest, Case3_PolicyEnabledNoRouteExists)
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
 
     // importNamespace
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     // syncNamespaceInRoute: no existing route → create new
@@ -381,7 +383,9 @@ TEST_F(CMSyncSynchronizeTest, Case4_PolicyEnabledHashChanged)
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     // hot-swap
@@ -418,7 +422,9 @@ TEST_F(CMSyncSynchronizeTest, Case4_RouteDisabledHashChanged)
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     EXPECT_CALL(*router, hotSwapNamespace("cmsync_standard", ::testing::_)).WillOnce(::testing::Return(std::nullopt));
@@ -467,7 +473,9 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenHotSwapFails)
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     // hot-swap fails
@@ -498,7 +506,9 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWhenImportNamespaceFails)
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
 
     // importNamespace throws
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .WillOnce(::testing::Throw(std::runtime_error("import failed")));
 
     // Rollback in downloadNamespace
@@ -529,7 +539,9 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWithNextSpaceAfterFailure)
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("custom"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     EXPECT_CALL(*router, getEntries()).WillOnce(::testing::Return(std::list<router::prod::Entry> {}));
@@ -560,7 +572,9 @@ TEST_F(CMSyncSynchronizeTest, DoesNotDeleteDummyNamespaceAfterSync)
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     EXPECT_CALL(*router, getEntries()).WillOnce(::testing::Return(std::list<router::prod::Entry> {}));
@@ -589,7 +603,9 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenPostEntryFails)
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     EXPECT_CALL(*router, getEntries()).WillOnce(::testing::Return(std::list<router::prod::Entry> {}));
@@ -622,7 +638,9 @@ TEST_F(CMSyncSynchronizeTest, RetriesNamespaceIdGenerationOnCollision)
 
     wiconnector::PolicyResources resources;
     EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
-    EXPECT_CALL(*crud, importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
+    EXPECT_CALL(
+        *crud,
+        importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     EXPECT_CALL(*router, getEntries()).WillOnce(::testing::Return(std::list<router::prod::Entry> {}));

--- a/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
+++ b/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
@@ -30,6 +30,7 @@ struct PolicyResources
 {
     std::vector<json::Json> kvdbs {};       ///< List of KVDB
     std::vector<json::Json> decoders {};    ///< List of decoder
+    std::vector<json::Json> filters {};     ///< List of filters
     std::vector<json::Json> integration {}; ///< List of integration decoder
     json::Json policy {};                   ///< The policy
 };

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -23,16 +23,20 @@ namespace
 /**
  * @brief List of policy resource aliases in the indexer
  */
-const std::vector<std::string> POLICY_ALIASES = {"wazuh-threatintel-kvdbs", "wazuh-threatintel-decoders", "wazuh-threatintel-integrations", "wazuh-threatintel-policies"};
+const std::vector<std::string> POLICY_ALIASES = {"wazuh-threatintel-kvdbs",
+                                                 "wazuh-threatintel-decoders",
+                                                 "wazuh-threatintel-filters",
+                                                 "wazuh-threatintel-integrations",
+                                                 "wazuh-threatintel-policies"};
 
-constexpr std::string_view PIT_KEEP_ALIVE {"5m"};                     ///< Keep alive duration for Point In Time
-constexpr std::string_view POLICY_INDEX {"wazuh-threatintel-policies"};            ///< Policy index name
-constexpr std::string_view IOC_INDEX {"wazuh-threatintel-enrichments"};                   ///< IOC index name
-constexpr std::string_view IOC_HASHES_DOC_ID {"__ioc_type_hashes__"}; ///< IOC hash manifest document ID
-constexpr std::size_t SINGLE_RESULT_SIZE {1};                         ///< Size for single result queries
-constexpr std::size_t HASH_QUERY_SIZE {1};                            ///< Size for hash query (expecting single result)
-constexpr std::size_t SAFE_STREAM_PAGE_SIZE {1000};                   ///< Hard cap for streaming page size
-constexpr std::string_view REMOTE_CONF_INDEX {".wazuh-settings"};     ///< remote conf index name
+constexpr std::string_view PIT_KEEP_ALIVE {"5m"};                       ///< Keep alive duration for Point In Time
+constexpr std::string_view POLICY_INDEX {"wazuh-threatintel-policies"}; ///< Policy index name
+constexpr std::string_view IOC_INDEX {"wazuh-threatintel-enrichments"}; ///< IOC index name
+constexpr std::string_view IOC_HASHES_DOC_ID {"__ioc_type_hashes__"};   ///< IOC hash manifest document ID
+constexpr std::size_t SINGLE_RESULT_SIZE {1};                           ///< Size for single result queries
+constexpr std::size_t HASH_QUERY_SIZE {1};                        ///< Size for hash query (expecting single result)
+constexpr std::size_t SAFE_STREAM_PAGE_SIZE {1000};               ///< Hard cap for streaming page size
+constexpr std::string_view REMOTE_CONF_INDEX {".wazuh-settings"}; ///< remote conf index name
 const std::array<std::string_view, 12> IOC_SOURCE_FILTER_INCLUDES = {"document.name",
                                                                      "document.type",
                                                                      "document.id",
@@ -51,6 +55,7 @@ enum class IndexResourceType
 {
     KVDB,
     DECODER,
+    FILTER,
     INTEGRATION_DECODER,
     POLICY
 };
@@ -58,9 +63,10 @@ enum class IndexResourceType
 IndexResourceType fromIndexName(std::string_view indexName)
 {
     // Static regex patterns compiled once
-    static const std::array<std::pair<std::regex, IndexResourceType>, 4> patterns = {
+    static const std::array<std::pair<std::regex, IndexResourceType>, 5> patterns = {
         {{std::regex(R"(.*-kvdbs$)"), IndexResourceType::KVDB},
          {std::regex(R"(.*-decoders$)"), IndexResourceType::DECODER},
+         {std::regex(R"(.*-filters$)"), IndexResourceType::FILTER},
          {std::regex(R"(.*-integrations$)"), IndexResourceType::INTEGRATION_DECODER},
          {std::regex(R"(.*-policies$)"), IndexResourceType::POLICY}}};
 
@@ -267,7 +273,6 @@ WIndexerConnector::WIndexerConnector(std::string_view jsonOssecConfig, const std
         m_maxHitsPerRequest = maxHitsPerRequest;
     }
 
-
     if (jsonOssecConfig.empty())
     {
         throw std::runtime_error("Empty JSON configuration for IndexerConnector");
@@ -296,7 +301,6 @@ WIndexerConnector::WIndexerConnector(const Config& config,
     {
         m_maxHitsPerRequest = maxHitsPerRequest;
     }
-
 
     nlohmann::json jsonConfig = nlohmann::json::parse(config.toJson(), nullptr, false);
     if (jsonConfig.is_discarded())
@@ -458,6 +462,7 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
     {
         std::size_t kvdbCount = 0;
         std::size_t decoderCount = 0;
+        std::size_t filterCount = 0;
         std::size_t integrationDecoderCount = 0;
         for (const auto& [type, _] : resourceList)
         {
@@ -465,11 +470,13 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
             {
                 case IndexResourceType::KVDB: ++kvdbCount; break;
                 case IndexResourceType::DECODER: ++decoderCount; break;
+                case IndexResourceType::FILTER: ++filterCount; break;
                 case IndexResourceType::INTEGRATION_DECODER: ++integrationDecoderCount; break;
                 case IndexResourceType::POLICY: break;
             }
         }
         policyMap.kvdbs.reserve(kvdbCount);
+        policyMap.filters.reserve(filterCount);
         policyMap.decoders.reserve(decoderCount);
         policyMap.integration.reserve(integrationDecoderCount);
     }
@@ -481,6 +488,7 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
         {
             case IndexResourceType::KVDB: policyMap.kvdbs.emplace_back(std::move(data)); break;
             case IndexResourceType::DECODER: policyMap.decoders.emplace_back(std::move(data)); break;
+            case IndexResourceType::FILTER: policyMap.filters.emplace_back(std::move(data)); break;
             case IndexResourceType::INTEGRATION_DECODER: policyMap.integration.emplace_back(std::move(data)); break;
         }
     }


### PR DESCRIPTION
## Description

This pull request aims to include filters during namespace synchronization. Filters are not included with the content (decoder, kvdbs, integrations, etc.) because they are user-created and promoted. If this occurs, the synchronization process will take them into account.

closes #35530


## Proposed Changes

### Indexer Connector (wiconnector)

- The filters vector was added to the PolicyResources structure to transport the retrieved JSON.

- Support for the FILTER resource type was added.
- The index detection logic was updated to recognize those ending in -filters (e.g., .engine-filters).
- The getPolicy method was modified to categorize and store the filter documents found in the indexer response.

### CM::CRUD Service (cmcrud)

- The importNamespace signature was updated to accept the new filter parameter.

- The filter import logic was implemented.
- The cm::store::detail::adaptFilter method was integrated to sanitize payloads and ensure their integrity before saving them.


### CM::Sync (cmsync)

- The downloadNamespace method was updated to pass the filters obtained from the connector to the CRUD service.

### Results and Evidence

<img width="1636" height="574" alt="Screenshot from 2026-04-21 15-13-35" src="https://github.com/user-attachments/assets/b5112523-1eb1-42df-8398-31d41c1eb409" />
<img width="1636" height="574" alt="Screenshot from 2026-04-21 15-14-42" src="https://github.com/user-attachments/assets/e6da770a-b468-48b5-ae0a-705abe6162d7" />
<img width="1828" height="564" alt="Screenshot from 2026-04-21 15-14-55" src="https://github.com/user-attachments/assets/b4f68f56-5571-48fb-aafe-f1729eef6672" />
<img width="1828" height="564" alt="Screenshot from 2026-04-21 15-15-14" src="https://github.com/user-attachments/assets/676d4eda-1330-494e-807b-1ab3ff58f94a" />
<img width="1828" height="564" alt="Screenshot from 2026-04-21 15-15-47" src="https://github.com/user-attachments/assets/e2c0975c-0414-4d7d-8b63-6159ad67c91f" />
<img width="1828" height="564" alt="Screenshot from 2026-04-21 15-15-52" src="https://github.com/user-attachments/assets/41ed4e77-bbea-4be0-857a-c95d17acf13c" />
<img width="1615" height="524" alt="image" src="https://github.com/user-attachments/assets/57763351-2836-4fcf-a850-4a9880da041a" />

```
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Store initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: KVDB IOC initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Geo initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Schema initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: HLP initialized.
2026/04/21 18:16:03 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Indexer Connector initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Scheduler initialized and started.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Stream logger initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Builder initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized.
2026/04/21 18:16:03 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized (index: wazuh-events-raw-v5).
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: 2000.
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized.
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: Archiver initialized.
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: Metrics stream logging enabled (interval: 1 seconds, on-demand channel creation).
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: Engine started and ready to process events.
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: [CMSync] Changes detected for space 'custom', updating...
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: [Router::hotSwapSpace] Hot swapped namespace for entry 'cmsync_custom' to 'cmsync_custom_3593'
2026/04/21 18:16:05 wazuh-manager-analysisd: INFO: [CMSync] Successfully synchronized space 'custom'

(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src/engine/test/acceptance_test/utils ‹enhancement/engine-synchronization-with-filters●› 
╰─# engine-private ns list                                                                                         130 ↵
- cmsync_custom_3593
- cmsync_standard_aae3
- cmsync_standard_1bd5
- cmsync_standard_3987

(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src/engine/test/acceptance_test/utils ‹enhancement/engine-synchronization-with-filters●› 
╰─# engine-private cm -n cmsync_custom_3593 list filter
- name: filter/nahuel/0
  uuid: 120a061c-bb08-47bb-997e-478106d681eb

(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src/engine/test/acceptance_test/utils ‹enhancement/engine-synchronization-with-filters●› 
╰─# engine-private cm -n cmsync_custom_3593 get 120a061c-bb08-47bb-997e-478106d681eb
{
    "name": "filter/nahuel/0",
    "type": "pre-filter",
    "check": "$host.os.platform == 'ubuntu'",
    "enabled": true,
    "id": "120a061c-bb08-47bb-997e-478106d681eb"
}

(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src/engine/test/acceptance_test/utils ‹enhancement/engine-synchronization-with-filters› 
╰─# engine-test run test01 -n cmsync_custom_3593 -dd                   

Enter any events [ENTER to send event, CTRL+C to finish]:

hello


---
traces:
[🔴] filter/nahuel/0 -> failed
  ↳ [check: $host.os.platform == 'ubuntu'] -> Failure

output:
  event:
    original: hello
  wazuh:
    protocol:
      location: /tmp
      queue: 49
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
