### PR TITLE
Send wodle command event in a WCS JSON compatible format.

### DIFF
--- a/src/unit_tests/wazuh_modules/command/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/command/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND tests_names "test_wm_command")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=_mtdebug1 \
                          -Wl,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER \
+                         -Wl,--wrap=wm_sendmsg \
                          -Wl,--wrap=wm_validate_command -Wl,--wrap=w_query_agentd")
 list(APPEND use_shared_libs 1)
 

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -196,7 +196,6 @@ static int teardown_test_payload(void **state) {
 }
 
 static void wm_command_prepare_single_iteration(void) {
-    will_return(__wrap_FOREVER, 1);
     will_return(__wrap_FOREVER, 0);
 }
 
@@ -253,80 +252,88 @@ static size_t wm_command_build_base_len_for_test(const char *event_start,
     return len;
 }
 
+static size_t wm_command_build_payload_len_for_test(const char *event_start,
+                                                    const char *tag,
+                                                    const char *command_line,
+                                                    const char *proc_name,
+                                                    const char *proc_path,
+                                                    char **proc_argv,
+                                                    int status,
+                                                    const char *output_text) {
+    cJSON *json_event = cJSON_CreateObject();
+    assert_non_null(json_event);
+
+    cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
+    cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
+    if (tag) {
+        cJSON_AddStringToObject(json_event, "tags", tag);
+    }
+
+    cJSON *process = cJSON_AddObjectToObject(json_event, "process");
+    assert_non_null(process);
+
+    cJSON *process_args = cJSON_AddArrayToObject(process, "args");
+    if (process_args && proc_argv) {
+        for (size_t i = 1; proc_argv[i]; ++i) {
+            cJSON_AddItemToArray(process_args, cJSON_CreateString(proc_argv[i]));
+        }
+    }
+
+    cJSON_AddStringToObject(process, "name", proc_name ? proc_name : "");
+    cJSON_AddStringToObject(process, "path", proc_path ? proc_path : "");
+    cJSON_AddStringToObject(process, "command_line", command_line ? command_line : "");
+    cJSON_AddNumberToObject(process, "exit_code", status);
+
+    cJSON *process_io = cJSON_AddObjectToObject(process, "io");
+    assert_non_null(process_io);
+    cJSON_AddStringToObject(process_io, "text", output_text ? output_text : "");
+
+    char *json_payload = cJSON_PrintUnformatted(json_event);
+    cJSON_Delete(json_event);
+
+    assert_non_null(json_payload);
+    size_t len = strlen(json_payload);
+    free(json_payload);
+    return len;
+}
+
 static size_t wm_command_compute_metadata_only_command_filler_len(void) {
     const size_t max_len = wm_command_max_json_payload_len();
     assert_true(max_len > 0);
 
-    const char *event_start = "2026-04-27T00:00:00Z";
+    const char *event_start = "2026-04-27T00:00:00.000Z";
     const char *tag = "test";
     const char *proc_path = "/bin/echo";
     const char *proc_name = "echo";
     const int status = 0;
     const char *prefix = "/bin/echo ";
 
-    // Measure slope by comparing filler length 0 vs 1.
-    char command0[64];
-    snprintf(command0, sizeof(command0), "%s", prefix);
-    char *command0_cpy = strdup(command0);
-    assert_non_null(command0_cpy);
-    char **argv0 = w_strtok(command0_cpy);
-    size_t base0 = wm_command_build_base_len_for_test(event_start, tag, command0, proc_name, proc_path, argv0, status);
-    free_strarray(argv0);
-    free(command0_cpy);
+    const char *probe_output = "\x1f"; // Control char: JSON-encodes to  (6 bytes), adding 4 net bytes vs empty.
 
-    char command1[64];
-    snprintf(command1, sizeof(command1), "%sA", prefix);
-    char *command1_cpy = strdup(command1);
-    assert_non_null(command1_cpy);
-    char **argv1 = w_strtok(command1_cpy);
-    size_t base1 = wm_command_build_base_len_for_test(event_start, tag, command1, proc_name, proc_path, argv1, status);
-    free_strarray(argv1);
-    free(command1_cpy);
-
-    const size_t slope = base1 - base0;
-    assert_true(slope > 0);
-
-    // Target: leave ~1 byte for output before escaping pushes it over.
-    const size_t target = max_len - 1;
-    assert_true(base0 < target);
-
-    size_t filler_len = (target - base0) / slope;
-
-    // Adjust to the closest value where base_len is within [max_len-1, max_len-1].
-    // (We just need base_len close enough so that a 1-char output that escapes will overflow.)
-    for (int i = 0; i < 1024; ++i) {
-        char *filler = calloc(filler_len + 1, 1);
-        assert_non_null(filler);
-        memset(filler, 'A', filler_len);
-        filler[filler_len] = '\0';
-
-        size_t cmd_len = strlen(prefix) + filler_len;
+    // Brute-force search for a command length where:
+    // - Metadata-only event (empty output) fits within the payload limit.
+    // - Event with a 1-char output that JSON-encodes to 6 bytes does NOT fit (triggering metadata-only fallback).
+    for (size_t filler_len = 0; filler_len < max_len; ++filler_len) {
+        const size_t cmd_len = strlen(prefix) + filler_len;
         char *cmdline = calloc(cmd_len + 1, 1);
         assert_non_null(cmdline);
         memcpy(cmdline, prefix, strlen(prefix));
-        memcpy(cmdline + strlen(prefix), filler, filler_len);
+        memset(cmdline + strlen(prefix), 'A', filler_len);
         cmdline[cmd_len] = '\0';
 
         char *cmd_cpy = strdup(cmdline);
         assert_non_null(cmd_cpy);
         char **argv = w_strtok(cmd_cpy);
-        size_t base_len = wm_command_build_base_len_for_test(event_start, tag, cmdline, proc_name, proc_path, argv, status);
+
+        const size_t len_empty = wm_command_build_payload_len_for_test(event_start, tag, cmdline, proc_name, proc_path, argv, status, "");
+        const size_t len_probe = wm_command_build_payload_len_for_test(event_start, tag, cmdline, proc_name, proc_path, argv, status, probe_output);
+
         free_strarray(argv);
         free(cmd_cpy);
-
         free(cmdline);
-        free(filler);
 
-        if (base_len == target) {
+        if (len_empty <= max_len && len_probe > max_len) {
             return filler_len;
-        }
-        if (base_len < target) {
-            filler_len++;
-        } else {
-            if (filler_len == 0) {
-                break;
-            }
-            filler_len--;
         }
     }
 
@@ -448,12 +455,31 @@ void test_interval_execution(void **state) {
 
     will_return_always(__wrap_wm_exec, 0);
 
-    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES);
+    // The module uses a do-while loop; to run exactly TEST_MAX_DATES iterations
+    // we need TEST_MAX_DATES-1 "continue" returns and a final "stop".
+    will_return_count(__wrap_FOREVER, 1, TEST_MAX_DATES - 1);
     will_return(__wrap_FOREVER, 0);
-    expect_any_always(__wrap__mtinfo, tag);
-    expect_any_always(__wrap__mtinfo, formatted_msg);
-    expect_any_always(__wrap__mtdebug1, tag);
-    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    const int verify_debug_calls =
+        ((module_data->md5_hash && module_data->md5_hash[0]) ? 1 : 0) +
+        ((module_data->sha1_hash && module_data->sha1_hash[0]) ? 1 : 0) +
+        ((module_data->sha256_hash && module_data->sha256_hash[0]) ? 1 : 0);
+
+    // Expected logs:
+    // - mtinfo: 1x module started + 1x per iteration ("Starting command")
+    // - mtdebug1: 1x per iteration ("finished") + 1x per hash in initial checksum validation
+    expect_any_count(__wrap__mtinfo, tag, 1 + TEST_MAX_DATES);
+    expect_any_count(__wrap__mtinfo, formatted_msg, 1 + TEST_MAX_DATES);
+    expect_any_count(__wrap__mtdebug1, tag, TEST_MAX_DATES + verify_debug_calls);
+    expect_any_count(__wrap__mtdebug1, formatted_msg, TEST_MAX_DATES + verify_debug_calls);
+
+    // Queue sends: 1 event per iteration.
+    expect_any_count(__wrap_wm_sendmsg, usec, TEST_MAX_DATES);
+    expect_any_count(__wrap_wm_sendmsg, queue, TEST_MAX_DATES);
+    expect_any_count(__wrap_wm_sendmsg, message, TEST_MAX_DATES);
+    expect_any_count(__wrap_wm_sendmsg, locmsg, TEST_MAX_DATES);
+    expect_any_count(__wrap_wm_sendmsg, loc, TEST_MAX_DATES);
+    will_return_always(__wrap_wm_sendmsg, 0);
 
     expect_any_always(__wrap_wm_validate_command, command);
     expect_any_always(__wrap_wm_validate_command, digest);
@@ -477,6 +503,15 @@ static void test_command_payload_normal_output(void **state) {
     will_return(__wrap_wm_exec, (char *)output);
     will_return(__wrap_wm_exec, 7);
     will_return(__wrap_wm_exec, 0);
+
+    // status > 0 triggers mtwarn + mtdebug2(OUTPUT).
+    expect_any(__wrap__mtwarn, tag);
+    expect_any(__wrap__mtwarn, formatted_msg);
+
+    expect_any_count(__wrap__mtinfo, tag, 2);
+    expect_any_count(__wrap__mtinfo, formatted_msg, 2);
+    expect_any(__wrap__mtdebug1, tag);
+    expect_any(__wrap__mtdebug1, formatted_msg);
 
     wm_command_prepare_single_iteration();
     wm_command_expect_sendmsg_json();
@@ -505,6 +540,11 @@ static void test_command_payload_empty_output(void **state) {
     will_return(__wrap_wm_exec, (char *)output);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
+
+    expect_any_count(__wrap__mtinfo, tag, 2);
+    expect_any_count(__wrap__mtinfo, formatted_msg, 2);
+    expect_any(__wrap__mtdebug1, tag);
+    expect_any(__wrap__mtdebug1, formatted_msg);
 
     wm_command_prepare_single_iteration();
     wm_command_expect_sendmsg_json();
@@ -542,6 +582,15 @@ static void test_command_payload_long_output_truncates(void **state) {
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
 
+    // Truncation path emits one warning.
+    expect_any(__wrap__mtwarn, tag);
+    expect_any(__wrap__mtwarn, formatted_msg);
+
+    expect_any_count(__wrap__mtinfo, tag, 2);
+    expect_any_count(__wrap__mtinfo, formatted_msg, 2);
+    expect_any(__wrap__mtdebug1, tag);
+    expect_any(__wrap__mtdebug1, formatted_msg);
+
     wm_command_prepare_single_iteration();
     wm_command_expect_sendmsg_json();
 
@@ -558,8 +607,44 @@ static void test_command_payload_long_output_truncates(void **state) {
 
 static void test_command_payload_metadata_only_fallback(void **state) {
     wm_command_t *command = (wm_command_t *)*state;
-    const size_t filler_len = wm_command_compute_metadata_only_command_filler_len();
+    
+    size_t filler_len = wm_command_compute_metadata_only_command_filler_len();
     const char *prefix = "/bin/echo ";
+
+    // Reduce until it actually fits at runtime
+    while (filler_len > 0) {
+        size_t cmd_len = strlen(prefix) + filler_len;
+
+        char *cmdline = calloc(cmd_len + 1, 1);
+        assert_non_null(cmdline);
+        memcpy(cmdline, prefix, strlen(prefix));
+        memset(cmdline + strlen(prefix), 'A', filler_len);
+        cmdline[cmd_len] = '\0';
+
+        char *cmd_cpy = strdup(cmdline);
+        char **argv = w_strtok(cmd_cpy);
+
+        size_t len_empty = wm_command_build_payload_len_for_test(
+            "2026-04-27T00:00:00.000Z",
+            command->tag,
+            cmdline,
+            "echo",
+            "/bin/echo",
+            argv,
+            0,
+            ""
+        );
+
+        free_strarray(argv);
+        free(cmd_cpy);
+        free(cmdline);
+
+        if (len_empty <= wm_command_max_json_payload_len()) {
+            break;
+        }
+
+        filler_len--;  // shrink until it fits
+    }
 
     // Replace the command line with a very long one that almost fills the max payload.
     free(command->command);
@@ -570,8 +655,11 @@ static void test_command_payload_metadata_only_fallback(void **state) {
     memset(command->command + strlen(prefix), 'A', filler_len);
     command->command[cmd_len] = '\0';
 
-    const char *output = "\""; // Escapes to two bytes (\") so a 1-char allowance will still overflow.
+    command->md5_hash = NULL;
+    command->sha1_hash = NULL;
+    command->sha256_hash = NULL;
 
+    const char *output = "\x1f"; // Control char: JSON-encodes to 6 bytes (), so truncation never fits.
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
@@ -582,6 +670,15 @@ static void test_command_payload_metadata_only_fallback(void **state) {
     will_return(__wrap_wm_exec, (char *)output);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
+
+    // First warning: truncation attempt; second warning: still too large, metadata-only fallback.
+    expect_any_count(__wrap__mtwarn, tag, 2);
+    expect_any_count(__wrap__mtwarn, formatted_msg, 2);
+
+    expect_any_count(__wrap__mtinfo, tag, 2);
+    expect_any_count(__wrap__mtinfo, formatted_msg, 2);
+    expect_any(__wrap__mtdebug1, tag);
+    expect_any(__wrap__mtdebug1, formatted_msg);
 
     wm_command_prepare_single_iteration();
     wm_command_expect_sendmsg_json();

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -15,10 +15,12 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <time.h>
+#include <string.h>
 
 #include "shared.h"
 #include "wmodules.h"
 #include "wm_command.h"
+#include "cJSON.h"
 
 #include "../scheduling/wmodules_scheduling_helpers.h"
 #include "../../wrappers/common.h"
@@ -34,6 +36,303 @@
 static wmodule *command_module;
 static OS_XML *lxml;
 extern int test_mode;
+
+typedef enum wm_command_payload_case {
+    WM_PAYLOAD_CASE_NORMAL = 0,
+    WM_PAYLOAD_CASE_EMPTY,
+    WM_PAYLOAD_CASE_TRUNCATED,
+    WM_PAYLOAD_CASE_METADATA_ONLY,
+} wm_command_payload_case;
+
+typedef struct wm_command_payload_expectation {
+    wm_command_payload_case payload_case;
+    const char *command_line;
+    const char *tag;
+    int exit_code;
+    const char *raw_output;
+    const char *expected_output;   // For NORMAL/EMPTY/METADATA_ONLY expects exact; for TRUNCATED expects prefix match.
+} wm_command_payload_expectation;
+
+static wm_command_payload_expectation g_payload_expectation;
+
+static size_t wm_command_max_json_payload_len(void) {
+    const char *extag = WM_COMMAND_CONTEXT.name;
+    const size_t header_len = 3 + strlen(extag); // "1:" + extag + ":"
+    return header_len < OS_MAXSTR ? (OS_MAXSTR - header_len - 1) : 0;
+}
+
+static const char *wm_command_json_get_string(const cJSON *obj, const char *key) {
+    const cJSON *item = cJSON_GetObjectItemCaseSensitive((cJSON *)obj, key);
+    if (!cJSON_IsString(item) || !item->valuestring) {
+        return NULL;
+    }
+    return item->valuestring;
+}
+
+static const cJSON *wm_command_json_get_object(const cJSON *obj, const char *key) {
+    const cJSON *item = cJSON_GetObjectItemCaseSensitive((cJSON *)obj, key);
+    return cJSON_IsObject(item) ? item : NULL;
+}
+
+static const cJSON *wm_command_json_get_array(const cJSON *obj, const char *key) {
+    const cJSON *item = cJSON_GetObjectItemCaseSensitive((cJSON *)obj, key);
+    return cJSON_IsArray(item) ? item : NULL;
+}
+
+static int check_wm_sendmsg_message_is_valid_command_json(const LargestIntegralType value,
+                                                          const LargestIntegralType check_data) {
+    (void)check_data;
+    const char *message = (const char *)value;
+    const size_t max_len = wm_command_max_json_payload_len();
+
+    assert_non_null(message);
+    assert_true(max_len > 0);
+    assert_true(strlen(message) <= max_len);
+
+    cJSON *root = cJSON_Parse(message);
+    assert_non_null(root);
+
+    const char *event_module = wm_command_json_get_string(root, "event.module");
+    assert_non_null(event_module);
+    assert_string_equal(event_module, "wazuh-wodle-cmd");
+
+    const char *event_start = wm_command_json_get_string(root, "event.start");
+    assert_non_null(event_start);
+
+    if (g_payload_expectation.tag) {
+        const char *tags = wm_command_json_get_string(root, "tags");
+        assert_non_null(tags);
+        assert_string_equal(tags, g_payload_expectation.tag);
+    }
+
+    const cJSON *process = wm_command_json_get_object(root, "process");
+    assert_non_null(process);
+
+    const char *proc_name = wm_command_json_get_string(process, "name");
+    assert_non_null(proc_name);
+    assert_string_equal(proc_name, "echo");
+
+    const char *proc_path = wm_command_json_get_string(process, "path");
+    assert_non_null(proc_path);
+    assert_true(strstr(proc_path, "echo") != NULL);
+
+    const char *command_line = wm_command_json_get_string(process, "command_line");
+    assert_non_null(command_line);
+    assert_string_equal(command_line, g_payload_expectation.command_line);
+
+    const cJSON *exit_code = cJSON_GetObjectItemCaseSensitive((cJSON *)process, "exit_code");
+    assert_true(cJSON_IsNumber(exit_code));
+    assert_int_equal(exit_code->valueint, g_payload_expectation.exit_code);
+
+    const cJSON *args = wm_command_json_get_array(process, "args");
+    assert_non_null(args);
+    // Validate expected args for the default command line used in most tests.
+    if (strcmp(g_payload_expectation.command_line, "/bin/echo arg1 arg2") == 0) {
+        assert_int_equal(cJSON_GetArraySize((cJSON *)args), 2);
+        const cJSON *arg0 = cJSON_GetArrayItem((cJSON *)args, 0);
+        const cJSON *arg1 = cJSON_GetArrayItem((cJSON *)args, 1);
+        assert_true(cJSON_IsString(arg0));
+        assert_true(cJSON_IsString(arg1));
+        assert_string_equal(arg0->valuestring, "arg1");
+        assert_string_equal(arg1->valuestring, "arg2");
+    }
+
+    const cJSON *process_io = wm_command_json_get_object(process, "io");
+    assert_non_null(process_io);
+    const char *io_text = wm_command_json_get_string(process_io, "text");
+    assert_non_null(io_text);
+
+    switch (g_payload_expectation.payload_case) {
+    case WM_PAYLOAD_CASE_NORMAL:
+    case WM_PAYLOAD_CASE_EMPTY:
+    case WM_PAYLOAD_CASE_METADATA_ONLY:
+        assert_string_equal(io_text, g_payload_expectation.expected_output ? g_payload_expectation.expected_output : "");
+        break;
+    case WM_PAYLOAD_CASE_TRUNCATED:
+        assert_non_null(g_payload_expectation.raw_output);
+        assert_true(strlen(io_text) < strlen(g_payload_expectation.raw_output));
+        if (g_payload_expectation.expected_output) {
+            assert_true(strncmp(io_text, g_payload_expectation.expected_output, strlen(g_payload_expectation.expected_output)) == 0);
+        }
+        break;
+    }
+
+    cJSON_Delete(root);
+    return 1;
+}
+
+static int setup_test_payload(void **state) {
+    wm_command_t *command = calloc(1, sizeof(wm_command_t));
+    assert_non_null(command);
+
+    command->enabled = 1;
+    command->run_on_start = 1;
+    command->ignore_output = 0;
+    command->agent_cfg = 0;
+    command->timeout = 0;
+
+    command->tag = strdup("test");
+    command->command = strdup("/bin/echo arg1 arg2");
+    assert_non_null(command->tag);
+    assert_non_null(command->command);
+
+    command->scan_config = init_config_from_string("<interval>10s</interval>\n");
+
+    wm_max_eps = 1000000; // Avoid division by zero; wm_sendmsg is wrapped in these tests.
+    *state = command;
+    return 0;
+}
+
+static int teardown_test_payload(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    if (command) {
+        sched_scan_free(&(command->scan_config));
+        free(command->tag);
+        free(command->command);
+        free(command->full_command);
+        free(command);
+    }
+    return 0;
+}
+
+static void wm_command_prepare_single_iteration(void) {
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_FOREVER, 0);
+}
+
+static void wm_command_expect_sendmsg_json(void) {
+    expect_any(__wrap_wm_sendmsg, usec);
+    expect_any(__wrap_wm_sendmsg, queue);
+    expect_check(__wrap_wm_sendmsg, message, check_wm_sendmsg_message_is_valid_command_json, 0);
+    expect_string(__wrap_wm_sendmsg, locmsg, WM_COMMAND_CONTEXT.name);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+    will_return(__wrap_wm_sendmsg, 0);
+}
+
+static size_t wm_command_build_base_len_for_test(const char *event_start,
+                                                 const char *tag,
+                                                 const char *command_line,
+                                                 const char *proc_name,
+                                                 const char *proc_path,
+                                                 char **proc_argv,
+                                                 int status) {
+    cJSON *json_event = cJSON_CreateObject();
+    assert_non_null(json_event);
+
+    cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
+    cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
+    if (tag) {
+        cJSON_AddStringToObject(json_event, "tags", tag);
+    }
+
+    cJSON *process = cJSON_AddObjectToObject(json_event, "process");
+    assert_non_null(process);
+
+    cJSON *process_args = cJSON_AddArrayToObject(process, "args");
+    if (process_args && proc_argv) {
+        for (size_t i = 1; proc_argv[i]; ++i) {
+            cJSON_AddItemToArray(process_args, cJSON_CreateString(proc_argv[i]));
+        }
+    }
+
+    cJSON_AddStringToObject(process, "name", proc_name ? proc_name : "");
+    cJSON_AddStringToObject(process, "path", proc_path ? proc_path : "");
+    cJSON_AddStringToObject(process, "command_line", command_line ? command_line : "");
+    cJSON_AddNumberToObject(process, "exit_code", status);
+
+    cJSON *process_io = cJSON_AddObjectToObject(process, "io");
+    assert_non_null(process_io);
+    cJSON_AddStringToObject(process_io, "text", "");
+
+    char *json_payload = cJSON_PrintUnformatted(json_event);
+    cJSON_Delete(json_event);
+
+    assert_non_null(json_payload);
+    size_t len = strlen(json_payload);
+    free(json_payload);
+    return len;
+}
+
+static size_t wm_command_compute_metadata_only_command_filler_len(void) {
+    const size_t max_len = wm_command_max_json_payload_len();
+    assert_true(max_len > 0);
+
+    const char *event_start = "2026-04-27T00:00:00Z";
+    const char *tag = "test";
+    const char *proc_path = "/bin/echo";
+    const char *proc_name = "echo";
+    const int status = 0;
+    const char *prefix = "/bin/echo ";
+
+    // Measure slope by comparing filler length 0 vs 1.
+    char command0[64];
+    snprintf(command0, sizeof(command0), "%s", prefix);
+    char *command0_cpy = strdup(command0);
+    assert_non_null(command0_cpy);
+    char **argv0 = w_strtok(command0_cpy);
+    size_t base0 = wm_command_build_base_len_for_test(event_start, tag, command0, proc_name, proc_path, argv0, status);
+    free_strarray(argv0);
+    free(command0_cpy);
+
+    char command1[64];
+    snprintf(command1, sizeof(command1), "%sA", prefix);
+    char *command1_cpy = strdup(command1);
+    assert_non_null(command1_cpy);
+    char **argv1 = w_strtok(command1_cpy);
+    size_t base1 = wm_command_build_base_len_for_test(event_start, tag, command1, proc_name, proc_path, argv1, status);
+    free_strarray(argv1);
+    free(command1_cpy);
+
+    const size_t slope = base1 - base0;
+    assert_true(slope > 0);
+
+    // Target: leave ~1 byte for output before escaping pushes it over.
+    const size_t target = max_len - 1;
+    assert_true(base0 < target);
+
+    size_t filler_len = (target - base0) / slope;
+
+    // Adjust to the closest value where base_len is within [max_len-1, max_len-1].
+    // (We just need base_len close enough so that a 1-char output that escapes will overflow.)
+    for (int i = 0; i < 1024; ++i) {
+        char *filler = calloc(filler_len + 1, 1);
+        assert_non_null(filler);
+        memset(filler, 'A', filler_len);
+        filler[filler_len] = '\0';
+
+        size_t cmd_len = strlen(prefix) + filler_len;
+        char *cmdline = calloc(cmd_len + 1, 1);
+        assert_non_null(cmdline);
+        memcpy(cmdline, prefix, strlen(prefix));
+        memcpy(cmdline + strlen(prefix), filler, filler_len);
+        cmdline[cmd_len] = '\0';
+
+        char *cmd_cpy = strdup(cmdline);
+        assert_non_null(cmd_cpy);
+        char **argv = w_strtok(cmd_cpy);
+        size_t base_len = wm_command_build_base_len_for_test(event_start, tag, cmdline, proc_name, proc_path, argv, status);
+        free_strarray(argv);
+        free(cmd_cpy);
+
+        free(cmdline);
+        free(filler);
+
+        if (base_len == target) {
+            return filler_len;
+        }
+        if (base_len < target) {
+            filler_len++;
+        } else {
+            if (filler_len == 0) {
+                break;
+            }
+            filler_len--;
+        }
+    }
+
+    fail_msg("Unable to compute filler length for metadata-only fallback");
+    return 0;
+}
 
 /****************************************************************/
 static void wmodule_cleanup(wmodule *module){
@@ -162,6 +461,139 @@ void test_interval_execution(void **state) {
     will_return_always(__wrap_wm_validate_command, 1);
 
     command_module->context->start(module_data);
+}
+
+static void test_command_payload_normal_output(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    const char *output = "hello \"world\"\\nsecond-line";
+
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, 0);
+
+    expect_any(__wrap_wm_exec, command);
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, (char *)output);
+    will_return(__wrap_wm_exec, 7);
+    will_return(__wrap_wm_exec, 0);
+
+    wm_command_prepare_single_iteration();
+    wm_command_expect_sendmsg_json();
+
+    g_payload_expectation.payload_case = WM_PAYLOAD_CASE_NORMAL;
+    g_payload_expectation.command_line = command->command;
+    g_payload_expectation.tag = command->tag;
+    g_payload_expectation.exit_code = 7;
+    g_payload_expectation.raw_output = output;
+    g_payload_expectation.expected_output = output;
+
+    WM_COMMAND_CONTEXT.start(command);
+}
+
+static void test_command_payload_empty_output(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    const char *output = "";
+
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, 0);
+
+    expect_any(__wrap_wm_exec, command);
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, (char *)output);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    wm_command_prepare_single_iteration();
+    wm_command_expect_sendmsg_json();
+
+    g_payload_expectation.payload_case = WM_PAYLOAD_CASE_EMPTY;
+    g_payload_expectation.command_line = command->command;
+    g_payload_expectation.tag = command->tag;
+    g_payload_expectation.exit_code = 0;
+    g_payload_expectation.raw_output = output;
+    g_payload_expectation.expected_output = "";
+
+    WM_COMMAND_CONTEXT.start(command);
+}
+
+static void test_command_payload_long_output_truncates(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    const size_t max_len = wm_command_max_json_payload_len();
+    assert_true(max_len > 0);
+
+    // Make output far larger than OS_MAXSTR so truncation path is hit.
+    const size_t output_len = max_len * 2;
+    char *output = calloc(output_len + 1, 1);
+    assert_non_null(output);
+    memset(output, 'B', output_len);
+    output[output_len] = '\0';
+
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, 0);
+
+    expect_any(__wrap_wm_exec, command);
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, output);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    wm_command_prepare_single_iteration();
+    wm_command_expect_sendmsg_json();
+
+    g_payload_expectation.payload_case = WM_PAYLOAD_CASE_TRUNCATED;
+    g_payload_expectation.command_line = command->command;
+    g_payload_expectation.tag = command->tag;
+    g_payload_expectation.exit_code = 0;
+    g_payload_expectation.raw_output = output;
+    g_payload_expectation.expected_output = "BBBB";
+
+    WM_COMMAND_CONTEXT.start(command);
+    free(output);
+}
+
+static void test_command_payload_metadata_only_fallback(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    const size_t filler_len = wm_command_compute_metadata_only_command_filler_len();
+    const char *prefix = "/bin/echo ";
+
+    // Replace the command line with a very long one that almost fills the max payload.
+    free(command->command);
+    size_t cmd_len = strlen(prefix) + filler_len;
+    command->command = calloc(cmd_len + 1, 1);
+    assert_non_null(command->command);
+    memcpy(command->command, prefix, strlen(prefix));
+    memset(command->command + strlen(prefix), 'A', filler_len);
+    command->command[cmd_len] = '\0';
+
+    const char *output = "\""; // Escapes to two bytes (\") so a 1-char allowance will still overflow.
+
+    expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQ, type, WRITE);
+    will_return(__wrap_StartMQ, 0);
+
+    expect_any(__wrap_wm_exec, command);
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, (char *)output);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    wm_command_prepare_single_iteration();
+    wm_command_expect_sendmsg_json();
+
+    g_payload_expectation.payload_case = WM_PAYLOAD_CASE_METADATA_ONLY;
+    g_payload_expectation.command_line = command->command;
+    g_payload_expectation.tag = command->tag;
+    g_payload_expectation.exit_code = 0;
+    g_payload_expectation.raw_output = output;
+    g_payload_expectation.expected_output = "";
+
+    WM_COMMAND_CONTEXT.start(command);
 }
 
 void test_fake_tag(void **state) {
@@ -335,9 +767,16 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_validate_command_checksums_success, setup_test_checksum, teardown_test_checksum),
         cmocka_unit_test_setup_teardown(test_validate_command_checksums_failure, setup_test_checksum, teardown_test_checksum)
     };
+    const struct CMUnitTest tests_payload_json[] = {
+        cmocka_unit_test_setup_teardown(test_command_payload_normal_output, setup_test_payload, teardown_test_payload),
+        cmocka_unit_test_setup_teardown(test_command_payload_empty_output, setup_test_payload, teardown_test_payload),
+        cmocka_unit_test_setup_teardown(test_command_payload_long_output_truncates, setup_test_payload, teardown_test_payload),
+        cmocka_unit_test_setup_teardown(test_command_payload_metadata_only_fallback, setup_test_payload, teardown_test_payload)
+    };
     int result;
     result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);
     result += cmocka_run_group_tests(tests_without_startup, NULL, NULL);
     result += cmocka_run_group_tests(tests_validate_command_checksums, NULL, NULL);
+    result += cmocka_run_group_tests(tests_payload_json, NULL, NULL);
     return result;
 }

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -100,9 +100,13 @@ static int check_wm_sendmsg_message_is_valid_command_json(const LargestIntegralT
     assert_non_null(event_start);
 
     if (g_payload_expectation.tag) {
-        const char *tags = wm_command_json_get_string(root, "tags");
+        const cJSON *tags = wm_command_json_get_array(root, "tags");
         assert_non_null(tags);
-        assert_string_equal(tags, g_payload_expectation.tag);
+        assert_int_equal(cJSON_GetArraySize((cJSON *)tags), 1);
+        const cJSON *tag_item = cJSON_GetArrayItem((cJSON *)tags, 0);
+        assert_non_null(tag_item);
+        assert_true(cJSON_IsString(tag_item));
+        assert_string_equal(tag_item->valuestring, g_payload_expectation.tag);
     }
 
     const cJSON *process = wm_command_json_get_object(root, "process");
@@ -221,7 +225,10 @@ static size_t wm_command_build_base_len_for_test(const char *event_start,
     cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
     cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
     if (tag) {
-        cJSON_AddStringToObject(json_event, "tags", tag);
+        cJSON *tags_array = cJSON_AddArrayToObject(json_event, "tags");
+        if (tags_array) {
+            cJSON_AddItemToArray(tags_array, cJSON_CreateString(tag));
+        }
     }
 
     cJSON *process = cJSON_AddObjectToObject(json_event, "process");
@@ -266,7 +273,10 @@ static size_t wm_command_build_payload_len_for_test(const char *event_start,
     cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
     cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
     if (tag) {
-        cJSON_AddStringToObject(json_event, "tags", tag);
+        cJSON *tags_array = cJSON_AddArrayToObject(json_event, "tags");
+        if (tags_array) {
+            cJSON_AddItemToArray(tags_array, cJSON_CreateString(tag));
+        }
     }
 
     cJSON *process = cJSON_AddObjectToObject(json_event, "process");

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -10,6 +10,22 @@
  */
 
 #include "wmodules.h"
+#include "time_op.h"
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#endif
+
+static char *wm_command_build_event_payload(const char *event_start,
+                                            const char *tag,
+                                            const char *command_line,
+                                            const char *proc_name,
+                                            const char *proc_path,
+                                            char **proc_argv,
+                                            const wm_command_t *command,
+                                            int status,
+                                            const char *payload_output);
 
 #ifdef WIN32
 static DWORD WINAPI wm_command_main(void *arg);             // Module main function. It won't return
@@ -19,6 +35,73 @@ static void * wm_command_main(wm_command_t * command);    // Module main functio
 static void wm_command_destroy(wm_command_t * command);   // Destroy data
 cJSON *wm_command_dump(const wm_command_t * command);
 int validate_command_checksums(wm_command_t * command, const char * full_path); // Validate checksums
+
+static char *wm_command_build_event_payload(const char *event_start,
+                                            const char *tag,
+                                            const char *command_line,
+                                            const char *proc_name,
+                                            const char *proc_path,
+                                            char **proc_argv,
+                                            const wm_command_t *command,
+                                            int status,
+                                            const char *payload_output) {
+    cJSON *json_event = NULL;
+    char *json_payload = NULL;
+
+    json_event = cJSON_CreateObject();
+    if (!json_event) {
+        return NULL;
+    }
+
+    cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
+    cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
+    if (tag) {
+        cJSON_AddStringToObject(json_event, "tags", tag);
+    }
+
+    cJSON *process = cJSON_AddObjectToObject(json_event, "process");
+    if (process) {
+        cJSON *process_args = cJSON_AddArrayToObject(process, "args");
+        if (process_args && proc_argv) {
+            for (size_t i = 1; proc_argv[i]; ++i) {
+                cJSON_AddItemToArray(process_args, cJSON_CreateString(proc_argv[i]));
+            }
+        }
+
+        cJSON_AddStringToObject(process, "name", proc_name ? proc_name : "");
+        cJSON_AddStringToObject(process, "path", proc_path ? proc_path : "");
+        cJSON_AddStringToObject(process, "command_line", command_line ? command_line : "");
+
+        if (command && ((command->md5_hash && command->md5_hash[0]) || (command->sha1_hash && command->sha1_hash[0]) ||
+                        (command->sha256_hash && command->sha256_hash[0]))) {
+            cJSON *hash = cJSON_AddObjectToObject(process, "hash");
+
+            if (hash) {
+                if (command->md5_hash && command->md5_hash[0]) {
+                    cJSON_AddStringToObject(hash, "md5", command->md5_hash);
+                }
+                if (command->sha1_hash && command->sha1_hash[0]) {
+                    cJSON_AddStringToObject(hash, "sha1", command->sha1_hash);
+                }
+                if (command->sha256_hash && command->sha256_hash[0]) {
+                    cJSON_AddStringToObject(hash, "sha256", command->sha256_hash);
+                }
+            }
+        }
+
+        cJSON_AddNumberToObject(process, "exit_code", status);
+
+        cJSON *process_io = cJSON_AddObjectToObject(process, "io");
+        if (process_io) {
+            cJSON_AddStringToObject(process_io, "text", payload_output ? payload_output : "");
+        }
+    }
+
+    json_payload = cJSON_PrintUnformatted(json_event);
+    cJSON_Delete(json_event);
+
+    return json_payload;
+}
 
 // Command module context definition
 
@@ -99,9 +182,10 @@ void * wm_command_main(wm_command_t * command) {
 
     // Set extended tag
 
-    extag_len = strlen(WM_COMMAND_CONTEXT.name) + strlen(command->tag) + 2;
+    // Keep a stable routing tag for all command events.
+    extag_len = strlen(WM_COMMAND_CONTEXT.name) + 1;
     os_malloc(extag_len * sizeof(char), extag);
-    snprintf(extag, extag_len, "%s_%s", WM_COMMAND_CONTEXT.name, command->tag);
+    snprintf(extag, extag_len, "%s", WM_COMMAND_CONTEXT.name);
 
     if (wm_state_io(extag, WM_IO_READ, &command->state, sizeof(command->state)) < 0) {
         memset(&command->state, 0, sizeof(command->state));
@@ -152,6 +236,8 @@ void * wm_command_main(wm_command_t * command) {
 
         int status = 0;
         char *output = NULL;
+        char event_start[32] = {0};
+        get_iso8601_utc_time(event_start, sizeof(event_start));
         switch (wm_exec(command->full_command, command->ignore_output ? NULL : &output, &status, command->timeout, NULL)) {
         case 0:
             if (status > 0) {
@@ -171,18 +257,201 @@ void * wm_command_main(wm_command_t * command) {
             break;
         }
 
-        if (!command->ignore_output && output != NULL) {
-            char *line;
-            char *save_ptr = NULL;
-            for (line = strtok_r(output, "\n", &save_ptr); line; line = strtok_r(NULL, "\n", &save_ptr)){
-            #ifdef WIN32
-                wm_sendmsg(usec, 0, line, extag, LOCALFILE_MQ);
-            #else
-                wm_sendmsg(usec, command->queue_fd, line, extag, LOCALFILE_MQ);
-            #endif
+        if (!command->ignore_output) {
+            char *json_payload = NULL;
+            const char *raw_output = output ? output : "";
+            const char *payload_output = raw_output;
+            char *truncated_output = NULL;
+            const size_t header_len = 3 + strlen(extag); // "1:" + extag + ":"
+            const size_t max_message_len = header_len < OS_MAXSTR ? (OS_MAXSTR - header_len - 1) : 0;
+
+            // Best-effort process details.
+            const char *command_line = command->full_command ? command->full_command : "";
+            char *command_line_cpy = NULL;
+            char **proc_argv = NULL;
+            const char *proc_argv0 = "";
+            char *tmp_full_path = NULL;
+            const char *proc_path = full_path ? full_path : "";
+            const char *proc_name = "";
+            if (command_line[0]) {
+                command_line_cpy = strdup(command_line);
+                if (command_line_cpy) {
+                    proc_argv = w_strtok(command_line_cpy);
+                    if (proc_argv && proc_argv[0]) {
+                        proc_argv0 = proc_argv[0];
+                    }
+                }
             }
 
-            os_free(output);
+            if (!full_path && proc_argv0 && proc_argv0[0]) {
+                if (get_binary_path(proc_argv0, &tmp_full_path) != OS_INVALID) {
+                    proc_path = tmp_full_path;
+                }
+            }
+
+            if (proc_path && proc_path[0]) {
+                const char *slash = strrchr(proc_path, '/');
+                const char *backslash = strrchr(proc_path, '\\');
+                const char *separator = slash;
+
+                if (backslash && (!separator || backslash > separator)) {
+                    separator = backslash;
+                }
+
+                proc_name = separator ? (separator + 1) : proc_path;
+            } else if (proc_argv0 && proc_argv0[0]) {
+                const char *slash = strrchr(proc_argv0, '/');
+                const char *backslash = strrchr(proc_argv0, '\\');
+                const char *separator = slash;
+
+                if (backslash && (!separator || backslash > separator)) {
+                    separator = backslash;
+                }
+
+                proc_name = separator ? (separator + 1) : proc_argv0;
+            }
+
+            size_t base_json_len = 0;
+
+            // Reset payload/truncation state on rebuild.
+            os_free(truncated_output);
+            truncated_output = NULL;
+            payload_output = raw_output;
+            os_free(json_payload);
+            json_payload = NULL;
+            base_json_len = 0;
+
+            // Compute JSON overhead with all fields except output content.
+            {
+                char *base_payload = wm_command_build_event_payload(event_start,
+                                                                    command->tag,
+                                                                    command_line,
+                                                                    proc_name,
+                                                                    proc_path,
+                                                                    proc_argv,
+                                                                    command,
+                                                                    status,
+                                                                    "");
+                if (base_payload) {
+                    base_json_len = strlen(base_payload);
+                    os_free(base_payload);
+                }
+            }
+
+            // Build JSON payload (single event with full output).
+            json_payload = wm_command_build_event_payload(event_start,
+                                                          command->tag,
+                                                          command_line,
+                                                          proc_name,
+                                                          proc_path,
+                                                          proc_argv,
+                                                          command,
+                                                          status,
+                                                          payload_output);
+
+            // If the final message could be truncated at the MQ layer, truncate the output and rebuild.
+            if (json_payload && max_message_len > 0 && strlen(json_payload) > max_message_len) {
+                const size_t output_len = strlen(raw_output);
+                size_t allowed_output_len = 0;
+                int attempts = 0;
+
+                if (base_json_len > 0 && max_message_len > base_json_len) {
+                    allowed_output_len = max_message_len - base_json_len;
+                }
+
+                // Best-effort: keep JSON valid by truncating the output field before encoding.
+                if (allowed_output_len > 0) {
+                    if (allowed_output_len > output_len) {
+                        allowed_output_len = output_len;
+                    }
+
+                    mtwarn(WM_COMMAND_LOGTAG, "Command output is too long to fit in a single message. Truncating.");
+
+                    do {
+                        os_free(truncated_output);
+                        truncated_output = NULL;
+
+                        os_malloc(allowed_output_len + 1, truncated_output);
+                        memcpy(truncated_output, raw_output, allowed_output_len);
+                        truncated_output[allowed_output_len] = '\0';
+                        payload_output = truncated_output;
+
+                        os_free(json_payload);
+                        json_payload = NULL;
+
+                        json_payload = wm_command_build_event_payload(event_start,
+                                                                      command->tag,
+                                                                      command_line,
+                                                                      proc_name,
+                                                                      proc_path,
+                                                                      proc_argv,
+                                                                      command,
+                                                                      status,
+                                                                      payload_output);
+
+                        if (json_payload && strlen(json_payload) <= max_message_len) {
+                            break;
+                        }
+
+                        // Reduce and try again (output escaping may enlarge JSON more than expected)
+                        allowed_output_len /= 2;
+                        attempts++;
+                    } while (allowed_output_len > 0 && attempts < 4);
+
+                    if (json_payload && strlen(json_payload) > max_message_len) {
+                        os_free(json_payload);
+                        json_payload = NULL;
+
+                        // Last-resort: send a metadata-only event.
+                        mtwarn(WM_COMMAND_LOGTAG, "Command event is too large even after truncation. Dropping output but sending metadata-only event.");
+                        json_payload = wm_command_build_event_payload(event_start,
+                                                                      command->tag,
+                                                                      command_line,
+                                                                      proc_name,
+                                                                      proc_path,
+                                                                      proc_argv,
+                                                                      command,
+                                                                      status,
+                                                                      "");
+                    }
+                } else {
+                    mtwarn(WM_COMMAND_LOGTAG, "Command output is too long to fit in a single message. Dropping output but sending metadata-only event.");
+                    os_free(json_payload);
+                    json_payload = wm_command_build_event_payload(event_start,
+                                                                  command->tag,
+                                                                  command_line,
+                                                                  proc_name,
+                                                                  proc_path,
+                                                                  proc_argv,
+                                                                  command,
+                                                                  status,
+                                                                  "");
+                }
+            }
+            if (json_payload) {
+            #ifdef WIN32
+                if (wm_sendmsg(usec, 0, json_payload, extag, LOCALFILE_MQ) < 0) {
+                    mterror(WM_COMMAND_LOGTAG, "Unable to send command event to queue.");
+                }
+            #else
+                if (wm_sendmsg(usec, command->queue_fd, json_payload, extag, LOCALFILE_MQ) < 0) {
+                    mterror(WM_COMMAND_LOGTAG, "Unable to send command event to queue.");
+                }
+            #endif
+                os_free(json_payload);
+            } else {
+                mtwarn(WM_COMMAND_LOGTAG, "Could not build command event payload. Dropping event.");
+            }
+
+            os_free(truncated_output);
+
+            os_free(tmp_full_path);
+            free_strarray(proc_argv);
+            free(command_line_cpy);
+
+            if (output) {
+                os_free(output);
+            }
         }
 
         mtdebug1(WM_COMMAND_LOGTAG, "Command '%s' finished.", command->tag);

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -313,14 +313,6 @@ void * wm_command_main(wm_command_t * command) {
 
             size_t base_json_len = 0;
 
-            // Reset payload/truncation state on rebuild.
-            os_free(truncated_output);
-            truncated_output = NULL;
-            payload_output = raw_output;
-            os_free(json_payload);
-            json_payload = NULL;
-            base_json_len = 0;
-
             // Compute JSON overhead with all fields except output content.
             {
                 char *base_payload = wm_command_build_event_payload(event_start,

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -12,9 +12,12 @@
 #include "wmodules.h"
 #include "time_op.h"
 
+// Each halving reduces allowed_output_len by 2^n; 4 attempts covers worst-case JSON escape expansion
+// (e.g. a single control character encodes to 6 bytes, so 3 halvings are enough with one spare).
+#define WM_COMMAND_TRUNCATE_MAX_ATTEMPTS 4
+
 #ifdef WIN32
 #include <windows.h>
-#else
 #endif
 
 static char *wm_command_build_event_payload(const char *event_start,
@@ -56,7 +59,10 @@ static char *wm_command_build_event_payload(const char *event_start,
     cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
     cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
     if (tag) {
-        cJSON_AddStringToObject(json_event, "tags", tag);
+        cJSON *tags_array = cJSON_AddArrayToObject(json_event, "tags");
+        if (tags_array) {
+            cJSON_AddItemToArray(tags_array, cJSON_CreateString(tag));
+        }
     }
 
     cJSON *process = cJSON_AddObjectToObject(json_event, "process");
@@ -234,7 +240,7 @@ void * wm_command_main(wm_command_t * command) {
 
         mtinfo(WM_COMMAND_LOGTAG, "Starting command '%s'.", command->tag);
 
-        int status = 0;
+        int status = -1;
         char *output = NULL;
         char event_start[32] = {0};
         get_iso8601_utc_time(event_start, sizeof(event_start));
@@ -249,10 +255,12 @@ void * wm_command_main(wm_command_t * command) {
             }
             break;
         case WM_ERROR_TIMEOUT:
+            status = -1;
             mterror(WM_COMMAND_LOGTAG, "%s: Timeout overtaken. You can modify your command timeout at '%s'. Exiting...", command->tag, WAZUHCONF);
             break;
 
         default:
+            status = -1;
             mterror(WM_COMMAND_LOGTAG, "Command '%s' failed.", command->tag);
             break;
         }
@@ -388,7 +396,7 @@ void * wm_command_main(wm_command_t * command) {
                         // Reduce and try again (output escaping may enlarge JSON more than expected)
                         allowed_output_len /= 2;
                         attempts++;
-                    } while (allowed_output_len > 0 && attempts < 4);
+                    } while (allowed_output_len > 0 && attempts < WM_COMMAND_TRUNCATE_MAX_ATTEMPTS);
 
                     if (json_payload && strlen(json_payload) > max_message_len) {
                         os_free(json_payload);


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes #35634 
Before this PR, the wodle command events were sent to the manager in plain text format as shown below:

``` console
1:command:<plain_text_output>
```

After this PR the intent is for the output to be in JSON and following the WCS schema. 
Here is an example of the new format:

``` console
{
    "event.module": "wazuh-wodle-cmd",
    "event.start": "2026-05-04T15:36:46.172Z",
    "tags": [
        "echo-test"
    ],
    "process": {
        "args": [
            "-la"
        ],
        "name": "ls",
        "path": "/usr/bin/ls",
        "command_line": "ls -la ",
        "exit_code": 0,
        "io": {
            "text": "total 56\ndrwxr-x--- 13 root  wazuh 4096 May  4 12:28 .\ndrwxr-xr-x 13 root  root  4096 May  4 12:28 ..\ndrwxr-x---  3 root  wazuh 4096 May  4 12:28 active-response\ndrwxr-x---  2 root  wazuh 4096 May  4 11:36 backup\ndrwxr-x---  2 root  root  4096 May  4 12:28 bin\ndrwxrwx---  3 root  wazuh 4096 May  4 12:33 etc\ndrwxr-x---  2 root  wazuh 4096 May  4 12:28 lib\ndrwxrwx---  3 wazuh wazuh 4096 May  4 12:32 logs\ndrwxrwx--- 10 wazuh wazuh 4096 May  4 12:28 queue\ndrwxr-x---  3 root  wazuh 4096 May  4 12:28 ruleset\ndrwxrwx--T  2 root  wazuh 4096 May  4 11:36 tmp\ndrwxr-x---  7 root  wazuh 4096 May  4 12:36 var\n-r--r-----  1 root  wazuh   73 May  4 11:36 VERSION.json\ndrwxr-x---  6 root  wazuh 4096 May  4 12:28 wodles\n"
        }
    }
}
```
## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->
Make the necessary code adjustments so that the event messages are no longes sent one line at a time, but rather the entire output along with its metadata in a single event message following the format described above.
### Results and Evidence

- For MacOS and Linux the wodle can be configured like this:
```
  <wodle name="command">
    <disabled>no</disabled>
    <tag>echo-test</tag>
    <interval>20</interval>
    <command>ls -la </command>
    <run_on_start>yes</run_on_start>
  </wodle>
```

Which produces an output like this:
```
{
    "event.module": "wazuh-wodle-cmd",
    "event.start": "2026-05-04T15:36:46.172Z",
    "tags": [
        "echo-test"
    ],
    "process": {
        "args": [
            "-la"
        ],
        "name": "ls",
        "path": "/usr/bin/ls",
        "command_line": "ls -la ",
        "exit_code": 0,
        "io": {
            "text": "total 56\ndrwxr-x--- 13 root  wazuh 4096 May  4 12:28 .\ndrwxr-xr-x 13 root  root  4096 May  4 12:28 ..\ndrwxr-x---  3 root  wazuh 4096 May  4 12:28 active-response\ndrwxr-x---  2 root  wazuh 4096 May  4 11:36 backup\ndrwxr-x---  2 root  root  4096 May  4 12:28 bin\ndrwxrwx---  3 root  wazuh 4096 May  4 12:33 etc\ndrwxr-x---  2 root  wazuh 4096 May  4 12:28 lib\ndrwxrwx---  3 wazuh wazuh 4096 May  4 12:32 logs\ndrwxrwx--- 10 wazuh wazuh 4096 May  4 12:28 queue\ndrwxr-x---  3 root  wazuh 4096 May  4 12:28 ruleset\ndrwxrwx--T  2 root  wazuh 4096 May  4 11:36 tmp\ndrwxr-x---  7 root  wazuh 4096 May  4 12:36 var\n-r--r-----  1 root  wazuh   73 May  4 11:36 VERSION.json\ndrwxr-x---  6 root  wazuh 4096 May  4 12:28 wodles\n"
        }
    }
}
```

- For Windows the wodle can be configured like this:
```
  <wodle name="command">
    <disabled>no</disabled>
    <tag>echo-test</tag>
    <interval>20</interval>         <!-- Run every 30 seconds -->
    <command>cmd.exe /c echo "Hello World"</command>
    <run_on_start>yes</run_on_start>
  </wodle>
```

Which produces an output like this:
```
{
    "event.module": "wazuh-wodle-cmd",
    "event.start": "2026-05-04T15:35:17.978Z",
    "tags": [
        "echo-test"
    ],
    "process": {
        "args": [
            "/c",
            "echo",
            "Hello World"
        ],
        "name": "cmd.exe",
        "path": "C:\\WINDOWS\\system32\\cmd.exe",
        "command_line": "cmd.exe /c echo \"Hello World\"",
        "exit_code": 0,
        "io": {
            "text": "\"Hello World\"\r\n"
        }
    }
}
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
 - N/A

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
 - N/A

### Tests Introduced
 - Wodle command tests
<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
