### PR TITLE
Fix rootcheck and security API IT

### DIFF
--- a/api/test/integration/test_rootcheck_endpoints.tavern.yaml
+++ b/api/test/integration/test_rootcheck_endpoints.tavern.yaml
@@ -401,11 +401,9 @@ stages:
       json:
         error: 0
         data:
-          affected_items:
-            - cis: !anystr
-            - cis: !anystr
+          affected_items: !anything
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: !anyint
           total_failed_items: 0
       verify_response_with:
         - function: tavern_utils:test_sort_response
@@ -598,9 +596,12 @@ stages:
         data:
           affected_items: !anything
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: !anyint
           total_failed_items: 0
         message: !anystr
+      save:
+        json:
+          initial_rootcheck_count: data.total_affected_items
 
   # DELETE /rootcheck/001
   - name: Delete rootcheck scans in agent 001

--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -598,7 +598,7 @@ stages:
   - name: Update admin user password (should fail - error 5011)
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/1"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/1"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT
@@ -617,7 +617,7 @@ stages:
   - name: Update wazuh-wui admin user password
     request:
       verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/security/users/2"
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/users/2"
       headers:
         Authorization: "Bearer {test_login_token}"
       method: PUT


### PR DESCRIPTION
## Description

Fix failing API IT.

## Proposed Changes

- Fix rootcheck API IT.
- Fix security API IT.

### Results and Evidence

https://jenkins-production.qa.wazuh.info/job/4.14.6/job/Test_integration_endpoints/13/

---
| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Issues Ref.** | **Status** |
|--|--|--|--|--|--|--|--|
| test_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_DELETE_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_GET_endpoints.tavern.yaml | 94 | 0 | 0 | 0 | 2 | https://github.com/wazuh/wazuh/issues/35659 | :red_circle: |
| test_agent_POST_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_PUT_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 1 | https://github.com/wazuh/wazuh/issues/35659 | :red_circle: |
| test_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cluster_endpoints.tavern.yaml | 50 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_decoder_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_default_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_event_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_manager_endpoints.tavern.yaml | 36 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_overview_endpoints.tavern.yaml | 0 | 0 | 0 | 0 | 1 | https://github.com/wazuh/wazuh/issues/35659 | :red_circle: |
| test_rbac_black_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_agent_endpoints.tavern.yaml | 43 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cluster_endpoints.tavern.yaml | 20 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_manager_endpoints.tavern.yaml | 17 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscollector_endpoints.tavern.yaml | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_agent_endpoints.tavern.yaml | 43 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_all_endpoints.tavern.yaml | 169 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cluster_endpoints.tavern.yaml | 20 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_manager_endpoints.tavern.yaml | 17 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscollector_endpoints.tavern.yaml | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rule_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_sca_endpoints.tavern.yaml | 45 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_DELETE_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_GET_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_POST_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_PUT_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscheck_endpoints.tavern.yaml | 34 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscollector_endpoints.tavern.yaml | 163 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_task_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided