### PR TITLE
Apply register_configure_agent.sh on reinstall after apt-get remove

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -124,7 +124,7 @@ case "$1" in
     fi
 
     # Register and configure agent if Wazuh environment variables are defined
-    if [ -z "$2" ] ; then
+    if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
         ${SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
     fi
 


### PR DESCRIPTION
## Description

This pull request fixes a regression in the Debian agent `postinst` script where reinstalling after `apt-get remove` (without `--purge`) left the `WAZUH_MANAGER` environment variable unsubstituted in `ossec.conf`, resulting in `<address>MANAGER_IP</address>` instead of the actual IP.

Closes #35534

## Proposed Changes

Single one-character change in `packages/debs/SPECS/wazuh-agent/debian/postinst`:

- Added `|| [ -f ${WAZUH_TMP_DIR}/create_conf ]` to the guard condition on `register_configure_agent.sh`, aligning it with the existing guard on the config-generation block (line 39).

### Root cause

When reinstalling a package that was previously removed (not purged), dpkg calls:

```
postinst configure <old-version>
```

with `$2` set to the old version. The script had **two separate conditions** that gated install-time behaviour on `[ -z "$2" ]`:

| Block | Condition (before fix) | Behaviour |
|---|---|---|
| Config file generation (line 39) | `[ -z "$2" ] \|\| [ -f …/create_conf ]` | ✅ already correct — `preinst` writes `create_conf` when `$2` is set but `ossec.conf` is absent |
| `register_configure_agent.sh` (line 127) | `[ -z "$2" ]` | ❌ skipped entirely on reinstall → `MANAGER_IP` never substituted |

`preinst` already creates the `create_conf` marker to signal "treat this as a fresh install even though `$2` is set". The fix simply uses the same signal in the second condition.

## Manual tests with their corresponding evidence

Tests run on **PPC64EL Debian Stretch** (kernel `4.9.0-13-powerpc64le`, container `a1b6d5192a3e`).

### Before fix — bug reproduced

```
# Step 1 — fresh install (works)
WAZUH_MANAGER='1.2.3.4' apt-get install ./wazuh-agent_4.14.5-1_ppc64el.deb
# grep address /var/ossec/etc/ossec.conf
      <address>1.2.3.4</address>          ✅

# Step 2 — remove (NOT purge)
apt-get remove wazuh-agent

# Step 3 — reinstall with different IP
WAZUH_MANAGER='5.6.7.8' apt-get install ./wazuh-agent_4.14.5-1_ppc64el.deb
# grep address /var/ossec/etc/ossec.conf
      <address>MANAGER_IP</address>        ❌  ← env var ignored
```

### After fix — bug resolved

```
# Step 1 — fresh install
WAZUH_MANAGER='1.2.3.4' apt-get install ./wazuh-agent_4.14.5-1_ppc64el_fixed.deb
# grep address /var/ossec/etc/ossec.conf
      <address>1.2.3.4</address>          ✅

# Step 2 — remove (NOT purge)
apt-get remove wazuh-agent

# Step 3 — reinstall with different IP
WAZUH_MANAGER='9.9.9.9' apt-get install ./wazuh-agent_4.14.5-1_ppc64el_fixed.deb
# grep address /var/ossec/etc/ossec.conf
      <address>9.9.9.9</address>          ✅  ← env var correctly applied
```

### Workaround (as per wazuh/wazuh#35534)

`apt-get purge wazuh-agent` before reinstalling avoids the issue because purge sets `$2` to empty in `postinst`, so the original `[ -z "$2" ]` guard was sufficient. The fix makes the `remove` path equally correct.

### Artifacts Affected

`packages/debs/SPECS/wazuh-agent/debian/postinst`

### Configuration Changes

None. The change only affects the Debian package installation script logic.

### Tests Introduced

N/A — verified manually on target hardware/OS as shown above.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality (Covered by CI pipeline execution)
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues