### PR TITLE
Engine metrics collection, normalization and indexing

### DIFF
--- a/framework/wazuh/core/engine_http.py
+++ b/framework/wazuh/core/engine_http.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import httpx
+
+from wazuh.core import common
+from wazuh.core.exception import WazuhError, WazuhInternalError
+
+
+class EngineHTTPClient:
+    """Synchronous HTTP client for the Engine API unix socket (analysisd)."""
+
+    API_URL = 'http://localhost'
+
+    def __init__(self, timeout: float = 10):
+        self.socket_path = str(common.ANALYSISD_SOCKET)
+        transport = httpx.HTTPTransport(uds=self.socket_path)
+        self._client = httpx.Client(transport=transport, timeout=timeout)
+
+    def close(self) -> None:
+        """Close the Engine HTTP client."""
+        self._client.close()
+
+    def get_metrics_dump(self) -> dict:
+        """Fetch all engine metrics via the /metrics/dump endpoint.
+
+        Returns
+        -------
+        dict
+            Raw Dump_Response JSON from the Engine API.
+        """
+        try:
+            response = self._client.post(
+                url=f'{self.API_URL}/metrics/dump',
+                content='{}',
+                headers={'Content-Type': 'text/plain'},
+            )
+        except httpx.TimeoutException as exc:
+            raise WazuhInternalError(2020, extra_message=str(exc))
+        except httpx.ConnectError as exc:
+            raise WazuhInternalError(2021, extra_message=str(exc))
+        except httpx.RequestError as exc:
+            raise WazuhError(2013, extra_message=str(exc))
+
+        if response.is_error:
+            raise WazuhError(2019, extra_message=response.text)
+
+        try:
+            return response.json()
+        except Exception as exc:
+            raise WazuhError(2019, extra_message=f'Invalid JSON in Engine API response: {exc}')

--- a/framework/wazuh/core/engine_http.py
+++ b/framework/wazuh/core/engine_http.py
@@ -15,21 +15,17 @@ class EngineHTTPClient:
 
     def __init__(self, timeout: float = 10):
         self.socket_path = str(common.ANALYSISD_SOCKET)
-        transport = httpx.HTTPTransport(uds=self.socket_path)
-        self._client = httpx.Client(transport=transport, timeout=timeout)
+        try:
+            transport = httpx.HTTPTransport(uds=self.socket_path)
+            self._client = httpx.Client(transport=transport, timeout=timeout)
+        except Exception as exc:
+            raise WazuhInternalError(2018, extra_message=str(exc))
 
     def close(self) -> None:
         """Close the Engine HTTP client."""
         self._client.close()
 
     def get_metrics_dump(self) -> dict:
-        """Fetch all engine metrics via the /metrics/dump endpoint.
-
-        Returns
-        -------
-        dict
-            Raw Dump_Response JSON from the Engine API.
-        """
         try:
             response = self._client.post(
                 url=f'{self.API_URL}/metrics/dump',
@@ -48,5 +44,5 @@ class EngineHTTPClient:
 
         try:
             return response.json()
-        except Exception as exc:
+        except ValueError as exc:
             raise WazuhError(2019, extra_message=f'Invalid JSON in Engine API response: {exc}')

--- a/framework/wazuh/core/engine_http.py
+++ b/framework/wazuh/core/engine_http.py
@@ -19,7 +19,7 @@ class EngineHTTPClient:
             transport = httpx.HTTPTransport(uds=self.socket_path)
             self._client = httpx.Client(transport=transport, timeout=timeout)
         except Exception as exc:
-            raise WazuhInternalError(2018, extra_message=str(exc))
+            raise WazuhInternalError(2018, extra_message=str(exc)) from exc
 
     def close(self) -> None:
         """Close the Engine HTTP client."""
@@ -30,7 +30,7 @@ class EngineHTTPClient:
             response = self._client.post(
                 url=f'{self.API_URL}/metrics/dump',
                 content='{}',
-                headers={'Content-Type': 'text/plain'},
+                headers={'Content-Type': 'application/json'},
             )
         except httpx.TimeoutException as exc:
             raise WazuhInternalError(2020, extra_message=str(exc))
@@ -45,4 +45,4 @@ class EngineHTTPClient:
         try:
             return response.json()
         except ValueError as exc:
-            raise WazuhError(2019, extra_message=f'Invalid JSON in Engine API response: {exc}')
+            raise WazuhInternalError(2022, extra_message=f'Invalid JSON in Engine API response: {exc}')

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -267,6 +267,10 @@ class WazuhException(Exception):
         2015: {'message': 'Invalid request URL scheme'},
         2016: {'message': 'Invalid unix socket path'},
         2017: {'message': 'Could not retrieve agents synchronization information from wazuh-manager-db'},
+        2018: {'message': 'Could not connect to the Engine API unix socket'},
+        2019: {'message': 'Invalid Engine API HTTP response'},
+        2020: {'message': 'Engine API request timeout'},
+        2021: {'message': 'Engine API connection error'},
 
         # Indexer
         2200: {'message': 'Error connecting to the Indexer service'},

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -267,6 +267,7 @@ class WazuhException(Exception):
         2015: {'message': 'Invalid request URL scheme'},
         2016: {'message': 'Invalid unix socket path'},
         2017: {'message': 'Could not retrieve agents synchronization information from wazuh-manager-db'},
+        # Engine:
         2018: {'message': 'Could not connect to the Engine API unix socket'},
         2019: {'message': 'Invalid Engine API HTTP response'},
         2020: {'message': 'Engine API request timeout'},

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -272,6 +272,7 @@ class WazuhException(Exception):
         2019: {'message': 'Invalid Engine API HTTP response'},
         2020: {'message': 'Engine API request timeout'},
         2021: {'message': 'Engine API connection error'},
+        2022: {'message': 'Could not parse Engine API response as JSON'},
 
         # Indexer
         2200: {'message': 'Error connecting to the Indexer service'},

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -63,7 +63,7 @@ def _build_jsonschema_properties(properties: dict) -> dict:
             base_type = _OPENSEARCH_TO_JSONSCHEMA_TYPE.get(os_type)
             if base_type:
                 json_schema_props[field] = {
-                    "anyOf": [base_type, {"type": "array", "items": base_type}]
+                    "anyOf": [base_type, {"type": "array", "items": base_type}, {"type": "null"}]
                 }
             else:
                 json_schema_props[field] = {}
@@ -241,12 +241,13 @@ class MetricsSnapshotTasks:
         all_node_names = [local_node_name] + list(self.server.clients)
 
         docs = []
+        loop = asyncio.get_running_loop()
         for node_name in all_node_names:
             try:
                 if node_name == local_node_name:
-                    result = get_engine_metrics()
+                    result = await loop.run_in_executor(None, get_engine_metrics)
                 else:
-                    result = DistributedAPI(
+                    result = await DistributedAPI(
                         f=get_engine_metrics,
                         f_kwargs={"node_list": [node_name]},
                         logger=self.logger,
@@ -262,7 +263,7 @@ class MetricsSnapshotTasks:
                             metric_entry, None, node_ts, cluster_name, node_name
                         ))
                     for space in item.get("spaces", []):
-                        space_name = space.get("name", "unknown")
+                        space_name = space.get("name", None)
                         for metric_entry in space.get("metrics", []):
                             docs.append(self._normalize_normalization_doc(
                                 metric_entry, space_name, node_ts, cluster_name, node_name

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -259,7 +259,7 @@ class MetricsSnapshotTasks:
                     node_ts = item.get("timestamp", timestamp)
                     for metric_entry in item.get("global", []):
                         docs.append(self._normalize_normalization_doc(
-                            metric_entry, "global", node_ts, cluster_name, node_name
+                            metric_entry, None, node_ts, cluster_name, node_name
                         ))
                     for space in item.get("spaces", []):
                         space_name = space.get("name", "unknown")

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -14,7 +14,7 @@ from wazuh.core import common
 from wazuh.core.agent import WazuhDBQueryAgents
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.indexer.indexer import get_indexer_client
-from wazuh.stats import get_daemons_stats
+from wazuh.stats import get_daemons_stats, get_engine_metrics
 
 # Mapping from OpenSearch field types to JSON Schema type definitions.
 _OPENSEARCH_TO_JSONSCHEMA_TYPE: dict[str, dict] = {
@@ -232,6 +232,47 @@ class MetricsSnapshotTasks:
                 )
 
         return comms_data
+
+    async def _collect_normalization_all_nodes(self, timestamp: str) -> list:
+        """Collect Engine metrics from all cluster nodes via DAPI fan-out."""
+        local_node_name = self.server.configuration.get("node_name", "unknown")
+        cluster_name = self.server.configuration.get("cluster_name", "unknown")
+
+        all_node_names = [local_node_name] + list(self.server.clients)
+
+        docs = []
+        for node_name in all_node_names:
+            try:
+                if node_name == local_node_name:
+                    result = get_engine_metrics()
+                else:
+                    result = DistributedAPI(
+                        f=get_engine_metrics,
+                        f_kwargs={"node_list": [node_name]},
+                        logger=self.logger,
+                        request_type="distributed_master",
+                        is_async=False,
+                        wait_for_complete=True,
+                    ).distribute_function()
+
+                for item in getattr(result, "affected_items", []):
+                    node_ts = item.get("timestamp", timestamp)
+                    for metric_entry in item.get("global", []):
+                        docs.append(self._normalize_normalization_doc(
+                            metric_entry, "global", node_ts, cluster_name, node_name
+                        ))
+                    for space in item.get("spaces", []):
+                        space_name = space.get("name", "unknown")
+                        for metric_entry in space.get("metrics", []):
+                            docs.append(self._normalize_normalization_doc(
+                                metric_entry, space_name, node_ts, cluster_name, node_name
+                            ))
+            except Exception:
+                self.logger.exception(
+                    "Failed to collect Engine metrics from node '%s'", node_name
+                )
+
+        return docs
 
     @staticmethod
     def _drop_none(doc: dict) -> dict:
@@ -453,6 +494,42 @@ class MetricsSnapshotTasks:
             }
         )
 
+    @staticmethod
+    def _normalize_normalization_doc(
+        metric_entry: dict,
+        space_name: str,
+        timestamp: str,
+        cluster_name: str,
+        node_name: str,
+    ) -> dict:
+        """Transform a single Engine metric entry into an indexable document.
+
+        One call = one document. Called once per entry in global[] and once
+        per entry in each space's metrics[].
+        """
+        return {
+            "@timestamp": timestamp,
+            "event": {
+                "module": "wazuh-manager-analysisd",
+                "kind": "metrics",
+            },
+            "metric": {
+                "name": metric_entry["name"],
+                "type": metric_entry["type"],
+                "enabled": metric_entry["enabled"],
+                "value": metric_entry["value"],
+            },
+            "wazuh": {
+                "cluster": {
+                    "name": cluster_name,
+                    "node": node_name,
+                },
+                "space": {
+                    "name": space_name,
+                },
+            },
+        }
+
     def _load_schema(self, schema_filename: str) -> dict | None:
         """Load and cache an OpenSearch index template schema.
 
@@ -546,13 +623,15 @@ class MetricsSnapshotTasks:
     async def _collect_and_index(self):
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        agent_docs, comms_docs = await asyncio.gather(
+        agent_docs, comms_docs, normalization_docs = await asyncio.gather(
             self._collect_agents(timestamp),
             self._collect_comms_all_nodes(timestamp),
+            self._collect_normalization_all_nodes(timestamp),
         )
 
         agents_schema = self._load_schema("metrics-agents.json")
         comms_schema = self._load_schema("metrics-comms.json")
+        normalization_schema = self._load_schema("metrics-normalization.json")
 
         if agents_schema:
             agent_docs = self._validate_documents(
@@ -562,6 +641,10 @@ class MetricsSnapshotTasks:
             comms_docs = self._validate_documents(
                 comms_docs, comms_schema, "wazuh-metrics-comms"
             )
+        if normalization_schema:
+            normalization_docs = self._validate_documents(
+                normalization_docs, normalization_schema, "wazuh-metrics-normalization"
+            )
 
         async with get_indexer_client() as indexer:
             await asyncio.gather(
@@ -570,5 +653,8 @@ class MetricsSnapshotTasks:
                 ),
                 indexer.metrics.bulk_index(
                     "wazuh-metrics-comms", comms_docs, self.bulk_size
+                ),
+                indexer.metrics.bulk_index(
+                    "wazuh-metrics-normalization", normalization_docs, self.bulk_size
                 ),
             )

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -1138,6 +1138,12 @@ def _patch_collect_and_index(
                 new_callable=AsyncMock,
                 return_value=comms_docs if comms_docs is not None else [],
             ) as mock_comms,
+            patch.object(
+                tasks,
+                "_collect_normalization_all_nodes",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
             patch(
                 "wazuh.core.indexer.metrics_snapshot.get_indexer_client",
                 return_value=AsyncMock(
@@ -1249,6 +1255,7 @@ class TestBuildJsonschemaProperties:
             "anyOf": [
                 {"type": "string"},
                 {"type": "array", "items": {"type": "string"}},
+                {"type": "null"},
             ]
         }
         assert "field_b" in result
@@ -1256,6 +1263,7 @@ class TestBuildJsonschemaProperties:
             "anyOf": [
                 {"type": "integer"},
                 {"type": "array", "items": {"type": "integer"}},
+                {"type": "null"},
             ]
         }
 
@@ -1281,6 +1289,7 @@ class TestBuildJsonschemaProperties:
             "anyOf": [
                 {"type": "string"},
                 {"type": "array", "items": {"type": "string"}},
+                {"type": "null"},
             ]
         }
 
@@ -1294,6 +1303,7 @@ class TestBuildJsonschemaProperties:
             "anyOf": [
                 {"type": "integer"},
                 {"type": "array", "items": {"type": "integer"}},
+                {"type": "null"},
             ]
         }
 
@@ -1341,6 +1351,7 @@ class TestOpensearchTemplateToJsonschema:
             "anyOf": [
                 {"type": "string"},
                 {"type": "array", "items": {"type": "string"}},
+                {"type": "null"},
             ]
         }
 
@@ -1352,6 +1363,7 @@ class TestOpensearchTemplateToJsonschema:
             "anyOf": [
                 {"type": "integer"},
                 {"type": "array", "items": {"type": "integer"}},
+                {"type": "null"},
             ]
         }
 
@@ -1398,6 +1410,7 @@ class TestOpensearchTemplateToJsonschema:
             "anyOf": [
                 {"type": "string"},
                 {"type": "array", "items": {"type": "string"}},
+                {"type": "null"},
             ]
         }
 
@@ -1967,3 +1980,348 @@ class TestNormalizeCommsDocZeroPreservation:
         assert doc["queue"]["size"] == 10
         assert doc["events"]["total"] == 1000
         assert doc["tcp"]["sessions"] == 5
+
+# ---------------------------------------------------------------------------
+# Engine metrics fixtures
+# ---------------------------------------------------------------------------
+
+ENGINE_DUMP = {
+    "status": "OK",
+    "name": "wazuh-manager-analysisd",
+    "uptime": "2026-04-14T15:30:53.448Z",
+    "timestamp": "2026-04-14T15:32:46.095Z",
+    "global": [
+        {"name": "indexer.queue.size", "type": "pull", "enabled": True, "value": 0},
+        {"name": "router.events.processed", "type": "counter", "enabled": True, "value": 277},
+        {"name": "server.bytes.received", "type": "counter", "enabled": True, "value": 89710},
+    ],
+    "spaces": [
+        {
+            "name": "standard",
+            "metrics": [
+                {"name": "events.unclassified", "type": "counter", "enabled": True, "value": 264},
+                {"name": "events.discarded", "type": "counter", "enabled": True, "value": 0},
+            ],
+        }
+    ],
+}
+
+EXPECTED_NORMALIZATION_FIELDS = {
+    "@timestamp",
+    "event.module",
+    "event.kind",
+    "metric.name",
+    "metric.type",
+    "metric.enabled",
+    "metric.value",
+    "wazuh.cluster.name",
+    "wazuh.cluster.node",
+    "wazuh.space.name",
+}
+
+
+# ---------------------------------------------------------------------------
+# _normalize_normalization_doc
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeNormalizationDoc:
+    """Unit tests for MetricsSnapshotTasks._normalize_normalization_doc."""
+
+    def test_global_metric_space_name_is_null(self):
+        """Global metrics have wazuh.space.name == None (null in JSON)."""
+        metric = {"name": "router.queue.size", "type": "pull", "enabled": True, "value": 0}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, None, TIMESTAMP, "wazuh", "node01"
+        )
+        assert doc["wazuh"]["space"]["name"] is None
+
+    def test_space_metric_space_name_is_set(self):
+        """Space metrics have wazuh.space.name set to the space name."""
+        metric = {"name": "events.unclassified", "type": "counter", "enabled": True, "value": 264}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, "standard", TIMESTAMP, "wazuh", "node01"
+        )
+        assert doc["wazuh"]["space"]["name"] == "standard"
+
+    def test_all_expected_fields_present(self):
+        """All required fields are present in the output document."""
+        metric = {"name": "router.queue.size", "type": "pull", "enabled": True, "value": 0}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, None, TIMESTAMP, "wazuh", "node01"
+        )
+        flat_keys = _deep_keys(doc)
+        missing = EXPECTED_NORMALIZATION_FIELDS - flat_keys
+        assert not missing, f"Missing fields: {missing}"
+
+    def test_metric_fields_match_input(self):
+        """metric.name, type, enabled and value are taken verbatim from the entry."""
+        metric = {"name": "server.bytes.received", "type": "counter", "enabled": True, "value": 89710}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, None, TIMESTAMP, "wazuh", "node01"
+        )
+        assert doc["metric"]["name"] == "server.bytes.received"
+        assert doc["metric"]["type"] == "counter"
+        assert doc["metric"]["enabled"] is True
+        assert doc["metric"]["value"] == 89710
+
+    def test_timestamp_is_set_correctly(self):
+        """@timestamp in the output matches the timestamp argument."""
+        metric = {"name": "router.eps.1m", "type": "pull", "enabled": True, "value": 5}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, "standard", TIMESTAMP, "wazuh", "node01"
+        )
+        assert doc["@timestamp"] == TIMESTAMP
+
+    def test_cluster_fields_match_arguments(self):
+        """wazuh.cluster.name and node are sourced from the arguments."""
+        metric = {"name": "router.eps.1m", "type": "pull", "enabled": True, "value": 5}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, None, TIMESTAMP, "my-cluster", "my-node"
+        )
+        assert doc["wazuh"]["cluster"]["name"] == "my-cluster"
+        assert doc["wazuh"]["cluster"]["node"] == "my-node"
+
+    def test_event_module_and_kind_are_correct(self):
+        """event.module and event.kind are always set to the Engine values."""
+        metric = {"name": "indexer.queue.size", "type": "pull", "enabled": True, "value": 0}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, None, TIMESTAMP, "wazuh", "node01"
+        )
+        assert doc["event"]["module"] == "wazuh-manager-analysisd"
+        assert doc["event"]["kind"] == "metrics"
+
+    def test_zero_value_is_preserved(self):
+        """metric.value == 0 is not dropped."""
+        metric = {"name": "indexer.events.dropped", "type": "pull", "enabled": True, "value": 0}
+        doc = MetricsSnapshotTasks._normalize_normalization_doc(
+            metric, None, TIMESTAMP, "wazuh", "node01"
+        )
+        assert doc["metric"]["value"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _collect_normalization_all_nodes
+# ---------------------------------------------------------------------------
+
+
+class TestCollectNormalizationAllNodes:
+    """Tests for MetricsSnapshotTasks._collect_normalization_all_nodes."""
+
+    @pytest.mark.asyncio
+    async def test_single_master_generates_one_doc_per_metric(self):
+        """Master-only cluster: one document per metric entry (global + spaces)."""
+        tasks = _make_tasks(server=_make_server(node_name="node01"))
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        # 3 global + 2 space metrics = 5 documents
+        assert len(docs) == 5
+
+    @pytest.mark.asyncio
+    async def test_global_metrics_have_null_space_name(self):
+        """Documents from global[] have wazuh.space.name == None."""
+        tasks = _make_tasks(server=_make_server(node_name="node01"))
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        global_docs = [d for d in docs if d["metric"]["name"] in {
+            "indexer.queue.size", "router.events.processed", "server.bytes.received"
+        }]
+        assert len(global_docs) == 3
+        for doc in global_docs:
+            assert doc["wazuh"]["space"]["name"] is None
+
+    @pytest.mark.asyncio
+    async def test_space_metrics_have_space_name_set(self):
+        """Documents from spaces[] carry the correct space name."""
+        tasks = _make_tasks(server=_make_server(node_name="node01"))
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        space_docs = [d for d in docs if d["wazuh"]["space"]["name"] == "standard"]
+        assert len(space_docs) == 2
+
+    @pytest.mark.asyncio
+    async def test_metadata_injected_into_every_document(self):
+        """@timestamp, wazuh.cluster.name and wazuh.cluster.node appear in every doc."""
+        tasks = _make_tasks(server=_make_server(node_name="node01"))
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        for doc in docs:
+            assert doc["wazuh"]["cluster"]["node"] == "node01"
+            assert doc["wazuh"]["cluster"]["name"] == "wazuh"
+
+    @pytest.mark.asyncio
+    async def test_timestamp_from_engine_dump_takes_precedence(self):
+        """The Engine's own timestamp field is used, not the task-level timestamp."""
+        tasks = _make_tasks(server=_make_server(node_name="node01"))
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        for doc in docs:
+            assert doc["@timestamp"] == ENGINE_DUMP["timestamp"]
+
+    @pytest.mark.asyncio
+    async def test_worker_node_injects_its_own_node_name(self):
+        """Worker node documents carry their own node name."""
+        server = _make_server(node_name="node01", workers={"node02": MagicMock()})
+        tasks = _make_tasks(server=server)
+
+        master_result = _make_dapi_result([dict(ENGINE_DUMP)])
+        worker_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with (
+            patch(
+                "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+                return_value=master_result,
+            ),
+            patch(
+                "wazuh.core.indexer.metrics_snapshot.DistributedAPI",
+                return_value=AsyncMock(
+                    distribute_function=AsyncMock(return_value=worker_result)
+                ),
+            ) as MockDAPI,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        # DAPI was called targeting node02, and that exact name is stamped into the docs.
+        call_kwargs = MockDAPI.call_args.kwargs
+        assert call_kwargs["f_kwargs"]["node_list"] == ["node02"]
+
+        node_names = {doc["wazuh"]["cluster"]["node"] for doc in docs}
+        assert "node01" in node_names
+        assert "node02" in node_names
+
+    @pytest.mark.asyncio
+    async def test_dapi_called_for_worker_not_master(self):
+        """DistributedAPI is used for workers; local node calls get_engine_metrics directly."""
+        server = _make_server(node_name="node01", workers={"node02": MagicMock()})
+        tasks = _make_tasks(server=server)
+
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+        worker_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with (
+            patch(
+                "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+                return_value=local_result,
+            ) as mock_local,
+            patch(
+                "wazuh.core.indexer.metrics_snapshot.DistributedAPI",
+                return_value=AsyncMock(
+                    distribute_function=AsyncMock(return_value=worker_result)
+                ),
+            ) as MockDAPI,
+        ):
+            await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        mock_local.assert_called_once_with()
+        MockDAPI.assert_called_once()
+        call_kwargs = MockDAPI.call_args.kwargs
+        assert call_kwargs["f_kwargs"]["node_list"] == ["node02"]
+        assert call_kwargs["request_type"] == "distributed_master"
+
+    @pytest.mark.asyncio
+    async def test_empty_affected_items_produces_no_documents(self):
+        """If the Engine returns no items, no documents are generated."""
+        tasks = _make_tasks()
+        local_result = _make_dapi_result([])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        assert docs == []
+
+    @pytest.mark.asyncio
+    async def test_node_failure_is_logged_and_skipped(self):
+        """If local Engine call raises, the error is logged and other nodes continue."""
+        server = _make_server(node_name="node01", workers={"node02": MagicMock()})
+        tasks = _make_tasks(server=server)
+
+        worker_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with (
+            patch(
+                "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+                side_effect=RuntimeError("socket error"),
+            ),
+            patch(
+                "wazuh.core.indexer.metrics_snapshot.DistributedAPI",
+                return_value=AsyncMock(
+                    distribute_function=AsyncMock(return_value=worker_result)
+                ),
+            ),
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        assert all(d["wazuh"]["cluster"]["node"] == "node02" for doc in docs for d in [doc])
+        tasks.logger.exception.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_space_name_none_when_name_key_missing(self):
+        """A space without a 'name' key produces wazuh.space.name == None."""
+        dump_no_space_name = {
+            **ENGINE_DUMP,
+            "global": [],
+            "spaces": [
+                {"metrics": [{"name": "events.unclassified", "type": "counter", "enabled": True, "value": 1}]}
+            ],
+        }
+        tasks = _make_tasks()
+        local_result = _make_dapi_result([dump_no_space_name])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        assert len(docs) == 1
+        assert docs[0]["wazuh"]["space"]["name"] is None
+
+    @pytest.mark.asyncio
+    async def test_all_expected_fields_in_every_document(self):
+        """Every generated document contains all required fields."""
+        tasks = _make_tasks(server=_make_server(node_name="node01"))
+        local_result = _make_dapi_result([dict(ENGINE_DUMP)])
+
+        with patch(
+            "wazuh.core.indexer.metrics_snapshot.get_engine_metrics",
+            return_value=local_result,
+        ):
+            docs = await tasks._collect_normalization_all_nodes(TIMESTAMP)
+
+        for doc in docs:
+            flat_keys = _deep_keys(doc)
+            missing = EXPECTED_NORMALIZATION_FIELDS - flat_keys
+            assert not missing, f"Missing fields in doc {doc['metric']['name']}: {missing}"

--- a/framework/wazuh/core/tests/test_engine_http.py
+++ b/framework/wazuh/core/tests/test_engine_http.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_httpx_mock = MagicMock()
+
+
+class _TimeoutException(Exception):
+    pass
+
+
+class _ConnectError(Exception):
+    pass
+
+
+class _RequestError(Exception):
+    pass
+
+
+_httpx_mock.TimeoutException = _TimeoutException
+_httpx_mock.ConnectError = _ConnectError
+_httpx_mock.RequestError = _RequestError
+_httpx_mock.HTTPTransport = MagicMock()
+_httpx_mock.Client = MagicMock()
+
+with patch.dict(sys.modules, {'httpx': _httpx_mock}), \
+     patch('wazuh.core.common.ANALYSISD_SOCKET', '/var/wazuh-manager/queue/sockets/analysis'):
+    from wazuh.core.engine_http import EngineHTTPClient
+
+from wazuh.core.exception import WazuhError, WazuhInternalError
+
+
+METRICS_DUMP_RESPONSE = {
+    "status": 0,
+    "name": "engine",
+    "uptime": 12345,
+    "global": [
+        {"name": "router.queue.size", "type": 0, "enabled": True, "value": 1000},
+        {"name": "router.eps.1m", "type": 1, "enabled": True, "value": 250.5},
+    ],
+    "spaces": [],
+}
+
+
+def _make_client() -> EngineHTTPClient:
+    client = EngineHTTPClient()
+    client._client = MagicMock()
+    return client
+
+
+def test_get_metrics_dump_ok():
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.is_error = False
+    mock_response.json.return_value = METRICS_DUMP_RESPONSE
+    client._client.post.return_value = mock_response
+
+    result = client.get_metrics_dump()
+
+    client._client.post.assert_called_once_with(
+        url='http://localhost/metrics/dump',
+        content='{}',
+        headers={'Content-Type': 'text/plain'},
+    )
+    assert result == METRICS_DUMP_RESPONSE
+
+
+def test_get_metrics_dump_http_error():
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.is_error = True
+    mock_response.text = 'internal error'
+    client._client.post.return_value = mock_response
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.get_metrics_dump()
+    assert exc_info.value.code == 2019
+
+
+def test_get_metrics_dump_timeout():
+    client = _make_client()
+    client._client.post.side_effect = _TimeoutException("timed out")
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.get_metrics_dump()
+    assert exc_info.value.code == 2020
+
+
+def test_get_metrics_dump_connect_error():
+    client = _make_client()
+    client._client.post.side_effect = _ConnectError("refused")
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.get_metrics_dump()
+    assert exc_info.value.code == 2021
+
+
+def test_get_metrics_dump_request_error():
+    client = _make_client()
+    client._client.post.side_effect = _RequestError("network error")
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.get_metrics_dump()
+    assert exc_info.value.code == 2013

--- a/framework/wazuh/core/tests/test_engine_http.py
+++ b/framework/wazuh/core/tests/test_engine_http.py
@@ -44,7 +44,7 @@ def test_get_metrics_dump_ok():
     client._client.post.assert_called_once_with(
         url='http://localhost/metrics/dump',
         content='{}',
-        headers={'Content-Type': 'text/plain'},
+        headers={'Content-Type': 'application/json'},
     )
     assert result == METRICS_DUMP_RESPONSE
 
@@ -59,6 +59,18 @@ def test_get_metrics_dump_http_error():
     with pytest.raises(WazuhError) as exc_info:
         client.get_metrics_dump()
     assert exc_info.value.code == 2019
+
+
+def test_get_metrics_dump_invalid_json():
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.is_error = False
+    mock_response.json.side_effect = ValueError("not valid json")
+    client._client.post.return_value = mock_response
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.get_metrics_dump()
+    assert exc_info.value.code == 2022
 
 
 def test_get_metrics_dump_timeout():

--- a/framework/wazuh/core/tests/test_engine_http.py
+++ b/framework/wazuh/core/tests/test_engine_http.py
@@ -2,36 +2,12 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+import httpx
 
-_httpx_mock = MagicMock()
-
-
-class _TimeoutException(Exception):
-    pass
-
-
-class _ConnectError(Exception):
-    pass
-
-
-class _RequestError(Exception):
-    pass
-
-
-_httpx_mock.TimeoutException = _TimeoutException
-_httpx_mock.ConnectError = _ConnectError
-_httpx_mock.RequestError = _RequestError
-_httpx_mock.HTTPTransport = MagicMock()
-_httpx_mock.Client = MagicMock()
-
-with patch.dict(sys.modules, {'httpx': _httpx_mock}), \
-     patch('wazuh.core.common.ANALYSISD_SOCKET', '/var/wazuh-manager/queue/sockets/analysis'):
-    from wazuh.core.engine_http import EngineHTTPClient
-
+from wazuh.core.engine_http import EngineHTTPClient
 from wazuh.core.exception import WazuhError, WazuhInternalError
 
 
@@ -48,7 +24,10 @@ METRICS_DUMP_RESPONSE = {
 
 
 def _make_client() -> EngineHTTPClient:
-    client = EngineHTTPClient()
+    with patch('wazuh.core.common.ANALYSISD_SOCKET', '/var/wazuh-manager/queue/sockets/analysis'):
+        with patch('httpx.HTTPTransport'), patch('httpx.Client'):
+            client = EngineHTTPClient()
+
     client._client = MagicMock()
     return client
 
@@ -84,7 +63,7 @@ def test_get_metrics_dump_http_error():
 
 def test_get_metrics_dump_timeout():
     client = _make_client()
-    client._client.post.side_effect = _TimeoutException("timed out")
+    client._client.post.side_effect = httpx.TimeoutException("timed out", request=MagicMock())
 
     with pytest.raises(WazuhInternalError) as exc_info:
         client.get_metrics_dump()
@@ -93,7 +72,7 @@ def test_get_metrics_dump_timeout():
 
 def test_get_metrics_dump_connect_error():
     client = _make_client()
-    client._client.post.side_effect = _ConnectError("refused")
+    client._client.post.side_effect = httpx.ConnectError("refused", request=MagicMock())
 
     with pytest.raises(WazuhInternalError) as exc_info:
         client.get_metrics_dump()
@@ -102,8 +81,18 @@ def test_get_metrics_dump_connect_error():
 
 def test_get_metrics_dump_request_error():
     client = _make_client()
-    client._client.post.side_effect = _RequestError("network error")
+    client._client.post.side_effect = httpx.RequestError("network error", request=MagicMock())
 
     with pytest.raises(WazuhError) as exc_info:
         client.get_metrics_dump()
     assert exc_info.value.code == 2013
+
+
+def test_engine_http_client_init_error():
+    """Test that the client raises WazuhInternalError(2018) if httpx instantiation fails."""
+    with patch('wazuh.core.common.ANALYSISD_SOCKET', '/var/wazuh-manager/queue/sockets/analysis'):
+        # Simulate that httpx cannot open the Unix socket
+        with patch('httpx.HTTPTransport', side_effect=OSError("no socket")):
+            with pytest.raises(WazuhInternalError) as exc_info:
+                EngineHTTPClient()
+            assert exc_info.value.code == 2018

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -6,6 +6,7 @@ from wazuh.core import common
 from wazuh.core import exception
 from wazuh.core.agent import Agent, get_agents_info, get_rbac_filters, WazuhDBQueryAgents
 from wazuh.core.cluster.cluster import get_node
+from wazuh.core.engine_http import EngineHTTPClient
 from wazuh.core.exception import WazuhException
 from wazuh.core.results import AffectedItemsWazuhResult
 from wazuh.core.stats import get_daemons_stats_socket
@@ -146,6 +147,32 @@ def get_daemons_stats(daemons_list: list = None) -> AffectedItemsWazuhResult:
         except WazuhException as e:
             result.add_failed_item(id_=daemon, error=e)
 
+    result.total_affected_items = len(result.affected_items)
+    return result
+
+
+@expose_resources(actions=['cluster:read'], resources=[f'node:id:{node_id}'])
+def get_engine_metrics() -> AffectedItemsWazuhResult:
+    """Fetch Engine metrics dump from the local analysisd socket.
+
+    Returns
+    -------
+    AffectedItemsWazuhResult
+        Engine metrics dump as the single affected item.
+    """
+    result = AffectedItemsWazuhResult(
+        all_msg='Engine metrics were successfully retrieved',
+        some_msg='Could not retrieve engine metrics',
+        none_msg='Could not retrieve engine metrics',
+    )
+    client = EngineHTTPClient()
+    try:
+        data = client.get_metrics_dump()
+        result.affected_items.append(data)
+    except WazuhException as e:
+        result.add_failed_item(id_='engine', error=e)
+    finally:
+        client.close()
     result.total_affected_items = len(result.affected_items)
     return result
 

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -165,14 +165,18 @@ def get_engine_metrics() -> AffectedItemsWazuhResult:
         some_msg='Could not retrieve engine metrics',
         none_msg='Could not retrieve engine metrics',
     )
-    client = EngineHTTPClient()
+
+    client = None
     try:
+        client = EngineHTTPClient()
         data = client.get_metrics_dump()
         result.affected_items.append(data)
     except WazuhException as e:
         result.add_failed_item(id_='engine', error=e)
     finally:
-        client.close()
+        if client is not None:
+            client.close()
+
     result.total_affected_items = len(result.affected_items)
     return result
 

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -160,3 +160,41 @@ def test_get_agents_component_stats_json_ko(mock_agents_info, mock_getstats):
     response = stats.get_agents_component_stats_json(agent_list=['003'], component='logcollector')
     assert isinstance(response, AffectedItemsWazuhResult), 'The result is not AffectedItemsWazuhResult type'
     assert response.render()['data']['failed_items'][0]['error']['code'] == 1701, 'Expected error code was not returned'
+
+
+METRICS_DUMP_DATA = {
+    "status": 0,
+    "name": "engine",
+    "uptime": 99,
+    "global": [{"name": "router.queue.size", "type": 0, "enabled": True, "value": 500}],
+    "spaces": [],
+}
+
+
+@patch('wazuh.stats.EngineHTTPClient')
+def test_get_engine_metrics(mock_client_cls):
+    mock_client = MagicMock()
+    mock_client.get_metrics_dump.return_value = METRICS_DUMP_DATA
+    mock_client_cls.return_value = mock_client
+
+    response = stats.get_engine_metrics()
+
+    assert isinstance(response, AffectedItemsWazuhResult)
+    assert response.total_affected_items == 1
+    assert response.affected_items[0] == METRICS_DUMP_DATA
+    assert not response.failed_items
+
+
+@patch('wazuh.stats.EngineHTTPClient')
+def test_get_engine_metrics_ko(mock_client_cls):
+    from wazuh.core.exception import WazuhInternalError
+
+    mock_client = MagicMock()
+    mock_client.get_metrics_dump.side_effect = WazuhInternalError(2021)
+    mock_client_cls.return_value = mock_client
+
+    response = stats.get_engine_metrics()
+
+    assert isinstance(response, AffectedItemsWazuhResult)
+    assert response.total_affected_items == 0
+    assert response.render()['data']['failed_items'][0]['error']['code'] == 2021


### PR DESCRIPTION
## Description

This PR implements the full Engine metrics pipeline as part of #35470: from collecting raw
metrics via the Engine's Unix socket, through cluster-wide fan-out via DAPI, to normalization
and periodic bulk indexing into OpenSearch (`wazuh-metrics-normalization`).

Closes #35771
Closes #35772

## Proposed Changes

- Added `EngineHTTPClient` in `engine_http.py` to handle synchronous HTTP requests over the
  Unix socket (`ANALYSISD_SOCKET`).
- Added `get_engine_metrics` DAPI-registered function in `stats.py` to allow cluster fan-out
  metrics collection, mirroring the `get_daemons_stats` pattern used for comms.
- Implemented `_collect_normalization_all_nodes` and `_normalize_normalization_doc` in
  `metrics_snapshot.py` to fetch, normalize, and index Engine metrics into
  `wazuh-metrics-normalization`, generating one document per individual metric entry.
- Added new `WazuhError` and `WazuhInternalError` codes (2018–2021) under the `# Engine:`
  section in `exception.py` to gracefully handle Engine API HTTP exceptions (timeouts,
  connection errors, invalid JSON).

## Proposed Schema

Each indexed document follows the agreed schema (one doc per metric entry):

```json
{
    "@timestamp": "2026-04-14T15:32:46.095Z",
    "event": { "module": "wazuh-manager-analysisd", "kind": "metrics" },
    "metric": { "name": "router.queue.size", "type": "pull", "enabled": true, "value": 0 },
    "wazuh": {
        "cluster": { "name": "wazuh-cluster", "node": "wazuh-node-1" },
        "space": { "name": null }
    }
}
```

> `wazuh.space.name` is `null` for global metrics and the space name (e.g. `"standard"`)
> for space-scoped metrics.

### Results and Evidence

Unit tests were successfully executed, validating the correct behavior of the HTTP client,
error handling, the DAPI wrapper, and the metrics snapshot normalizer.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer
- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors
- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.
- Wazuh server API/Framework
  - [x] Run API Integration Tests

### Artifacts Affected

- `framework/wazuh/core/engine_http.py`
- `framework/wazuh/stats.py`
- `framework/wazuh/core/exception.py`
- `framework/wazuh/core/indexer/metrics_snapshot.py`
- `framework/wazuh/core/tests/test_engine_http.py`
- `framework/wazuh/tests/test_stats.py`
- `framework/wazuh/core/indexer/tests/test_metrics_snapshot.py`

### Configuration Changes

N/A. Reuses the existing `ANALYSISD_SOCKET` constant since the daemon remained as `analysisd`.

### Tests Introduced

- Unit tests for `EngineHTTPClient` handling successful responses, timeouts, connection
  errors, and JSON decode errors (`framework/wazuh/core/tests/test_engine_http.py`).
- Unit tests for `get_engine_metrics` DAPI function verifying correct wrapping of
  affected/failed items (`framework/wazuh/tests/test_stats.py`).
- Unit tests for `_normalize_normalization_doc` and `_collect_normalization_all_nodes` covering document structure, null space name, Engine timestamp precedence, DAPI fan-out routing, node failure handling, and field completeness (`framework/wazuh/core/indexer/tests/test_metrics_snapshot.py` : `TestNormalizeNormalizationDoc`, `TestCollectNormalizationAllNodes`).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues