### PR TITLE
Update trojan signatures to avoid false positives on modern distros

### DIFF
--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -26,14 +26,14 @@ cat         !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh!
 bash        !proc\.h|/dev/[0-9]|/dev/[hijkz]!
 sh          !proc\.h|/dev/[0-9]|/dev/[hijkz]!
 uname       !bash|^/bin/sh|file\.h|proc\.h|^/bin/.*sh!
-date        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cln]|^/bin/.*sh!
+date        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
 du          !w0rm|/prof|file\.h!
 df          !bash|^/bin/sh|file\.h|proc\.h|/dev/[^clurdv]|^/bin/.*sh!
 login       !elite|SucKIT|xlogin|vejeta|porcao|lets_log|sukasuk!
-passwd      !bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[b-s,uvxz]!
+passwd      !bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[b-mo-s,uvxz]!
 mingetty    !bash|Dimensioni|pacchetto!
-chfn        !bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-s,uvxz]!
-chsh        !bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-s,uvxz]!
+chfn        !file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-mo-s,uvxz]!
+chsh        !file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-mo-s,uvxz]!
 mail        !bash|file\.h|proc\.h|/dev/[^nu]!
 su          !/dev/[d-s,abuvxz]|/dev/[A-D]|/dev/[F-Z]|/dev/[0-9]|satori|vejeta|conf\.inv!
 sudo        !satori|vejeta|conf\.inv!
@@ -41,7 +41,7 @@ crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
 diff        !bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh!
-md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
+md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!
 


### PR DESCRIPTION
## Description

False positives on _"Trojaned version of file detected."_ (rule 510) triggered on several modern distributions due to signatures matching legitimate strings present in current binary builds.

Closes #32142

## Proposed Changes

Minimal signature adjustments in `ruleset/rootcheck/db/rootkit_trojans.txt`:

| Binary | Distro | Root cause | Change |
|--------|--------|-----------|--------|
| `chsh`, `chfn` | Debian 13 (Trixie) | Modern `shadow` binaries contain the string `bash` (e.g. `BASH_ENV=` from PAM) | Removed `bash\|` from signature |
| `chsh`, `chfn` | Ubuntu 26.04 | `/dev/null` matched `[a-s,uvxz]` because `n` ∈ [a–s] | `[a-s,uvxz]` → `[a-mo-s,uvxz]` |
| `passwd` | Arch Linux, Ubuntu 26.04 | `/dev/null` matched `[b-s,uvxz]` because `n` ∈ [b–s] | `[b-s,uvxz]` → `[b-mo-s,uvxz]` |
| `date`, `md5sum` | Ubuntu 26.04 | Symlinks to a uutils-coreutils Rust multicall binary that legitimately embeds `/dev/urandom`, `/dev/random`, `/dev/stdout`, `/dev/stdin`, `/dev/tty`, `/dev/fd`, etc. | Widened negated character class: `[^cln]` / bare `/dev/` → `[^cfhlnrstuw]` |

Real trojan indicators (`/dev/kmem`, `/dev/mem`, `/dev/ptyXX`, `/dev/ttyo`, etc.) are unaffected — their leading characters (`k`, `m`, `p`, `o`, …) are not in the excluded set.

## Manual Tests with Their Corresponding Evidence

Tests run on **Incus containers** (Debian 13 Trixie, Arch Linux, Ubuntu 26.04 Resolute).

### Methodology

Each binary was inspected with `strings` and the output was matched against both the **old** and **new** signature using `grep -P`. An empty result means no match → no alert.

### Debian 13 — `/usr/bin/chsh`

Signature: `!bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-mo-s,uvxz]!`

```
# Old signature — MATCH (false positive)
$ strings /usr/bin/chsh | grep -P "bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-s,uvxz]"
BASH_ENV=

# New signature — NO MATCH ✅
$ strings /usr/bin/chsh | grep -P "file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-mo-s,uvxz]"
(no output)
```

### Arch Linux — `/usr/bin/passwd`

Signature: `!bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[b-mo-s,uvxz]!`

```
# Old signature — MATCH (false positive)
$ strings /usr/bin/passwd | grep -P "bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[b-s,uvxz]"
/dev/null

# New signature — NO MATCH ✅
$ strings /usr/bin/passwd | grep -P "bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[b-mo-s,uvxz]"
(no output)
```

### Ubuntu 26.04 — `/usr/bin/passwd`, `/usr/bin/chfn`, `/usr/bin/chsh`

Same `/dev/null` → `n` in range issue, resolved with `[a-mo-s,uvxz]` / `[b-mo-s,uvxz]`.

```
# New signatures — NO MATCH on all three ✅
$ strings /usr/bin/passwd | grep -P "bash|file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[b-mo-s,uvxz]"
(no output)
$ strings /usr/bin/chfn  | grep -P "file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-mo-s,uvxz]"
(no output)
$ strings /usr/bin/chsh  | grep -P "file\.h|proc\.h|/dev/ttyo|/dev/[A-Z]|/dev/[a-mo-s,uvxz]"
(no output)
```

### Ubuntu 26.04 — `/usr/bin/date` and `/usr/bin/md5sum` (uutils multicall)

Both are symlinks to `/usr/lib/cargo/bin/coreutils/date` (uutils-coreutils 0.8.0, Rust).

```
# Old signature for date — MATCH (false positive)
$ strings /usr/lib/cargo/bin/coreutils/date | grep -P "/dev/[^cln]" | grep -oP "/dev/." | sort -u
/dev/f
/dev/r
/dev/s
/dev/t
/dev/u
/dev/w

# New signature for date — NO MATCH ✅
$ strings /usr/lib/cargo/bin/coreutils/date | grep -P "/dev/[^cfhlnrstuw]" | grep -oP "/dev/." | sort -u
(no output)

# Old signature for md5sum — MATCH (false positive, bare /dev/)
# New signature for md5sum — NO MATCH ✅
$ strings /usr/lib/cargo/bin/coreutils/md5sum | grep -P "/dev/[^cfhlnrstuw]"
(no output)
```

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (manual validation on all affected distros)
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues