### PR TITLE
Remove unused SSL/TLS transport option from cluster

### DIFF
--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -98,10 +98,9 @@ async def test_master_main(helper_disabled: bool):
     cluster_config = {'test': 'config', HAPROXY_HELPER: {HAPROXY_DISABLED: helper_disabled}}
 
     class Arguments:
-        def __init__(self, performance_test, concurrency_test, ssl):
+        def __init__(self, performance_test, concurrency_test):
             self.performance_test = performance_test
             self.concurrency_test = concurrency_test
-            self.ssl = ssl
 
     class TaskPoolMock:
         def __init__(self):
@@ -148,7 +147,7 @@ async def test_master_main(helper_disabled: bool):
 
 
     wazuh_clusterd.cluster_utils = cluster_utils
-    args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test', ssl=True)
+    args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test')
     with patch('scripts.wazuh_clusterd.asyncio.gather', gather):
         with patch('wazuh.core.cluster.master.Master', MasterMock):
             with patch('wazuh.core.cluster.local_server.LocalServerMaster', LocalServerMasterMock):
@@ -168,10 +167,9 @@ async def test_worker_main(asyncio_sleep_mock):
     import wazuh.core.cluster.utils as cluster_utils
 
     class Arguments:
-        def __init__(self, performance_test, concurrency_test, ssl, send_file, send_string):
+        def __init__(self, performance_test, concurrency_test, send_file, send_string):
             self.performance_test = performance_test
             self.concurrency_test = concurrency_test
-            self.ssl = ssl
             self.send_file = send_file
             self.send_string = send_string
 
@@ -224,7 +222,7 @@ async def test_worker_main(asyncio_sleep_mock):
 
     wazuh_clusterd.cluster_utils = cluster_utils
     wazuh_clusterd.main_logger = LoggerMock
-    args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test', ssl=True,
+    args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test',
                      send_file=True, send_string=True)
 
     with patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock:

--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -112,11 +112,10 @@ async def test_master_main(helper_disabled: bool):
             assert second == range(1)
 
     class MasterMock:
-        def __init__(self, performance_test, concurrency_test, configuration, enable_ssl, logger, cluster_items):
+        def __init__(self, performance_test, concurrency_test, configuration, logger, cluster_items):
             assert performance_test == 'test_performance'
             assert concurrency_test == 'concurrency_test'
             assert configuration == cluster_config
-            assert enable_ssl is True
             assert logger == 'test_logger'
             assert cluster_items == {'node': 'item'}
             self.task_pool = TaskPoolMock()
@@ -125,12 +124,11 @@ async def test_master_main(helper_disabled: bool):
             return 'MASTER_START'
 
     class LocalServerMasterMock:
-        def __init__(self, performance_test, logger, concurrency_test, node, configuration, enable_ssl, cluster_items):
+        def __init__(self, performance_test, logger, concurrency_test, node, configuration, cluster_items):
             assert performance_test == 'test_performance'
             assert logger == 'test_logger'
             assert concurrency_test == 'concurrency_test'
             assert configuration == cluster_config
-            assert enable_ssl is True
             assert cluster_items == {'node': 'item'}
 
         def start(self):
@@ -194,11 +192,10 @@ async def test_worker_main(asyncio_sleep_mock):
 
     class WorkerMock:
         def __init__(self, performance_test, concurrency_test, configuration,
-                     enable_ssl, logger, cluster_items, file, string, task_pool):
+                     logger, cluster_items, file, string, task_pool):
             assert performance_test == 'test_performance'
             assert concurrency_test == 'concurrency_test'
             assert configuration == {'test': 'config'}
-            assert enable_ssl is True
             assert file is True
             assert string is True
             assert logger == 'test_logger'
@@ -210,12 +207,11 @@ async def test_worker_main(asyncio_sleep_mock):
             return 'WORKER_START'
 
     class LocalServerWorkerMock:
-        def __init__(self, performance_test, logger, concurrency_test, node, configuration, enable_ssl, cluster_items):
+        def __init__(self, performance_test, logger, concurrency_test, node, configuration, cluster_items):
             assert performance_test == 'test_performance'
             assert logger == 'test_logger'
             assert concurrency_test == 'concurrency_test'
             assert configuration == {'test': 'config'}
-            assert enable_ssl is True
             assert cluster_items == {'intervals': {'worker': {'connection_retry': 34}}}
 
         def start(self):
@@ -272,7 +268,6 @@ def test_get_script_arguments(argument_parser_mock):
              call('--concurrency_test', type=int, dest='concurrency_test', help='==SUPPRESS=='),
              call('--string', help='==SUPPRESS==', type=int, dest='send_string'),
              call('--file', help='==SUPPRESS==', type=str, dest='send_file'),
-             call('--ssl', help='Enable communication over SSL', action='store_true', dest='ssl', default=False),
              call('-f', help='Run in foreground', action='store_true', dest='foreground'),
              call('-d', help='Enable debug messages. Use twice to increase verbosity.', action='count',
                   dest='debug_level'),

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -86,7 +86,7 @@ async def master_main(args: argparse.Namespace, cluster_config: dict, cluster_it
 
     cluster_utils.context_tag.set('Master')
     my_server = master.Master(performance_test=args.performance_test, concurrency_test=args.concurrency_test,
-                              configuration=cluster_config, enable_ssl=args.ssl, logger=logger,
+                              configuration=cluster_config, logger=logger,
                               cluster_items=cluster_items)
     # Spawn pool processes
     if my_server.task_pool is not None:
@@ -94,7 +94,7 @@ async def master_main(args: argparse.Namespace, cluster_config: dict, cluster_it
 
     my_local_server = local_server.LocalServerMaster(performance_test=args.performance_test, logger=logger,
                                                      concurrency_test=args.concurrency_test, node=my_server,
-                                                     configuration=cluster_config, enable_ssl=args.ssl,
+                                                     configuration=cluster_config,
                                                      cluster_items=cluster_items)
     tasks = [my_server, my_local_server]
     if not cluster_config.get(cluster_utils.HAPROXY_HELPER, {}).get(cluster_utils.HAPROXY_DISABLED, True):
@@ -138,13 +138,13 @@ async def worker_main(args: argparse.Namespace, cluster_config: dict, cluster_it
         task_pool = None
 
     while True:
-        my_client = worker.Worker(configuration=cluster_config, enable_ssl=args.ssl,
+        my_client = worker.Worker(configuration=cluster_config,
                                   performance_test=args.performance_test, concurrency_test=args.concurrency_test,
                                   file=args.send_file, string=args.send_string, logger=logger,
                                   cluster_items=cluster_items, task_pool=task_pool)
         my_local_server = local_server.LocalServerWorker(performance_test=args.performance_test, logger=logger,
                                                          concurrency_test=args.concurrency_test, node=my_client,
-                                                         configuration=cluster_config, enable_ssl=args.ssl,
+                                                         configuration=cluster_config,
                                                          cluster_items=cluster_items)
         # Spawn pool processes
         if my_client.task_pool is not None:
@@ -182,7 +182,6 @@ def get_script_arguments() -> argparse.Namespace:
     # implemented in worker nodes.
     parser.add_argument('--file', help=argparse.SUPPRESS, type=str, dest='send_file')
     ####################################################################################################################
-    parser.add_argument('--ssl', help="Enable communication over SSL", action='store_true', dest='ssl', default=False)
     parser.add_argument('-f', help="Run in foreground", action='store_true', dest='foreground')
     parser.add_argument('-d', help="Enable debug messages. Use twice to increase verbosity.", action='count',
                         dest='debug_level')

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -5,7 +5,6 @@
 import asyncio
 import itertools
 import logging
-import ssl
 import traceback
 from time import perf_counter
 from typing import Tuple, Dict, List
@@ -21,7 +20,7 @@ class AbstractClientManager:
     Define an abstract client. Manage connection with server.
     """
 
-    def __init__(self, configuration: Dict, cluster_items: Dict, enable_ssl: bool, performance_test: int,
+    def __init__(self, configuration: Dict, cluster_items: Dict, performance_test: int,
                  concurrency_test: int, file: str, string: int, logger: logging.Logger = None,
                  tag: str = "Client Manager"):
         """Class constructor.
@@ -32,8 +31,6 @@ class AbstractClientManager:
             Client configuration.
         cluster_items : dict
             Cluster.json object containing cluster internal variables.
-        enable_ssl : bool
-            Whether to use SSL encryption or not.
         performance_test : int
             Value for the performance test function.
         concurrency_test : int
@@ -50,7 +47,6 @@ class AbstractClientManager:
         self.name = configuration['node_name']
         self.configuration = configuration
         self.cluster_items = cluster_items
-        self.ssl = enable_ssl
         self.performance_test = performance_test
         self.concurrency_test = concurrency_test
         self.file = file
@@ -94,7 +90,6 @@ class AbstractClientManager:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         self.loop.set_exception_handler(common.asyncio_exception_handler)
         on_con_lost = self.loop.create_future()
-        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH) if self.ssl else None
 
         while True:
             try:
@@ -104,8 +99,7 @@ class AbstractClientManager:
                                                                 fernet_key=self.configuration['key'],
                                                                 cluster_items=self.cluster_items,
                                                                 manager=self, **self.extra_args),
-                    host=self.configuration['nodes'][0], port=self.configuration['port'],
-                    ssl=ssl_context)
+                    host=self.configuration['nodes'][0], port=self.configuration['port'])
                 self.client = protocol
             except ConnectionRefusedError:
                 self.logger.error("Could not connect to master. Trying again in 10 seconds.")

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -131,7 +131,7 @@ class LocalClient(client.AbstractClientManager):
 
     def __init__(self):
         """Class constructor"""
-        super().__init__(configuration=wazuh.core.cluster.utils.read_config(), enable_ssl=False, performance_test=0,
+        super().__init__(configuration=wazuh.core.cluster.utils.read_config(), performance_test=0,
                          concurrency_test=0, file='', string=0, logger=logging.getLogger(), tag="Local Client",
                          cluster_items=wazuh.core.cluster.utils.get_cluster_items())
         self.request_result = None

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -8,8 +8,6 @@ import functools
 import inspect
 import itertools
 import logging
-import os
-import ssl
 import traceback
 from time import perf_counter
 from typing import Tuple, Dict
@@ -249,7 +247,7 @@ class AbstractServer:
     NO_RESULT = 'no_result'
 
     def __init__(self, performance_test: int, concurrency_test: int, configuration: Dict, cluster_items: Dict,
-                 enable_ssl: bool, logger: logging.Logger = None, tag: str = "Abstract Server"):
+                 logger: logging.Logger = None, tag: str = "Abstract Server"):
         """Class constructor.
 
         Parameters
@@ -262,8 +260,6 @@ class AbstractServer:
             ossec.conf cluster configuration.
         cluster_items : dict
             cluster.json cluster internal configuration.
-        enable_ssl : bool
-            Whether to enable asyncio's SSL support.
         logger : Logger object
             Logger to use.
         tag : str
@@ -274,7 +270,6 @@ class AbstractServer:
         self.concurrency = concurrency_test
         self.configuration = configuration
         self.cluster_items = cluster_items
-        self.enable_ssl = enable_ssl
         self.tag = tag
         self.logger = logging.getLogger('wazuh') if not logger else logger
         # logging tag
@@ -536,19 +531,12 @@ class AbstractServer:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         self.loop.set_exception_handler(c_common.asyncio_exception_handler)
 
-        if self.enable_ssl:
-            ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
-            ssl_context.load_cert_chain(certfile=os.path.join(common.WAZUH_PATH, 'etc', 'sslmanager.cert'),
-                                        keyfile=os.path.join(common.WAZUH_PATH, 'etc', 'sslmanager.key'))
-        else:
-            ssl_context = None
-
         try:
             server = await self.loop.create_server(
                 protocol_factory=lambda: self.handler_class(server=self, loop=self.loop, logger=self.logger,
                                                             fernet_key=self.configuration['key'],
                                                             cluster_items=self.cluster_items),
-                host=self.configuration['bind_addr'], port=self.configuration['port'], ssl=ssl_context)
+                host=self.configuration['bind_addr'], port=self.configuration['port'])
         except OSError as e:
             self.logger.error(f"Could not start master: {e}")
             raise KeyboardInterrupt

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -63,7 +63,7 @@ abstract_client = client.AbstractClient(loop=None, on_con_lost=future_mock, name
                                         logger=None, manager=None, cluster_items=cluster_items)
 with patch("asyncio.get_running_loop"):
     abstract_client_manager = client.AbstractClientManager(configuration=configuration, cluster_items=cluster_items,
-                                                           enable_ssl=True, performance_test=10,
+                                                           performance_test=10,
                                                            concurrency_test=10, file="/file/path", string=1000)
 
 
@@ -75,7 +75,6 @@ def test_acm_init():
     assert abstract_client_manager.name == "manager"
     assert abstract_client_manager.configuration == configuration
     assert abstract_client_manager.cluster_items == cluster_items
-    assert abstract_client_manager.ssl is True
     assert abstract_client_manager.performance_test == 10
     assert abstract_client_manager.concurrency_test == 10
     assert abstract_client_manager.file == "/file/path"

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -165,7 +165,7 @@ async def test_LocalServerHandler_get_send_file_response(send_request_mock:Async
         lsh.get_send_file_response(future=future)
         await wait_callback_called(send_res_callback_mock)
         send_request_mock.assert_awaited_once_with(command=b"send_f_res", data="test_get_send_file_response")
-        send_res_callback_mock.assert_called_once() 
+        send_res_callback_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -200,7 +200,7 @@ async def test_LocalServer_init(event_loop):
 
     with patch("asyncio.get_running_loop", return_value=event_loop):
         ls = LocalServer(node=node, performance_test=0, concurrency_test=0,
-                        configuration={}, cluster_items={}, )
+                        configuration={}, cluster_items={})
         assert ls.node == node
         assert ls.node.local_server == ls
         assert ls.handler_class == LocalServerHandler
@@ -355,7 +355,7 @@ async def test_LocalServerHandlerMaster_send_file_request(event_loop):
 
     def callback_mock(future: asyncio.Future):
         assert future.result() == 'send_file_return_value'
-        
+
     server_mock = ServerMock()
     lshm = LocalServerHandlerMaster(server=server_mock, loop=event_loop, fernet_key=None, cluster_items={})
     with pytest.raises(WazuhClusterError, match=".* 3022 .*"):
@@ -368,7 +368,7 @@ async def test_LocalServerHandlerMaster_send_file_request(event_loop):
             await wait_callback_called(get_send_file_response_callback_mock)
             await wait_callback_called(send_file_mock)
             send_file_mock.assert_awaited_with("/tmp")
-            
+
 
 @pytest.mark.asyncio
 async def test_LocalServerMaster_init(event_loop):
@@ -381,7 +381,7 @@ async def test_LocalServerMaster_init(event_loop):
     node = NodeMock()
     with patch("asyncio.get_running_loop", return_value=event_loop):
         lsm = LocalServerMaster(node=node, performance_test=0, concurrency_test=0,
-                                configuration={}, cluster_items={}, )
+                                configuration={}, cluster_items={})
         assert lsm.handler_class == LocalServerHandlerMaster
         assert isinstance(lsm.dapi, dapi.APIRequestQueue)
         assert isinstance(lsm.sendsync, dapi.SendSyncRequestQueue)
@@ -445,7 +445,7 @@ async def test_LocalServerHandlerWorker_process_request(process_request_mock, ev
         send_request_mock.reset_mock()
 
         results = lshw.process_request(command=b"sendasync", data=b"bye")
-        assert results == (b"ok", b"Added request to sendsync requests queue")        
+        assert results == (b"ok", b"Added request to sendsync requests queue")
         await asyncio.sleep(0.1)
         send_request_mock.assert_awaited_once_with(b"sendsync", b"test1 bye")
 
@@ -520,4 +520,3 @@ async def test_AsyncReloadRulesetFlag_async_context_manager():
         assert flag.is_set()
     # After context, flag should still be set (lock is released, not flag)
     assert flag.is_set()
-

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -200,7 +200,7 @@ async def test_LocalServer_init(event_loop):
 
     with patch("asyncio.get_running_loop", return_value=event_loop):
         ls = LocalServer(node=node, performance_test=0, concurrency_test=0,
-                        configuration={}, cluster_items={}, enable_ssl=True)
+                        configuration={}, cluster_items={}, )
         assert ls.node == node
         assert ls.node.local_server == ls
         assert ls.handler_class == LocalServerHandler
@@ -240,7 +240,7 @@ async def test_LocalServer_start(join_mock, gather_mock, event_loop):
     logger = logging.getLogger("connection_made")
     with patch.object(logger, "error") as logger_error_mock:
         ls = LocalServer(node=NodeMock(), performance_test=0, concurrency_test=0,
-                         configuration={}, cluster_items={}, enable_ssl=True, logger=logger)
+                         configuration={}, cluster_items={}, logger=logger)
 
     with patch.object(ls, "handler_class", handler_class_mock):
         with patch.object(event_loop, "create_unix_server", create_unix_server_mock):
@@ -381,7 +381,7 @@ async def test_LocalServerMaster_init(event_loop):
     node = NodeMock()
     with patch("asyncio.get_running_loop", return_value=event_loop):
         lsm = LocalServerMaster(node=node, performance_test=0, concurrency_test=0,
-                                configuration={}, cluster_items={}, enable_ssl=True)
+                                configuration={}, cluster_items={}, )
         assert lsm.handler_class == LocalServerHandlerMaster
         assert isinstance(lsm.dapi, dapi.APIRequestQueue)
         assert isinstance(lsm.sendsync, dapi.SendSyncRequestQueue)

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -57,7 +57,7 @@ def get_master_handler():
                                                                       'port': 1111},
                                                        cluster_items={'node': 'master-node',
                                                                       'intervals': {'worker': {'connection_retry': 1}}},
-                                                       enable_ssl=False, performance_test=False, logger=None,
+                                                       performance_test=False, logger=None,
                                                        concurrency_test=False, file='None', string=20)
 
     return master.MasterHandler(server=abstract_client, loop=loop, fernet_key=fernet_key, cluster_items=cluster_items)
@@ -69,7 +69,7 @@ def get_master():
         return master.Master(performance_test=False, concurrency_test=False,
                              configuration={'node_name': 'master', 'nodes': ['master'],
                                             'port': 1111, 'node_type': 'master'},
-                             cluster_items=cluster_items, enable_ssl=False)
+                             cluster_items=cluster_items)
 
 
 # Test ReceiveIntegrityTask class
@@ -1479,7 +1479,7 @@ def test_master_init(pool_executor_mock, get_running_loop_mock, warning_mock):
     master_class = master.Master(performance_test=False, concurrency_test=False,
                                  configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111},
                                  cluster_items=cluster_items,
-                                 enable_ssl=False)
+                                 )
 
     assert master_class.integrity_control == {}
     assert master_class.handler_class == master.MasterHandler
@@ -1498,7 +1498,7 @@ def test_master_init(pool_executor_mock, get_running_loop_mock, warning_mock):
     master_class = master.Master(performance_test=False, concurrency_test=False,
                                  configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111},
                                  cluster_items=cluster_items,
-                                 enable_ssl=False)
+                                 )
 
     warning_mock.assert_has_calls([call("In order to take advantage of Wazuh 4.3.0 cluster improvements, the directory "
                                         "'/dev/shm' must be accessible by the 'wazuh' user. Check that this file has "
@@ -1511,7 +1511,7 @@ def test_master_init(pool_executor_mock, get_running_loop_mock, warning_mock):
     master_class = master.Master(performance_test=False, concurrency_test=False,
                                  configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111},
                                  cluster_items=cluster_items,
-                                 enable_ssl=False)
+                                 )
 
     warning_mock.assert_has_calls([call("In order to take advantage of Wazuh 4.3.0 cluster improvements, the directory "
                                         "'/dev/shm' must be accessible by the 'wazuh' user. Check that this file has "
@@ -1530,7 +1530,7 @@ def test_master_to_dict(get_running_loop_mock):
                                  configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111,
                                                 "node_type": "master"},
                                  cluster_items=cluster_items,
-                                 enable_ssl=False)
+                                 )
 
     assert master_class.to_dict() == {
         'info': {'name': master_class.configuration['node_name'], 'type': master_class.configuration['node_type'],
@@ -1672,7 +1672,7 @@ async def test_master_file_status_update_ok(run_in_pool_mock, asyncio_sleep_mock
                                  configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111,
                                                 "node_type": "master"},
                                  cluster_items=cluster_items,
-                                 enable_ssl=False)
+                                 )
 
     class LoggerMock:
         """Auxiliary class."""
@@ -1743,7 +1743,7 @@ def test_master_get_health(get_running_loop_mock, get_agent_overview_mock):
     master_class = MockMaster(performance_test=False, concurrency_test=False,
                               configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111,
                                              'node_type': 'master'},
-                              cluster_items=cluster_items, enable_ssl=False)
+                              cluster_items=cluster_items)
     master_class.clients = {'1': MockDict({'testing': 'dict'})}
 
     assert master_class.get_health({'jey': 'value', 'hoy': 'value'}) == {'n_connected_nodes': 0, 'nodes': {}}
@@ -1763,7 +1763,7 @@ def test_master_get_node(get_running_loop_mock):
                                  configuration={'node_name': 'master', 'nodes': ['master'], 'port': 1111,
                                                 "node_type": "master", "name": "master"},
                                  cluster_items=cluster_items,
-                                 enable_ssl=False)
+                                 )
 
     assert master_class.get_node() == {'type': master_class.configuration['node_type'],
                                        'cluster': master_class.configuration['name'],

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -246,21 +246,20 @@ def test_AbstractServer_init(AbstractServerHandler_mock, keepalive_mock):
     """Check the correct initialization of the AbstractServer object."""
     with patch("wazuh.core.cluster.server.context_tag", ContextVar("tag", default="")) as mock_contextvar:
         abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                         cluster_items={"test4": 4}, enable_ssl=True)
+                                         cluster_items={"test4": 4})
 
         assert abstract_server.clients == {}
         assert abstract_server.performance == 1
         assert abstract_server.concurrency == 2
         assert abstract_server.configuration == {"test3": 3}
         assert abstract_server.cluster_items == {"test4": 4}
-        assert abstract_server.enable_ssl is True
         assert abstract_server.tag == "Abstract Server"
         assert mock_contextvar.get() == "Abstract Server"
         assert isinstance(abstract_server.logger, Logger)
 
         logger = Logger("abs")
         abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                         cluster_items={"test4": 4}, enable_ssl=True, logger=logger, tag="test")
+                                         cluster_items={"test4": 4}, logger=logger, tag="test")
         assert abstract_server.tag == "test"
         assert mock_contextvar.get() == "test"
         assert abstract_server.logger == logger
@@ -279,7 +278,7 @@ def test_AbstractServer_broadcast(AbstractServerHandler_mock, asynckeepalive_moc
     worker1_instance = Mock()
     worker2_instance = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
+                                     cluster_items={"test4": 4}, logger=logger_mock)
     abstract_server.clients = {"worker1": worker1_instance, "worker2": worker2_instance}
 
     abstract_server.broadcast(test_func, "test_param", keyword_param="param")
@@ -294,7 +293,7 @@ def test_AbstractServer_broadcast_ko():
     """Verify that expected error log is printed when an exception is raised."""
     logger_mock = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
+                                     cluster_items={"test4": 4}, logger=logger_mock)
     abstract_server.clients = {"worker1": "test"}
 
     abstract_server.broadcast("test_f", "test_param", keyword_param="param")
@@ -313,7 +312,7 @@ def test_AbstractServer_broadcast_add(uuid_mock):
     worker1_instance = Mock()
     worker2_instance = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
+                                     cluster_items={"test4": 4}, logger=logger_mock)
     abstract_server.broadcast_results = {}
     abstract_server.clients = {"worker1": worker1_instance, "worker2": worker2_instance}
 
@@ -329,7 +328,7 @@ def test_AbstractServer_broadcast_add_ko(uuid_mock):
     """Check that expected error log is printed and that broadcast_results is deleted."""
     logger_mock = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
+                                     cluster_items={"test4": 4}, logger=logger_mock)
     abstract_server.broadcast_results = {}
     abstract_server.clients = {"worker1": "test"}
 
@@ -352,7 +351,7 @@ def test_AbstractServer_broadcast_pop(broadcast_results, expected_response):
     """Check that expected response is returned for each case."""
     logger_mock = Mock()
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True, logger=logger_mock)
+                                     cluster_items={"test4": 4}, logger=logger_mock)
     abstract_server.broadcast_results = broadcast_results
     abstract_server.clients = {"worker1": "test", "worker2": "test"}
 
@@ -366,7 +365,7 @@ def test_AbstractServer_to_dict():
                      "nodes": [0, 1],
                      "node_name": "worker2"}
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration=configuration,
-                                     cluster_items={"test4": 4}, enable_ssl=True)
+                                     cluster_items={"test4": 4})
     assert abstract_server.to_dict() == {"info": {"ip": configuration["nodes"][0], "name": configuration['node_name']}}
 
 
@@ -375,7 +374,7 @@ def test_AbstractServer_setup_task_logger():
     """Check that a logger is created with a specific tag."""
     logger = Logger("setup_task_logger")
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True, logger=logger)
+                                     cluster_items={"test4": 4}, logger=logger)
     assert abstract_server.setup_task_logger(task_tag="zxf").name == "setup_task_logger.zxf"
 
     with patch.object(abstract_server.logger, "getChild") as mock_child:
@@ -389,7 +388,7 @@ def test_AbstractServer_get_connected_nodes(mock_process_array):
     """Check that all the necessary data is sent to the utils.process_array
     function to return all the information of the connected nodes."""
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True)
+                                     cluster_items={"test4": 4})
     basic_dict = {"info": {"first": "test"}}
 
     with patch.object(abstract_server, "to_dict", return_value=basic_dict):
@@ -407,7 +406,7 @@ def test_AbstractServer_get_connected_nodes(mock_process_array):
 def test_AbstractServer_get_connected_nodes_ko(mock_process_array):
     """Check all exceptions that can be returned by the get_connected_nodes function."""
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                     cluster_items={"test4": 4}, enable_ssl=True)
+                                     cluster_items={"test4": 4})
     basic_dict = {"info": {"first": "test"}}
 
     with patch.object(abstract_server, "to_dict", return_value=basic_dict):
@@ -451,7 +450,7 @@ async def test_AbstractServer_check_clients_keepalive(sleep_mock):
             with patch("wazuh.core.cluster.server.AbstractServer.setup_task_logger",
                        return_value=logger):
                 abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                                 cluster_items={"test4": 4}, enable_ssl=True, logger=logger)
+                                                 cluster_items={"test4": 4}, logger=logger)
                 tester = "check_clients_keepalive"
                 abstract_server.cluster_items = {"intervals": {"master": {"check_worker_lastkeepalive": tester}}}
                 try:
@@ -487,7 +486,7 @@ async def test_AbstractServer_performance_test(perf_counter_mock, sleep_mock):
     logger = Logger("test_echo")
     with patch.object(logger, "info") as mock_info:
         abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                         cluster_items={"test4": 4}, enable_ssl=True, logger=logger)
+                                         cluster_items={"test4": 4}, logger=logger)
         abstract_server.clients = {b"worker_test": ClientMock()}
         abstract_server.performance = 2
         try:
@@ -513,7 +512,7 @@ async def test_AbstractServer_concurrency_test(perf_counter_mock, sleep_mock):
     logger = Logger("test_echo")
     with patch.object(logger, "info") as mock_info:
         abstract_server = AbstractServer(performance_test=1, concurrency_test=2, configuration={"test3": 3},
-                                         cluster_items={"test4": 4}, enable_ssl=True, logger=logger)
+                                         cluster_items={"test4": 4}, logger=logger)
         abstract_server.clients = {b"worker_test": ClientMock()}
         abstract_server.concurrency = 777
         try:
@@ -553,7 +552,7 @@ async def test_AbstractServer_start(keepalive_mock, mock_path_join):
     cluster_items = {"intervals": {"master": {"check_worker_lastkeepalive": 987}}}
     abstract_server = AbstractServer(performance_test=1, concurrency_test=2,
                                         configuration={"bind_addr": "localhost", "port": 10000},
-                                        cluster_items=cluster_items, enable_ssl=False, logger=logger)
+                                        cluster_items=cluster_items, logger=logger)
     with patch("wazuh.core.cluster.server.context_tag", ContextVar("tag", default="")) as mock_contextvar:
         with patch.object(abstract_server, "handler_class"):
             abstract_server.loop = loop
@@ -564,20 +563,6 @@ async def test_AbstractServer_start(keepalive_mock, mock_path_join):
             loop.set_exception_handler.assert_called_once_with(c_common.asyncio_exception_handler)
             loop.create_server.assert_awaited_once()
 
-    abstract_server = AbstractServer(performance_test=1, concurrency_test=2,
-                            configuration={"bind_addr": 3, "port": 10000},
-                            cluster_items=cluster_items, enable_ssl=True,
-                            logger=logger)
-    with patch("wazuh.core.cluster.server.context_tag", ContextVar("tag", default="")) as mock_contextvar:
-        with patch.object(abstract_server, "handler_class"):
-            ssl_mock = SSLMock()
-            with patch("ssl.create_default_context", return_value=ssl_mock) as create_default_context_mock:
-                with patch.object(ssl_mock, "load_cert_chain") as load_cert_chain_mock:
-                    abstract_server.loop = loop
-                    await abstract_server.start()
-                    create_default_context_mock.assert_called_once_with(purpose=ssl.Purpose.CLIENT_AUTH)
-                    load_cert_chain_mock.assert_called_once_with(certfile="testing_path",
-                                                                            keyfile="testing_path")
 
 
 @pytest.mark.asyncio
@@ -593,7 +578,7 @@ async def test_AbstractServer_start_ko(keepalive_mock, set_event_loop_policy_moc
         def set_exception_handler(self, handler):
             pass
 
-        async def create_server(self, protocol_factory, host, port, ssl):
+        async def create_server(self, protocol_factory, host, port):
             raise OSError("test_start")
 
     logger = Logger("start")
@@ -608,7 +593,7 @@ async def test_AbstractServer_start_ko(keepalive_mock, set_event_loop_policy_moc
                                                                              {"check_worker_lastkeepalive": 987}
                                                                          }
                                                                     },
-                                                     enable_ssl=False, logger=logger)
+                                                     logger=logger)
                     abstract_server.configuration["key"] = fernet_key
                     await abstract_server.start()
                     mock_logger.assert_called_once_with("Could not start master: ")

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -48,7 +48,7 @@ def get_worker_handler(loop):
     with patch('asyncio.get_running_loop', return_value=loop):
         abstract_client = client.AbstractClientManager(configuration=configuration,
                                                        cluster_items=cluster_items,
-                                                       enable_ssl=False, performance_test=False, logger=None,
+                                                       performance_test=False, logger=None,
                                                        concurrency_test=False, file='None', string=20)
 
     return worker.WorkerHandler(cluster_name='Testing', node_type='master', version='4.0.0',
@@ -1355,7 +1355,7 @@ async def test_worker_init(api_request_queue, event_loop):
     """Check if the object Worker is being properly initialized."""
 
     task_pool = {'task_pool': ''}
-    nested_worker = worker.Worker(configuration=configuration, cluster_items=cluster_items, enable_ssl=False,
+    nested_worker = worker.Worker(configuration=configuration, cluster_items=cluster_items,
                                   performance_test=False, logger=None, concurrency_test=False, file='None', string=20,
                                   task_pool=task_pool)
 
@@ -1393,7 +1393,7 @@ async def test_worker_add_tasks(api_request_queue, acm_mock, event_loop):
 
     task_pool = {'task_pool': ''}
 
-    nested_worker = worker.Worker(configuration=configuration, cluster_items=cluster_items, enable_ssl=False,
+    nested_worker = worker.Worker(configuration=configuration, cluster_items=cluster_items,
                                   performance_test=False, logger=None, concurrency_test=False, file='None', string=20,
                                   task_pool=task_pool)
 
@@ -1408,7 +1408,7 @@ async def test_worker_get_node(api_request_queue, event_loop):
     """Check if the basic cluster information is returned."""
     task_pool = {'task_pool': ''}
 
-    nested_worker = worker.Worker(configuration=configuration, cluster_items=cluster_items, enable_ssl=False,
+    nested_worker = worker.Worker(configuration=configuration, cluster_items=cluster_items,
                                   performance_test=False, logger=None, concurrency_test=False, file='None', string=20,
                                   task_pool=task_pool)
 


### PR DESCRIPTION
## Description

This PR removes the non-functional and unmaintained SSL/TLS transport layer option from the cluster communication protocol. The cluster protocol already implements Fernet symmetric encryption at the application layer for message security, making the transport-level SSL option redundant.

The removed SSL implementation had several issues:
- Used incorrect SSL purpose (`CLIENT_AUTH` instead of `SERVER_AUTH`) on the client side
- Did not verify server certificates
- Did not require or verify client certificates
- Was not configurable through ossec.conf or cluster.json
- Required manual command-line flags that were undocumented
- Was not used in production deployments

## Proposed Changes

### Implementation Changes
- **server.py**: Removed `enable_ssl` parameter and SSL context creation
- **client.py**: Removed `enable_ssl` parameter and SSL context creation
- **wazuh_clusterd.py**: Removed `--ssl` command-line argument
- **local_client.py**: Removed hardcoded `enable_ssl=False` parameter

### Results and Evidence

**wazuh-clusterd help (before):**

```
usage: wazuh_clusterd.py [-h] [--ssl] [-f] [-d] [-V] [-r] [-t] [-c config]

options:
  -h, --help  show this help message and exit
  --ssl       Enable communication over SSL
  -f          Run in foreground
  -d          Enable debug messages. Use twice to increase verbosity.
  -V          Print version
  -r          Run as root
  -t          Test configuration
  -c config   Configuration file to use
```

**wazuh-clusterd help (after):**

```
usage: wazuh_clusterd.py [-h] [-f] [-d] [-V] [-r] [-t] [-c config]

options:
  -h, --help  show this help message and exit
  -f          Run in foreground
  -d          Enable debug messages. Use twice to increase verbosity.
  -V          Print version
  -r          Run as root
  -t          Test configuration
  -c config   Configuration file to use
```

This is consistent with the actual production usage of the cluster, where the SSL option was never enabled or documented.

### Artifacts Affected

- wazuh-clusterd

### Configuration Changes

No configuration changes required. The cluster configuration in `ossec.conf` remains unchanged.

There was never a documented SSL configuration option.

### Documentation Updates

No documentation updates required, as the SSL option was never documented for cluster usage.

### Tests Introduced

No new tests introduced. All existing tests have been updated to remove SSL-related assertions and parameters. All cluster functionality tests continue to pass with Fernet-based encryption.

**Test Files Updated:**
- `framework/wazuh/core/cluster/tests/test_server.py`
- `framework/wazuh/core/cluster/tests/test_client.py`
- `framework/wazuh/core/cluster/tests/test_master.py`
- `framework/wazuh/core/cluster/tests/test_worker.py`
- `framework/wazuh/core/cluster/tests/test_local_server.py`
- `framework/scripts/tests/test_wazuh_clusterd.py`

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided (Fernet encryption remains functional)
- [ ] Tests cover the functionality (all existing cluster tests updated and passing)
- [ ] Configuration changes documented (none required)
- [ ] Developer documentation reflects the changes (none required - option was undocumented)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
