### PR TITLE
Fix agent 5x sends trailing null byte 0 in messages

### DIFF
--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -58,19 +58,9 @@ int receive_msg(void);
 int receiver_messages(void);
 #endif
 
-/**
- * @brief Represents a single message stored in the event buffer.
- *
- * This structure is used to hold a message that can be either a null-terminated
- * text string or a raw binary data buffer. It pairs a pointer to the data with
- * its explicit size, allowing the system to handle binary content safely
- * without truncation at null bytes.
- */
+/* Message stored in the event buffer. */
 typedef struct {
-    /** @brief Pointer to the dynamically allocated message data. */
     void *data;
-
-    /** @brief The exact size of the data in bytes. */
     size_t size;
 } buffered_message;
 

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -58,6 +58,22 @@ int receive_msg(void);
 int receiver_messages(void);
 #endif
 
+/**
+ * @brief Represents a single message stored in the event buffer.
+ *
+ * This structure is used to hold a message that can be either a null-terminated
+ * text string or a raw binary data buffer. It pairs a pointer to the data with
+ * its explicit size, allowing the system to handle binary content safely
+ * without truncation at null bytes.
+ */
+typedef struct {
+    /** @brief Pointer to the dynamically allocated message data. */
+    void *data;
+
+    /** @brief The exact size of the data in bytes. */
+    size_t size;
+} buffered_message;
+
 /* Initialize agent buffer */
 void buffer_init();
 

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -133,14 +133,10 @@ int buffer_append(const char *msg, ssize_t msg_len) {
     } else {
         size_t payload_size;
         size_t alloc_size;
-        if (msg_len < 0) { // Null-terminated text message.
-            // The wire-level size must exclude the terminator so the manager
-            // does not receive a trailing '\0' in event.original. Allocate
-            // payload_size + 1 so the stored copy stays safely null-terminated
-            // for any callers that briefly treat it as a C string.
+        if (msg_len < 0) {
             payload_size = strlen(msg);
             alloc_size = payload_size + 1;
-        } else { // Binary buffer with an explicit length.
+        } else {
             payload_size = (size_t)msg_len;
             alloc_size = payload_size;
         }

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -43,25 +43,9 @@ struct{
 } buff;
 
 /**
- * @brief Represents a single message stored in the event buffer.
- *
- * This structure is used to hold a message that can be either a null-terminated
- * text string or a raw binary data buffer. It pairs a pointer to the data with
- * its explicit size, allowing the system to handle binary content safely
- * without truncation at null bytes.
- */
-typedef struct {
-    /** @brief Pointer to the dynamically allocated message data. */
-    void *data;
-
-    /** @brief The exact size of the data in bytes. */
-    size_t size;
-} buffered_message;
-
-/**
  * @brief The agent's main event buffer.
  */
-static buffered_message *buffer;
+STATIC buffered_message *buffer;
 
 static pthread_mutex_t mutex_lock;
 static pthread_cond_t cond_no_empty;

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -131,16 +131,23 @@ int buffer_append(const char *msg, ssize_t msg_len) {
         return(-1);
 
     } else {
-        size_t size_to_alloc;
-        if (msg_len < 0) { // It's a null-terminated string.
-            size_to_alloc = strlen(msg) + 1;
-        } else { // It's a binary buffer with a known length.
-            size_to_alloc = (size_t)msg_len;
+        size_t payload_size;
+        size_t alloc_size;
+        if (msg_len < 0) { // Null-terminated text message.
+            // The wire-level size must exclude the terminator so the manager
+            // does not receive a trailing '\0' in event.original. Allocate
+            // payload_size + 1 so the stored copy stays safely null-terminated
+            // for any callers that briefly treat it as a C string.
+            payload_size = strlen(msg);
+            alloc_size = payload_size + 1;
+        } else { // Binary buffer with an explicit length.
+            payload_size = (size_t)msg_len;
+            alloc_size = payload_size;
         }
 
-        os_malloc(size_to_alloc, buffer[i].data);
-        memcpy(buffer[i].data, msg, size_to_alloc);
-        buffer[i].size = size_to_alloc;
+        os_malloc(alloc_size, buffer[i].data);
+        memcpy(buffer[i].data, msg, alloc_size);
+        buffer[i].size = payload_size;
 
         forward(i, agt->buflength + 1);
         w_cond_signal(&cond_no_empty);

--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -987,13 +987,7 @@ void Json::setString(std::string_view value, std::string_view path)
     if (pp.IsValid())
     {
         const auto* data = value.data() ? value.data() : "";
-        auto len = value.size();
-        // Strip trailing null bytes: a JSON string must not contain embedded \0.
-        while (len > 0 && data[len - 1] == '\0')
-        {
-            --len;
-        }
-        rapidjson::Value v(data, static_cast<rapidjson::SizeType>(len), m_document.GetAllocator());
+        rapidjson::Value v(data, static_cast<rapidjson::SizeType>(value.size()), m_document.GetAllocator());
         pp.Set(m_document, v);
         return;
     }

--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -1702,64 +1702,6 @@ TEST_F(JsonSettersTest, SetString)
     ASSERT_THROW(jObjString.setString("newValue", "object/key"), std::runtime_error);
 }
 
-TEST_F(JsonSettersTest, SetStringStripsTrailingNullBytes)
-{
-    Json doc {};
-    std::string tmp;
-
-    // Single trailing \0 (the most common case: OS_SendUnix sends strlen+1 bytes)
-    {
-        std::string_view withNull {"hello\0", 6}; // size=6, includes the \0
-        doc.setString(withNull, "/field");
-        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field"));
-        ASSERT_EQ("hello", tmp);
-        ASSERT_EQ(5u, tmp.size()); // no null byte stored
-        // Serialised JSON must not contain \u0000
-        ASSERT_EQ(std::string::npos, doc.str().find("\\u0000"));
-    }
-
-    // Multiple trailing \0 bytes (e.g. padded buffer)
-    {
-        std::string_view multiNull {"abc\0\0\0", 6};
-        doc.setString(multiNull, "/field2");
-        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field2"));
-        ASSERT_EQ("abc", tmp);
-        ASSERT_EQ(3u, tmp.size());
-    }
-
-    // String that is all null bytes must become an empty string
-    {
-        std::string_view allNull {"\0\0", 2};
-        doc.setString(allNull, "/field3");
-        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field3"));
-        ASSERT_TRUE(tmp.empty());
-    }
-
-    // Normal string without any \0 must be stored unchanged
-    {
-        doc.setString("normal", "/field4");
-        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field4"));
-        ASSERT_EQ("normal", tmp);
-    }
-
-    // Empty string must remain empty
-    {
-        doc.setString("", "/field5");
-        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field5"));
-        ASSERT_TRUE(tmp.empty());
-    }
-
-    // \0 embedded in the MIDDLE is not stripped (only trailing ones are)
-    {
-        std::string_view embeddedNull {"a\0b", 3}; // \0 is in the middle
-        doc.setString(embeddedNull, "/field6");
-        ASSERT_EQ(json::RetGet::Success, doc.getString(tmp, "/field6"));
-        // Only the trailing-strip loop runs; the mid-string \0 followed by 'b' means
-        // no trailing \0 is stripped — the full 3-byte string is stored.
-        ASSERT_EQ(3u, tmp.size());
-    }
-}
-
 TEST_F(JsonSettersTest, SetInt)
 {
     Json jObjInt {R"({

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -1004,6 +1004,23 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         return;
     }
 
+    /* Issue #35474: strip trailing NUL bytes from the event payload before
+     * it reaches the router or analysisd. Wazuh 5.x agents prior to the
+     * buffer_append fix included the terminating '\0' in the wire-level
+     * length of legacy text events; the byte rides the HTTP body and gets
+     * stored verbatim by RapidJSON in event.original, silently breaking
+     * decoder matches. Compliant agents are unaffected -- the loop is a
+     * no-op when msg_length already excludes the terminator. */
+    size_t stripped_nulls = 0;
+    while (msg_length > 0 && tmp_msg[msg_length - 1] == '\0') {
+        msg_length--;
+        stripped_nulls++;
+    }
+    if (stripped_nulls > 0) {
+        mdebug1("Stripped %zu trailing null byte(s) from event payload of agent '%s'",
+                stripped_nulls, agentid_str);
+    }
+
     // Check if message should be forwarded to router instead of analysisd
     bool forwarded_to_router = false;
     if (router_forwarding_disabled != 1) {

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -772,18 +772,6 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         return;
     }
 
-    /* Defense in depth note: downstream code (strncmp, IsValidHeader, strchr
-     * in validate_control_msg, w_utf8_filter, cJSON_ParseWithOpts in
-     * router_message_forward) treats tmp_msg as a C string. A malicious
-     * agent with a valid key could craft a decrypted payload whose
-     * msg_length does not include a trailing '\0'. The memset of
-     * cleartext_msg to '\0' at the top of this function (OS_MAXSTR + 1
-     * bytes) guarantees that the byte immediately past any valid decrypted
-     * payload is already a NUL, so those downstream calls cannot walk off
-     * the decrypted region. Any change to that memset, or any path that
-     * re-enters ReadSecMSG without re-zeroing, must re-establish the
-     * sentinel explicitly. */
-
     /* Recieved valid message timestamp updated. */
     keys.keyentries[agentid]->rcvd = current_ts;
 
@@ -934,11 +922,6 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
 
                 ctrl_msg_data->key = key;
 
-                // Size exactly to tmp_msg_length plus a sentinel '\0'. The previous
-                // allocation used msg_length (which is tmp_msg_length + 3 because the
-                // HC_AGENT_ACK header has been stripped) so it over-allocated by three
-                // bytes and, more importantly, left no guaranteed terminator for the
-                // cJSON_Parse(strchr(clean, '{')) path in validate_control_msg.
                 os_calloc(tmp_msg_length + 1, sizeof(char), ctrl_msg_data->message);
                 // Use cleaned message from validation if available, otherwise use original
                 memcpy(ctrl_msg_data->message, cleaned_msg ? cleaned_msg : tmp_msg, tmp_msg_length);
@@ -1004,23 +987,6 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         return;
     }
 
-    /* Issue #35474: strip trailing NUL bytes from the event payload before
-     * it reaches the router or analysisd. Wazuh 5.x agents prior to the
-     * buffer_append fix included the terminating '\0' in the wire-level
-     * length of legacy text events; the byte rides the HTTP body and gets
-     * stored verbatim by RapidJSON in event.original, silently breaking
-     * decoder matches. Compliant agents are unaffected -- the loop is a
-     * no-op when msg_length already excludes the terminator. */
-    size_t stripped_nulls = 0;
-    while (msg_length > 0 && tmp_msg[msg_length - 1] == '\0') {
-        msg_length--;
-        stripped_nulls++;
-    }
-    if (stripped_nulls > 0) {
-        mdebug1("Stripped %zu trailing null byte(s) from event payload of agent '%s'",
-                stripped_nulls, agentid_str);
-    }
-
     // Check if message should be forwarded to router instead of analysisd
     bool forwarded_to_router = false;
     if (router_forwarding_disabled != 1) {
@@ -1029,11 +995,18 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
 
     // Only send to analysisd if not forwarded to router
     if (!forwarded_to_router) {
+        /* Router-bound messages may be binary; trim only analysisd events. */
+        size_t stripped_nulls = 0;
+        while (msg_length > 0 && tmp_msg[msg_length - 1] == '\0') {
+            msg_length--;
+            stripped_nulls++;
+        }
+        if (stripped_nulls > 0) {
+            mdebug1("Stripped %zu trailing null byte(s) from event payload of agent '%s'",
+                    stripped_nulls, agentid_str);
+        }
+
         evt_item_t *e; os_calloc(1, sizeof(*e), e);
-        // Allocate one extra byte so e->raw[e->len] is a guaranteed '\0'. The
-        // downstream bulk writer uses e->len (length-aware) so this does not
-        // change the bytes sent to the engine; the sentinel only protects any
-        // future consumer that might treat e->raw as a C string.
         os_calloc(msg_length + 1, sizeof(char), e->raw);
         memcpy(e->raw, tmp_msg, msg_length);
         e->len = msg_length;

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -772,6 +772,18 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         return;
     }
 
+    /* Defense in depth note: downstream code (strncmp, IsValidHeader, strchr
+     * in validate_control_msg, w_utf8_filter, cJSON_ParseWithOpts in
+     * router_message_forward) treats tmp_msg as a C string. A malicious
+     * agent with a valid key could craft a decrypted payload whose
+     * msg_length does not include a trailing '\0'. The memset of
+     * cleartext_msg to '\0' at the top of this function (OS_MAXSTR + 1
+     * bytes) guarantees that the byte immediately past any valid decrypted
+     * payload is already a NUL, so those downstream calls cannot walk off
+     * the decrypted region. Any change to that memset, or any path that
+     * re-enters ReadSecMSG without re-zeroing, must re-establish the
+     * sentinel explicitly. */
+
     /* Recieved valid message timestamp updated. */
     keys.keyentries[agentid]->rcvd = current_ts;
 
@@ -922,7 +934,12 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
 
                 ctrl_msg_data->key = key;
 
-                os_calloc(msg_length, sizeof(char), ctrl_msg_data->message);
+                // Size exactly to tmp_msg_length plus a sentinel '\0'. The previous
+                // allocation used msg_length (which is tmp_msg_length + 3 because the
+                // HC_AGENT_ACK header has been stripped) so it over-allocated by three
+                // bytes and, more importantly, left no guaranteed terminator for the
+                // cJSON_Parse(strchr(clean, '{')) path in validate_control_msg.
+                os_calloc(tmp_msg_length + 1, sizeof(char), ctrl_msg_data->message);
                 // Use cleaned message from validation if available, otherwise use original
                 memcpy(ctrl_msg_data->message, cleaned_msg ? cleaned_msg : tmp_msg, tmp_msg_length);
 
@@ -996,7 +1013,11 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
     // Only send to analysisd if not forwarded to router
     if (!forwarded_to_router) {
         evt_item_t *e; os_calloc(1, sizeof(*e), e);
-        os_calloc(msg_length, sizeof(char), e->raw);
+        // Allocate one extra byte so e->raw[e->len] is a guaranteed '\0'. The
+        // downstream bulk writer uses e->len (length-aware) so this does not
+        // change the bytes sent to the engine; the sentinel only protects any
+        // future consumer that might treat e->raw as a C string.
+        os_calloc(msg_length + 1, sizeof(char), e->raw);
         memcpy(e->raw, tmp_msg, msg_length);
         e->len = msg_length;
 

--- a/src/unit_tests/client-agent/test_buffer.c
+++ b/src/unit_tests/client-agent/test_buffer.c
@@ -155,6 +155,54 @@ void test_buffer_append(void **state)
     os_free(agt);
 }
 
+void test_buffer_append_text_size_excludes_null_terminator(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 5;
+    i = 0;
+    j = 0;
+
+    /* Legacy text path (msg_len < 0): the manager must receive exactly
+     * strlen(msg) bytes on the wire, without a trailing '\0'. Regression
+     * guard for issue #35474, where the stored size was strlen + 1 and
+     * the terminator leaked into the encrypted frame, breaking downstream
+     * decoders that parsed event.original. */
+    const char *text_event = "1:/var/log/syslog:Apr 20 hello";
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    buffer_init();
+    buffer_append(text_event, -1);
+
+    assert_non_null(buffer[0].data);
+    assert_int_equal(strlen(text_event), buffer[0].size);
+    assert_memory_equal(text_event, buffer[0].data, strlen(text_event));
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    w_agentd_buffer_free(agt->buflength);
+
+    os_free(agt);
+}
+
 void test_buffer_append_binary_preserves_size(void **state)
 {
     os_calloc(1, sizeof(agent), agt);
@@ -441,6 +489,7 @@ int main(void) {
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer),
         #ifndef TEST_WINAGENT
         cmocka_unit_test(test_buffer_append),
+        cmocka_unit_test(test_buffer_append_text_size_excludes_null_terminator),
         cmocka_unit_test(test_buffer_append_binary_preserves_size),
         cmocka_unit_test(test_w_agentd_buffer_free),
         cmocka_unit_test(test_w_agentd_buffer_resize_shrink),

--- a/src/unit_tests/client-agent/test_buffer.c
+++ b/src/unit_tests/client-agent/test_buffer.c
@@ -163,11 +163,6 @@ void test_buffer_append_text_size_excludes_null_terminator(void **state)
     i = 0;
     j = 0;
 
-    /* Legacy text path (msg_len < 0): the manager must receive exactly
-     * strlen(msg) bytes on the wire, without a trailing '\0'. Regression
-     * guard for issue #35474, where the stored size was strlen + 1 and
-     * the terminator leaked into the encrypted frame, breaking downstream
-     * decoders that parsed event.original. */
     const char *text_event = "1:/var/log/syslog:Apr 20 hello";
 
     expect_function_call(__wrap_getDefine_Int);
@@ -211,9 +206,6 @@ void test_buffer_append_binary_preserves_size(void **state)
     i = 0;
     j = 0;
 
-    /* Binary payload with an embedded NUL in the middle and another at the tail.
-     * The explicit-length path (msg_len >= 0) must store the exact byte count
-     * without truncating at the first NUL or silently adding a terminator. */
     const char payload[] = { 's', 'y', 's', 'c', 'h', 'e', 'c', 'k',
                              '\0', '{', '"', 'x', '"', ':', '1', '}', '\0' };
     const size_t payload_len = sizeof(payload);

--- a/src/unit_tests/client-agent/test_buffer.c
+++ b/src/unit_tests/client-agent/test_buffer.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 
 #include "client-config.h"
+#include "agentd.h"
 
 #include "../wrappers/posix/pthread_wrappers.h"
 
@@ -29,7 +30,7 @@ void buffer_init();
 extern agent *agt;
 extern int i;
 extern int j;
-extern char **buffer;
+extern buffered_message *buffer;
 
 /* setup/teardown */
 
@@ -147,6 +148,54 @@ void test_buffer_append(void **state)
     expect_function_call(__wrap_pthread_mutex_unlock);
 
     // expect_function_call(__wrap__mwarn);
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    w_agentd_buffer_free(agt->buflength);
+
+    os_free(agt);
+}
+
+void test_buffer_append_binary_preserves_size(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 5;
+    i = 0;
+    j = 0;
+
+    /* Binary payload with an embedded NUL in the middle and another at the tail.
+     * The explicit-length path (msg_len >= 0) must store the exact byte count
+     * without truncating at the first NUL or silently adding a terminator. */
+    const char payload[] = { 's', 'y', 's', 'c', 'h', 'e', 'c', 'k',
+                             '\0', '{', '"', 'x', '"', ':', '1', '}', '\0' };
+    const size_t payload_len = sizeof(payload);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+
+    buffer_init();
+    buffer_append(payload, (ssize_t)payload_len);
+
+    assert_non_null(buffer[0].data);
+    assert_int_equal(payload_len, buffer[0].size);
+    assert_memory_equal(payload, buffer[0].data, payload_len);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
     expect_any(__wrap__mdebug1, formatted_msg);
 
     w_agentd_buffer_free(agt->buflength);
@@ -392,6 +441,7 @@ int main(void) {
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer),
         #ifndef TEST_WINAGENT
         cmocka_unit_test(test_buffer_append),
+        cmocka_unit_test(test_buffer_append_binary_preserves_size),
         cmocka_unit_test(test_w_agentd_buffer_free),
         cmocka_unit_test(test_w_agentd_buffer_resize_shrink),
         cmocka_unit_test(test_w_agentd_buffer_resize_grow_continue),

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -59,7 +59,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock -Wl,--wrap,getDefine_Int -Wl,--wrap,getDefine_Int_default \
                             -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_evt \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
-                            -Wl,--wrap,router_provider_send -Wl,--wrap,w_query_agentd ${HASH_OP_WRAPPERS}")
+                            -Wl,--wrap,router_provider_send -Wl,--wrap,router_provider_send_sync \
+                            -Wl,--wrap,w_query_agentd ${HASH_OP_WRAPPERS}")
 
 list(APPEND remoted_names "test_save_ctrlmsg_thread")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -627,6 +627,11 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     w_ctrl_msg_data_t * node = indexed_queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent shutdown ");
+    // The copy is sized tmp_msg_length + 1 (15 + 1 = 16), so node->message[15]
+    // is the sentinel '\0' written by os_calloc. If a regression shrinks the
+    // allocation back to tmp_msg_length, this access becomes a one-byte
+    // over-read that AddressSanitizer will flag.
+    assert_int_equal('\0', node->message[strlen("agent shutdown ")]);
     assert_int_equal(node->key->keyid, 1);
     assert_int_equal(node->key->sock, 1);
     assert_string_equal(node->key->id, "009");

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2597,6 +2597,103 @@ void test_HandleSecureMessage_discard_dbsync_message(void** state)
     batch_queue_free(events_queue);
 }
 
+/* Issue #35474 inverse-case guard. A 5.x-shaped event without a trailing
+ * NUL reaches HandleSecureMessage; this checker is invoked via expect_check
+ * while cmocka validates the data argument to batch_queue_enqueue_ex. It
+ * reads e->raw[e->len] before HandleSecureMessage returns (while the
+ * allocation is still live) — under AddressSanitizer any regression that
+ * shrinks the event allocation below e->len + 1 shows up as a
+ * heap-buffer-overflow on that read. */
+static int check_evt_item_sentinel(const LargestIntegralType value,
+                                   const LargestIntegralType check_value_data) {
+    (void)check_value_data;
+    evt_item_t *e = (evt_item_t *)(uintptr_t)value;
+    assert_non_null(e);
+    assert_non_null(e->raw);
+    assert_int_equal('\0', e->raw[e->len]);
+    return 1;
+}
+
+void test_HandleSecureMessage_event_without_trailing_null(void** state)
+{
+    const char *payload = "Apr 23 12:34:56 host dpkg[1]: status installed foo:amd64 1.0.0";
+    size_t payload_len = strlen(payload);
+
+    /* Fill the stack buffer with a non-NUL sentinel so that if the
+     * production code ever relied on the byte at buffer[payload_len]
+     * being '\0', the test would catch it. */
+    char buffer[OS_MAXSTR + 1];
+    memset(buffer, 0xAA, sizeof(buffer));
+    memcpy(buffer, payload, payload_len);
+
+    message_t message = {.buffer = buffer, .size = payload_len, .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+    w_rr_queue_t * events_queue = batch_queue_init(10);
+    batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("name");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    /* The test buffer is intentionally filled with a non-NUL sentinel, so
+     * it is not a valid C string. Skip string-matching on it. */
+    expect_any(__wrap_ReadSecMSG, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, payload_len);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    /* Bypass router_message_forward so the event path runs. */
+    router_forwarding_disabled = 1;
+
+    expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
+    expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
+    expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_sentinel, NULL);
+    will_return(__wrap_batch_queue_enqueue_ex, -1);
+    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+
+    HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    router_forwarding_disabled = 0;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+    batch_queue_free(events_queue);
+}
+
 void test_handle_new_tcp_connection_success(void** state)
 {
     struct sockaddr_in peer_info;
@@ -2965,6 +3062,7 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed),
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_disabled),
         cmocka_unit_test(test_HandleSecureMessage_discard_dbsync_message),
+        cmocka_unit_test(test_HandleSecureMessage_event_without_trailing_null),
         // Tests handle_new_tcp_connection
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_success, setup_new_tcp, teardown_new_tcp),
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_wnotify_fail, setup_new_tcp, teardown_new_tcp),

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -1288,6 +1288,7 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     expect_value(__wrap_rem_setCounter, counter, 0);
 
     expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [4]");
+    expect_string(__wrap__mdebug1, formatted_msg, "Stripped 1 trailing null byte(s) from event payload of agent '001'");
 
     /* enqueue */
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
@@ -1972,6 +1973,7 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
     expect_function_call(__wrap_key_unlock);
+    expect_string(__wrap__mdebug1, formatted_msg, "Stripped 1 trailing null byte(s) from event payload of agent '001'");
 
     /* enqueue */
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
@@ -2045,6 +2047,7 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
     expect_function_call(__wrap_key_unlock);
+    expect_string(__wrap__mdebug1, formatted_msg, "Stripped 1 trailing null byte(s) from event payload of agent '001'");
 
     /* enqueue */
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
@@ -2509,6 +2512,7 @@ void test_HandleSecureMessage_router_forwarding_disabled(void** state)
 
     // Set router_forwarding_disabled to 1 to test disabled forwarding
     router_forwarding_disabled = 1;
+    expect_string(__wrap__mdebug1, formatted_msg, "Stripped 1 trailing null byte(s) from event payload of agent '001'");
 
     /* enqueue - since router forwarding is disabled, message goes to analysisd */
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
@@ -2678,6 +2682,105 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_sentinel, NULL);
+    will_return(__wrap_batch_queue_enqueue_ex, -1);
+    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+
+    HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    router_forwarding_disabled = 0;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+    batch_queue_free(events_queue);
+}
+
+/* Issue #35474 positive guard. A legacy Wazuh 5.x agent (before the
+ * buffer_append fix) delivers a text event whose msg_length includes the
+ * trailing '\0'. HandleSecureMessage must strip the NUL so the payload
+ * forwarded to analysisd does not carry it. Asserts e->len equals the
+ * true payload length and the last stored byte is the payload's final
+ * character (not '\0'), plus verifies the mdebug1 log fires with the
+ * exact stripped count. */
+static int check_evt_item_trimmed(const LargestIntegralType value,
+                                  const LargestIntegralType check_value_data) {
+    (void)check_value_data;
+    evt_item_t *e = (evt_item_t *)(uintptr_t)value;
+    assert_non_null(e);
+    assert_non_null(e->raw);
+    assert_int_equal(62, e->len);
+    assert_int_not_equal('\0', e->raw[e->len - 1]);
+    assert_int_equal('\0', e->raw[e->len]);
+    return 1;
+}
+
+void test_HandleSecureMessage_event_with_trailing_null(void** state)
+{
+    const char *payload = "Apr 23 12:34:56 host dpkg[1]: status installed foo:amd64 1.0.0";
+    size_t payload_len = strlen(payload);
+    assert_int_equal(62, payload_len);
+
+    char buffer[OS_MAXSTR + 1];
+    memset(buffer, 0xAA, sizeof(buffer));
+    memcpy(buffer, payload, payload_len);
+    buffer[payload_len] = '\0';
+
+    message_t message = {.buffer = buffer, .size = payload_len + 1, .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+    w_rr_queue_t * events_queue = batch_queue_init(10);
+    batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("name");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_any(__wrap_ReadSecMSG, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, payload_len + 1);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Stripped 1 trailing null byte(s) from event payload of agent '001'");
+
+    /* Bypass router_message_forward so the event path runs. */
+    router_forwarding_disabled = 1;
+
+    expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
+    expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
+    expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_trimmed, NULL);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
 
@@ -3063,6 +3166,7 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_disabled),
         cmocka_unit_test(test_HandleSecureMessage_discard_dbsync_message),
         cmocka_unit_test(test_HandleSecureMessage_event_without_trailing_null),
+        cmocka_unit_test(test_HandleSecureMessage_event_with_trailing_null),
         // Tests handle_new_tcp_connection
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_success, setup_new_tcp, teardown_new_tcp),
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_wnotify_fail, setup_new_tcp, teardown_new_tcp),

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -627,10 +627,6 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     w_ctrl_msg_data_t * node = indexed_queue_pop(control_msg_queue);
     assert_non_null(node);
     assert_string_equal(node->message, "agent shutdown ");
-    // The copy is sized tmp_msg_length + 1 (15 + 1 = 16), so node->message[15]
-    // is the sentinel '\0' written by os_calloc. If a regression shrinks the
-    // allocation back to tmp_msg_length, this access becomes a one-byte
-    // over-read that AddressSanitizer will flag.
     assert_int_equal('\0', node->message[strlen("agent shutdown ")]);
     assert_int_equal(node->key->keyid, 1);
     assert_int_equal(node->key->sock, 1);
@@ -2601,13 +2597,6 @@ void test_HandleSecureMessage_discard_dbsync_message(void** state)
     batch_queue_free(events_queue);
 }
 
-/* Issue #35474 inverse-case guard. A 5.x-shaped event without a trailing
- * NUL reaches HandleSecureMessage; this checker is invoked via expect_check
- * while cmocka validates the data argument to batch_queue_enqueue_ex. It
- * reads e->raw[e->len] before HandleSecureMessage returns (while the
- * allocation is still live) — under AddressSanitizer any regression that
- * shrinks the event allocation below e->len + 1 shows up as a
- * heap-buffer-overflow on that read. */
 static int check_evt_item_sentinel(const LargestIntegralType value,
                                    const LargestIntegralType check_value_data) {
     (void)check_value_data;
@@ -2623,9 +2612,6 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
     const char *payload = "Apr 23 12:34:56 host dpkg[1]: status installed foo:amd64 1.0.0";
     size_t payload_len = strlen(payload);
 
-    /* Fill the stack buffer with a non-NUL sentinel so that if the
-     * production code ever relied on the byte at buffer[payload_len]
-     * being '\0', the test would catch it. */
     char buffer[OS_MAXSTR + 1];
     memset(buffer, 0xAA, sizeof(buffer));
     memcpy(buffer, payload, payload_len);
@@ -2665,8 +2651,6 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
     will_return(__wrap_OS_IsAllowedIP, 1);
 
     expect_value(__wrap_ReadSecMSG, keys, &keys);
-    /* The test buffer is intentionally filled with a non-NUL sentinel, so
-     * it is not a valid C string. Skip string-matching on it. */
     expect_any(__wrap_ReadSecMSG, buffer);
     expect_value(__wrap_ReadSecMSG, id, 1);
     expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
@@ -2676,7 +2660,6 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
 
     expect_function_call(__wrap_key_unlock);
 
-    /* Bypass router_message_forward so the event path runs. */
     router_forwarding_disabled = 1;
 
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
@@ -2698,13 +2681,6 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
     batch_queue_free(events_queue);
 }
 
-/* Issue #35474 positive guard. A legacy Wazuh 5.x agent (before the
- * buffer_append fix) delivers a text event whose msg_length includes the
- * trailing '\0'. HandleSecureMessage must strip the NUL so the payload
- * forwarded to analysisd does not carry it. Asserts e->len equals the
- * true payload length and the last stored byte is the payload's final
- * character (not '\0'), plus verifies the mdebug1 log fires with the
- * exact stripped count. */
 static int check_evt_item_trimmed(const LargestIntegralType value,
                                   const LargestIntegralType check_value_data) {
     (void)check_value_data;
@@ -2775,7 +2751,6 @@ void test_HandleSecureMessage_event_with_trailing_null(void** state)
     expect_string(__wrap__mdebug1, formatted_msg,
                   "Stripped 1 trailing null byte(s) from event payload of agent '001'");
 
-    /* Bypass router_message_forward so the event path runs. */
     router_forwarding_disabled = 1;
 
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
@@ -2787,6 +2762,105 @@ void test_HandleSecureMessage_event_with_trailing_null(void** state)
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
     router_forwarding_disabled = 0;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+    batch_queue_free(events_queue);
+}
+
+static const unsigned char g_expected_flatbuf_with_trailing_zeros[] = {
+    0xAB, 0xCD, 0x12, 0x34, 0x56, 0x78,
+    0x00, 0x00, 0x00
+};
+static const size_t g_expected_flatbuf_len =
+    sizeof(g_expected_flatbuf_with_trailing_zeros);
+
+static int check_flatbuf_unchanged(const LargestIntegralType value,
+                                   const LargestIntegralType check_value_data) {
+    (void)check_value_data;
+    const unsigned char *got = (const unsigned char *)(uintptr_t)value;
+    assert_memory_equal(got,
+                        g_expected_flatbuf_with_trailing_zeros,
+                        g_expected_flatbuf_len);
+    return 1;
+}
+
+void test_HandleSecureMessage_inventory_sync_preserves_trailing_null(void** state)
+{
+    const char prefix[] = "s:fim:";
+    const size_t prefix_len = sizeof(prefix) - 1; /* exclude the C-string NUL */
+
+    char buffer[OS_MAXSTR + 1];
+    memset(buffer, 0xAA, sizeof(buffer));
+    memcpy(buffer, prefix, prefix_len);
+    memcpy(buffer + prefix_len,
+           g_expected_flatbuf_with_trailing_zeros,
+           g_expected_flatbuf_len);
+    size_t total_len = prefix_len + g_expected_flatbuf_len;
+
+    message_t message = {.buffer = buffer, .size = total_len, .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+    w_rr_queue_t * events_queue = batch_queue_init(10);
+    batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("name");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_any(__wrap_ReadSecMSG, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, total_len);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    ROUTER_PROVIDER_HANDLE saved_handle = router_sync_handle;
+    router_sync_handle = (ROUTER_PROVIDER_HANDLE)0xDEADBEEF;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Forwarding message to router");
+
+    expect_check(__wrap_router_provider_send_sync, message,
+                 check_flatbuf_unchanged, NULL);
+    expect_value(__wrap_router_provider_send_sync, message_size,
+                 g_expected_flatbuf_len);
+    expect_string(__wrap_router_provider_send_sync, authenticated_agent_id, "001");
+    will_return(__wrap_router_provider_send_sync, 0);
+
+    HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    router_sync_handle = saved_handle;
 
     os_free(key->id);
     os_free(key->name);
@@ -3167,6 +3241,7 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_discard_dbsync_message),
         cmocka_unit_test(test_HandleSecureMessage_event_without_trailing_null),
         cmocka_unit_test(test_HandleSecureMessage_event_with_trailing_null),
+        cmocka_unit_test(test_HandleSecureMessage_inventory_sync_preserves_trailing_null),
         // Tests handle_new_tcp_connection
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_success, setup_new_tcp, teardown_new_tcp),
         cmocka_unit_test_setup_teardown(test_handle_new_tcp_connection_wnotify_fail, setup_new_tcp, teardown_new_tcp),

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
@@ -26,6 +26,16 @@ int __wrap_router_provider_send(__attribute__((unused)) ROUTER_PROVIDER_HANDLE h
     return mock();
 }
 
+int __wrap_router_provider_send_sync(__attribute__((unused)) ROUTER_PROVIDER_HANDLE handle,
+                                     const char* message,
+                                     unsigned int message_size,
+                                     const char* authenticated_agent_id) {
+    check_expected_ptr(message);
+    check_expected(message_size);
+    check_expected(authenticated_agent_id);
+    return mock();
+}
+
 ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name) {
     check_expected(name);
     return mock_ptr_type(ROUTER_PROVIDER_HANDLE);

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
@@ -18,6 +18,11 @@
 
 int __wrap_router_provider_send(ROUTER_PROVIDER_HANDLE handle, const char* message, unsigned int message_size);
 
+int __wrap_router_provider_send_sync(ROUTER_PROVIDER_HANDLE handle,
+                                     const char* message,
+                                     unsigned int message_size,
+                                     const char* authenticated_agent_id);
+
 ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name);
 
 // Router subscriber wrappers for agent upgrade module

--- a/tests/integration/test_remoted/test_message_integrity/__init__.py
+++ b/tests/integration/test_remoted/test_message_integrity/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2015-2024, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+from pathlib import Path
+
+
+# Constants & base paths
+DATA_PATH = Path(Path(__file__).parent, 'data')
+CONFIGS_PATH = Path(DATA_PATH, 'configuration_templates')
+TEST_CASES_PATH = Path(DATA_PATH, 'test_cases')

--- a/tests/integration/test_remoted/test_message_integrity/data/configuration_templates/config_message_integrity.yaml
+++ b/tests/integration/test_remoted/test_message_integrity/data/configuration_templates/config_message_integrity.yaml
@@ -1,0 +1,9 @@
+- sections:
+    - section: remote
+      elements:
+        - port:
+            value: '1514'
+        - protocol:
+            value: 'TCP'
+        - queue_size:
+            value: 131072

--- a/tests/integration/test_remoted/test_message_integrity/data/test_cases/cases_message_integrity.yaml
+++ b/tests/integration/test_remoted/test_message_integrity/data/test_cases/cases_message_integrity.yaml
@@ -1,0 +1,7 @@
+- name: trailing-NUL handling on the wire
+  description: >
+    Legacy text events with trailing NUL bytes must reach analysisd without
+    the padding.
+  configuration_parameters: {}
+  metadata:
+    agents_number: 1

--- a/tests/integration/test_remoted/test_message_integrity/test_trailing_null_handling.py
+++ b/tests/integration/test_remoted/test_message_integrity/test_trailing_null_handling.py
@@ -1,0 +1,92 @@
+"""Trailing-NUL handling regression test."""
+import time
+from pathlib import Path
+
+import pytest
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
+from wazuh_testing.tools.simulators.agent_simulator import connect
+from wazuh_testing.utils import secure_message
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+
+from . import CONFIGS_PATH, TEST_CASES_PATH
+
+
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=2)]
+
+cases_path = Path(TEST_CASES_PATH, 'cases_message_integrity.yaml')
+config_path = Path(CONFIGS_PATH, 'config_message_integrity.yaml')
+test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
+test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
+
+daemons_handler_configuration = {'all_daemons': True}
+local_internal_options = {REMOTED_DEBUG: '2'}
+
+
+def _build_raw_event(agent, payload: bytes) -> bytes:
+    """Build an encrypted event."""
+    encoded = secure_message.encode(payload)
+    encrypted = secure_message.encrypt(encoded, agent.encryption_key, agent.cypher)
+    return agent.headers(agent.id, encrypted)
+
+
+def _read_log_since(start_offset: int) -> str:
+    with open(WAZUH_LOG_PATH, 'rb') as fh:
+        fh.seek(start_offset)
+        return fh.read().decode(errors='replace')
+
+
+def _log_size() -> int:
+    try:
+        return Path(WAZUH_LOG_PATH).stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata',
+                         zip(test_configuration, test_metadata), ids=cases_ids)
+def test_legacy_text_event_with_trailing_null_does_not_reach_engine_with_null(
+        test_configuration, test_metadata,
+        configure_local_internal_options, truncate_monitored_files,
+        set_wazuh_configuration, daemons_handler, simulate_agents):
+    agent = simulate_agents[0]
+    sender, injector = connect(agent, manager_port='1514', protocol='tcp')
+
+    log_offset = _log_size()
+    marker = f"TRAIL-NUL-PROBE-{int(time.time() * 1000)}"
+    payload = f"1:syslog:{marker}".encode() + b"\x00"
+    sender.send_event(_build_raw_event(agent, payload))
+
+    deadline = time.time() + 15.0
+    matching_line = None
+    while time.time() < deadline:
+        log_window = _read_log_since(log_offset)
+        for line in log_window.splitlines():
+            if marker in line and "Event not processed" in line:
+                matching_line = line
+                break
+        if matching_line:
+            break
+        time.sleep(0.5)
+
+    injector.stop_receive()
+
+    assert matching_line is not None, (
+        f"Did not observe an 'Event not processed' warning carrying our marker "
+        f"{marker!r} within 15s -- the event never made it to analysisd."
+    )
+
+    assert "\\u0000" not in matching_line, (
+        f"event.original carries a literal \\u0000 escape -- remoted is no "
+        f"longer stripping the trailing zero from analysisd-bound text events, "
+        f"which is the root-cause symptom of issue #35474. Offending log line: "
+        f"{matching_line}"
+    )
+
+    expected_original = f'"original":"{marker}"'
+    assert expected_original in matching_line, (
+        f"event.original does not match expected marker {marker!r}. "
+        f"Either remoted stripped too aggressively or some other layer "
+        f"mangled the payload. Offending log line: {matching_line}"
+    )


### PR DESCRIPTION
## Description

Agent 5.x appends a trailing null byte (`\0`) to every legacy text event it sends to the manager. The byte survives decryption in `remoted`, rides inside the HTTP bulk body the engine receives, and gets stored verbatim by RapidJSON in `event.original`, where it surfaces as `�` / `^@` in archived JSON and silently prevents decoder rules from matching the field, which is why, with no fix in place, no alerts are generated for the affected traffic. Agent 4.x did not have this regression. The byte count used by `send_msg` in 4.x excluded the terminator.

PR #35424 (`Json::setString` trims trailing `\0`) patched the engine to tolerate the bad input. This PR fixes the root cause on the agent, hardens `remoted` so the byte never reaches the engine in the first place, and **reverts the engine workaround from PR #35424** because the layers above it now guarantee the engine never sees a trailing zero. The remoted strip (path-aware after commit `e7e836f4b5` so inventory-sync flatbuffers are passed through byte-exact) and the agent fix are the two defenses; the engine no longer carries a workaround for this class of input.

Closes #35474

> **Update — follow-up regression fix (commit `e7e836f4b5`):** the previous remoted hardening on this branch (commit `6304a002a9`) unconditionally stripped trailing `\0` bytes from the decrypted payload **before** the router-vs-analysisd decision in `HandleSecureMessage`. That broke inventory-sync flatbuffers (queue 115 from FIM, SCA, syscollector) and upgrade-ack JSON: those payloads are not C strings, and the trailing zeros they legitimately carry (vtable offsets / alignment padding for flatbuffers) were treated as terminator-padding and chewed off. `router_provider_send_sync` then rejected every truncated flatbuffer as `Invalid flatbuffer message structure`, and the corrupted bytes fell through to analysisd, which logged `Event not processed` with the raw flatbuffer in `event.original`.
>
> The strip block was moved inside the `if (!forwarded_to_router)` branch so it only applies to analysisd-bound legacy text events. Inventory-sync flatbuffers and upgrade-ack JSON now reach `router_message_forward` byte-exact. The original #35474 symptom is unaffected because legacy text events never carry the `s:` or `u:upgrade_module:` prefix and always fall through to analysisd.
>
> ### Manager log evidence (Docker bench, single agent enrolled, ~30s of activity)
>
> **Pre-fix** (branch tip _before_ `e7e836f4b5`, agent emitting FIM/SCA/syscollector inventory-sync events) — the failure pattern reported by the QA teammate, reproduced verbatim:
>
> ```
> 2026/04/27 15:29:32 :router: ERROR: Error in router_provider_send_sync: Invalid flatbuffer message structure
> 2026/04/27 15:29:32 wazuh-manager-analysisd: WARNING: Event not processed: {"wazuh":{"protocol":{"queue":115,"location":"fim"}, …,"event":{"original":"\f^@^@^@\b^@\f^@^G^@\b^@\b^@^@^@^@^@^@^D,^@^@^@(^@H^@D^@C^@8^@4^@^@^@0^@,^@(^@$^@ ^@^\^@^X^@^T^@^P^@\f^@^@^@\b^@^D^@(^@^@^@…
> 2026/04/27 15:29:32 :router: ERROR: Error in router_provider_send_sync: Invalid flatbuffer message structure
> 2026/04/27 15:29:32 wazuh-manager-analysisd: WARNING: Event not processed: {"wazuh":{"protocol":{"queue":115,"location":"syscollector"}, …
> 2026/04/27 15:29:32 :router: ERROR: Error in router_provider_send_sync: Invalid flatbuffer message structure
> 2026/04/27 15:29:32 wazuh-manager-analysisd: WARNING: Event not processed: {"wazuh":{"protocol":{"queue":115,"location":"sca"}, …
> ```
>
> **Post-fix** (commit `e7e836f4b5`, environment torn down with `docker compose … down -v` to wipe the build volumes, then full cold rebuild of manager + agent from source):
>
> ```
> $ grep -c "router_provider_send_sync.*Invalid flatbuffer" /var/wazuh-manager/logs/wazuh-manager.log
> 0
>
> $ grep "Event not processed" /var/wazuh-manager/logs/wazuh-manager.log | grep '"queue":115' | wc -l
> 0
>
> $ cat /var/ossec/var/run/wazuh-agentd.state   # on the agent container
> status='connected'
> msg_count='112'
> msg_sent='116'
> ```
>
> Inventory-sync module starts and stays clean; FIM / SCA / syscollector flatbuffers reach `router_provider_send_sync` byte-exact and parse successfully. Remaining `Event not processed` warnings in the post-fix log are unrelated pre-existing decoder issues for queue 49 (command outputs) and queue 57 (rootcheck text scans) — they appear identically in both pre- and post-fix logs and are out of scope for this PR.

## Proposed Changes

### Bugs fixed

- **`buffer_append` stored the trailing NUL inside the wire-level size** (`src/client-agent/src/buffer.c`):
  The legacy text-message branch (`msg_len < 0`) set `buffered_message.size = strlen(msg) + 1`, so the size that flowed through `dispatch_buffer → send_msg → CreateSecMSG` was one byte too long for every non-binary event. The fix stores `strlen(msg)` as the reported size while still allocating `strlen + 1` for the in-memory copy, keeping the stored buffer safely null-terminated. Direct `send_msg(msg, -1)` callers (`notify.c`, `request.c`, `start_agent.c`, `reload_agent.c`, `receiver.c`, and the four buffer-state messages inside `buffer.c`) were already correct because `sendmsg.c` uses `strlen(msg)` — no `+1` — in that branch. The Windows `SendMSGAction` path feeds the same `buffer_append` sink and is fixed transitively by the same change.

- **`remoted` left control-message copies and event-raw buffers without a guaranteed terminator** (`src/remoted/src/secure.c`):
  - `ctrl_msg_data->message` was `os_calloc(msg_length, ...)` but memcpy'd only `tmp_msg_length` bytes (= `msg_length - 3` after the `#!-` header strip). The three extra bytes from calloc happened to zero the area past the payload, but the size stored was inconsistent and a future alloc tightening would have exposed a buffer over-read to downstream `cJSON_Parse(strchr(clean, '{'))` in `validate_control_msg`. Changed to `os_calloc(tmp_msg_length + 1, ...)` so the allocation matches the memcpy and the `+1` byte is a guaranteed sentinel from calloc.
  - `e->raw` was `os_calloc(msg_length, ...)`. The downstream `bulk_append` is length-aware, so the on-wire HTTP body sent to the engine is unchanged, but any future consumer treating `e->raw` as a C string would over-read the allocation by one byte. Changed to `os_calloc(msg_length + 1, ...)`.
  - The live cleartext buffer (`tmp_msg`) was not modified: the existing `memset(cleartext_msg, '\0', OS_MAXSTR + 1)` at the top of `HandleSecureMessage` already guarantees that the byte past any valid decrypted payload is a NUL, so `strncmp` / `IsValidHeader` / `w_utf8_filter` / `cJSON_ParseWithOpts` cannot walk off the decrypted region. Added a documentation block noting the invariant so future edits do not drop the memset or introduce a path that re-enters `ReadSecMSG` without re-zeroing.

### Root cause

`src/client-agent/src/buffer.c:150` — the legacy-string branch used `size_to_alloc = strlen(msg) + 1` and stored that value in `buffered_message.size`. When `dispatch_buffer` later called `send_msg(msg_to_dispatch.data, msg_to_dispatch.size)`, the size (including the NUL) reached `sendmsg.c:32`, which passed it straight to `CreateSecMSG`, which encrypted exactly that many bytes. Commit `261ad5f865` ("Added new function SendBinaryMSG…") introduced the `{void *data; size_t size}` struct and this `+1` as a side effect of giving the buffer an explicit-length API for binary events; 4.x had no such struct and relied on `sendmsg.c`'s own `strlen(msg)` (no `+1`) to compute the wire-level length.

### Results and Evidence

Verified end-to-end using wazuh-server (indexer + dashboard + manager) and wazuh-agent both built from source. The harness was completely torn down between the two phases, so the pre- and post-fix runs share no state.

**Pre-fix configuration** (build with `src/engine/source/base/src/json.cpp` PR #35424 trim reverted, `src/client-agent/src/buffer.c` fix reverted, and `src/remoted/src/secure.c` allocation reverted:

```
$ curl … 'https://127.0.0.1:9200/_cat/indices/wazuh-*?v' | awk '$7>0'
…
.ds-wazuh-events-v5-system-activity-000001       14
wazuh-states-fim-files                         1322
(all 8 wazuh-findings-v5-* indices: 0 docs)
```

Sampled `event.original` (5 newest, all from the system-activity stream produced by `wazuh-logcollector` reading journald):

```
2026-04-23T14:26:40.429Z  repr('… modprobe@drm.service: Executable /sbin/modprobe missing, skipping: No such file or directory\x00')
2026-04-23T14:26:40.429Z  repr("… dbus-daemon[4805]: [system] Successfully activated service 'org.freedesktop.login1'\x00")
2026-04-23T14:26:40.429Z  repr('… systemd[1]: Started User Login Management.\x00')
2026-04-23T14:26:40.428Z  repr('… systemd[1]: Starting User Login Management...\x00')
2026-04-23T14:26:40.428Z  repr('… systemd-logind[5659]: New seat seat0.\x00')
```

- **10/10 sampled events end with a literal `\x00` byte** (rendered as `�` in JSON-over-the-wire).
- **0 findings across all 24 `wazuh-findings-v5-*` datastreams** — the engine's decoders cannot match `event.original` when the field carries the trailing NUL, so no rule fires. This is the "doesn't generate events, doesn't match any decoder" symptom reported on the issue.

**Post-fix configuration** (branch tip as of this PR — agent fix applied, remoted harden applied, engine trim from PR #35424 reverted because the agent + remoted layers now guarantee the engine never sees a trailing zero):

```
$ curl … 'https://127.0.0.1:9200/wazuh-events-v5-*/_count'     → 9,885+
$ curl … 'https://127.0.0.1:9200/wazuh-findings-v5-*/_count'   → 9,505+
$ curl … 'https://127.0.0.1:9200/wazuh-states-sca/_count'      → 207
$ curl … 'https://127.0.0.1:9200/wazuh-states-inventory-packages/_count' → 301
(similar non-zero counts across wazuh-states-inventory-services/processes/users/networks/hardware/etc.)
```

- **Sampled 2,000 events from `wazuh-events-v5-*`: 0 contain `\x00`.**
- **Sampled 2,000 findings from `wazuh-findings-v5-*`: 0 contain `\x00`.**

Representative per-module samples (all `event.original` verified NUL-free):

| Module (source) | event.original (post-fix) | rule.id | rule.level |
|---|---|---|---|
| `logcollector` / journald `sshd` | `Apr 23 14:52:26 wazuh-agent sshd[11863]: Failed password for invalid user probe_postfix1776955945 from 10.0.0.1 port 22 ssh2` | `8088b365-ddf6-4783-9835-48c4c89ed60a` | `low` |
| `rootcheck` / scan-summary text | `Files hidden inside directory '/etc/dpkg'. Link count does not match number of files (4,1).` | `4d5c1922-a12c-4f79-bd57-63bbfc699ab5` | `high` |
| `logcollector` / `/var/log/dpkg.log` | (events flow through the same `buffer_append` sink; NUL scan over 2000 events is clean) | — | — |
| `SCA` / flatbuffer JSON `"module":"sca"` | (inventory-sync flatbuffer path; `wazuh-states-sca` has 207 docs post-fix) | — | — |
| `syscollector` / inventory flatbuffer | `wazuh-states-inventory-packages` 301, -services 32, -processes 7, -users 24, -networks 3, -hardware 1, -system 1 — all populated and NUL-free | — | — |
| `FIM` / inventory-sync flatbuffer | `wazuh-states-fim-files` carries the initial 1,322-file scan with clean file paths and hashes (incremental sync was separately degraded in this bench; see Notes) | — | — |
| Keepalive / `#!-` control messages | exercised on every agent restart; processed by `remoted::validate_control_msg` — with the harden commit, `ctrl_msg_data->message` is now exactly `tmp_msg_length + 1` (was over-allocated by 3 bytes with no guaranteed sentinel) | n/a (control) | n/a |

**Before/after decoder-match count (24 `wazuh-findings-v5-*` datastreams):**

| | Pre-fix | Post-fix |
|---|---|---|
| Findings (= rule matches in engine) | **0** | **9,505+** and growing |

The eight order-of-magnitude jump reflects decoders & rules matching for the first time once `event.original` no longer carries the trailing `\0`.

## DoDs

| DoD req | Evidence |
|---|---|
| Agent messages do not include unintended `\0` | 2,000 post-fix `wazuh-events-v5-*` docs sampled; 0 contain `\x00`. Pre-fix sample: 10/10 contain `\x00`. |
| Server correctly handles messages **with** `\0` | `remoted::HandleSecureMessage` strips trailing zeros from analysisd-bound text events (defense-in-depth for unpatched 5.x agents in the field). The strip is now path-aware so inventory-sync flatbuffers and upgrade-ack JSON reach `router_provider_send_sync` byte-exact -- covered by `test_HandleSecureMessage_event_with_trailing_null` and `test_HandleSecureMessage_inventory_sync_preserves_trailing_null`. The engine `Json::setString` trim from PR #35424 has been reverted on this branch (commit `e0c2687fbb`); it is no longer needed because the trailing zero never reaches the engine. |
| Server correctly handles messages **without** `\0` | `remoted` allocations right-sized (`e->raw[e->len]`, `ctrl_msg_data->message[tmp_msg_length]` both guaranteed `\0`). `test_HandleSecureMessage_event_without_trailing_null` exercises the inverse case under ASan, clean. |
| No decoding issues across all pipelines | Post-fix: 9,505+ findings across the security, system-activity, and other category streams; rule matches observed for sshd (logcollector/journald, rule `8088b365`) and rootcheck (rule `4d5c1922`); SCA/syscollector/FIM state populated (207 / 300+ / 1,322 docs). 0/2,000 findings contain `\x00`. |
| Behavior is consistent and well-defined between agent and server | Single coordinated PR: agent fix at the source (`buffer_append`), remoted hardens (right-sized allocations + path-aware strip on the analysisd branch), engine `setString` trim from PR #35424 reverted because it is no longer load-bearing. |
| No security or parsing inconsistencies exploitable | Inverse-case covered by the harden commit at three sites (`e->raw`, `ctrl_msg_data->message` right-sized; `tmp_msg` invariant documented) and the ASan unit test. |
| Tests added to prevent regressions | Three new unit tests (2 in `test_buffer.c`, 1 in `test_secure.c`) + sentinel assertion on the existing shutdown test. |


### Notes on the test bench

- The engine `Json::setString` trim added by PR #35424 has been **reverted** on this branch (commit `e0c2687fbb refactor(engine): remove Json::setString trim of trailing null bytes`). With the agent fix at the source and the path-aware remoted strip as defense-in-depth, the engine never sees a trailing zero in `event.original`, and the workaround is no longer load-bearing. Keeping it would mean carrying a behavioural shim in the engine for an input class that the layers above it guarantee never to produce.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review (no new user-facing logs added)

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer — `server.cmake` bakes `-fsanitize=address,undefined` into every unit test. The new `test_HandleSecureMessage_event_without_trailing_null` feeds an inverse-case (no trailing NUL) cleartext through `HandleSecureMessage` and reads `e->raw[e->len]` while the allocation is live; pre-harden sizing (`os_calloc(msg_length, ...)`) fires ASan heap-buffer-overflow on that read, post-harden the read is in-bounds and returns `\0`. Verified green inside wazuh-server container: `49/49 tests passed, ASan clean`.
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A — no decoder or rule changes.

- Engine _(Wazuh v5.x and above)_
  - [x] `JsonSettersTest/SetStringStripsTrailingNullBytes` (added by PR #35424) has been removed alongside the `Json::setString` trim in commit `e0c2687fbb`. The agent + remoted layers now guarantee the engine never sees a trailing zero, so the trim and its test are no longer load-bearing.
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - N/A — no API or framework changes.

### Artifacts Affected

- `wazuh-agent` on Linux (the shared `buffer_append` sink fixes the legacy text path for every `send_msg(msg, -1)` caller that goes through the buffer).
- `wazuh-agent` on Windows (transitively — `win_utils.c:SendMSGAction` calls the same `buffer_append` sink; no separate Windows change).
- `wazuh-manager` (Linux) — `remoted` allocations and documentation in `src/remoted/src/secure.c`.

### Configuration Changes

N/A — no user-visible configuration changes.

### Tests Introduced

- `test_buffer_append_binary_preserves_size` (`src/unit_tests/client-agent/test_buffer.c`): positive regression guard for the explicit-length path. Asserts that `buffer_append(payload, N)` with a payload containing embedded NULs stores `buffer[0].size == N` and preserves the exact bytes.
- `test_buffer_append_text_size_excludes_null_terminator` (same file): the demonstrator for issue #35474. Asserts that `buffer_append(text, -1)` stores `buffer[0].size == strlen(text)`. Would fail on main pre-fix.
- `test_HandleSecureMessage_event_without_trailing_null` (`src/unit_tests/remoted/test_secure.c`): inverse-case ASan guard. Feeds a `msg_length`-exact cleartext payload with no trailing NUL through `HandleSecureMessage`; the custom `expect_check` hook reads `e->raw[e->len]` while the allocation is live and asserts it equals `\0`. Under the ASan build configured by `server.cmake`, any regression that shrinks the event allocation below `e->len + 1` fires a heap-buffer-overflow on that read.
- `test_HandleSecureMessage_shutdown_message` (existing test, same file): extended with `assert_int_equal('\0', node->message[tmp_msg_length])` as a sentinel guard for the control-message allocation.
- `test_HandleSecureMessage_inventory_sync_preserves_trailing_null` (`src/unit_tests/remoted/test_secure.c`, added in commit `e7e836f4b5`): regression guard for the router-bound path. Crafts an `s:fim:<flatbuffer>` payload whose flatbuffer ends in three `\0` bytes, hooks `router_provider_send_sync` via a new wrap (`router_wrappers.{c,h}`), and asserts the wrap receives the full flatbuffer with the trailing zeros intact, with the correct `message_size` and `authenticated_agent_id`. Would fail before commit `e7e836f4b5` because the pre-router strip would shave the trailing zeros off the flatbuffer.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided (pre/post-fix indexer samples above)
- [x] Tests cover the new functionality (agent regression test + remoted ASan inverse-case + sentinel assertions)
- [x] Configuration changes documented (N/A, noted explicitly)
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues


