### PR TITLE
Don't trigger manager checks in draft PR

### DIFF
--- a/.github/workflows/5_builderpackage_engine-standalone_onpush.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone_onpush.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   call-build-workflow:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     uses: ./.github/workflows/5_builderpackage_engine-standalone.yml
     secrets: inherit
     with:

--- a/.github/workflows/5_builderpackage_manager-multiples.yml
+++ b/.github/workflows/5_builderpackage_manager-multiples.yml
@@ -45,6 +45,7 @@ concurrency:
 
 jobs:
   select-targets:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Select build targets (Wazuh Managers)
     runs-on: ubuntu-24.04
     outputs:
@@ -64,6 +65,7 @@ jobs:
             return { include: matrix };
           result-encoding: json
   build-wazuh-manager:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Wazuh Manager
     needs: select-targets
     permissions:

--- a/.github/workflows/5_buildpackage_internal_tools.yml
+++ b/.github/workflows/5_buildpackage_internal_tools.yml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build ${{ matrix.system }} / ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/5_codeanalysis_api-rbac-db-version.yml
+++ b/.github/workflows/5_codeanalysis_api-rbac-db-version.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   guard:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/5_codeanalysis_api-rbac-db-version.yml
+++ b/.github/workflows/5_codeanalysis_api-rbac-db-version.yml
@@ -3,6 +3,7 @@ name: 5.X - API RBAC DB Version Check
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/5_codeanalysis_api-rbac-db-version.yml"
       - "framework/wazuh/rbac/default/**"

--- a/.github/workflows/5_codeanalysis_python_bandit_pr.yml
+++ b/.github/workflows/5_codeanalysis_python_bandit_pr.yml
@@ -3,6 +3,7 @@ name: 5.X - Python static code analysis on PR
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/5_codeanalysis_python_bandit_pr.yml"
       - 'framework/**/*.py'

--- a/.github/workflows/5_codeanalysis_python_bandit_pr.yml
+++ b/.github/workflows/5_codeanalysis_python_bandit_pr.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   bandit-scan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: wz-linux-amd64
     steps:
       - name: Checkout repo

--- a/.github/workflows/5_codelinter_clangformat.yml
+++ b/.github/workflows/5_codelinter_clangformat.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   style:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/5_testcomponent_contentmanager.yml
+++ b/.github/workflows/5_testcomponent_contentmanager.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   contentmanager-tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: true

--- a/.github/workflows/5_testcomponent_router.yml
+++ b/.github/workflows/5_testcomponent_router.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   router-tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: true

--- a/.github/workflows/5_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/5_testcomponent_vulnerability-scanner.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   vulnerability-scanner-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -49,6 +50,7 @@ jobs:
           target: "vulnerability_scanner_component_tests"
 
   vulnerability-scanner-modules-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/5_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_api-tier-0-1.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/5_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_api-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/5_testintegration_api-tier-0-1.yml"
         - "api/**"

--- a/.github/workflows/5_testintegration_engine.yml
+++ b/.github/workflows/5_testintegration_engine.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Server
     runs-on: ubuntu-latest
     steps:
@@ -54,10 +55,8 @@ jobs:
             src/external/rocksdb/build/librocksdb.so.8.3.2
 
   helper_tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Helper Functions Test
-
-    # Only runs if the PR status is different to Draft
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 60
@@ -122,10 +121,8 @@ jobs:
       run: engine-helper-test -e /tmp/actions generate-doc --input-dir ${{env.ENGINE_DIR}}/test/helper_tests/helpers_description/ -o /tmp/helper_docs/
 
   api_tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: API Endpoints Test
-
-    # Only runs if the PR status is different to Draft
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 60

--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   inventory-sync-integration-tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: inventory-sync-integration-tests
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/5_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_rbac-tier-0-1.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/5_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/5_testintegration_rbac-tier-0-1.yml
@@ -2,6 +2,7 @@ name: 5.X - RBAC (Framework) - Integration tests - Tier 0 and 1
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/5_testintegration_rbac-tier-0-1.yml"
         - "framework/wazuh/rbac/"

--- a/.github/workflows/5_testintegration_vulnerability-scanner.yml
+++ b/.github/workflows/5_testintegration_vulnerability-scanner.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   vulnerability-scanner-integration:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/5_testunit_api.yml
+++ b/.github/workflows/5_testunit_api.yml
@@ -23,7 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build: 
+  build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/5_testunit_api.yml
+++ b/.github/workflows/5_testunit_api.yml
@@ -2,6 +2,7 @@ name: 5.X - API - Unit tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/5_testunit_api.yml'
       - 'api/**'

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   contentmanager-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -53,6 +54,7 @@ jobs:
           threshold: "65"
 
   contentmanager-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04 ]

--- a/.github/workflows/5_testunit_engine.yml
+++ b/.github/workflows/5_testunit_engine.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Manager
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/5_testunit_framework.yml
+++ b/.github/workflows/5_testunit_framework.yml
@@ -23,7 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build: 
+  build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/5_testunit_framework.yml
+++ b/.github/workflows/5_testunit_framework.yml
@@ -2,6 +2,7 @@ name: 5.X - Framework - Unit tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/5_testunit_framework.yml'
       - 'framework/**'

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   indexerconnector-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -53,6 +54,7 @@ jobs:
           validate_function_coverage: "false"
 
   indexerconnector-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04 ]

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   inventorysync-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -54,6 +55,7 @@ jobs:
           validate_function_coverage: "false"
 
   inventorysync-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04 ]

--- a/.github/workflows/5_testunit_python-coverage.yml
+++ b/.github/workflows/5_testunit_python-coverage.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/5_testunit_python-coverage.yml
+++ b/.github/workflows/5_testunit_python-coverage.yml
@@ -1,6 +1,7 @@
 name: 5.X - Unit tests coverage - Python
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/5_testunit_python-coverage.yml'
   workflow_dispatch:

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   router-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -53,6 +54,7 @@ jobs:
           validate_function_coverage: "false"
 
   router-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04 ]

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   shared_modules_utils-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -52,6 +53,7 @@ jobs:
           validate_function_coverage: "false"
 
   shared_modules_utils-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04 ]

--- a/.github/workflows/5_testunit_vulnerability-scanner.yml
+++ b/.github/workflows/5_testunit_vulnerability-scanner.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   vulnerability-scanner-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
@@ -56,6 +57,7 @@ jobs:
           validate_function_coverage: "false"
 
   vulnerability-scanner-modules-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Adds `if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}` to 24 workflows to prevent execution when PRs are in draft state.

## Proposed Changes

Modified workflows:
- Builds (3): Engine standalone, Manager multiples, Internal tools
- Code quality (3): API/RBAC/DB analysis, Python Bandit, ClangFormat
- Tests (18): Component, integration, and unit tests for manager/API/framework/server components

Benefits:
- Saves CI/CD resources during development
- Workflows auto-run when PR marked "Ready for review"
- Manual triggers unaffected

### Results and Evidence

<img width="912" height="708" alt="image" src="https://github.com/user-attachments/assets/c9aca823-4dfd-4311-8c0f-cf77ffcefb61" />

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided