### PR TITLE
Don't trigger the agent's PR checks in drafts

### DIFF
--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -54,7 +54,7 @@ concurrency:
 jobs:
   # ===================== DEB JOBS =====================
   build-deb-arm64:
-    if: github.event_name == 'pull_request' || inputs.system == 'deb'
+    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'deb'
     runs-on: wz-linux-arm64
     timeout-minutes: 30
     name: Build DEB package
@@ -304,7 +304,7 @@ jobs:
 
   # ===================== RPM JOBS =====================
   build-rpm-arm64:
-    if: github.event_name == 'pull_request' || inputs.system == 'rpm'
+    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'rpm'
     runs-on: wz-linux-arm64
     timeout-minutes: 30
     name: Build RPM package

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -58,7 +58,7 @@ concurrency:
 jobs:
   # ===================== DEB JOBS =====================
   build-deb:
-    if: github.event_name == 'pull_request' || inputs.system == 'deb'
+    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'deb'
     runs-on: wz-linux-amd64
     timeout-minutes: 30
     name: Build DEB ${{ matrix.arch }} package
@@ -328,7 +328,7 @@ jobs:
 
   # ===================== RPM JOBS =====================
   build-rpm:
-    if: github.event_name == 'pull_request' || inputs.system == 'rpm'
+    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'rpm'
     runs-on: wz-linux-amd64
     timeout-minutes: 30
     name: Build RPM ${{ matrix.arch }} package
@@ -625,6 +625,7 @@ jobs:
     secrets: inherit
 
   detect-changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: wz-linux-amd64
     timeout-minutes: 10
     name: Detect changed Linux test modules

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   build-macos-intel64:
-    if: github.event_name == 'pull_request' || inputs.architecture == 'intel64'
+    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.architecture == 'intel64'
     runs-on: macos-14-large
     timeout-minutes: 90
     name: Build PKG package (intel64)
@@ -280,7 +280,7 @@ jobs:
           fi
 
   build-macos-arm64:
-    if: github.event_name == 'pull_request' || inputs.architecture == 'arm64'
+    if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.architecture == 'arm64'
     runs-on: macos-14
     timeout-minutes: 90
     name: Build PKG package (arm64)
@@ -520,6 +520,7 @@ jobs:
     secrets: inherit
 
   detect-changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: wz-linux-amd64
     timeout-minutes: 10
     name: Detect changed macOS test modules

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -41,6 +41,7 @@ concurrency:
 
 jobs:
   detect-changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     name: Detect changed Windows test modules
     outputs:

--- a/.github/workflows/5_codeanalysis_scanbuild.yml
+++ b/.github/workflows/5_codeanalysis_scanbuild.yml
@@ -2,6 +2,7 @@ name: 5.X - Scan build
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/5_codeanalysis_scanbuild.yml"
@@ -12,6 +13,7 @@ concurrency:
 
 jobs:
   scan-build-linux:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -45,6 +47,7 @@ jobs:
         run: exit 1
 
   scan-build-ubuntu-mingw-windows:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
@@ -76,6 +79,7 @@ jobs:
         run: exit 1
 
   scan-build-macos-agent:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_agent_info-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_info-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Module Agent Info for Agent/Winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -18,6 +19,7 @@ concurrency:
 
 jobs:
   Agent-Info-Unit-Tests:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Module agent_metadata for agent/winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -16,6 +17,7 @@ concurrency:
 
 jobs:
   rtr:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testcomponent_build-macos.yml
+++ b/.github/workflows/5_testcomponent_build-macos.yml
@@ -2,6 +2,7 @@ name: 5.X - macOS compilation test
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_build-macos.yml"
@@ -12,6 +13,7 @@ concurrency:
 
 jobs:
   build-sonoma:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_sca-rtr.yml
+++ b/.github/workflows/5_testcomponent_sca-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Module SCA for Agent/Winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -18,6 +19,7 @@ concurrency:
 
 jobs:
   SCA-Unit-Tests:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
+++ b/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Shared Modules - File Helper - Unit tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -16,6 +17,7 @@ concurrency:
 
 jobs:
   rtr:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
+++ b/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Module sync_protocol for agent/winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -16,6 +17,7 @@ concurrency:
 
 jobs:
   rtr:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscheck-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Module syscheck for agent/winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -18,6 +19,7 @@ concurrency:
 
 jobs:
   rtr:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscollector-rtr.yml
@@ -3,6 +3,7 @@ name: 5.X - Running RTR. Module syscollector and its dependencies for agent/wina
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -19,6 +20,7 @@ concurrency:
 
 jobs:
   rtr:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -3,6 +3,7 @@ name: 5.X - Testing DLL search order to prevent hijack
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_windows-dll-hijack.yml"
@@ -13,6 +14,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -2,6 +2,7 @@ name: 5.X - Windows binaries' details
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_windows-files.yml"
@@ -12,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -2,6 +2,7 @@ name: 5.X - Windows upgrade test
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_windows-installer-upgrade.yml"
@@ -12,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     steps:
       - name: Install mingw

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -2,6 +2,7 @@ name: 5.X - MsGraph on Linux - Integration tests - Tier 0 and 1
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml"
         - "src/config/src/wmodules-ms-graph.c"
@@ -23,6 +24,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -2,6 +2,7 @@ name: 5.X - Wazuh - Legacy Unit tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - "src/**"
         - ".github/workflows/5_testunit_linux-win.yml"
@@ -18,6 +19,7 @@ concurrency:
 
 jobs:
   Unit-Tests:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/5_testunit_macos.yml
+++ b/.github/workflows/5_testunit_macos.yml
@@ -2,6 +2,7 @@ name: 5.X - macOS - Unit tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/5_testunit_macos.yml"
@@ -13,6 +14,7 @@ concurrency:
 
 jobs:
   build-sonoma:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-15
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testunit_wodles.yml
+++ b/.github/workflows/5_testunit_wodles.yml
@@ -2,6 +2,7 @@ name: 5.X - Wodles - Unit tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/5_testunit_wodles.yml'
       - 'wodles/**'
@@ -24,6 +25,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Adds `if: github.event_name != 'pull_request' || !github.event.pull_request.draft` to agent workflows to prevent execution when PRs are in draft state.

## Proposed Changes

Benefits:
- Saves CI/CD resources during development
- Workflows auto-run when PR marked "Ready for review"
- Manual triggers unaffected

### Results and Evidence

<img width="902" height="626" alt="image" src="https://github.com/user-attachments/assets/64460271-46da-4911-aba4-1b8b2868f41f" />

### Artifacts Affected

Modified workflows:
- Agent builder package
- Code analysis
- Tests: Component (RTR), integration, and unit tests

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided