### PR TITLE
Modify ruleset for NullSessionShares in CIS Windows 2022

### DIFF
--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -1493,6 +1493,7 @@ checks:
       - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters'
       - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes'
       - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> !r:HydraLSPipe|TermServLicensing|BROWSER'
+      - 'not r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S+'
 
   # 2.3.10.8 (L1) Configure 'Network access: Remotely accessible registry paths' is configured. (Automated)
   - id: 27052


### PR DESCRIPTION

## Description

The current rule does not cater for when the NullSessionShares is set to <blank>, even though the description/remediation explicitly mention this as a correct setting

## Proposed Changes

Addition of regex check for blank values in sca ruleset

### Artifacts Affected

- Ruleset

## Review Checklist

- [x] Code changes reviewed
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
