### PR TITLE
Flush feed RocksDB memtable before marking feed ready on download completion

### DIFF
--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -627,8 +627,9 @@ private:
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0)
                         .count();
                 logInfo(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Slice %zu/%zu complete — %zu docs in %ldms",
+                        "IndexerDownloader: Slice %zu (%zu/%zu) complete — %zu docs in %ldms",
                         sliceId,
+                        sliceId + 1,
                         numSlices,
                         sliceProcessed,
                         elapsed);
@@ -641,7 +642,7 @@ private:
             }
         };
 
-        for (size_t i = 1; i <= numSlices; ++i)
+        for (size_t i = 0; i < numSlices; ++i)
         {
             threads.emplace_back(sliceWorker, i);
         }

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -641,7 +641,7 @@ private:
             }
         };
 
-        for (size_t i = 0; i < numSlices; ++i)
+        for (size_t i = 1; i <= numSlices; ++i)
         {
             threads.emplace_back(sliceWorker, i);
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -331,6 +331,12 @@ public:
                         // usable for scanning before marking it ready or triggering rescans.
                         if (msgType == "indexer_complete")
                         {
+                            // WAL is disabled for the feed database, so committed batches live in
+                            // the memtable until RocksDB decides to flush. Force a flush here to
+                            // guarantee all downloaded CVEs are on disk before marking the feed
+                            // ready — avoids data loss on a crash or SIGKILL after this point.
+                            feedDatabase->flush();
+
                             if (!this->reloadGlobalMaps())
                             {
                                 if (m_feedDatabase->columnExists(FEED_METADATA_COLUMN))


### PR DESCRIPTION
## Description

### Problem

The vulnerability feed database (RocksDB) is opened with WAL disabled for performance reasons during bulk downloads. As a result, `commitBatch()` writes only to RocksDB's in-memory memtable. The memtable is only flushed to SST files when RocksDB decides to do so automatically (based on memtable size thresholds).

This creates a window between a successful feed download and the data being persisted to disk: if the manager process is killed (e.g., `SIGKILL` or OOM) after the download completes but before RocksDB triggers its automatic flush, the last batch of CVEs, those still in the memtable, will be lost. On the next startup, the manager would operate with an incomplete feed until the next full re-download cycle.

The issue was observable externally: reading the RocksDB with `OpenForReadOnly` (which only reads SST files, not the memtable) immediately after a download would show fewer CVEs than expected. After a graceful restart, the memtable was flushed to SST on shutdown and the correct count was visible.

### Solution

Force an explicit `flush()` on the feed database when `indexer_complete` is received, before `reloadGlobalMaps()` marks the feed as ready. This guarantees that all downloaded CVEs are persisted to SST files before the feed is considered valid and made available to the vulnerability scanner.

A single flush at the end of the download is the correct approach: flushing per page would multiply I/O operations (~1340 flushes for a full 335K-CVE feed with pageSize=250), and enabling the WAL would add disk write overhead on every `commitBatch()` call throughout the entire download. Since the feed is always re-downloadable from the indexer, WAL-level durability during the download itself is not required, only durability after a successful completion matters.

## Proposed Changes

- `src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp`: call `feedDatabase->flush()` on `indexer_complete`, before `reloadGlobalMaps()`.

### Results and Evidence

Before the fix, reading the feed RocksDB with an external read-only tool immediately after a 16-slice download showed 8 fewer CVEs (319,916) than expected (319,924). After a graceful restart, which flushes the memtable to SST on shutdown, the correct count was restored.

After the fix, the flush forces all memtable data to SST before the feed is marked ready, so the correct count is visible immediately after the download completes and the data is durable on disk.

## Small log imporvement
Fixes manager's IndexerDownloader's Slice logs, which displayed the wrong slice number:
``` sql
2026/04/22 15:03:26 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0/2 complete — 168487 docs in 237950ms
2026/04/22 15:03:26 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1/2 complete — 168342 docs in 238081ms
```

``` sql
2026/04/23 13:46:31 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 168487 docs in 214797ms
2026/04/23 13:46:32 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 168342 docs in 215738ms
```


### Artifacts Affected

- `wazuh-manager`

### Configuration Changes

No configuration changes.

### Documentation Updates

No documentation updates required.

### Tests Introduced

No new tests. The existing `databaseFeedManager` unit tests cover the `indexer_complete` handling path. The flush call does not alter the observable behavior of the feed from the scanner's perspective — it only affects durability guarantees.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
