### PR TITLE
Remove selinux from manager

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -146,6 +146,4 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/wazuh-manager/var/download,root,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/var/multigroups,wazuh-manager,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/var/run,root,wazuh-manager,770,directory,drwxrwx---,,
-/var/wazuh-manager/var/selinux,root,wazuh-manager,770,directory,drwxrwx---,,
-/var/wazuh-manager/var/selinux/wazuh.pp,root,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/var/upgrade,root,wazuh-manager,770,directory,drwxrwx---,,

--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -2,7 +2,7 @@ Source: wazuh-manager
 Section: admin
 Priority: extra
 Maintainer: Wazuh <info@wazuh.com>
-Build-Depends: debhelper (>= 7.0.50~), libssl-dev, linux-libc-dev, gawk, libaudit-dev, selinux-basics
+Build-Depends: debhelper (>= 7.0.50~), libssl-dev, linux-libc-dev, gawk, libaudit-dev
 Standards-Version: 3.8.4
 Homepage: http://www.wazuh.com
 

--- a/packages/debs/SPECS/wazuh-manager/debian/postinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/postinst
@@ -194,13 +194,6 @@ case "$1" in
     # strict "etc/ MUST NOT be overwritten" contract from the upgrade rules.
     restore_upgrade_preserve
 
-    # Check if SELinux is installed and enabled
-    if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
-        if [ $(getenforce) !=  "Disabled" ]; then
-            semodule -i ${DIR}/var/selinux/wazuh.pp
-            semodule -e wazuh
-        fi
-    fi
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || true

--- a/packages/debs/SPECS/wazuh-manager/debian/postrm
+++ b/packages/debs/SPECS/wazuh-manager/debian/postrm
@@ -75,14 +75,6 @@ case "$1" in
             rm -rf ${DIR}/data
         fi
 
-        # Delete audisp wazuh plugin if exists
-        if [ -e /etc/audit/plugins.d/af_wazuh.conf ]; then
-            rm -f -- /etc/audit/plugins.d/af_wazuh.conf
-        fi
-        if [ -e /etc/audisp/plugins.d/af_wazuh.conf ]; then
-            rm -f -- /etc/audisp/plugins.d/af_wazuh.conf
-        fi
-
         # Delete old .save
         find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
 

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -41,7 +41,7 @@ override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
 	# Build the binaries
 	make -C src deps TARGET=manager
-	make -j$(JOBS) -C src/ TARGET=manager USE_SELINUX=no DEBUG=$(DEBUG_ENABLED)
+	make -j$(JOBS) -C src/ TARGET=manager DEBUG=$(DEBUG_ENABLED)
 
 	USER_LANGUAGE="en" \
 	USER_INSTALL_TYPE="manager" \

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -41,7 +41,7 @@ override_dh_install:
 	rm -rf $(INSTALLATION_DIR)/
 	# Build the binaries
 	make -C src deps TARGET=manager
-	make -j$(JOBS) -C src/ TARGET=manager USE_SELINUX=yes DEBUG=$(DEBUG_ENABLED)
+	make -j$(JOBS) -C src/ TARGET=manager USE_SELINUX=no DEBUG=$(DEBUG_ENABLED)
 
 	USER_LANGUAGE="en" \
 	USER_INSTALL_TYPE="manager" \

--- a/packages/debs/amd64/manager/Dockerfile
+++ b/packages/debs/amd64/manager/Dockerfile
@@ -18,7 +18,7 @@ RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 -
     apt-get install -y --force-yes \
     curl g++ bzip2 debhelper gcc rename make sudo wget expect gnupg perl-base perl \
     libc-bin libc6 libc6-dev build-essential dpkg-dev\
-    cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
+    cdbs devscripts equivs automake autoconf libtool libaudit-dev \
     libdb5.3 libdb5.3-dev libssl1.0.0 libssl-dev procps git gawk libsigsegv2
 
 RUN echo "deb-src http://archive.debian.org/debian jessie contrib main non-free" >> /etc/apt/sources.list

--- a/packages/debs/arm64/manager/Dockerfile
+++ b/packages/debs/arm64/manager/Dockerfile
@@ -17,7 +17,7 @@ RUN /usr/local/bin/retry.sh --attempts 5 --delay 10 --backoff 2 --max-delay 40 -
     curl gcc g++ make sudo expect gnupg \
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
-    autoconf libtool libaudit-dev selinux-basics \
+    autoconf libtool libaudit-dev \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
 # Add Debian's source repository and, Install NodeJS 12

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -58,7 +58,7 @@ make clean
 
 # Build Wazuh sources
 make deps TARGET=manager
-make -j%{_threads} TARGET=manager USE_SELINUX=yes DEBUG=%{_debugenabled}
+make -j%{_threads} TARGET=manager USE_SELINUX=no DEBUG=%{_debugenabled}
 
 popd
 
@@ -367,14 +367,6 @@ rm -f %{_localstatedir}/etc/shared/merged.mg  >/dev/null 2>&1
 # Set merged.mg permissions to new ones
 find %{_localstatedir}/etc/shared/ -type f -name 'merged.mg' -exec chmod 644 {} \;
 
-# Add the SELinux policy
-if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
-  if [ $(getenforce) != "Disabled" ]; then
-    semodule -i %{_localstatedir}/var/selinux/wazuh.pp
-    semodule -e wazuh
-  fi
-fi
-
 # Restore wazuh-manager.conf permissions after upgrading
 chown root:wazuh-manager %{_localstatedir}/etc/wazuh-manager.conf
 chmod 0660 %{_localstatedir}/etc/wazuh-manager.conf
@@ -417,15 +409,6 @@ if [ $1 = 0 ]; then
   fi
   %{_localstatedir}/bin/wazuh-manager-control stop > /dev/null 2>&1
 
-  # Remove the SELinux policy
-  if command -v getenforce > /dev/null 2>&1 && command -v semodule > /dev/null 2>&1; then
-    if [ $(getenforce) != "Disabled" ]; then
-      if (semodule -l | grep wazuh > /dev/null); then
-        semodule -r wazuh > /dev/null
-      fi
-    fi
-  fi
-
 fi
 
 %postun
@@ -467,14 +450,6 @@ if [ $1 = 0 ];then
   rm -rf %{_localstatedir}/logs/
   rm -rf %{_localstatedir}/tmp
   rm -rf %{_localstatedir}/data
-
-  # Delete audisp wazuh plugin if exists
-  if [ -e /etc/audit/plugins.d/af_wazuh.conf ]; then
-    rm -f -- /etc/audit/plugins.d/af_wazuh.conf
-  fi
-  if [ -e /etc/audisp/plugins.d/af_wazuh.conf ]; then
-    rm -f -- /etc/audisp/plugins.d/af_wazuh.conf
-  fi
 fi
 
 # posttrans code is the last thing executed in a install/upgrade
@@ -675,8 +650,6 @@ rm -fr %{buildroot}
 %dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/download
 %dir %attr(770, wazuh-manager, wazuh-manager) %{_localstatedir}/var/multigroups
 %dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/run
-%dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/selinux
-%attr(640, root, wazuh-manager) %{_localstatedir}/var/selinux/*
 %dir %attr(770, root, wazuh-manager) %{_localstatedir}/var/upgrade
 
 %files -n wazuh-manager-debuginfo -f debugfiles.list

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -58,7 +58,7 @@ make clean
 
 # Build Wazuh sources
 make deps TARGET=manager
-make -j%{_threads} TARGET=manager USE_SELINUX=no DEBUG=%{_debugenabled}
+make -j%{_threads} TARGET=manager DEBUG=%{_debugenabled}
 
 popd
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -157,6 +157,11 @@ else
 USE_SELINUX=no
 endif
 
+
+ifeq (${TARGET},manager)
+override USE_SELINUX := no
+endif
+
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
 		PRECOMPILED_OS:=linux
@@ -335,7 +340,7 @@ agent: ${CPPLIBDEPS}
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 
 ifneq (,$(filter ${USE_SELINUX},YES yes y Y 1))
-server manager agent: selinux
+agent: selinux
 endif
 
 selinux: $(SELINUX_POLICY)

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,9 +92,6 @@ else
 WAZUH_USER?=wazuh
 WAZUH_GROUP?=wazuh
 endif
-SELINUX_MODULE=selinux/wazuh.mod
-SELINUX_ENFORCEMENT=selinux/wazuh.te
-SELINUX_POLICY=selinux/wazuh.pp
 USE_INOTIFY=no
 USE_BIG_ENDIAN=no
 USE_AUDIT=no
@@ -156,7 +153,6 @@ endif
 else
 USE_SELINUX=no
 endif
-
 
 ifeq (${TARGET},manager)
 override USE_SELINUX := no
@@ -340,8 +336,10 @@ agent: ${CPPLIBDEPS}
 	${MAKE} ${BUILD_CMAKE_PROJECTS}
 
 ifneq (,$(filter ${USE_SELINUX},YES yes y Y 1))
+SELINUX_MODULE=selinux/wazuh.mod
+SELINUX_ENFORCEMENT=selinux/wazuh.te
+SELINUX_POLICY=selinux/wazuh.pp
 agent: selinux
-endif
 
 selinux: $(SELINUX_POLICY)
 
@@ -350,6 +348,7 @@ $(SELINUX_POLICY): $(SELINUX_MODULE)
 
 $(SELINUX_MODULE): $(SELINUX_ENFORCEMENT)
 	checkmodule -M -m -o $@ $?
+endif
 
 ifeq (${MAKECMDGOALS},winagent)
 $(error Do not use 'winagent' directly, use 'TARGET=winagent')
@@ -834,8 +833,8 @@ clean-internals:
 	rm -f wazuh_modules/vulnerability_scanner/include/*_generated.h
 	rm -f wazuh_modules/vulnerability_scanner/include/*_schema.h
 # Selinux
-	rm -f ${SELINUX_MODULE}
-	rm -f ${SELINUX_POLICY}
+	rm -f selinux/wazuh.mod
+	rm -f selinux/wazuh.pp
 
 clean-framework:
 	${MAKE} -C ../framework clean

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -841,12 +841,15 @@ InstallCommon()
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var
   ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/run
   ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/upgrade
-  ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/selinux
 
-  if [ -f selinux/wazuh.pp ]
-  then
-    ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} selinux/wazuh.pp ${INSTALLDIR}/var/selinux/
-    InstallSELinuxPolicyPackage
+  # SELinux policy is shipped only with the agent (FIM whodata uses
+  # auditd/audisp). The manager does not install any SELinux policy.
+  if [ "X${INSTYPE}" = "Xagent" ]; then
+    ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/selinux
+    if [ -f selinux/wazuh.pp ]; then
+      ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} selinux/wazuh.pp ${INSTALLDIR}/var/selinux/
+      InstallSELinuxPolicyPackage
+    fi
   fi
 
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/backup

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -842,8 +842,6 @@ InstallCommon()
   ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/run
   ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/upgrade
 
-  # SELinux policy is shipped only with the agent (FIM whodata uses
-  # auditd/audisp). The manager does not install any SELinux policy.
   if [ "X${INSTYPE}" = "Xagent" ]; then
     ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/var/selinux
     if [ -f selinux/wazuh.pp ]; then


### PR DESCRIPTION
## Description

The SELinux policy (`wazuh.te`) shipped by Wazuh is exclusively required by the FIM whodata engine, which relies on the auditd/audisp subsystem to receive kernel audit events. This subsystem is used only by the **agent**. The manager has no interaction with the audit dispatcher.

After the agent/manager separation, the manager continued to compile, install, and load the policy unnecessarily. This PR corrects that by fully removing SELinux support from the manager build and packaging pipeline.

## Proposed Changes

### `src/Makefile`
- Added an unconditional `override USE_SELINUX := no` guard for `TARGET=manager`, preventing SELinux compilation regardless of whether `checkmodule`/`semodule_package` are available in the build environment.
- Restricted the `selinux` build-target dependency from `server manager agent` to `agent` only.

### `src/init/inst-functions.sh`
- Wrapped the `var/selinux/` directory creation and `wazuh.pp` installation inside `if [ "X${INSTYPE}" = "Xagent" ]`, so the SELinux policy is only deployed during agent installations.

### `packages/rpms/SPECS/wazuh-manager.spec`
- Changed `USE_SELINUX=yes` to `USE_SELINUX=no` in the `%build` section.
- Removed the `%preun` block that unloaded the SELinux module on uninstall.
- Removed the `%postun` block that deleted `af_wazuh.conf` audisp plugin config files (it belongs to the agent).
- Removed `var/selinux/` directory and `var/selinux/wazuh.pp` from the `%files` section.

### `packages/debs/SPECS/wazuh-manager/debian/rules`
- Changed `USE_SELINUX=yes` to `USE_SELINUX=no`.

### `packages/debs/SPECS/wazuh-manager/debian/postinst`
- Removed the block that called `semodule -i` and `semodule -e` during package installation.

### `packages/debs/SPECS/wazuh-manager/debian/postrm`
- Removed the block that deleted `af_wazuh.conf` audisp plugin config files on package purge.

### `packages/debs/SPECS/wazuh-manager/debian/control`
- Removed `selinux-basics` from `Build-Depends`.

### `packages/debs/amd64/manager/Dockerfile` and `packages/debs/arm64/manager/Dockerfile`
- Removed `selinux-basics` from the build container package list.

### `.github/actions/check_files/manager_base.csv`
- Removed `var/selinux/` directory and `var/selinux/wazuh.pp` from the manager installation file manifest.

### Results and Evidence

- ossec.conf

```
[root@centos9-manager home]# grep "syscheck" -A10 /var/ossec/etc/ossec.conf
  <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>30</frequency>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>
    <directories check_all="yes" whodata="yes" realtime="yes" report_changes="yes">/tmp/whodata</directories>
    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
--
  </syscheck>

``` 


- packages

```
root@indexer:/# apt install ./wazuh-manager_5.0.0-0_amd64_ea6af05.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_5.0.0-0_amd64_ea6af05.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/107 MB of archives.
After this operation, 448 MB of additional disk space will be used.
Get:1 /wazuh-manager_5.0.0-0_amd64_ea6af05.deb wazuh-manager amd64 5.0.0-0 [107 MB]
Selecting previously unselected package wazuh-manager.
(Reading database ... 50821 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_5.0.0-0_amd64_ea6af05.deb ...
Unpacking wazuh-manager (5.0.0-0) ...
Setting up wazuh-manager (5.0.0-0) ...
Scanning processes...                                                                                                                                                                   
Scanning linux images...                                                                                                                                                                

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.



root@indexer:/# apt install ./wazuh-agent_5.0.0-0_amd64_fd83b9f.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_5.0.0-0_amd64_fd83b9f.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/13.7 MB of archives.
After this operation, 53.9 MB of additional disk space will be used.
Get:1 /wazuh-agent_5.0.0-0_amd64_fd83b9f.deb wazuh-agent amd64 5.0.0-0 [13.7 MB]
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 60530 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_fd83b9f.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Scanning processes...                                                                                                                                                                   
Scanning linux images...                                                                                                                                                                

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.

root@indexer:/# find /var/ossec/ -iname "*selinux*"
/var/ossec/var/selinux
root@indexer:/# find /var/wazuh-manager/ -iname "*selinux*"
root@indexer:/# 

```

- installing by sources

```

make[1]: Entering directory '/home/vagrant/git/wazuh/src'

General settings:
    TARGET:             agent
    V:                  
    DEBUG:              
    INSTALLDIR:         /var/ossec
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                gcc
    MAKE              make
make[1]: Leaving directory '/home/vagrant/git/wazuh/src'

Done building agent

Wait for success...
success
Removing old SCA policies...
Installing SCA policies...


Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-agent.service → /usr/lib/systemd/system/wazuh-agent.service.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


 - More information at: 
   https://documentation.wazuh.com/

[root@centos9-manager wazuh]# find /var/ossec/ -iname "*selinux*"
/var/ossec/var/selinux

```

- event
 
```
[root@centos9-manager /]# tail -n 20 /var/ossec/logs/ossec.log
2026/05/11 08:34:05 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/11 08:34:05 wazuh-modulesd:agent-info: INFO: AgentInfo initialized.
2026/05/11 08:34:05 wazuh-modulesd:sca: INFO: SCA initialized.
2026/05/11 08:34:05 wazuh-modulesd:sca: INFO: Started (pid: 102140).
2026/05/11 08:34:05 wazuh-modulesd:sca: INFO: SCA module running.
2026/05/11 08:34:05 wazuh-modulesd:syscollector: INFO: Module started.
2026/05/11 08:34:05 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/11 08:34:05 wazuh-modulesd:sca: INFO: SCA module scan on start.
2026/05/11 08:34:05 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/11 08:34:06 wazuh-syscheckd: INFO: (6046): Internal audit queue size set to '16384'.
2026/05/11 08:34:07 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/05/11 08:34:07 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/11 08:34:09 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/05/11 08:34:12 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/11 08:34:12 wazuh-syscheckd: INFO: (6019): File integrity monitoring real-time Whodata engine started.
2026/05/11 08:34:26 wazuh-rootcheck: INFO: Ending rootcheck scan.
2026/05/11 08:34:48 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/11 08:35:23 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/11 08:35:58 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/11 08:36:33 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
[root@centos9-manager /]# echo "Forcing" >> /tmp/whodata/test4.txt

``` 

```

2026/05/11 08:42:46 wazuh-manager-analysisd: WARNING: Event not processed: {"wazuh":{"protocol":{"queue":56,"location":"syscheck"},"agent":{"host":{"os":{"name":"CentOS Stream","version":"9","platform":"centos","type":"linux"},"architecture":"x86_64","hostname":"centos9-manager"},"id":"001","name":"centos9-manager","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"0f0a590d-b153-43f5-8d4a-b03033ac0c8f"}},"event":{"original":"{\"collector\":\"file\",\"module\":\"fim\",\"data\":{\"event\":{\"created\":\"2026-05-11T08:42:46.793Z\",\"type\":\"added\"},\"file\":{\"size\":8,\"permissions\":[\"rw-r--r--\"],\"uid\":\"0\",\"owner\":\"root\",\"gid\":\"0\",\"group\":\"root\",\"inode\":\"207541672\",\"device\":\"64768\",\"mtime\":\"2026-05-11T08:42:46.000Z\",\"hash\":{\"md5\":\"ce76c6a34b3922e6348ecfdf76f95964\",\"sha1\":\"17022dd5b2779aa4fd8746b459667e1f369a6ae7\",\"sha256\":\"e60c34d8af45928a16d2d973252d3a7b51c761a2e3ce1523ea8db0ca688863d3\"},\"path\":\"/tmp/whodata/test4.txt\",\"mode\":\"whodata\",\"audit\":{\"user_id\":\"0\",\"user_name\":\"root\",\"process_name\":\"/usr/bin/bash (deleted)\",\"process_id\":5040,\"cwd\":\"/\",\"group_id\":\"0\",\"group_name\":\"root\",\"audit_uid\":\"1000\",\"audit_name\":\"vagrant\",\"effective_uid\":\"0\",\"effective_name\":\"root\",\"parent_name\":\"/usr/bin/su (deleted)\",\"parent_cwd\":\"/\",\"ppid\":5039}}}}"},"@timestamp":"2026-05-11T08:42:46.794Z"}
2026/05/11 08:42:46 wazuh-manager-analysisd: WARNING: Event not processed: {"wazuh":{"protocol":{"queue":56,"location":"syscheck"},"agent":{"host":{"os":{"name":"CentOS Stream","version":"9","platform":"centos","type":"linux"},"architecture":"x86_64","hostname":"centos9-manager"},"id":"001","name":"centos9-manager","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"6dfc00f9-9e92-428b-8fe7-9a70392e2e9a"}},"event":{"original":"{\"collector\":\"file\",\"module\":\"fim\",\"data\":{\"event\":{\"created\":\"2026-05-11T08:42:46.800Z\",\"type\":\"deleted\"},\"file\":{\"size\":12,\"permissions\":[\"rw-r--r--\"],\"uid\":\"0\",\"owner\":\"root\",\"gid\":\"0\",\"group\":\"root\",\"inode\":\"207541486\",\"device\":\"64768\",\"mtime\":\"2026-05-11T08:23:58.000Z\",\"hash\":{\"md5\":\"f0ef7081e1539ac00ef5b761b4fb01b3\",\"sha1\":\"33ab5639bfd8e7b95eb1d8d0b87781d4ffea4d5d\",\"sha256\":\"1894a19c85ba153acbf743ac4e43fc004c891604b26f8c69e1e83ea2afc7c48f\"},\"path\":\"/tmp/whodata/victoria.txt\",\"mode\":\"whodata\",\"audit\":{\"user_id\":\"0\",\"user_name\":\"root\",\"process_name\":\"/usr/bin/rm\",\"process_id\":105802,\"cwd\":\"/\",\"group_id\":\"0\",\"group_name\":\"root\",\"audit_uid\":\"1000\",\"audit_name\":\"vagrant\",\"effective_uid\":\"0\",\"effective_name\":\"root\",\"parent_name\":\"/usr/bin/bash (deleted)\",\"parent_cwd\":\"/\",\"ppid\":5040}}}}"},"@timestamp":"2026-05-11T08:42:46.838Z"}
2026/05/11 08:42:48 wazuh-manager-analysisd: WARNING: Event not processed: {"wazuh":{"protocol":{"queue":49,"location":"/var/log/audit/audit.log"},"agent":{"host":{"os":{"name":"CentOS Stream","version":"9","platform":"centos","type":"linux"},"architecture":"x86_64","hostname":"centos9-manager"},"id":"001","name":"centos9-manager","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"9e50f90f-c3b8-4202-b4e3-59c86f8431ca"}},"event":{"original":"type=SYSCALL msg=audit(1778488966.785:2398): arch=c000003e syscall=257 success=yes exit=3 a0=ffffff9c a1=55d2b3add810 a2=441 a3=1b6 items=2 ppid=5039 pid=5040 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=5 comm=\"bash\" exe=2F7573722F62696E2F62617368202864656C6574656429 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=\"wazuh_fim\"\u001DARCH=x86_64 SYSCALL=openat AUID=\"vagrant\" UID=\"root\" GID=\"root\" EUID=\"root\" SUID=\"root\" FSUID=\"root\" EGID=\"root\" SGID=\"root\" FSGID=\"root\" type=CWD msg=audit(1778488966.785:2398): cwd=\"/\" type=PATH msg=audit(1778488966.785:2398): item=0 name=\"/tmp/whodata/\" inode=207541667 dev=fd:00 mode=040755 ouid=0 ogid=0 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\u001DOUID=\"root\" OGID=\"root\" type=PATH msg=audit(1778488966.785:2398): item=1 name=\"/tmp/whodata/test4.txt\" inode=207541672 dev=fd:00 mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=unconfined_u:object_r:user_tmp_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\u001DOUID=\"root\" OGID=\"root\" type=PROCTITLE msg=audit(1778488966.785:2398): proctitle=\"bash\""},"@timestamp":"2026-05-11T08:42:48.633Z"}

``` 

```
[root@centos9-manager home]# echo "HELLO WOLRD" > /tmp/whodata/test5.txt


2026/05/11 16:03:56 wazuh-syscheckd[249538] run_check.c:330 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"collector":"file","module":"fim","data":{"event":{"created":"2026-05-11T16:03:56.776Z","type":"added"},"file":{"size":12,"permissions":["rw-r--r--"],"uid":"0","owner":"root","gid":"0","group":"root","inode":"207541658","device":"64768","mtime":"2026-05-11T16:03:56.000Z","hash":{"md5":"883d8ddda3b9afa43801e847799a9bbf","sha1":"84386c9fe582a225643ff60eaeb444cf0c496210","sha256":"28e522bb7968d30bdff91dad6d75f92fa1fbbb70ea3240f4e06788b367c62dce"},"path":"/tmp/whodata/test5.txt","mode":"whodata","audit":{"user_id":"0","user_name":"root","process_name":"/usr/bin/bash (deleted)","process_id":5040,"cwd":"/home","group_id":"0","group_name":"root","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","parent_name":"/usr/bin/su (deleted)","parent_cwd":"/","ppid":5039}}}}

```


<img width="1863" height="677" alt="image" src="https://github.com/user-attachments/assets/5aeadc5b-ecce-4752-8f72-50ca2bef5241" />


## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues