### PR TITLE
Graceful termination via cooperative cancellation

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
@@ -104,7 +104,7 @@ void test_wm_agent_upgrade_listen_messages_upgrade_command(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -205,7 +205,7 @@ void test_wm_agent_upgrade_listen_messages_upgrade_custom_command(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -307,7 +307,7 @@ void test_wm_agent_upgrade_listen_messages_agent_update_status_command(void **st
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -411,7 +411,7 @@ void test_wm_agent_upgrade_listen_messages_upgrade_result_command(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -490,7 +490,7 @@ void test_wm_agent_upgrade_listen_messages_parse_error(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -547,7 +547,7 @@ void test_wm_agent_upgrade_listen_messages_parse_error_with_message(void **state
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -595,7 +595,7 @@ void test_wm_agent_upgrade_listen_messages_receive_empty(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -629,7 +629,7 @@ void test_wm_agent_upgrade_listen_messages_receive_error(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -663,7 +663,7 @@ void test_wm_agent_upgrade_listen_messages_receive_sock_error(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -698,7 +698,7 @@ void test_wm_agent_upgrade_listen_messages_accept_error_eintr(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -737,7 +737,7 @@ void test_wm_agent_upgrade_listen_messages_accept_error(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -778,7 +778,7 @@ void test_wm_agent_upgrade_listen_messages_select_zero(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -815,7 +815,7 @@ void test_wm_agent_upgrade_listen_messages_select_error_eintr(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 
@@ -850,7 +850,7 @@ void test_wm_agent_upgrade_listen_messages_select_error(void **state)
     expect_value(__wrap_OS_BindUnixDomainWithPerms, perm, 0660);
     will_return(__wrap_OS_BindUnixDomainWithPerms, socket);
 
-    expect_value(__wrap_sleep, seconds, WM_AGENT_UPGRADE_START_WAIT_TIME);
+    expect_value_count(__wrap_sleep, seconds, 1, WM_AGENT_UPGRADE_START_WAIT_TIME);
 
     will_return(__wrap_wm_agent_upgrade_cancel_pending_upgrades, 1);
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_upgrades.c
@@ -59,8 +59,9 @@ static int teardown_string(void **state) {
 static int setup_config(void **state) {
     wm_manager_configs *config = NULL;
     os_calloc(1, sizeof(wm_manager_configs), config);
+    config->max_threads = 8;
     *state = config;
-    upgrade_queue = linked_queue_init();
+    wm_agent_upgrade_init_upgrade_queue(config->max_threads);
     return 0;
 }
 

--- a/src/unit_tests/wazuh_modules/aws/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/aws/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Tests list and flags
 list(APPEND tests_names "test_wm_aws")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
-                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=wm_aws_run_s3,--wrap=StartMQ,--wrap=FOREVER \
+                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=wm_aws_run_s3,--wrap=StartMQ,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible \
                          -Wl,--wrap=atexit -Wl,--wrap=wm_state_io -Wl,--wrap=w_query_agentd")
 list(APPEND use_shared_libs 1)
 

--- a/src/unit_tests/wazuh_modules/azure/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/azure/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Tests list and flags
 list(APPEND tests_names "test_wm_azure")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
-                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER,--wrap=SendMSG \
+                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible,--wrap=SendMSG \
                          -Wl,--wrap=atexit -Wl,--wrap=w_query_agentd")
 list(APPEND use_shared_libs 1)
 

--- a/src/unit_tests/wazuh_modules/command/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/command/CMakeLists.txt
@@ -9,7 +9,7 @@
 list(APPEND tests_names "test_wm_command")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=_mtdebug1 \
-                         -Wl,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER \
+                         -Wl,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible \
                          -Wl,--wrap=wm_sendmsg \
                          -Wl,--wrap=wm_validate_command -Wl,--wrap=w_query_agentd")
 list(APPEND use_shared_libs 1)

--- a/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/docker/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Tests list and flags
 list(APPEND tests_names "test_wm_docker")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
-                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=wpclose,--wrap=fgets \
+                         -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible,--wrap=wpclose,--wrap=fgets \
                          -Wl,--wrap=wpopenl,--wrap=fclose,--wrap=fflush,--wrap=fprintf,--wrap=fopen,--wrap=fread,--wrap=fseek \
                          -Wl,--wrap=fwrite,--wrap=remove,--wrap=atexit -Wl,--wrap,fgetpos -Wl,--wrap=fgetc -Wl,--wrap=wfopen -Wl,--wrap,popen -Wl,--wrap=w_query_agentd")
 list(APPEND use_shared_libs 1)

--- a/src/unit_tests/wazuh_modules/gcp/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/gcp/CMakeLists.txt
@@ -12,7 +12,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND tests_names "test_wm_gcp")
 list(APPEND tests_flags "-Wl,--wrap,wm_exec \
                          -Wl,--wrap,sched_scan_dump,--wrap,sched_scan_get_time_until_next_scan \
-                         -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,FOREVER,--wrap,w_get_timestamp \
+                         -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,FOREVER -Wl,--wrap,wm_sleep_until_interruptible,--wrap,w_get_timestamp \
                          -Wl,--wrap,w_sleep_until,--wrap,isDebug -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 list(APPEND use_shared_libs 0)
 

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -111,8 +111,8 @@ void test_github_main_enable(void **state) {
     expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:github");
     expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub started.");
 
-    expect_value(__wrap_sleep, __seconds, 2);
-    will_return(__wrap_sleep, 0);
+    expect_value_count(__wrap_sleep, __seconds, 1, 2);
+    will_return_count(__wrap_sleep, 0, 2);
 
     wm_github_main(data->github_config);
 }

--- a/src/unit_tests/wazuh_modules/ms_graph/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/ms_graph/CMakeLists.txt
@@ -14,7 +14,7 @@ list(APPEND tests_flags "-Wl,--wrap=_merror -Wl,--wrap=_mtinfo -Wl,--wrap=_mtwar
                         -Wl,--wrap,atexit -Wl,--wrap,time -Wl,--wrap,wm_state_io -Wl,--wrap,StartMQ -Wl,--wrap,gmtime_r -Wl,--wrap,isDebug \
                         -Wl,--wrap,sched_scan_get_time_until_next_scan -Wl,--wrap,is_fim_shutdown -Wl,--wrap,fim_db_teardown -Wl,--wrap,Start_win32_Syscheck \
                         -Wl,--wrap,strftime -Wl,--wrap,_mtdebug2 -Wl,--wrap,wm_sendmsg -Wl,--wrap,strerror \
-                        -Wl,--wrap,syscom_dispatch -Wl,--wrap,_imp__dbsync_initialize -Wl,--wrap,w_get_timestamp -Wl,--wrap,os_random -Wl,--wrap,FOREVER -Wl,--wrap,w_query_agentd \
+                        -Wl,--wrap,syscom_dispatch -Wl,--wrap,_imp__dbsync_initialize -Wl,--wrap,w_get_timestamp -Wl,--wrap,os_random -Wl,--wrap,FOREVER -Wl,--wrap,wm_sleep_until_interruptible -Wl,--wrap,w_query_agentd \
                         -Wl,--wrap,w_sleep_until")
 
 

--- a/src/unit_tests/wrappers/wazuh/shared/time_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/time_op_wrappers.c
@@ -22,6 +22,10 @@ void __wrap_w_sleep_until(const time_t new_time){
     current_time = new_time;
 }
 
+void __wrap_wm_sleep_until_interruptible(const time_t new_time){
+    current_time = new_time;
+}
+
 void __wrap_w_time_delay(unsigned long int msec){
     current_time += (msec/1000);
 }

--- a/src/unit_tests/wrappers/wazuh/shared/time_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/time_op_wrappers.h
@@ -15,6 +15,8 @@
 
 void __wrap_w_sleep_until(const time_t new_time);
 
+void __wrap_wm_sleep_until_interruptible(const time_t new_time);
+
 void __wrap_w_time_delay(unsigned long int msec);
 
 char* __wrap_w_get_timestamp(time_t time);

--- a/src/wazuh_modules/include/wmodules.h
+++ b/src/wazuh_modules/include/wmodules.h
@@ -86,6 +86,12 @@ extern int wm_task_nice;        // Nice value for tasks.
 extern int wm_max_eps;          // Maximum events per second sent by Wazuh Module
 extern int wm_kill_timeout;     // Time for a process to quit before killing it
 extern int wm_debug_level;
+extern volatile sig_atomic_t wm_shutdown_requested;
+
+void wm_sleep_interruptible(int seconds);
+void wm_sleep_until_interruptible(time_t abs_time);
+// Like select() on a single read fd but checks wm_shutdown_requested every second; returns 0 on shutdown.
+int wm_select_interruptible(int sock, fd_set *fdset);
 
 // Read XML configuration and internal options
 int wm_config();

--- a/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -27,25 +27,18 @@
 #endif
 
 const char* upgrade_values[] = {
-    [WM_UPGRADE_SUCCESSFUL] = "0",
-    [WM_UPGRADE_FAILED_INTERMEDIATE] = "1",
-    [WM_UPGRADE_FAILED] = "2"
-};
+    [WM_UPGRADE_SUCCESSFUL] = "0", [WM_UPGRADE_FAILED_INTERMEDIATE] = "1", [WM_UPGRADE_FAILED] = "2"};
 
-const char* upgrade_messages[] = {
-    [WM_UPGRADE_SUCCESSFUL] = "Upgrade was successful",
-    [WM_UPGRADE_FAILED_INTERMEDIATE] = "Upgrade failed: intermediate version required",
-    [WM_UPGRADE_FAILED] = "Upgrade failed"
-};
+const char* upgrade_messages[] = {[WM_UPGRADE_SUCCESSFUL] = "Upgrade was successful",
+                                  [WM_UPGRADE_FAILED_INTERMEDIATE] = "Upgrade failed: intermediate version required",
+                                  [WM_UPGRADE_FAILED] = "Upgrade failed"};
 
-static const char *task_statuses_map[] = {
-    [WM_UPGRADE_SUCCESSFUL] = WM_TASK_STATUS_DONE,
-    [WM_UPGRADE_FAILED_INTERMEDIATE] = WM_TASK_STATUS_FAILED,
-    [WM_UPGRADE_FAILED] = WM_TASK_STATUS_FAILED
-};
+static const char* task_statuses_map[] = {[WM_UPGRADE_SUCCESSFUL] = WM_TASK_STATUS_DONE,
+                                          [WM_UPGRADE_FAILED_INTERMEDIATE] = WM_TASK_STATUS_FAILED,
+                                          [WM_UPGRADE_FAILED] = WM_TASK_STATUS_FAILED};
 
 // CA certificates
-char **wcom_ca_store = NULL;
+char** wcom_ca_store = NULL;
 
 #ifndef WIN32
 
@@ -53,7 +46,7 @@ char **wcom_ca_store = NULL;
  * Listen to the upgrade socket in order to receive commands
  * @return only on errors, socket will be closed
  * */
-STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void *arg);
+STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void* arg);
 
 #endif
 
@@ -73,7 +66,7 @@ STATIC void wm_agent_upgrade_check_status(const wm_agent_configs* agent_config) 
  * @retval true information was found on the upgrade_result file
  * @retval either the upgrade_result file does not exist or contains invalid information
  * */
-STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd);
+STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd);
 
 /**
  * Reads the upgrade_result file if it is present and sends the upgrade result message to the manager.
@@ -89,99 +82,101 @@ STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd);
  * @param state upgrade result state
  * @param raw_code raw numeric code read from upgrade_result file
  * */
-STATIC void wm_upgrade_agent_send_ack_message(int *queue_fd, wm_upgrade_agent_state state, unsigned int raw_code);
+STATIC void wm_upgrade_agent_send_ack_message(int* queue_fd, wm_upgrade_agent_state state, unsigned int raw_code);
 
-void wm_agent_upgrade_start_agent_module(const wm_agent_configs* agent_config, const int enabled) {
+void wm_agent_upgrade_start_agent_module(const wm_agent_configs* agent_config, const int enabled)
+{
 
     // Check if module is enabled
-    if (!enabled) {
+    if (!enabled)
+    {
         allow_upgrades = false;
-    } else {
+    }
+    else
+    {
         mtinfo(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_MODULE_STARTED);
     }
 
-    #ifndef WIN32
-        w_create_thread(wm_agent_upgrade_listen_messages, NULL);
-    #endif
+#ifndef WIN32
+    w_create_thread(wm_agent_upgrade_listen_messages, NULL);
+#endif
 
-    if (enabled) {
+    if (enabled)
+    {
         wm_agent_upgrade_check_status(agent_config);
     }
 }
 
 #ifndef WIN32
 
-STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void *arg) {
+STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void* arg)
+{
     // Initialize socket
     char sockname[PATH_MAX + 1];
 
-	strcpy(sockname, AGENT_UPGRADE_SOCK);
+    strcpy(sockname, AGENT_UPGRADE_SOCK);
 
     int sock = OS_BindUnixDomainWithPerms(sockname, SOCK_STREAM, OS_MAXSTR, getuid(), wm_getGroupID(), 0660);
-    if (sock < 0) {
+    if (sock < 0)
+    {
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_BIND_SOCK_ERROR, AGENT_UPGRADE_SOCK, strerror(errno));
         return NULL;
     }
 
-    while(1) {
+    while (!wm_shutdown_requested)
+    {
         // listen - wait connection
         fd_set fdset;
         FD_ZERO(&fdset);
         FD_SET(sock, &fdset);
 
-        switch (select(sock + 1, &fdset, NULL, NULL, NULL)) {
-        case -1:
-            if (errno != EINTR) {
+        switch (wm_select_interruptible(sock, &fdset))
+        {
+            case -1:
                 mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_SELECT_ERROR, strerror(errno));
                 close(sock);
                 return NULL;
-            }
-            continue;
-        case 0:
-            continue;
+            case 0: continue;
         }
 
-        //Accept
+        // Accept
         int peer;
-        if (peer = accept(sock, NULL, NULL), peer < 0) {
-            if (errno != EINTR) {
+        if (peer = accept(sock, NULL, NULL), peer < 0)
+        {
+            if (errno != EINTR)
+            {
                 mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_ACCEPT_ERROR, strerror(errno));
             }
             continue;
         }
 
         // Get request string
-        char *buffer = NULL;
+        char* buffer = NULL;
 
         os_calloc(OS_MAXSTR, sizeof(char), buffer);
         int length;
-        switch (length = OS_RecvSecureTCP(peer, buffer, OS_MAXSTR), length) {
-        case OS_SOCKTERR:
-            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_SOCKTERR_ERROR);
-            break;
-        case -1:
-            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_RECV_ERROR, strerror(errno));
-            break;
-        case 0:
-            mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_EMPTY_MESSAGE);
-            break;
-        default:
-            mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_INCOMMING_MESSAGE, buffer);
-            char* message = NULL;
-            size_t length = wm_agent_upgrade_process_command(buffer, &message);
+        switch (length = OS_RecvSecureTCP(peer, buffer, OS_MAXSTR), length)
+        {
+            case OS_SOCKTERR: mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_SOCKTERR_ERROR); break;
+            case -1: mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_RECV_ERROR, strerror(errno)); break;
+            case 0: mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_EMPTY_MESSAGE); break;
+            default:
+                mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_INCOMMING_MESSAGE, buffer);
+                char* message = NULL;
+                size_t length = wm_agent_upgrade_process_command(buffer, &message);
 
-            mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_RESPONSE_MESSAGE, message);
-            OS_SendSecureTCP(peer, length, message);
-            os_free(message);
-            break;
+                mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_RESPONSE_MESSAGE, message);
+                OS_SendSecureTCP(peer, length, message);
+                os_free(message);
+                break;
         }
 
         os_free(buffer);
         close(peer);
 
-    #ifdef WAZUH_UNIT_TESTING
+#ifdef WAZUH_UNIT_TESTING
         break;
-    #endif
+#endif
     }
 
     close(sock);
@@ -191,19 +186,27 @@ STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void *arg)
 
 #endif
 
-STATIC void wm_agent_upgrade_check_status(const wm_agent_configs* agent_config) {
+STATIC void wm_agent_upgrade_check_status(const wm_agent_configs* agent_config)
+{
     /**
      *  StartMQ will wait until agent connection which is when the pkg_install.sh will write
      *  the upgrade result
-    */
+     */
     int queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     // Wait until pkg_installer script verifies the agent was connected and writes the upgrade_result file
-    sleep(WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
+    wm_sleep_interruptible(WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
+    if (wm_shutdown_requested)
+    {
+        return;
+    }
 
-    if (queue_fd < 0) {
+    if (queue_fd < 0)
+    {
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_QUEUE_FD);
-    } else {
+    }
+    else
+    {
         bool result_available = true;
         unsigned int wait_time = agent_config->upgrade_wait_start;
         /**
@@ -211,46 +214,57 @@ STATIC void wm_agent_upgrade_check_status(const wm_agent_configs* agent_config) 
          * If the manager is able to update the upgrade status will notify the agent
          * erasing the result file and exiting this loop
          * */
-        while (result_available) {
+        while (result_available)
+        {
             result_available = wm_upgrade_agent_search_upgrade_result(&queue_fd);
 
-            if(result_available) {
-                sleep(wait_time);
+            if (result_available)
+            {
+                wm_sleep_interruptible((int)wait_time);
+                if (wm_shutdown_requested)
+                {
+                    break;
+                }
 
                 wait_time *= agent_config->upgrade_wait_factor_increase;
-                if (wait_time > agent_config->upgrade_wait_max) {
+                if (wait_time > agent_config->upgrade_wait_max)
+                {
                     wait_time = agent_config->upgrade_wait_max;
                 }
             }
         }
-    #ifndef WIN32
+#ifndef WIN32
         close(queue_fd);
-    #endif
+#endif
     }
 
-    if (!allow_upgrades) {
+    if (!allow_upgrades)
+    {
         allow_upgrades = true;
     }
 }
 
-STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd) {
+STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd)
+{
     char buffer[20];
-    const char * PATH = WM_AGENT_UPGRADE_RESULT_FILE;
+    const char* PATH = WM_AGENT_UPGRADE_RESULT_FILE;
 
-    FILE *result_file = wfopen(PATH, "r");
-    if (result_file) {
-        if (fgets(buffer, 20, result_file) == NULL) {
+    FILE* result_file = wfopen(PATH, "r");
+    if (result_file)
+    {
+        if (fgets(buffer, 20, result_file) == NULL)
+        {
             fclose(result_file);
             return true;
         }
         fclose(result_file);
 
-        char *endptr;
+        char* endptr;
         unsigned long raw_code = strtoul(buffer, &endptr, 10);
-        if (endptr != buffer && (*endptr == '\0' || *endptr == '\n' || *endptr == '\r')) {
-            wm_upgrade_agent_state state = (raw_code < WM_UPGRADE_MAX_STATE)
-                                           ? (wm_upgrade_agent_state)raw_code
-                                           : WM_UPGRADE_FAILED;
+        if (endptr != buffer && (*endptr == '\0' || *endptr == '\n' || *endptr == '\r'))
+        {
+            wm_upgrade_agent_state state =
+                (raw_code < WM_UPGRADE_MAX_STATE) ? (wm_upgrade_agent_state)raw_code : WM_UPGRADE_FAILED;
             wm_upgrade_agent_send_ack_message(queue_fd, state, (unsigned int)raw_code);
             return true;
         }
@@ -258,25 +272,30 @@ STATIC bool wm_upgrade_agent_search_upgrade_result(int *queue_fd) {
     return false;
 }
 
-STATIC void wm_upgrade_agent_send_ack_message(int *queue_fd, wm_upgrade_agent_state state, unsigned int raw_code) {
+STATIC void wm_upgrade_agent_send_ack_message(int* queue_fd, wm_upgrade_agent_state state, unsigned int raw_code)
+{
     int msg_delay = 1000000 / wm_max_eps;
     cJSON* root = cJSON_CreateObject();
     cJSON* parameters = cJSON_CreateObject();
 
-    cJSON_AddStringToObject(root, task_manager_json_keys[WM_TASK_COMMAND], task_manager_commands_list[WM_TASK_UPGRADE_UPDATE_STATUS]);
+    cJSON_AddStringToObject(
+        root, task_manager_json_keys[WM_TASK_COMMAND], task_manager_commands_list[WM_TASK_UPGRADE_UPDATE_STATUS]);
     cJSON_AddNumberToObject(parameters, task_manager_json_keys[WM_TASK_ERROR], raw_code);
     cJSON_AddStringToObject(parameters, task_manager_json_keys[WM_TASK_ERROR_MESSAGE], upgrade_messages[state]);
-    cJSON_AddStringToObject(parameters,  task_manager_json_keys[WM_TASK_STATUS], task_statuses_map[state]);
+    cJSON_AddStringToObject(parameters, task_manager_json_keys[WM_TASK_STATUS], task_statuses_map[state]);
     cJSON_AddItemToObject(root, task_manager_json_keys[WM_TASK_PARAMETERS], parameters);
 
-    char *msg_string = cJSON_PrintUnformatted(root);
-    if (wm_sendmsg(msg_delay, *queue_fd, msg_string, task_manager_modules_list[WM_TASK_UPGRADE_MODULE], UPGRADE_MQ) < 0) {
+    char* msg_string = cJSON_PrintUnformatted(root);
+    if (wm_sendmsg(msg_delay, *queue_fd, msg_string, task_manager_modules_list[WM_TASK_UPGRADE_MODULE], UPGRADE_MQ) < 0)
+    {
         mterror(WM_AGENT_UPGRADE_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
-        if(*queue_fd >= 0){
+        if (*queue_fd >= 0)
+        {
             close(*queue_fd);
         }
         *queue_fd = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
-        if (*queue_fd < 0) {
+        if (*queue_fd < 0)
+        {
             mterror_exit(WM_AGENT_UPGRADE_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);
         }
     }

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -95,8 +95,8 @@ void wm_agent_upgrade_start_manager_module(const wm_manager_configs* manager_con
     // Initialize task hashmap
     wm_agent_upgrade_init_task_map();
 
-    // Initialize upgrade queue
-    wm_agent_upgrade_init_upgrade_queue();
+    // Initialize upgrade queue (also initializes the dispatcher semaphore)
+    wm_agent_upgrade_init_upgrade_queue(manager_configs->max_threads);
 
     // Start listener
     wm_agent_upgrade_listen_messages(manager_configs);
@@ -118,7 +118,11 @@ STATIC void wm_agent_upgrade_listen_messages(const wm_manager_configs* manager_c
     }
 
     // Wait a few seconds until the task manager starts
-    sleep(WM_AGENT_UPGRADE_START_WAIT_TIME);
+    wm_sleep_interruptible(WM_AGENT_UPGRADE_START_WAIT_TIME);
+    if (wm_shutdown_requested) {
+        close(sock);
+        return;
+    }
 
     // Cancel pending upgrade tasks since they were lost
     wm_agent_upgrade_cancel_pending_upgrades();
@@ -129,22 +133,19 @@ STATIC void wm_agent_upgrade_listen_messages(const wm_manager_configs* manager_c
     // Start router subscriber thread
     w_create_thread(wm_agent_upgrade_router_subscriber_thread, NULL);
 
-    while (1) {
+    while (!wm_shutdown_requested) {
         // listen - wait connection
         fd_set fdset;
-        FD_ZERO(&fdset);
-        FD_SET(sock, &fdset);
 
-        switch (select(sock + 1, &fdset, NULL, NULL, NULL)) {
+        switch (wm_select_interruptible(sock, &fdset)) {
         case -1:
-            if (errno != EINTR) {
-                mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_SELECT_ERROR, strerror(errno));
-                close(sock);
-                return;
-            }
-            continue;
+            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_SELECT_ERROR, strerror(errno));
+            close(sock);
+            return;
         case 0:
             continue;
+        default:
+            break;
         }
 
         //Accept

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_upgrades.c
@@ -30,6 +30,9 @@ STATIC w_linked_queue_t *upgrade_queue;
 /* Running threads semaphore */
 sem_t upgrade_semaphore;
 
+/* Unique address used as a non-NULL sentinel to signal shutdown via the upgrade queue */
+static int upgrade_shutdown_sentinel;
+
 /* Definition of upgrade arguments structure */
 typedef struct _wm_upgrade_args {
     wm_manager_configs *config;
@@ -126,8 +129,9 @@ STATIC int wm_agent_upgrade_send_sha1(int agent_id, int wpk_message_format, cons
  * */
 STATIC int wm_agent_upgrade_send_upgrade(int agent_id, int wpk_message_format, const char *wpk_file, const char *installer) __attribute__((nonnull));
 
-void wm_agent_upgrade_init_upgrade_queue() {
+void wm_agent_upgrade_init_upgrade_queue(int max_threads) {
     upgrade_queue = linked_queue_init();
+    sem_init(&upgrade_semaphore, 0, (unsigned int)max_threads);
 }
 
 void wm_agent_upgrade_destroy_upgrade_queue() {
@@ -155,13 +159,23 @@ void* wm_agent_upgrade_dispatch_upgrades(void *arg) {
     wm_manager_configs *config = (wm_manager_configs *)arg;
     wm_upgrade_args *upgrade_config = NULL;
 
-    sem_init(&upgrade_semaphore, 0, config->max_threads);
-
-    while (1) {
+    while (!wm_shutdown_requested) {
         // Blocks until an available thread is ready
         sem_wait(&upgrade_semaphore);
 
-        wm_agent_task *agent_task = linked_queue_pop_ex(upgrade_queue);
+        if (wm_shutdown_requested) {
+            sem_post(&upgrade_semaphore);
+            break;
+        }
+
+        void *raw_task = linked_queue_pop_ex(upgrade_queue);
+
+        if (raw_task == (void *)&upgrade_shutdown_sentinel) {
+            sem_post(&upgrade_semaphore);
+            break;
+        }
+
+        wm_agent_task *agent_task = (wm_agent_task *)raw_task;
 
         os_calloc(1, sizeof(wm_upgrade_args), upgrade_config);
         upgrade_config->config = config;
@@ -178,6 +192,12 @@ void* wm_agent_upgrade_dispatch_upgrades(void *arg) {
     sem_destroy(&upgrade_semaphore);
 
     return NULL;
+}
+
+void wm_agent_upgrade_stop_dispatch() {
+    if (!upgrade_queue) return;
+    sem_post(&upgrade_semaphore);
+    linked_queue_push_ex(upgrade_queue, (void *)&upgrade_shutdown_sentinel);
 }
 
 STATIC void* wm_agent_upgrade_start_upgrade(void *arg) {

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_upgrades.h
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_upgrades.h
@@ -16,9 +16,12 @@
 #include <semaphore.h>
 
 /**
- * Upgrade queue initialization
+ * Upgrade queue and dispatcher semaphore initialization. Both are initialized
+ * together so that stop_dispatch() can safely call sem_post() as soon as
+ * upgrade_queue is non-NULL.
+ * @param max_threads Maximum number of concurrent upgrade threads
  * */
-void wm_agent_upgrade_init_upgrade_queue();
+void wm_agent_upgrade_init_upgrade_queue(int max_threads);
 
 /**
  * Upgrade queue destructor
@@ -35,6 +38,11 @@ void wm_agent_upgrade_prepare_upgrades();
  * @param arg Module configuration
  * */
 void* wm_agent_upgrade_dispatch_upgrades(void *arg) __attribute__((nonnull));
+
+/**
+ * Signal the dispatch loop to stop
+ * */
+void wm_agent_upgrade_stop_dispatch(void);
 
 /**
  * Send a command to the agent and return the response

--- a/src/wazuh_modules/src/agent_upgrade/wm_agent_upgrade.c
+++ b/src/wazuh_modules/src/agent_upgrade/wm_agent_upgrade.c
@@ -23,6 +23,7 @@
 #include "wm_agent_upgrade_agent.h"
 #else
 #include "wm_agent_upgrade_manager.h"
+#include "manager/wm_agent_upgrade_upgrades.h"
 #endif
 
 /**
@@ -35,6 +36,7 @@ STATIC void* wm_agent_upgrade_main(wm_agent_upgrade* upgrade_config);
 #endif
 STATIC void wm_agent_upgrade_destroy(wm_agent_upgrade* upgrade_config);
 STATIC cJSON *wm_agent_upgrade_dump(const wm_agent_upgrade* upgrade_config);
+STATIC void wm_agent_upgrade_stop(wm_agent_upgrade* upgrade_config);
 
 /* Context definition */
 const wm_context WM_AGENT_UPGRADE_CONTEXT = {
@@ -43,7 +45,7 @@ const wm_context WM_AGENT_UPGRADE_CONTEXT = {
     .destroy = (void(*)(void *))wm_agent_upgrade_destroy,
     .dump = (cJSON * (*)(const void *))wm_agent_upgrade_dump,
     .sync = NULL,
-    .stop = NULL,
+    .stop = (void(*)(void *))wm_agent_upgrade_stop,
     .query = NULL,
 };
 
@@ -63,6 +65,13 @@ STATIC void *wm_agent_upgrade_main(wm_agent_upgrade* upgrade_config) {
     return 0;
 #else
     return NULL;
+#endif
+}
+
+STATIC void wm_agent_upgrade_stop(wm_agent_upgrade* upgrade_config) {
+    (void)upgrade_config;
+#ifndef CLIENT
+    wm_agent_upgrade_stop_dispatch();
 #endif
 }
 

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -9,6 +9,11 @@
  * Foundation.
  */
 
+// Required for pthread_timedjoin_np on Linux (GNU extension)
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "wmodules.h"
 #include <sys/types.h>
 #include "startup_gate_op.h"
@@ -262,14 +267,40 @@ void wm_handler(int signum)
     case SIGHUP:
     case SIGINT:
     case SIGTERM:
-        // For the moment only gracefull shutdown will be for syscollector, in the future
-        // it will be modified for all wmodules, modifying the mainloop of each thread.
         mdebug1("Shutting down Wazuh modules.");
+
+        // Signal all module loops to exit before calling their stop() callbacks
+        // so that modules blocked in wm_sleep_interruptible / wm_select_interruptible
+        // wake up immediately.
+        wm_shutdown_requested = 1;
+
         for (cur_module = wmodules; cur_module && cur_module->context && cur_module->context->name; cur_module = cur_module->next) {
             if (cur_module->context->stop) {
                 cur_module->context->stop(cur_module->data);
             }
         }
+
+        // Wait for all module threads to finish cleanly, with a shared 30-second
+        // total budget. This prevents RocksDB lock leaks and other resource
+        // corruption caused by abrupt thread termination.
+        {
+            struct timespec deadline;
+            clock_gettime(CLOCK_REALTIME, &deadline);
+            deadline.tv_sec += 30;
+
+            for (cur_module = wmodules; cur_module && cur_module->context && cur_module->context->name; cur_module = cur_module->next) {
+                if (cur_module->thread == (pthread_t)0) continue;
+                if (cur_module->thread == pthread_self()) continue;
+#ifdef __linux__
+                if (pthread_timedjoin_np(cur_module->thread, NULL, &deadline) != 0) {
+                    mwarn("Module '%s' did not stop within the shutdown timeout.", cur_module->context->name);
+                }
+#else
+                pthread_join(cur_module->thread, NULL);
+#endif
+            }
+        }
+
         exit(EXIT_SUCCESS);
     default:
         merror("unknown signal (%d)", signum);

--- a/src/wazuh_modules/src/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/src/task_manager/wm_task_manager.c
@@ -31,6 +31,7 @@ extern void mock_assert(const int result, const char* const expression,
 STATIC int wm_task_manager_init(wm_task_manager *task_config) __attribute__((nonnull));
 STATIC void* wm_task_manager_main(wm_task_manager* task_config);    // Module main function. It won't return
 STATIC void wm_task_manager_destroy(wm_task_manager* task_config);
+STATIC void wm_task_manager_stop(wm_task_manager* task_config);
 STATIC cJSON* wm_task_manager_dump(const wm_task_manager* task_config);
 
 /* Context definition */
@@ -40,7 +41,7 @@ const wm_context WM_TASK_MANAGER_CONTEXT = {
     .destroy = (void (*)(void *))wm_task_manager_destroy,
     .dump = (cJSON * (*)(const void *))wm_task_manager_dump,
     .sync = NULL,
-    .stop = NULL,
+    .stop = (void (*)(void *))wm_task_manager_stop,
     .query = NULL,
 };
 
@@ -139,18 +140,13 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
 
     mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_START);
 
-    while (1) {
-        // Wait for socket
-        FD_ZERO(&fdset);
-        FD_SET(sock, &fdset);
+    while (!wm_shutdown_requested) {
 
-        switch (select(sock + 1, &fdset, NULL, NULL, NULL)) {
+        switch (wm_select_interruptible(sock, &fdset)) {
         case -1:
-            if (errno != EINTR) {
-                mterror(WM_TASK_MANAGER_LOGTAG, MOD_TASK_SELECT_ERROR, strerror(errno));
-                pthread_exit(NULL);
-            }
-            continue;
+            mterror(WM_TASK_MANAGER_LOGTAG, MOD_TASK_SELECT_ERROR, strerror(errno));
+            pthread_exit(NULL);
+            break;
         case 0:
             continue;
         default:
@@ -198,6 +194,10 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
 
     close(sock);
     return NULL;
+}
+
+STATIC void wm_task_manager_stop(__attribute__((unused)) wm_task_manager* task_config) {
+    wm_shutdown_requested = 1;
 }
 
 STATIC void wm_task_manager_destroy(wm_task_manager* task_config) {

--- a/src/wazuh_modules/src/wm_aws.c
+++ b/src/wazuh_modules/src/wm_aws.c
@@ -79,8 +79,10 @@ void* wm_aws_main(wm_aws *aws_config) {
             timestamp = w_get_timestamp(next_scan_time);
             mtdebug2(WM_AWS_LOGTAG, "Sleeping until: %s", timestamp);
             os_free(timestamp);
-            w_sleep_until(next_scan_time);
+            wm_sleep_until_interruptible(next_scan_time);
+            if (wm_shutdown_requested) break;
         }
+        if (wm_shutdown_requested) break;
         mtinfo(WM_AWS_LOGTAG, "Starting fetching of logs.");
 
         for (cur_bucket = aws_config->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
@@ -200,7 +202,7 @@ void* wm_aws_main(wm_aws *aws_config) {
 
         mtinfo(WM_AWS_LOGTAG, "Fetching logs finished.");
 
-    } while (FOREVER());
+    } while (FOREVER() && !wm_shutdown_requested);
 
 #ifdef WIN32
     return 0;

--- a/src/wazuh_modules/src/wm_azure.c
+++ b/src/wazuh_modules/src/wm_azure.c
@@ -73,8 +73,10 @@ void* wm_azure_main(wm_azure_t *azure_config) {
             timestamp = w_get_timestamp(next_scan_time);
             mtdebug2(WM_AZURE_LOGTAG, "Sleeping until: %s", timestamp);
             os_free(timestamp);
-            w_sleep_until(next_scan_time);
+            wm_sleep_until_interruptible(next_scan_time);
+            if (wm_shutdown_requested) break;
         }
+        if (wm_shutdown_requested) break;
         mtinfo(WM_AZURE_LOGTAG, "Starting fetching of logs.");
 
         snprintf(msg, OS_SIZE_6144, "Starting Azure-logs scan.");
@@ -103,7 +105,7 @@ void* wm_azure_main(wm_azure_t *azure_config) {
 
         mtdebug1(WM_AZURE_LOGTAG, "Fetching logs finished.");
 
-    } while (FOREVER());
+    } while (FOREVER() && !wm_shutdown_requested);
 
     return NULL;
 }

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -227,8 +227,10 @@ void * wm_command_main(wm_command_t * command) {
             timestamp = w_get_timestamp(next_scan_time);
             mtdebug2(WM_COMMAND_LOGTAG, "Sleeping until: %s", timestamp);
             os_free(timestamp);
-            w_sleep_until(next_scan_time);
+            wm_sleep_until_interruptible(next_scan_time);
+            if (wm_shutdown_requested) break;
         }
+        if (wm_shutdown_requested) break;
 
         if (full_path != NULL && verify_command && !command->skip_verification) {
             mtinfo(WM_COMMAND_LOGTAG, "Verifying command checksum '%s'.", command->tag);
@@ -455,7 +457,7 @@ void * wm_command_main(wm_command_t * command) {
         }
 
         mtdebug1(WM_COMMAND_LOGTAG, "Command '%s' finished.", command->tag);
-    } while (FOREVER());
+    } while (FOREVER() && !wm_shutdown_requested);
 
     os_free(full_path);
     free(extag);

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -18,6 +18,7 @@
 
 static void *wm_control_main();
 static void wm_control_destroy();
+static void wm_control_stop();
 cJSON *wm_control_dump();
 static void *process_control();
 
@@ -27,7 +28,7 @@ const wm_context WM_CONTROL_CONTEXT = {
     .destroy = (void(*)(void *))wm_control_destroy,
     .dump = (cJSON * (*)(const void *))wm_control_dump,
     .sync = NULL,
-    .stop = NULL,
+    .stop = (void(*)(void *))wm_control_stop,
     .query = NULL,
 };
 
@@ -42,6 +43,10 @@ static void *wm_control_main() {
 }
 
 static void wm_control_destroy() {
+}
+
+static void wm_control_stop() {
+    wm_shutdown_requested = 1;
 }
 
 wmodule *wm_control_read() {
@@ -201,20 +206,16 @@ static void *process_control() {
         return NULL;
     }
 
-    while (1) {
+    while (!wm_shutdown_requested) {
 
-        FD_ZERO(&fdset);
-        FD_SET(sock, &fdset);
-
-        switch (select(sock + 1, &fdset, NULL, NULL, NULL)) {
+        switch (wm_select_interruptible(sock, &fdset)) {
         case -1:
-            if (errno != EINTR) {
-                mterror_exit(WM_CONTROL_LOGTAG, "At process_control(): select(): %s", strerror(errno));
-            }
-            continue;
-
+            mterror_exit(WM_CONTROL_LOGTAG, "At process_control(): select(): %s", strerror(errno));
+            break;
         case 0:
             continue;
+        default:
+            break;
         }
 
         if (peer = accept(sock, NULL, NULL), peer < 0) {

--- a/src/wazuh_modules/src/wm_database.c
+++ b/src/wazuh_modules/src/wm_database.c
@@ -60,6 +60,8 @@ int wdb_wmdb_sock = -1;
 
 // Module main function. It won't return
 static void* wm_database_main(wm_database *data);
+// Stop module
+static void wm_database_stop(wm_database *data);
 // Destroy data
 static void wm_database_destroy(wm_database *data);
 // Read config
@@ -86,7 +88,7 @@ const wm_context WM_DATABASE_CONTEXT = {
     .destroy = (void(*)(void *))wm_database_destroy,
     .dump = (cJSON * (*)(const void *))wm_database_dump,
     .sync = NULL,
-    .stop = NULL,
+    .stop = (void(*)(void *))wm_database_stop,
     .query = NULL,
 };
 
@@ -106,7 +108,8 @@ void* wm_database_main(wm_database *data) {
     // in the master.
 
     // Wait for inventory_sync to subscribe to router before sending deletion messages
-    sleep(5);
+    wm_sleep_interruptible(5);
+    if (wm_shutdown_requested) return NULL;
     wm_sync_agents();
 
     // Groups synchronization with the database
@@ -119,8 +122,10 @@ void* wm_database_main(wm_database *data) {
 
         wm_inotify_setup(data);
 
-        while (1) {
+        while (!wm_shutdown_requested) {
             path = wm_inotify_pop();
+
+            if (!path) break;
 
             if (!strcmp(path, KEYS_FILE)) {
                 // The syncronization with client.keys only happens in worker nodes
@@ -151,9 +156,9 @@ void* wm_database_main(wm_database *data) {
         struct timespec spec1;
 
         // Initial wait
-        sleep(data->interval);
+        wm_sleep_interruptible(data->interval);
 
-        while (1) {
+        while (!wm_shutdown_requested) {
             tstart = (long long) time(NULL);
             cstart = clock();
             gettime(&spec0);
@@ -168,7 +173,7 @@ void* wm_database_main(wm_database *data) {
             mtdebug1(WM_DATABASE_LOGTAG, "Cycle completed: %.3lf ms (%.3f clock ms).", spec1.tv_sec * 1000 + spec1.tv_nsec / 1000000.0, (double)(clock() - cstart) / CLOCKS_PER_SEC * 1000);
 
             if (tsleep = tstart + (long long) data->interval - (long long) time(NULL), tsleep >= 0) {
-                sleep(tsleep);
+                wm_sleep_interruptible((int)tsleep);
             } else {
                 mtwarn(WM_DATABASE_LOGTAG, "Time interval exceeded by %lld seconds.", -tsleep);
             }
@@ -444,6 +449,15 @@ void wm_database_destroy(wm_database *data) {
     free(data);
 }
 
+static void wm_database_stop(wm_database *data) {
+    (void)data;
+#ifdef INOTIFY_ENABLED
+    w_mutex_lock(&mutex_queue);
+    w_cond_broadcast(&cond_pending);
+    w_mutex_unlock(&mutex_queue);
+#endif
+}
+
 // Read configuration and return a module (if enabled) or NULL (if disabled)
 wmodule* wm_database_read() {
     wm_database data;
@@ -687,8 +701,13 @@ char * wm_inotify_pop() {
 
     w_mutex_lock(&mutex_queue);
 
-    while (queue_empty(queue)) {
+    while (queue_empty(queue) && !wm_shutdown_requested) {
         w_cond_wait(&cond_pending, &mutex_queue);
+    }
+
+    if (wm_shutdown_requested) {
+        w_mutex_unlock(&mutex_queue);
+        return NULL;
     }
 
     path = queue_pop(queue);

--- a/src/wazuh_modules/src/wm_docker.c
+++ b/src/wazuh_modules/src/wm_docker.c
@@ -54,8 +54,10 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
             timestamp = w_get_timestamp(next_scan_time);
             mtdebug2(WM_DOCKER_LOGTAG, "Sleeping until: %s", timestamp);
             os_free(timestamp);
-            w_sleep_until(next_scan_time);
+            wm_sleep_until_interruptible(next_scan_time);
+            if (wm_shutdown_requested) break;
         }
+        if (wm_shutdown_requested) break;
         mtinfo(WM_DOCKER_LOGTAG, "Starting to listening Docker events.");
 
         // Running the docker listener script
@@ -111,7 +113,7 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
             }
             mtwarn(WM_DOCKER_LOGTAG, "Docker-listener finished unexpectedly (code %d). Retrying to run in next scheduled time...", exitcode);
         }
-    } while (FOREVER());
+    } while (FOREVER() && !wm_shutdown_requested);
 
     return NULL;
 }

--- a/src/wazuh_modules/src/wm_gcp.c
+++ b/src/wazuh_modules/src/wm_gcp.c
@@ -142,14 +142,16 @@ void* wm_gcp_pubsub_main(wm_gcp_pubsub *data) {
             timestamp = w_get_timestamp(next_scan_time);
             mtdebug2(WM_GCP_PUBSUB_LOGTAG, "Sleeping until: %s", timestamp);
             os_free(timestamp);
-            w_sleep_until(next_scan_time);
+            wm_sleep_until_interruptible(next_scan_time);
+            if (wm_shutdown_requested) break;
         }
+        if (wm_shutdown_requested) break;
         mtdebug1(WM_GCP_PUBSUB_LOGTAG, "Starting fetching of logs.");
 
         wm_gcp_pubsub_run(data);
 
         mtdebug1(WM_GCP_PUBSUB_LOGTAG, "Fetching logs finished.");
-    } while (FOREVER());
+    } while (FOREVER() && !wm_shutdown_requested);
 
 #ifdef WIN32
     return 0;
@@ -183,8 +185,10 @@ void* wm_gcp_bucket_main(wm_gcp_bucket_base *data) {
             timestamp = w_get_timestamp(next_scan_time);
             mtdebug2(WM_GCP_BUCKET_LOGTAG, "Sleeping until: %s", timestamp);
             os_free(timestamp);
-            w_sleep_until(next_scan_time);
+            wm_sleep_until_interruptible(next_scan_time);
+            if (wm_shutdown_requested) break;
         }
+        if (wm_shutdown_requested) break;
         mtdebug1(WM_GCP_BUCKET_LOGTAG, "Starting fetching of logs.");
 
         for (cur_bucket = data->buckets; cur_bucket; cur_bucket = cur_bucket->next) {
@@ -223,7 +227,7 @@ void* wm_gcp_bucket_main(wm_gcp_bucket_base *data) {
         }
 
         mtdebug1(WM_GCP_BUCKET_LOGTAG, "Fetching logs finished.");
-    } while (FOREVER());
+    } while (FOREVER() && !wm_shutdown_requested);
 
 #ifdef WIN32
     return 0;

--- a/src/wazuh_modules/src/wm_github.c
+++ b/src/wazuh_modules/src/wm_github.c
@@ -107,8 +107,9 @@ void * wm_github_main(wm_github* github_config) {
         // Execute initial scan
         wm_github_execute_scan(github_config, 1);
 
-        while (1) {
-            sleep(github_config->interval);
+        while (!wm_shutdown_requested) {
+            wm_sleep_interruptible(github_config->interval);
+            if (wm_shutdown_requested) break;
             wm_github_execute_scan(github_config, 0);
             #ifdef WAZUH_UNIT_TESTING
                 break;

--- a/src/wazuh_modules/src/wm_ms_graph.c
+++ b/src/wazuh_modules/src/wm_ms_graph.c
@@ -77,7 +77,7 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
         int i;
         wm_ms_graph_auth *it;
 
-        while (FOREVER()) {
+        while (FOREVER() && !wm_shutdown_requested) {
             const time_t time_sleep = sched_scan_get_time_until_next_scan(&ms_graph->scan_config, WM_MS_GRAPH_LOGTAG, ms_graph->run_on_start);
 
             if (ms_graph->state.next_time == 0) {
@@ -89,7 +89,8 @@ void* wm_ms_graph_main(wm_ms_graph* ms_graph) {
                 timestamp = w_get_timestamp(next_scan_time);
                 mtdebug1(WM_MS_GRAPH_LOGTAG, "Waiting until: %s", timestamp);
                 os_free(timestamp);
-                w_sleep_until(next_scan_time);
+                wm_sleep_until_interruptible(next_scan_time);
+                if (wm_shutdown_requested) break;
             }
 
             for (i = 0; ms_graph->auth_config[i]; i++) {
@@ -228,7 +229,8 @@ static curl_response* wm_ms_graph_http_get_with_retry(char** headers, const char
                 relationship_name, retry_after, attempt + 1, WM_MS_GRAPH_MAX_RETRIES);
             wurl_free_response(response);
             response = NULL;
-            w_sleep_until(time(NULL) + retry_after);
+            wm_sleep_until_interruptible(time(NULL) + retry_after);
+            if (wm_shutdown_requested) break;
             continue;
         }
         break;

--- a/src/wazuh_modules/src/wm_office365.c
+++ b/src/wazuh_modules/src/wm_office365.c
@@ -144,8 +144,9 @@ void * wm_office365_main(wm_office365* office365_config) {
         // Execute initial scan
         wm_office365_execute_scan(office365_config, 1);
 
-        while (1) {
-            sleep(office365_config->interval);
+        while (!wm_shutdown_requested) {
+            wm_sleep_interruptible(office365_config->interval);
+            if (wm_shutdown_requested) break;
             wm_office365_execute_scan(office365_config, 0);
             #ifdef WAZUH_UNIT_TESTING
                 break;

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -789,9 +789,20 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
         mtdebug1(WM_SYS_LOGTAG, "Stop called from syscollector worker thread. Skipping synchronous shutdown wait.");
     }
 
-    while (need_shutdown_wait && !called_from_sys_main_thread)
+    if (need_shutdown_wait && !called_from_sys_main_thread)
     {
-        w_cond_wait(&sys_stop_condition, &sys_stop_mutex);
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += 10;
+
+        while (need_shutdown_wait)
+        {
+            if (pthread_cond_timedwait(&sys_stop_condition, &sys_stop_mutex, &ts) == ETIMEDOUT)
+            {
+                mtwarn(WM_SYS_LOGTAG, "Timeout waiting for Syscollector to complete shutdown.");
+                break;
+            }
+        }
     }
 
     w_mutex_unlock(&sys_stop_mutex);

--- a/src/wazuh_modules/src/wmcom.c
+++ b/src/wazuh_modules/src/wmcom.c
@@ -137,22 +137,17 @@ void * wmcom_main(__attribute__((unused)) void * arg) {
         return NULL;
     }
 
-    while (1) {
+    while (!wm_shutdown_requested) {
 
-        // Wait for socket
-        FD_ZERO(&fdset);
-        FD_SET(sock, &fdset);
 
-        switch (select(sock + 1, &fdset, NULL, NULL, NULL)) {
+        switch (wm_select_interruptible(sock, &fdset)) {
         case -1:
-            if (errno != EINTR) {
-                merror_exit("At wmcom_main(): select(): %s", strerror(errno));
-            }
-
-            continue;
-
+            merror_exit("At wmcom_main(): select(): %s", strerror(errno));
+            break;
         case 0:
             continue;
+        default:
+            break;
         }
 
         if (peer = accept(sock, NULL, NULL), peer < 0) {

--- a/src/wazuh_modules/src/wmodules.c
+++ b/src/wazuh_modules/src/wmodules.c
@@ -28,6 +28,33 @@ static gid_t wm_gid;               // Group ID.
 int wm_max_eps;             // Maximum events per second
 int wm_kill_timeout;        // Time for a process to quit before killing it
 int wm_debug_level;
+volatile sig_atomic_t wm_shutdown_requested = 0;
+
+void wm_sleep_interruptible(int seconds) {
+    for (int i = 0; i < seconds && !wm_shutdown_requested; i++) {
+        sleep(1);
+    }
+}
+
+void wm_sleep_until_interruptible(time_t abs_time) {
+    while (time(NULL) < abs_time && !wm_shutdown_requested) {
+        sleep(1);
+    }
+}
+
+int wm_select_interruptible(int sock, fd_set *fdset) {
+    struct timeval tv;
+    int r;
+    while (!wm_shutdown_requested) {
+        FD_ZERO(fdset);
+        FD_SET(sock, fdset);
+        tv = (struct timeval){ .tv_sec = 1, .tv_usec = 0 };
+        r = select(sock + 1, fdset, NULL, NULL, &tv);
+        if (r > 0) return r;
+        if (r < 0 && errno != EINTR) return r;
+    }
+    return 0;
+}
 
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -60,6 +60,13 @@ void VulnerabilityScannerFacade::runScanner(Utils::RocksDBWrapper& dataStore, co
 // already excluded
 void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
 {
+    // Bail out immediately if stop() was called — avoids blocking teardown() on in-progress scans.
+    if (m_shouldStop.load(std::memory_order_acquire))
+    {
+        logInfo(WM_VULNSCAN_LOGTAG, "Feed update scan skipped: shutdown in progress.");
+        return;
+    }
+
     if (!m_scanOrchestrator || !m_indexerConnector)
     {
         logWarn(WM_VULNSCAN_LOGTAG, "Feed update scan skipped: scanner not initialized.");
@@ -73,6 +80,11 @@ void VulnerabilityScannerFacade::runScanAfterFeedUpdate()
         m_indexerConnector,
         [this](std::shared_ptr<ScanContext> agentContext)
         {
+            // Re-check on every agent so a shutdown mid-scan exits as soon as possible.
+            if (m_shouldStop.load(std::memory_order_acquire))
+            {
+                return;
+            }
             auto context = std::move(agentContext);
             m_scanOrchestrator->runScanAfterFeedUpdate(std::move(context));
         },


### PR DESCRIPTION
## Summary

Fixes #34479

`wazuh-modulesd` did not shut down gracefully on SIGTERM: module threads blocked in `sleep()`, `select()`, `sem_wait()`, or `pthread_cond_wait()` with no timeout and no stop mechanism, leaving the process to be killed forcefully by the service manager.




## Tested Scenarios
| Scenario | What was tested | Result |
| --- | --- | --- |
| Manager restart during active feed download | Manager shutdown while `content-updater` was downloading the vulnerability feed. | 🟢 Download slices were interrupted cleanly; no 30-second wait. |
| Manager restart while agent sends events continuously | The agent generated journald events in a loop while the manager was restarted. | 🟢 Restart: `8 s`; manager stopped cleanly and came back with pending events preserved. |
| Agent stop while logcollector processes active writes | A loop appended events to a monitored log file while the agent was stopped. | 🟢 Stop: `1 s`; logcollector exited cleanly and the agent restarted normally. |
| Simultaneous manager and agent restart | Manager and agent control scripts were restarted at the same time. | 🟢 Combined restart: `9 s`; both sides returned to running state and the agent reconnected. |
| Manager restart immediately after startup | The manager was restarted again one second after a previous restart completed. | 🟢 Restarts: `6 s` each; modules handled shutdown during fresh startup state. |
| Agent stop just after startup module activity | The agent was stopped immediately after rootcheck, FIM, SCA, and syscollector startup activity. | 🟢 Stop: `2 s`; modules released resources normally. |
| Timeout/forced-kill log search | Searched manager and agent logs for timeout/kill indicators after the stress scenarios. | 🟢 No forced-kill fallback observed. Only internal `agent-upgrade` timeout warnings, with no shutdown delay. |

- Full commands output and ossec.log: 
[graceful-termination-ubuntu24-stress.txt](https://github.com/user-attachments/files/27521277/graceful-termination-ubuntu24-stress.raw.txt)


Conclusion: the tested shutdown paths do not approach the 30-second forced-kill fallback. Manager shutdown, agent shutdown, and modulesd-related shutdown activity completed in a few seconds across the tested scenarios.
