### PR TITLE
Fix stale generated headers after clean

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -825,6 +825,9 @@ clean-internals:
 # Flatbuffers
 	rm -rf shared_modules/utils/flatbuffers/build
 	rm -rf shared_modules/utils/flatbuffers/include
+	rm -f wazuh_modules/syscollector/include/*_generated.h
+	rm -f wazuh_modules/vulnerability_scanner/include/*_generated.h
+	rm -f wazuh_modules/vulnerability_scanner/include/*_schema.h
 # Selinux
 	rm -f ${SELINUX_MODULE}
 	rm -f ${SELINUX_POLICY}

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -130,8 +130,8 @@ add_library(vulnerability_scanner SHARED ${VULNERABILITY_SCANNER_SRC})
 target_include_directories(
   vulnerability_scanner
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
-         ${CMAKE_CURRENT_SOURCE_DIR}/include
          ${CMAKE_CURRENT_BINARY_DIR}/include
+         ${CMAKE_CURRENT_SOURCE_DIR}/include
          ${CMAKE_CURRENT_SOURCE_DIR}/src/databaseFeedManager
          ${CMAKE_CURRENT_SOURCE_DIR}/src/scanOrchestrator)
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/CMakeLists.txt
@@ -11,9 +11,9 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-include_directories("../include")
-# Include build directory for generated schema headers
 include_directories("${CMAKE_BINARY_DIR}/wazuh_modules/vulnerability_scanner/include")
+# Keep generated schema headers ahead of source-tree copies.
+include_directories("../include")
 
 add_library(database_feed STATIC ${DATABASE_FEED_SRC})
 


### PR DESCRIPTION
## Description

This PR fixes a build issue in the manager/server after cleanup.

The root cause was a stale generated header left in the source tree. After `clean-internals`, the build could still pick that stale file instead of the freshly generated one from `build/`, which caused the FlatBuffers API mismatch.

## Proposed Changes

- Remove ignored generated headers from `clean-internals`.
- Prefer generated vulnerability scanner headers from `build/` over source-tree copies.
- Keep the fix limited to cleanup and include order.

### Results and Evidence

Local validation completed:

- `make clean-internals`
- `make TARGET=server -j16`
- `make TARGET=server DEBUG=1 TEST=1 -j16`

Result: all three commands completed successfully.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Manager/server build
- Vulnerability scanner generated headers
- Internal cleanup flow

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
