### PR TITLE
wazuh-engine: Async router worker pool

### DIFF
--- a/src/engine/source/api/event/test/src/unit/handlers_test.cpp
+++ b/src/engine/source/api/event/test/src/unit/handlers_test.cpp
@@ -181,11 +181,11 @@ INSTANTIATE_TEST_SUITE_P(
             {
                 auto dumper = std::make_shared<testing::StrictMock<dumper::mocks::MockDumper>>();
 
-                const std::string expectedArchived = std::string("H ") + HDR1 + "\n" + "E " + EV1;
+                const std::string expectedDumped = std::string("H ") + HDR1 + "\n" + "E " + EV1;
 
                 EXPECT_CALL(*dumper, dump(testing::A<std::string_view>()))
-                    .WillOnce(testing::Invoke([expectedArchived](std::string_view v)
-                                              { EXPECT_EQ(v, std::string_view {expectedArchived}); }));
+                    .WillOnce(testing::Invoke([expectedDumped](std::string_view v)
+                                              { EXPECT_EQ(v, std::string_view {expectedDumped}); }));
 
                 // inner handler stores only weak_ptr, so keep dump alive by capturing it
                 auto inner = pushEvent(orchestrator, dumper);

--- a/src/engine/source/api/ioccrud/src/handlersSync.cpp
+++ b/src/engine/source/api/ioccrud/src/handlersSync.cpp
@@ -349,14 +349,12 @@ adapter::RouteHandler syncIoc(const std::shared_ptr<::ioc::kvdb::IKVDBManager>& 
         // Schedule asynchronous task for IOC synchronization
         try
         {
-            scheduler::TaskConfig taskConfig {.interval = 0,    // One-time task (execute as soon as possible)
-                                              .CPUPriority = 0, // Normal priority
-                                              .timeout = 0,     // No timeout
-                                              .taskFunction = [weakKvdbManager, weakStore, filePath, fileHash]()
-                                              {
-                                                  detail::performIOCSync(
-                                                      weakKvdbManager, weakStore, filePath, fileHash);
-                                              }};
+            scheduler::TaskConfig taskConfig {
+                .interval = 0, // One-time task (execute as soon as possible)
+                .runImmediately = false,
+                .CPUPriority = 0, // Normal priority
+                .taskFunction = [weakKvdbManager, weakStore, filePath, fileHash]()
+                { detail::performIOCSync(weakKvdbManager, weakStore, filePath, fileHash); }};
 
             // Schedule the task with a unique name
             const std::string taskName = "ioc-sync-" + base::utils::generators::randomHexString(8);

--- a/src/engine/source/api/router/include/api/router/handlers.hpp
+++ b/src/engine/source/api/router/include/api/router/handlers.hpp
@@ -2,8 +2,8 @@
 #define _API_ROUTER_HANDLERS_HPP
 
 #include <api/adapter/adapter.hpp>
-#include <router/iapi.hpp>
 #include <cmstore/icmstore.hpp>
+#include <router/iapi.hpp>
 namespace api::router::handlers
 {
 

--- a/src/engine/source/base/test/src/unit/logger_test.cpp
+++ b/src/engine/source/base/test/src/unit/logger_test.cpp
@@ -541,7 +541,8 @@ TEST_F(DailyRotatingFileSinkTest, SingleRotationWhenTimeAndSizeCoincide)
     auto sink = std::make_shared<logging::daily_rotating_file_sink>(logging::daily_rotating_file_sink::Config {
         .filePath = m_logFile,
         .maxFileSize = 5 * 1024,     // 5KB
-        .rotationIntervalSeconds = 1 // Deterministic test-only time rotation
+        .rotationIntervalSeconds = 1, // Deterministic test-only time rotation
+        .compressionEnabled = false
     });
 
     auto logger = std::make_shared<spdlog::logger>("test", sink);

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -117,7 +117,7 @@ Conf::Conf(std::shared_ptr<IFileLoader> fileLoader)
     addUnit<size_t>(key::STREAMLOG_EVENTS_MAX_SIZE, "WAZUH_STREAMLOG_EVENTS_MAX_SIZE", 0);
     addUnit<size_t>(key::STREAMLOG_EVENTS_BUFFER_SIZE, "WAZUH_STREAMLOG_EVENTS_BUFFER_SIZE", 0x1 << 20);
     addUnit<std::string>(
-        key::STREAMLOG_DUMPER_PATTERN, "WAZUH_STREAMLOG_DUMPER_PATTERN", "${YYYY}/${MMM}/wazuh-${name}-${DD}.json");
+        key::STREAMLOG_DUMPER_PATTERN, "WAZUH_STREAMLOG_DUMPER_PATTERN", "${YYYY}/${MMM}/wazuh-${name}-${DD}.log");
     addUnit<size_t>(key::STREAMLOG_DUMPER_MAX_SIZE, "WAZUH_STREAMLOG_DUMPER_MAX_SIZE", 0);
     addUnit<size_t>(key::STREAMLOG_DUMPER_BUFFER_SIZE, "WAZUH_STREAMLOG_DUMPER_BUFFER_SIZE", 0x1 << 20);
 

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -384,8 +384,7 @@ int main(int argc, char* argv[])
         // Scheduler -> Should be terminated before all modules to ensure any scheduled are stopped before shutdown
         {
             scheduler = std::make_shared<scheduler::Scheduler>();
-            scheduler->start();
-            LOG_INFO("Scheduler initialized and started.");
+            LOG_INFO("Scheduler initialized.");
             exitHandler.add([scheduler]() { scheduler->stop(); });
         }
 
@@ -612,12 +611,9 @@ int main(int argc, char* argv[])
             scheduler->scheduleTask(
                 "cm-sync-task",
                 scheduler::TaskConfig {.interval = confManager.get<std::size_t>(conf::key::CM_SYNC_INTERVAL),
+                                       .runImmediately = false,
                                        .CPUPriority = 0,
-                                       .timeout = 0,
-                                       .taskFunction = [cmSyncService]()
-                                       {
-                                           cmSyncService->synchronize();
-                                       }});
+                                       .taskFunction = [cmSyncService]() { cmSyncService->synchronize(); }});
         }
 
         // IOCSync
@@ -637,14 +633,12 @@ int main(int argc, char* argv[])
             auto iocSyncInterval = confManager.get<std::size_t>(conf::key::IOC_SYNC_INTERVAL);
             if (iocSyncInterval > 0)
             {
-                scheduler->scheduleTask("ioc-sync-task",
-                                        scheduler::TaskConfig {.interval = iocSyncInterval,
-                                                               .CPUPriority = 0,
-                                                               .timeout = 0,
-                                                               .taskFunction = [iocSyncService]()
-                                                               {
-                                                                   iocSyncService->synchronize();
-                                                               }});
+                scheduler->scheduleTask(
+                    "ioc-sync-task",
+                    scheduler::TaskConfig {.interval = iocSyncInterval,
+                                           .runImmediately = false,
+                                           .CPUPriority = 0,
+                                           .taskFunction = [iocSyncService]() { iocSyncService->synchronize(); }});
                 LOG_DEBUG("IOC Sync task scheduled with interval: {} seconds, {} max retries, {} seconds for retry "
                           "interval and {} for batch size",
                           iocSyncInterval,
@@ -675,12 +669,10 @@ int main(int argc, char* argv[])
                 scheduler->scheduleTask(
                     "geo-sync-task",
                     scheduler::TaskConfig {.interval = geoSyncInterval,
+                                           .runImmediately = false,
                                            .CPUPriority = 0,
-                                           .timeout = 0,
                                            .taskFunction = [geoManager, manifestUrl, cityPath, asnPath]()
-                                           {
-                                               geoManager->remoteUpsert(manifestUrl, cityPath, asnPath);
-                                           }});
+                                           { geoManager->remoteUpsert(manifestUrl, cityPath, asnPath); }});
                 LOG_DEBUG("Geo sync scheduled with interval: {} seconds.", geoSyncInterval);
             }
             else
@@ -712,14 +704,12 @@ int main(int argc, char* argv[])
         if (enableProcessing)
         {
             const auto remoteConfSyncInterval = confManager.get<std::size_t>(conf::key::REMOTE_CONF_SYNC_INTERVAL);
-            scheduler->scheduleTask("remote-conf-sync",
-                                    scheduler::TaskConfig {.interval = remoteConfSyncInterval,
-                                                           .CPUPriority = 0,
-                                                           .timeout = 0,
-                                                           .taskFunction = [remoteConf]()
-                                                           {
-                                                               remoteConf->synchronize();
-                                                           }});
+            scheduler->scheduleTask(
+                "remote-conf-sync",
+                scheduler::TaskConfig {.interval = remoteConfSyncInterval,
+                                       .runImmediately = false,
+                                       .CPUPriority = 0,
+                                       .taskFunction = [remoteConf]() { remoteConf->synchronize(); }});
             LOG_DEBUG("Remote configuration synchronize scheduled with interval: {} seconds.", remoteConfSyncInterval);
         }
 
@@ -810,12 +800,10 @@ int main(int argc, char* argv[])
 
                 scheduler::TaskConfig metricsConfig {.interval =
                                                          confManager.get<size_t>(conf::key::METRICS_LOG_INTERVAL),
+                                                     .runImmediately = false,
                                                      .CPUPriority = 0,
-                                                     .timeout = 0,
                                                      .taskFunction = [metricsWriter, metricsManager]()
-                                                     {
-                                                         metricsManager->writeAllMetrics(metricsWriter);
-                                                     }};
+                                                     { metricsManager->writeAllMetrics(metricsWriter); }};
 
                 scheduler->scheduleTask("MetricsLogger", std::move(metricsConfig));
                 LOG_INFO("Metrics stream logging enabled (interval: {} seconds, on-demand channel creation).",
@@ -859,19 +847,26 @@ int main(int argc, char* argv[])
         if (enableProcessing)
         {
             // Async Synchronize on startup
-            scheduler->scheduleTask("initial-sync",
-                                    scheduler::TaskConfig {.interval = 0,
-                                                           .CPUPriority = 0,
-                                                           .timeout = 0,
-                                                           .taskFunction = [=]()
-                                                           {
-                                                               cmSyncService->synchronize();
-                                                               iocSyncService->synchronize();
-                                                               remoteConf->synchronize();
-                                                               geoManager->remoteUpsert(confManager.get<std::string>(conf::key::GEO_MANIFEST_URL),
-                                                                                      confManager.get<std::string>(conf::key::GEO_DB_PATH) + "/GeoLite2-City.mmdb",
-                                                                                      confManager.get<std::string>(conf::key::GEO_DB_PATH) + "/GeoLite2-ASN.mmdb");
-                                                           }});
+            scheduler->scheduleTask(
+                "initial-sync",
+                scheduler::TaskConfig {
+                    .interval = 0,
+                    .runImmediately = false,
+                    .CPUPriority = 0,
+                    .taskFunction = [=]()
+                    {
+                        cmSyncService->synchronize();
+                        iocSyncService->synchronize();
+                        remoteConf->synchronize();
+                        geoManager->remoteUpsert(
+                            confManager.get<std::string>(conf::key::GEO_MANIFEST_URL),
+                            confManager.get<std::string>(conf::key::GEO_DB_PATH) + "/GeoLite2-City.mmdb",
+                            confManager.get<std::string>(conf::key::GEO_DB_PATH) + "/GeoLite2-ASN.mmdb");
+                    }});
+            scheduler->scheduleTaskFirst("initial-sync");
+
+            scheduler->start();
+            LOG_INFO("Scheduler started.");
 
             while (engineRemoteServer->isRunning())
             {
@@ -886,6 +881,8 @@ int main(int argc, char* argv[])
         }
         else
         {
+            scheduler->start();
+            LOG_INFO("Scheduler started.");
             // Event processing disabled, just wait for shutdown signal
             LOG_INFO("Waiting for shutdown signal (event processing is disabled)...");
             while (!g_shutdown_requested)

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -606,17 +606,6 @@ int main(int argc, char* argv[])
             LOG_INFO("Content Manager Sync Service initialized.");
 
             exitHandler.add([cmSyncService]() { cmSyncService->requestShutdown(); });
-
-            // Add sync to scheduler
-            scheduler->scheduleTask(
-                "cm-sync-task",
-                scheduler::TaskConfig {.interval = confManager.get<std::size_t>(conf::key::CM_SYNC_INTERVAL),
-                                       .runImmediately = false,
-                                       .CPUPriority = 0,
-                                       .taskFunction = [cmSyncService]()
-                                       {
-                                           cmSyncService->synchronize();
-                                       }});
         }
 
         // IOCSync
@@ -638,7 +627,7 @@ int main(int argc, char* argv[])
             {
                 scheduler->scheduleTask("ioc-sync-task",
                                         scheduler::TaskConfig {.interval = iocSyncInterval,
-                                                               .runImmediately = false,
+                                                               .runImmediately = true,
                                                                .CPUPriority = 0,
                                                                .taskFunction = [iocSyncService]()
                                                                {
@@ -674,7 +663,7 @@ int main(int argc, char* argv[])
                 scheduler->scheduleTask(
                     "geo-sync-task",
                     scheduler::TaskConfig {.interval = geoSyncInterval,
-                                           .runImmediately = false,
+                                           .runImmediately = true,
                                            .CPUPriority = 0,
                                            .taskFunction = [geoManager, manifestUrl, cityPath, asnPath]()
                                            {
@@ -713,7 +702,7 @@ int main(int argc, char* argv[])
             const auto remoteConfSyncInterval = confManager.get<std::size_t>(conf::key::REMOTE_CONF_SYNC_INTERVAL);
             scheduler->scheduleTask("remote-conf-sync",
                                     scheduler::TaskConfig {.interval = remoteConfSyncInterval,
-                                                           .runImmediately = false,
+                                                           .runImmediately = true,
                                                            .CPUPriority = 0,
                                                            .taskFunction = [remoteConf]()
                                                            {
@@ -859,26 +848,20 @@ int main(int argc, char* argv[])
         {
             // Async Synchronize on startup
             scheduler->scheduleTask(
-                "initial-sync",
-                scheduler::TaskConfig {
-                    .interval = 0,
-                    .runImmediately = false,
-                    .CPUPriority = 0,
-                    .taskFunction = [=]()
-                    {
-                        // Expand the router worker pool before the initial content synchronization.
-                        // This ensures the initial sync mutates the complete worker pool instead of
-                        // only the primary worker.
-                        orchestrator->expandWorkerPool();
-                        cmSyncService->synchronize();
-                        iocSyncService->synchronize();
-                        remoteConf->synchronize();
-                        geoManager->remoteUpsert(
-                            confManager.get<std::string>(conf::key::GEO_MANIFEST_URL),
-                            confManager.get<std::string>(conf::key::GEO_DB_PATH) + "/GeoLite2-City.mmdb",
-                            confManager.get<std::string>(conf::key::GEO_DB_PATH) + "/GeoLite2-ASN.mmdb");
-                    }});
-            scheduler->scheduleTaskFirst("initial-sync");
+                "cm-sync-task",
+                scheduler::TaskConfig {.interval = confManager.get<std::size_t>(conf::key::CM_SYNC_INTERVAL),
+                                       .runImmediately = false,
+                                       .CPUPriority = 0,
+                                       .taskFunction = [=]()
+                                       {
+                                           // Expand the router worker pool before the initial
+                                           // content synchronization. This ensures the initial sync
+                                           // mutates the complete worker pool instead of only the
+                                           // primary worker.
+                                           orchestrator->expandWorkerPool();
+                                           cmSyncService->synchronize();
+                                       }});
+            scheduler->scheduleTaskFirst("cm-sync-task");
 
             scheduler->start();
             LOG_INFO("Scheduler started.");

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -850,7 +850,7 @@ int main(int argc, char* argv[])
             scheduler->scheduleTask(
                 "cm-sync-task",
                 scheduler::TaskConfig {.interval = confManager.get<std::size_t>(conf::key::CM_SYNC_INTERVAL),
-                                       .runImmediately = false,
+                                       .runImmediately = true,
                                        .CPUPriority = 0,
                                        .taskFunction = [=]()
                                        {

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -613,7 +613,10 @@ int main(int argc, char* argv[])
                 scheduler::TaskConfig {.interval = confManager.get<std::size_t>(conf::key::CM_SYNC_INTERVAL),
                                        .runImmediately = false,
                                        .CPUPriority = 0,
-                                       .taskFunction = [cmSyncService]() { cmSyncService->synchronize(); }});
+                                       .taskFunction = [cmSyncService]()
+                                       {
+                                           cmSyncService->synchronize();
+                                       }});
         }
 
         // IOCSync
@@ -633,12 +636,14 @@ int main(int argc, char* argv[])
             auto iocSyncInterval = confManager.get<std::size_t>(conf::key::IOC_SYNC_INTERVAL);
             if (iocSyncInterval > 0)
             {
-                scheduler->scheduleTask(
-                    "ioc-sync-task",
-                    scheduler::TaskConfig {.interval = iocSyncInterval,
-                                           .runImmediately = false,
-                                           .CPUPriority = 0,
-                                           .taskFunction = [iocSyncService]() { iocSyncService->synchronize(); }});
+                scheduler->scheduleTask("ioc-sync-task",
+                                        scheduler::TaskConfig {.interval = iocSyncInterval,
+                                                               .runImmediately = false,
+                                                               .CPUPriority = 0,
+                                                               .taskFunction = [iocSyncService]()
+                                                               {
+                                                                   iocSyncService->synchronize();
+                                                               }});
                 LOG_DEBUG("IOC Sync task scheduled with interval: {} seconds, {} max retries, {} seconds for retry "
                           "interval and {} for batch size",
                           iocSyncInterval,
@@ -672,7 +677,9 @@ int main(int argc, char* argv[])
                                            .runImmediately = false,
                                            .CPUPriority = 0,
                                            .taskFunction = [geoManager, manifestUrl, cityPath, asnPath]()
-                                           { geoManager->remoteUpsert(manifestUrl, cityPath, asnPath); }});
+                                           {
+                                               geoManager->remoteUpsert(manifestUrl, cityPath, asnPath);
+                                           }});
                 LOG_DEBUG("Geo sync scheduled with interval: {} seconds.", geoSyncInterval);
             }
             else
@@ -704,12 +711,14 @@ int main(int argc, char* argv[])
         if (enableProcessing)
         {
             const auto remoteConfSyncInterval = confManager.get<std::size_t>(conf::key::REMOTE_CONF_SYNC_INTERVAL);
-            scheduler->scheduleTask(
-                "remote-conf-sync",
-                scheduler::TaskConfig {.interval = remoteConfSyncInterval,
-                                       .runImmediately = false,
-                                       .CPUPriority = 0,
-                                       .taskFunction = [remoteConf]() { remoteConf->synchronize(); }});
+            scheduler->scheduleTask("remote-conf-sync",
+                                    scheduler::TaskConfig {.interval = remoteConfSyncInterval,
+                                                           .runImmediately = false,
+                                                           .CPUPriority = 0,
+                                                           .taskFunction = [remoteConf]()
+                                                           {
+                                                               remoteConf->synchronize();
+                                                           }});
             LOG_DEBUG("Remote configuration synchronize scheduled with interval: {} seconds.", remoteConfSyncInterval);
         }
 
@@ -803,7 +812,9 @@ int main(int argc, char* argv[])
                                                      .runImmediately = false,
                                                      .CPUPriority = 0,
                                                      .taskFunction = [metricsWriter, metricsManager]()
-                                                     { metricsManager->writeAllMetrics(metricsWriter); }};
+                                                     {
+                                                         metricsManager->writeAllMetrics(metricsWriter);
+                                                     }};
 
                 scheduler->scheduleTask("MetricsLogger", std::move(metricsConfig));
                 LOG_INFO("Metrics stream logging enabled (interval: {} seconds, on-demand channel creation).",
@@ -855,6 +866,10 @@ int main(int argc, char* argv[])
                     .CPUPriority = 0,
                     .taskFunction = [=]()
                     {
+                        // Expand the router worker pool before the initial content synchronization.
+                        // This ensures the initial sync mutates the complete worker pool instead of
+                        // only the primary worker.
+                        orchestrator->expandWorkerPool();
                         cmSyncService->synchronize();
                         iocSyncService->synchronize();
                         remoteConf->synchronize();

--- a/src/engine/source/router/README.md
+++ b/src/engine/source/router/README.md
@@ -148,8 +148,14 @@ The `Orchestrator` constructor:
 1. Validates the `Options` struct (thread count 0–128, non-null pointers, timeout > 0).
 2. Creates a shared `EnvironmentBuilder` from the builder and controller maker.
 3. Loads persisted router/tester configuration from the Store (`router/router/0`, `router/tester/0`).
-4. Creates N `RouterWorker` instances (defaults to `hardware_concurrency` if thread count is 0), each initialized with the saved route table.
+4. Creates exactly **1** `RouterWorker` synchronously, initialized with the saved route table. Additional workers are deferred to `expandWorkerPool()` (see below).
 5. Creates 1 `TesterWorker` initialized with saved test sessions.
+
+### Deferred Worker Pool Expansion
+
+`expandWorkerPool()` is called at startup, before content synchronization begins. It synchronously builds workers 2..N, each initialized from a snapshot of the first worker's route table.
+
+The write lock (`m_syncMutex`) is held for the full snapshot → build → publish cycle of each worker. This serializes expansion against concurrent route mutations, which is the correct trade-off given that expansion happens once at startup. If a worker fails to initialize or start, the pool remains unchanged and the caller may invoke `expandWorkerPool()` again to retry.
 
 ### Multi-Worker Replication
 
@@ -212,7 +218,7 @@ Unit tests cover each internal class independently using GMock:
 - **`environmentBuilder_test`**: Policy build, controller creation, error handling
 - **`router_test`**: Entry CRUD, priority changes, event ingestion, hot swap
 - **`tester_test`**: Entry CRUD, rename, test ingestion with traces, asset listing
-- **`orchestrator_test`**: Full lifecycle, multi-worker replication, store persistence, queue contention
+- **`orchestrator_test`**: Full lifecycle, multi-worker replication, store persistence, queue contention, worker pool expansion
 - **`entryConverter_test`**: JSON ↔ Entry round-trip conversion
 
 Component tests exercise the integrated subsystems with mock backends.

--- a/src/engine/source/router/include/router/orchestrator.hpp
+++ b/src/engine/source/router/include/router/orchestrator.hpp
@@ -3,15 +3,16 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <list>
 #include <memory>
 #include <shared_mutex>
 
 #include <bk/icontroller.hpp>
 #include <builder/ibuilder.hpp>
-#include <fastqueue/iqueue.hpp>
 #include <fastmetrics/iManager.hpp>
 #include <fastmetrics/slidingWindowRate.hpp>
+#include <fastqueue/iqueue.hpp>
 #include <rawevtindexer/iraweventindexer.hpp>
 #include <store/istore.hpp>
 
@@ -46,17 +47,20 @@ protected:
     mutable std::shared_mutex m_syncMutex;  ///< Mutex for the Workers synchronization (1 query at a time)
     std::atomic<bool> m_isShutdown {false}; ///< Flag to indicate orchestrator has been shutdown
 
+    std::size_t m_targetWorkerCount {1}; ///< Desired router worker pool size (set in constructor)
+
     // Workers configuration
-    std::shared_ptr<ProdQueueType> m_eventQueue;      ///< The event queue
-    std::shared_ptr<TestQueueType> m_testQueue;       ///< The test queue
-    std::shared_ptr<EnvironmentBuilder> m_envBuilder; ///< The environment builder
+    std::shared_ptr<ProdQueueType> m_eventQueue;                        ///< The event queue
+    std::shared_ptr<TestQueueType> m_testQueue;                         ///< The test queue
+    std::shared_ptr<EnvironmentBuilder> m_envBuilder;                   ///< The environment builder
+    std::function<std::shared_ptr<IWorker<IRouter>>()> m_workerFactory; ///< Factory for expansion workers
 
     // Event queue contention monitoring
     std::atomic<bool> m_eventQueueContended {false};       ///< True while queue load is above contention threshold
     std::atomic<int64_t> m_contentionStartUsec {0};        ///< First contention timestamp (steady_clock, usec)
     std::atomic<int64_t> m_lastContentionWarningUsec {0};  ///< Last warning timestamp (steady_clock, usec)
     std::atomic<uint64_t> m_droppedEventsInContention {0}; ///< Failed push count in current contention window
-    std::shared_ptr<fastmetrics::ICounter> m_droppedInputCounter; ///< Total events dropped at input (never resets)
+    std::shared_ptr<fastmetrics::ICounter> m_droppedInputCounter;     ///< Total events dropped at input (never resets)
     static constexpr int64_t CONTENTION_WARNING_INTERVAL_SEC = 600LL; ///< Interval in seconds
     static constexpr int64_t CONTENTION_WARNING_INTERVAL_USEC =
         CONTENTION_WARNING_INTERVAL_SEC * 1000LL * 1000LL;               ///< 10 minutes
@@ -142,6 +146,18 @@ public:
      */
     void requestShutdown();
 
+    /**
+     * @brief Expand the router worker pool up to the configured target size.
+     *
+     * Intended to be called at startup, before content synchronization begins.
+     * Runs synchronously; the caller provides the async context.
+     * Safe no-op if already at target size or after shutdown.
+     *
+     * If worker construction or start fails, the pool remains unchanged and the
+     * caller may invoke this method again to retry.
+     */
+    void expandWorkerPool();
+
     /**************************************************************************
      * IRouterAPI
      *************************************************************************/
@@ -154,8 +170,7 @@ public:
     /**
      * @copydoc router::IRouterAPI::hotSwapNamespace
      */
-    base::OptError hotSwapNamespace(const std::string& name,
-                                    const cm::store::NamespaceId& newNamespace) override;
+    base::OptError hotSwapNamespace(const std::string& name, const cm::store::NamespaceId& newNamespace) override;
 
     /**
      * @copydoc router::IRouterAPI::existsEntry

--- a/src/engine/source/router/src/orchestrator.cpp
+++ b/src/engine/source/router/src/orchestrator.cpp
@@ -353,15 +353,22 @@ Orchestrator::Orchestrator(const Options& opt)
         LOG_DEBUG("No thread count provided. Using {} worker threads based on system hardware.", numThreads);
     }
 
-    for (std::size_t i = 0; i < numThreads; ++i)
+    m_targetWorkerCount = numThreads;
+    m_workerFactory = [this]()
+    {
+        return std::make_shared<RouterWorker>(m_envBuilder, m_eventQueue, m_rawIndexer, m_epsRate);
+    };
+
     {
         auto r = std::make_shared<router::RouterWorker>(m_envBuilder, m_eventQueue, m_rawIndexer, m_epsRate);
         if (auto err = initRouterWorker(r, routerEntries))
         {
-            LOG_ERROR("Router: Cannot load initial states from store: {}", err->message);
+            LOG_ERROR("Router: Cannot load initial states from store for primary worker: {}", err->message);
         }
         m_routerWorkers.emplace_back(std::move(r));
     }
+    LOG_DEBUG("Router: {} additional worker(s) will be started asynchronously.",
+              m_targetWorkerCount > 1 ? m_targetWorkerCount - 1 : 0);
 
     {
         auto t = std::make_shared<router::TesterWorker>(m_envBuilder, m_testQueue);
@@ -409,6 +416,70 @@ void Orchestrator::requestShutdown()
     m_eventQueue.reset();
     m_testQueue.reset();
     m_wStore.reset();
+    m_workerFactory = nullptr;
+}
+
+/**************************************************************************
+ * Dynamic pool expansion
+ *************************************************************************/
+void Orchestrator::expandWorkerPool()
+{
+    {
+        std::unique_lock lock {m_syncMutex};
+        if (m_isShutdown.load(std::memory_order_acquire))
+            return;
+        if (m_routerWorkers.empty())
+        {
+            LOG_WARNING("[Orchestrator] Cannot expand worker pool: no primary worker available.");
+            return;
+        }
+    }
+
+    // The write lock is held for the full snapshot → build → publish cycle of each worker.
+    // This serializes expansion against all route mutations (postEntry, deleteEntry, …),
+    // which is the correct trade-off given that expansion happens once at startup.
+    // TODO: if contention during expansion becomes measurable, revisit using a generation
+    // counter (snapshot generation, build outside the lock, verify generation before publish)
+    // to allow route mutations to proceed concurrently with the (expensive) build step.
+    while (true)
+    {
+        std::unique_lock lock {m_syncMutex};
+
+        if (m_isShutdown.load(std::memory_order_acquire) || m_routerWorkers.size() >= m_targetWorkerCount)
+            return;
+
+        auto entrySnapshot = m_routerWorkers.front()->get()->getEntries();
+        std::vector<EntryConverter> converters;
+        converters.reserve(entrySnapshot.size());
+        for (const auto& entry : entrySnapshot) converters.emplace_back(entry);
+
+        auto newWorker = m_workerFactory();
+        if (auto err = initRouterWorker(newWorker, converters))
+        {
+            LOG_ERROR("[Orchestrator] Worker expansion failed: {}", err->message);
+            return;
+        }
+
+        if (m_isShutdown.load(std::memory_order_acquire))
+            return;
+
+        try
+        {
+            newWorker->start();
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("[Orchestrator] Worker start failed during expansion: {}", e.what());
+            return;
+        }
+        catch (...)
+        {
+            LOG_ERROR("[Orchestrator] Worker start failed during expansion with unknown exception.");
+            return;
+        }
+
+        m_routerWorkers.emplace_back(std::move(newWorker));
+    }
 }
 
 /**************************************************************************

--- a/src/engine/source/router/src/orchestrator.cpp
+++ b/src/engine/source/router/src/orchestrator.cpp
@@ -85,10 +85,15 @@ base::OptError loadTesterOnWorker(const std::vector<EntryConverter>& entries,
 }
 
 base::OptError loadRouterOnWoker(const std::vector<EntryConverter>& entries,
-                                 const std::shared_ptr<IWorker<IRouter>>& worker)
+                                 const std::shared_ptr<IWorker<IRouter>>& worker,
+                                 const std::atomic<bool>& isShutdown)
 {
     for (const auto& entry : entries)
     {
+        if (isShutdown.load(std::memory_order_acquire))
+        {
+            return base::Error {"Loading aborted: orchestrator shutting down"};
+        }
         auto err = worker->get()->addEntry(prod::EntryPost(entry), /*ignoreFail=*/true);
         if (err)
         {
@@ -169,7 +174,7 @@ std::vector<EntryConverter> getEntriesFromStore(const std::shared_ptr<store::ISt
 base::OptError Orchestrator::initRouterWorker(const std::shared_ptr<IWorker<IRouter>>& worker,
                                               const std::vector<EntryConverter>& routerEntries)
 {
-    auto error = loadRouterOnWoker(routerEntries, worker);
+    auto error = loadRouterOnWoker(routerEntries, worker, m_isShutdown);
 
     if (error)
     {

--- a/src/engine/source/router/src/orchestrator.cpp
+++ b/src/engine/source/router/src/orchestrator.cpp
@@ -443,10 +443,16 @@ void Orchestrator::expandWorkerPool()
     // to allow route mutations to proceed concurrently with the (expensive) build step.
     while (true)
     {
+        if (m_isShutdown.load(std::memory_order_acquire))
+        {
+            return;
+        }
         std::unique_lock lock {m_syncMutex};
 
-        if (m_isShutdown.load(std::memory_order_acquire) || m_routerWorkers.size() >= m_targetWorkerCount)
+        if (m_routerWorkers.size() >= m_targetWorkerCount)
+        {
             return;
+        }
 
         auto entrySnapshot = m_routerWorkers.front()->get()->getEntries();
         std::vector<EntryConverter> converters;
@@ -461,7 +467,9 @@ void Orchestrator::expandWorkerPool()
         }
 
         if (m_isShutdown.load(std::memory_order_acquire))
+        {
             return;
+        }
 
         try
         {

--- a/src/engine/source/router/test/src/unit/orchestrator_test.cpp
+++ b/src/engine/source/router/test/src/unit/orchestrator_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <deque>
 
 #include <base/logging.hpp>
 #include <queue/mockQueue.hpp>
@@ -37,6 +38,27 @@ MATCHER_P(isEqualsEvent, expectedJson, "is not equal to expected JSON")
     return recv == expected;
 }
 
+std::shared_ptr<testing::NiceMock<MockRouterWorker>> makeMockWorkerOk(std::list<prod::Entry> entries = {})
+{
+    auto w = std::make_shared<testing::NiceMock<MockRouterWorker>>();
+    auto r = std::make_shared<testing::NiceMock<MockRouter>>();
+    auto ir = std::static_pointer_cast<router::IRouter>(r);
+    ON_CALL(*w, get()).WillByDefault(testing::Return(ir));
+    ON_CALL(*r, getEntries()).WillByDefault(testing::Return(entries));
+    ON_CALL(*r, addEntry(testing::_, testing::_)).WillByDefault(testing::Return(std::nullopt));
+    ON_CALL(*r, enableEntry(testing::_)).WillByDefault(testing::Return(std::nullopt));
+    return w;
+}
+
+std::shared_ptr<testing::NiceMock<MockRouterWorker>> makeMockWorkerFailBuild()
+{
+    auto w = std::make_shared<testing::NiceMock<MockRouterWorker>>();
+    auto r = std::make_shared<testing::NiceMock<MockRouter>>();
+    ON_CALL(*w, get()).WillByDefault(testing::Return(std::static_pointer_cast<router::IRouter>(r)));
+    ON_CALL(*r, addEntry(testing::_, testing::_)).WillByDefault(testing::Return(base::Error {"build error"}));
+    return w;
+}
+
 } // namespace
 /// @brief Orchestrator to test, helper class
 class OrchestratorToTest : public router::Orchestrator
@@ -47,6 +69,7 @@ public:
     std::shared_ptr<fastqueue::mocks::MockQueue<test::EventTest>> m_mockTestQueue;
     std::list<std::shared_ptr<MockRouterWorker>> m_routerMocks;
     std::shared_ptr<MockTesterWorker> m_testerWorkerMock;
+    std::deque<std::function<std::shared_ptr<IWorker<IRouter>>()>> m_factoryQueue;
 
     OrchestratorToTest()
         : router::Orchestrator()
@@ -61,6 +84,16 @@ public:
 
         m_testerWorkerMock = std::make_shared<MockTesterWorker>();
         m_testerWorker = m_testerWorkerMock;
+        m_workerFactory = [this]() -> std::shared_ptr<IWorker<IRouter>>
+        {
+            if (!m_factoryQueue.empty())
+            {
+                auto f = std::move(m_factoryQueue.front());
+                m_factoryQueue.pop_front();
+                return f();
+            }
+            return makeMockWorkerOk();
+        };
     };
 
     auto forEachWorkerMock(std::function<void(std::shared_ptr<MockRouterWorker>)> func)
@@ -81,6 +114,15 @@ public:
         return workerMock;
     }
 
+    std::shared_ptr<testing::NiceMock<MockRouterWorker>> addWorkerToPool(std::list<prod::Entry> entries = {})
+    {
+        auto w = makeMockWorkerOk(std::move(entries));
+        m_routerWorkers.emplace_back(w);
+        return w;
+    }
+
+    void simulateShutdown() { m_isShutdown.store(true, std::memory_order_release); }
+
     void setContentionState(bool contended, int64_t startUsec, int64_t lastWarningUsec, uint64_t dropped)
     {
         m_eventQueueContended.store(contended, std::memory_order_relaxed);
@@ -93,6 +135,14 @@ public:
     int64_t contentionStartUsec() const { return m_contentionStartUsec.load(std::memory_order_relaxed); }
     int64_t lastContentionWarningUsec() const { return m_lastContentionWarningUsec.load(std::memory_order_relaxed); }
     uint64_t droppedEventsInContention() const { return m_droppedEventsInContention.load(std::memory_order_relaxed); }
+
+    // Expansion helpers
+    std::size_t workerPoolSize()
+    {
+        std::shared_lock lock {m_syncMutex};
+        return m_routerWorkers.size();
+    }
+    void setTargetWorkerCount(std::size_t n) { m_targetWorkerCount = n; }
 
     /**************************************************************************
      * TESTER EXPECTS CALL
@@ -952,4 +1002,182 @@ TEST_F(OrchestratorTest, postEventLowLoadResetsContentionState)
     EXPECT_EQ(m_orchestrator->contentionStartUsec(), 0);
     EXPECT_EQ(m_orchestrator->lastContentionWarningUsec(), 0);
     EXPECT_EQ(m_orchestrator->droppedEventsInContention(), 0U);
+}
+
+/**************************************************************************
+ * Worker pool expansion tests
+ *************************************************************************/
+
+class ExpansionTest : public ::testing::Test
+{
+protected:
+    std::unique_ptr<OrchestratorToTest> m_orch;
+
+    void SetUp() override { m_orch = std::make_unique<OrchestratorToTest>(); }
+    void TearDown() override { m_orch.reset(); }
+};
+
+TEST_F(ExpansionTest, expandsPoolToTarget)
+{
+    m_orch->setTargetWorkerCount(3);
+    m_orch->addWorkerToPool();
+
+    for (int i = 0; i < 2; ++i)
+    {
+        m_orch->m_factoryQueue.push_back(
+            []()
+            {
+                auto w = makeMockWorkerOk();
+                EXPECT_CALL(*w, start()).Times(1);
+                return w;
+            });
+    }
+
+    m_orch->expandWorkerPool();
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 3U);
+}
+
+TEST_F(ExpansionTest, noopWhenAlreadyAtTarget)
+{
+    m_orch->setTargetWorkerCount(2);
+    m_orch->addWorkerToPool();
+    m_orch->addWorkerToPool();
+
+    m_orch->expandWorkerPool();
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 2U);
+}
+
+TEST_F(ExpansionTest, buildFailurePreservesPool)
+{
+    const std::list<prod::Entry> entries {prod::EntryPost {"route-x", G_NAMESPACE_ALT, 10}};
+
+    m_orch->setTargetWorkerCount(3);
+    m_orch->addWorkerToPool(entries);
+    m_orch->m_factoryQueue.push_back([]() { return makeMockWorkerFailBuild(); });
+
+    m_orch->expandWorkerPool();
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 1U);
+}
+
+TEST_F(ExpansionTest, allWorkersReceiveConsistentEntries)
+{
+    const std::list<prod::Entry> sharedEntries {
+        prod::EntryPost {"route-a", G_NAMESPACE_ALT, 10},
+        prod::EntryPost {"route-b", G_NAMESPACE_ALT, 20},
+    };
+
+    m_orch->setTargetWorkerCount(3);
+    m_orch->addWorkerToPool(sharedEntries);
+
+    std::vector<std::vector<std::string>> capturedNames(2);
+
+    for (std::size_t idx = 0; idx < 2; ++idx)
+    {
+        m_orch->m_factoryQueue.push_back(
+            [&, idx]()
+            {
+                auto w = std::make_shared<testing::NiceMock<MockRouterWorker>>();
+                auto r = std::make_shared<testing::NiceMock<MockRouter>>();
+                ON_CALL(*w, get()).WillByDefault(testing::Return(std::static_pointer_cast<IRouter>(r)));
+                ON_CALL(*r, addEntry(testing::_, testing::_))
+                    .WillByDefault(
+                        [&capturedNames, idx](const prod::EntryPost& e, bool) -> base::OptError
+                        {
+                            capturedNames[idx].push_back(e.name());
+                            return std::nullopt;
+                        });
+                ON_CALL(*r, enableEntry(testing::_)).WillByDefault(testing::Return(std::nullopt));
+                return w;
+            });
+    }
+
+    m_orch->expandWorkerPool();
+
+    ASSERT_EQ(m_orch->workerPoolSize(), 3U);
+    for (std::size_t idx = 0; idx < 2; ++idx)
+    {
+        EXPECT_EQ(capturedNames[idx], (std::vector<std::string> {"route-a", "route-b"}))
+            << "Worker " << idx << " has inconsistent entries";
+    }
+}
+
+TEST_F(ExpansionTest, shutdownPreventsExpansion)
+{
+    m_orch->setTargetWorkerCount(3);
+    m_orch->addWorkerToPool();
+    m_orch->simulateShutdown();
+
+    m_orch->expandWorkerPool();
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 1U);
+}
+
+TEST_F(ExpansionTest, enableEntryFailureStillPublishesWorker)
+{
+    m_orch->setTargetWorkerCount(2);
+    m_orch->addWorkerToPool({prod::EntryPost {"route-a", G_NAMESPACE_ALT, 10}});
+
+    m_orch->m_factoryQueue.push_back(
+        []()
+        {
+            auto w = std::make_shared<testing::NiceMock<MockRouterWorker>>();
+            auto r = std::make_shared<testing::NiceMock<MockRouter>>();
+            ON_CALL(*w, get()).WillByDefault(testing::Return(std::static_pointer_cast<IRouter>(r)));
+            ON_CALL(*r, addEntry(testing::_, testing::_)).WillByDefault(testing::Return(std::nullopt));
+            ON_CALL(*r, enableEntry(testing::_)).WillByDefault(testing::Return(base::Error {"enable failed"}));
+            return w;
+        });
+
+    m_orch->expandWorkerPool();
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 2U);
+}
+
+TEST_F(ExpansionTest, startThrowingPreservesPool)
+{
+    m_orch->setTargetWorkerCount(2);
+    m_orch->addWorkerToPool();
+
+    m_orch->m_factoryQueue.push_back(
+        []()
+        {
+            auto w = makeMockWorkerOk();
+            ON_CALL(*w, start()).WillByDefault(testing::Throw(std::runtime_error {"start failed"}));
+            return w;
+        });
+
+    ASSERT_NO_THROW(m_orch->expandWorkerPool());
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 1U);
+}
+
+TEST_F(ExpansionTest, emptyPoolNoopWithWarning)
+{
+    m_orch->setTargetWorkerCount(3);
+    // No workers added — m_routerWorkers is empty
+
+    ASSERT_NO_THROW(m_orch->expandWorkerPool());
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 0U);
+}
+
+TEST_F(ExpansionTest, shutdownDuringBuildPreventsPublish)
+{
+    m_orch->setTargetWorkerCount(2);
+    m_orch->addWorkerToPool();
+
+    m_orch->m_factoryQueue.push_back(
+        [this]()
+        {
+            // Simulate shutdown completing while the worker is being built
+            m_orch->simulateShutdown();
+            return makeMockWorkerOk();
+        });
+
+    m_orch->expandWorkerPool();
+
+    EXPECT_EQ(m_orch->workerPoolSize(), 1U);
 }

--- a/src/engine/source/scheduler/README.md
+++ b/src/engine/source/scheduler/README.md
@@ -4,7 +4,7 @@
 
 The **scheduler** module provides a multi-threaded, priority-aware task scheduling system for the Wazuh engine. It manages the execution of periodic and one-time background tasks using a configurable thread pool and a sorted, thread-safe priority queue.
 
-Tasks are identified by unique names and configured with an execution interval, CPU priority (nice value), and a callable function. The scheduler handles task lifecycle—including automatic removal of one-time tasks and rescheduling of recurring ones—while guaranteeing thread safety across all operations.
+Tasks are identified by unique names and configured with an execution interval, an optional immediate-execution flag, CPU priority (nice value), and a callable function. The scheduler handles task lifecycle—including automatic removal of one-time tasks and rescheduling of recurring ones—while guaranteeing thread safety across all operations.
 
 ## Architecture
 
@@ -13,12 +13,15 @@ Tasks are identified by unique names and configured with an execution interval, 
 │                     Consumers                          │
 │  (main.cpp, streamlog, api/ioccrud)                    │
 │                                                        │
-│   scheduleTask("task-name", {interval, prio, fn})      │
+│   scheduleTask("name", {interval, runImmediately, …})  │
+│   scheduleTaskFirst("name", {interval, …})             │
 └──────────────────────┬─────────────────────────────────┘
                        │
               ┌────────▼────────┐
               │   IScheduler     │  (interface)
               │  scheduleTask()  │
+              │  scheduleTask-   │
+              │    First()       │
               │  removeTask()    │
               │  getActiveCount  │
               │  getThreadCount  │
@@ -46,14 +49,17 @@ Defined in `ischeduler.hpp`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `interval` | `std::size_t` | Execution interval in seconds. `0` = one-time task |
+| `runImmediately` | `bool` | If `true` and `interval > 0`, first execution happens immediately; then recurs at `interval`. No effect when `interval == 0` |
 | `CPUPriority` | `int` | Linux nice value (`-20` highest to `19` lowest). `0` = default |
-| `timeout` | `int` | Reserved for future use (currently unused) |
 | `taskFunction` | `std::function<void()>` | The callable to execute |
+
+Fields must be specified in the order listed above when using C++20 designated initializers.
 
 ### One-Time vs Recurring Tasks
 
-- **One-time** (`interval = 0`): Scheduled for immediate execution. Automatically removed from the task map after completion.
-- **Recurring** (`interval > 0`): First execution occurs after `interval` seconds. After each execution, the task is rescheduled with a new `nextRun` time = `now + interval`.
+- **One-time** (`interval = 0`): Scheduled for immediate execution (`nextRun = now()`). Automatically removed from the task map after completion. `runImmediately` has no additional effect.
+- **Recurring** (`interval > 0`, `runImmediately = false`): First execution occurs after `interval` seconds (`nextRun = now() + interval`). After each execution, rescheduled with `nextRun = now() + interval`.
+- **Recurring with immediate first run** (`interval > 0`, `runImmediately = true`): First execution is immediate (`nextRun = now()`). Subsequent executions recur at `interval` seconds.
 
 ### Task Queue (`TaskQueue`)
 
@@ -75,6 +81,14 @@ The scheduler creates a fixed number of worker threads (configurable, minimum 1)
 5. Execute the task function (catching exceptions)
 6. Restore default priority
 7. Reschedule (recurring) or remove (one-time) the task
+
+### Deferred Start
+
+The scheduler is designed to be **created before tasks are registered** and **started only after all tasks have been scheduled**. This ensures workers begin processing a fully populated queue rather than spinning on an empty one during engine initialization.
+
+- Tasks can be enqueued via `scheduleTask()` or `scheduleTaskFirst()` at any time before or after `start()`.
+- Worker threads are launched only when `start()` is explicitly called.
+- In `main.cpp`, `start()` is called immediately after the last `scheduleTaskFirst("initial-sync", …)` call in each execution branch.
 
 ### CPU Priority
 
@@ -105,6 +119,7 @@ scheduler/
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `scheduleTask` | `(string_view name, TaskConfig&& config) → void` | Schedule a new task; throws if name is duplicate or function is null |
+| `scheduleTaskFirst` | `(string_view name, TaskConfig&& config) → void` | Schedule a task forcing it to the front of the queue (executes before all other pending tasks); same validation as `scheduleTask` |
 | `removeTask` | `(string_view name) → void` | Remove a task by name; no-op if not found |
 | `getActiveTasksCount` | `() → size_t` | Number of tasks currently registered |
 | `getThreadCount` | `() → size_t` | Number of worker threads (constant after construction) |
@@ -137,9 +152,17 @@ The implementation uses two separate synchronization mechanisms:
 ```
 scheduleTask()
     ├── Validate: taskFunction != null, name is unique
-    ├── Create ScheduledTask (compute nextRun)
+    ├── Create ScheduledTask (compute nextRun based on interval / runImmediately)
     ├── Insert into m_tasks map
-    └── Push TaskItem into m_taskQueue
+    └── Push TaskItem into m_taskQueue (sorted by nextRun)
+
+scheduleTaskFirst()
+    ├── Validate: taskFunction != null, name is unique
+    ├── Create ScheduledTask
+    ├── Insert into m_tasks map
+    └── Push TaskItem with nextRun = time_point{} (epoch)
+            → lower_bound returns begin() → inserted at position 0
+            → always executes before any other queued task
 
 workerThread()
     ├── pop() from m_taskQueue (blocks)
@@ -150,10 +173,14 @@ workerThread()
         one-time? → erase from m_tasks
 ```
 
+#### `scheduleTaskFirst` ordering guarantee
+
+Multiple calls before `start()` are ordered such that the **last call executes first**. Each new task with `nextRun = epoch` is inserted at position 0 (before any existing epoch-time task), so the most-recently registered task is always at the head of the queue when workers start.
+
 ### Error Handling
 
 - Task functions are executed inside a `try/catch` block; exceptions are logged as warnings but do not crash the scheduler or affect other tasks.
-- `scheduleTask` throws `std::invalid_argument` for null functions and `std::runtime_error` for duplicate names.
+- `scheduleTask` and `scheduleTaskFirst` throw `std::invalid_argument` for null functions and `std::runtime_error` for duplicate names.
 - Worker thread names are set to `"sched-worker"` via `base::process::setThreadName`.
 
 ## CMake Targets
@@ -186,6 +213,11 @@ Use a real 2-thread scheduler with atomic counters and short sleeps to verify be
 | `StartStopScheduler` | Lifecycle transitions |
 | `ScheduleOneTimeTask` | Executes once, auto-removed from task map |
 | `ScheduleRecurringTask` | Executes at least once within interval window |
+| `RunImmediately_ExecutesOnFirstCycle` | `runImmediately=true` fires before one full interval elapses |
+| `RunImmediately_ThenRecurresAtInterval` | Immediate first fire, then normal recurring cadence, task not removed |
+| `RunImmediately_NoEffectOnOneTimeTask` | `runImmediately=true` on one-time task: runs once, removed, no double execution |
+| `ScheduleTaskFirst_ExecutesBeforeOtherPendingTasks` | Task registered via `scheduleTaskFirst` runs before a previously registered one-time task |
+| `ScheduleTaskFirst_LastCallIsFirst` | Second `scheduleTaskFirst` call executes before first call |
 | `RemoveTask` | Task removed before execution does not fire |
 | `MultipleTasks` | Mix of one-time + recurring tasks coexist |
 | `TaskPriority` | Tasks with different CPU priorities all execute |
@@ -194,18 +226,21 @@ Use a real 2-thread scheduler with atomic counters and short sleeps to verify be
 
 ## Consumers
 
-The scheduler is instantiated once in `main.cpp` as `std::make_shared<scheduler::Scheduler>()`, started, and injected into consumers:
+The scheduler is instantiated once in `main.cpp` as `std::make_shared<scheduler::Scheduler>()`. Tasks are registered during engine initialization; `start()` is called only after the last task has been scheduled.
 
-| Task Name | Interval | Consumer | Purpose |
-|-----------|----------|----------|---------|
-| `cm-sync-task` | `CM_SYNC_INTERVAL` | Content Manager | Synchronizes content manager data |
-| `ioc-sync-task` | `IOC_SYNC_INTERVAL` | IOC Sync | Indicator of Compromise synchronization |
-| `geo-sync-task` | `GEO_SYNC_INTERVAL` | Geo Manager | Updates GeoIP databases (GeoLite2-City, GeoLite2-ASN) |
-| `remote-conf-sync` | `REMOTE_CONF_SYNC_INTERVAL` | Remote Config | Remote configuration synchronization |
-| *(dynamic)* | One-time | streamlog | Gzip compression of rotated log files |
+| Task Name | Interval | Method | Consumer | Purpose |
+|-----------|----------|--------|----------|---------|
+| `cm-sync-task` | `CM_SYNC_INTERVAL` | `scheduleTask` | Content Manager | Synchronizes content manager data |
+| `ioc-sync-task` | `IOC_SYNC_INTERVAL` | `scheduleTask` | IOC Sync | Indicator of Compromise synchronization |
+| `geo-sync-task` | `GEO_SYNC_INTERVAL` | `scheduleTask` | Geo Manager | Updates GeoIP databases (GeoLite2-City, GeoLite2-ASN) |
+| `remote-conf-sync` | `REMOTE_CONF_SYNC_INTERVAL` | `scheduleTask` | Remote Config | Remote configuration synchronization |
+| `MetricsLogger` | `METRICS_LOG_INTERVAL` | `scheduleTask` | Metrics | Writes all metrics to the stream logger |
+| `initial-sync` | one-time | `scheduleTaskFirst` | main.cpp | Triggers cm/ioc/geo/remote-conf synchronization at startup; guaranteed to run before all other pending tasks |
+| *(dynamic)* | one-time | `scheduleTask` | streamlog | Gzip compression of rotated log files |
+| *(dynamic)* | one-time | `scheduleTask` | api/ioccrud | On-demand IOC sync triggered via API |
 
 ### Injection Patterns
 
 - **streamlog**: Stores `std::weak_ptr<scheduler::IScheduler>` and dynamically schedules one-time compression tasks when log files rotate.
 - **api/ioccrud**: Receives the scheduler as a parameter in API route handlers for managing IOC sync operations.
-- **main.cpp**: Directly calls `scheduler->scheduleTask()` for all core periodic sync tasks.
+- **main.cpp**: Calls `scheduleTask()` for all periodic tasks during initialization, then `scheduleTaskFirst()` for the one-time `initial-sync` startup task. `start()` is deferred until after all tasks are registered.

--- a/src/engine/source/scheduler/README.md
+++ b/src/engine/source/scheduler/README.md
@@ -33,7 +33,7 @@ Tasks are identified by unique names and configured with an execution interval, 
               │  m_tasks (map)  ←→  m_taskQueue (sorted) │
               │                                          │
               │  ┌──────────┐ ┌──────────┐ ┌──────────┐ │
-              │  │ worker 0 │ │ worker 1 │ │ worker N │ │
+              │  │ worker 0 │ │ worker 2 │ │ worker N │ │
               │  └──────────┘ └──────────┘ └──────────┘ │
               │       ↕             ↕             ↕      │
               │         pop() → execute → reschedule     │
@@ -72,7 +72,7 @@ An internal thread-safe sorted list that orders tasks by their `nextRun` time (e
 
 ### Thread Pool
 
-The scheduler creates a fixed number of worker threads (configurable, minimum 1). Each worker runs a loop:
+The scheduler creates a fixed number of worker threads (configurable, minimum 2). Each worker runs a loop:
 
 1. `pop()` a task from the queue (blocks if empty)
 2. If `nextRun > now`, push the task back and sleep 100 ms
@@ -130,7 +130,7 @@ Extends `IScheduler` with lifecycle control:
 
 | Method | Description |
 |--------|-------------|
-| `Scheduler(int threads = 1)` | Create a stopped scheduler with the given thread count (min 1) |
+| `Scheduler(int threads = 2)` | Create a stopped scheduler with the given thread count (min 2) |
 | `start()` | Launch worker threads; idempotent |
 | `stop()` | Gracefully shut down: signal queue, join all workers, clear tasks; idempotent |
 | `isRunning()` | Check if the scheduler is active |

--- a/src/engine/source/scheduler/include/scheduler/scheduler.hpp
+++ b/src/engine/source/scheduler/include/scheduler/scheduler.hpp
@@ -204,6 +204,26 @@ public:
         std::lock_guard<std::mutex> lock(m_mutex);
         m_tasks.clear();
     }
+
+    /**
+     * @brief Move a task to the front of the queue by name.
+     * @return true if found and moved; false if task is not currently in the queue.
+     */
+    bool reprioritizeToFront(const std::string& taskName)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = std::find_if(
+            m_tasks.begin(), m_tasks.end(), [&taskName](const TaskItem& item) { return item.name == taskName; });
+        if (it == m_tasks.end())
+        {
+            return false;
+        }
+        TaskItem item = *it;
+        item.nextRun = std::chrono::steady_clock::time_point {};
+        m_tasks.erase(it);
+        m_tasks.push_front(item);
+        return true;
+    }
 };
 ;
 
@@ -229,7 +249,7 @@ struct ScheduledTask
     {
         nextRun = [&]() -> std::chrono::steady_clock::time_point
         {
-            if (isOneTime)
+            if (isOneTime || config.runImmediately)
             {
                 return std::chrono::steady_clock::now();
             }
@@ -370,6 +390,11 @@ public:
      * @copydoc IScheduler::scheduleTask
      */
     void scheduleTask(std::string_view taskName, TaskConfig&& config) override;
+
+    /**
+     * @copydoc IScheduler::scheduleTaskFirst
+     */
+    void scheduleTaskFirst(std::string_view taskName) override;
 
     /**
      * @copydoc IScheduler::removeTask

--- a/src/engine/source/scheduler/include/scheduler/scheduler.hpp
+++ b/src/engine/source/scheduler/include/scheduler/scheduler.hpp
@@ -142,28 +142,41 @@ public:
     }
 
     /**
-     * @brief Get a task from the queue (blocking)
-     * @return TaskItem or empty if shutdown
+     * @brief Get a task from the queue (blocking, timed).
+     * @details Blocks until the front task is due, a new earlier task is pushed,
+     *          reprioritizeToFront() is called, or shutdown is signaled.
+     *          Returns nullopt immediately on shutdown.
+     * @return TaskItem (deep copy) or nullopt on shutdown
      */
     std::optional<TaskItem> pop()
     {
         std::unique_lock<std::mutex> lock(m_mutex);
-        m_condition.wait(lock, [this] { return !m_tasks.empty() || m_shutdown; });
-
-        if (m_shutdown && m_tasks.empty())
+        while (true)
         {
-            return std::nullopt;
-        }
+            if (m_shutdown)
+            {
+                return std::nullopt;
+            }
 
-        if (!m_tasks.empty())
-        {
-            // DEEP COPY to avoid data races
-            TaskItem item = m_tasks.front(); // Copy constructor
-            m_tasks.pop_front();
-            return item;
-        }
+            if (m_tasks.empty())
+            {
+                m_condition.wait(lock, [this] { return !m_tasks.empty() || m_shutdown; });
+                continue;
+            }
 
-        return std::nullopt;
+            auto now = std::chrono::steady_clock::now();
+            if (m_tasks.front().nextRun <= now)
+            {
+                // DEEP COPY to avoid data races
+                TaskItem item = m_tasks.front();
+                m_tasks.pop_front();
+                return item;
+            }
+
+            // Front task not yet due — sleep until its deadline or until interrupted
+            auto deadline = m_tasks.front().nextRun;
+            m_condition.wait_until(lock, deadline);
+        }
     }
 
     /**
@@ -211,17 +224,20 @@ public:
      */
     bool reprioritizeToFront(const std::string& taskName)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = std::find_if(
-            m_tasks.begin(), m_tasks.end(), [&taskName](const TaskItem& item) { return item.name == taskName; });
-        if (it == m_tasks.end())
         {
-            return false;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            auto it = std::find_if(
+                m_tasks.begin(), m_tasks.end(), [&taskName](const TaskItem& item) { return item.name == taskName; });
+            if (it == m_tasks.end())
+            {
+                return false;
+            }
+            TaskItem item = *it;
+            item.nextRun = std::chrono::steady_clock::time_point {};
+            m_tasks.erase(it);
+            m_tasks.push_front(item);
         }
-        TaskItem item = *it;
-        item.nextRun = std::chrono::steady_clock::time_point {};
-        m_tasks.erase(it);
-        m_tasks.push_front(item);
+        m_condition.notify_one(); // wake a worker: epoch task is now at front and immediately due
         return true;
     }
 };

--- a/src/engine/source/scheduler/include/scheduler/scheduler.hpp
+++ b/src/engine/source/scheduler/include/scheduler/scheduler.hpp
@@ -359,10 +359,10 @@ public:
      * @details Creates a new scheduler with the specified number of worker threads.
      *          The scheduler is created in stopped state and must be started explicitly.
      *
-     * @param threads Number of worker threads to create (minimum 1)
-     * @note If threads <= 0, exactly 1 thread will be created
+     * @param threads Number of worker threads to create (minimum 2)
+     * @note If threads <= 0, exactly 2 thread will be created
      */
-    Scheduler(int threads = 1);
+    Scheduler(int threads = 2);
 
     /**
      * @brief Destructor

--- a/src/engine/source/scheduler/interface/scheduler/ischeduler.hpp
+++ b/src/engine/source/scheduler/interface/scheduler/ischeduler.hpp
@@ -15,8 +15,10 @@ namespace scheduler
 struct TaskConfig
 {
     std::size_t interval;               ///< Execution interval in seconds. 0 means run once (one-time task)
+    bool runImmediately;                ///< If true and interval > 0, executes immediately on first schedule,
+                                        ///< then continues with the regular interval cadence.
+                                        ///< Has no effect when interval == 0 (one-time tasks always run immediately).
     int CPUPriority;                    ///< Process nice value for CPU priority. Range: -20 (highest) to 19 (lowest)
-    int timeout;                        ///< Task timeout in seconds. 0 means no timeout (reserved for future use)
     std::function<void()> taskFunction; ///< The callable function/lambda to execute when the task runs
 };
 
@@ -46,8 +48,10 @@ public:
     /**
      * @brief Schedule a new task for execution
      * @details Adds a new task to the scheduler. The task will be executed according
-     *          to its configuration. One-time tasks run immediately, recurring tasks
-     *          are scheduled for their first execution after the specified interval.
+     *          to its configuration. One-time tasks (interval = 0) run immediately.
+     *          Recurring tasks (interval > 0) normally first execute after the
+     *          specified interval, unless runImmediately is true, in which case
+     *          the first execution happens immediately.
      *
      * @param taskName Unique identifier for the task
      * @param config Task configuration including function, interval, and priority
@@ -60,6 +64,26 @@ public:
      * @note This method is thread-safe
      */
     virtual void scheduleTask(std::string_view taskName, TaskConfig&& config) = 0;
+
+    /**
+     * @brief Move an already-registered task to the front of the execution queue.
+     * @details Finds the task by name in the execution queue and reorders it so
+     *          it executes before all other pending tasks. The task must have been
+     *          previously registered via scheduleTask().
+     *
+     *          If the task is currently mid-execution (temporarily out of the queue),
+     *          this is a no-op — the task will reschedule itself normally after finishing.
+     *
+     *          If called multiple times, the last call ends up at position 0
+     *          (each reprioritization uses push_front, so the most recent call wins).
+     *
+     * @param taskName Name of the already-registered task to reprioritize
+     *
+     * @throws std::invalid_argument if no task with taskName is registered
+     *
+     * @note Thread-safe. Works before or after start().
+     */
+    virtual void scheduleTaskFirst(std::string_view taskName) = 0;
 
     /**
      * @brief Remove a scheduled task

--- a/src/engine/source/scheduler/src/scheduler.cpp
+++ b/src/engine/source/scheduler/src/scheduler.cpp
@@ -109,6 +109,27 @@ void Scheduler::scheduleTask(std::string_view taskName, TaskConfig&& config)
     m_taskQueue.push(taskItem);
 }
 
+void Scheduler::scheduleTaskFirst(std::string_view taskName)
+{
+    std::string name(taskName);
+
+    {
+        std::lock_guard<std::mutex> lock(m_tasksMutex);
+        if (m_tasks.find(name) == m_tasks.end())
+        {
+            throw std::invalid_argument("Task with name '" + name + "' is not registered");
+        }
+    }
+
+    if (!m_taskQueue.reprioritizeToFront(name))
+    {
+        LOG_WARNING("[Scheduler] Task '{}' not in queue (mid-execution); skipping reprioritization", name);
+        return;
+    }
+
+    LOG_DEBUG("[Scheduler] Task '{}' moved to front of queue", name);
+}
+
 void Scheduler::removeTask(std::string_view taskName)
 {
     std::lock_guard<std::mutex> lock(m_tasksMutex);

--- a/src/engine/source/scheduler/src/scheduler.cpp
+++ b/src/engine/source/scheduler/src/scheduler.cpp
@@ -171,18 +171,6 @@ void Scheduler::workerThread()
 
         const auto& task = taskItem.value();
 
-        // Check if it's time to execute
-        auto now = std::chrono::steady_clock::now();
-        if (task.nextRun > now)
-        {
-            // Task is not ready yet, put it back
-            m_taskQueue.push(task);
-
-            // Sleep for a short time to avoid busy waiting
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            continue;
-        }
-
         // Check if task still exists in task map (might have been removed)
         {
             std::lock_guard<std::mutex> tasksLock(m_tasksMutex);
@@ -201,14 +189,19 @@ void Scheduler::workerThread()
         // Reschedule if it's a recurring task, otherwise remove it from task map
         if (!task.isOneTime && task.config.interval > 0)
         {
-            LOG_DEBUG("[Scheduler] Rescheduling recurring task '{}'", task.name);
-            // Create updated task with new next run time
-            auto updatedTask = task; // Copy the task
-            // Update next run time manually since TaskItem doesn't have updateNextRun anymore
-            updatedTask.nextRun = std::chrono::steady_clock::now() + std::chrono::seconds(task.config.interval);
-
-            // Add back to queue
-            m_taskQueue.push(updatedTask);
+            bool stillRegistered;
+            {
+                std::lock_guard<std::mutex> tasksLock(m_tasksMutex);
+                stillRegistered = m_tasks.count(task.name) > 0;
+            }
+            if (stillRegistered)
+            {
+                LOG_DEBUG("[Scheduler] Rescheduling recurring task '{}'", task.name);
+                auto updatedTask = task;
+                updatedTask.nextRun = std::chrono::steady_clock::now() + std::chrono::seconds(task.config.interval);
+                m_taskQueue.push(updatedTask);
+            }
+            // else: task was removed while executing — skip re-queue (RC-2 fix)
         }
         else
         {

--- a/src/engine/source/scheduler/src/scheduler.cpp
+++ b/src/engine/source/scheduler/src/scheduler.cpp
@@ -15,7 +15,7 @@ namespace scheduler
 
 Scheduler::Scheduler(int threads)
     : m_running(false)
-    , m_numThreads(std::max(1, threads))
+    , m_numThreads(std::max(2, threads))
 {
 }
 

--- a/src/engine/source/scheduler/test/mocks/scheduler/mockScheduler.hpp
+++ b/src/engine/source/scheduler/test/mocks/scheduler/mockScheduler.hpp
@@ -11,6 +11,7 @@ class MockIScheduler : public ::scheduler::IScheduler
 {
 public:
     MOCK_METHOD(void, scheduleTask, (std::string_view taskName, TaskConfig&& config), (override));
+    MOCK_METHOD(void, scheduleTaskFirst, (std::string_view taskName), (override));
     MOCK_METHOD(void, removeTask, (std::string_view taskName), (override));
     MOCK_METHOD(std::size_t, getActiveTasksCount, (), (const, override));
     MOCK_METHOD(std::size_t, getThreadCount, (), (const, override));

--- a/src/engine/source/scheduler/test/src/component/scheduler_test.cpp
+++ b/src/engine/source/scheduler/test/src/component/scheduler_test.cpp
@@ -54,8 +54,8 @@ TEST_F(SchedulerTest, ScheduleOneTimeTask)
 
     scheduler::TaskConfig config;
     config.interval = 0; // One-time task
+    config.runImmediately = false;
     config.CPUPriority = 10;
-    config.timeout = 0;
     config.taskFunction = [&taskExecuted]()
     {
         taskExecuted.store(true);
@@ -82,8 +82,8 @@ TEST_F(SchedulerTest, ScheduleRecurringTask)
 
     scheduler::TaskConfig config;
     config.interval = 1; // Every 1 second
+    config.runImmediately = false;
     config.CPUPriority = 5;
-    config.timeout = 0;
     config.taskFunction = [&executionCount]()
     {
         executionCount.fetch_add(1);
@@ -103,14 +103,161 @@ TEST_F(SchedulerTest, ScheduleRecurringTask)
     scheduler->stop();
 }
 
+TEST_F(SchedulerTest, RunImmediately_ExecutesOnFirstCycle)
+{
+    std::atomic<int> executionCount {0};
+
+    scheduler::TaskConfig config;
+    config.interval = 5; // 5-second interval — would not fire in test window without flag
+    config.runImmediately = true;
+    config.CPUPriority = 0;
+    config.taskFunction = [&executionCount]()
+    {
+        executionCount.fetch_add(1);
+    };
+
+    scheduler->start();
+    scheduler->scheduleTask("immRecurringTask", std::move(config));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    EXPECT_GE(executionCount.load(), 1);
+
+    scheduler->stop();
+}
+
+TEST_F(SchedulerTest, RunImmediately_ThenRecurresAtInterval)
+{
+    std::atomic<int> executionCount {0};
+
+    scheduler::TaskConfig config;
+    config.interval = 1;
+    config.runImmediately = true;
+    config.CPUPriority = 0;
+    config.taskFunction = [&executionCount]()
+    {
+        executionCount.fetch_add(1);
+    };
+
+    scheduler->start();
+    scheduler->scheduleTask("immRecurringTask2", std::move(config));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    EXPECT_GE(executionCount.load(), 1); // immediate first execution
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    EXPECT_GE(executionCount.load(), 2); // at least one recurrence after interval
+
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 1); // task not removed (not one-time)
+
+    scheduler->stop();
+}
+
+TEST_F(SchedulerTest, RunImmediately_NoEffectOnOneTimeTask)
+{
+    std::atomic<int> executionCount {0};
+
+    scheduler::TaskConfig config;
+    config.interval = 0;
+    config.runImmediately = true;
+    config.CPUPriority = 0;
+    config.taskFunction = [&executionCount]()
+    {
+        executionCount.fetch_add(1);
+    };
+
+    scheduler->start();
+    scheduler->scheduleTask("oneTimeImmediate", std::move(config));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    EXPECT_EQ(executionCount.load(), 1);            // executed exactly once
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0); // removed from map
+
+    scheduler->stop();
+}
+
+TEST_F(SchedulerTest, ScheduleTaskFirst_ExecutesBeforeOtherPendingTasks)
+{
+    std::vector<std::string> executionOrder;
+    std::mutex orderMutex;
+
+    scheduler::TaskConfig regularConfig;
+    regularConfig.interval = 0;
+    regularConfig.runImmediately = false;
+    regularConfig.CPUPriority = 0;
+    regularConfig.taskFunction = [&]()
+    {
+        std::lock_guard<std::mutex> lock(orderMutex);
+        executionOrder.push_back("regular");
+    };
+
+    scheduler::TaskConfig firstConfig;
+    firstConfig.interval = 0;
+    firstConfig.runImmediately = false;
+    firstConfig.CPUPriority = 0;
+    firstConfig.taskFunction = [&]()
+    {
+        std::lock_guard<std::mutex> lock(orderMutex);
+        executionOrder.push_back("first");
+    };
+
+    // Register regular first (earlier nextRun), then priority task
+    scheduler->scheduleTask("regularTask", std::move(regularConfig));
+    scheduler->scheduleTask("priorityTask", std::move(firstConfig));
+    // Reprioritize: "priorityTask" must now execute before "regularTask"
+    scheduler->scheduleTaskFirst("priorityTask");
+
+    scheduler->start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    std::lock_guard<std::mutex> lock(orderMutex);
+    ASSERT_EQ(executionOrder.size(), 2u);
+    EXPECT_EQ(executionOrder[0], "first");
+    EXPECT_EQ(executionOrder[1], "regular");
+}
+
+TEST_F(SchedulerTest, ScheduleTaskFirst_LastCallIsFirst)
+{
+    std::vector<std::string> executionOrder;
+    std::mutex orderMutex;
+
+    auto makeConfig = [&](std::string label)
+    {
+        scheduler::TaskConfig config;
+        config.interval = 0;
+        config.runImmediately = false;
+        config.CPUPriority = 0;
+        config.taskFunction = [&, label = std::move(label)]()
+        {
+            std::lock_guard<std::mutex> lock(orderMutex);
+            executionOrder.push_back(label);
+        };
+        return config;
+    };
+
+    scheduler->scheduleTask("taskA", makeConfig("A"));
+    scheduler->scheduleTask("taskB", makeConfig("B"));
+    scheduler->scheduleTaskFirst("taskA"); // A goes to front
+    scheduler->scheduleTaskFirst("taskB"); // B goes to front, A pushed to position 1
+
+    scheduler->start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    std::lock_guard<std::mutex> lock(orderMutex);
+    ASSERT_EQ(executionOrder.size(), 2u);
+    EXPECT_EQ(executionOrder[0], "B");
+    EXPECT_EQ(executionOrder[1], "A");
+}
+
 TEST_F(SchedulerTest, RemoveTask)
 {
     std::atomic<bool> taskExecuted {false};
 
     scheduler::TaskConfig config;
     config.interval = 2; // Every 2 seconds
+    config.runImmediately = false;
     config.CPUPriority = 10;
-    config.timeout = 0;
     config.taskFunction = [&taskExecuted]()
     {
         taskExecuted.store(true);
@@ -140,18 +287,18 @@ TEST_F(SchedulerTest, MultipleTasks)
     std::atomic<int> task2Count {0};
 
     scheduler::TaskConfig config1;
-    config1.interval = 0;    // One-time
+    config1.interval = 0; // One-time
+    config1.runImmediately = false;
     config1.CPUPriority = 0; // No priority change for testing
-    config1.timeout = 0;
     config1.taskFunction = [&task1Count]()
     {
         task1Count.fetch_add(1);
     };
 
     scheduler::TaskConfig config2;
-    config2.interval = 1;    // Recurring
+    config2.interval = 1; // Recurring
+    config2.runImmediately = false;
     config2.CPUPriority = 0; // No priority change for testing
-    config2.timeout = 0;
     config2.taskFunction = [&task2Count]()
     {
         task2Count.fetch_add(1);
@@ -180,8 +327,8 @@ TEST_F(SchedulerTest, TaskPriority)
     {
         scheduler::TaskConfig config;
         config.interval = 0; // One-time
+        config.runImmediately = false;
         config.CPUPriority = priority;
-        config.timeout = 0;
         config.taskFunction = [&, taskId]()
         {
             {
@@ -223,8 +370,8 @@ TEST_F(SchedulerTest, TaskExecutionOrder)
     {
         scheduler::TaskConfig config;
         config.interval = 0; // One-time
+        config.runImmediately = false;
         config.CPUPriority = 0;
-        config.timeout = 0;
         config.taskFunction = [&, taskName]()
         {
             {
@@ -271,8 +418,8 @@ TEST_F(SchedulerTest, TaskQueueOrdering)
     {
         scheduler::TaskConfig config;
         config.interval = intervalSeconds; // Recurring task
+        config.runImmediately = false;
         config.CPUPriority = 0;
-        config.timeout = 0;
         config.taskFunction = [&, taskName]()
         {
             {

--- a/src/engine/source/scheduler/test/src/component/scheduler_test.cpp
+++ b/src/engine/source/scheduler/test/src/component/scheduler_test.cpp
@@ -453,3 +453,204 @@ TEST_F(SchedulerTest, TaskQueueOrdering)
 
     scheduler->stop();
 }
+
+// --- Input validation ---
+
+TEST_F(SchedulerTest, ScheduleTask_ThrowsOnNullFunction)
+{
+    scheduler::TaskConfig config;
+    config.interval = 1;
+    config.runImmediately = false;
+    config.CPUPriority = 0;
+    config.taskFunction = nullptr;
+
+    EXPECT_THROW(scheduler->scheduleTask("nullTask", std::move(config)), std::invalid_argument);
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0);
+}
+
+TEST_F(SchedulerTest, ScheduleTask_ThrowsOnDuplicateName)
+{
+    auto makeConfig = []()
+    {
+        scheduler::TaskConfig config;
+        config.interval = 60;
+        config.runImmediately = false;
+        config.CPUPriority = 0;
+        config.taskFunction = []() {};
+        return config;
+    };
+
+    scheduler->scheduleTask("duplicate", makeConfig());
+    EXPECT_THROW(scheduler->scheduleTask("duplicate", makeConfig()), std::runtime_error);
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 1);
+}
+
+TEST_F(SchedulerTest, ScheduleTaskFirst_ThrowsOnUnregisteredTask)
+{
+    EXPECT_THROW(scheduler->scheduleTaskFirst("notRegistered"), std::invalid_argument);
+}
+
+TEST_F(SchedulerTest, RemoveTask_NoopForNonExistentTask)
+{
+    EXPECT_NO_THROW(scheduler->removeTask("doesNotExist"));
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0);
+}
+
+// --- Lifecycle ---
+
+TEST_F(SchedulerTest, StartStop_Idempotent)
+{
+    scheduler->start();
+    scheduler->start(); // second call must be a no-op — no extra threads spawned
+    EXPECT_TRUE(scheduler->isRunning());
+
+    // Scheduler must still be functional after double-start
+    std::atomic<bool> executed {false};
+    scheduler::TaskConfig config;
+    config.interval = 0;
+    config.runImmediately = false;
+    config.CPUPriority = 0;
+    config.taskFunction = [&executed]() { executed.store(true); };
+    scheduler->scheduleTask("probe", std::move(config));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_TRUE(executed.load());
+
+    scheduler->stop();
+    scheduler->stop(); // second call must be a no-op — no crash or deadlock
+    EXPECT_FALSE(scheduler->isRunning());
+}
+
+TEST_F(SchedulerTest, TasksClearedAfterStop)
+{
+    scheduler->start();
+
+    for (int i = 0; i < 5; ++i)
+    {
+        scheduler::TaskConfig config;
+        config.interval = 60; // far future — won't execute in test window
+        config.runImmediately = false;
+        config.CPUPriority = 0;
+        config.taskFunction = []() {};
+        scheduler->scheduleTask("task" + std::to_string(i), std::move(config));
+    }
+
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 5);
+    scheduler->stop();
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0);
+}
+
+// --- RC-2 fix: recurring task removed during execution must not re-queue ---
+
+TEST_F(SchedulerTest, RemoveRecurringTask_WhileExecuting_DoesNotReschedule)
+{
+    std::atomic<int> executionCount {0};
+    std::atomic<bool> taskStarted {false};
+    std::atomic<bool> allowFinish {false};
+
+    scheduler::TaskConfig config;
+    config.interval = 1;
+    config.runImmediately = true; // fires immediately so we can catch it mid-execution
+    config.CPUPriority = 0;
+    config.taskFunction = [&]()
+    {
+        executionCount.fetch_add(1);
+        taskStarted.store(true);
+        while (!allowFinish.load())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    };
+
+    scheduler->start();
+    scheduler->scheduleTask("recurringTask", std::move(config));
+
+    // Wait until the task is executing
+    while (!taskStarted.load())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // Remove while task body is still running
+    scheduler->removeTask("recurringTask");
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0);
+
+    // Let the task finish — worker must not re-queue it after execution
+    allowFinish.store(true);
+
+    // Wait well past one interval to confirm no second execution
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+    EXPECT_EQ(executionCount.load(), 1);
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0);
+
+    scheduler->stop();
+}
+
+// --- RC-5 fix: scheduleTaskFirst on a running scheduler must execute promptly ---
+
+TEST_F(SchedulerTest, ScheduleTaskFirst_WhileRunning_ReprioritizesImmediately)
+{
+    std::atomic<bool> executed {false};
+
+    scheduler::TaskConfig config;
+    config.interval = 60; // 60 s interval — would never fire in this test
+    config.runImmediately = false;
+    config.CPUPriority = 0;
+    config.taskFunction = [&executed]() { executed.store(true); };
+
+    scheduler->start();
+    scheduler->scheduleTask("slowTask", std::move(config));
+
+    // Confirm the task has not fired yet (nextRun is 60 s in the future)
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(executed.load());
+
+    // Reprioritize: worker blocked in wait_until must wake and execute immediately
+    scheduler->scheduleTaskFirst("slowTask");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_TRUE(executed.load());
+
+    scheduler->stop();
+}
+
+// --- Thread safety: concurrent schedule + remove from multiple threads ---
+
+TEST_F(SchedulerTest, ConcurrentScheduleRemove_IsThreadSafe)
+{
+    scheduler->start();
+
+    const int taskCount = 20;
+    std::vector<std::thread> threads;
+    threads.reserve(taskCount);
+
+    for (int i = 0; i < taskCount; ++i)
+    {
+        threads.emplace_back(
+            [&, i]()
+            {
+                std::string name = "concTask" + std::to_string(i);
+                scheduler::TaskConfig config;
+                config.interval = 0;
+                config.runImmediately = false;
+                config.CPUPriority = 0;
+                config.taskFunction = []() {};
+                scheduler->scheduleTask(name, std::move(config));
+                // removeTask races with execution — both outcomes are valid
+                scheduler->removeTask(name);
+            });
+    }
+
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    // Allow any in-flight tasks to finish
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Every task either executed (and was auto-removed) or was removed before execution
+    EXPECT_EQ(scheduler->getActiveTasksCount(), 0);
+
+    scheduler->stop();
+}

--- a/src/engine/source/streamlog/src/channel.cpp
+++ b/src/engine/source/streamlog/src/channel.cpp
@@ -850,8 +850,8 @@ scheduler::TaskConfig ChannelHandler::createCompressionTaskConfig(const std::fil
 
     return scheduler::TaskConfig {
         .interval = 0, // One-time task
+        .runImmediately = false,
         .CPUPriority = 0,
-        .timeout = 0,
         .taskFunction = [filePath,
                          gzPath = std::move(gzPath),
                          compressionLevel = m_config.compressionLevel,
@@ -922,9 +922,7 @@ void ChannelHandler::deleteOldFilesStatic(const std::filesystem::path& basePath,
 
     auto statInode = [](const std::filesystem::path& path, ino_t& inode, struct stat* stOut = nullptr) -> bool
     {
-        struct stat st
-        {
-        };
+        struct stat st {};
         if (::stat(path.c_str(), &st) != 0)
         {
             return false;
@@ -978,9 +976,7 @@ void ChannelHandler::deleteOldFilesStatic(const std::filesystem::path& basePath,
 
                 const auto& filePath = entry.path();
 
-                struct stat fileStat
-                {
-                };
+                struct stat fileStat {};
                 ino_t fileInode {};
                 if (!statInode(filePath, fileInode, &fileStat))
                 {

--- a/src/engine/source/streamlog/test/src/unit/channel_test.cpp
+++ b/src/engine/source/streamlog/test/src/unit/channel_test.cpp
@@ -1743,7 +1743,6 @@ TEST_F(ChannelHandlerTest, CompressionWithMockScheduler)
                 // Verify task configuration
                 EXPECT_EQ(config.interval, 0); // One-time task
                 EXPECT_EQ(config.CPUPriority, 0);
-                EXPECT_EQ(config.timeout, 0);
                 EXPECT_NE(config.taskFunction, nullptr);
 
                 // Verify task name format

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -317,27 +317,8 @@ WIndexerConnector::WIndexerConnector(const Config& config,
         throw std::runtime_error("Invalid JSON configuration for IndexerConnector");
     }
 
-    auto inner = std::make_unique<IndexerConnectorAsync>(jsonConfig, "engine-output", logFunction, BASEQUEUEPATH);
-    m_indexerConnectorAsync = std::make_unique<IndexerConnectorAsyncAdapter>(std::move(inner));
-}
-
-WIndexerConnector::WIndexerConnector(std::unique_ptr<IIndexerConnectorAsync> async, const std::size_t maxHitsPerRequest)
-{
-    if (!async)
-    {
-        throw std::runtime_error("IndexerConnectorAsync instance cannot be null");
-    }
-    m_indexerConnectorAsync = std::move(async);
-
-    if (maxHitsPerRequest == 0)
-    {
-        LOG_WARNING("[indexer-connector] maxHitsPerRequest must be greater than zero, default to 1");
-        m_maxHitsPerRequest = 1;
-    }
-    else
-    {
-        m_maxHitsPerRequest = maxHitsPerRequest;
-    }
+    m_indexerConnectorAsync =
+        std::make_unique<IndexerConnectorAsync>(jsonConfig, "engine-output", logFunction, BASEQUEUEPATH);
 }
 
 WIndexerConnector::~WIndexerConnector() = default;

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -317,8 +317,27 @@ WIndexerConnector::WIndexerConnector(const Config& config,
         throw std::runtime_error("Invalid JSON configuration for IndexerConnector");
     }
 
-    m_indexerConnectorAsync =
-        std::make_unique<IndexerConnectorAsync>(jsonConfig, "engine-output", logFunction, BASEQUEUEPATH);
+    auto inner = std::make_unique<IndexerConnectorAsync>(jsonConfig, "engine-output", logFunction, BASEQUEUEPATH);
+    m_indexerConnectorAsync = std::make_unique<IndexerConnectorAsyncAdapter>(std::move(inner));
+}
+
+WIndexerConnector::WIndexerConnector(std::unique_ptr<IIndexerConnectorAsync> async, const std::size_t maxHitsPerRequest)
+{
+    if (!async)
+    {
+        throw std::runtime_error("IndexerConnectorAsync instance cannot be null");
+    }
+    m_indexerConnectorAsync = std::move(async);
+
+    if (maxHitsPerRequest == 0)
+    {
+        LOG_WARNING("[indexer-connector] maxHitsPerRequest must be greater than zero, default to 1");
+        m_maxHitsPerRequest = 1;
+    }
+    else
+    {
+        m_maxHitsPerRequest = maxHitsPerRequest;
+    }
 }
 
 WIndexerConnector::~WIndexerConnector() = default;

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -297,14 +297,14 @@ wait_for_wazuh_engine_ready()
         curl --silent --fail-with-body --unix-socket ${DIR}/queue/sockets/analysis \
             -X POST -H "Content-Type: application/json" \
             -d '{}' \
-            http://localhost/_internal/router/table/get \
+            http://localhost/_internal/event-dumper/status \
             > /dev/null 2>&1
         if [ $? -eq 0 ]; then
             return 0
         fi
 
         if ! kill -0 "$ENGINE_PID" 2>/dev/null; then
-            echo "wazuh-manager-analysisd died during route check."
+            echo "wazuh-manager-analysisd died during event dumper check."
             return 1
         fi
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR implements dynamic scaling for the Engine router worker pool to reduce `wazuh-engine` startup time. Previously, the `Orchestrator` initialized all N router workers synchronously at construction time — each requiring a full environment build from the route table. This blocked the main thread and, critically, held `m_syncMutex` as a `unique_lock` across the entire operation, preventing the `/_internal/router/table/get` readiness endpoint from responding. On a 22-worker deployment with 119 policy assets, this blocked subsequent daemon startup (`remoted`, `monitord`, `modulesd`) for up to **30 seconds** on first boot.

With this change, the engine starts with a **single router worker** and expands the pool asynchronously at runtime via the new `expandWorkerPool()` method, called from the `initial-sync` scheduler task. The readiness endpoint becomes responsive within ~2 seconds, and remaining workers are spawned in the background without interrupting event processing.

Closes #33784

## Proposed Changes

### 1. Dynamic Router Worker Pool (`expandWorkerPool`)

The `Orchestrator` constructor now creates exactly **1 primary router worker**. A new public method `expandWorkerPool()` spawns the remaining N-1 workers one at a time, acquiring and releasing `m_syncMutex` independently for each worker. This allows the readiness endpoint (`getEntries()`, which requires a `shared_lock`) to respond between worker creation iterations.

New internal members added:
- `m_targetWorkerCount` — stores the configured pool size for deferred expansion.
- `m_workerFactory` — `std::function` that encapsulates the worker construction logic, enabling reuse between constructor and `expandWorkerPool()`.

Each new worker receives a snapshot of the current route table via `addEntry()`, ensuring consistency with the primary worker without requiring a global lock for the full duration.

### 2. Deferred Scheduler Start

Previously the scheduler was started immediately after creation, before any tasks were registered. Worker threads would spin on an empty queue via a `sleep_for(100ms)` busy-wait loop during the entire engine initialization phase.

**Now:** The scheduler is created early but `start()` is called only after all tasks (including `initial-sync`) have been registered. This ensures the first task executes immediately when workers begin, and avoids unnecessary CPU usage during init.

### 3. `scheduleTaskFirst` / `reprioritizeToFront` API

New scheduler method that moves an already-registered task to the front of the execution queue. Used to ensure `initial-sync` runs before any periodic tasks (cm-sync, ioc-sync, geo-sync, remote-conf-sync) regardless of registration order. The underlying `TaskQueue::reprioritizeToFront()` notifies the condition variable so a blocked `pop()` wakes immediately.

### 4. `runImmediately` field in `TaskConfig`

New boolean field replacing the removed `timeout` field. When `true` and `interval > 0`, the first execution happens immediately (`nextRun = now()`) instead of waiting one full interval. Has no effect on one-time tasks (which always run immediately).

### 5. Timed `pop()` in `TaskQueue`

Previously, `TaskQueue::pop()` returned tasks immediately even if they weren't due yet. The worker thread would then re-push the task and `sleep_for(100ms)` in a busy-wait loop.

**Now:** `pop()` uses `wait_until(deadline)` to block until the front task is due, eliminating busy-waiting and reducing unnecessary CPU usage. The condition variable is notified when a new earlier task is pushed or when `reprioritizeToFront()` moves a task to the head of the queue.

### 6. Integration in `main.cpp`

The `cm-sync` task now orchestrates the full bootstrap sequence:

```cpp
// 1. Expand worker pool (async, lock released between each worker)
orchestrator->expandWorkerPool();
// 2. Run content-manager synchronization (downloads resources, calls postEntry)
cmSyncService->synchronize();
```

The task is registered with `runImmediately = true` and promoted via `scheduleTaskFirst("initial-sync")` so it executes first when the scheduler starts.


### Results and Evidence

**Before changes (main) 22 worker threads — (from wazuh-manager.log):**
```
2026/05/04 18:37:51 wazuh-manager-analysisd[196610] fileDriver.cpp:94 at readDoc(): DEBUG: FileDriver readDoc name: 'router/router/0'.
2026/05/04 18:37:51 wazuh-manager-analysisd[196610] fileDriver.cpp:94 at readDoc(): DEBUG: FileDriver readDoc name: 'router/tester/0'.
2026/05/04 18:37:51 wazuh-manager-analysisd[196610] orchestrator.cpp:162 at getEntriesFromStore(): DEBUG: Router: router/tester/0 table is empty
2026/05/04 18:37:51 wazuh-manager-analysisd[196610] orchestrator.cpp:353 at Orchestrator(): DEBUG: No thread count provided. Using 22 worker threads based on system hardware.

2026/05/04 18:37:51 wazuh-manager-analysisd[196610] orchestrator.cpp:162 at getEntriesFromStore(): DEBUG: Router: router/tester/0 table is empty
2026/05/04 18:37:51 wazuh-manager-analysisd[196610] orchestrator.cpp:353 at Orchestrator(): DEBUG: No thread count provided. Using 22 worker threads based on system hardware.
2026/05/04 18:38:21 wazuh-manager-authd: WARNING: Duplicate name 'wazuh-agent-4143-rocky8', rejecting enrollment. Agent '001' can't be replaced since it is not disconnected.
2026/05/04 18:38:21 wazuh-manager-authd: WARNING: Duplicate name 'wazuh-agent-50-rocky8', rejecting enrollment. Agent '002' can't be replaced since it is not disconnected.
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 16456167533141653126 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 13956241387966669261 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15860847478402283323 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2974320299331246351 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15096825736212368494 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 12556402053912705567 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15573155093697938675 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 9994152131103360137 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 13551857794182483335 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 8445536528069980529 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 13263475450740260176 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 851612318381742345 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15443022920046461298 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 18139687490881193655 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 6334705144974036123 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 5163400742706183906 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 17757683973831641709 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 5639676193599552667 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 18034477185629496956 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 4446501550609114471 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2834487391414489953 started
2026/05/04 18:38:21 wazuh-manager-analysisd[196610] main.cpp:595 at main(): INFO: Orchestrator initialized and started with event queue size: 131072, events per second: unlimited.
```

- Start time all demons ~35s:
```console
time /var/wazuh-manager/bin/wazuh-manager-control start 
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
/var/wazuh-manager/bin/wazuh-manager-control start  1.82s user 0.43s system 6% cpu 35.363 total
```

**After changes 22 worker threads (first init after install):**
```
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] scheduler.cpp:184 at workerThread(): DEBUG: [Scheduler] Executing task 'cm-sync-task'
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] scheduler.cpp:184 at workerThread(): DEBUG: [Scheduler] Executing task 'ioc-sync-task'
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] iocsync.cpp:434 at synchronize(): DEBUG: [IOC::Sync] Checking for IOC database updates to synchronize
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2717210011061636246 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 1405558098657352873 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 9555766468373536298 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2070071951855153588 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 5013388570609774671 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 16373518891490079185 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 4843002059109048182 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 13834160232988969322 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 10554774686216516584 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2441410314061166317 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 16490209566228817456 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 17639925726070559421 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15928296889083776052 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 11398957371473543662 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 1499122529399317168 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 9933577146444130495 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 16133574343861478102 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2010226201187259323 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 14809192207815372534 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 14231025396640346628 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] cmsync.cpp:414 at synchronize(): DEBUG: [CMSync] Checking for namespace updates to synchronize
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 6683847509493827111 started
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] cmsync.cpp:443 at synchronize(): DEBUG: [CMSync] Synchronizing namespace for space 'standard'
2026/05/05 15:21:24 IndexerConnector[113928] indexerConnectorAsyncImpl.hpp:699 at operator()(): DEBUG: PIT created successfully. PIT ID: g-O6QQEdd2F6dWgtdGhyZWF0aW50ZWwtZW5yaWNobWVudHMWUWhrdnhQWnNSZjJTNnBWdlBZSTdYQQAWdEJOOF84VHVSZEtKcFhUWUs4YktFdwAAAAAAAABCphZtN2EtQjEwV1NfU01lLWhzTmgwdmF3ARZRaGt2eFBac1JmMlM2cFZ2UFlJN1hBAAA=, Creation time: 1777994484822
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] cmsync.cpp:541 at synchronize(): INFO: [CMSync] Changes detected for space 'standard', updating...
2026/05/05 15:21:24 wazuh-manager-analysisd[113928] windexerconnector.cpp:835 at queryByBatches(): DEBUG: [indexer-connector] Processed docs 1
2026/05/05 15:21:24 IndexerConnector[113928] indexerConnectorAsyncImpl.hpp:699 at operator()(): DEBUG: PIT created successfully. PIT ID: g-O6QQUZd2F6dWgtdGhyZWF0aW50ZWwtZmlsdGVycxY5aV95MzFlNVR0YTQ0MHV2MUROQm9BABZ0Qk44XzhUdVJkS0pwWFRZSzhiS0V3AAAAAAAAAEKpFm03YS1CMTBXU19TTWUtaHNOaDB2YXcad2F6dWgtdGhyZWF0aW50ZWwtcG9saWNpZXMWbkdBb3pjRF9RRGFQaWhqNGR6czR3UQAWdEJOOF84VHVSZEtKcFhUWUs4YktFdwAAAAAAAABCrBZtN2EtQjEwV1NfU01lLWhzTmgwdmF3GndhenVoLXRocmVhdGludGVsLWRlY29kZXJzFl9MOHl2NHc0UlN1bHFHU0hnUEVjLWcAFnRCTjhfOFR1UmRLSnBYVFlLOGJLRXcAAAAAAAAAQqgWbTdhLUIxMFdTX1NNZS1oc05oMHZhdxd3YXp1aC10aHJlYXRpbnRlbC1rdmRicxY0TXhreU5uLVNaV3JRbUtYRUdvQTdnABZ0Qk44XzhUdVJkS0pwWFRZSzhiS0V3AAAAAAAAAEKrFm03YS1CMTBXU19TTWUtaHNOaDB2YXced2F6dWgtdGhyZWF0aW50ZWwtaW50ZWdyYXRpb25zFnJJZGw4YUlOVGRXdUQ4d1VZdDJacmcAFnRCTjhfOFR1UmRLSnBYVFlLOGJLRXcAAAAAAAAAQqoWbTdhLUIxMFdTX1NNZS1oc05oMHZhdwUWX0w4eXY0dzRSU3VscUdTSGdQRWMtZwAAFjRNeGt5Tm4tU1pXclFtS1hFR29BN2cAABY5aV95MzFlNVR0YTQ0MHV2MUROQm9BAAAWbkdBb3pjRF9RRGFQaWhqNGR6czR3UQAAFnJJZGw4YUlOVGRXdUQ4d1VZdDJacmcAAA==, Creation time: 1777994484825
2026/05/05 15:21:24 IndexerConnector[113928] indexerConnectorAsyncImpl.hpp:752 at operator()(): DEBUG: PIT successfully deleted. Response: {"pits":[{"successful":true,"pit_id":"g-O6QQEdd2F6dWgtdGhyZWF0aW50ZWwtZW5yaWNobWVudHMWUWhrdnhQWnNSZjJTNnBWdlBZSTdYQQAWdEJOOF84VHVSZEtKcFhUWUs4YktFdwAAAAAAAABCphZtN2EtQjEwV1NfU01lLWhzTmgwdmF3ARZRaGt2eFBac1JmMlM2cFZ2UFlJN1hBAAA="}]}
```

- Start time all demons ~5s:
```console
 time /var/wazuh-manager/bin/wazuh-manager-control start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
/var/wazuh-manager/bin/wazuh-manager-control start  1.97s user 0.33s system 43% cpu 5.308 total
```

**After changes 22 worker threads (with environments):**
```
2026/05/04 18:19:13 wazuh-manager-analysisd[174570] fileDriver.cpp:94 at readDoc(): DEBUG: FileDriver readDoc name: 'router/router/0'.
2026/05/04 18:19:13 wazuh-manager-analysisd[174570] fileDriver.cpp:94 at readDoc(): DEBUG: FileDriver readDoc name: 'router/tester/0'.
2026/05/04 18:19:13 wazuh-manager-analysisd[174570] orchestrator.cpp:162 at getEntriesFromStore(): DEBUG: Router: router/tester/0 table is empty
2026/05/04 18:19:13 wazuh-manager-analysisd[174570] orchestrator.cpp:353 at Orchestrator(): DEBUG: No thread count provided. Using 22 worker threads based on system hardware.
2026/05/04 18:19:16 wazuh-manager-analysisd[174570] orchestrator.cpp:370 at Orchestrator(): DEBUG: Router: 21 additional worker(s) will be started asynchronously.

2026/05/04 18:19:16 wazuh-manager-analysisd[174570] scheduler.cpp:184 at workerThread(): DEBUG: [Scheduler] Executing task 'initial-sync'
2026/05/04 18:19:16 wazuh-manager-analysisd[174570] server.cpp:120 at Server::Server(API services)::before_processing(): DEBUG: Request: POST /_internal/router/table/get '{}'
2026/05/04 18:19:18 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 11038112832429500466 started
2026/05/04 18:19:18 wazuh-manager-analysisd[174570] server.cpp:92 at Server::Server(API services)::after_processing(): DEBUG: Request: POST /_internal/router/table/get '{}' - Response: 200 '{"status":"OK","table":[{"name":"cmsync_standard","namespaceId":"cmsync_standard_e0b7","priority":1,"entry_status":"ENABLED","uptime":2}]}'
2026/05/04 18:19:18 wazuh-manager-remoted: INFO: Started (pid: 174871). Listening on port 1514/TCP (secure).
2026/05/04 18:19:18 wazuh-manager-monitord: INFO: Started (pid: 174901).
2026/05/04 18:19:19 wazuh-manager-modulesd: INFO: Started (pid: 174907).
2026/05/04 18:19:19 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/05/04 18:19:19 wazuh-manager-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/04 18:19:19 wazuh-manager-modulesd:inventory-sync: INFO: Starting inventory_sync module.
2026/05/04 18:19:19 wazuh-manager-modulesd:content_manager: INFO: Starting content_manager module.
2026/05/04 18:19:19 wazuh-manager-modulesd:router: INFO: Starting router module.
2026/05/04 18:19:19 wazuh-manager-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/05/04 18:19:19 wazuh-manager-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2026/05/04 18:19:19 wazuh-manager-modulesd:database: INFO: Module started.
2026/05/04 18:19:19 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/05/04 18:19:19 logger-helper: INFO: InventorySyncFacade started.
2026/05/04 18:19:19 wazuh-manager-modulesd:vulnerability-scanner: WARNING: The local feed database is incomplete at startup: required global maps are missing. Clearing updater state to force a clean rebuild.
2026/05/04 18:19:19 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 't1-vulnerabilities-5_public-vulnerabilities-5' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/05/04 18:19:19 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/05/04 18:19:19 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/05/04 18:19:19 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/05/04 18:19:21 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2570584368286509811 started
2026/05/04 18:19:25 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 8399508417308804435 started
2026/05/04 18:19:28 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 267885441517771145 started
2026/05/04 18:19:28 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/05/04 18:19:32 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 10528241009539796802 started
2026/05/04 18:19:35 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 12006503247534961897 started
2026/05/04 18:19:38 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 4759233430536923306 started
2026/05/04 18:19:41 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 5696980847994414692 started
2026/05/04 18:19:42 :router: ERROR: Agent ID spoofing detected! Authenticated agent '002' claimed to be '001'. Connection rejected.
2026/05/04 18:19:42 wazuh-manager-analysisd[174570] server.cpp:105 at Server::Server(Event services)::set_logger(): DEBUG: [Server] Event services request received
2026/05/04 18:19:44 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15792050394637634267 started
2026/05/04 18:19:48 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 11847266149461480802 started
2026/05/04 18:19:51 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 1466073616065343686 started
2026/05/04 18:19:55 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2932968197985428114 started
2026/05/04 18:19:58 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 2910804231857551618 started
2026/05/04 18:20:02 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 17946052510698092192 started
2026/05/04 18:20:05 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 10294691055542005393 started
2026/05/04 18:20:08 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 3049640272286053690 started
2026/05/04 18:20:11 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 8267243229191206357 started
2026/05/04 18:20:13 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 9312323266999690255 started
2026/05/04 18:20:16 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 4282456936196934639 started
2026/05/04 18:20:18 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 10417466854803132898 started
2026/05/04 18:20:21 wazuh-manager-analysisd[174570] cmsync.cpp:414 at synchronize(): DEBUG: [CMSync] Checking for namespace updates to synchronize
2026/05/04 18:20:21 wazuh-manager-analysisd[174570] cmsync.cpp:443 at synchronize(): DEBUG: [CMSync] Synchronizing namespace for space 'standard'
2026/05/04 18:20:21 wazuh-manager-analysisd[174570] worker.cpp:36 at start::<lambda>routerWorkerThread(): DEBUG: Router Worker 15168129140323948625 started

2026/05/04 18:22:08 wazuh-manager-analysisd[174570] scheduler.cpp:211 at workerThread(): DEBUG: [Scheduler] Removed one-time task 'initial-sync' after execution
```

- Start time all demons ~8s:
```console
 time /var/wazuh-manager/bin/wazuh-manager-control start  
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
/var/wazuh-manager/bin/wazuh-manager-control start  1.96s user 0.32s system 27% cpu 8.265 total
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows (N/A — engine is Linux-only)
  - [ ] MAC OS X (N/A — engine is Linux-only)
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity (N/A)
  - [ ] UMDH (N/A)
- Memory tests for macOS
  - [ ] Leaks (N/A)
  - [ ] AddressSanitizer (N/A)

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" (N/A)
  - [ ] `runtests.py` executed without errors (N/A)

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine

- Wazuh server API/Framework
  - [ ] Run API Integration Tests (N/A)

### Artifacts Affected

- `wazuh-manager-analysisd` (engine binary)
- No configuration file changes
- No package changes

### Configuration Changes

N/A — No user-visible configuration changes. The `timeout` field was removed from `TaskConfig` (internal API) and replaced by `runImmediately`. All existing consumers have been updated.

### Tests Introduced

**Orchestrator — `ExpansionTest` suite** (`orchestrator_test.cpp`):

| Test | Description |
|------|-------------|
| `expandsPoolToTarget` | Expands from 1 to the configured target size, verifies final worker count |
| `noopWhenAlreadyAtTarget` | No-op when pool already equals target (no extra workers created) |
| `buildFailurePreservesPool` | Worker build throws exception → existing pool intact, no partial state |
| `allWorkersReceiveConsistentEntries` | New workers receive the current route table snapshot via `addEntry()` |
| `shutdownPreventsExpansion` | Shutdown flag set before call → expansion aborts immediately |
| `enableEntryFailureStillPublishesWorker` | `enableEntry()` failure does not discard the newly created worker |
| `startThrowingPreservesPool` | Worker `start()` throws → existing pool preserved |
| `emptyPoolNoopWithWarning` | Empty pool (no primary) → logs warning, no crash |
| `shutdownDuringBuildPreventsPublish` | Shutdown flag set mid-iteration → stops adding workers |

**Scheduler component tests** (`scheduler_test.cpp`):

| Test | Description |
|------|-------------|
| `RunImmediately_ExecutesOnFirstCycle` | `runImmediately=true` fires before one full interval elapses |
| `RunImmediately_ThenRecurresAtInterval` | Immediate first fire, then normal recurring cadence, task not removed |
| `RunImmediately_NoEffectOnOneTimeTask` | `runImmediately=true` on one-time: runs once, removed, no double execution |
| `ScheduleTaskFirst_ExecutesBeforeOtherPendingTasks` | Task promoted via `scheduleTaskFirst` runs before previously registered one-time task |
| `ScheduleTaskFirst_LastCallIsFirst` | Second `scheduleTaskFirst` call executes before the first |
| `ScheduleTask_ThrowsOnNullFunction` | Null function validation |
| `ScheduleTask_ThrowsOnDuplicateName` | Duplicate name validation |
| `ScheduleTaskFirst_ThrowsOnUnregisteredTask` | Unregistered task validation |
| `RemoveTask_NoopForNonExistentTask` | No-op for missing tasks |
| `StartStop_Idempotent` | Double start/stop safety |
| `TasksClearedAfterStop` | Tasks removed on shutdown |
| `RemoveRecurringTask_WhileExecuting_DoesNotReschedule` | Recurring task removed during execution is not re-queued |
| `ScheduleTaskFirst_WhileRunning_ReprioritizesImmediately` | Reprioritization wakes blocked `pop()` immediately |
| `ConcurrentScheduleRemove_IsThreadSafe` | 20 threads concurrently scheduling and removing tasks |

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes (README.md updated for scheduler and router)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
