### PR TITLE
Defer engine sync while indexer is updating

### DIFF
--- a/src/engine/ruleset/schemas/engine-schema.json
+++ b/src/engine/ruleset/schemas/engine-schema.json
@@ -4369,7 +4369,7 @@
       "type": "keyword"
     },
     "threat.indicator.confidence": {
-      "type": "keyword"
+      "type": "short"
     },
     "threat.indicator.description": {
       "type": "keyword"
@@ -6439,7 +6439,7 @@
       "type": "keyword"
     },
     "wazuh.threat.indicator.confidence": {
-      "type": "keyword"
+      "type": "short"
     },
     "wazuh.threat.indicator.description": {
       "type": "keyword"

--- a/src/engine/ruleset/schemas/wazuh-decoders.json
+++ b/src/engine/ruleset/schemas/wazuh-decoders.json
@@ -9659,8 +9659,10 @@
           ]
         },
         "threat.indicator.confidence": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nIdentifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.",
+          "description": "Module: ecs\nIndexerType: short\n\nIndicator confidence rating.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
+            "number",
             "string"
           ]
         },
@@ -14099,8 +14101,10 @@
           ]
         },
         "wazuh.threat.indicator.confidence": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nIdentifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.",
+          "description": "Module: ecs\nIndexerType: short\n\nIndicator confidence rating.",
+          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "type": [
+            "number",
             "string"
           ]
         },

--- a/src/engine/source/cmsync/README.md
+++ b/src/engine/source/cmsync/README.md
@@ -47,6 +47,23 @@ The module persists its own state (which spaces are tracked and their current na
 
 ## Key Concepts
 
+### Consumer Validation for Consistency
+
+To prevent partial policy downloads when the wazuh-indexer is mid-update, `CMSync` implements **consumer validation via Point-In-Time (PIT)**:
+
+1. **Hash check phase**: `getPolicyHashAndEnabledFromRemote()` passes `STANDARD_RULESET_CONSUMER_ID` to the indexer connector.
+   - The connector creates a multi-index PIT (policy indices + `.wazuh-cti-consumers`).
+   - It validates the consumer is in the `idle` status within that PIT snapshot.
+   - If idle: returns the hash and enabled status (and the check is consistent).
+   - If not idle: returns `std::nullopt` → sync cycle is skipped.
+
+2. **Download phase**: `downloadAndEnrichNamespace()` → `downloadNamespace()` calls `getPolicy()` with the same consumer ID.
+   - The connector again validates the consumer is idle within a NEW PIT snapshot.
+   - If idle: retrieves full policy resources within that PIT.
+   - If not idle: returns `std::nullopt` → download is skipped, partial namespace is rolled back.
+
+This two-phase validation ensures the indexer is NOT actively updating policy/decoder/KVDB assets before or during the download.
+
 ### Synchronization Lifecycle
 
 The `synchronize()` method iterates through all tracked spaces and handles four cases:
@@ -74,9 +91,10 @@ An internal class (defined in `cmsync.cpp`) that tracks the state of a single sy
 
 ### Download and Enrich
 
-`downloadAndEnrichNamespace()` performs a two-phase operation:
+`downloadAndEnrichNamespace()` performs a two-phase operation with consumer validation:
 
-1. **Download** — fetches KVDBs, decoders, integrations, and the policy from the wazuh-indexer via `wiconnector::getPolicy()`, then imports them into a new namespace via `cmcrud::importNamespace()` with `softValidation = true`.
+1. **Download** — fetches KVDBs, decoders, integrations, and the policy from the wazuh-indexer via `wiconnector::getPolicy(consumerIdToValidate=STANDARD_RULESET_CONSUMER_ID)`, then imports them into a new namespace via `cmcrud::importNamespace()` with `softValidation = true`.
+   - If the consumer is not idle (returns `std::nullopt`), download is skipped and `std::nullopt` is returned (sync cycle aborts gracefully).
 2. **Enrich** — placeholder for adding local-only assets (outputs, default filters) that don't come from the indexer.
 
 The target namespace gets a unique random ID (`cmsync_<space>_<hex4>`) to avoid collisions. On failure the namespace is rolled back.
@@ -206,8 +224,8 @@ for each SyncedNamespace in m_namespacesState:
 | Method | Purpose |
 |---|---|
 | `existSpaceInRemote(space)` | Checks policy existence in indexer with retry |
-| `downloadNamespace(origin, dst)` | Downloads policy resources and imports into namespace via `cmcrud::importNamespace()` |
-| `getPolicyHashAndEnabledFromRemote(space)` | Gets SHA-256 hash and enabled flag with retry |
+| `downloadNamespace(origin, dst)` | Downloads policy resources via `getPolicy(consumerIdToValidate)` and imports into namespace. Returns `bool` (false if consumer not idle). |
+| `getPolicyHashAndEnabledFromRemote(space)` | Gets SHA-256 hash and enabled flag with retry, passing consumer validation. Returns `std::optional` (nullopt if consumer not idle). |
 | `downloadAndEnrichNamespace(origin)` | Generates unique NS ID, downloads, enriches (placeholder), returns NS ID |
 | `syncNamespaceInRoute(nsState, newNsId)` | Hot-swaps or creates router route |
 | `addSpaceToSync(space)` | Adds a space to the tracked list |

--- a/src/engine/source/cmsync/include/cmsync/cmsync.hpp
+++ b/src/engine/source/cmsync/include/cmsync/cmsync.hpp
@@ -50,18 +50,26 @@ private:
      *
      * @param originSpace Define the source space in the indexer
      * @param dstNamespace Define the destination namespace in the local store (Must not exist)
+     * @param consumerId Optional consumer ID to validate during policy retrieval
+     * @return true if the download succeeded, false if consumer is not idle
      * @throws std::runtime_error on errors.
      */
-    void downloadNamespace(std::string_view originSpace, const cm::store::NamespaceId& dstNamespace);
+    bool downloadNamespace(std::string_view originSpace,
+                           const cm::store::NamespaceId& dstNamespace,
+                           const std::optional<std::string_view>& consumerId = std::nullopt);
 
     /**
      * @brief Get remote policy hash and enabled status from the indexer
      *
      * @param space Space name in the indexer
-     * @return A pair containing the policy hash as a string and a boolean indicating if the policy is enabled
+     * @param consumerId Optional consumer ID to validate within PIT
+     * @return An optional pair containing the policy hash and enabled status.
+     *         Returns std::nullopt if the consumer is provided and is not idle.
      * @throws std::runtime_error on errors.
      */
-    std::pair<std::string, bool> getPolicyHashAndEnabledFromRemote(std::string_view space);
+    std::optional<std::pair<std::string, bool>>
+    getPolicyHashAndEnabledFromRemote(std::string_view space,
+                                      const std::optional<std::string_view>& consumerId = std::nullopt);
 
     /**
      * @brief Downloads a namespace from the indexer and enriches it with local assets
@@ -74,13 +82,16 @@ private:
      * automatic rollback on failure, ensuring the local store remains consistent.
      *
      * @param originSpace The source space name in the wazuh-indexer to download from
-     * @return cm::store::NamespaceId The newly created namespace ID in the local store,
+     * @param consumerId Optional consumer ID to validate during policy retrieval
+     * @return An optional NamespaceId. Returns std::nullopt if consumer is provided and not idle.
      * @throws std::runtime_error if any step of the process fails
      * @warning There is no ganrantee that the returned namespace is valid, should be verified by the router.
      * @note If the operation fails at any point, the temporary namespace is automatically deleted
      *       to maintain store consistency
      */
-    cm::store::NamespaceId downloadAndEnrichNamespace(std::string_view originSpace);
+    std::optional<cm::store::NamespaceId>
+    downloadAndEnrichNamespace(std::string_view originSpace,
+                               const std::optional<std::string_view>& consumerId = std::nullopt);
 
     /**
      * @brief Syncs a namespace in the router by updating or creating its route

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -504,7 +504,8 @@ void CMSync::synchronize()
             const auto hashResult = getPolicyHashAndEnabledFromRemote(nsState.getOriginSpace(), consumerIdOpt);
             if (!hashResult.has_value())
             {
-                LOG_INFO("[CMSync] Synchronization skipped for space '{}' because consumer '{}' is not idle",
+                LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer is updating the policy "
+                         "or consumer is not idle (consumer ID: '{}')",
                          nsState.getOriginSpace(),
                          nsState.getConsumerId().value_or("unknown"));
                 continue;

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -17,6 +17,7 @@ namespace
 const base::Name STORE_NAME_CMSYNC {"cmsync/status/0"};          ///< Name of the internal store document
 const cm::store::NamespaceId DUMMY_NAMESPACE_ID {"dummy_ns_id"}; ///< Dummy namespace ID
 constexpr std::string_view COMPONENT_NAME = "CMSync";            ///< Component name for logging
+constexpr std::string_view STANDARD_SPACE_NAME = "standard";     ///< Standard space name
 
 /**
  * @brief Generate a random namespace ID for the given origin space
@@ -40,12 +41,14 @@ namespace cm::sync
 class SyncedNamespace
 {
 private:
-    std::string m_originSpace;     ///< Origin space in the indexer
-    std::string m_routeName;       ///< Route name in the router
-    cm::store::NamespaceId m_nsId; ///< Destination namespace ID in the local store
+    std::string m_originSpace;               ///< Origin space in the indexer
+    std::string m_routeName;                 ///< Route name in the router
+    cm::store::NamespaceId m_nsId;           ///< Destination namespace ID in the local store
+    std::optional<std::string> m_consumerId; ///< Optional CTI consumer doc ID to validate during sync
 
     static constexpr std::string_view JPATH_ORIGIN = "/origin_space";       ///< JSON path for origin space
     static constexpr std::string_view JPATH_NAMESPACE_ID = "/namespace_id"; ///< JSON path for namespace ID
+    static constexpr std::string_view JPATH_CONSUMER_ID = "/consumer_id";   ///< JSON path for consumer ID
 
     /**
      * @brief Generate a route name for the given origin space
@@ -64,11 +67,13 @@ public:
      * This constructor is used to create a dummy SyncedNamespace with only the origin space, used when adding a new
      * space to sync before the first synchronization.
      * @param originSpace Origin space name
+     * @param consumerId Optional consumer document ID for CTI validation
      */
-    explicit SyncedNamespace(std::string_view originSpace)
+    explicit SyncedNamespace(std::string_view originSpace, std::optional<std::string> consumerId = std::nullopt)
         : m_originSpace(originSpace)
         , m_routeName(generateRouteName(originSpace))
         , m_nsId(DUMMY_NAMESPACE_ID)
+        , m_consumerId(std::move(consumerId))
     {
     }
 
@@ -77,11 +82,15 @@ public:
      *
      * @param originSpace Origin space name
      * @param nsId Destination namespace ID in the local store
+     * @param consumerId Optional consumer document ID for CTI validation
      */
-    SyncedNamespace(std::string_view originSpace, cm::store::NamespaceId nsId)
+    SyncedNamespace(std::string_view originSpace,
+                    cm::store::NamespaceId nsId,
+                    std::optional<std::string> consumerId = std::nullopt)
         : m_originSpace(originSpace)
         , m_routeName(generateRouteName(originSpace))
         , m_nsId(std::move(nsId))
+        , m_consumerId(std::move(consumerId))
     {
     }
 
@@ -89,7 +98,9 @@ public:
     const std::string& getOriginSpace() const { return m_originSpace; }
     const cm::store::NamespaceId& getNamespaceId() const { return m_nsId; }
     const std::string& getRouteName() const { return m_routeName; }
+    const std::optional<std::string>& getConsumerId() const { return m_consumerId; }
     void setNamespaceId(const cm::store::NamespaceId& nsId) { m_nsId = nsId; }
+    void setConsumerId(const std::optional<std::string>& consumerId) { m_consumerId = consumerId; }
 
     /**
      * @brief Serialize the SyncedNamespace to a JSON object
@@ -101,6 +112,10 @@ public:
         json::Json j {};
         j.setString(m_originSpace, JPATH_ORIGIN);
         j.setString(m_nsId.toStr(), JPATH_NAMESPACE_ID);
+        if (m_consumerId.has_value())
+        {
+            j.setString(*m_consumerId, JPATH_CONSUMER_ID);
+        }
         return j;
     }
 
@@ -125,7 +140,14 @@ public:
             throw std::runtime_error("NsSyncState::fromJson: Missing namespace_id field");
         }
 
-        return {origin, cm::store::NamespaceId(nsId)};
+        std::optional<std::string> consumerId = std::nullopt;
+        std::string consumerIdStr;
+        if (j.getString(consumerIdStr, JPATH_CONSUMER_ID) == json::RetGet::Success && !consumerIdStr.empty())
+        {
+            consumerId = std::move(consumerIdStr);
+        }
+
+        return {origin, cm::store::NamespaceId(nsId), std::move(consumerId)};
     }
 };
 
@@ -153,7 +175,8 @@ CMSync::CMSync(const std::shared_ptr<wiconnector::IWIndexerConnector>& indexerPt
     LOG_DEBUG("[CMSync] First setup detected, initializing default sync spaces");
 
     // Populate directly and dump once to avoid multiple unnecessary store writes
-    m_namespacesState.emplace_back("standard");
+    m_namespacesState.emplace_back("standard",
+                                   std::optional<std::string>(std::string(wiconnector::STANDARD_RULESET_CONSUMER_ID)));
     m_namespacesState.emplace_back("custom");
     dumpStateToStore();
 }
@@ -172,29 +195,37 @@ bool CMSync::existSpaceInRemote(std::string_view space)
                                          m_shutdownRequested);
 }
 
-void CMSync::downloadNamespace(std::string_view originSpace, const cm::store::NamespaceId& dstNamespace)
+bool CMSync::downloadNamespace(std::string_view originSpace,
+                               const cm::store::NamespaceId& dstNamespace,
+                               const std::optional<std::string_view>& consumerId)
 {
     auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
     auto cmcrudPtr = base::utils::lockWeakPtr(m_cmcrudPtr, "CMCrudService");
 
-    // Download policy from wazuh-indexer
-    auto policyResource =
-        base::utils::executeWithRetry([&indexerPtr, originSpace]() { return indexerPtr->getPolicy(originSpace); },
-                                      fmt::format("{}::downloadNamespace()", COMPONENT_NAME),
-                                      fmt::format("Download '{}' space from wazuh-indexer", originSpace),
-                                      m_attempts,
-                                      m_waitSeconds,
-                                      m_shutdownRequested);
+    // Download policy from wazuh-indexer (with optional consumer validation in PIT)
+    auto policyResource = base::utils::executeWithRetry(
+        [&indexerPtr, originSpace, &consumerId]() { return indexerPtr->getPolicy(originSpace, consumerId); },
+        fmt::format("{}::downloadNamespace()", COMPONENT_NAME),
+        fmt::format("Download '{}' space from wazuh-indexer", originSpace),
+        m_attempts,
+        m_waitSeconds,
+        m_shutdownRequested);
+
+    // If consumer is not idle, getPolicy returns nullopt
+    if (!policyResource.has_value())
+    {
+        return false;
+    }
 
     // Create destNamespace
     try
     {
         cmcrudPtr->importNamespace(dstNamespace,
-                                   policyResource.kvdbs,
-                                   policyResource.decoders,
-                                   policyResource.filters,
-                                   policyResource.integration,
-                                   policyResource.policy,
+                                   policyResource->kvdbs,
+                                   policyResource->decoders,
+                                   policyResource->filters,
+                                   policyResource->integration,
+                                   policyResource->policy,
                                    /*softValidation=*/true);
     }
     catch (const std::exception& e)
@@ -212,14 +243,17 @@ void CMSync::downloadNamespace(std::string_view originSpace, const cm::store::Na
         throw std::runtime_error(
             fmt::format("Failed to store resources in namespace '{}': {}", dstNamespace.toStr(), e.what()));
     }
+
+    return true;
 }
 
-std::pair<std::string, bool> CMSync::getPolicyHashAndEnabledFromRemote(std::string_view space)
+std::optional<std::pair<std::string, bool>>
+CMSync::getPolicyHashAndEnabledFromRemote(std::string_view space, const std::optional<std::string_view>& consumerId)
 {
     auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "Indexer Connector");
 
     return base::utils::executeWithRetry(
-        [&indexerPtr, space]() { return indexerPtr->getPolicyHashAndEnabled(space); },
+        [&indexerPtr, space, &consumerId]() { return indexerPtr->getPolicyHashAndEnabled(space, consumerId); },
         fmt::format("{}::getInfoFromRemote()", COMPONENT_NAME),
         fmt::format("Get policy hash and enabled status for '{}' space from wazuh-indexer", space),
         m_attempts,
@@ -227,7 +261,8 @@ std::pair<std::string, bool> CMSync::getPolicyHashAndEnabledFromRemote(std::stri
         m_shutdownRequested);
 }
 
-cm::store::NamespaceId CMSync::downloadAndEnrichNamespace(std::string_view originSpace)
+std::optional<cm::store::NamespaceId>
+CMSync::downloadAndEnrichNamespace(std::string_view originSpace, const std::optional<std::string_view>& consumerId)
 {
 
     auto cmcrudPtr = base::utils::lockWeakPtr(m_cmcrudPtr, "CMCrud Service");
@@ -243,7 +278,10 @@ cm::store::NamespaceId CMSync::downloadAndEnrichNamespace(std::string_view origi
         return tempNsId;
     }();
 
-    downloadNamespace(originSpace, newNs);
+    if (!downloadNamespace(originSpace, newNs, consumerId))
+    {
+        return std::nullopt; // Consumer not idle
+    }
 
     // Enrich the namespace with local-only assets
     /*
@@ -449,14 +487,29 @@ void CMSync::synchronize()
                 continue;
             }
 
-            // Get remote policy hash and enabled status
+            // Get remote policy hash and enabled status (with consumer validation in PIT if configured)
             if (m_shutdownRequested.load(std::memory_order_relaxed))
             {
                 LOG_INFO("[CMSync] Synchronization aborted before getting policy info for space '{}'",
                          nsState.getOriginSpace());
                 return;
             }
-            const auto [remoteHash, remoteEnabled] = getPolicyHashAndEnabledFromRemote(nsState.getOriginSpace());
+
+            std::optional<std::string_view> consumerIdOpt = std::nullopt;
+            if (nsState.getConsumerId().has_value())
+            {
+                consumerIdOpt = *nsState.getConsumerId();
+            }
+
+            const auto hashResult = getPolicyHashAndEnabledFromRemote(nsState.getOriginSpace(), consumerIdOpt);
+            if (!hashResult.has_value())
+            {
+                LOG_INFO("[CMSync] Synchronization skipped for space '{}' because consumer '{}' is not idle",
+                         nsState.getOriginSpace(),
+                         nsState.getConsumerId().value_or("unknown"));
+                continue;
+            }
+            const auto& [remoteHash, remoteEnabled] = *hashResult;
 
             // Check the current route/ns configuration to avoid unnecessary synchronization.
             const auto routeConfig = [&]() -> std::optional<std::tuple<bool, cm::store::NamespaceId, std::string>>
@@ -548,8 +601,15 @@ void CMSync::synchronize()
                 return;
             }
 
-            // Download and enrich the namespace
-            const auto newNsId = downloadAndEnrichNamespace(nsState.getOriginSpace());
+            // Download and enrich the namespace (consumer validated again within PIT)
+            const auto newNsIdOpt = downloadAndEnrichNamespace(nsState.getOriginSpace(), consumerIdOpt);
+            if (!newNsIdOpt.has_value())
+            {
+                LOG_INFO("[CMSync] Download skipped for space '{}' because consumer is not idle",
+                         nsState.getOriginSpace());
+                continue;
+            }
+            const auto& newNsId = *newNsIdOpt;
 
             // Sync the namespace in the router
             try

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -175,7 +175,7 @@ CMSync::CMSync(const std::shared_ptr<wiconnector::IWIndexerConnector>& indexerPt
     LOG_DEBUG("[CMSync] First setup detected, initializing default sync spaces");
 
     // Populate directly and dump once to avoid multiple unnecessary store writes
-    m_namespacesState.emplace_back("standard",
+    m_namespacesState.emplace_back(STANDARD_SPACE_NAME,
                                    std::optional<std::string>(std::string(wiconnector::STANDARD_RULESET_CONSUMER_ID)));
     m_namespacesState.emplace_back("custom");
     dumpStateToStore();
@@ -510,7 +510,8 @@ void CMSync::synchronize()
 
                 if (!ready)
                 {
-                    LOG_INFO("[CMSync] Consumer '{}' for space '{}' is not ready (not idle or no data yet), skipping",
+                    LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer consumer '{}' is "
+                             "not ready for sync (might be updating or no data)",
                              nsState.getConsumerId().value(),
                              nsState.getOriginSpace());
                     continue;

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -495,13 +495,30 @@ void CMSync::synchronize()
                 return;
             }
 
-            std::optional<std::string_view> consumerIdOpt = std::nullopt;
+            // Pre-flight check: verify consumer is idle and has data (local_offset != 0)
             if (nsState.getConsumerId().has_value())
             {
-                consumerIdOpt = *nsState.getConsumerId();
+                auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
+                const bool ready = base::utils::executeWithRetry(
+                    [&indexerPtr, &consumerId = nsState.getConsumerId().value()]()
+                    { return indexerPtr->isConsumerReadyForSync(consumerId); },
+                    fmt::format("{}", COMPONENT_NAME),
+                    fmt::format("Check consumer readiness for space '{}'", nsState.getOriginSpace()),
+                    m_attempts,
+                    m_waitSeconds,
+                    m_shutdownRequested);
+
+                if (!ready)
+                {
+                    LOG_INFO("[CMSync] Consumer '{}' for space '{}' is not ready (not idle or no data yet), skipping",
+                             nsState.getConsumerId().value(),
+                             nsState.getOriginSpace());
+                    continue;
+                }
             }
 
-            const auto hashResult = getPolicyHashAndEnabledFromRemote(nsState.getOriginSpace(), consumerIdOpt);
+            const auto hashResult =
+                getPolicyHashAndEnabledFromRemote(nsState.getOriginSpace(), nsState.getConsumerId());
             if (!hashResult.has_value())
             {
                 LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer is updating the policy "
@@ -603,7 +620,7 @@ void CMSync::synchronize()
             }
 
             // Download and enrich the namespace (consumer validated again within PIT)
-            const auto newNsIdOpt = downloadAndEnrichNamespace(nsState.getOriginSpace(), consumerIdOpt);
+            const auto newNsIdOpt = downloadAndEnrichNamespace(nsState.getOriginSpace(), nsState.getConsumerId());
             if (!newNsIdOpt.has_value())
             {
                 LOG_INFO("[CMSync] Download skipped for space '{}' because consumer is not idle",

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -18,6 +18,7 @@ const base::Name STORE_NAME_CMSYNC {"cmsync/status/0"};          ///< Name of th
 const cm::store::NamespaceId DUMMY_NAMESPACE_ID {"dummy_ns_id"}; ///< Dummy namespace ID
 constexpr std::string_view COMPONENT_NAME = "CMSync";            ///< Component name for logging
 constexpr std::string_view STANDARD_SPACE_NAME = "standard";     ///< Standard space name
+constexpr std::string_view CUSTOM_SPACE_NAME = "custom";       ///< Custom space name
 
 /**
  * @brief Generate a random namespace ID for the given origin space
@@ -177,7 +178,7 @@ CMSync::CMSync(const std::shared_ptr<wiconnector::IWIndexerConnector>& indexerPt
     // Populate directly and dump once to avoid multiple unnecessary store writes
     m_namespacesState.emplace_back(STANDARD_SPACE_NAME,
                                    std::optional<std::string>(std::string(wiconnector::STANDARD_RULESET_CONSUMER_ID)));
-    m_namespacesState.emplace_back("custom");
+    m_namespacesState.emplace_back(CUSTOM_SPACE_NAME);
     dumpStateToStore();
 }
 
@@ -512,8 +513,8 @@ void CMSync::synchronize()
                 {
                     LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer consumer '{}' is "
                              "not ready for sync (might be updating or no data)",
-                             nsState.getOriginSpace()),
-                             nsState.getConsumerId().value();
+                             nsState.getOriginSpace(),
+                             nsState.getConsumerId().value());
                     continue;
                 }
             }

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -512,8 +512,8 @@ void CMSync::synchronize()
                 {
                     LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer consumer '{}' is "
                              "not ready for sync (might be updating or no data)",
-                             nsState.getConsumerId().value(),
-                             nsState.getOriginSpace());
+                             nsState.getOriginSpace()),
+                             nsState.getConsumerId().value();
                     continue;
                 }
             }

--- a/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
+++ b/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
@@ -19,6 +19,8 @@ const base::Name STORE_NAME_CMSYNC {"cmsync/status/0"};
 constexpr size_t DEFAULT_ATTEMPTS = 3U;
 constexpr size_t DEFAULT_WAIT_SECONDS = 5U;
 
+constexpr std::string_view STANDARD_CONSUMER_ID = "beta-2-ruleset-5_public-ruleset-5";
+
 json::Json createStoredState()
 {
     json::Json state {};
@@ -27,6 +29,7 @@ json::Json createStoredState()
     json::Json standard {};
     standard.setString(std::string(STORE_ORIGIN_STANDARD), "/origin_space");
     standard.setString("stored_standard_ns", "/namespace_id");
+    standard.setString(std::string(STANDARD_CONSUMER_ID), "/consumer_id");
     state.appendJson(standard);
 
     json::Json custom {};
@@ -45,6 +48,10 @@ json::Json createStoredStateWithNs(const std::string& space, const std::string& 
     json::Json entry {};
     entry.setString(space, "/origin_space");
     entry.setString(nsId, "/namespace_id");
+    if (space == STORE_ORIGIN_STANDARD)
+    {
+        entry.setString(std::string(STANDARD_CONSUMER_ID), "/consumer_id");
+    }
     state.appendJson(entry);
 
     return state;
@@ -264,8 +271,8 @@ TEST_F(CMSyncSynchronizeTest, Case1_PolicyDisabledWithExistingRoute)
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
 
     // getPolicyHashAndEnabledFromRemote → disabled
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash1"), false)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), false))));
 
     // Route exists
     EXPECT_CALL(*router, existsEntry("cmsync_standard")).WillOnce(::testing::Return(true));
@@ -293,8 +300,8 @@ TEST_F(CMSyncSynchronizeTest, Case1_PolicyDisabledNoRoute)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash1"), false)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), false))));
 
     // No route
     EXPECT_CALL(*router, existsEntry("cmsync_standard")).WillOnce(::testing::Return(false));
@@ -309,8 +316,8 @@ TEST_F(CMSyncSynchronizeTest, Case2_PolicyEnabledHashUnchanged)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("same_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("same_hash"), true))));
 
     // Route exists with same hash
     EXPECT_CALL(*router, existsEntry("cmsync_standard")).WillOnce(::testing::Return(true));
@@ -329,8 +336,8 @@ TEST_F(CMSyncSynchronizeTest, Case3_PolicyEnabledNoRouteExists)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("new_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
     // Route does NOT exist (for synchronize's route check)
     EXPECT_CALL(*router, existsEntry("cmsync_standard"))
@@ -342,7 +349,8 @@ TEST_F(CMSyncSynchronizeTest, Case3_PolicyEnabledNoRouteExists)
 
     // getPolicy for download
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
 
     // importNamespace
     EXPECT_CALL(
@@ -368,8 +376,8 @@ TEST_F(CMSyncSynchronizeTest, Case4_PolicyEnabledHashChanged)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("new_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
     // Route exists with different hash
     auto entry = makeRouterEntry("cmsync_standard", "old_ns", 1, router::env::State::ENABLED, "old_hash");
@@ -382,15 +390,15 @@ TEST_F(CMSyncSynchronizeTest, Case4_PolicyEnabledHashChanged)
     // downloadAndEnrichNamespace
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
     // hot-swap
-    EXPECT_CALL(*router, hotSwapNamespace("cmsync_standard", ::testing::_))
-        .WillOnce(::testing::Return(std::nullopt));
+    EXPECT_CALL(*router, hotSwapNamespace("cmsync_standard", ::testing::_)).WillOnce(::testing::Return(std::nullopt));
 
     // Dump state
     EXPECT_CALL(*store, upsertDoc(STORE_NAME_CMSYNC, ::testing::_))
@@ -409,8 +417,8 @@ TEST_F(CMSyncSynchronizeTest, Case4_RouteDisabledHashChanged)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("new_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
     // Route exists but DISABLED — enabledRoute is false, so hash comparison is skipped → sync happens
     auto entry = makeRouterEntry("cmsync_standard", "old_ns", 1, router::env::State::DISABLED, "old_hash");
@@ -422,14 +430,14 @@ TEST_F(CMSyncSynchronizeTest, Case4_RouteDisabledHashChanged)
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
         .Times(1);
 
-    EXPECT_CALL(*router, hotSwapNamespace("cmsync_standard", ::testing::_))
-        .WillOnce(::testing::Return(std::nullopt));
+    EXPECT_CALL(*router, hotSwapNamespace("cmsync_standard", ::testing::_)).WillOnce(::testing::Return(std::nullopt));
     EXPECT_CALL(*store, upsertDoc(STORE_NAME_CMSYNC, ::testing::_))
         .WillOnce(::testing::Return(store::mocks::storeOk()));
     EXPECT_CALL(*crud, deleteNamespace(cm::store::NamespaceId("old_ns"))).Times(1);
@@ -444,8 +452,8 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWhenGetEntryFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash1"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), true))));
 
     EXPECT_CALL(*router, existsEntry("cmsync_standard")).WillOnce(::testing::Return(true));
     EXPECT_CALL(*router, getEntry("cmsync_standard"))
@@ -462,8 +470,8 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenHotSwapFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("new_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
     auto entry = makeRouterEntry("cmsync_standard", "old_ns", 1, router::env::State::ENABLED, "old_hash");
     EXPECT_CALL(*router, existsEntry("cmsync_standard"))
@@ -474,7 +482,8 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenHotSwapFails)
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
@@ -498,14 +507,15 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWhenImportNamespaceFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("new_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
     EXPECT_CALL(*router, existsEntry("cmsync_standard")).WillOnce(::testing::Return(false));
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
 
     // importNamespace throws
     EXPECT_CALL(
@@ -531,8 +541,8 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWithNextSpaceAfterFailure)
 
     // Custom — enabled, no route, full sync
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("custom"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("custom")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash_custom"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("custom"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash_custom"), true))));
 
     EXPECT_CALL(*router, existsEntry("cmsync_custom"))
         .WillOnce(::testing::Return(false))
@@ -540,7 +550,8 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWithNextSpaceAfterFailure)
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("custom"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("custom"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
@@ -564,8 +575,8 @@ TEST_F(CMSyncSynchronizeTest, DoesNotDeleteDummyNamespaceAfterSync)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash1"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), true))));
 
     EXPECT_CALL(*router, existsEntry("cmsync_standard"))
         .WillOnce(::testing::Return(false))
@@ -573,7 +584,8 @@ TEST_F(CMSyncSynchronizeTest, DoesNotDeleteDummyNamespaceAfterSync)
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
@@ -595,8 +607,8 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenPostEntryFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash"), true))));
 
     EXPECT_CALL(*router, existsEntry("cmsync_standard"))
         .WillOnce(::testing::Return(false))
@@ -604,7 +616,8 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenPostEntryFails)
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
@@ -626,8 +639,8 @@ TEST_F(CMSyncSynchronizeTest, RetriesNamespaceIdGenerationOnCollision)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash"), true))));
 
     EXPECT_CALL(*router, existsEntry("cmsync_standard"))
         .WillOnce(::testing::Return(false))
@@ -639,7 +652,8 @@ TEST_F(CMSyncSynchronizeTest, RetriesNamespaceIdGenerationOnCollision)
         .WillOnce(::testing::Return(false));
 
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))
@@ -691,10 +705,9 @@ TEST_F(CMSyncSynchronizeTest, AbortsBeforeDownload)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::DoAll(
-            ::testing::InvokeWithoutArgs([&sync]() { sync->requestShutdown(); }),
-            ::testing::Return(std::make_pair(std::string("new_hash"), true))));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::DoAll(::testing::InvokeWithoutArgs([&sync]() { sync->requestShutdown(); }),
+                                   ::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true)))));
 
     // No route exists — case 3 (new sync needed), but shutdown triggers before download
     EXPECT_CALL(*router, existsEntry("cmsync_standard")).WillOnce(::testing::Return(false));
@@ -710,8 +723,8 @@ TEST_F(CMSyncSynchronizeTest, RollsBackOnHotSwapFailure)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard")))
-        .WillOnce(::testing::Return(std::make_pair(std::string("new_hash"), true)));
+    EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
     // Route exists → hot swap path
     EXPECT_CALL(*router, existsEntry("cmsync_standard"))
@@ -723,7 +736,8 @@ TEST_F(CMSyncSynchronizeTest, RollsBackOnHotSwapFailure)
 
     EXPECT_CALL(*crud, existsNamespace(::testing::_)).WillOnce(::testing::Return(false));
     wiconnector::PolicyResources resources;
-    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(resources));
+    EXPECT_CALL(*indexer, getPolicy(::testing::Eq("standard"), ::testing::_))
+        .WillOnce(::testing::Return(std::optional(resources)));
     EXPECT_CALL(
         *crud,
         importNamespace(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_, true))

--- a/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
+++ b/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
@@ -270,6 +270,9 @@ TEST_F(CMSyncSynchronizeTest, Case1_PolicyDisabledWithExistingRoute)
     // existSpaceInRemote
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
 
+    // isConsumerReadyForSync → ready
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
+
     // getPolicyHashAndEnabledFromRemote → disabled
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), false))));
@@ -300,6 +303,7 @@ TEST_F(CMSyncSynchronizeTest, Case1_PolicyDisabledNoRoute)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), false))));
 
@@ -316,6 +320,7 @@ TEST_F(CMSyncSynchronizeTest, Case2_PolicyEnabledHashUnchanged)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("same_hash"), true))));
 
@@ -336,6 +341,7 @@ TEST_F(CMSyncSynchronizeTest, Case3_PolicyEnabledNoRouteExists)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
@@ -376,6 +382,7 @@ TEST_F(CMSyncSynchronizeTest, Case4_PolicyEnabledHashChanged)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
@@ -417,6 +424,7 @@ TEST_F(CMSyncSynchronizeTest, Case4_RouteDisabledHashChanged)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
@@ -452,6 +460,7 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWhenGetEntryFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), true))));
 
@@ -470,6 +479,7 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenHotSwapFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
@@ -507,6 +517,7 @@ TEST_F(CMSyncSynchronizeTest, ContinuesWhenImportNamespaceFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
@@ -575,6 +586,7 @@ TEST_F(CMSyncSynchronizeTest, DoesNotDeleteDummyNamespaceAfterSync)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash1"), true))));
 
@@ -607,6 +619,7 @@ TEST_F(CMSyncSynchronizeTest, RollsBackWhenPostEntryFails)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash"), true))));
 
@@ -639,6 +652,7 @@ TEST_F(CMSyncSynchronizeTest, RetriesNamespaceIdGenerationOnCollision)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("hash"), true))));
 
@@ -705,6 +719,7 @@ TEST_F(CMSyncSynchronizeTest, AbortsBeforeDownload)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::DoAll(::testing::InvokeWithoutArgs([&sync]() { sync->requestShutdown(); }),
                                    ::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true)))));
@@ -723,6 +738,7 @@ TEST_F(CMSyncSynchronizeTest, RollsBackOnHotSwapFailure)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(true));
     EXPECT_CALL(*indexer, getPolicyHashAndEnabled(::testing::Eq("standard"), ::testing::_))
         .WillOnce(::testing::Return(std::optional(std::make_pair(std::string("new_hash"), true))));
 
@@ -760,6 +776,35 @@ TEST_F(CMSyncSynchronizeTest, WorksNormallyWithoutShutdown)
     auto sync = createSyncWithState(state);
 
     EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(false));
+
+    EXPECT_NO_THROW(sync->synchronize());
+}
+
+// Consumer not ready: isConsumerReadyForSync returns false — sync skipped for that space
+TEST_F(CMSyncSynchronizeTest, SkipsWhenConsumerNotReady)
+{
+    auto state = createStoredStateWithNs("standard", "dummy_ns_id");
+    auto sync = createSyncWithState(state);
+
+    EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(false));
+
+    // No getPolicyHashAndEnabled, no download — StrictMock ensures nothing else is called
+    EXPECT_NO_THROW(sync->synchronize());
+}
+
+// Consumer not ready for standard, but custom (no consumer) proceeds normally
+TEST_F(CMSyncSynchronizeTest, SkipsStandardWhenConsumerNotReadyButCustomProceeds)
+{
+    auto state = createStoredState(); // standard + custom
+    auto sync = createSyncWithState(state);
+
+    // Standard — exists but consumer not ready
+    EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("standard"))).WillOnce(::testing::Return(true));
+    EXPECT_CALL(*indexer, isConsumerReadyForSync(::testing::_)).WillOnce(::testing::Return(false));
+
+    // Custom — no consumer ID, so no isConsumerReadyForSync check, but space doesn't exist
+    EXPECT_CALL(*indexer, existsPolicy(::testing::Eq("custom"))).WillOnce(::testing::Return(false));
 
     EXPECT_NO_THROW(sync->synchronize());
 }

--- a/src/engine/source/iocsync/README.md
+++ b/src/engine/source/iocsync/README.md
@@ -70,6 +70,23 @@ The module runs as a periodic task and is designed so that readers of the IOC da
 
 ## Key Concepts
 
+### Consumer Validation for Consistency
+
+To prevent data inconsistency when the wazuh-indexer is mid-update, `iocsync` implements **consumer validation via Point-In-Time (PIT)**:
+
+1. **Hash check phase**: `getRemoteHashesFromRemote()` passes `IOC_ENRICHMENT_CONSUMER_ID` to the indexer connector.
+   - The connector creates a multi-index PIT (`wazuh-threatintel-enrichments` + `.wazuh-cti-consumers`).
+   - It validates the consumer is in the `idle` status within that PIT snapshot.
+   - If idle: returns the hashes (and the check is consistent).
+   - If not idle: returns `std::nullopt` → sync cycle is skipped.
+
+2. **Download phase**: `downloadAndPopulateDB()` passes the same consumer ID to `streamIocsByType()`.
+   - The connector again validates the consumer is idle within a NEW PIT snapshot.
+   - If idle: streams IOCs within that PIT snapshot.
+   - If not idle: returns `std::nullopt` → download is skipped, temp DB is rolled back.
+
+This two-phase validation ensures the indexer is NOT actively updating the IOCs before or during the download.
+
 ### Hash-Based Change Detection
 
 Each IOC type has a remote hash maintained by the Wazuh Indexer. `IocSync` stores the last known hash per type in `SyncedIOCDatabase::m_lastDataHash`. A sync cycle only downloads data when the hashes differ, minimizing unnecessary network and disk I/O.
@@ -152,7 +169,7 @@ class IIocSync {
 
 **`syncIOCType()`**: Per-type logic — compares hashes, downloads to temp DB via `downloadAndPopulateDB()`, ensures target exists, performs `hotSwap()`, updates local hash. Returns `true` if the database was updated.
 
-**`downloadAndPopulateDB()`**: Streams IOC documents from the indexer in batches of 1000. Each document's key is normalized to lowercase. Values are stored via `ioc::kvdb::details::updateValueInDB()` which appends to arrays if the key already exists.
+**`downloadAndPopulateDB()`**: Streams IOC documents from the indexer in batches of 1000 via `streamIocsByType()`, passing `IOC_ENRICHMENT_CONSUMER_ID` for consumer validation. Returns `bool` (false if consumer not idle). Each document's key is normalized to lowercase. Values are stored via `ioc::kvdb::details::updateValueInDB()` which appends to arrays if the key already exists. On consumer-not-idle or download failure, rolls back the temp database.
 
 ### `SyncedIOCDatabase` (internal class in iocsync.cpp)
 

--- a/src/engine/source/iocsync/include/iocsync/iocsync.hpp
+++ b/src/engine/source/iocsync/include/iocsync/iocsync.hpp
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -48,10 +49,10 @@ private:
     /**
      * @brief Get remote per-type hashes from special IOC hashes document.
      *
-     * @return Map(type -> hash)
+     * @return Optional Map(type -> hash). Returns std::nullopt if the IOC consumer is not idle.
      * @throws std::runtime_error on errors.
      */
-    std::unordered_map<std::string, std::string> getRemoteHashesFromRemote();
+    std::optional<std::unordered_map<std::string, std::string>> getRemoteHashesFromRemote();
 
     /**
      * @brief Download IOCs from indexer and populate a KVDB database
@@ -61,9 +62,10 @@ private:
      *
      * @param iocType IOC type to filter (e.g., connection, url_domain, url_full, hash_md5, hash_sha1, hash_sha256)
      * @param dbName Database name in kvdbioc to populate
+     * @return true if the download succeeded, false if the IOC consumer is not idle (data is being updated)
      * @throws std::runtime_error on errors.
      */
-    void downloadAndPopulateDB(std::string_view iocType, const std::string& dbName);
+    bool downloadAndPopulateDB(std::string_view iocType, const std::string& dbName);
 
     /**
      * @brief Synchronize a single IOC type

--- a/src/engine/source/iocsync/src/iocsync.cpp
+++ b/src/engine/source/iocsync/src/iocsync.cpp
@@ -483,7 +483,8 @@ void IocSync::synchronize()
 
             if (!ready)
             {
-                LOG_INFO("[IOC::Sync] IOC consumer is not ready (not idle or no data yet), skipping sync cycle");
+                LOG_INFO("[IOC::Sync] IOC syncronization skipped because wazuh-indexer consumer for IOCs is not ready "
+                         "for sync (might be updating or no data yet)");
                 return;
             }
         }

--- a/src/engine/source/iocsync/src/iocsync.cpp
+++ b/src/engine/source/iocsync/src/iocsync.cpp
@@ -470,6 +470,24 @@ void IocSync::synchronize()
         const auto kvdbiocPtr = base::utils::lockWeakPtr(m_kvdbiocManagerPtr, "KVDBIOCManager");
         std::unique_lock lock(m_mutex);
 
+        // Pre-flight check: verify IOC consumer is idle and has data (local_offset != 0)
+        {
+            auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
+            const bool ready = base::utils::executeWithRetry(
+                [&indexerPtr]() { return indexerPtr->isConsumerReadyForSync(wiconnector::IOC_ENRICHMENT_CONSUMER_ID); },
+                fmt::format("{}", COMPONENT_NAME),
+                "Check IOC consumer readiness",
+                m_attempts,
+                m_waitSeconds,
+                m_shutdownRequested);
+
+            if (!ready)
+            {
+                LOG_INFO("[IOC::Sync] IOC consumer is not ready (not idle or no data yet), skipping sync cycle");
+                return;
+            }
+        }
+
         // Check if remote index exists
         if (!existIocDataInRemote())
         {
@@ -481,8 +499,8 @@ void IocSync::synchronize()
         const auto remoteTypeHashesOpt = getRemoteHashesFromRemote();
         if (!remoteTypeHashesOpt.has_value())
         {
-            LOG_INFO(
-                "[IOC::Sync] IOC syncronization skipped because the IOC consumer is not idle (data is being updated in the indexer)");
+            LOG_INFO("[IOC::Sync] IOC syncronization skipped because the IOC consumer is not idle (data is being "
+                     "updated in the indexer)");
             return;
         }
         const auto& remoteTypeHashes = *remoteTypeHashesOpt;

--- a/src/engine/source/iocsync/src/iocsync.cpp
+++ b/src/engine/source/iocsync/src/iocsync.cpp
@@ -165,19 +165,20 @@ bool IocSync::existIocDataInRemote()
                                          m_shutdownRequested);
 }
 
-std::unordered_map<std::string, std::string> IocSync::getRemoteHashesFromRemote()
+std::optional<std::unordered_map<std::string, std::string>> IocSync::getRemoteHashesFromRemote()
 {
     auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "Indexer Connector");
 
-    return base::utils::executeWithRetry([&indexerPtr]() { return indexerPtr->getIocTypeHashes(); },
-                                         fmt::format("{}", COMPONENT_NAME),
-                                         "Get IOC type hashes from wazuh-indexer",
-                                         m_attempts,
-                                         m_waitSeconds,
-                                         m_shutdownRequested);
+    return base::utils::executeWithRetry(
+        [&indexerPtr]() { return indexerPtr->getIocTypeHashes(wiconnector::IOC_ENRICHMENT_CONSUMER_ID); },
+        fmt::format("{}", COMPONENT_NAME),
+        "Get IOC type hashes from wazuh-indexer",
+        m_attempts,
+        m_waitSeconds,
+        m_shutdownRequested);
 }
 
-void IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string& dbName)
+bool IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string& dbName)
 {
     auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
     auto kvdbiocPtr = base::utils::lockWeakPtr(m_kvdbiocManagerPtr, "KVDBIOCManager");
@@ -187,10 +188,9 @@ void IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
 
     try
     {
-        std::size_t processedDocs = 0;
         std::size_t stored = 0;
 
-        processedDocs = indexerPtr->streamIocsByType(
+        auto processedDocsOpt = indexerPtr->streamIocsByType(
             iocType,
             m_iocSyncBatchSize,
             [&stored, &kvdbiocPtr, &dbName](const std::string& key, const std::string& value)
@@ -200,9 +200,28 @@ void IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
                 json::Json valueJson {value.c_str()};
                 ioc::kvdb::details::updateValueInDB(kvdbiocPtr, dbName, normalizedKey, valueJson);
                 stored++;
-            });
+            },
+            wiconnector::IOC_ENRICHMENT_CONSUMER_ID);
 
-        LOG_DEBUG("[IOC::Sync] Downloaded {} IOCs of type '{}' (processed {} docs)", stored, iocType, processedDocs);
+        // Consumer is not idle — rollback and signal caller
+        if (!processedDocsOpt.has_value())
+        {
+            LOG_DEBUG(
+                "[IOC::Sync] Consumer is not idle for IOC type '{}', rolling back database '{}'", iocType, dbName);
+            try
+            {
+                kvdbiocPtr->remove(dbName);
+            }
+            catch (const std::exception& ex)
+            {
+                LOG_WARNING(
+                    "[IOC::Sync] Failed to rollback database '{}' after consumer not idle: {}", dbName, ex.what());
+            }
+            return false;
+        }
+
+        LOG_DEBUG(
+            "[IOC::Sync] Downloaded {} IOCs of type '{}' (processed {} docs)", stored, iocType, *processedDocsOpt);
 
         if (stored == 0)
         {
@@ -224,6 +243,8 @@ void IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
         }
         throw std::runtime_error(fmt::format("Failed to download IOCs to database '{}': {}", dbName, e.what()));
     }
+
+    return true;
 }
 
 void IocSync::addIOCTypeToSync(std::string_view iocType)
@@ -366,7 +387,11 @@ bool IocSync::syncIOCType(SyncedIOCDatabase& dbState,
 
         try
         {
-            downloadAndPopulateDB(dbState.getIocType(), tempDBName);
+            if (!downloadAndPopulateDB(dbState.getIocType(), tempDBName))
+            {
+                LOG_DEBUG("[IOC::Sync] IOC consumer is not idle for type '{}', skipping", dbState.getIocType());
+                return false;
+            }
         }
         catch (const std::exception& e)
         {
@@ -452,8 +477,15 @@ void IocSync::synchronize()
             return;
         }
 
-        // Get remote hashes
-        const auto remoteTypeHashes = getRemoteHashesFromRemote();
+        // Get remote hashes (returns nullopt if IOC consumer is not idle)
+        const auto remoteTypeHashesOpt = getRemoteHashesFromRemote();
+        if (!remoteTypeHashesOpt.has_value())
+        {
+            LOG_INFO(
+                "[IOC::Sync] IOC syncronization skipped because the IOC consumer is not idle (data is being updated in the indexer)");
+            return;
+        }
+        const auto& remoteTypeHashes = *remoteTypeHashesOpt;
 
         // Synchronize each IOC type
         bool stateChanged = false;

--- a/src/engine/source/wiconnector/README.md
+++ b/src/engine/source/wiconnector/README.md
@@ -65,8 +65,8 @@ This pattern is used by:
 
 | Constant | Value | Used By | Purpose |
 |---|---|---|---|
-| `STANDARD_RULESET_CONSUMER_ID` | `"beta-2-ruleset-5_public-ruleset-5"` | cmsync | Validates policy consumer before sync |
-| `IOC_ENRICHMENT_CONSUMER_ID` | `"t1-iocs-5_public-iocs-5"` | iocsync | Validates IOC consumer before sync |
+| `STANDARD_RULESET_CONSUMER_ID` | `"cti:catalog:consumer:ruleset"` | cmsync | Validates policy consumer before sync |
+| `IOC_ENRICHMENT_CONSUMER_ID` | `"cti:catalog:consumer:iocs"` | iocsync | Validates IOC consumer before sync |
 
 ### Thread Safety
 

--- a/src/engine/source/wiconnector/README.md
+++ b/src/engine/source/wiconnector/README.md
@@ -46,6 +46,28 @@ Internally the module wraps an asynchronous `IndexerConnectorAsync` instance (fr
 
 ## Key Concepts
 
+### Consumer Validation via Point-In-Time (PIT)
+
+To prevent **TOCTOU (time-of-check time-of-use) races** between policy/IOC hash validation and subsequent data download, the connector implements **consumer validation within a PIT snapshot**. When downstream modules (`cmsync`, `iocsync`) pass a `consumerIdToValidate` parameter:
+
+1. A **multi-index PIT** is created that includes both the data index AND `.wazuh-cti-consumers`.
+2. Within the same PIT snapshot, the consumer document is queried and validated to be in the `idle` status.
+3. If the consumer is not idle, the method returns `std::nullopt` (graceful skip — data download is deferred).
+4. If the consumer is idle, data retrieval proceeds within the same PIT, guaranteeing consistency.
+
+This pattern is used by:
+- `getPolicy()` — validates `STANDARD_RULESET_CONSUMER_ID` before fetching policy resources.
+- `getPolicyHashAndEnabled()` — validates consumer before checking hash.
+- `getIocTypeHashes()` — validates `IOC_ENRICHMENT_CONSUMER_ID` before reading hashes.
+- `streamIocsByType()` → `queryByBatches()` — validates consumer before pagination.
+
+### Well-Known Consumer IDs
+
+| Constant | Value | Used By | Purpose |
+|---|---|---|---|
+| `STANDARD_RULESET_CONSUMER_ID` | `"beta-2-ruleset-5_public-ruleset-5"` | cmsync | Validates policy consumer before sync |
+| `IOC_ENRICHMENT_CONSUMER_ID` | `"t1-iocs-5_public-iocs-5"` | iocsync | Validates IOC consumer before sync |
+
 ### Thread Safety
 
 Every public method acquires either a **shared lock** (read operations, indexing) or an **exclusive lock** (`shutdown`). After `shutdown()` resets the internal `IndexerConnectorAsync`, subsequent calls degrade gracefully — `index()` silently returns, while query methods throw `std::runtime_error`.
@@ -64,13 +86,17 @@ In `main.cpp`, the exit handler registers both: `requestShutdown()` executes fir
 
 For large result sets (`getPolicy`, `queryByBatches`), the connector opens a **Point-In-Time** snapshot on the wazuh-indexer with a keep-alive of 5 minutes. Results are retrieved in pages using `search_after` cursors, guaranteeing a consistent view even if the index is being concurrently updated. The PIT is automatically deleted via an RAII guard.
 
-### Batched Query Abstraction
+### Batched Query Abstraction with Consumer Validation
 
 The private `queryByBatches()` method provides a reusable pagination loop used by `getIocTypeHashes()`, `streamIocsByType()`, and potentially other query paths. It accepts:
 
 - An index name, query body, and batch size (capped at `SAFE_STREAM_PAGE_SIZE = 1000`).
 - An `onDocument` callback invoked for each hit.
 - An optional source filter for field-level projection.
+- An **optional `consumerIdToValidate`** parameter:
+  - When provided: PIT is created over both the data index AND `.wazuh-cti-consumers`; consumer is validated to be `idle` before pagination begins.
+  - When not provided: PIT is created over the data index only; no consumer validation.
+  - **Returns `std::optional<std::size_t>`**: `std::nullopt` if consumer not idle, otherwise the number of documents processed.
 
 ### Well-Known Indices
 
@@ -220,22 +246,57 @@ private:
 
 Acquires shared lock, delegates to `IndexerConnectorAsync::indexDataStream()`. Exceptions are caught and logged as warnings — indexing failures do not propagate to callers.
 
-#### `getPolicy(space)`
+#### `getPolicy(space, consumerIdToValidate?)`
 
-1. Opens a PIT across all 4 policy aliases (`wazuh-threatintel-kvdbs`, `wazuh-threatintel-decoders`, `wazuh-threatintel-integrations`, `wazuh-threatintel-policies`).
-2. Paginates through results using `search_after` cursors.
-3. Classifies each hit by index name suffix into `IndexResourceType`.
-4. Accumulates resources into `PolicyResources` vectors (with pre-reserved capacity).
-5. Enriches the policy with `origin_space` field.
-6. PIT is automatically cleaned up via RAII guard.
+1. **When `consumerIdToValidate` is provided** (typically `STANDARD_RULESET_CONSUMER_ID`):
+   - Opens a **multi-index PIT** including all 4 policy aliases AND `.wazuh-cti-consumers`.
+   - Validates consumer is `idle` within the PIT snapshot.
+   - Returns `std::nullopt` if consumer not idle (cmsync skips sync cycle).
+2. **Otherwise** (no consumer validation):
+   - Opens a PIT across all 4 policy aliases only.
+3. Paginates through results using `search_after` cursors.
+4. Classifies each hit by index name suffix into `IndexResourceType`.
+5. Accumulates resources into `PolicyResources` vectors (with pre-reserved capacity).
+6. Enriches the policy with `origin_space` field.
+7. PIT is automatically cleaned up via RAII guard.
 
-#### `getPolicyHashAndEnabled(space)`
+#### `getPolicyHashAndEnabled(space, consumerIdToValidate?)`
 
-Queries `wazuh-threatintel-policies` for a single document matching the space, extracts `space.hash.sha256`, `document.enabled`, and `document.integrations`. Returns the hash and `enabled && hasIntegrations`.
+**When `consumerIdToValidate` is provided** (typically `STANDARD_RULESET_CONSUMER_ID`):
+- Creates a multi-index PIT including both `wazuh-threatintel-policies` AND `.wazuh-cti-consumers`.
+- Validates consumer is `idle` within the PIT snapshot.
+- Queries policy within the same PIT to guarantee consistency.
+- Returns `std::nullopt` if consumer not idle.
 
-#### `streamIocsByType(iocType, batchSize, onIoc)`
+**Otherwise** (no consumer validation):
+- Performs a direct search without PIT.
+
+Returns the hash and `enabled && hasIntegrations`.
+
+#### `streamIocsByType(iocType, batchSize, onIoc, consumerIdToValidate?)`
 
 Uses `queryByBatches()` with a `term` query on `document.type`, projecting only the 12 IOC source fields. For each hit, extracts `document.name` as key and the serialised `document` as value, invoking the callback.
+
+**With consumer validation**:
+- If `consumerIdToValidate` is provided (typically `IOC_ENRICHMENT_CONSUMER_ID`), validates the consumer is idle before streaming.
+- Returns `std::nullopt` if the consumer is not idle (allowing `iocsync` to skip the sync cycle).
+- Returns `std::nullopt` if consumer validation fails with an exception.
+
+**Without consumer validation**:
+- Streams IOCs normally without any consumer checks.
+
+#### `getIocTypeHashes(consumerIdToValidate?)`
+
+**When `consumerIdToValidate` is provided** (typically `IOC_ENRICHMENT_CONSUMER_ID`):
+- Creates a multi-index PIT including both `wazuh-threatintel-enrichments` AND `.wazuh-cti-consumers`.
+- Validates consumer is `idle` within the PIT snapshot.
+- Queries IOC hashes within the same PIT to guarantee consistency.
+- Returns `std::nullopt` if consumer not idle (iocsync skips sync cycle).
+
+**Otherwise** (no consumer validation):
+- Queries directly without PIT.
+
+Parses the `__ioc_type_hashes__` manifest into a `map<type, sha256>`.
 
 #### `getEngineRemoteConfig()`
 

--- a/src/engine/source/wiconnector/include/wiconnector/windexerconnector.hpp
+++ b/src/engine/source/wiconnector/include/wiconnector/windexerconnector.hpp
@@ -146,16 +146,14 @@ public:
                      const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) override;
 
     /**
-     * @brief Retrieves normalized remote engine configuration from wazuh-indexer.
-     *
-     * Implements IWIndexerConnector::getEngineRemoteConfig by reading one document
-     * from `.wazuh-settings`, extracting `/_source/engine`, validating it is an object,
-     * and returning only that object.
-     *
-     * @return json::Json Engine settings object with runtime key/value pairs.
-     * @throws std::exception on connector/search failures or invalid payload shape.
+     * @copydoc IWIndexerConnector::getEngineRemoteConfig
      */
     json::Json getEngineRemoteConfig() override;
+
+    /**
+     * @copydoc IWIndexerConnector::isConsumerReadyForSync
+     */
+    bool isConsumerReadyForSync(std::string_view consumerId) override;
 
     /**
      * @copydoc IWIndexerConnector::getQueueSize

--- a/src/engine/source/wiconnector/include/wiconnector/windexerconnector.hpp
+++ b/src/engine/source/wiconnector/include/wiconnector/windexerconnector.hpp
@@ -60,11 +60,13 @@ private:
     std::size_t m_maxHitsPerRequest;
     std::atomic<bool> m_shutdownRequested {false}; ///< Flag to signal in-flight pagination loops to abort
 
-    std::size_t queryByBatches(std::string_view indexName,
-                               std::string_view query,
-                               std::size_t batchSize,
-                               const std::function<void(const json::Json&)>& onDocument,
-                               const std::optional<std::string_view>& sourceFilter = std::nullopt);
+    std::optional<std::size_t>
+    queryByBatches(std::string_view indexName,
+                   std::string_view query,
+                   std::size_t batchSize,
+                   const std::function<void(const json::Json&)>& onDocument,
+                   const std::optional<std::string_view>& sourceFilter = std::nullopt,
+                   const std::optional<std::string_view>& consumerIdToValidate = std::nullopt);
 
     bool existsIndex(std::string_view indexName);
 
@@ -131,13 +133,17 @@ public:
     /**
      * @copydoc IWIndexerConnector::getIocTypeHashes
      */
-    std::unordered_map<std::string, std::string> getIocTypeHashes() override;
+    std::optional<std::unordered_map<std::string, std::string>>
+    getIocTypeHashes(const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) override;
 
     /**
      * @copydoc IWIndexerConnector::streamIocsByType
      */
-    std::size_t
-    streamIocsByType(std::string_view iocType, std::size_t batchSize, const IocRecordCallback& onIoc) override;
+    std::optional<std::size_t>
+    streamIocsByType(std::string_view iocType,
+                     std::size_t batchSize,
+                     const IocRecordCallback& onIoc,
+                     const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) override;
 
     /**
      * @brief Retrieves normalized remote engine configuration from wazuh-indexer.

--- a/src/engine/source/wiconnector/include/wiconnector/windexerconnector.hpp
+++ b/src/engine/source/wiconnector/include/wiconnector/windexerconnector.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
@@ -106,12 +107,16 @@ public:
     /**
      * @copydoc IWIndexerConnector::getPolicy
      */
-    PolicyResources getPolicy(std::string_view space) override;
+    std::optional<PolicyResources>
+    getPolicy(std::string_view space,
+              const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) override;
 
     /**
-     * @copydoc IWIndexerConnector::getPolicyHash
+     * @copydoc IWIndexerConnector::getPolicyHashAndEnabled
      */
-    std::pair<std::string, bool> getPolicyHashAndEnabled(std::string_view space) override;
+    std::optional<std::pair<std::string, bool>>
+    getPolicyHashAndEnabled(std::string_view space,
+                            const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) override;
 
     /**
      * @copydoc IWIndexerConnector::existsPolicy

--- a/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
+++ b/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
@@ -2,6 +2,7 @@
 #define _IWINDEXER_CONNECTOR_HPP
 
 #include <functional>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -19,6 +20,9 @@
  */
 namespace wiconnector
 {
+
+/// @brief Consumer document ID for the standard ruleset in `.wazuh-cti-consumers`
+constexpr std::string_view STANDARD_RULESET_CONSUMER_ID = "beta-2-ruleset-5_public-ruleset-5";
 
 /**
  * @brief Structure to hold policy resources retrieved from the indexer.
@@ -55,12 +59,16 @@ public:
      * @brief Retrieves policy resources associated with the specified space.
      *
      * @param space The name of the space from which to retrieve policy resources
-     * @return A PolicyResources structure containing the retrieved resources
+     * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
+     *        When provided, the PIT will include `.wazuh-cti-consumers` and the consumer document
+     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
+     * @return An optional PolicyResources. Returns std::nullopt if the consumer is provided and is not idle.
      * @throws std::invalid_argument if the space name is empty or invalid
      * @throws IndexerConnectorException if there is an error during retrieval
      * @throws std::exception for other unexpected errors
      */
-    virtual PolicyResources getPolicy(std::string_view space) = 0;
+    virtual std::optional<PolicyResources>
+    getPolicy(std::string_view space, const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) = 0;
 
     /**
      * @brief Retrieves the policy hash and enabled status for the specified space.
@@ -70,13 +78,19 @@ public:
      * for the given space name.
      *
      * @param space The name of the space to retrieve the information for
-     * @return A pair containing the SHA-256 hash as a string and a boolean indicating if the policy is enabled
+     * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
+     *        When provided, a PIT will include `.wazuh-cti-consumers` and the consumer document
+     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
+     * @return An optional pair containing the SHA-256 hash and enabled status.
+     *         Returns std::nullopt if the consumer is provided and is not idle.
      * @throws std::invalid_argument if the space name is empty
      * @throws IndexerConnectorException if the query returns zero or more than one result, or if required fields are
      * missing
      * @throws std::exception for other unexpected errors
      */
-    virtual std::pair<std::string, bool> getPolicyHashAndEnabled(std::string_view space) = 0;
+    virtual std::optional<std::pair<std::string, bool>>
+    getPolicyHashAndEnabled(std::string_view space,
+                            const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) = 0;
 
     /**
      * @brief Checks if a policy exists for the specified space.

--- a/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
+++ b/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
@@ -24,6 +24,9 @@ namespace wiconnector
 /// @brief Consumer document ID for the standard ruleset in `.wazuh-cti-consumers`
 constexpr std::string_view STANDARD_RULESET_CONSUMER_ID = "beta-2-ruleset-5_public-ruleset-5";
 
+/// @brief Consumer document ID for the IOC enrichment data in `.wazuh-cti-consumers`
+constexpr std::string_view IOC_ENRICHMENT_CONSUMER_ID = "t1-iocs-5_public-iocs-5";
+
 /**
  * @brief Structure to hold policy resources retrieved from the indexer.
  *
@@ -118,10 +121,14 @@ public:
      * Reads `__ioc_type_hashes__` from `wazuh-threatintel-enrichments` and returns all available
      * `hash.sha256` values for the supported IOC types.
      *
-     * @return Map(type -> sha256 hash)
+     * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
+     *        When provided, a PIT will include `.wazuh-cti-consumers` and the consumer document
+     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
+     * @return An optional map(type -> sha256 hash). Returns std::nullopt if the consumer is provided and is not idle.
      * @throws IndexerConnectorException if the manifest is missing or invalid
      */
-    virtual std::unordered_map<std::string, std::string> getIocTypeHashes() = 0;
+    virtual std::optional<std::unordered_map<std::string, std::string>>
+    getIocTypeHashes(const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) = 0;
 
     /**
      * @brief Streams IOC documents for a specific IOC type.
@@ -133,11 +140,18 @@ public:
      * @param iocType IOC type (e.g. connection, url_domain, url_full, hash_md5, hash_sha1, hash_sha256)
      * @param batchSize Number of documents requested per page
      * @param onIoc Callback invoked for each valid IOC record
-     * @return Number of IOC documents delivered to the callback
+     * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
+     *        When provided, the PIT will include `.wazuh-cti-consumers` and the consumer document
+     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
+     * @return An optional number of IOC documents delivered to the callback.
+     *         Returns std::nullopt if the consumer is provided and is not idle.
      * @throws IndexerConnectorException if there is an indexer/query error
      */
-    virtual std::size_t
-    streamIocsByType(std::string_view iocType, std::size_t batchSize, const IocRecordCallback& onIoc) = 0;
+    virtual std::optional<std::size_t>
+    streamIocsByType(std::string_view iocType,
+                     std::size_t batchSize,
+                     const IocRecordCallback& onIoc,
+                     const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) = 0;
 
     /**
      * @brief Retrieves remote engine runtime configuration from wazuh-indexer.

--- a/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
+++ b/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
@@ -22,10 +22,10 @@ namespace wiconnector
 {
 
 /// @brief Consumer document ID for the standard ruleset in `.wazuh-cti-consumers`
-constexpr std::string_view STANDARD_RULESET_CONSUMER_ID = "beta-2-ruleset-5_public-ruleset-5";
+constexpr std::string_view STANDARD_RULESET_CONSUMER_ID = "cti:catalog:consumer:ruleset";
 
 /// @brief Consumer document ID for the IOC enrichment data in `.wazuh-cti-consumers`
-constexpr std::string_view IOC_ENRICHMENT_CONSUMER_ID = "t1-iocs-5_public-iocs-5";
+constexpr std::string_view IOC_ENRICHMENT_CONSUMER_ID = "cti:catalog:consumer:iocs";
 
 /**
  * @brief Structure to hold policy resources retrieved from the indexer.
@@ -152,6 +152,24 @@ public:
                      std::size_t batchSize,
                      const IocRecordCallback& onIoc,
                      const std::optional<std::string_view>& consumerIdToValidate = std::nullopt) = 0;
+
+    /**
+     * @brief Pre-flight check: is the consumer ready for synchronization?
+     *
+     * Queries `.wazuh-cti-consumers` for the specified consumer document and verifies
+     * two conditions:
+     *   1. `status` == `"idle"` — the indexer is not actively updating data.
+     *   2. `local_offset` != 0 — the consumer has received at least one CTI update,
+     *      so hash/data documents actually exist in the data indices.
+     *
+     * This is a lightweight, non-PIT check intended to be called **before** requesting
+     * hashes or data, to avoid unnecessary network calls when the consumer has no data yet.
+     *
+     * @param consumerId The `_id` of the consumer document (e.g. `STANDARD_RULESET_CONSUMER_ID`).
+     * @return true if the consumer is idle and has a non-zero local_offset; false otherwise
+     *         (including on any error — safe default to skip sync).
+     */
+    virtual bool isConsumerReadyForSync(std::string_view consumerId) = 0;
 
     /**
      * @brief Retrieves remote engine runtime configuration from wazuh-indexer.

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -802,6 +802,81 @@ bool WIndexerConnector::existsIocDataIndex()
     return existsIndex(IOC_INDEX);
 }
 
+bool WIndexerConnector::isConsumerReadyForSync(std::string_view consumerId)
+{
+    std::shared_lock lock(m_mutex);
+    if (!m_indexerConnectorAsync)
+    {
+        LOG_DEBUG("[indexer-connector] IndexerConnectorAsync not initialized, consumer '{}' not ready",
+                  std::string(consumerId));
+        return false;
+    }
+
+    try
+    {
+        nlohmann::json query = {{"ids", {{"values", {consumerId}}}}};
+        nlohmann::json source = {{"includes", {"status", "local_offset"}}, {"excludes", nlohmann::json::array()}};
+
+        nlohmann::json hits = m_indexerConnectorAsync->search(CTI_CONSUMERS_INDEX, SINGLE_RESULT_SIZE, query, source);
+
+        size_t totalHits = getTotalHits(hits);
+        if (totalHits == 0)
+        {
+            LOG_DEBUG("[indexer-connector] Consumer document '{}' not found", std::string(consumerId));
+            return false;
+        }
+
+        const auto& hitArray = hits["hits"];
+        if (!hitArray.is_array() || hitArray.empty() || !hitArray[0].contains("_source"))
+        {
+            LOG_DEBUG("[indexer-connector] Invalid consumer hit for '{}'", std::string(consumerId));
+            return false;
+        }
+
+        const auto& src = hitArray[0]["_source"];
+
+        // Check status == "idle"
+        if (!src.contains("status") || !src["status"].is_string())
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' missing 'status' field", std::string(consumerId));
+            return false;
+        }
+
+        const auto status = src["status"].get<std::string>();
+        if (status != "idle")
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {})", std::string(consumerId), status);
+            return false;
+        }
+
+        // Check local_offset != 0
+        if (!src.contains("local_offset") || !src["local_offset"].is_number())
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' missing or non-numeric 'local_offset' field",
+                      std::string(consumerId));
+            return false;
+        }
+
+        const auto localOffset = src["local_offset"].get<int64_t>();
+        if (localOffset == 0)
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' has local_offset=0, data not yet available",
+                      std::string(consumerId));
+            return false;
+        }
+
+        LOG_DEBUG("[indexer-connector] Consumer '{}' is ready for sync (idle, local_offset={})",
+                  std::string(consumerId),
+                  localOffset);
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        LOG_DEBUG("[indexer-connector] Error checking consumer '{}' readiness: {}", std::string(consumerId), e.what());
+        return false;
+    }
+}
+
 std::optional<std::unordered_map<std::string, std::string>>
 WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consumerIdToValidate)
 {

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -211,6 +211,100 @@ std::string buildIocSourceFilter()
     return nlohmann::json {{"includes", std::move(includes)}, {"excludes", nlohmann::json::array()}}.dump();
 }
 
+/// @brief RAII guard type for automatic PIT cleanup
+using PitGuard = std::unique_ptr<PointInTime, std::function<void(PointInTime*)>>;
+
+/**
+ * @brief Creates a RAII guard that deletes the PIT on scope exit.
+ * @param pit Reference to the PIT object to guard (must outlive the guard).
+ * @param async Reference to the async connector used to delete the PIT.
+ * @return PitGuard that will call deletePointInTime on destruction.
+ */
+PitGuard makePitGuard(PointInTime& pit, IIndexerConnectorAsync& async)
+{
+    return PitGuard(&pit,
+                    [&async](PointInTime* p)
+                    {
+                        try
+                        {
+                            async.deletePointInTime(*p);
+                        }
+                        catch (const IndexerConnectorException& e)
+                        {
+                            LOG_WARNING_L(
+                                "pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
+                        }
+                    });
+}
+
+/**
+ * @brief Builds the list of PIT indices, appending the CTI consumers index when consumer validation is needed.
+ * @param baseIndices The base set of indices for the query.
+ * @param consumerIdToValidate If present, CTI_CONSUMERS_INDEX is appended.
+ * @return The (potentially augmented) vector of index names.
+ */
+std::vector<std::string> buildPitIndices(std::vector<std::string> baseIndices,
+                                         const std::optional<std::string_view>& consumerIdToValidate)
+{
+    if (consumerIdToValidate.has_value())
+    {
+        baseIndices.emplace_back(CTI_CONSUMERS_INDEX);
+    }
+    return baseIndices;
+}
+
+/**
+ * @brief Validates that a CTI consumer is in "idle" state within a PIT snapshot.
+ *
+ * Queries the consumer document by ID inside the given PIT and checks its status field.
+ *
+ * @param async Reference to the async connector.
+ * @param pit The PIT snapshot to query within.
+ * @param consumerId The consumer document ID to look up.
+ * @return true if consumer status is "idle".
+ * @return false if consumer status is NOT "idle" (logs DEBUG).
+ * @throws IndexerConnectorException if the consumer document is not found or has invalid structure.
+ */
+bool validateConsumerIdleInPit(IIndexerConnectorAsync& async, const PointInTime& pit, std::string_view consumerId)
+{
+    nlohmann::json consumerQuery = {{"ids", {{"values", {consumerId}}}}};
+    nlohmann::json consumerSort = getSortCriteria();
+    nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
+
+    nlohmann::json consumerHits =
+        async.search(pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
+
+    size_t consumerTotalHits = getTotalHits(consumerHits);
+    if (consumerTotalHits == 0)
+    {
+        throw IndexerConnectorException("Consumer document not found in PIT: " + std::string(consumerId));
+    }
+
+    const auto& consumerHitArray = consumerHits["hits"];
+    if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
+    {
+        throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(consumerId));
+    }
+
+    const auto& consumerSrc = consumerHitArray[0]["_source"];
+    if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
+    {
+        throw IndexerConnectorException("Consumer document missing 'status' in PIT for: " + std::string(consumerId));
+    }
+
+    const auto status = consumerSrc["status"].get<std::string>();
+    if (status != "idle")
+    {
+        LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
+                  std::string(consumerId),
+                  status);
+        return false;
+    }
+
+    LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(consumerId));
+    return true;
+}
+
 } // namespace
 
 /****************************************************************************************
@@ -417,69 +511,19 @@ std::optional<PolicyResources> WIndexerConnector::getPolicy(std::string_view spa
     std::vector<std::pair<IndexResourceType, json::Json>> resourceList;
 
     // Build PIT indices: policy aliases + optionally the CTI consumers index
-    std::vector<std::string> pitIndices = POLICY_ALIASES;
-    if (consumerIdToValidate.has_value())
-    {
-        pitIndices.emplace_back(CTI_CONSUMERS_INDEX);
-    }
+    auto pitIndices = buildPitIndices(POLICY_ALIASES, consumerIdToValidate);
 
     // Create Point In Time (PIT) - Can throw IndexerConnectorException
     auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
-
-    auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
-        &pit,
-        [this](auto* p)
-        {
-            try
-            {
-                m_indexerConnectorAsync->deletePointInTime(*p);
-            }
-            catch (const IndexerConnectorException& e)
-            {
-                LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
-            }
-        });
+    auto pitGuard = makePitGuard(pit, *m_indexerConnectorAsync);
 
     // --- Pre-check: validate consumer is idle within the PIT snapshot ---
     if (consumerIdToValidate.has_value())
     {
-        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
-        nlohmann::json consumerSort = getSortCriteria();
-        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
-
-        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
-            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
-
-        size_t consumerTotalHits = getTotalHits(consumerHits);
-        if (consumerTotalHits == 0)
+        if (!validateConsumerIdleInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
         {
-            throw IndexerConnectorException("Consumer document not found in PIT: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerHitArray = consumerHits["hits"];
-        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
-        {
-            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerSrc = consumerHitArray[0]["_source"];
-        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
-        {
-            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto preStatus = consumerSrc["status"].get<std::string>();
-        if (preStatus != "idle")
-        {
-            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
-                      std::string(*consumerIdToValidate),
-                      preStatus);
             return std::nullopt;
         }
-
-        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
     }
 
     // Prepare query and sort criteria
@@ -626,61 +670,14 @@ WIndexerConnector::getPolicyHashAndEnabled(std::string_view space,
     if (consumerIdToValidate.has_value())
     {
         // Use PIT with consumer validation
-        std::vector<std::string> pitIndices = {std::string(POLICY_INDEX), std::string(CTI_CONSUMERS_INDEX)};
+        auto pitIndices = buildPitIndices({std::string(POLICY_INDEX)}, consumerIdToValidate);
         auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
+        auto pitGuard = makePitGuard(pit, *m_indexerConnectorAsync);
 
-        auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
-            &pit,
-            [this](auto* p)
-            {
-                try
-                {
-                    m_indexerConnectorAsync->deletePointInTime(*p);
-                }
-                catch (const IndexerConnectorException& e)
-                {
-                    LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
-                }
-            });
-
-        // Validate consumer is idle within the PIT snapshot
-        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
-        nlohmann::json consumerSort = getSortCriteria();
-        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
-
-        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
-            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
-
-        size_t consumerTotalHits = getTotalHits(consumerHits);
-        if (consumerTotalHits == 0)
+        if (!validateConsumerIdleInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
         {
-            throw IndexerConnectorException("Consumer document not found in PIT: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerHitArray = consumerHits["hits"];
-        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
-        {
-            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerSrc = consumerHitArray[0]["_source"];
-        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
-        {
-            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto preStatus = consumerSrc["status"].get<std::string>();
-        if (preStatus != "idle")
-        {
-            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
-                      std::string(*consumerIdToValidate),
-                      preStatus);
             return std::nullopt;
         }
-
-        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
 
         // Query policy hash within the same PIT
         nlohmann::json policySort = getSortCriteria();
@@ -886,84 +883,34 @@ WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consu
         throw std::runtime_error("IndexerConnectorAsync is not initialized");
     }
 
-    if (consumerIdToValidate.has_value())
-    {
-        // Use PIT with consumer validation
-        std::vector<std::string> pitIndices = {std::string(IOC_INDEX), std::string(CTI_CONSUMERS_INDEX)};
-        auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
-
-        auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
-            &pit,
-            [this](auto* p)
-            {
-                try
-                {
-                    m_indexerConnectorAsync->deletePointInTime(*p);
-                }
-                catch (const IndexerConnectorException& e)
-                {
-                    LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
-                }
-            });
-
-        // Validate consumer is idle within the PIT snapshot
-        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
-        nlohmann::json consumerSort = getSortCriteria();
-        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
-
-        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
-            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
-
-        size_t consumerTotalHits = getTotalHits(consumerHits);
-        if (consumerTotalHits == 0)
-        {
-            throw IndexerConnectorException("Consumer document not found in PIT: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerHitArray = consumerHits["hits"];
-        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
-        {
-            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerSrc = consumerHitArray[0]["_source"];
-        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
-        {
-            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto preStatus = consumerSrc["status"].get<std::string>();
-        if (preStatus != "idle")
-        {
-            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
-                      std::string(*consumerIdToValidate),
-                      preStatus);
-            return std::nullopt;
-        }
-
-        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
-    }
-
-    // Fall through to normal hash retrieval (either no consumer check or consumer was idle)
+    // Hash retrieval with consumer validation delegated to queryByBatches
+    // (creates a single PIT including CTI consumers index and validates idle atomically)
     std::optional<json::Json> hashesDoc = std::nullopt;
     const std::string queryBody = fmt::format(R"({{"ids": {{"values": ["{}"]}}}})", IOC_HASHES_DOC_ID);
 
-    queryByBatches(IOC_INDEX,
-                   queryBody,
-                   1,
-                   [&hashesDoc](const json::Json& doc)
-                   {
-                       if (hashesDoc.has_value())
-                       {
-                           return;
-                       }
+    auto result = queryByBatches(
+        IOC_INDEX,
+        queryBody,
+        1,
+        [&hashesDoc](const json::Json& doc)
+        {
+            if (hashesDoc.has_value())
+            {
+                return;
+            }
 
-                       auto docCopy = doc;
-                       docCopy.erase("/_id");
-                       hashesDoc = std::move(docCopy);
-                   });
+            auto docCopy = doc;
+            docCopy.erase("/_id");
+            hashesDoc = std::move(docCopy);
+        },
+        std::nullopt,
+        consumerIdToValidate);
+
+    // Consumer was not idle — propagate nullopt
+    if (!result.has_value())
+    {
+        return std::nullopt;
+    }
 
     if (!hashesDoc.has_value())
     {
@@ -1068,68 +1015,18 @@ WIndexerConnector::queryByBatches(std::string_view indexName,
     const std::size_t effectiveBatchSize = std::max<std::size_t>(1, std::min(batchSize, SAFE_STREAM_PAGE_SIZE));
 
     // Build PIT indices: include consumer index when consumer validation is requested
-    std::vector<std::string> pitIndices = {std::string(indexName)};
-    if (consumerIdToValidate.has_value())
-    {
-        pitIndices.emplace_back(std::string(CTI_CONSUMERS_INDEX));
-    }
+    auto pitIndices = buildPitIndices({std::string(indexName)}, consumerIdToValidate);
 
     auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
-
-    auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
-        &pit,
-        [this](auto* p)
-        {
-            try
-            {
-                m_indexerConnectorAsync->deletePointInTime(*p);
-            }
-            catch (const IndexerConnectorException& e)
-            {
-                LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
-            }
-        });
+    auto pitGuard = makePitGuard(pit, *m_indexerConnectorAsync);
 
     // Validate consumer is idle within the PIT snapshot before streaming
     if (consumerIdToValidate.has_value())
     {
-        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
-        nlohmann::json consumerSort = getSortCriteria();
-        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
-
-        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
-            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
-
-        size_t consumerTotalHits = getTotalHits(consumerHits);
-        if (consumerTotalHits == 0)
+        if (!validateConsumerIdleInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
         {
-            throw IndexerConnectorException("Consumer document not found in PIT: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerHitArray = consumerHits["hits"];
-        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
-        {
-            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
-        }
-
-        const auto& consumerSrc = consumerHitArray[0]["_source"];
-        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
-        {
-            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
-                                            + std::string(*consumerIdToValidate));
-        }
-
-        const auto preStatus = consumerSrc["status"].get<std::string>();
-        if (preStatus != "idle")
-        {
-            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
-                      std::string(*consumerIdToValidate),
-                      preStatus);
             return std::nullopt;
         }
-
-        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
     }
 
     nlohmann::json sort = getSortCriteria();

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -39,6 +39,7 @@ constexpr std::size_t SINGLE_RESULT_SIZE {1};                           ///< Siz
 constexpr std::size_t HASH_QUERY_SIZE {1};                        ///< Size for hash query (expecting single result)
 constexpr std::size_t SAFE_STREAM_PAGE_SIZE {1000};               ///< Hard cap for streaming page size
 constexpr std::string_view REMOTE_CONF_INDEX {".wazuh-settings"}; ///< remote conf index name
+constexpr std::string_view CTI_CONSUMERS_INDEX {".wazuh-cti-consumers"}; ///< CTI consumers index name
 const std::array<std::string_view, 12> IOC_SOURCE_FILTER_INCLUDES = {"document.name",
                                                                      "document.type",
                                                                      "document.id",
@@ -404,7 +405,8 @@ void WIndexerConnector::index(std::string_view index, std::string_view data)
     }
 }
 
-PolicyResources WIndexerConnector::getPolicy(std::string_view space)
+std::optional<PolicyResources> WIndexerConnector::getPolicy(std::string_view space,
+                                                            const std::optional<std::string_view>& consumerIdToValidate)
 {
     std::shared_lock lock(m_mutex);
     if (!m_indexerConnectorAsync)
@@ -414,8 +416,15 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
 
     std::vector<std::pair<IndexResourceType, json::Json>> resourceList;
 
+    // Build PIT indices: policy aliases + optionally the CTI consumers index
+    std::vector<std::string> pitIndices = POLICY_ALIASES;
+    if (consumerIdToValidate.has_value())
+    {
+        pitIndices.emplace_back(CTI_CONSUMERS_INDEX);
+    }
+
     // Create Point In Time (PIT) - Can throw IndexerConnectorException
-    auto pit = m_indexerConnectorAsync->createPointInTime(POLICY_ALIASES, PIT_KEEP_ALIVE, true);
+    auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
 
     auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
         &pit,
@@ -430,6 +439,48 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
                 LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
             }
         });
+
+    // --- Pre-check: validate consumer is idle within the PIT snapshot ---
+    if (consumerIdToValidate.has_value())
+    {
+        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
+        nlohmann::json consumerSort = getSortCriteria();
+        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
+
+        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
+            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
+
+        size_t consumerTotalHits = getTotalHits(consumerHits);
+        if (consumerTotalHits == 0)
+        {
+            throw IndexerConnectorException("Consumer document not found in PIT: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerHitArray = consumerHits["hits"];
+        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
+        {
+            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerSrc = consumerHitArray[0]["_source"];
+        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
+        {
+            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto preStatus = consumerSrc["status"].get<std::string>();
+        if (preStatus != "idle")
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
+                      std::string(*consumerIdToValidate),
+                      preStatus);
+            return std::nullopt;
+        }
+
+        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
+    }
 
     // Prepare query and sort criteria
     nlohmann::json query = getQueryFilter(space);
@@ -472,6 +523,13 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
         for (const auto& hit : hitArray)
         {
             auto indexName = hit["_index"].get<std::string>();
+
+            // Skip documents from the CTI consumers index (they were included only for PIT consistency)
+            if (indexName == CTI_CONSUMERS_INDEX)
+            {
+                continue;
+            }
+
             auto sourceData = extractDocumentFromHit(hit);
             IndexResourceType resourceType = fromIndexName(indexName);
 
@@ -546,7 +604,9 @@ PolicyResources WIndexerConnector::getPolicy(std::string_view space)
     return policyMap;
 }
 
-std::pair<std::string, bool> WIndexerConnector::getPolicyHashAndEnabled(std::string_view space)
+std::optional<std::pair<std::string, bool>>
+WIndexerConnector::getPolicyHashAndEnabled(std::string_view space,
+                                           const std::optional<std::string_view>& consumerIdToValidate)
 {
     std::shared_lock lock(m_mutex);
     if (!m_indexerConnectorAsync)
@@ -557,12 +617,80 @@ std::pair<std::string, bool> WIndexerConnector::getPolicyHashAndEnabled(std::str
     // Prepare query filter for the space
     nlohmann::json query = getQueryFilter(space);
 
-    // Prepare source filter to only retrieve space.hash.sha256
+    // Prepare source filter to only retrieve the needed fields
     nlohmann::json source = {{"includes", {"space.hash.sha256", "document.enabled", "document.integrations"}},
                              {"excludes", nlohmann::json::array()}};
 
-    // Execute search query
-    nlohmann::json hits = m_indexerConnectorAsync->search(POLICY_INDEX, HASH_QUERY_SIZE, query, source);
+    nlohmann::json hits;
+
+    if (consumerIdToValidate.has_value())
+    {
+        // Use PIT with consumer validation
+        std::vector<std::string> pitIndices = {std::string(POLICY_INDEX), std::string(CTI_CONSUMERS_INDEX)};
+        auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
+
+        auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
+            &pit,
+            [this](auto* p)
+            {
+                try
+                {
+                    m_indexerConnectorAsync->deletePointInTime(*p);
+                }
+                catch (const IndexerConnectorException& e)
+                {
+                    LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
+                }
+            });
+
+        // Validate consumer is idle within the PIT snapshot
+        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
+        nlohmann::json consumerSort = getSortCriteria();
+        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
+
+        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
+            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
+
+        size_t consumerTotalHits = getTotalHits(consumerHits);
+        if (consumerTotalHits == 0)
+        {
+            throw IndexerConnectorException("Consumer document not found in PIT: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerHitArray = consumerHits["hits"];
+        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
+        {
+            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerSrc = consumerHitArray[0]["_source"];
+        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
+        {
+            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto preStatus = consumerSrc["status"].get<std::string>();
+        if (preStatus != "idle")
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
+                      std::string(*consumerIdToValidate),
+                      preStatus);
+            return std::nullopt;
+        }
+
+        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
+
+        // Query policy hash within the same PIT
+        nlohmann::json policySort = getSortCriteria();
+        hits = m_indexerConnectorAsync->search(pit, HASH_QUERY_SIZE, query, policySort, std::nullopt, source);
+    }
+    else
+    {
+        // Direct search without PIT (no consumer validation needed)
+        hits = m_indexerConnectorAsync->search(POLICY_INDEX, HASH_QUERY_SIZE, query, source);
+    }
 
     // Check total hits
     size_t totalHits = getTotalHits(hits);
@@ -619,7 +747,7 @@ std::pair<std::string, bool> WIndexerConnector::getPolicyHashAndEnabled(std::str
     const bool hasIntegrations = !source_data["document"]["integrations"].empty();
     const bool enabled = source_data["document"]["enabled"].get<bool>();
 
-    return {source_data["space"]["hash"]["sha256"].get<std::string>(), enabled && hasIntegrations};
+    return std::make_pair(source_data["space"]["hash"]["sha256"].get<std::string>(), enabled && hasIntegrations);
 }
 
 bool WIndexerConnector::existsPolicy(std::string_view space)

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -877,12 +877,6 @@ bool WIndexerConnector::isConsumerReadyForSync(std::string_view consumerId)
 std::optional<std::unordered_map<std::string, std::string>>
 WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consumerIdToValidate)
 {
-    std::shared_lock lock(m_mutex);
-    if (!m_indexerConnectorAsync)
-    {
-        throw std::runtime_error("IndexerConnectorAsync is not initialized");
-    }
-
     // Hash retrieval with consumer validation delegated to queryByBatches
     // (creates a single PIT including CTI consumers index and validates idle atomically)
     std::optional<json::Json> hashesDoc = std::nullopt;

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -802,8 +802,76 @@ bool WIndexerConnector::existsIocDataIndex()
     return existsIndex(IOC_INDEX);
 }
 
-std::unordered_map<std::string, std::string> WIndexerConnector::getIocTypeHashes()
+std::optional<std::unordered_map<std::string, std::string>>
+WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consumerIdToValidate)
 {
+    std::shared_lock lock(m_mutex);
+    if (!m_indexerConnectorAsync)
+    {
+        throw std::runtime_error("IndexerConnectorAsync is not initialized");
+    }
+
+    if (consumerIdToValidate.has_value())
+    {
+        // Use PIT with consumer validation
+        std::vector<std::string> pitIndices = {std::string(IOC_INDEX), std::string(CTI_CONSUMERS_INDEX)};
+        auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
+
+        auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
+            &pit,
+            [this](auto* p)
+            {
+                try
+                {
+                    m_indexerConnectorAsync->deletePointInTime(*p);
+                }
+                catch (const IndexerConnectorException& e)
+                {
+                    LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
+                }
+            });
+
+        // Validate consumer is idle within the PIT snapshot
+        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
+        nlohmann::json consumerSort = getSortCriteria();
+        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
+
+        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
+            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
+
+        size_t consumerTotalHits = getTotalHits(consumerHits);
+        if (consumerTotalHits == 0)
+        {
+            throw IndexerConnectorException("Consumer document not found in PIT: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerHitArray = consumerHits["hits"];
+        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
+        {
+            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerSrc = consumerHitArray[0]["_source"];
+        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
+        {
+            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto preStatus = consumerSrc["status"].get<std::string>();
+        if (preStatus != "idle")
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
+                      std::string(*consumerIdToValidate),
+                      preStatus);
+            return std::nullopt;
+        }
+
+        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
+    }
+
+    // Fall through to normal hash retrieval (either no consumer check or consumer was idle)
     std::optional<json::Json> hashesDoc = std::nullopt;
     const std::string queryBody = fmt::format(R"({{"ids": {{"values": ["{}"]}}}})", IOC_HASHES_DOC_ID);
 
@@ -831,8 +899,11 @@ std::unordered_map<std::string, std::string> WIndexerConnector::getIocTypeHashes
     return parseIocHashesDocument(*hashesDoc);
 }
 
-std::size_t
-WIndexerConnector::streamIocsByType(std::string_view iocType, std::size_t batchSize, const IocRecordCallback& onIoc)
+std::optional<std::size_t>
+WIndexerConnector::streamIocsByType(std::string_view iocType,
+                                    std::size_t batchSize,
+                                    const IocRecordCallback& onIoc,
+                                    const std::optional<std::string_view>& consumerIdToValidate)
 {
     if (iocType.empty())
     {
@@ -848,7 +919,7 @@ WIndexerConnector::streamIocsByType(std::string_view iocType, std::size_t batchS
     const auto sourceFilter = buildIocSourceFilter();
     std::size_t streamedDocs = 0;
 
-    queryByBatches(
+    auto result = queryByBatches(
         IOC_INDEX,
         queryBody,
         batchSize,
@@ -871,16 +942,24 @@ WIndexerConnector::streamIocsByType(std::string_view iocType, std::size_t batchS
             onIoc(docName, optDocument->str());
             ++streamedDocs;
         },
-        sourceFilter);
+        sourceFilter,
+        consumerIdToValidate);
+
+    if (!result.has_value())
+    {
+        return std::nullopt;
+    }
 
     return streamedDocs;
 }
 
-std::size_t WIndexerConnector::queryByBatches(std::string_view indexName,
-                                              std::string_view queryStr,
-                                              std::size_t batchSize,
-                                              const std::function<void(const json::Json&)>& onDocument,
-                                              const std::optional<std::string_view>& sourceFilter)
+std::optional<std::size_t>
+WIndexerConnector::queryByBatches(std::string_view indexName,
+                                  std::string_view queryStr,
+                                  std::size_t batchSize,
+                                  const std::function<void(const json::Json&)>& onDocument,
+                                  const std::optional<std::string_view>& sourceFilter,
+                                  const std::optional<std::string_view>& consumerIdToValidate)
 {
     std::shared_lock lock(m_mutex);
     if (!m_indexerConnectorAsync)
@@ -913,7 +992,14 @@ std::size_t WIndexerConnector::queryByBatches(std::string_view indexName,
 
     const std::size_t effectiveBatchSize = std::max<std::size_t>(1, std::min(batchSize, SAFE_STREAM_PAGE_SIZE));
 
-    auto pit = m_indexerConnectorAsync->createPointInTime({std::string(indexName)}, PIT_KEEP_ALIVE, true);
+    // Build PIT indices: include consumer index when consumer validation is requested
+    std::vector<std::string> pitIndices = {std::string(indexName)};
+    if (consumerIdToValidate.has_value())
+    {
+        pitIndices.emplace_back(std::string(CTI_CONSUMERS_INDEX));
+    }
+
+    auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
 
     auto pitGuard = std::unique_ptr<decltype(pit), std::function<void(decltype(pit)*)>>(
         &pit,
@@ -928,6 +1014,48 @@ std::size_t WIndexerConnector::queryByBatches(std::string_view indexName,
                 LOG_WARNING_L("pitGuard", "[indexer-connector] Error deleting Point In Time (PIT): {}", e.what());
             }
         });
+
+    // Validate consumer is idle within the PIT snapshot before streaming
+    if (consumerIdToValidate.has_value())
+    {
+        nlohmann::json consumerQuery = {{"ids", {{"values", {*consumerIdToValidate}}}}};
+        nlohmann::json consumerSort = getSortCriteria();
+        nlohmann::json consumerSource = {{"includes", {"status"}}, {"excludes", nlohmann::json::array()}};
+
+        nlohmann::json consumerHits = m_indexerConnectorAsync->search(
+            pit, SINGLE_RESULT_SIZE, consumerQuery, consumerSort, std::nullopt, consumerSource);
+
+        size_t consumerTotalHits = getTotalHits(consumerHits);
+        if (consumerTotalHits == 0)
+        {
+            throw IndexerConnectorException("Consumer document not found in PIT: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerHitArray = consumerHits["hits"];
+        if (!consumerHitArray.is_array() || consumerHitArray.empty() || !consumerHitArray[0].contains("_source"))
+        {
+            throw IndexerConnectorException("Invalid consumer hit in PIT for: " + std::string(*consumerIdToValidate));
+        }
+
+        const auto& consumerSrc = consumerHitArray[0]["_source"];
+        if (!consumerSrc.contains("status") || !consumerSrc["status"].is_string())
+        {
+            throw IndexerConnectorException("Consumer document missing 'status' in PIT for: "
+                                            + std::string(*consumerIdToValidate));
+        }
+
+        const auto preStatus = consumerSrc["status"].get<std::string>();
+        if (preStatus != "idle")
+        {
+            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
+                      std::string(*consumerIdToValidate),
+                      preStatus);
+            return std::nullopt;
+        }
+
+        LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(*consumerIdToValidate));
+    }
 
     nlohmann::json sort = getSortCriteria();
     std::optional<nlohmann::json> searchAfter = std::nullopt;

--- a/src/engine/source/wiconnector/test/mocks/wiconnector/mockswindexerconnector.hpp
+++ b/src/engine/source/wiconnector/test/mocks/wiconnector/mockswindexerconnector.hpp
@@ -10,10 +10,16 @@ class MockWIndexerConnector : public ::wiconnector::IWIndexerConnector
 {
 public:
     MOCK_METHOD(void, index, (std::string_view index, std::string_view data), (override));
-    MOCK_METHOD(PolicyResources, getPolicy, (std::string_view space), (override));
+    MOCK_METHOD((std::optional<PolicyResources>),
+                getPolicy,
+                (std::string_view space, const std::optional<std::string_view>& consumerIdToValidate),
+                (override));
     MOCK_METHOD(uint64_t, getQueueSize, (), (override));
     MOCK_METHOD(uint64_t, getDroppedEvents, (), (override));
-    MOCK_METHOD((std::pair<std::string, bool>), getPolicyHashAndEnabled, (std::string_view space), (override));
+    MOCK_METHOD((std::optional<std::pair<std::string, bool>>),
+                getPolicyHashAndEnabled,
+                (std::string_view space, const std::optional<std::string_view>& consumerIdToValidate),
+                (override));
     MOCK_METHOD(bool, existsPolicy, (std::string_view space), (override));
     MOCK_METHOD(bool, existsIocDataIndex, (), (override));
     MOCK_METHOD((std::unordered_map<std::string, std::string>), getIocTypeHashes, (), (override));

--- a/src/engine/source/wiconnector/test/mocks/wiconnector/mockswindexerconnector.hpp
+++ b/src/engine/source/wiconnector/test/mocks/wiconnector/mockswindexerconnector.hpp
@@ -34,6 +34,7 @@ public:
                  const std::optional<std::string_view>& consumerIdToValidate),
                 (override));
     MOCK_METHOD(json::Json, getEngineRemoteConfig, (), (override));
+    MOCK_METHOD(bool, isConsumerReadyForSync, (std::string_view consumerId), (override));
 };
 } // namespace wiconnector::mocks
 

--- a/src/engine/source/wiconnector/test/mocks/wiconnector/mockswindexerconnector.hpp
+++ b/src/engine/source/wiconnector/test/mocks/wiconnector/mockswindexerconnector.hpp
@@ -22,10 +22,16 @@ public:
                 (override));
     MOCK_METHOD(bool, existsPolicy, (std::string_view space), (override));
     MOCK_METHOD(bool, existsIocDataIndex, (), (override));
-    MOCK_METHOD((std::unordered_map<std::string, std::string>), getIocTypeHashes, (), (override));
-    MOCK_METHOD(std::size_t,
+    MOCK_METHOD((std::optional<std::unordered_map<std::string, std::string>>),
+                getIocTypeHashes,
+                (const std::optional<std::string_view>& consumerIdToValidate),
+                (override));
+    MOCK_METHOD((std::optional<std::size_t>),
                 streamIocsByType,
-                (std::string_view iocType, std::size_t batchSize, const IocRecordCallback& onIoc),
+                (std::string_view iocType,
+                 std::size_t batchSize,
+                 const IocRecordCallback& onIoc,
+                 const std::optional<std::string_view>& consumerIdToValidate),
                 (override));
     MOCK_METHOD(json::Json, getEngineRemoteConfig, (), (override));
 };

--- a/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
+++ b/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
@@ -501,9 +501,10 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledHappyPath)
     nlohmann::json hits = {{"total", {{"value", 1}}}, {"hits", {policyHit("abc123", true)}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
-    auto [hash, enabled] = connector->getPolicyHashAndEnabled("default");
-    EXPECT_EQ(hash, "abc123");
-    EXPECT_TRUE(enabled);
+    auto result = connector->getPolicyHashAndEnabled("default");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->first, "abc123");
+    EXPECT_TRUE(result->second);
 }
 
 TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledDisabledWhenNoIntegrations)
@@ -511,9 +512,10 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledDisabledWhenNoIntegrati
     nlohmann::json hits = {{"total", {{"value", 1}}}, {"hits", {policyHit("zz", true, {})}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
-    auto [hash, enabled] = connector->getPolicyHashAndEnabled("default");
-    EXPECT_EQ(hash, "zz");
-    EXPECT_FALSE(enabled);
+    auto result = connector->getPolicyHashAndEnabled("default");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->first, "zz");
+    EXPECT_FALSE(result->second);
 }
 
 TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledDisabledWhenEnabledFalse)
@@ -522,7 +524,8 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledDisabledWhenEnabledFals
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
     auto pair = connector->getPolicyHashAndEnabled("default");
-    EXPECT_FALSE(pair.second);
+    ASSERT_TRUE(pair.has_value());
+    EXPECT_FALSE(pair->second);
 }
 
 TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledZeroHitsThrows)
@@ -626,16 +629,17 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHappyPath)
     auto connector = makeConnector(/*maxHits=*/10);
     auto resources = connector->getPolicy("default");
 
-    EXPECT_EQ(resources.kvdbs.size(), 1U);
-    EXPECT_EQ(resources.decoders.size(), 1U);
-    EXPECT_EQ(resources.filters.size(), 1U);
-    EXPECT_EQ(resources.integration.size(), 1U);
-    EXPECT_TRUE(resources.policy.isObject());
+    ASSERT_TRUE(resources.has_value());
+    EXPECT_EQ(resources->kvdbs.size(), 1U);
+    EXPECT_EQ(resources->decoders.size(), 1U);
+    EXPECT_EQ(resources->filters.size(), 1U);
+    EXPECT_EQ(resources->integration.size(), 1U);
+    EXPECT_TRUE(resources->policy.isObject());
     std::string hash;
-    EXPECT_EQ(resources.policy.getString(hash, "/hash"), json::RetGet::Success);
+    EXPECT_EQ(resources->policy.getString(hash, "/hash"), json::RetGet::Success);
     EXPECT_EQ(hash, "HASHX");
     std::string originSpace;
-    EXPECT_EQ(resources.policy.getString(originSpace, "/origin_space"), json::RetGet::Success);
+    EXPECT_EQ(resources->policy.getString(originSpace, "/origin_space"), json::RetGet::Success);
     EXPECT_EQ(originSpace, "default");
 }
 
@@ -650,10 +654,11 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyEmptyResultEndsPagination)
 
     auto connector = makeConnector();
     auto resources = connector->getPolicy("default");
-    EXPECT_TRUE(resources.kvdbs.empty());
-    EXPECT_TRUE(resources.decoders.empty());
-    EXPECT_TRUE(resources.filters.empty());
-    EXPECT_TRUE(resources.integration.empty());
+    ASSERT_TRUE(resources.has_value());
+    EXPECT_TRUE(resources->kvdbs.empty());
+    EXPECT_TRUE(resources->decoders.empty());
+    EXPECT_TRUE(resources->filters.empty());
+    EXPECT_TRUE(resources->integration.empty());
 }
 
 TEST_F(WIndexerConnectorMockTest, GetPolicyEmptySpaceThrows)
@@ -804,9 +809,10 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesHappyPath)
 
     auto connector = makeConnector();
     auto result = connector->getIocTypeHashes();
-    EXPECT_EQ(result.size(), 2U);
-    EXPECT_EQ(result["ip"], "h-ip");
-    EXPECT_EQ(result["domain"], "h-dom");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->size(), 2U);
+    EXPECT_EQ((*result)["ip"], "h-ip");
+    EXPECT_EQ((*result)["domain"], "h-dom");
 }
 
 TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesNoDocumentThrows)
@@ -841,7 +847,8 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesFlatFormat)
 
     auto connector = makeConnector();
     auto result = connector->getIocTypeHashes();
-    EXPECT_EQ(result["ip"], "h-ip");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ((*result)["ip"], "h-ip");
 }
 
 /**************************

--- a/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
+++ b/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
@@ -949,3 +949,363 @@ TEST_F(WIndexerConnectorMockTest, StreamIocsByTypePaginatesAndStopsOnShutdown)
     EXPECT_THROW(connector->streamIocsByType("ip", 2, [](const std::string&, const std::string&) {}),
                  IndexerConnectorException);
 }
+
+/****************************************************************************************
+ * Consumer validation (consumerIdToValidate) & PIT tests
+ ****************************************************************************************/
+
+namespace
+{
+/// Helper: consumer hit with given status
+nlohmann::json consumerHit(const std::string& status)
+{
+    return {{"_source", {{"status", status}}}, {"sort", nlohmann::json::array({1, "a"})}};
+}
+
+/// Helper: consumer hit with status and local_offset
+nlohmann::json consumerHitWithOffset(const std::string& status, int64_t offset)
+{
+    return {{"_source", {{"status", status}, {"local_offset", offset}}}, {"sort", nlohmann::json::array({1, "a"})}};
+}
+
+/// Helper: consumer search response
+nlohmann::json consumerResponse(const std::string& status)
+{
+    return {{"total", {{"value", 1}}}, {"hits", {consumerHit(status)}}};
+}
+
+/// Helper: empty consumer response (not found)
+nlohmann::json emptyConsumerResponse()
+{
+    return {{"total", {{"value", 0}}}, {"hits", nlohmann::json::array()}};
+}
+
+/// Helper: consumer response with status and local_offset (for isConsumerReadyForSync)
+nlohmann::json consumerReadyResponse(const std::string& status, int64_t offset)
+{
+    return {{"total", {{"value", 1}}}, {"hits", {consumerHitWithOffset(status, offset)}}};
+}
+} // namespace
+
+/**************************
+ * isConsumerReadyForSync
+ **************************/
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncIdleWithOffset)
+{
+    nlohmann::json resp = consumerReadyResponse("idle", 42);
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
+    auto connector = makeConnector();
+    EXPECT_TRUE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncNotIdle)
+{
+    nlohmann::json resp = consumerReadyResponse("updating", 42);
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
+    auto connector = makeConnector();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncIdleWithZeroOffset)
+{
+    nlohmann::json resp = consumerReadyResponse("idle", 0);
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
+    auto connector = makeConnector();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncNotFound)
+{
+    nlohmann::json resp = emptyConsumerResponse();
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
+    auto connector = makeConnector();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncMissingStatusField)
+{
+    nlohmann::json resp = {
+        {"total", {{"value", 1}}},
+        {"hits", {{{"_source", {{"local_offset", 10}}}, {"sort", nlohmann::json::array({1, "a"})}}}}};
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
+    auto connector = makeConnector();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncMissingLocalOffsetField)
+{
+    nlohmann::json resp = {{"total", {{"value", 1}}},
+                           {"hits", {{{"_source", {{"status", "idle"}}}, {"sort", nlohmann::json::array({1, "a"})}}}}};
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
+    auto connector = makeConnector();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncReturnsFalseAfterShutdown)
+{
+    auto connector = makeConnector();
+    connector->shutdown();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncReturnsFalseOnException)
+{
+    EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Throw(std::runtime_error("network error")));
+    auto connector = makeConnector();
+    EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
+}
+
+/**************************
+ * getPolicyHashAndEnabled with consumerIdToValidate
+ **************************/
+TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    // First PIT search: consumer validation → idle
+    // Second PIT search: policy hash query
+    nlohmann::json consumerResp = consumerResponse("idle");
+    nlohmann::json policyResp = {{"total", {{"value", 1}}}, {"hits", {policyHit("hash-abc", true)}}};
+
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _))
+        .WillOnce(Return(consumerResp))
+        .WillOnce(Return(policyResp));
+
+    auto connector = makeConnector();
+    auto result = connector->getPolicyHashAndEnabled("default", std::optional<std::string_view>("my-consumer"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->first, "hash-abc");
+    EXPECT_TRUE(result->second);
+}
+
+TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerNotIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = consumerResponse("updating");
+
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    auto result = connector->getPolicyHashAndEnabled("default", std::optional<std::string_view>("my-consumer"));
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerNotFound)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = emptyConsumerResponse();
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    EXPECT_THROW(connector->getPolicyHashAndEnabled("default", std::optional<std::string_view>("no-such-consumer")),
+                 IndexerConnectorException);
+}
+
+TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerMissingStatus)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = {
+        {"total", {{"value", 1}}},
+        {"hits", {{{"_source", {{"other", "field"}}}, {"sort", nlohmann::json::array({1, "a"})}}}}};
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    EXPECT_THROW(connector->getPolicyHashAndEnabled("default", std::optional<std::string_view>("my-consumer")),
+                 IndexerConnectorException);
+}
+
+/**************************
+ * getPolicy with consumerIdToValidate
+ **************************/
+TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    // First PIT search: consumer validation → idle
+    nlohmann::json consumerResp = consumerResponse("idle");
+    // Second PIT search: policy resources (includes a consumer index hit that should be skipped)
+    nlohmann::json policyPage = {
+        {"total", {{"value", 3}}},
+        {"hits",
+         {// Consumer hit from PIT — should be skipped
+          {{"_index", ".wazuh-cti-consumers"},
+           {"_source", {{"status", "idle"}}},
+           {"sort", nlohmann::json::array({0, "z"})}},
+          makePolicyHit("wazuh-threatintel-decoders", "d1", nlohmann::json::array({1, "a"})),
+          makePolicyHit(
+              "wazuh-threatintel-policies", "policy1", nlohmann::json::array({2, "b"}), std::string("HASH1"))}}};
+
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _))
+        .WillOnce(Return(consumerResp))
+        .WillOnce(Return(policyPage));
+
+    auto connector = makeConnector(/*maxHits=*/10);
+    auto resources = connector->getPolicy("standard", std::optional<std::string_view>("my-consumer"));
+    ASSERT_TRUE(resources.has_value());
+    EXPECT_EQ(resources->decoders.size(), 1U);
+    EXPECT_TRUE(resources->policy.isObject());
+    // Consumer index hit was filtered out
+    EXPECT_TRUE(resources->kvdbs.empty());
+}
+
+TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerNotIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = consumerResponse("updating");
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    auto resources = connector->getPolicy("standard", std::optional<std::string_view>("my-consumer"));
+    EXPECT_FALSE(resources.has_value());
+}
+
+TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerNotFound)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = emptyConsumerResponse();
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    EXPECT_THROW(connector->getPolicy("standard", std::optional<std::string_view>("no-consumer")),
+                 IndexerConnectorException);
+}
+
+/**************************
+ * getIocTypeHashes with consumerIdToValidate
+ **************************/
+TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    // First PIT search: consumer validation → idle
+    nlohmann::json consumerResp = consumerResponse("idle");
+    // Second PIT search: hash document
+    nlohmann::json hashPage = {{"hits",
+                                {{{"_id", "__ioc_type_hashes__"},
+                                  {"_source", {{"type_hashes", {{"ip", {{"hash", {{"sha256", "h-ip"}}}}}}}}},
+                                  {"sort", nlohmann::json::array({1, "a"})}}}}};
+    nlohmann::json emptyPage = {{"hits", nlohmann::json::array()}};
+
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _))
+        .WillOnce(Return(consumerResp))
+        .WillOnce(Return(hashPage))
+        .WillOnce(Return(emptyPage));
+
+    auto connector = makeConnector();
+    auto result = connector->getIocTypeHashes(std::optional<std::string_view>("my-consumer"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->size(), 1U);
+    EXPECT_EQ((*result)["ip"], "h-ip");
+}
+
+TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerNotIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = consumerResponse("updating");
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    auto result = connector->getIocTypeHashes(std::optional<std::string_view>("my-consumer"));
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerNotFound)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = emptyConsumerResponse();
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    EXPECT_THROW(connector->getIocTypeHashes(std::optional<std::string_view>("no-consumer")),
+                 IndexerConnectorException);
+}
+
+/**************************
+ * streamIocsByType with consumerIdToValidate
+ **************************/
+TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = consumerResponse("idle");
+    nlohmann::json iocPage = {{"hits",
+                               {{{"_id", "ioc1"},
+                                 {"_source", {{"document", {{"name", "ioc1"}, {"type", "ip"}}}}},
+                                 {"sort", nlohmann::json::array({1, "a"})}}}}};
+
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _))
+        .WillOnce(Return(consumerResp))
+        .WillOnce(Return(iocPage));
+
+    std::vector<std::string> received;
+    auto connector = makeConnector();
+    auto count = connector->streamIocsByType(
+        "ip",
+        10,
+        [&received](const std::string& k, const std::string&) { received.push_back(k); },
+        std::optional<std::string_view>("my-consumer"));
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(*count, 1U);
+    EXPECT_EQ(received.size(), 1U);
+    EXPECT_EQ(received[0], "ioc1");
+}
+
+TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerNotIdle)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = consumerResponse("updating");
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    auto count = connector->streamIocsByType(
+        "ip", 10, [](const std::string&, const std::string&) {}, std::optional<std::string_view>("my-consumer"));
+    EXPECT_FALSE(count.has_value());
+}
+
+TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerNotFound)
+{
+    auto pit = makePit();
+    EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
+    EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
+
+    nlohmann::json consumerResp = emptyConsumerResponse();
+    EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
+
+    auto connector = makeConnector();
+    EXPECT_THROW(
+        connector->streamIocsByType(
+            "ip", 10, [](const std::string&, const std::string&) {}, std::optional<std::string_view>("no-consumer")),
+        IndexerConnectorException);
+}

--- a/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
+++ b/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
@@ -485,9 +485,7 @@ TEST_F(WIndexerConnectorMockTest, ExistsIocDataIndexAfterShutdownThrows)
  **************************/
 namespace
 {
-nlohmann::json policyHit(const std::string& hash,
-                         bool enabled,
-                         const std::vector<std::string>& integrations = {"int1"})
+nlohmann::json policyHit(const std::string& hash, bool enabled, const std::vector<std::string>& integrations = {"int1"})
 {
     nlohmann::json hit = {{"_source",
                            {{"space", {{"hash", {{"sha256", hash}}}}},
@@ -557,8 +555,7 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledMissingEnabledThrows)
     nlohmann::json hits = {
         {"total", {{"value", 1}}},
         {"hits",
-         {{{"_source",
-            {{"space", {{"hash", {{"sha256", "abc"}}}}}, {"document", {{"integrations", {"a"}}}}}}}}}};
+         {{{"_source", {{"space", {{"hash", {{"sha256", "abc"}}}}}, {"document", {{"integrations", {"a"}}}}}}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
     EXPECT_THROW(connector->getPolicyHashAndEnabled("default"), IndexerConnectorException);
@@ -568,8 +565,7 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledMissingIntegrationsThro
 {
     nlohmann::json hits = {
         {"total", {{"value", 1}}},
-        {"hits",
-         {{{"_source", {{"space", {{"hash", {{"sha256", "abc"}}}}}, {"document", {{"enabled", true}}}}}}}}};
+        {"hits", {{{"_source", {{"space", {{"hash", {{"sha256", "abc"}}}}}, {"document", {{"enabled", true}}}}}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
     EXPECT_THROW(connector->getPolicyHashAndEnabled("default"), IndexerConnectorException);
@@ -613,16 +609,15 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHappyPath)
     EXPECT_CALL(*mock, createPointInTime(_, _, true)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json hits = {{"total", {{"value", 5}}},
-                           {"hits",
-                            {makePolicyHit("wazuh-threatintel-kvdbs", "kv1", nlohmann::json::array({1, "a"})),
-                             makePolicyHit("wazuh-threatintel-decoders", "d1", nlohmann::json::array({2, "b"})),
-                             makePolicyHit("wazuh-threatintel-filters", "f1", nlohmann::json::array({3, "c"})),
-                             makePolicyHit("wazuh-threatintel-integrations", "i1", nlohmann::json::array({4, "d"})),
-                             makePolicyHit("wazuh-threatintel-policies",
-                                           "policy1",
-                                           nlohmann::json::array({5, "e"}),
-                                           std::string("HASHX"))}}};
+    nlohmann::json hits = {
+        {"total", {{"value", 5}}},
+        {"hits",
+         {makePolicyHit("wazuh-threatintel-kvdbs", "kv1", nlohmann::json::array({1, "a"})),
+          makePolicyHit("wazuh-threatintel-decoders", "d1", nlohmann::json::array({2, "b"})),
+          makePolicyHit("wazuh-threatintel-filters", "f1", nlohmann::json::array({3, "c"})),
+          makePolicyHit("wazuh-threatintel-integrations", "i1", nlohmann::json::array({4, "d"})),
+          makePolicyHit(
+              "wazuh-threatintel-policies", "policy1", nlohmann::json::array({5, "e"}), std::string("HASHX"))}}};
 
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(hits));
 
@@ -694,9 +689,8 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyUnknownIndexNameThrows)
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json hits = {
-        {"total", {{"value", 1}}},
-        {"hits", {makePolicyHit("not-a-known-index", "x", nlohmann::json::array({1, "a"}))}}};
+    nlohmann::json hits = {{"total", {{"value", 1}}},
+                           {"hits", {makePolicyHit("not-a-known-index", "x", nlohmann::json::array({1, "a"}))}}};
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(hits));
 
     auto connector = makeConnector();
@@ -712,9 +706,7 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyMissingPolicyHashThrows)
     // Provide a hit whose _source.space.hash.sha256 is the wrong type (number instead of string)
     // so the get<string>() conversion throws, exercising the catch in getPolicy.
     nlohmann::json badHit = {{"_index", "wazuh-threatintel-policies"},
-                             {"_source",
-                              {{"document", {{"name", "p"}}},
-                               {"space", {{"hash", {{"sha256", 12345}}}}}}},
+                             {"_source", {{"document", {{"name", "p"}}}, {"space", {{"hash", {{"sha256", 12345}}}}}}},
                              {"sort", nlohmann::json::array({1, "a"})}};
     nlohmann::json hits = {{"total", {{"value", 1}}}, {"hits", {badHit}}};
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(hits));
@@ -728,9 +720,8 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyMissingPolicyHashThrows)
  **************************/
 TEST_F(WIndexerConnectorMockTest, GetEngineRemoteConfigHappyPath)
 {
-    nlohmann::json hits = {
-        {"total", {{"value", 1}}},
-        {"hits", {{{"_source", {{"engine", {{"index_raw_events", false}}}}}}}}};
+    nlohmann::json hits = {{"total", {{"value", 1}}},
+                           {"hits", {{{"_source", {{"engine", {{"index_raw_events", false}}}}}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
 
     auto connector = makeConnector();
@@ -750,8 +741,7 @@ TEST_F(WIndexerConnectorMockTest, GetEngineRemoteConfigMultipleHitsThrows)
 {
     nlohmann::json hits = {
         {"total", {{"value", 2}}},
-        {"hits",
-         {{{"_source", {{"engine", {{"a", 1}}}}}}, {{"_source", {{"engine", {{"b", 2}}}}}}}}};
+        {"hits", {{{"_source", {{"engine", {{"a", 1}}}}}}, {{"_source", {{"engine", {{"b", 2}}}}}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
     EXPECT_THROW(connector->getEngineRemoteConfig(), IndexerConnectorException);
@@ -759,8 +749,7 @@ TEST_F(WIndexerConnectorMockTest, GetEngineRemoteConfigMultipleHitsThrows)
 
 TEST_F(WIndexerConnectorMockTest, GetEngineRemoteConfigMissingEngineThrows)
 {
-    nlohmann::json hits = {{"total", {{"value", 1}}},
-                           {"hits", {{{"_source", {{"other", "value"}}}}}}};
+    nlohmann::json hits = {{"total", {{"value", 1}}}, {"hits", {{{"_source", {{"other", "value"}}}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
     EXPECT_THROW(connector->getEngineRemoteConfig(), IndexerConnectorException);
@@ -768,8 +757,7 @@ TEST_F(WIndexerConnectorMockTest, GetEngineRemoteConfigMissingEngineThrows)
 
 TEST_F(WIndexerConnectorMockTest, GetEngineRemoteConfigEngineNotObjectThrows)
 {
-    nlohmann::json hits = {{"total", {{"value", 1}}},
-                           {"hits", {{{"_source", {{"engine", "not-an-object"}}}}}}};
+    nlohmann::json hits = {{"total", {{"value", 1}}}, {"hits", {{{"_source", {{"engine", "not-an-object"}}}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(hits));
     auto connector = makeConnector();
     EXPECT_THROW(connector->getEngineRemoteConfig(), IndexerConnectorException);
@@ -796,16 +784,13 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesHappyPath)
          {{{"_id", "__ioc_type_hashes__"},
            {"_source",
             {{"type_hashes",
-              {{"ip", {{"hash", {{"sha256", "h-ip"}}}}},
-               {"domain", {{"hash", {{"sha256", "h-dom"}}}}}}}}},
+              {{"ip", {{"hash", {{"sha256", "h-ip"}}}}}, {"domain", {{"hash", {{"sha256", "h-dom"}}}}}}}}},
            {"sort", nlohmann::json::array({1, "a"})}}}}};
     nlohmann::json emptyPage = {{"hits", nlohmann::json::array()}};
 
     // batchSize is 1: queryByBatches keeps paginating while size == batchSize, so we need
     // a second empty response to terminate the loop.
-    EXPECT_CALL(*mock, search(_, _, _, _, _, _))
-        .WillOnce(Return(firstPage))
-        .WillOnce(Return(emptyPage));
+    EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(firstPage)).WillOnce(Return(emptyPage));
 
     auto connector = makeConnector();
     auto result = connector->getIocTypeHashes();
@@ -834,16 +819,13 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesFlatFormat)
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json firstPage = {
-        {"hits",
-         {{{"_id", "__ioc_type_hashes__"},
-           {"_source", {{"ip", {{"hash", {{"sha256", "h-ip"}}}}}}},
-           {"sort", nlohmann::json::array({1, "a"})}}}}};
+    nlohmann::json firstPage = {{"hits",
+                                 {{{"_id", "__ioc_type_hashes__"},
+                                   {"_source", {{"ip", {{"hash", {{"sha256", "h-ip"}}}}}}},
+                                   {"sort", nlohmann::json::array({1, "a"})}}}}};
     nlohmann::json emptyPage = {{"hits", nlohmann::json::array()}};
 
-    EXPECT_CALL(*mock, search(_, _, _, _, _, _))
-        .WillOnce(Return(firstPage))
-        .WillOnce(Return(emptyPage));
+    EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(firstPage)).WillOnce(Return(emptyPage));
 
     auto connector = makeConnector();
     auto result = connector->getIocTypeHashes();
@@ -862,22 +844,23 @@ TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeHappyPath)
 
     auto makeIocHit = [](const std::string& name, const nlohmann::json& sortVal)
     {
-        return nlohmann::json {{"_id", name},
-                               {"_source", {{"document", {{"name", name}, {"type", "ip"}}}}},
-                               {"sort", sortVal}};
+        return nlohmann::json {
+            {"_id", name}, {"_source", {{"document", {{"name", name}, {"type", "ip"}}}}}, {"sort", sortVal}};
     };
 
     // Two hits: first call returns 2, which equals batchSize → loop terminates.
-    nlohmann::json firstPage = {{"hits",
-                                 {makeIocHit("ioc1", nlohmann::json::array({1, "a"})),
-                                  makeIocHit("ioc2", nlohmann::json::array({2, "b"}))}}};
+    nlohmann::json firstPage = {
+        {"hits",
+         {makeIocHit("ioc1", nlohmann::json::array({1, "a"})), makeIocHit("ioc2", nlohmann::json::array({2, "b"}))}}};
 
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(firstPage));
 
     std::vector<std::pair<std::string, std::string>> received;
     auto connector = makeConnector();
-    auto count = connector->streamIocsByType(
-        "ip", /*batchSize=*/10, [&received](const std::string& k, const std::string& v) { received.emplace_back(k, v); });
+    auto count = connector->streamIocsByType("ip",
+                                             /*batchSize=*/10,
+                                             [&received](const std::string& k, const std::string& v)
+                                             { received.emplace_back(k, v); });
     EXPECT_EQ(count, 2U);
     EXPECT_EQ(received.size(), 2U);
     EXPECT_EQ(received[0].first, "ioc1");
@@ -904,17 +887,15 @@ TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeSkipsHitWithoutDocumentName)
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json hits = {
-        {"hits",
-         {{{"_id", "missing-name"},
-           {"_source", {{"document", {{"type", "ip"}}}}},
-           {"sort", nlohmann::json::array({1, "a"})}}}}};
+    nlohmann::json hits = {{"hits",
+                            {{{"_id", "missing-name"},
+                              {"_source", {{"document", {{"type", "ip"}}}}},
+                              {"sort", nlohmann::json::array({1, "a"})}}}}};
 
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(hits));
 
     auto connector = makeConnector();
-    auto count =
-        connector->streamIocsByType("ip", 10, [](const std::string&, const std::string&) {});
+    auto count = connector->streamIocsByType("ip", 10, [](const std::string&, const std::string&) {});
     EXPECT_EQ(count, 0U);
 }
 
@@ -929,8 +910,7 @@ TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeSkipsHitWithoutSource)
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(hits));
 
     auto connector = makeConnector();
-    auto count =
-        connector->streamIocsByType("ip", 10, [](const std::string&, const std::string&) {});
+    auto count = connector->streamIocsByType("ip", 10, [](const std::string&, const std::string&) {});
     EXPECT_EQ(count, 0U);
 }
 
@@ -957,14 +937,15 @@ TEST_F(WIndexerConnectorMockTest, StreamIocsByTypePaginatesAndStopsOnShutdown)
     // First call returns a full page, then we trigger shutdown so the
     // second iteration short-circuits with an exception.
     EXPECT_CALL(*mock, search(_, _, _, _, _, _))
-        .WillOnce(DoAll(Invoke([connector_ptr = connector.get()](
-                                   const PointInTime&, std::size_t, const nlohmann::json&,
-                                   const nlohmann::json&, const std::optional<nlohmann::json>&,
-                                   const std::optional<nlohmann::json>&)
+        .WillOnce(DoAll(Invoke([connector_ptr = connector.get()](const PointInTime&,
+                                                                 std::size_t,
+                                                                 const nlohmann::json&,
+                                                                 const nlohmann::json&,
+                                                                 const std::optional<nlohmann::json>&,
+                                                                 const std::optional<nlohmann::json>&)
                                { connector_ptr->requestShutdown(); }),
                         Return(fullPage("a"))));
 
     EXPECT_THROW(connector->streamIocsByType("ip", 2, [](const std::string&, const std::string&) {}),
                  IndexerConnectorException);
 }
-

--- a/src/engine/tools/devContainer/e2e/agents/init.sh
+++ b/src/engine/tools/devContainer/e2e/agents/init.sh
@@ -63,8 +63,8 @@ WAZUH_4X_VERSION="${WAZUH_4X_VERSION:-4.14.3-1}"
 WAZUH_4X_DEB_URL="https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${WAZUH_4X_VERSION}_amd64.deb"
 WAZUH_4X_RPM_URL="https://packages.wazuh.com/4.x/yum/wazuh-agent-${WAZUH_4X_VERSION}.x86_64.rpm"
 
-WAZUH_5X_YAML_URL="https://packages-staging.xdrsiem.wazuh.info/nightly/5.0.0/artifact_urls_5.0.0-latest.yaml"
-
+#  WAZUH_5X_YAML_URL="https://packages-staging.xdrsiem.wazuh.info/nightly/5.0.0/artifact-urls/artifact_urls_5.0.0-latest.yaml"
+WAZUH_5X_YAML_URL="https://packages-staging.xdrsiem.wazuh.info/nightly-backup/artifact_urls_5.0.0-latest.yaml"
 PKGS_DIR="${SCRIPT_DIR}/pkgs"
 mkdir -p "$PKGS_DIR"
 

--- a/src/engine/tools/devContainer/e2e/init.sh
+++ b/src/engine/tools/devContainer/e2e/init.sh
@@ -218,36 +218,37 @@ function download_and_unzip_artifact() {
 }
 
 #
-# Find and filter artifacts by prefix, and for each artifact define a "dest_file" # according to the prefix.
+# Find and filter artifacts by regex, and for each artifact define a destination
+# file according to the first matching pattern.
 #   args:
 #     $1 => repo (e.g. "wazuh/wazuh-indexer")
 #     $2 => run_id (e.g. "123456789")
 #     $3 => output_dir (e.g. "wazuh-indexer")
-#     from $4 => list of prefix::filename pairs (e.g.
-#                "prefix1::file1.zip" "wazuh-indexer-setup-5.0::wazuh-indexer-setup-5.0.0.0.zip"
+#     from $4 => list of regex::filename pairs (e.g.
+#                "^prefix1-[[:alnum:]]+\\.zip$::file1.zip"
+#                "^wazuh-indexer_5\\.0\\.0-[[:alnum:]]+_amd64\\.deb$::wazuh-indexer_5.0.0-latest_amd64.deb"
 #
-function fetch_artifacts_with_prefixes() {
+function fetch_artifacts_with_patterns() {
   local repo=$1
   local run_id=$2
   local output_dir=$3
-  shift 3 # Shift the first three arguments to get the prefixes
+  shift 3
 
-  # Build the jq filter to select artifacts by prefix and create the prefix map "NAME URL"
+  # Build the jq filter to select artifacts by regex and create the regex map.
   local jq_filter=""
-  local -a prefix_map=()
+  local -a pattern_map=()
 
   for pair in "$@"; do
-    # pair is in the format "prefix::filename", we split it into prefix and final_filename
-    # prefix is the prefix to match, final_filename is the name of the file to save the artifact as
-    local prefix="${pair%%::*}"
+    local pattern="${pair%%::*}"
+    local jq_pattern="${pattern//\\/\\\\}"
+    jq_pattern="${jq_pattern//\"/\\\"}"
     local final_filename="${pair##*::}"
-    prefix_map+=("$prefix|$final_filename")
+    pattern_map+=("$pattern|$final_filename")
 
-    # Add to jq filter
     if [[ -z "$jq_filter" ]]; then
-      jq_filter="(.name | startswith(\"$prefix\"))"
+      jq_filter="(.name | test(\"$jq_pattern\"))"
     else
-      jq_filter="$jq_filter or (.name | startswith(\"$prefix\"))"
+      jq_filter="$jq_filter or (.name | test(\"$jq_pattern\"))"
     fi
   done
 
@@ -257,29 +258,28 @@ function fetch_artifacts_with_prefixes() {
     gh api "repos/$repo/actions/runs/$run_id/artifacts" \
       -q ".artifacts[]
           | select($jq_filter and (.name | test(\"\\\\.(sha512|sha256|md5)$\") | not))
-          | \"\(.name) \(.archive_download_url)\"" \
+          | [ .name, .archive_download_url ]
+          | @tsv" \
     | cat
   )
 
   if [[ -z "$raw_kv_art" ]]; then
-    echo "==> Cannot find any artifacts matching given prefixes in $repo / run_id $run_id. See http://github.com/$repo/actions/runs/$run_id"
+    echo "==> Cannot find any artifacts matching the given patterns in $repo / run_id $run_id. See http://github.com/$repo/actions/runs/$run_id"
     return 0
   fi
 
   echo ""
   echo "==> Downloading artifacts of interest..."
 
-  while read -r artifact_line; do
-    local artifact_name artifact_url
-    artifact_name="$(echo "$artifact_line" | awk '{print $1}')"
-    artifact_url="$(echo "$artifact_line"  | awk '{print $2}')"
+  while IFS=$'\t' read -r artifact_name artifact_url; do
+    [[ -z "$artifact_name" || -z "$artifact_url" ]] && continue
 
     # Determine the destination file
-    for pm in "${prefix_map[@]}"; do
-      local pre="${pm%%|*}"
+    for pm in "${pattern_map[@]}"; do
+      local pattern="${pm%%|*}"
       local final_f="${pm##*|}"
 
-      if [[ "$artifact_name" == "$pre"* ]]; then
+      if [[ "$artifact_name" =~ $pattern ]]; then
         download_and_unzip_artifact "$repo" "$run_id" "$artifact_url" "$output_dir" "$final_f"
         break
       fi
@@ -314,11 +314,11 @@ function get_indexer_artifact() {
   list_run_artifacts "$repo" "$run_id"
 
   # Download:
-  #  - If artifact_name starts with "wazuh-indexer_5.0.0-latest_amd64.deb",
+  #  - If artifact_name matches wazuh-indexer_5.0.0-${VAR}_amd64.deb,
   #    save it as "wazuh-indexer_5.0.0-latest_amd64.deb"
-  fetch_artifacts_with_prefixes \
+  fetch_artifacts_with_patterns \
     "$repo" "$run_id" "wazuh-indexer" \
-    "wazuh-indexer_5.0.0-::wazuh-indexer_5.0.0-latest_amd64.deb"
+    '^wazuh-indexer_5\.0\.0-[[:alnum:]]+_amd64\.deb$::wazuh-indexer_5.0.0-latest_amd64.deb'
 }
 
 
@@ -347,11 +347,11 @@ function get_dashboard_artifact() {
   list_run_artifacts "$repo" "$run_id"
 
   # Download:
-  #  - If artifact_name starts with "wazuh-dashboard_5.0.0-latest_amd64.deb",
+  #  - If artifact_name matches wazuh-dashboard_5.0.0-${VAR}_amd64.deb,
   #    save it as "wazuh-dashboard_5.0.0-latest_amd64.deb"
-  fetch_artifacts_with_prefixes \
+  fetch_artifacts_with_patterns \
     "$repo" "$run_id" "wazuh-dashboard" \
-    "wazuh-dashboard_5.0.0-::wazuh-dashboard_5.0.0-latest_amd64.deb"
+    '^wazuh-dashboard_5\.0\.0-[[:alnum:]]+_amd64\.deb$::wazuh-dashboard_5.0.0-latest_amd64.deb'
 }
 
 ####################################################

--- a/src/engine/tools/devContainer/e2e/init.sh
+++ b/src/engine/tools/devContainer/e2e/init.sh
@@ -318,7 +318,7 @@ function get_indexer_artifact() {
   #    save it as "wazuh-indexer_5.0.0-latest_amd64.deb"
   fetch_artifacts_with_prefixes \
     "$repo" "$run_id" "wazuh-indexer" \
-    "wazuh-indexer_5.0.0-latest_amd64.deb::wazuh-indexer_5.0.0-latest_amd64.deb"
+    "wazuh-indexer_5.0.0-::wazuh-indexer_5.0.0-latest_amd64.deb"
 }
 
 
@@ -351,7 +351,7 @@ function get_dashboard_artifact() {
   #    save it as "wazuh-dashboard_5.0.0-latest_amd64.deb"
   fetch_artifacts_with_prefixes \
     "$repo" "$run_id" "wazuh-dashboard" \
-    "wazuh-dashboard_5.0.0-latest_amd64.deb::wazuh-dashboard_5.0.0-latest_amd64.deb"
+    "wazuh-dashboard_5.0.0-::wazuh-dashboard_5.0.0-latest_amd64.deb"
 }
 
 ####################################################

--- a/src/shared_modules/content_manager/README.md
+++ b/src/shared_modules/content_manager/README.md
@@ -62,7 +62,7 @@ After all pages are processed, the downloader signals completion via `indexer_co
             },
             "index": ".wazuh-threatintel-vulnerabilities",
             "consumerStatusIndex": ".wazuh-cti-consumers",
-            "consumerStatusId": "t1-vulnerabilities-5_public-vulnerabilities-5",
+            "consumerStatusId": "cti:catalog:consumer:vulnerabilities",
             "pageSize": 250,
             "numSlices": 2
         }

--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -136,7 +136,7 @@ Example:
             },
             "index": ".wazuh-threatintel-vulnerabilities",
             "consumerStatusIndex": ".wazuh-cti-consumers",
-            "consumerStatusId": "t1-vulnerabilities-5_public-vulnerabilities-5",
+            "consumerStatusId": "cti:catalog:consumer:vulnerabilities",
             "pageSize": 250,
             "numSlices": 2
         }

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -52,7 +52,7 @@
  * {
  *   "index":               ".wazuh-threatintel-vulnerabilities", // Indexer CVE index name
  *   "consumerStatusIndex": ".wazuh-cti-consumers",    // Consumer status index (optional)
- *   "consumerStatusId":    "t1-vulnerabilities-5_public-vulnerabilities-5", // Consumer status document id (optional)
+ *   "consumerStatusId":    "cti:catalog:consumer:vulnerabilities", // Consumer status document id (optional)
  *   "pageSize":            250,                       // Documents per page (optional, default 250)
  *   "numSlices":           2,                         // Parallel PIT slices (optional, default 2)
  *   <standard IndexerConnector SSL/auth config>

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -18,7 +18,7 @@ OPENSEARCH_IP = "127.0.0.1:9200"
 OPENSEARCH_URL = f"http://{OPENSEARCH_IP}"
 CTI_FEED_INDEX = ".wazuh-threatintel-vulnerabilities"
 CTI_CONSUMERS_INDEX = ".wazuh-cti-consumers"
-CTI_CONSUMER_DOC_ID = "t1-vulnerabilities-5_public-vulnerabilities-5"
+CTI_CONSUMER_DOC_ID = "cti:catalog:consumer:vulnerabilities"
 CTI_FEED_FILE = Path("wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json")
 
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -39,7 +39,7 @@ namespace
 {
     constexpr std::string_view INDEXER_FEED_INDEX {".wazuh-threatintel-vulnerabilities"};
     constexpr std::string_view INDEXER_CONSUMER_STATUS_INDEX {".wazuh-cti-consumers"};
-    constexpr std::string_view INDEXER_CONSUMER_STATUS_ID {"t1-vulnerabilities-5_public-vulnerabilities-5"};
+    constexpr std::string_view INDEXER_CONSUMER_STATUS_ID {"cti:catalog:consumer:vulnerabilities"};
 
     bool shouldSkipPostUpdateScan()
     {


### PR DESCRIPTION
## Description

Closes #35835

Engine (`wazuh-analysisd`) was updating its feed/policies without checking whether the Indexer was still publishing CTI content, which could result in consuming incomplete or inconsistent data. Following the coordination mechanism defined in #35166, Engine now reads the guard document in the `.wazuh-cti-consumers` index before each sync cycle and defers the update to the next cycle when `status != "idle"`.

## Proposed Changes

**`wiconnector` (windexerconnector) — guard-document validation**
- New constants: `STANDARD_RULESET_CONSUMER_ID = "beta-2-ruleset-5_public-ruleset-5"`, `IOC_ENRICHMENT_CONSUMER_ID = "t1-iocs-5_public-iocs-5"`, `CTI_CONSUMERS_INDEX = ".wazuh-cti-consumers"`.
- `IWIndexerConnector` methods (`getPolicy`, `getPolicyHashAndEnabled`, `getIocTypeHashes`, `streamIocsByType`) now accept an optional `consumerIdToValidate` and return `std::optional<...>`.
- When `consumerIdToValidate` is provided, the implementation includes `.wazuh-cti-consumers` in the same Point-in-Time (PIT) used to query CTI data, verifies that the guard document's `status == "idle"` before and after the query, and returns `std::nullopt` otherwise. This guarantees the consumer-status check and the data read are taken from the same transactional snapshot.

**`cmsync` — per-namespace consumer ID and skip-on-non-idle**
- `SyncedNamespace` gains an `std::optional<std::string> m_consumerId` (serialized under `/consumer_id`) with its getter/setter.
- Default state initialization: the `standard` namespace is created with `STANDARD_RULESET_CONSUMER_ID`; `custom` is created without a consumer ID.
- `synchronize()` extracts the consumer ID from each namespace's state and forwards it to `wiconnector`. When the connector returns `std::nullopt`, the affected space is logged and skipped — it will be retried on the next scheduled cycle (no tight retry loop).

**`iocsync` — defer the entire IOC sync cycle when the consumer is updating**
- `getIocTypeHashes()` and `streamIocsByType()` are called with `IOC_ENRICHMENT_CONSUMER_ID`.
- If the connector returns `std::nullopt`, the whole IOC sync cycle is aborted, the temporary KVDB used during ingestion is rolled back, and a log entry is emitted indicating the next cycle will retry.

## Results and Evidence


**IOC and vd Fail but cmsync ok**
```
026/05/11 19:16:14 wazuh-manager-analysisd: INFO: [IOC::Sync] IOC syncronization skipped because wazuh-indexer consumer for IOCs is not ready for sync (might be updating or no data yet)
2026/05/11 19:16:14 wazuh-manager-analysisd: INFO: [CMSync] Changes detected for space 'standard', updating...
2026/05/11 19:16:15 wazuh-manager-remoted: INFO: Started (pid: 130532). Listening on port 1514/TCP (secure).
2026/05/11 19:16:15 wazuh-manager-monitord: INFO: Started (pid: 130562).
2026/05/11 19:16:15 wazuh-manager-modulesd: INFO: Started (pid: 130568).
2026/05/11 19:16:15 wazuh-manager-modulesd:database: INFO: Module started.
2026/05/11 19:16:15 wazuh-manager-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2026/05/11 19:16:15 wazuh-manager-modulesd:router: INFO: Starting router module.
2026/05/11 19:16:15 wazuh-manager-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/11 19:16:15 wazuh-manager-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/05/11 19:16:15 wazuh-manager-modulesd:inventory-sync: INFO: Starting inventory_sync module.
2026/05/11 19:16:15 wazuh-manager-modulesd:content_manager: INFO: Starting content_manager module.
2026/05/11 19:16:15 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/05/11 19:16:15 IndexerConnector: WARNING: No username and password found in the keystore, using default values.
2026/05/11 19:16:15 logger-helper: INFO: InventorySyncFacade started.
2026/05/11 19:16:15 wazuh-manager-modulesd:vulnerability-scanner: WARNING: The local feed database is incomplete at startup: required global maps are missing. Clearing updater state to force a clean rebuild.
2026/05/11 19:16:15 wazuh-manager-analysisd: INFO: Remote settings synchronized: changes detected and applied.
2026/05/11 19:16:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' not found in '.wazuh-cti-consumers'. Waiting 60 s before retrying.
2026/05/11 19:16:15 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/05/11 19:16:25 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/05/11 19:16:53 wazuh-manager-analysisd: INFO: [CMSync] Successfully synchronized space 'standard'
```



**VD Ok**

```

2026/05/11 19:16:11 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Stop requested while waiting for consumer 'cti:catalog:consumer:vulnerabilities' to become idle.
.....
2026/05/11 19:17:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' is still updating in '.wazuh-cti-consumers'. Waiting 60 s before retrying.
2026/05/11 19:18:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/05/11 19:18:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/05/11 19:18:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
```



CMSync fail but IOC OK

```
2026/05/11 19:23:37 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'connection'
2026/05/11 19:23:37 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_full', updating...
2026/05/11 19:23:40 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_full'
2026/05/11 19:23:40 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_domain', updating...
2026/05/11 19:23:51 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_domain'
2026/05/11 19:23:51 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_md5', updating...
2026/05/11 19:23:52 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_md5'
2026/05/11 19:23:52 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha1', updating...
2026/05/11 19:23:52 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha1'
2026/05/11 19:23:52 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha256', updating...
2026/05/11 19:23:53 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha256'
2026/05/11 19:24:02 wazuh-manager-analysisd: INFO: [CMSync] Synchronization skipped for space 'cti:catalog:consumer:ruleset' because wazuh-indexer consumer 'standard' is not ready for sync (might be updating or no data)
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [x] Test run in parallel
  - [x] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-engine` (manager binary).

### Configuration Changes

N/A — no new configuration parameters. The consumer IDs and the `.wazuh-cti-consumers` index name are defined as constants in `wiconnector`.

### Tests Introduced

- Updated `cmsync` unit tests (`cmsync_test.cpp`) to cover the new `consumer_id` field in `SyncedNamespace`, the propagation of `consumerIdToValidate` to `wiconnector`, and the skip behavior when the connector returns `std::nullopt`.
- Updated `wiconnector` mocks (`mockswindexerconnector.hpp`) to reflect the new `std::optional` return types and the optional `consumerIdToValidate` parameter.
- No new tests added for `iocsync` in this PR.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
