### PR TITLE
Add workflow_dispatch to engine unit and integration tests

### DIFF
--- a/.github/workflows/5_testintegration_engine.yml
+++ b/.github/workflows/5_testintegration_engine.yml
@@ -5,6 +5,7 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/5_testunit_engine.yml
+++ b/.github/workflows/5_testunit_engine.yml
@@ -5,6 +5,7 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds workflow_dispatch trigger to 5_testunit_engine.yml so the workflow can be triggered manually via gh CLI or GitHub UI, in addition to pull_request events.

## Evidence
- Integration test
  - https://github.com/wazuh/wazuh/actions/runs/25396715839
- Unit test
  - https://github.com/wazuh/wazuh/actions/runs/25392855395