### PR TITLE
Fix WUA hotfix collection regression in Windows Agent v5.0.0

### DIFF
--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -179,6 +179,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
             ws2_32
             wbemuuid
             uuid
+            wuguid
             ole32
             oleaut32
             shell32

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -19,12 +19,6 @@
 #include "utilsWrapperWin.hpp"
 #include <shellapi.h>
 
-// Define GUIDs for Windows Update API in this .cpp file to instantiate them
-#include <initguid.h>
-DEFINE_GUID(CLSID_UpdateSearcher, 0xB699E5E8, 0x67FF, 0x4177, 0x88, 0xB0, 0x36, 0x84, 0xA3, 0x38, 0x8F, 0x27);
-DEFINE_GUID(IID_IUpdateSearcher, 0x8F45ABF1, 0xF9AE, 0x4B95, 0xA9, 0x33, 0xF0, 0xF6, 0x6E, 0x50, 0x56, 0xEA);
-
-
 // Implement WMI functions
 HRESULT ComHelper::CreateWmiLocator(IWbemLocator*& pLoc)
 {

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -27,7 +27,7 @@
 #include <codecvt>
 #include "wuapi.h"
 
-// Declare Windows Update API GUIDs (defined in utilsWrapperWin.cpp)
+// Forward declarations for Windows Update API GUIDs (defined in wuguid library)
 extern "C" const GUID CLSID_UpdateSearcher;
 extern "C" const GUID IID_IUpdateSearcher;
 


### PR DESCRIPTION
## Description

Closes #35636

This PR fixes a regression where Windows Agent v5.0 reports only 9 hotfixes instead of 11 (compared to v4.14.4) on Windows Server 2022. The missing hotfixes are KB2267602 and KB4052623.

**Root Cause:**  
Version 5.0.0 introduced two breaking changes to the Windows Update API (WUA) integration:
1. Added manual `DEFINE_GUID` definitions that conflict with Windows SDK, causing COM error `0x80040154` (REGDB_E_CLASSNOTREG) when initializing IUpdateSearcher
2. Removed `wuguid` library from the linker configuration in CMakeLists.txt

The Windows SDK provides GUID declarations in `wuapi.h` (headers), but GUID definitions (actual data) are in `wuguid.lib`. Using manual DEFINE_GUID with `#include <initguid.h>` creates incorrect local definitions that cause COM initialization failures.

## Proposed Changes

**Two changes are required** to fix this regression:

1. Remove GUID definitions from utilsWrapperWin.cpp

```diff
--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -19,10 +19,6 @@
 #include "utilsWrapperWin.hpp"
 #include <shellapi.h>
 
-// Define GUIDs for Windows Update API in this .cpp file to instantiate them
-#include <initguid.h>
-DEFINE_GUID(CLSID_UpdateSearcher, 0xB699E5E8, 0x67FF, 0x4177, 0x88, 0xB0, 0x36, 0x84, 0xA3, 0x38, 0x8F, 0x27);
-DEFINE_GUID(IID_IUpdateSearcher, 0x8F45ABF1, 0xF9AE, 0x4B95, 0xA9, 0x33, 0xF0, 0xF6, 0x6E, 0x50, 0x56, 0xEA);
 
 // Implement WMI functions
 HRESULT ComHelper::CreateWmiLocator(IWbemLocator*& pLoc)
```

2. Add wuguid library back to CMakeLists.txt

```diff
--- a/src/data_provider/CMakeLists.txt
+++ b/src/data_provider/CMakeLists.txt
@@ -145,6 +145,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
             ws2_32
             wbemuuid
             uuid
+            wuguid
             ole32
             oleaut32
             shell32
```

**Rationale**: 
- The Windows SDK provides GUID declarations in `wuapi.h`, but the GUID **definitions** (actual data) are in `wuguid.lib`
- Manual `DEFINE_GUID` creates incorrect local definitions that cause COM error 0x80040154
- Linking with `wuguid.lib` provides the correct pre-compiled GUID definitions from the Windows SDK

### Results and Evidence

**Before fix (v5.0 main):**
- Hotfixes reported: **9** :x: 
- Missing: KB2267602, KB4052623
- WUA error log: `WUA: UpdateSearcher error. Code: 80040154` (REGDB_E_CLASSNOTREG)

<img width="1919" height="961" alt="Captura desde 2026-04-23 17-42-02" src="https://github.com/user-attachments/assets/87d063be-eecb-41d6-b588-c75199db9054" />


**After fix:**
- Hotfixes reported: **11** ✅
- All hotfixes correctly collected from Windows Update API
- No COM errors during IUpdateSearcher initialization

<img width="1919" height="961" alt="Captura desde 2026-04-23 17-46-32" src="https://github.com/user-attachments/assets/24d1bef4-a847-4d2a-b8ef-79f88cf25884" />

### Artifacts Affected

- Component: Syscollector → data_provider → hotfix collection (Windows only)

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality (manual testing completed)
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
