### PR TITLE
Change VD provider name

### DIFF
--- a/src/shared_modules/content_manager/README.md
+++ b/src/shared_modules/content_manager/README.md
@@ -60,7 +60,7 @@ After all pages are processed, the downloader signals completion via `indexer_co
                 "certificate": "",
                 "key": ""
             },
-            "index": "wazuh-threatintel-vulnerabilities",
+            "index": ".wazuh-threatintel-vulnerabilities",
             "consumerStatusIndex": ".wazuh-cti-consumers",
             "consumerStatusId": "t1-vulnerabilities-5_public-vulnerabilities-5",
             "pageSize": 250,

--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-The [Indexer Downloader](../../src/components/IndexerDownloader.hpp) stage is part of the Content Manager orchestration and downloads content directly from the Wazuh Indexer using Point-In-Time (PIT) pagination. It is used by the Vulnerability Detection module to fetch CVE data from the `wazuh-threatintel-vulnerabilities` index, replacing the CTI API as the CVE data source.
+The [Indexer Downloader](../../src/components/IndexerDownloader.hpp) stage is part of the Content Manager orchestration and downloads content directly from the Wazuh Indexer using Point-In-Time (PIT) pagination. It is used by the Vulnerability Detection module to fetch CVE data from the `.wazuh-threatintel-vulnerabilities` index, replacing the CTI API as the CVE data source.
 
 Content is delivered synchronously to the `fileProcessingCallback` as structured `nlohmann::json` objects page by page.
 
@@ -101,7 +101,7 @@ The `indexer` sub-object must be present under `configData` when `contentSource`
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `index` | string | Target index name (e.g. `wazuh-threatintel-vulnerabilities`) |
+| `index` | string | Target index name (e.g. `.wazuh-threatintel-vulnerabilities`) |
 | `consumerStatusIndex` | string | Index containing the consumer status document to poll before downloading (optional) |
 | `consumerStatusId` | string | Consumer status document id to poll before downloading (optional) |
 | `pageSize` | integer | Documents per page. Default: `250` |
@@ -134,7 +134,7 @@ Example:
                 "certificate": "",
                 "key": ""
             },
-            "index": "wazuh-threatintel-vulnerabilities",
+            "index": ".wazuh-threatintel-vulnerabilities",
             "consumerStatusIndex": ".wazuh-cti-consumers",
             "consumerStatusId": "t1-vulnerabilities-5_public-vulnerabilities-5",
             "pageSize": 250,

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -50,7 +50,7 @@
  *
  * Configuration expected under configData["indexer"]:
  * {
- *   "index":               "wazuh-threatintel-vulnerabilities", // Indexer CVE index name
+ *   "index":               ".wazuh-threatintel-vulnerabilities", // Indexer CVE index name
  *   "consumerStatusIndex": ".wazuh-cti-consumers",    // Consumer status index (optional)
  *   "consumerStatusId":    "t1-vulnerabilities-5_public-vulnerabilities-5", // Consumer status document id (optional)
  *   "pageSize":            250,                       // Documents per page (optional, default 250)

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -16,7 +16,7 @@ import docker
 LOGGER = logging.getLogger(__name__)
 OPENSEARCH_IP = "127.0.0.1:9200"
 OPENSEARCH_URL = f"http://{OPENSEARCH_IP}"
-CTI_FEED_INDEX = "wazuh-threatintel-vulnerabilities"
+CTI_FEED_INDEX = ".wazuh-threatintel-vulnerabilities"
 CTI_CONSUMERS_INDEX = ".wazuh-cti-consumers"
 CTI_CONSUMER_DOC_ID = "t1-vulnerabilities-5_public-vulnerabilities-5"
 CTI_FEED_FILE = Path("wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json")

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -37,7 +37,7 @@ extern "C" bool vdTesttoolSkipPostUpdateScan() __attribute__((weak));
 // LCOV_EXCL_START - only called from the DatabaseFeedManager callback inside start(), which is already excluded
 namespace
 {
-    constexpr std::string_view INDEXER_FEED_INDEX {"wazuh-threatintel-vulnerabilities"};
+    constexpr std::string_view INDEXER_FEED_INDEX {".wazuh-threatintel-vulnerabilities"};
     constexpr std::string_view INDEXER_CONSUMER_STATUS_INDEX {".wazuh-cti-consumers"};
     constexpr std::string_view INDEXER_CONSUMER_STATUS_ID {"t1-vulnerabilities-5_public-vulnerabilities-5"};
 


### PR DESCRIPTION
## Summary
- Update the VD feed index name to `.wazuh-threatintel-vulnerabilities`.
- Update related documentation and QA references.

Closes #35861

## Validation
- `git diff --check`
- Verified no `wazuh-threatintel-vulnerabilities` references remain without the leading dot.
