### PR TITLE
 Add wazuh.event.id to correlate events from a single log

### DIFF
--- a/src/engine/source/router/src/worker.cpp
+++ b/src/engine/source/router/src/worker.cpp
@@ -4,6 +4,7 @@
 #include <base/logging.hpp>
 #include <base/process.hpp>
 #include <base/utils/timeUtils.hpp>
+#include <base/utils/generator.hpp>
 #include <fastmetrics/registry.hpp>
 #include <rawevtindexer/iraweventindexer.hpp>
 
@@ -12,11 +13,14 @@ namespace router
 
 namespace
 {
-std::string makeRawIndexPayload(const IngestEvent& queuedEvent, const std::string& timestamp)
+std::string makeRawIndexPayload(const IngestEvent& queuedEvent,
+                                const std::string& timestamp,
+                                const std::string& eventId)
 {
     json::Json rawDoc(*queuedEvent.first);
     rawDoc.setString(timestamp, "/@timestamp");
     rawDoc.setString(queuedEvent.second, "/event/original");
+    rawDoc.setString(eventId, "/wazuh/event/id");
     return rawDoc.str();
 }
 } // namespace
@@ -58,16 +62,18 @@ void RouterWorker::start()
                 try
                 {
                     const auto timestamp = base::utils::time::getCurrentISO8601();
+                    const auto eventId   = base::utils::generators::generateUUIDv4();
 
                     // Raw indexing (now throttled by queue drain)
                     if (m_rawIndexer && m_rawIndexer->isEnabled())
                     {
-                        m_rawIndexer->index(makeRawIndexPayload(queuedEvent, timestamp));
+                        m_rawIndexer->index(makeRawIndexPayload(queuedEvent, timestamp, eventId));
                     }
 
                     // Parse + route to pipeline
                     auto event = base::eventParsers::parseLegacyEvent(queuedEvent.second, *queuedEvent.first);
                     event->setString(timestamp, "/@timestamp");
+                    event->setString(eventId, "/wazuh/event/id");
                     m_router->ingest(std::move(event));
 
                     // Track processed events (hot path: direct atomic access ~3ns)


### PR DESCRIPTION
## Description

The Wazuh Manager can generate multiple events (raw, standard, custom) from a single log, but they are not linked. This makes correlation and analysis difficult.

To solve that, we are adding a new field `wazuh.event.id` to the schema, which is shared by all the related events derived from the same log, so they are linked uniquely.

Closes [#35631](https://github.com/wazuh/wazuh/issues/35631)}

## Proposed changes

- A UUIDv4 is generated once per ingested log in the `RouterWorker` hot path.
- The ID is propagated to the raw event payload (indexed in `wazuh-events-raw-v5`) and to the parsed event that flows through the pipeline (indexed in `wazuh-events-v5-*`).
- No changes to the pipeline stages, outputs, or schema mapping are required in the engine — the field travels in the event JSON object automatically.

### Build and install

```bash
General settings:
    TARGET:             manager
    V:                  
    DEBUG:              yes
    INSTALLDIR:         
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh-manager
    WAZUH_USER:         wazuh-manager
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                gcc
    MAKE              /usr/bin/make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building manager

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35631-wazuh-event-id-correlation●› 
╰─# service wazuh-manager status 
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35631-wazuh-event-id-correlation●› 
╰─# engine-router list
engine-private ns list

- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_6639
  priority: 1
  uptime: 384

- cmsync_standard_6639
```

### Testing

1. Generate test event from the agent.

```bash
sh-4.4# echo 'May 04 18:40:00 agent wazuh-jam-test-001' >> /var/ossec/logs/active-responses.log
sh-4.4# tail -n 5 /var/ossec/logs/active-responses.log
Tue Apr 14 16:51:02 UTC 2026 active-response/bin/restart.sh agent reload   
May 04 18:40:00 agent wazuh-jam-test-001
```

2. Validate the standard event in the indexer.

```bash
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e ‹enhancement/35631-wazuh-event-id-correlation●› 
╰─# curl -k -u admin:admin \
  "https://localhost:9200/wazuh-events-v5-*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{
    "query": {
      "simple_query_string": {
        "query": "\"wazuh-jam-test-001\"",
        "fields": ["*"]
      }
    },
    "_source": [
      "@timestamp",
      "event.original",
      "wazuh.event.id",
      "wazuh.integration.name",
      "wazuh.integration.decoders",
      "wazuh.agent.id",
      "wazuh.agent.name"
    ],
    "sort": [
      { "@timestamp": "desc" }
    ],
    "size": 10
  }'

{
  "took" : 7,
  "timed_out" : false,
  "_shards" : {
    "total" : 24,
    "successful" : 24,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [
      {
        "_index" : ".ds-wazuh-events-v5-system-activity-000001",
        "_id" : "o4VH9J0BGj4lTOJIJy4T",
        "_score" : null,
        "_source" : {
          "@timestamp" : "2026-05-04T18:36:26.573Z",
          "wazuh" : {
            "agent" : {
              "name" : "agent-4143-rocky8",
              "id" : "001"
            },
            "integration" : {
              "name" : "syslog",
              "decoders" : [
                "decoder/core-wazuh-message/0",
                "decoder/syslog/0"
              ]
            },
            "event" : {
              "id" : "6d21158f-04f7-4e83-84c1-b364570a26fd"
            }
          },
          "event" : {
            "original" : "May 04 18:40:00 agent wazuh-jam-test-001"
          }
        },
        "sort" : [
          1777919786573
        ]
      }
    ]
  }
}
```

3. Validate raw correlation using the same `wazuh.event.id`.

```bash
╭─root@wazuh5x-dev /workspaces/Wazuh_5x 
╰─# curl -k -u admin:admin \
  "https://localhost:9200/wazuh-events-raw-v5*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{
    "query": {
      "term": {
        "wazuh.event.id": "6d21158f-04f7-4e83-84c1-b364570a26fd"
      }
    },
    "_source": [
      "@timestamp",
      "event.original",
      "wazuh.event.id",
      "wazuh.agent.id",
      "wazuh.agent.name"
    ],
    "sort": [
      { "@timestamp": "desc" }
    ]
  }'

{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 3,
    "successful" : 3,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 0,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [ ]
  }
}
```

---

<p align="center">
  <img src="https://github.com/user-attachments/assets/843cbc1b-f34c-4fd3-b8af-1336c56f6165"  width="1825" height="585">
  <br>
  <em>
     Standard event generated from wazuh-jam-test-001 showing wazuh.event.id in the system-activity stream
  </em>
</p>

---

<p align="center">
  <img src="https://github.com/user-attachments/assets/cf3373fd-dad6-4ceb-a7b7-9cf3a2d9837c"  width="933" height="971" >
  <br>
  <em>
     Expanded standard event document for wazuh-jam-test-001 showing wazuh.event.id and syslog decoder metadata
  </em>
</p>

* Testing with raw event

<p align="center">
  <img width="1166" height="192"  src="https://github.com/user-attachments/assets/ff40efa0-38e2-4146-acbb-c99441f24b18" >
  <br>
  <em>
     Enabled Raw Event 
  </em>
</p>

---


```bash

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹enhancement/35631-wazuh-event-id-correlation●› 
╰─# engine-private rawevt status

enabled

sh-4.4# tail -n 5 /var/ossec/logs/active-responses.log
Tue Apr 14 16:51:02 UTC 2026 active-response/bin/restart.sh agent reload   
May 04 18:40:00 agent wazuh-jam-test-001
May 04 19:30:00 agent wazuh-jam-test-002



(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e ‹enhancement/35631-wazuh-event-id-correlation●› 
╰─# curl -k -u admin:admin \
  "https://localhost:9200/wazuh-events-v5-*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{
    "query": {
      "simple_query_string": {
        "query": "\"wazuh-jam-test-002\"",
        "fields": ["*"]
      }
    },
    "_source": [
      "@timestamp",
      "event.original",
      "wazuh.event.id",
      "wazuh.integration.name",
      "wazuh.integration.decoders",
      "wazuh.agent.id",
      "wazuh.agent.name"
    ],
    "sort": [
      { "@timestamp": "desc" }
    ],
    "size": 10
  }'

{
  "took" : 5,
  "timed_out" : false,
  "_shards" : {
    "total" : 24,
    "successful" : 24,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [
      {
        "_index" : ".ds-wazuh-events-v5-system-activity-000001",
        "_id" : "9YVv9J0BGj4lTOJIFjLl",
        "_score" : null,
        "_source" : {
          "@timestamp" : "2026-05-04T19:20:04.816Z",
          "wazuh" : {
            "agent" : {
              "name" : "wazuh-agent-4143-rocky8",
              "id" : "002"
            },
            "integration" : {
              "name" : "syslog",
              "decoders" : [
                "decoder/core-wazuh-message/0",
                "decoder/syslog/0"
              ]
            },
            "event" : {
              "id" : "cfb14b5d-285b-4b03-bd35-8654c5dab41a"
            }
          },
          "event" : {
            "original" : "May 04 19:30:00 agent wazuh-jam-test-002"
          }
        },
        "sort" : [
          1777922404816
        ]
      }
    ]
  }
}


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e ‹enhancement/35631-wazuh-event-id-correlation●› 
╰─# curl -k -u admin:admin \
  "https://localhost:9200/wazuh-events-raw-v5*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{
    "query": {
      "term": {
        "wazuh.event.id": "cfb14b5d-285b-4b03-bd35-8654c5dab41a"
      }
    },
    "_source": [
      "@timestamp",
      "event.original",
      "wazuh.event.id",
      "wazuh.agent.id",
      "wazuh.agent.name"
    ],
    "sort": [
      { "@timestamp": "desc" }
    ]
  }'

{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 3,
    "successful" : 3,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [
      {
        "_index" : ".ds-wazuh-events-raw-v5-000001",
        "_id" : "9IVv9J0BGj4lTOJIFjLl",
        "_score" : null,
        "_source" : {
          "@timestamp" : "2026-05-04T19:20:04.816Z",
          "wazuh" : {
            "agent" : {
              "name" : "wazuh-agent-4143-rocky8",
              "id" : "002"
            },
            "event" : {
              "id" : "cfb14b5d-285b-4b03-bd35-8654c5dab41a"
            }
          },
          "event" : {
            "original" : "1:/var/ossec/logs/active-responses.log:May 04 19:30:00 agent wazuh-jam-test-002"
          }
        },
        "sort" : [
          1777922404816
        ]
      }
    ]
  }
}

```
--- 

<p align="center">
  <img width="1844" height="665" src="https://github.com/user-attachments/assets/53b88420-2619-4434-8503-d3c928e4bff0" >
  <br>
  <em>
    wazuh-events*
  </em>
</p>

--- 

<p align="center">
  <img width="1844" height="665"  src="https://github.com/user-attachments/assets/3ce44ea3-b854-4f06-b70f-4de177c5aab0" >
  <br>
  <em>
     wazuh-events-raw-v5*
  </em>
</p>


--- 

<p align="center">
  <img width="1827" height="946"  src="https://github.com/user-attachments/assets/5eafb575-570a-4756-a630-87d498f56ded" >
  <br>
  <em>
   wazuh.event id on raw, standar and custom 
  </em>
</p>

