### PR TITLE
Handle stop signal during vulnerability feed download

### DIFF
--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -466,6 +466,12 @@ private:
 
         while (true)
         {
+            if (context.spUpdaterBaseContext->spStopCondition->check())
+            {
+                logInfo(WM_CONTENTUPDATER, "IndexerDownloader: Stop requested during PIT fetch — aborting.");
+                break;
+            }
+
             const auto hitsObj = syncConnector.search(pit, pageSize, query, sort, searchAfter, sourceFilter);
             const auto& hitArray = hitsObj.at("hits");
 
@@ -570,6 +576,12 @@ private:
 
                 while (true)
                 {
+                    if (context.spUpdaterBaseContext->spStopCondition->check())
+                    {
+                        logInfo(WM_CONTENTUPDATER, "IndexerDownloader: Stop requested — slice %zu aborting.", sliceId);
+                        break;
+                    }
+
                     const auto hitsObj =
                         sliceConnector.search(pit, pageSize, query, sort, searchAfter, sourceFilter, sliceParam);
                     const auto& hitArray = hitsObj.at("hits");

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -638,11 +638,13 @@ private:
                 auto elapsed =
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0)
                         .count();
+                const bool stopped = context.spUpdaterBaseContext->spStopCondition->check();
                 logInfo(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Slice %zu (%zu/%zu) complete — %zu docs in %ldms",
+                        "IndexerDownloader: Slice %zu (%zu/%zu) %s — %zu docs in %ldms",
                         sliceId,
                         sliceId + 1,
                         numSlices,
+                        stopped ? "interrupted" : "complete",
                         sliceProcessed,
                         elapsed);
             }
@@ -731,8 +733,10 @@ private:
 
             if (totalProcessed > 0)
             {
+                const bool stopped = context.spUpdaterBaseContext->spStopCondition->check();
                 logInfo(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Initial load download phase complete — %zu documents, cursor: '%s'",
+                        "IndexerDownloader: Initial load download phase %s — %zu documents, cursor: '%s'",
+                        stopped ? "interrupted" : "complete",
                         totalProcessed,
                         context.data.value("cursor", std::string {}).c_str());
                 return totalProcessed;
@@ -770,9 +774,11 @@ private:
         const nlohmann::json query = {{"range", {{"offset", {{"gt", std::stoull(lastCursor)}}}}}};
 
         const size_t totalProcessed = fetchWithPit(context, query, lastCursor);
+        const bool stopped = context.spUpdaterBaseContext->spStopCondition->check();
 
         logInfo(WM_CONTENTUPDATER,
-                "IndexerDownloader: Incremental update download phase complete — %zu documents, new cursor: '%s'",
+                "IndexerDownloader: Incremental update download phase %s — %zu documents, new cursor: '%s'",
+                stopped ? "interrupted" : "complete",
                 totalProcessed,
                 context.data.value("cursor", std::string {}).c_str());
         return totalProcessed;


### PR DESCRIPTION
## Description

Stopping wazuh-manager while the vulnerability feed download is in progress causes `wazuh-manager-modulesd` to exceed the 30-second stop timeout and be force-killed (`SIGKILL`) by the control script.

Root cause: the pagination loops inside `IndexerDownloader::fetchWithPit()` and `IndexerDownloader::fetchWithSlicedPit()` never check the `spStopCondition` flag. When a stop signal arrives, the `~Action()` destructor sets the condition and tries to `join()` the scheduler thread, but that thread is stuck inside the download loop iterating through ~1,340 pages with no way to break out. The `join()` blocks indefinitely until the control script kills the process.

Closes #35638

## Proposed Changes

Added `spStopCondition->check()` at the top of both pagination loops in `IndexerDownloader.hpp`:

- `fetchWithPit()` (single-thread path): checks before each page fetch. Breaks with an informational log message.
- `fetchWithSlicedPit()` (multi-slice path): each slice worker thread checks before each page fetch. Breaks with a per-slice log message.

With these checks, the download loops exit within one HTTP round-trip of the stop signal being set. The `~Action()` destructor's `join()` completes promptly, allowing `VulnerabilityScannerFacade::stop()` to return and the process to exit cleanly.

Additionally, improved log messages to distinguish between a completed and an interrupted download. Per-slice, initial load, and incremental update log lines now say "interrupted" instead of "complete" when a stop signal was received, avoiding confusion in log analysis.

On next startup the feed is re-downloaded from scratch since `FEED_COMPLETE_KEY` is never written for interrupted downloads and the updater state is cleared.

### Results and Evidence

#### Stop timeout reproduced (BEFORE fix)

Ensuring feed is clean and manager starts correctly:
```
root@aio:~/docs# rm -rf /var/wazuh-manager/queue/vd/feed/*
root@aio:~/docs# rm -rf /var/wazuh-manager/queue/vd_updater/*
root@aio:~/docs# /var/wazuh-manager/bin/wazuh-manager-control start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
```

Waiting for download to start:
```
2026/04/22 22:03:30 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/04/22 22:03:30 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/04/22 22:03:30 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
```

Stopping the manager and measuring time — **Run 1**:
```
root@aio:~/docs# time /var/wazuh-manager/bin/wazuh-manager-control stop
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
...
Process wazuh-manager-modulesd couldn't be terminated. It will be killed.
Wazuh v5.0.0 Stopped

real  0m29.194s
```

**Run 2**: `real 0m29.161s` — same result.
**Run 3**: `real 0m29.146s` — same result.

#### GDB backtrace confirming root cause (BEFORE fix)

Attached GDB to `wazuh-manager-modulesd` during active feed download. The download runs inside `fetchWithSlicedPit()`, which spawns N slice worker threads (2 by default) and joins them. Each slice worker runs a pagination loop:

```cpp
// IndexerDownloader.hpp — fetchWithSlicedPit() slice worker
while (true)                                    // ← no stop check
{
    const auto hitsObj =
        sliceConnector.search(pit, ...);        // ← HTTP request to indexer

    // ... extract hits ...

    processPage(context, hitArray, sliceCursor); // ← write to RocksDB

    if (hitArray.size() < pageSize)
        break;                                  // ← only exits when index exhausted

    searchAfter = lastHit.at("sort");
}
```

GDB backtraces during download confirm the two slice workers are inside this loop:

**Slice 0** — inside `processPage()`, writing to RocksDB:
```
Thread 10:
  IndexerDownloader::processPage(...)             at IndexerDownloader.hpp:415
  IndexerDownloader::fetchWithSlicedPit::lambda(sliceId=0)  at IndexerDownloader.hpp:588
```

**Slice 1** — inside `search()`, HTTP request to indexer:
```
Thread 9:
  HTTPRequest::post(...)
  IndexerConnectorSync::search(...)               at indexerConnectorSync.cpp:171
  IndexerDownloader::fetchWithSlicedPit::lambda(sliceId=1)  at IndexerDownloader.hpp:574
```

**Scheduler thread (Thread 16)** — blocked joining the slice workers:
```
Thread 16:
  std::thread::join()                             ← BLOCKED waiting for slice threads
  IndexerDownloader::fetchWithSlicedPit(...)       at IndexerDownloader.hpp:651
  IndexerDownloader::initialLoad(...)              at IndexerDownloader.hpp:703
  IndexerDownloader::handleRequest(...)            at IndexerDownloader.hpp:819
  ActionOrchestrator::run(...)                     at actionOrchestrator.hpp:113
  Action::runAction(...)                           at action.hpp:214
  Action::runActionScheduled(...)                  at action.hpp:120
```

#### Clean stop during download (AFTER fix)

Ensuring feed is clean and manager starts correctly:
```
root@aio:~/docs# rm -rf /var/wazuh-manager/queue/vd/feed/*
root@aio:~/docs# rm -rf /var/wazuh-manager/queue/vd_updater/*
root@aio:~/docs# /var/wazuh-manager/bin/wazuh-manager-control start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
```

Waiting for download to start:
```
2026/04/22 22:03:30 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/04/22 22:03:30 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/04/22 22:03:30 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
```

Stopping the manager and measuring time — **Run 1**:
```
root@aio:/Users/fabioc/ubuntu-data/wazuh# time /var/wazuh-manager/bin/wazuh-manager-control stop
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
Killing wazuh-manager-monitord...
Killing wazuh-manager-remoted...
Killing wazuh-manager-analysisd...
Killing wazuh-manager-db...
Killing wazuh-manager-authd...
Killing wazuh-manager-apid...
Wazuh v5.0.0 Stopped

real	0m2.104s
```

**Run 2**: `real 0m2.111s`
**Run 3**: `real 0m3.110s`

#### Log confirmation of graceful abort (AFTER fix)

Manager now logs when stopped during download:
```
2026/04/23 13:44:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Stop requested — slice 0 aborting.
2026/04/23 13:44:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0/2 interrupted — 42000 docs in 27950ms
2026/04/23 13:44:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Stop requested — slice 1 aborting.
2026/04/23 13:44:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1/2 interrupted — 41750 docs in 28216ms
2026/04/23 13:44:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase interrupted — 83750 documents, cursor: '83859'
```

#### Feed recovers after interrupted download (AFTER fix)

After a clean stop mid-download, the next startup performs a full re-download from scratch and the final document count matches a run with no interruption:

With mid-download stop:
```
2026/04/23 13:46:05 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/04/23 13:46:05 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/04/23 13:46:05 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
...
2026/04/23 13:50:25 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0/2 complete — 169992 docs in 259467ms
2026/04/23 13:50:25 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1/2 complete — 169857 docs in 259621ms
2026/04/23 13:50:25 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 339849 documents, cursor: '361214'
```

Without mid-download stop (baseline):
```
2026/04/23 13:52:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/04/23 13:52:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/04/23 13:52:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
...
2026/04/23 13:56:08 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0/2 complete — 169992 docs in 241787ms
2026/04/23 13:56:08 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1/2 complete — 169857 docs in 241970ms
2026/04/23 13:56:08 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 339849 documents, cursor: '361214'
```

Both runs produce 339,849 documents with cursor 361,214.

Same procedure but with slices = 16

With mid-download stop:
```
2026/04/23 17:01:35 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/04/23 17:01:35 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=16)
2026/04/23 17:01:35 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 16 slices, pageSize=250
...
2026/04/23 17:06:37 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 4/16 complete — 21223 docs in 301417ms
2026/04/23 17:06:37 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 7/16 complete — 21059 docs in 301435ms
2026/04/23 17:06:38 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 2/16 complete — 21118 docs in 302929ms
2026/04/23 17:06:38 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 5/16 complete — 21058 docs in 302999ms
2026/04/23 17:06:39 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 10/16 complete — 21139 docs in 303366ms
2026/04/23 17:06:41 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 14/16 complete — 21146 docs in 305667ms
2026/04/23 17:06:42 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 9/16 complete — 21102 docs in 306572ms
2026/04/23 17:06:43 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0/16 complete — 21387 docs in 307922ms
2026/04/23 17:06:44 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 6/16 complete — 21184 docs in 308666ms
2026/04/23 17:06:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 15/16 complete — 21172 docs in 309391ms
2026/04/23 17:06:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1/16 complete — 21370 docs in 309885ms
2026/04/23 17:06:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 8/16 complete — 21337 docs in 309929ms
2026/04/23 17:06:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 3/16 complete — 21340 docs in 310078ms
2026/04/23 17:06:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 11/16 complete — 21315 docs in 310155ms
2026/04/23 17:06:47 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 12/16 complete — 21458 docs in 311672ms
2026/04/23 17:06:48 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 13/16 complete — 21441 docs in 312617ms
2026/04/23 17:06:48 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 339849 documents, cursor: '361214'
```

Without mid-download stop (baseline):
```
2026/04/23 17:08:25 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/04/23 17:08:25 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=16)
2026/04/23 17:08:25 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 16 slices, pageSize=250
...
2026/04/23 17:13:34 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 2/16 complete — 21118 docs in 309633ms
2026/04/23 17:13:34 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 9/16 complete — 21102 docs in 309744ms
2026/04/23 17:13:37 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 4/16 complete — 21223 docs in 311845ms
2026/04/23 17:13:37 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 15/16 complete — 21172 docs in 312790ms
2026/04/23 17:13:39 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 6/16 complete — 21184 docs in 313807ms
2026/04/23 17:13:44 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 5/16 complete — 21058 docs in 319133ms
2026/04/23 17:13:44 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 7/16 complete — 21059 docs in 319197ms
2026/04/23 17:13:44 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 10/16 complete — 21139 docs in 319485ms
2026/04/23 17:13:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 14/16 complete — 21146 docs in 319993ms
2026/04/23 17:13:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0/16 complete — 21387 docs in 320449ms
2026/04/23 17:13:46 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 12/16 complete — 21458 docs in 321698ms
2026/04/23 17:13:46 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 3/16 complete — 21340 docs in 321764ms
2026/04/23 17:13:47 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 8/16 complete — 21337 docs in 321782ms
2026/04/23 17:13:47 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1/16 complete — 21370 docs in 322051ms
2026/04/23 17:13:47 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 13/16 complete — 21441 docs in 322675ms
2026/04/23 17:13:47 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 11/16 complete — 21315 docs in 322716ms
2026/04/23 17:13:48 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 339849 documents, cursor: '361214'
```

Both runs produce 339,849 documents with cursor 361,214.

### Artifacts Affected

- `libcontent_manager.so` (all platforms: manager)

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

None

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
