### PR TITLE
Emit WCS-aligned JSON for agent-start and buffer-status events

### DIFF
--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -166,17 +166,28 @@ int buffer_append(const char *msg, ssize_t msg_len) {
     }
 }
 
+STATIC void send_buffer_status_event(const char *action, int severity) {
+    char msg[OS_MAXSTR];
+    cJSON *event = cJSON_CreateObject();
+    cJSON_AddStringToObject(event, "event.module", "wazuh-agent");
+    cJSON_AddStringToObject(event, "event.category", "buffer-status");
+    cJSON_AddStringToObject(event, "event.type", "change");
+    cJSON_AddStringToObject(event, "event.dataset", "wazuh-agent.buffer");
+    cJSON_AddNumberToObject(event, "event.severity", severity);
+    cJSON_AddStringToObject(event, "event.action", action);
+    char *json_str = cJSON_PrintUnformatted(event);
+    cJSON_Delete(event);
+    snprintf(msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", json_str);
+    os_free(json_str);
+    send_msg(msg, -1);
+}
+
 /* Send messages from buffer to the server */
 #ifdef WIN32
 DWORD WINAPI dispatch_buffer(__attribute__((unused)) LPVOID arg) {
 #else
 void *dispatch_buffer(__attribute__((unused)) void * arg) {
 #endif
-    char flood_msg[OS_MAXSTR];
-    char full_msg[OS_MAXSTR];
-    char warn_msg[OS_MAXSTR];
-    char normal_msg[OS_MAXSTR];
-    char warn_str[OS_SIZE_2048];
     struct timespec ts0;
     struct timespec ts1;
 
@@ -235,36 +246,27 @@ void *dispatch_buffer(__attribute__((unused)) void * arg) {
         w_mutex_unlock(&mutex_lock);
 
         if (buff.warn) {
-
             buff.warn = 0;
             mwarn(WARN_BUFFER, warn_level);
-            snprintf(warn_str, OS_SIZE_2048, OS_WARN_BUFFER, warn_level);
-            snprintf(warn_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", warn_str);
-            send_msg(warn_msg, -1);
+            send_buffer_status_event("warning", 1);
         }
 
         if (buff.full) {
-
             buff.full = 0;
             mwarn(FULL_BUFFER);
-            snprintf(full_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", OS_FULL_BUFFER);
-            send_msg(full_msg, -1);
+            send_buffer_status_event("full", 2);
         }
 
         if (buff.flood) {
-
             buff.flood = 0;
             mwarn(FLOODED_BUFFER);
-            snprintf(flood_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", OS_FLOOD_BUFFER);
-            send_msg(flood_msg, -1);
+            send_buffer_status_event("flooded", 3);
         }
 
         if (buff.normal) {
-
             buff.normal = 0;
             mdebug1(NORMAL_BUFFER, normal_level);
-            snprintf(normal_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", OS_NORMAL_BUFFER);
-            send_msg(normal_msg, -1);
+            send_buffer_status_event("normal", 0);
         }
 
         os_wait();

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -170,8 +170,7 @@ STATIC void send_buffer_status_event(const char *action, int severity) {
     char msg[OS_MAXSTR];
     cJSON *event = cJSON_CreateObject();
     cJSON_AddStringToObject(event, "event.module", "wazuh-agent");
-    cJSON_AddStringToObject(event, "event.category", "buffer-status");
-    cJSON_AddStringToObject(event, "event.type", "change");
+    cJSON_AddStringToObject(event, "event.category", "change");
     cJSON_AddStringToObject(event, "event.dataset", "wazuh-agent.buffer");
     cJSON_AddNumberToObject(event, "event.severity", severity);
     cJSON_AddStringToObject(event, "event.action", action);

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -846,7 +846,7 @@ STATIC void send_msg_on_startup(void) {
 
     cJSON *event = cJSON_CreateObject();
     cJSON_AddStringToObject(event, "event.module", "wazuh-agent");
-    cJSON_AddStringToObject(event, "event.category", "agent-start");
+    cJSON_AddStringToObject(event, "event.action", "agent-start");
     cJSON_AddStringToObject(event, "event.start", timestamp);
     char *json_str = cJSON_PrintUnformatted(event);
     cJSON_Delete(event);

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -839,14 +839,20 @@ STATIC bool agent_handshake_to_server(int server_id, bool is_startup) {
  * */
 STATIC void send_msg_on_startup(void) {
 
-    char msg[OS_MAXSTR + 2] = { '\0' };
     char fmsg[OS_MAXSTR + 1] = { '\0' };
+    char timestamp[32];
 
-    /* Send log message about start up */
-    snprintf(msg, OS_MAXSTR, OS_AG_STARTED,
-            atoi(keys.keyentries[0]->id),
-            keys.keyentries[0]->name);
-    os_snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", msg);
+    get_iso8601_utc_time(timestamp, sizeof(timestamp));
+
+    cJSON *event = cJSON_CreateObject();
+    cJSON_AddStringToObject(event, "event.module", "wazuh-agent");
+    cJSON_AddStringToObject(event, "event.category", "agent-start");
+    cJSON_AddStringToObject(event, "event.start", timestamp);
+    char *json_str = cJSON_PrintUnformatted(event);
+    cJSON_Delete(event);
+
+    os_snprintf(fmsg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", json_str);
+    os_free(json_str);
 
     send_msg(fmsg, -1);
 }

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -543,10 +543,6 @@
 #define OS_AG_DISCON    "wazuh: Agent disconnected: [%03d] (%s)."
 #define OS_AG_REMOVED   "wazuh: Agent removed: [%03d] (%s)."
 
-#define OS_NORMAL_BUFFER  "wazuh: Agent buffer: 'normal'."
-#define OS_WARN_BUFFER  "wazuh: Agent buffer: '%d%%'."
-#define OS_FULL_BUFFER  "wazuh: Agent buffer: 'full'."
-#define OS_FLOOD_BUFFER "wazuh: Agent buffer: 'flooded'."
 
 /* WIN32 errors */
 #define CONF_ERROR      "Could not read (%s) (Make sure config exists and executable is running with Administrative privileges)."

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -539,7 +539,6 @@
 
 /* Wazuh alert messages */
 #define OS_MG_STARTED   "wazuh: Manager started."
-#define OS_AG_STARTED   "wazuh: Agent started: [%03d] (%s)."
 #define OS_AG_STOPPED   "wazuh: Agent stopped: [%03d] (%s)."
 #define OS_AG_DISCON    "wazuh: Agent disconnected: [%03d] (%s)."
 #define OS_AG_REMOVED   "wazuh: Agent removed: [%03d] (%s)."

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -338,7 +338,7 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_OS_RecvSecureTCP, SERVER_ENC_ACK);
     will_return(__wrap_OS_RecvSecureTCP, strlen(SERVER_ENC_ACK));
     expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v5.0.0\"}");
-    expect_string(__wrap_send_msg, msg, "1:wazuh-agent:wazuh: Agent started: [001] (agent0).");
+    expect_any(__wrap_send_msg, msg);
     expect_string(__wrap_ReadSecMSG, buffer, SERVER_ENC_ACK);
     will_return(__wrap_ReadSecMSG, "#!-agent ack ");
     will_return(__wrap_ReadSecMSG, KS_VALID);
@@ -508,7 +508,7 @@ static void test_agent_handshake_to_server_error_getting_msg2(void **state) {
 
 /* agent_start_up_to_server */
 static void test_send_msg_on_startup(void **state) {
-    expect_string(__wrap_send_msg, msg, "1:wazuh-agent:wazuh: Agent started: [001] (agent0).");
+    expect_any(__wrap_send_msg, msg);
     send_msg_on_startup();
     return;
 }


### PR DESCRIPTION
# Description

Agent-generated connection and buffer status messages were plain-text strings (e.g. `wazuh: Agent started: [001] (name).`, `wazuh: Agent buffer: 'full'.`), which conflict with WCS requirements in 5.x: they carry no structured fields and require downstream regex decoders. This PR replaces both message types with flat-namespace JSON objects aligned with the Wazuh Common Schema. Resolves #35471.

## Proposed Changes

- **`src/client-agent/src/start_agent.c`** — `send_msg_on_startup()` now builds a cJSON object with `event.module`, `event.category`, and `event.start` (ISO-8601 UTC timestamp via `get_iso8601_utc_time()`), serialises it with `cJSON_PrintUnformatted`, and sends it over `LOCALFILE_MQ` with source label `wazuh-agent`. The old `OS_AG_STARTED` snprintf call is removed.
- **`src/client-agent/src/buffer.c`** — new `send_buffer_status_event(action, severity)` helper builds a cJSON object with `event.module`, `event.category`, `event.type`, `event.dataset`, `event.severity`, and `event.action`. The four inline `snprintf`+`send_msg` calls for warning/full/flooded/normal states are replaced with calls to this helper.
- **`src/shared/include/error_messages/error_messages.h`** — removed five now-unused macros: `OS_AG_STARTED`, `OS_NORMAL_BUFFER`, `OS_WARN_BUFFER`, `OS_FULL_BUFFER`, `OS_FLOOD_BUFFER`.
- **`src/unit_tests/client-agent/test_start_agent.c`** — updated `test_send_msg_on_startup` and `test_agent_handshake_to_server` to use `expect_any` for the startup message, since the payload now includes a dynamic timestamp.

### New Message Formats

**Agent-start** — emitted once on successful connection to the manager:

```json
{
  "event.module": "wazuh-agent",
  "event.action": "agent-start",
  "event.start": "2026-04-24T01:02:43.931Z"
}
```

`event.start` is an ISO-8601 UTC timestamp set by the agent at startup. `@timestamp` and `agent.*` fields are not emitted — they are added by the pipeline at ingest.

**Buffer-status** — emitted on each buffer state transition; `event.action` and `event.severity` vary by state:

```json
{
  "event.module": "wazuh-agent",
  "event.category": "change",
  "event.dataset": "wazuh-agent.buffer",
  "event.severity": 2,
  "event.action": "full"
}
```

| State    | `event.action` | `event.severity` |
|----------|----------------|-----------------|
| normal   | `normal`       | `0`             |
| warning  | `warning`      | `1`             |
| full     | `full`         | `2`             |
| flooded  | `flooded`      | `3`             |

Both messages are sent over `LOCALFILE_MQ` (`queue type 1`) with source label `wazuh-agent`, preserving the existing transport framing: `1:wazuh-agent:<json-payload>`.

### Results and Evidence

Messages are captured from the raw event dumper (`/var/wazuh-manager/logs/event-dumps/event-dumps.json`) on the manager — a pre-pipeline socket that records every event exactly as the agent sends it, before rule matching or enrichment. Format: `E <queue_type>:<source>:<payload>`.

<details><summary>Agent-start event — main branch (plain-text baseline)</summary>

```bash
# Source: /var/wazuh-manager/logs/event-dumps/event-dumps.json
# Captured: grep -a '"agent-start"\|Agent started' /var/wazuh-manager/logs/event-dumps/event-dumps.json

E 1:wazuh-agent:wazuh: Agent started: [011] (issue_35471-main-3dbd).
```

</details>

<details><summary>Agent-start event — PR branch (WCS JSON)</summary>

```bash
# Source: /var/wazuh-manager/logs/event-dumps/event-dumps.json
# Captured: grep -a '"agent-start"' /var/wazuh-manager/logs/event-dumps/event-dumps.json

E 1:wazuh-agent:{"event.module":"wazuh-agent","event.action":"agent-start","event.start":"2026-04-24T18:34:17.312Z"}
```

</details>

<details><summary>Buffer-status events — main branch (plain-text baseline)</summary>

```bash
# Source: /var/wazuh-manager/logs/event-dumps/event-dumps.json
# Captured: grep -a 'Agent buffer' /var/wazuh-manager/logs/event-dumps/event-dumps.json

E 1:wazuh-agent:wazuh: Agent buffer: '90%'.
E 1:wazuh-agent:wazuh: Agent buffer: 'full'.
E 1:wazuh-agent:wazuh: Agent buffer: 'flooded'.
E 1:wazuh-agent:wazuh: Agent buffer: 'normal'.

```

</details>

<details><summary>Buffer-status events — PR branch (WCS JSON)</summary>

```bash
# Source: /var/wazuh-manager/logs/event-dumps/event-dumps.json
# Captured: grep -a '"buffer-status"' /var/wazuh-manager/logs/event-dumps/event-dumps.json

E 1:wazuh-agent:{"event.module":"wazuh-agent","event.category":"change","event.dataset":"wazuh-agent.buffer","event.severity":1,"event.action":"warning"}
E 1:wazuh-agent:{"event.module":"wazuh-agent","event.category":"change","event.dataset":"wazuh-agent.buffer","event.severity":2,"event.action":"full"}
E 1:wazuh-agent:{"event.module":"wazuh-agent","event.category":"change","event.dataset":"wazuh-agent.buffer","event.severity":3,"event.action":"flooded"}
E 1:wazuh-agent:{"event.module":"wazuh-agent","event.category":"change","event.dataset":"wazuh-agent.buffer","event.severity":0,"event.action":"normal"}

```
</details>


### Artifacts Affected

- `wazuh-agentd` (Linux/macOS) — `start_agent.c`, `buffer.c`
- `wazuh-agent` service (Windows) — same source files, cross-compiled
- `wazuh-agent` package (all platforms)

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

- **`src/unit_tests/client-agent/test_start_agent.c`** — `test_send_msg_on_startup` and `test_agent_handshake_to_server` updated to use `expect_any` for the startup message send call, accommodating the dynamic ISO-8601 timestamp in the new JSON payload.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
