### PR TITLE
Fixed an issue in eBPF with LSM hooks and improved the health check

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -26,7 +26,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2468288,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,479064,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526040,0.1
-/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,44760,0.1
+/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,57024,0.1
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2034120,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,574920,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -26,7 +26,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2673916,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,516264,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,470148,0.1
-/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,47248,0.1
+/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,57476,0.1
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2123404,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,594996,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -96,7 +96,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2234552,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,466648,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526048,0.1
-/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,44600,0.1
+/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,53616,0.1
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2009608,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,554376,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -96,7 +96,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2606452,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,491660,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,470152,0.1
-/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,43120,0.1
+/var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,52720,0.1
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,1984136,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,562192,0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -707,6 +707,95 @@ All notable changes to this project will be documented in this file.
 - Added the `security:revoke` action to the `PUT /security/user/revoke` endpoint. ([#26255](https://github.com/wazuh/wazuh/pull/26255))
 
 
+## [v4.10.5]
+
+
+## [v4.10.4]
+
+### Manager
+
+#### Changed
+
+- Masked `authd.pass` in configuration API responses for users without update permissions. ([#34128](https://github.com/wazuh/wazuh/pull/34128))
+
+#### Fixed
+
+- Fixed analysisd plugin decoder argument alignment. ([#35222](https://github.com/wazuh/wazuh/pull/35222))
+- Fixed path traversal in authd via agent group name validation. ([#35258](https://github.com/wazuh/wazuh/pull/35258))
+- Hardened cluster deserialization by restricting callable decoding to Wazuh modules and improving error handling. ([#35256](https://github.com/wazuh/wazuh/pull/35256))
+- Fixed DAPI callable resolution to restrict invocations to exposed resources only. ([#35256](https://github.com/wazuh/wazuh/pull/35256))
+- Fixed admin protection in update user endpoint. ([#35469](https://github.com/wazuh/wazuh/pull/35469))
+- Fixed protected settings checks when multiple `<ossec_config>` blocks are present. ([#34690](https://github.com/wazuh/wazuh/pull/34690))
+- Restricted cluster file transfer write paths. ([#34659](https://github.com/wazuh/wazuh/pull/34659))
+- Improved cluster file synchronization path handling by adding safe path joins. ([#35008](https://github.com/wazuh/wazuh/pull/35008))
+- Fixed Vulnerability Detector offset DB update to occur only after processing (backport from 4.12.0). ([#31901](https://github.com/wazuh/wazuh/pull/31901))
+
+### Agent
+
+#### Added
+
+- Added detection of the `-a never,task` Audit rule in FIM whodata for Linux. ([#34661](https://github.com/wazuh/wazuh/pull/34661))
+
+#### Changed
+
+- Changed sync primitive disposal to stop and soften teardown failures. ([#34680](https://github.com/wazuh/wazuh/pull/34680))
+
+#### Fixed
+
+- Fixed Windows FIM Registry scan crash on non-null-terminated values. ([#34679](https://github.com/wazuh/wazuh/pull/34679))
+
+### Other
+
+#### Changed
+
+- Updated curl dependency to 8.12.1. ([#34687](https://github.com/wazuh/wazuh/pull/34687))
+- Updated `starlette` dependency to 0.49.1. ([#33383](https://github.com/wazuh/wazuh/pull/33383))
+- Upgraded Python embedded interpreter to 3.10.19. ([#32790](https://github.com/wazuh/wazuh/pull/32790))
+
+
+## [v4.10.3]
+
+### Other
+
+#### Changed
+
+- Updated `requests` to version 2.32.4 (backport from 4.14.0). ([#30829](https://github.com/wazuh/wazuh/pull/30829))
+- Updated `urllib3` to version 2.5.0 and `protobuf` to version 5.29.5 (backport from 4.14.0). ([#30829](https://github.com/wazuh/wazuh/pull/30829))
+- Updated dependencies: setuptools, Jinja2, and PyJWT (backport from 4.14.0). ([#29933](https://github.com/wazuh/wazuh/pull/29933))
+
+
+## [v4.10.2]
+
+### Manager
+
+#### Fixed
+
+- Enabled inventory synchronization in Vulnerability Detector when the Indexer module is disabled (backport from 4.11.0). ([#29612](https://github.com/wazuh/wazuh/pull/29612))
+- Fixed the OS CPE build for package scans with data from Wazuh-DB (backport from 4.11.1). ([#29613](https://github.com/wazuh/wazuh/pull/29613))
+- Fixed heap buffer overflow in Analysisd rule parser (backport from 4.11.1). ([#29599](https://github.com/wazuh/wazuh/pull/29599))
+- Improved the signal handling during processes stop (backport from 4.12.0). ([#29615](https://github.com/wazuh/wazuh/pull/29615))
+- Fixed crash when reading email alerts missing the `email_to` attribute (backport from 4.12.0). ([#29616](https://github.com/wazuh/wazuh/pull/29616))
+
+#### Changed
+
+- Improved SCA and Syscheck decoders (backport from 4.11.0). ([#29633](https://github.com/wazuh/wazuh/pull/29633))
+
+### Agent
+
+#### Fixed
+
+- Fixed a bug that could cause `wazuh-modulesd` to crash at startup (backport from 4.12.0). ([#29598](https://github.com/wazuh/wazuh/pull/29598))
+- Fixed WPK package upgrades for DEB when upgrading from version 4.3.11 or earlier (backport from 4.12.0). ([#29600](https://github.com/wazuh/wazuh/pull/29600))
+- Fixed error in event processing on AWS Custom Logs Buckets module (backport from 4.11.0). ([#29635](https://github.com/wazuh/wazuh/pull/29635))
+- Improved URL validation in the Maltiverse integration (backport from 4.12.0). ([#29604](https://github.com/wazuh/wazuh/pull/29604))
+
+### Other
+
+#### Changed
+
+- Upgraded python-multipart to 0.0.20, starlette to 0.42.0 and Werkzeug to 3.1.3 (backport from 4.12.0), h11 to 0.16.0 and httpcore to 1.0.9. ([#29669](https://github.com/wazuh/wazuh/pull/29669))
+
+
 ## [v4.10.1] - 2025-01-17
 
 ### Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -707,9 +707,6 @@ All notable changes to this project will be documented in this file.
 - Added the `security:revoke` action to the `PUT /security/user/revoke` endpoint. ([#26255](https://github.com/wazuh/wazuh/pull/26255))
 
 
-## [v4.10.5]
-
-
 ## [v4.10.4]
 
 ### Manager

--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -76,6 +76,30 @@ wazuh-agent (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
+wazuh-agent (4.10.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-agent (4.10.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-agent (4.10.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 19 Aug 2025 00:00:00 +0000
+
+wazuh-agent (4.10.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 21 May 2025 00:00:00 +0000
+
 wazuh-agent (4.10.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
@@ -105,6 +129,12 @@ wazuh-agent (4.9.0-RELEASE) stable; urgency=low
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 05 Sep 2024 00:00:00 +0000
+
+wazuh-agent (4.8.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 22 Aug 2024 00:00:00 +0000
 
 wazuh-agent (4.8.1-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -76,12 +76,6 @@ wazuh-agent (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
-wazuh-agent (4.10.5-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
-
- -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
-
 wazuh-agent (4.10.4-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -76,12 +76,6 @@ wazuh-manager (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
-wazuh-manager (4.10.5-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
-
- -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
-
 wazuh-manager (4.10.4-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -76,6 +76,30 @@ wazuh-manager (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
+wazuh-manager (4.10.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-manager (4.10.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-manager (4.10.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 19 Aug 2025 00:00:00 +0000
+
+wazuh-manager (4.10.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 21 May 2025 00:00:00 +0000
+
 wazuh-manager (4.10.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
@@ -105,6 +129,12 @@ wazuh-manager (4.9.0-RELEASE) stable; urgency=low
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 05 Sep 2024 00:00:00 +0000
+
+wazuh-manager (4.8.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 22 Aug 2024 00:00:00 +0000
 
 wazuh-manager (4.8.1-RELEASE) stable; urgency=low
 

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -833,8 +833,6 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
-* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
 * Thu May 21 2026 support <info@wazuh.com> - 4.10.4
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
 * Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -833,6 +833,14 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.4
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+* Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+* Wed May 21 2025 support <info@wazuh.com> - 4.10.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
 * Thu Jan 16 2025 support <info@wazuh.com> - 4.10.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
 * Thu Jan 09 2025 support <info@wazuh.com> - 4.10.0
@@ -843,6 +851,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html
 * Thu Sep 05 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Thu Aug 22 2024 support <info@wazuh.com> - 4.8.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 * Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -999,6 +999,14 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.4
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+* Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+* Wed May 21 2025 support <info@wazuh.com> - 4.10.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
 * Thu Jan 16 2025 support <info@wazuh.com> - 4.10.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
 * Thu Jan 09 2025 support <info@wazuh.com> - 4.10.0
@@ -1009,6 +1017,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html
 * Thu Sep 05 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Thu Aug 22 2024 support <info@wazuh.com> - 4.8.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 * Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -999,8 +999,6 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
-* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
 * Thu May 21 2026 support <info@wazuh.com> - 4.10.4
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
 * Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -493,6 +493,7 @@
 #define FIM_ERROR_EBPF_INVALID_KERNEL               "(6980): Invalid Kernel version detected. Must be +5.8."
 #define FIM_ERROR_EBPF_HEALTHCHECK_ACTION_FAILED    "(6981): eBPF healthcheck action failed: %s. %s"
 #define FIM_ERROR_EBPF_HEALTHCHECK_ACTION_SKIPPED   "(6982): eBPF healthcheck action skipped: %s. %s"
+#define FIM_ERROR_EBPF_OBJ_ATTACH_DETAIL            "(6983): Attaching BPF program '%s' failed (errno=%d: %s)."
 #define FIM_EBPF_HEALTHCHECK_EVENT_CONSUME_DETAIL   "Failed while consuming healthcheck events."
 #define FIM_EBPF_HEALTHCHECK_EVENT_TIMEOUT_DETAIL   "Timed out waiting for the corresponding event."
 #define FIM_EBPF_HEALTHCHECK_CREATE_DETAIL          "Could not create the temporary healthcheck file."

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -491,6 +491,16 @@
 #define FIM_ERROR_EBPF_HEALTHCHECK_TIMEOUT          "(6978): eBPF healthcheck timeout."
 #define FIM_ERROR_EBPF_HEALTHCHECK_FILE_DEL         "(6979): Healthcheck file can't be removed. Path: %s"
 #define FIM_ERROR_EBPF_INVALID_KERNEL               "(6980): Invalid Kernel version detected. Must be +5.8."
+#define FIM_ERROR_EBPF_HEALTHCHECK_ACTION_FAILED    "(6981): eBPF healthcheck action failed: %s. %s"
+#define FIM_ERROR_EBPF_HEALTHCHECK_ACTION_SKIPPED   "(6982): eBPF healthcheck action skipped: %s. %s"
+#define FIM_EBPF_HEALTHCHECK_EVENT_CONSUME_DETAIL   "Failed while consuming healthcheck events."
+#define FIM_EBPF_HEALTHCHECK_EVENT_TIMEOUT_DETAIL   "Timed out waiting for the corresponding event."
+#define FIM_EBPF_HEALTHCHECK_CREATE_DETAIL          "Could not create the temporary healthcheck file."
+#define FIM_EBPF_HEALTHCHECK_CONTENT_DETAIL         "Could not open the healthcheck file for append."
+#define FIM_EBPF_HEALTHCHECK_STAT_DETAIL            "Could not stat the healthcheck file. Path: %s. Error: %s"
+#define FIM_EBPF_HEALTHCHECK_CHMOD_DETAIL           "Could not update file permissions. Path: %s. Error: %s"
+#define FIM_EBPF_HEALTHCHECK_DELETE_DETAIL          "Could not remove the temporary healthcheck file."
+#define FIM_EBPF_HEALTHCHECK_SKIP_DETAIL            "Skipped because the healthcheck file is not available."
 
 /* Wazuh Logtest error messsages */
 #define LOGTEST_ERROR_BIND_SOCK                     "(7300): Unable to bind to socket '%s'. Errno: (%d) %s"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -65,6 +65,8 @@
 
 #define FIM_EBPF_INIT                       "(6047): Initializing eBPF driver for FIM whodata."
 #define FIM_EBPF_HEALTHCHECK_SUCCESS        "(6048): Healthcheck for eBPF FIM whodata module success."
+#define FIM_EBPF_HEALTHCHECK_ACTION_SUCCESS "(6049): eBPF healthcheck action succeeded: %s."
+#define FIM_EBPF_HEALTHCHECK_CLEANUP        "(6050): Removed a leftover eBPF healthcheck file before starting the validation sequence."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -67,6 +67,8 @@
 #define FIM_EBPF_HEALTHCHECK_SUCCESS        "(6048): Healthcheck for eBPF FIM whodata module success."
 #define FIM_EBPF_HEALTHCHECK_ACTION_SUCCESS "(6049): eBPF healthcheck action succeeded: %s."
 #define FIM_EBPF_HEALTHCHECK_CLEANUP        "(6050): Removed a leftover eBPF healthcheck file before starting the validation sequence."
+#define FIM_EBPF_LSM_ACTIVE                 "(6051): BPF LSM is active in the running kernel; using LSM hooks for create/modify/delete events."
+#define FIM_EBPF_LSM_INACTIVE               "(6052): BPF LSM is not active (not present in /sys/kernel/security/lsm); falling back to kprobe hooks. To enable LSM-based capture append 'bpf' to the kernel boot parameter 'lsm=' and reboot."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/syscheckd/src/ebpf/include/bpf_helpers.h
+++ b/src/syscheckd/src/ebpf/include/bpf_helpers.h
@@ -77,8 +77,12 @@ typedef int (*ring_buffer__poll_t)(struct ring_buffer *rb, int timeout);
 typedef void (*ring_buffer__free_t)(struct ring_buffer *rb);
 typedef void (*bpf_object__close_t)(struct bpf_object *obj);
 typedef struct bpf_program *(*bpf_object__next_program_t)(const struct bpf_object *obj, struct bpf_program *prog);
-typedef int (*bpf_program__attach_t)(struct bpf_program *prog);
+typedef struct bpf_link *(*bpf_program__attach_t)(struct bpf_program *prog);
 typedef int (*bpf_object__find_map_fd_by_name_t)(struct bpf_object *obj, const char *name);
+typedef int (*bpf_program__set_autoload_t)(struct bpf_program *prog, bool autoload);
+typedef bool (*bpf_program__autoload_t)(const struct bpf_program *prog);
+typedef const char *(*bpf_program__section_name_t)(const struct bpf_program *prog);
+typedef const char *(*bpf_program__name_t)(const struct bpf_program *prog);
 
 // Function pointers to execute stateless requests to BPF
 void (*bpf_object__destroy_skeleton)(struct bpf_object_skeleton *obj) = NULL;
@@ -109,6 +113,10 @@ typedef struct {
     bpf_object__next_program_t bpf_object_next_program;
     bpf_program__attach_t bpf_program_attach;
     bpf_object__find_map_fd_by_name_t bpf_object_find_map_fd_by_name;
+    bpf_program__set_autoload_t bpf_program_set_autoload;
+    bpf_program__autoload_t bpf_program_autoload;
+    bpf_program__section_name_t bpf_program_section_name;
+    bpf_program__name_t bpf_program_name;
 
     bpf_object__open_skeleton_t bpf_object_open_skeleton;
     bpf_object__destroy_skeleton_t bpf_object_destroy_skeleton;
@@ -146,6 +154,10 @@ inline bool w_bpf_deinit(std::unique_ptr<w_bpf_helpers_t>& bpf_helpers) {
         bpf_helpers->bpf_object_next_program = NULL;
         bpf_helpers->bpf_program_attach = NULL;
         bpf_helpers->bpf_object_find_map_fd_by_name = NULL;
+        bpf_helpers->bpf_program_set_autoload = NULL;
+        bpf_helpers->bpf_program_autoload = NULL;
+        bpf_helpers->bpf_program_section_name = NULL;
+        bpf_helpers->bpf_program_name = NULL;
 
         // Reset skeleton-specific function pointers to NULL
         bpf_helpers->bpf_object_open_skeleton = NULL;

--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -33,9 +33,41 @@
 #define BPF_OBJ_INSTALL_PATH "lib/modern.bpf.o"
 #define WAIT_MS 500
 #define HC_ACTION_TIMEOUT_S 10
+#define LSM_LIST_FILE "/sys/kernel/security/lsm"
 
 // Global
 static bpf_object* global_obj = nullptr;
+static bool g_bpf_lsm_active = false;
+
+/*
+ * Returns true if the running kernel has "bpf" in its active LSM list.
+ *
+ * BPF LSM programs (SEC("lsm/...")) attach successfully whenever
+ * CONFIG_BPF_LSM=y, but their hooks are only invoked when "bpf" is
+ * present in /sys/kernel/security/lsm (controlled by CONFIG_LSM=
+ * and the kernel boot parameter lsm=). Distributions like Ubuntu do
+ * not enable BPF in the active LSM list by default, which makes LSM
+ * BPF programs silently inert. We use this detection to choose
+ * between the LSM and kprobe variants of our hooks at load time.
+ */
+static bool is_bpf_lsm_active() {
+    std::ifstream file(LSM_LIST_FILE);
+    if (!file) {
+        return false;
+    }
+    std::string lsm_list;
+    if (!std::getline(file, lsm_list)) {
+        return false;
+    }
+    std::stringstream ss(lsm_list);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        if (token == "bpf") {
+            return true;
+        }
+    }
+    return false;
+}
 
 std::unique_ptr<w_bpf_helpers_t> bpf_helpers = nullptr;
 std::unique_ptr<DefaultDynamicLibraryWrapper> sym_load;
@@ -340,6 +372,10 @@ int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> local_sym_load) {
     bpf_helpers->bpf_object_next_program     = (bpf_object__next_program_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__next_program");
     bpf_helpers->bpf_program_attach          = (bpf_program__attach_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__attach");
     bpf_helpers->bpf_object_find_map_fd_by_name = (bpf_object__find_map_fd_by_name_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__find_map_fd_by_name");
+    bpf_helpers->bpf_program_set_autoload    = (bpf_program__set_autoload_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__set_autoload");
+    bpf_helpers->bpf_program_autoload        = (bpf_program__autoload_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__autoload");
+    bpf_helpers->bpf_program_section_name    = (bpf_program__section_name_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__section_name");
+    bpf_helpers->bpf_program_name            = (bpf_program__name_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__name");
 
 
     /* Load all required symbols */
@@ -355,6 +391,10 @@ int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> local_sym_load) {
         !bpf_helpers->bpf_object_next_program ||
         !bpf_helpers->bpf_program_attach ||
         !bpf_helpers->bpf_object_find_map_fd_by_name ||
+        !bpf_helpers->bpf_program_set_autoload ||
+        !bpf_helpers->bpf_program_autoload ||
+        !bpf_helpers->bpf_program_section_name ||
+        !bpf_helpers->bpf_program_name ||
         !bpf_helpers->bpf_object_open_skeleton ||
         !bpf_helpers->bpf_object_destroy_skeleton ||
         !bpf_helpers->bpf_object_load_skeleton ||
@@ -381,6 +421,62 @@ void close_libbpf(std::unique_ptr<DynamicLibraryWrapper> local_sym_load) {
     }
 }
 
+/*
+ * libbpf encodes attach failures as either NULL or as an ERR_PTR-like
+ * value in the top page of address space. Treat both as failure so we
+ * don't silently keep going with an invalid bpf_link.
+ */
+static inline bool bpf_link_is_error(const struct bpf_link *link) {
+    if (link == nullptr) {
+        return true;
+    }
+    return reinterpret_cast<uintptr_t>(link) >= static_cast<uintptr_t>(-4095UL);
+}
+
+/*
+ * Decide which programs in the loaded object should autoload.
+ *
+ * On systems where BPF LSM is active in /sys/kernel/security/lsm we
+ * prefer the lsm/* programs (cleaner semantics, fewer kernel-version
+ * pitfalls). Otherwise the lsm/* programs would attach but never fire,
+ * so we disable them and rely on the kprobe/* fallbacks instead.
+ *
+ * security_inode_setattr is always enabled regardless of LSM state.
+ */
+static void select_programs(bpf_object* obj, bool use_lsm) {
+    bpf_program* prog;
+    bpf_object__for_each_program(bpf_helpers, prog, obj) {
+        const char* sec  = bpf_helpers->bpf_program_section_name(prog);
+        const char* name = bpf_helpers->bpf_program_name(prog);
+        if (!sec) {
+            continue;
+        }
+
+        const bool is_lsm = (strncmp(sec, "lsm/", 4) == 0);
+        const bool is_create_or_unlink_kprobe =
+            (strncmp(sec, "kprobe/", 7) == 0) &&
+            (strstr(sec, "vfs_open") != nullptr ||
+             strstr(sec, "vfs_unlink") != nullptr);
+
+        bool keep = true;
+        if (use_lsm && is_create_or_unlink_kprobe) {
+            keep = false;
+        } else if (!use_lsm && is_lsm) {
+            keep = false;
+        }
+
+        bpf_helpers->bpf_program_set_autoload(prog, keep);
+
+        if (fimebpf::instance().m_loggingFunction) {
+            char msg[256] = {0};
+            snprintf(msg, sizeof(msg),
+                     "eBPF program '%s' (%s): autoload=%s",
+                     name ? name : "?", sec, keep ? "true" : "false");
+            fimebpf::instance().m_loggingFunction(LOG_DEBUG_VERBOSE, msg);
+        }
+    }
+}
+
 int init_bpfobj() {
     auto logFn = fimebpf::instance().m_loggingFunction;
     auto abspathFn = fimebpf::instance().m_abspath;
@@ -400,6 +496,12 @@ int init_bpfobj() {
     }
     global_obj = obj;
 
+    /* Decide LSM vs kprobe set BEFORE loading so the verifier only sees
+     * the programs we actually intend to attach. */
+    g_bpf_lsm_active = is_bpf_lsm_active();
+    logFn(LOG_INFO, g_bpf_lsm_active ? FIM_EBPF_LSM_ACTIVE : FIM_EBPF_LSM_INACTIVE);
+    select_programs(obj, g_bpf_lsm_active);
+
     int err = bpf_helpers->bpf_object_load(obj);
     if (err) {
         logFn(LOG_ERROR, FIM_ERROR_EBPF_OBJ_LOAD);
@@ -410,7 +512,24 @@ int init_bpfobj() {
 
     bpf_program* prog;
     bpf_object__for_each_program(bpf_helpers, prog, obj) {
-        if (!bpf_helpers->bpf_program_attach(prog)) {
+        /* Skip programs we explicitly disabled in select_programs;
+         * libbpf would otherwise return -EINVAL because they were
+         * never JIT'd. */
+        if (!bpf_helpers->bpf_program_autoload(prog)) {
+            continue;
+        }
+
+        struct bpf_link* link = (struct bpf_link*)bpf_helpers->bpf_program_attach(prog);
+        if (bpf_link_is_error(link)) {
+            const int saved_errno = errno;
+            const char* name = bpf_helpers->bpf_program_name(prog);
+            char error_message[4200] = {0};
+            snprintf(error_message, sizeof(error_message),
+                     FIM_ERROR_EBPF_OBJ_ATTACH_DETAIL,
+                     name ? name : "?",
+                     saved_errno,
+                     strerror(saved_errno));
+            logFn(LOG_ERROR, error_message);
             logFn(LOG_ERROR, FIM_ERROR_EBPF_OBJ_ATTACH);
             bpf_helpers->bpf_object_close(obj);
             global_obj = nullptr;

--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -9,7 +9,9 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cerrno>
 #include <sstream>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "modern.skel.h"
 #include <fstream>
@@ -30,6 +32,7 @@
 #define LIB_INSTALL_PATH "bpf"
 #define BPF_OBJ_INSTALL_PATH "lib/modern.bpf.o"
 #define WAIT_MS 500
+#define HC_ACTION_TIMEOUT_S 10
 
 // Global
 static bpf_object* global_obj = nullptr;
@@ -98,6 +101,170 @@ int healthcheck_event(void* ctx, void* data, size_t data_sz) {
         event_received = true;
     }
     return 0;
+}
+
+using healthcheck_operation_t = bool (*)(const char*, char*, size_t);
+
+static void log_healthcheck_message(modules_log_level_t level,
+                                    const char* format,
+                                    const char* action,
+                                    const char* detail = nullptr) {
+    auto logFn = fimebpf::instance().m_loggingFunction;
+    char log_message[4200] = {0};
+
+    if (!logFn) {
+        return;
+    }
+
+    if (detail) {
+        snprintf(log_message,
+                 sizeof(log_message),
+                 format,
+                 action,
+                 detail);
+    } else {
+        snprintf(log_message,
+                 sizeof(log_message),
+                 format,
+                 action);
+    }
+
+    logFn(level, log_message);
+}
+
+static bool wait_for_healthcheck_event(ring_buffer* rb, char* detail, size_t detail_size) {
+    auto logFn = fimebpf::instance().m_loggingFunction;
+
+    if (!logFn) {
+        return false;
+    }
+
+    event_received = false;
+    time_t start_time = w_time(nullptr);
+
+    while (!event_received) {
+        int ret = bpf_helpers->ring_buffer_poll(rb, WAIT_MS);
+        if (ret < 0) {
+            logFn(LOG_ERROR, FIM_ERROR_EBPF_RINGBUFF_CONSUME);
+            snprintf(detail, detail_size, "%s", FIM_EBPF_HEALTHCHECK_EVENT_CONSUME_DETAIL);
+            return false;
+        }
+
+        if (w_time(nullptr) - start_time >= HC_ACTION_TIMEOUT_S) {
+            snprintf(detail, detail_size, "%s", FIM_EBPF_HEALTHCHECK_EVENT_TIMEOUT_DETAIL);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool create_healthcheck_file(const char* file_path, char* detail, size_t detail_size) {
+    char error_message[4200] = {0};
+    auto logFn = fimebpf::instance().m_loggingFunction;
+
+    if (!logFn) {
+        return false;
+    }
+
+    std::ofstream file(file_path);
+    if (!file.is_open()) {
+        snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_HEALTHCHECK_FILE, file_path);
+        logFn(LOG_ERROR, error_message);
+        snprintf(detail, detail_size, "%s", FIM_EBPF_HEALTHCHECK_CREATE_DETAIL);
+        return false;
+    }
+
+    file << "Testing eBPF healthcheck\n";
+    file.close();
+
+    return true;
+}
+
+static bool modify_healthcheck_file_content(const char* file_path, char* detail, size_t detail_size) {
+    std::ofstream file(file_path, std::ios::app);
+
+    if (!file.is_open()) {
+        snprintf(detail, detail_size, "%s", FIM_EBPF_HEALTHCHECK_CONTENT_DETAIL);
+        return false;
+    }
+
+    file << "Updating eBPF healthcheck\n";
+    file.close();
+
+    return true;
+}
+
+static bool modify_healthcheck_file_metadata(const char* file_path, char* detail, size_t detail_size) {
+    struct stat file_stat = {};
+
+    if (stat(file_path, &file_stat) != 0) {
+        snprintf(detail,
+                 detail_size,
+                 FIM_EBPF_HEALTHCHECK_STAT_DETAIL,
+                 file_path,
+                 strerror(errno));
+        return false;
+    }
+
+    mode_t current_mode = file_stat.st_mode & 0777;
+    mode_t new_mode = (current_mode ^ S_IXUSR) & 0777;
+
+    if (chmod(file_path, new_mode) != 0) {
+        snprintf(detail,
+                 detail_size,
+                 FIM_EBPF_HEALTHCHECK_CHMOD_DETAIL,
+                 file_path,
+                 strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+static bool delete_healthcheck_file(const char* file_path, char* detail, size_t detail_size) {
+    char error_message[4200] = {0};
+    auto logFn = fimebpf::instance().m_loggingFunction;
+
+    if (!logFn) {
+        return false;
+    }
+
+    if (std::remove(file_path) != 0) {
+        snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_HEALTHCHECK_FILE_DEL, file_path);
+        logFn(LOG_ERROR, error_message);
+        snprintf(detail, detail_size, "%s", FIM_EBPF_HEALTHCHECK_DELETE_DETAIL);
+        return false;
+    }
+
+    return true;
+}
+
+static bool run_healthcheck_action(ring_buffer* rb,
+                                   const char* action,
+                                   const char* file_path,
+                                   healthcheck_operation_t operation,
+                                   bool enabled) {
+    char detail[4200] = {0};
+
+    if (!enabled) {
+        log_healthcheck_message(LOG_ERROR,
+                                FIM_ERROR_EBPF_HEALTHCHECK_ACTION_SKIPPED,
+                                action,
+                                FIM_EBPF_HEALTHCHECK_SKIP_DETAIL);
+        return false;
+    }
+
+    if (!operation(file_path, detail, sizeof(detail)) || !wait_for_healthcheck_event(rb, detail, sizeof(detail))) {
+        log_healthcheck_message(LOG_ERROR,
+                                FIM_ERROR_EBPF_HEALTHCHECK_ACTION_FAILED,
+                                action,
+                                detail);
+        return false;
+    }
+
+    log_healthcheck_message(LOG_INFO, FIM_EBPF_HEALTHCHECK_ACTION_SUCCESS, action);
+    return true;
 }
 
 int check_invalid_kernel_version() {
@@ -342,7 +509,8 @@ int ebpf_whodata_healthcheck() {
     auto logFn = fimebpf::instance().m_loggingFunction;
     auto abspathFn = fimebpf::instance().m_abspath;
     char ebpf_hc_abs_path[PATH_MAX] = {0};
-    char error_message[4200];
+    bool healthcheck_failed = false;
+    bool healthcheck_file_available = false;
 
     if (!bpf_helpers) {
         bpf_helpers = std::make_unique<w_bpf_helpers_t>();
@@ -366,42 +534,51 @@ int ebpf_whodata_healthcheck() {
         return 1;
     }
 
-    time_t start_time = w_time(nullptr);
-    while (!event_received) {
-        int ret = bpf_helpers->ring_buffer_poll(rb, WAIT_MS);
-        if (ret < 0) {
-            logFn(LOG_ERROR, FIM_ERROR_EBPF_RINGBUFF_CONSUME);
-            break;
-        }
-        if (w_time(nullptr) - start_time >= 10) {
-            logFn(LOG_ERROR, FIM_ERROR_EBPF_HEALTHCHECK_TIMEOUT);
-            break;
-        }
+    event_received = false;
+    ebpf_hc_created = false;
+    abspathFn(EBPF_HC_FILE, ebpf_hc_abs_path, sizeof(ebpf_hc_abs_path));
 
-        if (!ebpf_hc_created) {
-            abspathFn(EBPF_HC_FILE, ebpf_hc_abs_path, sizeof(ebpf_hc_abs_path));
-            std::ofstream file(ebpf_hc_abs_path);
-            if (!file.is_open()) {
-                snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_HEALTHCHECK_FILE, ebpf_hc_abs_path);
-                logFn(LOG_ERROR, error_message);
-                break;
-            }
-            file << "Testing eBPF healthcheck\n";
-            file.close();
-            ebpf_hc_created = true;
-        }
+    if (std::remove(ebpf_hc_abs_path) == 0) {
+        logFn(LOG_DEBUG_VERBOSE, FIM_EBPF_HEALTHCHECK_CLEANUP);
     }
 
-    // Remove the tmp file
-    if (std::remove(ebpf_hc_abs_path) != 0) {
-        snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_HEALTHCHECK_FILE_DEL, ebpf_hc_abs_path);
-        logFn(LOG_ERROR, error_message);
-    }
+    healthcheck_failed |= !run_healthcheck_action(rb,
+                                                  "create file",
+                                                  ebpf_hc_abs_path,
+                                                  create_healthcheck_file,
+                                                  true);
+    ebpf_hc_created = (access(ebpf_hc_abs_path, F_OK) == 0);
+    healthcheck_file_available = ebpf_hc_created;
+
+    healthcheck_failed |= !run_healthcheck_action(rb,
+                                                  "modify content",
+                                                  ebpf_hc_abs_path,
+                                                  modify_healthcheck_file_content,
+                                                  healthcheck_file_available);
+
+    healthcheck_failed |= !run_healthcheck_action(rb,
+                                                  "modify metadata",
+                                                  ebpf_hc_abs_path,
+                                                  modify_healthcheck_file_metadata,
+                                                  healthcheck_file_available);
+
+    healthcheck_failed |= !run_healthcheck_action(rb,
+                                                  "delete file",
+                                                  ebpf_hc_abs_path,
+                                                  delete_healthcheck_file,
+                                                  healthcheck_file_available);
+    healthcheck_file_available = (access(ebpf_hc_abs_path, F_OK) == 0);
 
     // Free healthcheck ring buffer
     bpf_helpers->ring_buffer_free(rb);
 
-    if (!event_received) {
+    if (healthcheck_file_available && std::remove(ebpf_hc_abs_path) != 0 && errno != ENOENT) {
+        char error_message[4200] = {0};
+        snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_HEALTHCHECK_FILE_DEL, ebpf_hc_abs_path);
+        logFn(LOG_ERROR, error_message);
+    }
+
+    if (healthcheck_failed) {
         return 1;
     }
 

--- a/src/syscheckd/src/ebpf/src/modern-arm.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern-arm.bpf.c
@@ -402,16 +402,18 @@ int kprobe__security_inode_setattr(struct pt_regs *ctx) {
 SEC("kprobe/vfs_unlink")
 int kprobe__vfs_unlink(struct pt_regs *ctx)
 {
+    /*
+     * Use PT_REGS_PARM*_CORE for conditional ctx accesses so the strict
+     * verifier on recent kernels (e.g. Ubuntu 24 ARM) accepts the load.
+     */
     struct dentry *dentry;
     if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 12, 0)) {
-        dentry = (struct dentry *)PT_REGS_PARM3(ctx);
-        if (!dentry) // This condition is necessary to open the BPF program
-            return 0;
+        dentry = (struct dentry *)PT_REGS_PARM3_CORE(ctx);
     } else {
-        dentry = (struct dentry *)PT_REGS_PARM2(ctx);
-        if (!dentry) // This condition is necessary to open the BPF program
-            return 0;
+        dentry = (struct dentry *)PT_REGS_PARM2_CORE(ctx);
     }
+    if (!dentry)
+        return 0;
 
     struct inode *d_inode = NULL;
     bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &dentry->d_inode);

--- a/src/syscheckd/src/ebpf/src/modern.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern.bpf.c
@@ -337,13 +337,16 @@ statfunc void submit_event(const char *filename,
 }
 
 /*
-* Intercepts vfs_open calls. Now it only reports if the file was newly created
-* (FMODE_CREATED or O_CREAT set), for regular files.
+* Intercepts vfs_open calls. Reports newly-created regular files
+* (FMODE_CREATED or O_CREAT set).
+*
+* This program is always compiled in. The user-space loader decides
+* whether to autoload it based on whether BPF LSM hooks are active
+* on the running system (see ebpf_whodata.cpp).
 */
 SEC("kprobe/vfs_open")
 int kprobe__vfs_open(struct pt_regs *ctx)
 {
-if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     struct path *path = (struct path *)PT_REGS_PARM1(ctx);
     if (!path)
         return 0;
@@ -352,20 +355,16 @@ if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     if (!file)
         return 0;
 
-    /* Check if the file is newly created */
     fmode_t f_mode = 0;
     bpf_probe_read_kernel(&f_mode, sizeof(f_mode), &file->f_mode);
 
-    /* Also retrieve f_flags to handle creation if FMODE_CREATED fails */
     __u32 f_flags = 0;
     bpf_probe_read_kernel(&f_flags, sizeof(f_flags), &file->f_flags);
 
-    /* If not created, skip */
     if (!(f_mode & FMODE_CREATED) && !(f_flags & O_CREAT)) {
         return 0;
     }
 
-    /* Retrieve the dentry. */
     struct dentry *dentry = NULL;
     bpf_probe_read_kernel(&dentry, sizeof(dentry), &path->dentry);
     if (!dentry)
@@ -379,11 +378,9 @@ if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     __u32 mode = 0;
     bpf_probe_read_kernel(&mode, sizeof(mode), &d_inode->i_mode);
 
-    /* Only report regular files (0100000 is the S_IFREG mask). */
     if (((mode & 00170000) != 0100000))
         return 0;
 
-    /* Reconstruct the path. */
     struct buffer *string_buf = bpf_map_lookup_elem(&heaps_map, &(u32){0});
     if (!string_buf)
         return 0;
@@ -392,29 +389,34 @@ if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     if (get_path_str_from_path(&full_path, path, string_buf) < 0)
         return 0;
 
-    /* Extract inode/device. */
     __u64 inode = 0, dev = 0;
     get_inode_dev(d_inode, &inode, &dev);
 
-    /* Report file creation event. */
     submit_event((const char *)full_path, inode, dev);
-}
     return 0;
 }
 
 SEC("kprobe/security_inode_setattr")
 int kprobe__security_inode_setattr(struct pt_regs *ctx)
 {
+    /*
+     * Conditional ctx field reads must go through PT_REGS_PARM*_CORE
+     * (which expands to BPF_CORE_READ -> bpf_probe_read_kernel) so the
+     * compiler doesn't emit a "modified ctx pointer dereference"
+     * pattern that the strict verifier on recent kernels rejects.
+     *
+     * Argument layout for security_inode_setattr:
+     *   pre-6.0 :  (struct dentry *dentry, struct iattr *attr)               -> dentry @ PARM1
+     *   6.0+    :  (struct {user_namespace,mnt_idmap} *, struct dentry *,...) -> dentry @ PARM2
+     */
     struct dentry *dentry;
     if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 0, 0)) {
-        dentry = (struct dentry *)PT_REGS_PARM1(ctx);
-        if (!dentry) // Necessary condition to validate BPF program
-            return 0;
+        dentry = (struct dentry *)PT_REGS_PARM1_CORE(ctx);
     } else {
-        dentry = (struct dentry *)PT_REGS_PARM2(ctx);
-        if (!dentry) // Necessary condition to validate BPF program
-            return 0;
+        dentry = (struct dentry *)PT_REGS_PARM2_CORE(ctx);
     }
+    if (!dentry)
+        return 0;
 
     struct inode *d_inode = NULL;
     bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &dentry->d_inode);
@@ -470,22 +472,33 @@ int kprobe__security_inode_setattr(struct pt_regs *ctx)
 
 /*
 * Intercepts vfs_unlink calls to detect file removal (delete).
-* The path is retrieved from unlink_path_map to record which file was removed.
+*
+* This program is always compiled in. The user-space loader decides
+* whether to autoload it based on whether BPF LSM hooks are active
+* on the running system (see ebpf_whodata.cpp).
+*
+* vfs_unlink signature evolved across kernels:
+*   pre-5.12 :  vfs_unlink(struct inode *dir, struct dentry *dentry, ...)            -> dentry @ PARM2
+*   5.12+    :  vfs_unlink(struct user_namespace *, struct inode *dir, struct dentry *, ...)
+*   6.3+     :  vfs_unlink(struct mnt_idmap *,    struct inode *dir, struct dentry *, ...) -> dentry @ PARM3
 */
 SEC("kprobe/vfs_unlink")
 int kprobe__vfs_unlink(struct pt_regs *ctx)
 {
-if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
+    /*
+     * Use PT_REGS_PARM*_CORE for the conditional access so the compiler
+     * doesn't fold the two PARM offsets into a "modified ctx pointer +
+     * deref" sequence that the strict verifier on recent kernels (e.g.
+     * Ubuntu 24's 6.8) rejects with -EACCES.
+     */
     struct dentry *dentry;
     if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 12, 0)) {
-        dentry = (struct dentry *)PT_REGS_PARM2(ctx);
-        if (!dentry) // Necessary condition to validate BPF program
-            return 0;
+        dentry = (struct dentry *)PT_REGS_PARM2_CORE(ctx);
     } else {
-        dentry = (struct dentry *)PT_REGS_PARM3(ctx);
-        if (!dentry) // Necessary condition to validate BPF program
-            return 0;
+        dentry = (struct dentry *)PT_REGS_PARM3_CORE(ctx);
     }
+    if (!dentry)
+        return 0;
 
     struct inode *d_inode = NULL;
     bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &dentry->d_inode);
@@ -512,7 +525,6 @@ if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     if (!mnt)
         return 0;
 
-    /* Build a path struct from dentry + mnt. */
     struct path path = {
         .dentry = dentry,
         .mnt    = mnt
@@ -526,42 +538,38 @@ if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     if (get_path_str_from_path(&full_path, &path, string_buf) < 0)
         return 0;
 
-    /* Extract inode/device. */
     __u64 inode = 0, dev = 0;
     get_inode_dev(d_inode, &inode, &dev);
 
     submit_event((const char *)full_path, inode, dev);
-}
     return 0;
 }
 
+/*
+* LSM hook for file open. Reports newly-created or write-opened regular
+* files. Only invoked when "bpf" is part of the active LSM list
+* (CONFIG_LSM= or kernel cmdline lsm=...,bpf). The user-space loader
+* disables autoload of this program when BPF LSM is not active.
+*/
 SEC("lsm/file_open")
 int BPF_PROG(file_open, struct file *file)
 {
-if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
     struct path *path = NULL;
     bpf_probe_read_kernel(&path, sizeof(path), &file->f_path);
     if (!path)
         return 0;
 
-    /* Check if the file is newly created */
     fmode_t f_mode = 0;
     bpf_probe_read_kernel(&f_mode, sizeof(f_mode), &file->f_mode);
-    if (!f_mode)
-        return 0;
 
-    /* Also retrieve f_flags to handle creation if FMODE_CREATED fails */
     __u32 f_flags = 0;
     bpf_probe_read_kernel(&f_flags, sizeof(f_flags), &file->f_flags);
-    if (!f_flags)
-        return 0;
 
-    /* If not created, skip */
+    /* Report on creation OR on any non-read-only open (writes / rw / append). */
     if (!(f_mode & FMODE_CREATED) && !(f_flags & O_CREAT) && !(f_flags & O_ACCMODE)) {
         return 0;
     }
 
-    /* Retrieve the dentry. */
     struct dentry *dentry = NULL;
     bpf_probe_read_kernel(&dentry, sizeof(dentry), &path->dentry);
     if (!dentry)
@@ -574,10 +582,7 @@ if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
 
     __u32 mode = 0;
     bpf_probe_read_kernel(&mode, sizeof(mode), &f_inode->i_mode);
-    if (!mode)
-        return 0;
 
-    /* Only report regular files (0100000 is the S_IFREG mask). */
     if (((mode & 00170000) != 0100000))
         return 0;
 
@@ -589,20 +594,21 @@ if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
     if (ret < 0)
         return 0;
 
-    /* Extract inode/device. */
     __u64 inode = 0, dev = 0;
     get_inode_dev(f_inode, &inode, &dev);
 
     submit_event((const char *)full_path, inode, dev);
-}
     return 0;
 }
 
 
+/*
+* LSM hook for path-based unlink. Same activation rules as lsm/file_open.
+* Requires CONFIG_SECURITY_PATH=y in the running kernel.
+*/
 SEC("lsm/path_unlink")
 int BPF_PROG(path_unlink, struct path *path, struct dentry *dentry)
 {
-if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
     struct inode *d_inode = NULL;
     bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &dentry->d_inode);
     if (!d_inode)
@@ -610,10 +616,7 @@ if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
 
     __u32 mode = 0;
     bpf_probe_read_kernel(&mode, sizeof(mode), &d_inode->i_mode);
-    if (!mode)
-        return 0;
 
-    /* Only report regular files (0100000 is the S_IFREG mask). */
     if (((mode & 00170000) != 0100000))
         return 0;
 
@@ -625,13 +628,11 @@ if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
     if (ret < 0)
         return 0;
 
-    /* Get the file name pointer from dentry->d_name.name */
     const char *file_name_ptr;
     bpf_probe_read_kernel(&file_name_ptr, sizeof(file_name_ptr), &dentry->d_name.name);
     if (!file_name_ptr)
         return 0;
 
-    /* Reconstruct the path. */
     struct buffer *string_buf = bpf_map_lookup_elem(&heaps_map, &(u32){0});
     if (!string_buf)
         return 0;
@@ -641,12 +642,10 @@ if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
     if (ret < 0)
         return 0;
 
-    /* Extract inode/device. */
     __u64 inode = 0, dev = 0;
     get_inode_dev(d_inode, &inode, &dev);
 
     submit_event((const char *)full_path, inode, dev);
-}
     return 0;
 }
 

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -103,6 +103,10 @@ ring_buffer* mock_ring_buffer_new_failure([[maybe_unused]] int fd, [[maybe_unuse
 }
 
 int mock_ring_buffer_poll_success([[maybe_unused]]ring_buffer* rb, [[maybe_unused]]int timeout_ms) { return 1; }
+int mock_ring_buffer_poll_healthcheck_success([[maybe_unused]]ring_buffer* rb, [[maybe_unused]]int timeout_ms) {
+    event_received = true;
+    return 1;
+}
 int mock_ring_buffer_poll_failure([[maybe_unused]]ring_buffer* rb, [[maybe_unused]]int timeout_ms) { return -1; }
 void mock_ring_buffer_free([[maybe_unused]]ring_buffer* rb) {}
 void mock_bpf_object_close([[maybe_unused]]void* obj) {}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -88,9 +88,18 @@ int mock_bpf_object_load_success([[maybe_unused]] void* obj) { return 0; }
 int mock_bpf_object_load_failure([[maybe_unused]] void* obj) { return 1; }
 void mock_bpf_object_close_called([[maybe_unused]] void* obj) { return; }
 bpf_program* mock_bpf_object_next_program([[maybe_unused]] void* obj, [[maybe_unused]] bpf_program* pos) { return nullptr; }
-bpf_program* mock_bpf_object_next_program_in([[maybe_unused]] void* obj, [[maybe_unused]] bpf_program* pos) { return (bpf_program *)1; }
+bpf_program* mock_bpf_object_next_program_in([[maybe_unused]] void* obj, bpf_program* pos) {
+    /* Stateless single-step iteration: yield one program then stop.
+     * Avoids infinite loops in select_programs / attach loops. */
+    return pos == nullptr ? (bpf_program*)1 : nullptr;
+}
 int mock_bpf_program_attach_success([[maybe_unused]] void* prog) { return 1; }
 int mock_bpf_program_attach_failure([[maybe_unused]] void* prog) { return 0; }
+int mock_bpf_program_set_autoload([[maybe_unused]] void* prog, [[maybe_unused]] bool autoload) { return 0; }
+bool mock_bpf_program_autoload_true([[maybe_unused]] const void* prog) { return true; }
+bool mock_bpf_program_autoload_false([[maybe_unused]] const void* prog) { return false; }
+const char* mock_bpf_program_section_name_kprobe([[maybe_unused]] const void* prog) { return "kprobe/security_inode_setattr"; }
+const char* mock_bpf_program_name_default([[maybe_unused]] const void* prog) { return "mock_prog"; }
 int mock_bpf_object_find_map_fd_by_name_success([[maybe_unused]] void* obj, [[maybe_unused]] const char* name) { return 1; }
 int mock_bpf_object_find_map_fd_by_name_failure([[maybe_unused]] void* obj, [[maybe_unused]] const char* name) { return -1; }
 

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
@@ -13,6 +13,10 @@ class EbpfWhodataTest : public ::testing::Test {
 protected:
 
     virtual void SetUp() {
+        event_received = false;
+        ebpf_hc_created = false;
+        fake_time_now = 0;
+        w_time = time;
         MockFimebpf::mock_loggingFunction = mock_loggingFunction;
         MockFimebpf::mock_abspath = mock_abspath;
         MockFimebpf::SetMockFunctions();
@@ -28,6 +32,10 @@ protected:
     }
 
     virtual void TearDown() {
+        std::remove("/tmp/ebpf_hc");
+        event_received = false;
+        ebpf_hc_created = false;
+        w_time = time;
         bpf_helpers.reset();
     }
 };
@@ -78,7 +86,7 @@ TEST_F(EbpfWhodataTest, RingBufferPollError) {
 
 TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestSuccess) {
 
-    event_received = true;
+    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_healthcheck_success;
 
     EXPECT_FALSE(ebpf_whodata_healthcheck());
 }

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_bpf_obj_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_bpf_obj_test.cpp
@@ -36,6 +36,10 @@ TEST_F(InitBpfobjTest, Success) {
     bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
     bpf_helpers->bpf_program_attach = (bpf_program__attach_t)mock_bpf_program_attach_success;
     bpf_helpers->bpf_object_next_program = (bpf_object__next_program_t)mock_bpf_object_next_program;
+    bpf_helpers->bpf_program_set_autoload = (bpf_program__set_autoload_t)mock_bpf_program_set_autoload;
+    bpf_helpers->bpf_program_autoload = (bpf_program__autoload_t)mock_bpf_program_autoload_true;
+    bpf_helpers->bpf_program_section_name = (bpf_program__section_name_t)mock_bpf_program_section_name_kprobe;
+    bpf_helpers->bpf_program_name = (bpf_program__name_t)mock_bpf_program_name_default;
 
     MockFimebpf::SetMockFunctions();
     int result = init_bpfobj();
@@ -68,6 +72,10 @@ TEST_F(InitBpfobjTest, FailureDueLoadeBPFobject) {
     bpf_helpers->bpf_program_attach = (bpf_program__attach_t)mock_bpf_program_attach_failure;
     bpf_helpers->bpf_object_next_program = (bpf_object__next_program_t)mock_bpf_object_next_program;
     bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+    bpf_helpers->bpf_program_set_autoload = (bpf_program__set_autoload_t)mock_bpf_program_set_autoload;
+    bpf_helpers->bpf_program_autoload = (bpf_program__autoload_t)mock_bpf_program_autoload_true;
+    bpf_helpers->bpf_program_section_name = (bpf_program__section_name_t)mock_bpf_program_section_name_kprobe;
+    bpf_helpers->bpf_program_name = (bpf_program__name_t)mock_bpf_program_name_default;
 
     int result = init_bpfobj();
     ASSERT_EQ(result, 1);
@@ -79,6 +87,10 @@ TEST_F(InitBpfobjTest, FailureDueAttachBPFobject) {
     bpf_helpers->bpf_object_next_program = (bpf_object__next_program_t)mock_bpf_object_next_program_in;
     bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
     bpf_helpers->bpf_program_attach = (bpf_program__attach_t)mock_bpf_program_attach_failure;
+    bpf_helpers->bpf_program_set_autoload = (bpf_program__set_autoload_t)mock_bpf_program_set_autoload;
+    bpf_helpers->bpf_program_autoload = (bpf_program__autoload_t)mock_bpf_program_autoload_true;
+    bpf_helpers->bpf_program_section_name = (bpf_program__section_name_t)mock_bpf_program_section_name_kprobe;
+    bpf_helpers->bpf_program_name = (bpf_program__name_t)mock_bpf_program_name_default;
 
     int result = init_bpfobj();
     ASSERT_EQ(result, 1);


### PR DESCRIPTION
## Description

On Ubuntu 24 and Ubuntu 26, the eBPF FIM whodata module silently stopped delivering file creation, content modification and deletion events; only metadata changes still arrived. The module still loaded cleanly and bpftool prog show listed every program, so the failure was effectively invisible. Fedora 42/43 were unaffected.

#### Root cause: 
For kernels ≥ 6.8 the module relied exclusively on `BPF LSM(SEC("lsm/file_open"), SEC("lsm/path_unlink"))` for create/modify/delete. These programs attach successfully whenever `CONFIG_BPF_LSM=y`, but their hooks are only invoked when bpf is in the active LSM list at boot (`/sys/kernel/security/lsm`, controlled by `CONFIG_LSM=` and the kernel `cmdline lsm=`). Ubuntu does not include bpf in that list by default, so the LSM programs attached but never fired. Metadata kept working because _`kprobe/security_inode_setattr`_ is a regular kprobe and is therefore independent of the LSM dispatch list.

A second, latent issue was uncovered while validating the fix: the _kprobe_ fallback for `vfs_unlink` was rejected by the strict ctx-access verifier on Ubuntu 24's 6.8 kernel because Clang folded the conditional `PT_REGS_PARM2/PARM3` reads into a "modify ctx pointer, then dereference" sequence (`-EACCES`, dereference of modified `ctx ptr R1 off=96` disallowed).

## Proposed Changes

- **Health check**: Improvements to the health check to detect: file creation, changes to file content, changes to file metadata, and file deletion.
- **BPF programs**: removed kernel-version gates so _kprobe_ and _LSM_ variants are always compiled in; selection is moved to user space.                                                      
- **Loader**: detects bpf in `/sys/kernel/security/lsm`; disables autoload of LSM programs when inactive (_kprobe_ fallback) or of the create/delete _kprobes_ when active. Logs the chosen path and remediation hint.                                                                                                                                                                  
- **Verifier fix**: switched the conditional `PT_REGS_PARM2/PARM3` reads in `vfs_unlink` and `security_inode_setattr` to `PT_REGS_PARM*_CORE` to avoid the "modified ctx pointer dereference" rejection on Ubuntu 24's 6.8 kernel. Mirrored in _modern-arm.bpf.c_.                                                                                                                     
- **Loader hardening**: fixed `bpf_program__attach` typedef (struct bpf_link *, not int); attach failures now log program name and errno; new `bpf_link_is_error` catches both `NULL` and `ERR_PTR` returns.                                                                                                                                                                              
- **Logs**: added (6051) `LSM active`, (6052) _LSM inactive_ (with cmdline hint), (6983) attach failure detail.

### Results and Evidence

<details><summary>LSM disabled</summary>

- Ubuntu 24:
```
2026/04/30 15:48:08 wazuh-syscheckd: INFO: (6047): Initializing eBPF driver for FIM whodata.
2026/04/30 15:48:08 wazuh-syscheckd: INFO: (6052): BPF LSM is not active (not present in /sys/kernel/security/lsm); falling back to kprobe hooks. To enable LSM-based capture append 'bpf' to the kernel boot parameter 'lsm=' and reboot.
2026/04/30 15:48:09 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: create file.
2026/04/30 15:48:09 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify content.
2026/04/30 15:48:09 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify metadata.
2026/04/30 15:48:09 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: delete file.
2026/04/30 15:48:09 wazuh-syscheckd: INFO: (6048): Healthcheck for eBPF FIM whodata module success.
```

- Ubuntu 26:
```
2026/04/30 15:48:11 wazuh-syscheckd: INFO: (6047): Initializing eBPF driver for FIM whodata.
2026/04/30 15:48:11 wazuh-syscheckd: INFO: (6052): BPF LSM is not active (not present in /sys/kernel/security/lsm); falling back to kprobe hooks. To enable LSM-based capture append 'bpf' to the kernel boot parameter 'lsm=' and reboot.
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: create file.
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify content.
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify metadata.
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: delete file.
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6048): Healthcheck for eBPF FIM whodata module success.
```

- Ubuntu 22:
```
2026/04/30 15:48:12 wazuh-syscheckd: INFO: (6047): Initializing eBPF driver for FIM whodata.
2026/04/30 15:48:12 wazuh-syscheckd: INFO: (6052): BPF LSM is not active (not present in /sys/kernel/security/lsm); falling back to kprobe hooks. To enable LSM-based capture append 'bpf' to the kernel boot parameter 'lsm=' and reboot.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: create file.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify content.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify metadata.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: delete file.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6048): Healthcheck for eBPF FIM whodata module success.
```

</details>


<details><summary>LSM enabled</summary>

- Fedora 43:
```
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6047): Initializing eBPF driver for FIM whodata.
2026/04/30 15:48:14 wazuh-syscheckd: INFO: (6051): BPF LSM is active in the running kernel; using LSM hooks for create/modify/delete events.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: create file.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify content.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: modify metadata.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6049): eBPF healthcheck action succeeded: delete file.
2026/04/30 15:48:15 wazuh-syscheckd: INFO: (6048): Healthcheck for eBPF FIM whodata module success.
```

</details>


### Tests Introduced

No new test files were added; the existing `InitBpfobjTest` suite was updated to exercise the new code paths:
- Updated `InitBpfobjTest` mocks for the four new libbpf helpers; made `mock_bpf_object_next_program_in` stateful to avoid infinite loops in the new selection / attach loops.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
