### PR TITLE
Solved the deliminer bug in enrich protocol

### DIFF
--- a/docs/ref/modules/engine/spec-events.yaml
+++ b/docs/ref/modules/engine/spec-events.yaml
@@ -23,27 +23,83 @@ paths:
     post:
       tags:
         - Events
-      summary: Ingest enriched events (NDJSON)
+      summary: Ingest enriched events (H/E batch protocol)
       description: |
-        Accepts a newline-delimited JSON (NDJSON) stream of enriched events over HTTP via Unix domain socket.
+        Accepts a batch of events using the H/E wire protocol over HTTP via Unix domain socket.
         Socket path: /var/wazuh-manager/queue/sockets/queue-http.sock
+
+        ## Wire Format
+
+        ```
+        H <json-metadata>\n
+        E <queue>:<location>:<message>\n
+        E <queue>:<location>:<message>\n
+        ```
+
+        - **Header line** (`H `): JSON object with agent and cluster metadata.
+        - **Event lines** (`E `): Legacy event format `<queue_byte>:<location>:<message>`.
+        - **Event delimiter**: The 3-byte sequence `\nE ` (newline + E + space) separates events.
+
+        ## Multi-line Events (Continuation-line Indentation)
+
+        When an event payload contains embedded newlines (e.g., multi-line logs, command
+        outputs), continuation lines are **indented with a single leading space** by the
+        sender to prevent false delimiter matches.
+
+        The receiver strips exactly one leading space from each continuation line to
+        recover the original payload.
+
+        ### Quick example
+
+        ```
+        H {"wazuh":{"agent":{"id":"001","name":"srv1"}}}
+        E 1:/var/log/app.log:START
+         continuation (indented with a space)
+         E this line starts with E+space (not a delimiter)
+        E 2:/var/log/syslog:single-line event
+        ```
+
+        See the `examples` section below for more detailed scenarios.
+
       requestBody:
         required: true
         content:
           application/x-ndjson:
             schema:
               type: string
-              description: Newline-delimited JSON; one JSON object per line.
+              description: |
+                H/E batch protocol. First line is the header (`H <json>`),
+                followed by one or more event lines (`E <queue>:<location>:<message>`).
+                Multi-line event payloads use continuation-line indentation (one leading space).
             examples:
-              sample:
+              singleLineEvents:
+                summary: Two single-line events
                 value: |-
-                  {"ts":"2025-09-01T10:00:00Z","rule_id":1001,"agent_id":"001","data":{"k":"v"}}
-                  {"ts":"2025-09-01T10:00:01Z","rule_id":1002,"agent_id":"001","data":{"k2":"v2"}}
+                  H {"wazuh":{"agent":{"id":"001","name":"srv1"},"cluster":{"name":"wazuh","node":"node01"}}}
+                  E 1:/var/log/syslog:May 07 10:00:00 srv1 sshd: Accepted publickey
+                  E 2:/var/log/auth.log:session opened for user root
+              multiLineEvent:
+                summary: Multi-line event with indented continuations
+                value: "H {\"wazuh\":{\"agent\":{\"id\":\"001\",\"name\":\"srv1\"}}}\nE 1:/var/log/app.log:START\n line2\n E this starts with E+space\n line4\nE 2:/var/log/syslog:next event\n"
+              mixedBatch:
+                summary: Mixed batch (multiline, single, multiline, single)
+                value: "H {\"wazuh\":{\"agent\":{\"id\":\"001\",\"name\":\"srv1\"}}}\nE 1:/var/log/app.log:BEGIN\n continuation1\n continuation2\nE 2:/var/log/auth.log:single line event\nE 3:/var/log/daemon.log:MULTI\n E looks like delimiter but isn't\n last line\nE 1:/etc/passwd:another single\n"
+              commandOutput:
+                summary: Command output with multi-line result (netstat)
+                value: "H {\"wazuh\":{\"agent\":{\"id\":\"001\",\"name\":\"srv1\"}}}\nE 1:netstat listening ports:ossec: output: 'netstat listening ports':\n tcp 0.0.0.0:22 0.0.0.0:* 534/sshd\n tcp6 :::22 :::* 534/sshd\n udp 0.0.0.0:68 0.0.0.0:* 1362/dhclient\n"
+              continuationWithLeadingSpace:
+                summary: Payload line that already starts with a space (two spaces on wire)
+                value: "H {\"wazuh\":{\"agent\":{\"id\":\"001\",\"name\":\"srv1\"}}}\nE 1:/var/log/app.log:yaml block:\n   key: value\n   nested: true\n"
+              vulnerabilityScannerEvent:
+                summary: Vulnerability Scanner event (single-line JSON, no indentation needed)
+                value: |-
+                  H {"wazuh":{"agent":{"id":"001","name":"srv1"},"cluster":{"name":"wazuh","node":"node01"}}}
+                  E v:vulnerability-scanner:{"collector":"packages","module":"vulnerability-scanner","data":{"event":{"created":"2026-05-07T10:00:00Z","type":"upsert"},"vulnerability":{"id":"CVE-2024-1234"}}}
       responses:
         "200":
           description: Events accepted. (Empty body)
         "400":
-          description: Invalid NDJSON payload.
+          description: Invalid payload.
           content:
             application/json:
               schema:
@@ -55,12 +111,12 @@ paths:
                     type: integer
                 required: [error, code]
               examples:
-                emptyBatch:
-                  value: {"error":"NDJson parser error, empty batch","code":400}
-                emptyLine:
-                  value: {"error":"NDJson parser error, empty line","code":400}
-                invalidLine:
-                  value: {"error":"NDJson parser error, invalid ndjson line or event: '...'", "code":400}
+                missingHeader:
+                  value: {"error":"NDJson parser error, Missing newline after header","code":400}
+                invalidHeader:
+                  value: {"error":"NDJson parser error, Invalid header format, expected 'H {json}'","code":400}
+                invalidEvent:
+                  value: {"error":"NDJson parser error, Invalid format: event must be at least 5 bytes (\"<byte>:<location>:<message>\")","code":400}
         "500":
           description: Internal server error.
           content:

--- a/src/engine/source/api/event/include/api/event/ndJsonParser.hpp
+++ b/src/engine/source/api/event/include/api/event/ndJsonParser.hpp
@@ -17,6 +17,46 @@ using EventHook = std::function<void(IngestEvent&&)>;
 
 constexpr auto PARSER_ERROR_MSG = "NDJson parser error, {}";
 
+/**
+ * @brief Strip continuation-line indentation from raw event text.
+ *
+ * The wire format indents every continuation line (line after the first within
+ * a multi-line event) with a single space character to prevent false "\nE "
+ * delimiter matches inside event content.  This function removes exactly one
+ * leading space from each continuation line, restoring the original payload.
+ */
+inline std::string unindentContinuation(std::string_view indented)
+{
+    // Fast path: no newlines means nothing to unindent
+    if (indented.find('\n') == std::string_view::npos)
+    {
+        return std::string(indented);
+    }
+
+    std::string result;
+    result.reserve(indented.size());
+
+    std::size_t pos = 0;
+    while (pos < indented.size())
+    {
+        auto nl = indented.find('\n', pos);
+        if (nl == std::string_view::npos)
+        {
+            result.append(indented.data() + pos, indented.size() - pos);
+            break;
+        }
+        // Append up to and including the newline
+        result.append(indented.data() + pos, nl - pos + 1);
+        pos = nl + 1;
+        // Strip exactly one leading space (the continuation indent)
+        if (pos < indented.size() && indented[pos] == ' ')
+        {
+            ++pos;
+        }
+    }
+    return result;
+}
+
 inline void parseNDJson(std::string_view batch, const EventHook& hook)
 {
     try
@@ -79,7 +119,8 @@ inline void parseNDJson(std::string_view batch, const EventHook& hook)
 
             if (hook)
             {
-                IngestEvent ingestEvent {header, std::string(rawEvent)};
+                // Remove continuation-line indentation added by the sender
+                IngestEvent ingestEvent {header, unindentContinuation(rawEvent)};
                 hook(std::move(ingestEvent));
             }
 

--- a/src/engine/source/api/event/test/src/unit/ndJsonParser_test.cpp
+++ b/src/engine/source/api/event/test/src/unit/ndJsonParser_test.cpp
@@ -44,14 +44,45 @@ class NdJsonParserTest : public ::testing::TestWithParam<EventT>
 template<size_t multiplyOriginalJson = 1, typename... Args>
 std::string makeRawNdJson(Args&&... args)
 {
+    // Collect all lines passed by the caller
+    std::vector<std::string> lines;
+    (lines.emplace_back(std::forward<Args>(args)), ...);
+
+    // Build the wire-format string.
+    // Continuation lines (those not starting with "H " or "E " and not empty) are
+    // prefixed with a single space, matching the sender's space-stuffing escape.
     std::string rawNdJson;
-    (
-        [&](const auto& arg)
+    bool inEvent = false;
+
+    for (const auto& ln : lines)
+    {
+        if (ln.size() >= 2 && ln[0] == 'H' && ln[1] == ' ')
         {
-            rawNdJson += arg;
+            rawNdJson += ln;
             rawNdJson += '\n';
-        }(args),
-        ...);
+            inEvent = false;
+        }
+        else if (ln.size() >= 2 && ln[0] == 'E' && ln[1] == ' ')
+        {
+            rawNdJson += ln;
+            rawNdJson += '\n';
+            inEvent = true;
+        }
+        else if (ln.empty())
+        {
+            rawNdJson += '\n';
+        }
+        else
+        {
+            // Continuation line: prefix with space (sender escape)
+            if (inEvent)
+            {
+                rawNdJson += ' ';
+            }
+            rawNdJson += ln;
+            rawNdJson += '\n';
+        }
+    }
 
     // For the new H/E protocol, only the first header line is allowed.
     // When multiplying, repeat only the portion after the first newline (events payload),
@@ -363,6 +394,67 @@ INSTANTIATE_TEST_SUITE_P(
         // FAIL: unexpected line outside an event
         EventT(makeRawNdJson(H(HDR1), "stray line", E(EV1)), FAILURE(), CaseMode::Runner, ""),
 
+        // OK: continuation line starts with "E " — previously caused false split (Case A: HTTP 400)
+        // Wire format: space-prefixed continuation ensures "\nE " does not match.
+        EventT(std::string("H " + HDR1
+                           + "\n"
+                             "E 1:/var/log/ndjson_bug.log:START\n"
+                             " E this line starts with E+space\n"
+                             " line3\n"),
+               SUCCESS(
+                   [&]()
+                   {
+                       json::Json hdr(std::string_view {HDR1});
+                       std::vector<base::Event> v;
+                       v.push_back(base::eventParsers::parseLegacyEvent(
+                           "1:/var/log/ndjson_bug.log:START\nE this line starts with E+space\nline3", hdr));
+                       return v;
+                   }()),
+               CaseMode::Runner,
+               ""),
+
+        // OK: continuation line is "E <queue>:<loc>:<msg>" — previously caused silent split (Case B: HTTP 200 with
+        // incorrect extra event)
+        EventT(std::string("H " + HDR1
+                           + "\n"
+                             "E 1:/var/log/ndjson_bug.log:START\n"
+                             " lineA\n"
+                             " E 1:/var/log/ndjson_bug.log:payload_that_looks_like_an_event\n"
+                             " lineC\n"),
+               SUCCESS(
+                   [&]()
+                   {
+                       json::Json hdr(std::string_view {HDR1});
+                       std::vector<base::Event> v;
+                       v.push_back(base::eventParsers::parseLegacyEvent(
+                           "1:/var/log/ndjson_bug.log:START\nlineA\n"
+                           "E 1:/var/log/ndjson_bug.log:payload_that_looks_like_an_event\nlineC",
+                           hdr));
+                       return v;
+                   }()),
+               CaseMode::Runner,
+               ""),
+
+        // OK: multiple continuation lines starting with "E ", followed by a real second event
+        EventT(std::string("H " + HDR1
+                           + "\n"
+                             "E 3:/var/log/app.log:BEGIN\n"
+                             " E first false alarm\n"
+                             " E second false alarm\n"
+                             "E 1:/etc/passwd:File modified md5=abc\n"),
+               SUCCESS(
+                   [&]()
+                   {
+                       json::Json hdr(std::string_view {HDR1});
+                       std::vector<base::Event> v;
+                       v.push_back(base::eventParsers::parseLegacyEvent(
+                           "3:/var/log/app.log:BEGIN\nE first false alarm\nE second false alarm", hdr));
+                       v.push_back(base::eventParsers::parseLegacyEvent("1:/etc/passwd:File modified md5=abc", hdr));
+                       return v;
+                   }()),
+               CaseMode::Runner,
+               ""),
+
         // FAIL: E without payload -> legacy event parser should fail
         EventT(std::string(H(HDR1) + "\nE "), FAILURE(), CaseMode::Runner, ""),
 
@@ -380,6 +472,33 @@ INSTANTIATE_TEST_SUITE_P(
                FAILURE(),
                CaseMode::HookThrowsWrapped,
                "NDJson parser error, hook failure"),
+
+        // OK: mixed batch — multiline, single-line, multiline, single-line
+        EventT(std::string("H " + HDR1
+                           + "\n"
+                             "E 1:/var/log/app.log:START\n"
+                             " continuation1\n"
+                             " continuation2\n"
+                             "E 2:/var/log/auth.log:single line event\n"
+                             "E 3:/var/log/daemon.log:MULTI\n"
+                             " E looks like delimiter\n"
+                             " last line\n"
+                             "E 1:/etc/passwd:another single\n"),
+               SUCCESS(
+                   [&]()
+                   {
+                       json::Json hdr(std::string_view {HDR1});
+                       std::vector<base::Event> v;
+                       v.push_back(base::eventParsers::parseLegacyEvent(
+                           "1:/var/log/app.log:START\ncontinuation1\ncontinuation2", hdr));
+                       v.push_back(base::eventParsers::parseLegacyEvent("2:/var/log/auth.log:single line event", hdr));
+                       v.push_back(base::eventParsers::parseLegacyEvent(
+                           "3:/var/log/daemon.log:MULTI\nE looks like delimiter\nlast line", hdr));
+                       v.push_back(base::eventParsers::parseLegacyEvent("1:/etc/passwd:another single", hdr));
+                       return v;
+                   }()),
+               CaseMode::Runner,
+               ""),
 
         // FailsWhenEventMarkerIsMalformed
         EventT(std::string {"H " + HDR1 + "\nE\t" + EV1}, FAILURE(), CaseMode::RunnerThrows, "")));

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -1350,6 +1350,37 @@ static void drop_consumer(void *data, void *user) {
     dispose_evt_item((evt_item_t *)data);
 }
 
+/**
+ * @brief Append event payload with continuation-line indentation.
+ *
+ * Multi-line payloads contain embedded '\n' characters.  The framing protocol
+ * uses "\nE " to delimit events.  To avoid ambiguity when a continuation line
+ * begins with "E ", we indent every continuation line with a single space.
+ * The receiver strips exactly one leading space from each continuation line to
+ * recover the original payload.
+ */
+static int bulk_append_indented(bulk_t *b, const char *raw, size_t len) {
+    const char *p = raw;
+    const char *end = raw + len;
+
+    while (p < end) {
+        const char *nl = (const char *)memchr(p, '\n', (size_t)(end - p));
+        if (!nl) {
+            // No more newlines: append the remaining chunk
+            return bulk_append(b, p, (size_t)(end - p));
+        }
+        // Append everything up to and including the '\n'
+        size_t chunk = (size_t)(nl - p) + 1;
+        if (bulk_append(b, p, chunk) < 0) return -1;
+        // Prefix the continuation line with a space
+        if (nl + 1 < end) {
+            if (bulk_append(b, " ", 1) < 0) return -1;
+        }
+        p = nl + 1;
+    }
+    return 0;
+}
+
 // Consumer: Only accumulates in ctx->bulk. Releases each item individually.
 static void rr_collect_one(void *data, void *user) {
     evt_item_t *e = (evt_item_t*)data;
@@ -1362,9 +1393,11 @@ static void rr_collect_one(void *data, void *user) {
         }
     }
 
-    // Event Framing: "E <payload>\n"
+    // Event Framing: "E <indented_payload>\n"
+    // Continuation lines within multi-line payloads are space-indented to
+    // prevent false "\nE " delimiter matches inside event content.
     if (bulk_append_fmt(&ctx->bulk, "E ") < 0 ||
-        bulk_append(&ctx->bulk, e->raw, e->len) < 0 ||
+        bulk_append_indented(&ctx->bulk, e->raw, e->len) < 0 ||
         bulk_append(&ctx->bulk, "\n", 1) < 0) {
         mwarn("Unable to append event for agent '%s'", ctx->agent_id ?: "?");
     }

--- a/src/unit_tests/remoted/test_bulk.c
+++ b/src/unit_tests/remoted/test_bulk.c
@@ -186,6 +186,125 @@ static void test_append_fmt_chain_small_then_large(void **state) {
     bulk_free(&b);
 }
 
+/* ===== bulk_append_indented tests ===== */
+
+/**
+ * @brief Local copy of bulk_append_indented for unit testing.
+ *
+ * The production version is static in secure.c.  We replicate it here
+ * so that the test links cleanly against bulk.o only.
+ */
+static int bulk_append_indented(bulk_t *b, const char *raw, size_t len) {
+    const char *p = raw;
+    const char *end = raw + len;
+
+    while (p < end) {
+        const char *nl = (const char *)memchr(p, '\n', (size_t)(end - p));
+        if (!nl) {
+            return bulk_append(b, p, (size_t)(end - p));
+        }
+        size_t chunk = (size_t)(nl - p) + 1;
+        if (bulk_append(b, p, chunk) < 0) return -1;
+        if (nl + 1 < end) {
+            if (bulk_append(b, " ", 1) < 0) return -1;
+        }
+        p = nl + 1;
+    }
+    return 0;
+}
+
+/*
+ * Test: test_append_indented_single_line
+ * Purpose: A payload without newlines is appended unchanged.
+ */
+static void test_append_indented_single_line(void **state) {
+    (void)state;
+    bulk_t b;
+    bulk_init(&b, 0);
+
+    const char *raw = "1:/var/log/syslog:hello world";
+    assert_int_equal(bulk_append_indented(&b, raw, strlen(raw)), 0);
+    assert_int_equal(b.len, strlen(raw));
+    assert_memory_equal(b.buf, raw, b.len);
+
+    bulk_free(&b);
+}
+
+/*
+ * Test: test_append_indented_multiline_adds_space
+ * Purpose: Each continuation line after a '\n' gets a leading space.
+ */
+static void test_append_indented_multiline_adds_space(void **state) {
+    (void)state;
+    bulk_t b;
+    bulk_init(&b, 0);
+
+    const char *raw = "START\nline2\nline3";
+    const char *expected = "START\n line2\n line3";
+    assert_int_equal(bulk_append_indented(&b, raw, strlen(raw)), 0);
+    assert_int_equal(b.len, strlen(expected));
+    assert_memory_equal(b.buf, expected, b.len);
+
+    bulk_free(&b);
+}
+
+/*
+ * Test: test_append_indented_line_starting_with_E_space
+ * Purpose: A continuation line starting with "E " becomes " E " on the wire,
+ *          preventing false delimiter matches.
+ */
+static void test_append_indented_line_starting_with_E_space(void **state) {
+    (void)state;
+    bulk_t b;
+    bulk_init(&b, 0);
+
+    const char *raw = "START\nE this is dangerous\nend";
+    const char *expected = "START\n E this is dangerous\n end";
+    assert_int_equal(bulk_append_indented(&b, raw, strlen(raw)), 0);
+    assert_int_equal(b.len, strlen(expected));
+    assert_memory_equal(b.buf, expected, b.len);
+
+    bulk_free(&b);
+}
+
+/*
+ * Test: test_append_indented_trailing_newline_no_extra_space
+ * Purpose: A trailing '\n' at the end of the payload does NOT add a space
+ *          (there is no continuation after it).
+ */
+static void test_append_indented_trailing_newline_no_extra_space(void **state) {
+    (void)state;
+    bulk_t b;
+    bulk_init(&b, 0);
+
+    const char *raw = "line1\nline2\n";
+    const char *expected = "line1\n line2\n";
+    assert_int_equal(bulk_append_indented(&b, raw, strlen(raw)), 0);
+    assert_int_equal(b.len, strlen(expected));
+    assert_memory_equal(b.buf, expected, b.len);
+
+    bulk_free(&b);
+}
+
+/*
+ * Test: test_append_indented_preserves_existing_leading_space
+ * Purpose: A continuation line that already starts with a space gets an
+ *          additional space (the receiver strips exactly one).
+ */
+static void test_append_indented_preserves_existing_leading_space(void **state) {
+    (void)state;
+    bulk_t b;
+    bulk_init(&b, 0);
+
+    const char *raw = "first\n second";
+    const char *expected = "first\n  second";  // two spaces: one added + one original
+    assert_int_equal(bulk_append_indented(&b, raw, strlen(raw)), 0);
+    assert_int_equal(b.len, strlen(expected));
+    assert_memory_equal(b.buf, expected, b.len);
+
+    bulk_free(&b);
+}
+
 /*
  * Test runner
  */
@@ -199,6 +318,12 @@ int main(void) {
         cmocka_unit_test(test_append_fmt_small_uses_stack_tmp),
         cmocka_unit_test(test_append_fmt_large_allocates_and_appends),
         cmocka_unit_test(test_append_fmt_chain_small_then_large),
+        // bulk_append_indented tests
+        cmocka_unit_test(test_append_indented_single_line),
+        cmocka_unit_test(test_append_indented_multiline_adds_space),
+        cmocka_unit_test(test_append_indented_line_starting_with_E_space),
+        cmocka_unit_test(test_append_indented_trailing_newline_no_extra_space),
+        cmocka_unit_test(test_append_indented_preserves_existing_leading_space),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventSendReport.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventSendReport.hpp
@@ -174,6 +174,13 @@ public:
                 {
                     event["data"]["vulnerability"] = ecs["vulnerability"];
                 }
+
+                // NOTE: No continuation-line indentation needed here.
+                // event.dump() always produces a single-line JSON string (newlines in
+                // values are escaped as "\n"), so the H/E delimiter "\nE " cannot
+                // appear inside the payload. Only raw multi-line payloads (agent events
+                // forwarded by remoted) require indentation.
+                // See: https://github.com/wazuh/wazuh/blob/main/docs/ref/modules/engine/spec-events.yaml
                 std::string line;
                 line.reserve(64 + event.dump().size());
                 line.append("E ");


### PR DESCRIPTION
## Description

The `/events/enriched` endpoint uses `\nE ` (newline + E + space) as the delimiter between events in the H/E batch protocol. When an event payload contains embedded newlines (multi-line logs, command outputs like `netstat`, `last -n 20`, or `multi-line-regex` with `replace="no-replace"`), any continuation line that begins with `E ` is indistinguishable from a real event delimiter.

This causes two failure modes:

- **Hard failure (HTTP 400):** The continuation line is parsed as a new event but doesn't match the expected `<queue>:<location>:<message>` format.
- **Silent split (HTTP 200):** The continuation line happens to match the legacy event format, so a single logical event is silently split into multiple indexed documents.

### Affected sources

Any event containing real `\n` bytes where a line starts with `E `:

- `multi-line-regex` with `replace="no-replace"`
- Command outputs (`full_command`, `command`)
- Any `localfile` producing multi-line entries

### Not affected

- **Vulnerability Scanner (`eventSendReport.hpp`):** Uses `nlohmann::json::dump()` which always produces single-line output (newlines in strings are escaped as `\n` literal). The delimiter collision is impossible, so no changes are needed there.
- Single-line events (syslog, journald, JSON log_format)
- `multi-line-regex` with `replace="wspace"` (newlines replaced by spaces before sending)

## Proposed Changes

Apply **space-stuffing** (same technique as RFC 2822 header folding):

1. **Sender (`remoted/src/secure.c` — `bulk_append_indented`):** After each `\n` within an event payload, insert a single leading space on the next line. This guarantees continuation lines always start with ` ` (space), never with `E `.

2. **Receiver (`engine/.../ndJsonParser.hpp` — `unindentContinuation`):** After splitting events by `\nE `, strip exactly one leading space from each continuation line, recovering the original payload byte-for-byte.

3. **Tests (`engine/.../ndJsonParser_test.cpp`):** Added cases for both failure modes (Case A: HTTP 400, Case B: silent split) and multiple consecutive `E `-prefixed continuation lines.

### Wire format example

```
H {"agent":{"id":"001"}}
E 1:/var/log/app.log:START
E this line starts with E+space
line3
E 2:/var/log/syslog:next event
```

The receiver strips the leading space from continuation lines → original payload: `START\nE this line starts with E+space\nline3`.

### Properties

- **Correctness:** `unindent(indent(payload)) == payload` for all inputs, regardless of content.
- **Zero overhead for single-line events:** No newlines → no indentation added.
- **Backward compatible:** The protocol structure is unchanged; only the content encoding of multi-line payloads is affected.

### Results and Evidence

```
<localfile>
  <location>/var/log/ndjson_bug.log</location>
  <log_format>multi-line-regex</log_format>
  <multiline_regex match="start" replace="no-replace" timeout="5">^START$</multiline_regex>
</localfile>
```

## Previously, it produced an error because it detected a delimiter and the Legacy Parser failed.
```
root@debian10:/home/vagrant# printf "START\nline1\nE this line starts with E+space\nline3\nSTART\n" >> /var/log/ndjson_bug.log
```

## Standard wazuh event V5 file
```
{"wazuh":{"protocol":{"queue":49,"location":"/var/log/ndjson_bug.log"},"agent":{"host":{"os":{"name":"Debian GNU/Linux","version":"10","platform":"debian","type":"linux"},"architecture":"x86_64","hostname":"debian10"},"id":"001","name":"debian10","version":"Wazuh v4.12.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"ce63c9d1-cd2c-46a2-a5ea-5f088faab519"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"START\nline1\nE this line starts with E+space\nline3"},"@timestamp":"2026-05-07T16:22:47.433Z"}
{"wazuh":{"protocol":{"queue":49,"location":"/var/log/ndjson_bug.log"},"agent":{"host":{"os":{"name":"Debian GNU/Linux","version":"10","platform":"debian","type":"linux"},"architecture":"x86_64","hostname":"debian10"},"id":"001","name":"debian10","version":"Wazuh v4.12.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"ccce4feb-027e-4d37-a418-abecba552483"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"START"},"@timestamp":"2026-05-07T16:22:53.177Z"}
```

## Enable unclasified events
<img width="1831" height="732" alt="Screenshot from 2026-05-07 13-23-37" src="https://github.com/user-attachments/assets/564c6bfc-427b-4ec1-89d8-043c62130d95" />


## Previously, it produced an erroneous success result because it detected a delimiter and the legacy parser was also fulfilled.
```
root@debian10:/home/vagrant# printf "START\nline1\nE this line starts with E+space\nline3\nSTART\n" >> /var/log/ndjson_bug.log
```

## Standard wazuh event V5 file

```
{"wazuh":{"protocol":{"queue":49,"location":"/var/log/ndjson_bug.log"},"agent":{"host":{"os":{"name":"Debian GNU/Linux","version":"10","platform":"debian","type":"linux"},"architecture":"x86_64","hostname":"debian10"},"id":"001","name":"debian10","version":"Wazuh v4.12.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"b9bd22dc-55f3-4d11-8362-0e9dfb88aa62"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"START\nlineA\nE 1:/var/log/ndjson_bug.log:payload_that_looks_like_an_event\nlineC"},"@timestamp":"2026-05-07T16:45:18.714Z"}
{"wazuh":{"protocol":{"queue":49,"location":"/var/log/ndjson_bug.log"},"agent":{"host":{"os":{"name":"Debian GNU/Linux","version":"10","platform":"debian","type":"linux"},"architecture":"x86_64","hostname":"debian10"},"id":"001","name":"debian10","version":"Wazuh v4.12.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"10be7974-b2df-451c-b467-acfbaf10a107"},"integration":{"category":"security","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"START\nline_dummy"},"@timestamp":"2026-05-07T16:45:24.248Z"}
```

## Enable unclasified events
<img width="1841" height="712" alt="Screenshot from 2026-05-07 13-52-25" src="https://github.com/user-attachments/assets/1ab850f9-0e27-429d-b492-7d1a1b6beec8" />

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
