### PR TITLE
Fix Coverity Medium Impact Defects - Release 5.0.0 Beta 1 (Agent)

### DIFF
--- a/src/client-agent/src/agcom.c
+++ b/src/client-agent/src/agcom.c
@@ -327,9 +327,10 @@ void * agcom_main(__attribute__((unused)) void * arg) {
         os_free(buffer);
     }
 
-    // coverity[unreachable] - intentional cleanup code: the while(1) loop above
-    // currently exits only via merror_exit(). This block ensures proper resource
-    // release if a graceful exit path is added in the future.
+    /* Intentional cleanup code: the while(1) loop above currently exits only via
+     * merror_exit(). This block ensures proper resource release if a graceful
+     * exit path is added in the future. */
+    // coverity[unreachable]
     close(sock);
     return NULL;
 }

--- a/src/client-agent/src/agcom.c
+++ b/src/client-agent/src/agcom.c
@@ -327,6 +327,9 @@ void * agcom_main(__attribute__((unused)) void * arg) {
         os_free(buffer);
     }
 
+    // coverity[unreachable] - intentional cleanup code: the while(1) loop above
+    // currently exits only via merror_exit(). This block ensures proper resource
+    // release if a graceful exit path is added in the future.
     close(sock);
     return NULL;
 }

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -260,8 +260,10 @@ void *dispatch_buffer(__attribute__((unused)) void * arg) {
         if (msg_to_dispatch.data != NULL) {
             send_msg(msg_to_dispatch.data, msg_to_dispatch.size);
             os_free(msg_to_dispatch.data);
+            w_mutex_lock(&mutex_lock);
             buffer[original_j_for_nulling].data = NULL;
             buffer[original_j_for_nulling].size = 0;
+            w_mutex_unlock(&mutex_lock);
         }
 
         gettime(&ts1);

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -64,9 +64,10 @@ static void delay(struct timespec * ts_loop);
 /* Create agent buffer */
 void buffer_init(){
 
-    // coverity[missing_lock] buffer_init() is called either before threads start
-    // or under external serialization (config reload path). No race condition exists.
     if (!buffer) {
+        /* buffer_init() is called either before threads start or under external
+        * serialization (config reload path). No race condition exists. */
+        // coverity[missing_lock]
         os_calloc(agt->buflength + 1, sizeof(buffered_message), buffer);
     }
 

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -230,7 +230,11 @@ void *dispatch_buffer(__attribute__((unused)) void * arg) {
         }
 
         buffered_message msg_to_dispatch = buffer[j];
-        unsigned int original_j_for_nulling = j;
+        /* Clear the slot while still holding the lock, before advancing the
+         * consumer index. This prevents the producer from wrapping around and
+         * reusing this slot while it still holds a stale pointer. */
+        buffer[j].data = NULL;
+        buffer[j].size = 0;
         forward(j, agt->buflength + 1);
         w_mutex_unlock(&mutex_lock);
 
@@ -263,10 +267,6 @@ void *dispatch_buffer(__attribute__((unused)) void * arg) {
         if (msg_to_dispatch.data != NULL) {
             send_msg(msg_to_dispatch.data, msg_to_dispatch.size);
             os_free(msg_to_dispatch.data);
-            w_mutex_lock(&mutex_lock);
-            buffer[original_j_for_nulling].data = NULL;
-            buffer[original_j_for_nulling].size = 0;
-            w_mutex_unlock(&mutex_lock);
         }
 
         gettime(&ts1);

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -64,6 +64,8 @@ static void delay(struct timespec * ts_loop);
 /* Create agent buffer */
 void buffer_init(){
 
+    // coverity[missing_lock] buffer_init() is called either before threads start
+    // or under external serialization (config reload path). No race condition exists.
     if (!buffer) {
         os_calloc(agt->buflength + 1, sizeof(buffered_message), buffer);
     }

--- a/src/config/src/syscheck-config.c
+++ b/src/config/src/syscheck-config.c
@@ -201,8 +201,9 @@ OSList *fim_copy_directory_list(const OSList *source) {
     OSListNode *node_it;
     w_rwlock_rdlock((pthread_rwlock_t *)&source->wr_mutex);
 
-    // coverity[missing_lock] - source->first_node is protected by source->wr_mutex (rwlock),
-    // not by source->mutex. The rdlock above is the correct guard for this field.
+    /* source->first_node is protected by source->wr_mutex (rwlock),
+     * not by source->mutex. The rdlock above is the correct guard for this field. */
+    // coverity[missing_lock]
     for (node_it = source->first_node; node_it != NULL; node_it = node_it->next) {
         directory_t *dir = (directory_t *)node_it->data;
         directory_t *dir_copy = fim_copy_directory(dir);

--- a/src/config/src/syscheck-config.c
+++ b/src/config/src/syscheck-config.c
@@ -201,6 +201,8 @@ OSList *fim_copy_directory_list(const OSList *source) {
     OSListNode *node_it;
     w_rwlock_rdlock((pthread_rwlock_t *)&source->wr_mutex);
 
+    // coverity[missing_lock] - source->first_node is protected by source->wr_mutex (rwlock),
+    // not by source->mutex. The rdlock above is the correct guard for this field.
     for (node_it = source->first_node; node_it != NULL; node_it = node_it->next) {
         directory_t *dir = (directory_t *)node_it->data;
         directory_t *dir_copy = fim_copy_directory(dir);

--- a/src/config/src/wmodules-sca.c
+++ b/src/config/src/wmodules-sca.c
@@ -98,15 +98,15 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_INTERVAL) == 0) {
             long t = w_parse_time(node[i]->content);
 
-            if (t <= 0) {
+            if (t <= 0 || t > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                sca->sync.sync_interval = t;
+                sca->sync.sync_interval = (uint32_t) t;
             }
         } else if (strcmp(node[i]->element, XML_DB_SYNC_END_DELAY) == 0) {
             long sync_end_delay = w_parse_time(node[i]->content);
 
-            if (sync_end_delay < 0) {
+            if (sync_end_delay < 0 || sync_end_delay > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.sync_end_delay = (uint32_t) sync_end_delay;
@@ -114,7 +114,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_RESPONSE_TIMEOUT) == 0) {
             long response_timeout = w_parse_time(node[i]->content);
 
-            if (response_timeout < 0) {
+            if (response_timeout < 0 || response_timeout > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.sync_response_timeout = (uint32_t) response_timeout;
@@ -131,7 +131,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_INTEGRITY_INTERVAL) == 0) {
             long integrity_interval = w_parse_time(node[i]->content);
 
-            if (integrity_interval < 0) {
+            if (integrity_interval < 0 || integrity_interval > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.integrity_interval = (uint32_t) integrity_interval;

--- a/src/config/src/wmodules-sca.c
+++ b/src/config/src/wmodules-sca.c
@@ -98,7 +98,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_INTERVAL) == 0) {
             long t = w_parse_time(node[i]->content);
 
-            if (t <= 0 || t > (long)UINT32_MAX) {
+            if (t <= 0 || (unsigned long)t > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.sync_interval = (uint32_t) t;
@@ -106,7 +106,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_END_DELAY) == 0) {
             long sync_end_delay = w_parse_time(node[i]->content);
 
-            if (sync_end_delay < 0 || sync_end_delay > (long)UINT32_MAX) {
+            if (sync_end_delay < 0 || (unsigned long)sync_end_delay > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.sync_end_delay = (uint32_t) sync_end_delay;
@@ -114,7 +114,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_RESPONSE_TIMEOUT) == 0) {
             long response_timeout = w_parse_time(node[i]->content);
 
-            if (response_timeout < 0 || response_timeout > (long)UINT32_MAX) {
+            if (response_timeout < 0 || (unsigned long)response_timeout > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.sync_response_timeout = (uint32_t) response_timeout;
@@ -131,7 +131,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
         } else if (strcmp(node[i]->element, XML_DB_SYNC_INTEGRITY_INTERVAL) == 0) {
             long integrity_interval = w_parse_time(node[i]->content);
 
-            if (integrity_interval < 0 || integrity_interval > (long)UINT32_MAX) {
+            if (integrity_interval < 0 || (unsigned long)integrity_interval > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.integrity_interval = (uint32_t) integrity_interval;

--- a/src/config/src/wmodules-syscollector.c
+++ b/src/config/src/wmodules-syscollector.c
@@ -49,7 +49,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_DB_SYNC_INTERVAL) == 0) {
             long t = w_parse_time(node[i]->content);
 
-            if (t <= 0 || t > (long)UINT32_MAX) {
+            if (t <= 0 || (unsigned long)t > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_interval = (uint32_t) t;
@@ -57,7 +57,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_DB_SYNC_END_DELAY) == 0) {
             long sync_end_delay = w_parse_time(node[i]->content);
 
-            if (sync_end_delay < 0 || sync_end_delay > (long)UINT32_MAX) {
+            if (sync_end_delay < 0 || (unsigned long)sync_end_delay > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_end_delay = (uint32_t) sync_end_delay;
@@ -65,7 +65,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_DB_SYNC_RESPONSE_TIMEOUT) == 0) {
             long response_timeout = w_parse_time(node[i]->content);
 
-            if (response_timeout < 0 || response_timeout > (long)UINT32_MAX) {
+            if (response_timeout < 0 || (unsigned long)response_timeout > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_response_timeout = (uint32_t) response_timeout;
@@ -82,7 +82,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_INTEGRITY_INTERVAL) == 0) {
             long integrity_interval = w_parse_time(node[i]->content);
 
-            if (integrity_interval < 0 || integrity_interval > (long)UINT32_MAX) {
+            if (integrity_interval < 0 || (unsigned long)integrity_interval > UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.integrity_interval = (uint32_t) integrity_interval;

--- a/src/config/src/wmodules-syscollector.c
+++ b/src/config/src/wmodules-syscollector.c
@@ -49,15 +49,15 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_DB_SYNC_INTERVAL) == 0) {
             long t = w_parse_time(node[i]->content);
 
-            if (t <= 0) {
+            if (t <= 0 || t > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
-                syscollector->sync.sync_interval = t;
+                syscollector->sync.sync_interval = (uint32_t) t;
             }
         } else if (strcmp(node[i]->element, XML_DB_SYNC_END_DELAY) == 0) {
             long sync_end_delay = w_parse_time(node[i]->content);
 
-            if (sync_end_delay < 0) {
+            if (sync_end_delay < 0 || sync_end_delay > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_end_delay = (uint32_t) sync_end_delay;
@@ -65,7 +65,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_DB_SYNC_RESPONSE_TIMEOUT) == 0) {
             long response_timeout = w_parse_time(node[i]->content);
 
-            if (response_timeout < 0) {
+            if (response_timeout < 0 || response_timeout > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_response_timeout = (uint32_t) response_timeout;
@@ -82,7 +82,7 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
         } else if (strcmp(node[i]->element, XML_INTEGRITY_INTERVAL) == 0) {
             long integrity_interval = w_parse_time(node[i]->content);
 
-            if (integrity_interval < 0) {
+            if (integrity_interval < 0 || integrity_interval > (long)UINT32_MAX) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.integrity_interval = (uint32_t) integrity_interval;

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -212,7 +212,11 @@ namespace PackageLinuxHelper
             {
                 // timegm converts tm to UTC epoch (not affected by local timezone)
                 time_t epoch = timegm(&tm);
-                install_time = std::to_string(static_cast<uint32_t>(epoch));
+
+                if (epoch >= 0)
+                {
+                    install_time = std::to_string(static_cast<uint32_t>(epoch));
+                }
             }
         }
 

--- a/src/shared/src/batch_queue_op.c
+++ b/src/shared/src/batch_queue_op.c
@@ -354,8 +354,9 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
         pthread_mutex_lock(&sched->ring_mu);
         void *val2 = NULL;
         if (hm_get(&sched->agent_index, agent_key, &val2) && (w_rr_agent_slot_t *)val2 == slot) {
-            if (!slot->in_ring) {
-                ring_append(sched, slot);
+            w_rr_agent_slot_t *current_slot = (w_rr_agent_slot_t *)val2;
+            if (!current_slot->in_ring) {
+                ring_append(sched, current_slot);
                 pthread_cond_signal(&sched->any_available);
             }
         }

--- a/src/shared/src/batch_queue_op.c
+++ b/src/shared/src/batch_queue_op.c
@@ -305,6 +305,9 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
 
     // 2) Take the queue lock **before releasing ring_mu** (safe handover)
     pthread_mutex_lock(&slot->q->mutex);
+    // Read max_items_per_agent under ring_mu before releasing it, to avoid a data
+    // race with batch_queue_set_agent_max(), which writes it under ring_mu.
+    const size_t max_per_agent = sched->max_items_per_agent;
 
     // 3) Release ring_mu to reduce global contention
     pthread_mutex_unlock(&sched->ring_mu);
@@ -313,7 +316,7 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
     int reject = 0;
     int need_ring_append = (slot->q->elements == 0);
 
-    if (sched->max_items_per_agent && slot->q->elements >= sched->max_items_per_agent) {
+    if (max_per_agent && slot->q->elements >= max_per_agent) {
         reject = 1;
     } else {
         w_linked_queue_node_t *n;
@@ -349,9 +352,12 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
     // 5) If queue transitioned empty->non-empty, (re)insert into the ring and signal availability
     if (need_ring_append) {
         pthread_mutex_lock(&sched->ring_mu);
-        if (!slot->in_ring) {
-            ring_append(sched, slot);
-            pthread_cond_signal(&sched->any_available);
+        void *val2 = NULL;
+        if (hm_get(&sched->agent_index, agent_key, &val2) && (w_rr_agent_slot_t *)val2 == slot) {
+            if (!slot->in_ring) {
+                ring_append(sched, slot);
+                pthread_cond_signal(&sched->any_available);
+            }
         }
         pthread_mutex_unlock(&sched->ring_mu);
     }

--- a/src/shared/src/enrollment_op.c
+++ b/src/shared/src/enrollment_op.c
@@ -457,6 +457,10 @@ static int w_enrollment_process_agent_key(char *buffer) {
 
     *tmpstr = '\0';
     char **entrys = OS_StrBreak(' ', keys, 4);
+    if (!entrys) {
+        merror("Invalid keys format received: failed to split key fields.");
+        return ret;
+    }
     if (OS_IsValidID(entrys[ENTRY_ID]) && OS_IsValidName(entrys[ENTRY_NAME]) &&
             OS_IsValidIP(entrys[ENTRY_IP], NULL) && OS_IsValidName(entrys[ENTRY_KEY])) {
         if( !w_enrollment_store_key_entry(keys) ) {

--- a/src/shared/src/hashmap_op.c
+++ b/src/shared/src/hashmap_op.c
@@ -184,7 +184,7 @@ int hm_put(hashmap_t* hm, const char* key, void* value)
         {
             // insert into empty slot (reuse tombstone if found earlier)
             hm_entry_t* target = first_tomb ? first_tomb : e;
-            if (first_tomb)
+            if (first_tomb && hm->tombstones > 0)
                 hm->tombstones--;
             os_strdup(key, target->key);
             if (!target->key)

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -2236,22 +2236,24 @@ void SQLiteDBEngine::updateTableRowCounter(const std::string& table, const long 
 
 void SQLiteDBEngine::closeAndDeleteDatabase(const std::string& path)
 {
-    std::lock_guard<std::mutex> lock(m_stmtMutex);
-
-    // Clear the statement cache
-    m_statementsCache.clear();
-
-    // Commit and release the transaction
-    if (m_transaction)
     {
-        m_transaction->commit();
-        m_transaction.reset();
-    }
+        std::lock_guard<std::mutex> lock(m_stmtMutex);
 
-    // Close the SQLite connection
-    if (m_sqliteConnection)
-    {
-        m_sqliteConnection.reset();
+        // Clear the statement cache
+        m_statementsCache.clear();
+
+        // Commit and release the transaction
+        if (m_transaction)
+        {
+            m_transaction->commit();
+            m_transaction.reset();
+        }
+
+        // Close the SQLite connection
+        if (m_sqliteConnection)
+        {
+            m_sqliteConnection.reset();
+        }
     }
 
     // Delete the database file

--- a/src/shared_modules/file_helper/file_io/src/file_io_utils.cpp
+++ b/src/shared_modules/file_helper/file_io/src/file_io_utils.cpp
@@ -75,6 +75,11 @@ namespace file_io
             }
         }
 
+        if (!spBuffer)
+        {
+            return std::vector<char> {};
+        }
+
         return std::vector<char> {spBuffer.get(), spBuffer.get() + static_cast<std::size_t>(size)};
     }
 }; // namespace file_io

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -1016,6 +1016,8 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
                 // Manager auto-enqueues when all gaps are filled and sends EndAck{Ok}
                 // without needing us to resend End. Wait again in the next iteration.
                 resendEnd = false;
+                // coverity[double_unlock] - unique_lock tracks ownership via owns_ flag;
+                // destructor will not call unlock() again after explicit lock.unlock() above.
                 continue;
             }
 

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -1015,9 +1015,10 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
 
                 // Manager auto-enqueues when all gaps are filled and sends EndAck{Ok}
                 // without needing us to resend End. Wait again in the next iteration.
+                /* unique_lock tracks ownership via owns_ flag; destructor will not call
+                 * unlock() again after the explicit lock.unlock() above. */
                 resendEnd = false;
-                // coverity[double_unlock] - unique_lock tracks ownership via owns_ flag;
-                // destructor will not call unlock() again after explicit lock.unlock() above.
+                // coverity[double_unlock]
                 continue;
             }
 

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -68,21 +68,33 @@ static int mq_send_binary_stub(int, const void* msg, size_t, const char*, char)
 
 int main()
 {
-
-    LoggerFunc testLogger =
-        [](modules_log_level_t /*level*/, const std::string & msg)
+    try
     {
-        std::cout << "[Test sync_protocol]: " << msg << std::endl;
-    };
+        LoggerFunc testLogger =
+            [](modules_log_level_t /*level*/, const std::string & msg)
+        {
+            std::cout << "[Test sync_protocol]: " << msg << std::endl;
+        };
 
-    MQ_Functions mq{&mq_start_stub, &mq_send_binary_stub};
-    AgentSyncProtocol proto{"sync_protocol", ":memory:", mq, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(timeout), retries, maxEps, nullptr};
-    g_proto = &proto;
+        MQ_Functions mq{&mq_start_stub, &mq_send_binary_stub};
+        AgentSyncProtocol proto{"sync_protocol", ":memory:", mq, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(timeout), retries, maxEps, nullptr};
+        g_proto = &proto;
 
-    proto.persistDifference("id1", Operation::CREATE, "idx1", "{\"k\":\"v1\"}", 1);
-    proto.persistDifference("id2", Operation::MODIFY, "idx2", "{\"k\":\"v2\"}", 2);
+        proto.persistDifference("id1", Operation::CREATE, "idx1", "{\"k\":\"v1\"}", 1);
+        proto.persistDifference("id2", Operation::MODIFY, "idx2", "{\"k\":\"v2\"}", 2);
 
-    bool ok = proto.synchronizeModule(Mode::FULL);
-    std::cout << (ok ? "OK" : "FAIL") << std::endl;
-    return ok ? 0 : 1;
+        bool ok = proto.synchronizeModule(Mode::FULL);
+        std::cout << (ok ? "OK" : "FAIL") << std::endl;
+        return ok ? 0 : 1;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "[Test sync_protocol] Unhandled exception: " << e.what() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "[Test sync_protocol] Unknown unhandled exception" << std::endl;
+        return 1;
+    }
 }

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -486,6 +486,11 @@ void fim_initialize() {
             synced_docs_ptr = &synced_docs_registry_values;
         }
 
+        if (synced_docs_ptr == NULL) {
+            mwarn("fim_initialize: unknown table name '%s', skipping limit check.", table_name);
+            continue;
+        }
+
         *synced_docs_ptr = fim_db_count_synced_docs(table_name);
         if (*synced_docs_ptr != 0) { // No need to check if no scans have been run
             if (limit == 0) { // If moving from limited agent to unlimited, promote everything

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -95,6 +95,9 @@ int fim_execute_is_pause_completed(void) {
 
     atomic_int_set(&syscheck.fim_pausing_is_allowed, 1);
     mdebug1("FIM pause acknowledged — scan mutexes acquired for coordination");
+    // Locks are intentionally held here: ownership is transferred to fim_execute_resume(),
+    // which releases fim_scan_mutex (and fim_realtime_mutex / fim_registry_scan_mutex on WIN32).
+    // coverity[missing_unlock]
     return 0;
 }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -173,7 +173,7 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
     }
 
     // Initial delay before first run to allow other modules to start
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    m_cv.wait_for(lock, std::chrono::seconds(5), [this] { return m_stopped; });
 
     // Run at least once
     do
@@ -1890,9 +1890,13 @@ bool AgentInfoImpl::shouldPerformIntegrityCheck(const std::string& table, int in
     if (lastCheck == 0)
     {
         // Release lock before calling updateLastIntegrityTime to avoid deadlock
+        // (updateLastIntegrityTime internally acquires m_syncFlagsMutex).
         lock.unlock();
         updateLastIntegrityTime(table);
         m_logFunction(LOG_DEBUG, "Initialized integrity check timestamp for " + table);
+        // coverity[double_unlock] - unique_lock owns_ is false after explicit unlock() above;
+        // destructor will not call unlock() again. Coverity's built-in model does not track
+        // the owns_ flag correctly when updateLastIntegrityTime re-acquires the same mutex.
         return false;
     }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1894,9 +1894,10 @@ bool AgentInfoImpl::shouldPerformIntegrityCheck(const std::string& table, int in
         lock.unlock();
         updateLastIntegrityTime(table);
         m_logFunction(LOG_DEBUG, "Initialized integrity check timestamp for " + table);
-        // coverity[double_unlock] - unique_lock owns_ is false after explicit unlock() above;
-        // destructor will not call unlock() again. Coverity's built-in model does not track
-        // the owns_ flag correctly when updateLastIntegrityTime re-acquires the same mutex.
+        /* unique_lock owns_ is false after explicit unlock() above; destructor will not call
+         * unlock() again. Coverity's built-in model does not track the owns_ flag correctly
+         * when updateLastIntegrityTime re-acquires the same mutex. */
+        // coverity[double_unlock]
         return false;
     }
 

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -280,6 +280,9 @@ static void *process_control() {
         buffer = NULL;
     }
 
+    // coverity[unreachable] - intentional cleanup code: the while(1) loop above
+    // currently exits only via merror_exit(). This block ensures proper resource
+    // release if a graceful exit path is added in the future.
     close(sock);
     return NULL;
 }

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -280,9 +280,10 @@ static void *process_control() {
         buffer = NULL;
     }
 
-    // coverity[unreachable] - intentional cleanup code: the while(1) loop above
-    // currently exits only via merror_exit(). This block ensures proper resource
-    // release if a graceful exit path is added in the future.
+    /* Intentional cleanup code: the while(1) loop above currently exits only via
+     * merror_exit(). This block ensures proper resource release if a graceful
+     * exit path is added in the future. */
+    // coverity[unreachable]
     close(sock);
     return NULL;
 }

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -521,18 +521,19 @@ void Syscollector::setAgentdQueryFunction(AgentdQueryFunc queryFunc)
 void Syscollector::start()
 {
     // Don't start if initialization failed
-    if (!m_initialized)
-    {
-        if (m_logFunction)
-        {
-            m_logFunction(LOG_ERROR, "Cannot start Syscollector - module initialization failed");
-        }
-
-        return;
-    }
-
     {
         std::scoped_lock<std::mutex> lock{m_scan_mutex};
+
+        if (!m_initialized)
+        {
+            if (m_logFunction)
+            {
+                m_logFunction(LOG_ERROR, "Cannot start Syscollector - module initialization failed");
+            }
+
+            return;
+        }
+
         m_stopping = false;
     }
 


### PR DESCRIPTION
## Description

Closes #35954 

This PR fixes 22 `Medium` impact defects detected by Coverity scan for Wazuh 5.0.0 Beta 1, as reported in issue #35864. Defects from `/src/external/flatbuffers/` and of type "Unchecked return value" are excluded from this scope.

## Proposed Changes

All defects were analyzed using the Coverity dashboard event traces. Fixes are categorized as follows:

#### Synchronization Issues (5 defects)

| CID | Type | File | Function | Fix Applied |
|-----|------|------|----------|-------------|
| 560747 | Waiting while holding a lock | `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp` | `start` | Replaced `std::this_thread::sleep_for` with `m_cv.wait_for`, which atomically releases the mutex during the wait |
| 560744 | Missing unlock | `src/syscheckd/src/syscom.c` | `fim_execute_is_pause_completed` | Added `// coverity[missing_unlock]` annotation — lock ownership is intentionally transferred to `fim_execute_resume()` |
| 560702 | Waiting while holding a lock | `src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp` | `closeAndDeleteDatabase` | Scoped `lock_guard` to a nested block covering only shared-state operations; `cleanDB()` (filesystem) is called after the lock is released |
| 560700 | Double unlock | `src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp` | `sendEndAndWaitAck` | Added `// coverity[double_unlock]` annotation — false positive; `unique_lock::owns_` is `false` after explicit `unlock()`, so the destructor does not call `unlock()` again |
| 560692 | Double unlock | `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp` | `shouldPerformIntegrityCheck` | Added `// coverity[double_unlock]` annotation — same pattern as CID 560700; `updateLastIntegrityTime` re-acquires the same mutex internally, which Coverity's built-in model misinterprets as a double unlock |

#### Concurrent Data Access Violations (6 defects)

| CID | Type | File | Function | Fix Applied |
|-----|------|------|----------|-------------|
|560829	 | Data race condition | `src/client-agent/src/buffer.c` | `buffer_init`	| Added `// coverity[missing_lock]` annotation — false positive; `buffer_init()` is called either before threads start or under external serialization (config reload path), so no race condition exists |
| 560715 | Data race condition | `src/shared/src/batch_queue_op.c` | `batch_queue_enqueue_ex` | Snapshot of `max_items_per_agent` into a local variable while `ring_mu` is still held (step 2), before releasing it in step 3, preventing a concurrent write from `batch_queue_set_agent_max()` |
| 560703 | Data race condition | `src/client-agent/src/buffer.c` | `dispatch_buffer` | Nulling of `buffer[original_j_for_nulling].data/.size` now protected with `mutex_lock`, consistent with all other write accesses to the same field |
| 560671 | Data race condition | `src/wazuh_modules/syscollector/src/syscollectorImp.cpp` | `start` | Moved the read of `m_initialized` inside the `m_scan_mutex` block together with the `m_stopping = false` assignment, eliminating the unguarded read |
| 558403 | Value not atomically updated | `src/shared/src/batch_queue_op.c` | `batch_queue_enqueue_ex` | Re-validate slot via `hm_get` under `ring_mu` before dereferencing it in step 5; `batch_queue_drop_agent()` may have freed the slot between the two critical sections |
| 558321 | Data race condition | `src/config/src/syscheck-config.c` | `fim_copy_directory_list` | Added `// coverity[missing_lock]` annotation — false positive; `source->first_node` is guarded by `source->wr_mutex` (rwlock), not `source->mutex`, as confirmed by `OSList_GetFirstNode()` |

#### Null Pointer Dereferences (3 defects)

| CID | Type | File | Function | Fix Applied |
|-----|------|------|----------|-------------|
| 560707 | Explicit null dereferenced | `src/syscheckd/src/syscheck.c` | `fim_initialize` | Added `if (synced_docs_ptr == NULL)` guard with `continue` before dereferencing; triggered when `table_name` does not match any known table constant |
| 558156 | Explicit null dereferenced | `src/shared_modules/file_helper/file_io/src/file_io_utils.cpp` | `getBinaryContent` | Added `if (!spBuffer)` guard returning an empty vector before constructing it with a null pointer; `spBuffer` stays null when the file cannot be opened or the buffer is unavailable |
| 557912 | Dereference null return value | `src/shared/src/enrollment_op.c` | `w_enrollment_process_agent_key` | Added `if (!entrys)` null check after `OS_StrBreak()`, which returns NULL when the input string cannot be split into the expected fields |

#### Integer Handling Issues (3 defects)

| CID | Type | File | Function | Fix Applied |
|-----|------|------|----------|-------------|
| 560701 | Improper use of negative value | `src/data_provider/src/packages/packageLinuxParserHelper.h` | `parseSnap` | Added `if (epoch >= 0)` guard before casting `time_t` to `uint32_t`; `timegm()` returns `-1` on error, which wraps to `UINT32_MAX` without the check |
| 560664 | Overflowed constant | `src/config/src/wmodules-sca.c`, `src/config/src/wmodules-syscollector.c` | `parse_synchronization_section` | Added `> (long)UINT32_MAX` upper bound check for all `uint32_t` fields assigned from `w_parse_time()`; `LONG_MAX` silently truncates to an incorrect value without it |
| 557986 | Overflowed constant | `src/shared/src/hashmap_op.c` | `hm_put` | Added `hm->tombstones > 0` guard before `hm->tombstones--`; `hm_maybe_grow()` can reset it to `0`, causing unsigned underflow to `SIZE_MAX` |

#### Control Flow Issues (2 defects)

| CID | Type | File | Function | Fix Applied |
|-----|------|------|----------|-------------|
| 560733 | Structurally dead code | `src/client-agent/src/agcom.c` | `agcom_main` | Added `// coverity[unreachable]` annotation — intentional cleanup code; `close(sock)` ensures proper resource release if a graceful exit path is added in the future |
| 560721 | Structurally dead code | `src/wazuh_modules/src/wm_control.c` | `process_control` | Added `// coverity[unreachable]` annotation — same pattern as CID 560733 |

#### Uncaught Exceptions (3 defects)

| CID | Type | File | Function | Fix Applied |
|-----|------|------|----------|-------------|
| 560740 | Uncaught exception | `src/shared_modules/sync_protocol/testtool/main.cpp` | `main` | Wrapped the entire `main()` body in a `try/catch(const std::exception&)` and `catch(...)` block to handle any exception thrown by `AgentSyncProtocol` constructor, `persistDifference()`, or `synchronizeModule()` |
| 560699 | Uncaught exception | `src/shared_modules/sync_protocol/testtool/main.cpp` | `main` | Same fix as CID 560740 — all three CIDs point to the same unprotected call sites in `main()` |
| 560686 | Uncaught exception | `src/shared_modules/sync_protocol/testtool/main.cpp` | `main` | Same fix as CID 560740 — all three CIDs point to the same unprotected call sites in `main()` |

### Results and Evidence

#### Snapshot 95759

<details><summary>14 fixed</summary>
<p>

<img width="1205" height="422" alt="image" src="https://github.com/user-attachments/assets/953e8923-0607-4f95-9861-ee96d11941d0" />

</p>
</details> 

<details><summary>1 newly detected</summary>
<p>

<img width="1205" height="120" alt="image" src="https://github.com/user-attachments/assets/3b21cdfe-6cc4-4bf7-b9cc-d54b7680499c" />

</p>
</details> 

#### Snapshot 95828

<details><summary>1 fixed</summary>
<p>

<img width="1205" height="213" alt="Captura desde 2026-05-11 16-31-15" src="https://github.com/user-attachments/assets/29b0f65a-b343-4875-81fd-5ff3b9988dff" />

</p>
</details> 



### Artifacts Affected

- Wazuh agent (Linux, macOS, Windows)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. Existing unit tests cover the affected code paths. Coverity re-scan is required to confirm resolution.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues