### PR TITLE
Update wodle command arg construction for Windows paths

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -78,6 +78,7 @@
     - [Schemas](ref/modules/vulnerability-scanner/flatbuffers.md)
     - [Test Tools](ref/modules/vulnerability-scanner/test-tools.md)
     - [Events description](ref/modules/vulnerability-scanner/events.md)
+  - [Command](ref/modules/command/README.md)
   - [Inventory Sync](ref/modules/inventory-sync/README.md)
     - [Architecture](ref/modules/inventory-sync/architecture.md)
     - [API Reference](ref/modules/inventory-sync/api-reference.md)

--- a/docs/ref/modules/README.md
+++ b/docs/ref/modules/README.md
@@ -4,6 +4,7 @@
 - [Agent Management](agent-management/) - Centralized configuration and group management for agents
 - [Integrations](integrations/) - Cloud services and third-party platform integrations
 - [Control](control/) - Manager control operations (restart, reload) via wm_control module
+- [Command](command/) - Scheduled command execution through the command wodle
 - [Syscollector](syscollector/) - System inventory collection and monitoring
 - [Logcollector](logcollector/) - Log ingestion
 - [FIM](fim/) - File Integrity Monitoring with persistent state synchronization

--- a/docs/ref/modules/command/README.md
+++ b/docs/ref/modules/command/README.md
@@ -107,8 +107,10 @@ When `ignore_output` is `no`, the command module sends a JSON event with command
 
 ```json
 {
-  "event.module": "wazuh-wodle-cmd",
-  "event.start": "2026-05-11T12:00:00Z",
+  "event": {
+    "module": "wazuh-wodle-cmd",
+    "start": "2026-05-11T12:00:00Z"
+  },
   "tags": ["periodic-whoami"],
   "process": {
     "args": [],

--- a/docs/ref/modules/command/README.md
+++ b/docs/ref/modules/command/README.md
@@ -1,0 +1,162 @@
+# Command Module
+
+## Introduction
+
+The Wazuh command module executes configured operating system commands at scheduled intervals and can forward their output for analysis. It runs inside `wazuh-modulesd` as the `<wodle name="command">` module.
+
+Use this module for periodic command-based telemetry when a native collector is not available. The module executes the configured command locally on the agent or manager where the configuration is applied.
+
+## How it works
+
+For each configured command wodle, `wazuh-modulesd`:
+
+1. Reads the `<wodle name="command">` configuration from `ossec.conf` or `agent.conf`.
+2. Builds the command schedule from `interval`, `day`, `wday`, and `time`.
+3. Optionally validates the executable checksum before execution.
+4. Executes the command with the configured timeout.
+5. Sends a structured event to the local queue when `ignore_output` is set to `no`.
+
+The command module uses the routing tag `command` for the generated events. The configured `tag` value is stored inside the event payload.
+
+## Configuration
+
+Configure the module inside the `<ossec_config>` block:
+
+```xml
+<wodle name="command">
+  <disabled>no</disabled>
+  <tag>periodic-whoami</tag>
+  <command>/usr/bin/whoami</command>
+  <interval>2m</interval>
+  <ignore_output>no</ignore_output>
+  <run_on_start>yes</run_on_start>
+  <timeout>30</timeout>
+</wodle>
+```
+
+Windows example with checksum verification:
+
+```xml
+<wodle name="command">
+  <disabled>no</disabled>
+  <tag>periodic-whoami</tag>
+  <command>C:\\Windows\\System32\\whoami.exe</command>
+  <interval>2m</interval>
+  <ignore_output>no</ignore_output>
+  <run_on_start>yes</run_on_start>
+  <timeout>30</timeout>
+  <verify_sha1>9746e91bfc629d3a2e1fe6289b549c0452702004</verify_sha1>
+</wodle>
+```
+
+### Configuration options
+
+| Option | Required | Default | Description |
+|--------|:--------:|---------|-------------|
+| `disabled` | No | `no` | Disables this command when set to `yes`. |
+| `tag` | No | Empty | Custom tag included in the generated event. It is also used in module log messages. |
+| `command` | Yes | Not set | Command line to execute. The first token is treated as the executable for checksum verification and process metadata. |
+| `interval` | No | `2s` | Time interval between executions. Supports `s`, `m`, `h`, `d`, `w`, and `M` suffixes. |
+| `day` | No | Not set | Day of the month for scheduled execution. Cannot be combined with `wday`. |
+| `wday` | No | Not set | Day of the week for scheduled execution. Cannot be combined with `day`. |
+| `time` | No | Not set | Time of day for scheduled execution, in `HH:MM` format. |
+| `ignore_output` | No | `no` | Executes the command without sending the command output event when set to `yes`. |
+| `run_on_start` | No | `yes` | Executes the command immediately when the module starts. |
+| `timeout` | No | `0` | Maximum command execution time in seconds. A value of `0` disables the timeout. |
+| `verify_md5` | No | Not set | Expected MD5 hash of the executable. Must be 32 characters. |
+| `verify_sha1` | No | Not set | Expected SHA1 hash of the executable. Must be 40 characters. |
+| `verify_sha256` | No | Not set | Expected SHA256 hash of the executable. Must be 64 characters. |
+| `skip_verification` | No | `no` | Logs checksum verification failures as warnings and continues execution when set to `yes`. |
+
+### Scheduling
+
+The command module uses the shared Wazuh module scheduler:
+
+- `interval` executes the command periodically.
+- `time` executes the command at a specific time of day and requires an interval that is a multiple of one day.
+- `wday` executes the command on a specific weekday and requires an interval that is a multiple of one week.
+- `day` executes the command on a specific day of the month and requires a month interval.
+
+When `run_on_start` is `yes`, the first execution happens immediately. When it is `no`, the first execution waits for the next scheduled time.
+
+## Centralized configuration
+
+The command module can be configured through `agent.conf`, but remote commands are disabled by default. If a command wodle comes from centralized configuration, the agent only runs it when the `wazuh_command.remote_commands` internal option is enabled.
+
+If remote commands are disabled, the agent logs the command as ignored and exits that module instance.
+
+## Checksum verification
+
+Checksum verification applies to the executable resolved from the first token of `command`. Command arguments are preserved for execution, but they are not part of the hash calculation.
+
+When any of `verify_md5`, `verify_sha1`, or `verify_sha256` is configured, the module:
+
+1. Splits the command line to identify the executable.
+2. Resolves the executable path.
+3. Validates each configured checksum.
+4. Builds the full command line using the resolved executable path and the original arguments.
+5. Revalidates the checksum before each scheduled execution unless `skip_verification` is set to `yes`.
+
+On Windows, the module disables WOW64 file system redirection while resolving and validating the executable.
+
+If verification fails, the command is not executed. When `skip_verification` is set to `yes`, the module logs a warning and continues.
+
+## Event format
+
+When `ignore_output` is `no`, the command module sends a JSON event with command metadata and output:
+
+```json
+{
+  "event.module": "wazuh-wodle-cmd",
+  "event.start": "2026-05-11T12:00:00Z",
+  "tags": ["periodic-whoami"],
+  "process": {
+    "args": [],
+    "name": "whoami",
+    "path": "/usr/bin/whoami",
+    "command_line": "/usr/bin/whoami",
+    "hash": {
+      "sha1": "9746e91bfc629d3a2e1fe6289b549c0452702004"
+    },
+    "exit_code": 0,
+    "io": {
+      "text": "wazuh\n"
+    }
+  }
+}
+```
+
+### Event fields
+
+| Field | Description |
+|-------|-------------|
+| `event.module` | Static module identifier: `wazuh-wodle-cmd`. |
+| `event.start` | UTC timestamp captured before command execution. |
+| `tags` | Array containing the configured command `tag`. If `tag` is omitted, the value is an empty string. |
+| `process.args` | Command arguments, excluding the executable. |
+| `process.name` | Executable name. |
+| `process.path` | Resolved executable path when available. |
+| `process.command_line` | Full command line used for execution. |
+| `process.hash` | Configured verification hashes. Present only when checksum verification is configured. |
+| `process.exit_code` | Command exit code. Timeout and execution failures use `-1`. |
+| `process.io.text` | Captured command output. |
+
+If the output is too large for a single queue message, the module attempts to truncate `process.io.text`. If the event still does not fit, it sends a metadata-only event with an empty output field.
+
+## Troubleshooting
+
+Check the module logs:
+
+```bash
+grep "wazuh-modulesd:command" /var/ossec/logs/ossec.log
+```
+
+Common messages:
+
+| Message | Meaning |
+|---------|---------|
+| `Remote commands are disabled. Ignoring '<tag>'.` | The command came from centralized configuration, but remote commands are disabled. |
+| `Cannot check binary: '<binary>'. Cannot stat binary file.` | The executable could not be resolved for checksum verification. |
+| `SHA1 checksum verification failed for command '<command>'.` | The executable hash did not match the configured `verify_sha1` value. |
+| `Timeout overtaken.` | The command exceeded the configured `timeout`. |
+| `Command output is too long to fit in a single message.` | The output was truncated or dropped to keep the event within queue limits. |

--- a/src/unit_tests/wazuh_modules/command/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/command/CMakeLists.txt
@@ -11,7 +11,8 @@ list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_unti
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=_mtdebug1 \
                          -Wl,--wrap=wm_exec,--wrap=StartMQ,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible \
                          -Wl,--wrap=wm_sendmsg \
-                         -Wl,--wrap=wm_validate_command -Wl,--wrap=w_query_agentd")
+                         -Wl,--wrap=wm_validate_command -Wl,--wrap=w_query_agentd \
+                         -Wl,--wrap=get_binary_path")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -1046,6 +1046,99 @@ static void test_full_command_quoted_args(void **state) {
     assert_string_equal(command->full_command, "/bin/bash \"my script.sh\" \"arg with spaces\"");
 }
 
+static void test_full_command_quoted_binary_with_spaces(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("\"C:\\\\Program Files\\\\app.exe\" --flag value");
+
+    expect_string(__wrap_get_binary_path, command, "C:\\Program Files\\app.exe");
+    will_return(__wrap_get_binary_path, strdup("C:\\Program Files\\app.exe"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "\"C:\\Program Files\\app.exe\" --flag value");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "\"C:\\Program Files\\app.exe\" --flag value");
+}
+
+static void test_full_command_leading_spaces(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("  /usr/bin/echo hello");
+
+    expect_string(__wrap_get_binary_path, command, "/usr/bin/echo");
+    will_return(__wrap_get_binary_path, strdup("/usr/bin/echo"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "/usr/bin/echo hello");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "/usr/bin/echo hello");
+}
+
+static void test_full_command_unquoted_path_with_spaces(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("C:\\\\Program\\ Files\\\\app.exe --verbose");
+
+    expect_string(__wrap_get_binary_path, command, "C:\\Program Files\\app.exe");
+    will_return(__wrap_get_binary_path, strdup("C:\\Program Files\\app.exe"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "\"C:\\Program Files\\app.exe\" --verbose");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "\"C:\\Program Files\\app.exe\" --verbose");
+}
+
 int main(void) {
     const struct CMUnitTest tests_with_startup[] = {
         cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions)
@@ -1071,7 +1164,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_full_command_windows_no_args, setup_test_full_command, teardown_test_full_command),
         cmocka_unit_test_setup_teardown(test_full_command_windows_with_args, setup_test_full_command, teardown_test_full_command),
         cmocka_unit_test_setup_teardown(test_full_command_linux_no_args, setup_test_full_command, teardown_test_full_command),
-        cmocka_unit_test_setup_teardown(test_full_command_quoted_args, setup_test_full_command, teardown_test_full_command)
+        cmocka_unit_test_setup_teardown(test_full_command_quoted_args, setup_test_full_command, teardown_test_full_command),
+        cmocka_unit_test_setup_teardown(test_full_command_quoted_binary_with_spaces, setup_test_full_command, teardown_test_full_command),
+        cmocka_unit_test_setup_teardown(test_full_command_leading_spaces, setup_test_full_command, teardown_test_full_command),
+        cmocka_unit_test_setup_teardown(test_full_command_unquoted_path_with_spaces, setup_test_full_command, teardown_test_full_command)
     };
     int result;
     result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -25,6 +25,7 @@
 #include "../scheduling/wmodules_scheduling_helpers.h"
 #include "../../wrappers/common.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../../wrappers/wazuh/shared/binaries_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wm_exec_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wmodules_wrappers.h"
@@ -464,6 +465,10 @@ void test_interval_execution(void **state) {
     module_data->scan_config.interval = 60; // 1min
     module_data->scan_config.month_interval = false;
 
+    expect_any(__wrap_get_binary_path, command);
+    will_return(__wrap_get_binary_path, strdup("/bin/bash"));
+    will_return(__wrap_get_binary_path, 0);
+
     expect_string(__wrap_StartMQ, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQ, type, WRITE);
     will_return(__wrap_StartMQ, 0);
@@ -523,6 +528,10 @@ static void test_command_payload_normal_output(void **state) {
     will_return(__wrap_wm_exec, 7);
     will_return(__wrap_wm_exec, 0);
 
+    expect_any(__wrap_get_binary_path, command);
+    will_return(__wrap_get_binary_path, strdup("/bin/echo"));
+    will_return(__wrap_get_binary_path, 0);
+
     // status > 0 triggers mtwarn + mtdebug2(OUTPUT).
     expect_any(__wrap__mtwarn, tag);
     expect_any(__wrap__mtwarn, formatted_msg);
@@ -559,6 +568,10 @@ static void test_command_payload_empty_output(void **state) {
     will_return(__wrap_wm_exec, (char *)output);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
+
+    expect_any(__wrap_get_binary_path, command);
+    will_return(__wrap_get_binary_path, strdup("/bin/echo"));
+    will_return(__wrap_get_binary_path, 0);
 
     expect_any_count(__wrap__mtinfo, tag, 2);
     expect_any_count(__wrap__mtinfo, formatted_msg, 2);
@@ -600,6 +613,10 @@ static void test_command_payload_long_output_truncates(void **state) {
     will_return(__wrap_wm_exec, output);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
+
+    expect_any(__wrap_get_binary_path, command);
+    will_return(__wrap_get_binary_path, strdup("/bin/echo"));
+    will_return(__wrap_get_binary_path, 0);
 
     // Truncation path emits one warning.
     expect_any(__wrap__mtwarn, tag);
@@ -689,6 +706,10 @@ static void test_command_payload_metadata_only_fallback(void **state) {
     will_return(__wrap_wm_exec, (char *)output);
     will_return(__wrap_wm_exec, 0);
     will_return(__wrap_wm_exec, 0);
+
+    expect_any(__wrap_get_binary_path, command);
+    will_return(__wrap_get_binary_path, strdup("/bin/echo"));
+    will_return(__wrap_get_binary_path, 0);
 
     // First warning: truncation attempt; second warning: still too large, metadata-only fallback.
     expect_any_count(__wrap__mtwarn, tag, 2);
@@ -868,6 +889,132 @@ void test_validate_command_checksums_failure(void **state) {
     assert_int_equal(validate_command_checksums(command, "/test/file.sh"), -1);
 }
 
+static int setup_test_full_command(void **state) {
+    wm_command_t *command = calloc(1, sizeof(wm_command_t));
+    assert_non_null(command);
+
+    command->enabled = 1;
+    command->run_on_start = 1;
+    command->ignore_output = 1;
+    command->agent_cfg = 0;
+    command->timeout = 0;
+    command->skip_verification = 0;
+
+    command->tag = strdup("test-cmd");
+    command->sha1_hash = strdup("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    command->scan_config = init_config_from_string("<interval>10s</interval>\n");
+
+    wm_max_eps = 1000000;
+    *state = command;
+    return 0;
+}
+
+static int teardown_test_full_command(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    if (command) {
+        sched_scan_free(&(command->scan_config));
+        free(command->tag);
+        free(command->command);
+        free(command->full_command);
+        free(command->sha1_hash);
+        free(command);
+    }
+    return 0;
+}
+
+static void test_full_command_windows_no_args(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("C:\\\\Windows\\\\System32\\\\whoami.exe");
+
+    expect_string(__wrap_get_binary_path, command, "C:\\Windows\\System32\\whoami.exe");
+    will_return(__wrap_get_binary_path, strdup("C:\\Windows\\System32\\whoami.exe"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "C:\\Windows\\System32\\whoami.exe");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "C:\\Windows\\System32\\whoami.exe");
+}
+
+static void test_full_command_windows_with_args(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("C:\\\\Windows\\\\System32\\\\cmd.exe /c dir");
+
+    expect_string(__wrap_get_binary_path, command, "C:\\Windows\\System32\\cmd.exe");
+    will_return(__wrap_get_binary_path, strdup("C:\\Windows\\System32\\cmd.exe"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "C:\\Windows\\System32\\cmd.exe /c dir");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "C:\\Windows\\System32\\cmd.exe /c dir");
+}
+
+static void test_full_command_linux_no_args(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("/usr/bin/uptime");
+
+    expect_string(__wrap_get_binary_path, command, "/usr/bin/uptime");
+    will_return(__wrap_get_binary_path, strdup("/usr/bin/uptime"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "/usr/bin/uptime");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "/usr/bin/uptime");
+}
+
 int main(void) {
     const struct CMUnitTest tests_with_startup[] = {
         cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions)
@@ -889,10 +1036,16 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_command_payload_long_output_truncates, setup_test_payload, teardown_test_payload),
         cmocka_unit_test_setup_teardown(test_command_payload_metadata_only_fallback, setup_test_payload, teardown_test_payload)
     };
+    const struct CMUnitTest tests_full_command[] = {
+        cmocka_unit_test_setup_teardown(test_full_command_windows_no_args, setup_test_full_command, teardown_test_full_command),
+        cmocka_unit_test_setup_teardown(test_full_command_windows_with_args, setup_test_full_command, teardown_test_full_command),
+        cmocka_unit_test_setup_teardown(test_full_command_linux_no_args, setup_test_full_command, teardown_test_full_command)
+    };
     int result;
     result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);
     result += cmocka_run_group_tests(tests_without_startup, NULL, NULL);
     result += cmocka_run_group_tests(tests_validate_command_checksums, NULL, NULL);
     result += cmocka_run_group_tests(tests_payload_json, NULL, NULL);
+    result += cmocka_run_group_tests(tests_full_command, NULL, NULL);
     return result;
 }

--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -1015,6 +1015,37 @@ static void test_full_command_linux_no_args(void **state) {
     assert_string_equal(command->full_command, "/usr/bin/uptime");
 }
 
+static void test_full_command_quoted_args(void **state) {
+    wm_command_t *command = (wm_command_t *)*state;
+    command->command = strdup("/bin/bash \"my script.sh\" \"arg with spaces\"");
+
+    expect_string(__wrap_get_binary_path, command, "/bin/bash");
+    will_return(__wrap_get_binary_path, strdup("/bin/bash"));
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_any_always(__wrap_wm_validate_command, command);
+    expect_any_always(__wrap_wm_validate_command, digest);
+    expect_any_always(__wrap_wm_validate_command, ctype);
+    will_return_always(__wrap_wm_validate_command, 1);
+
+    expect_any_always(__wrap__mtinfo, tag);
+    expect_any_always(__wrap__mtinfo, formatted_msg);
+    expect_any_always(__wrap__mtdebug1, tag);
+    expect_any_always(__wrap__mtdebug1, formatted_msg);
+
+    expect_string(__wrap_wm_exec, command, "/bin/bash \"my script.sh\" \"arg with spaces\"");
+    expect_any(__wrap_wm_exec, secs);
+    expect_any(__wrap_wm_exec, add_path);
+    will_return(__wrap_wm_exec, 0);
+    will_return(__wrap_wm_exec, 0);
+
+    will_return(__wrap_FOREVER, 0);
+
+    WM_COMMAND_CONTEXT.start(command);
+
+    assert_string_equal(command->full_command, "/bin/bash \"my script.sh\" \"arg with spaces\"");
+}
+
 int main(void) {
     const struct CMUnitTest tests_with_startup[] = {
         cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions)
@@ -1039,7 +1070,8 @@ int main(void) {
     const struct CMUnitTest tests_full_command[] = {
         cmocka_unit_test_setup_teardown(test_full_command_windows_no_args, setup_test_full_command, teardown_test_full_command),
         cmocka_unit_test_setup_teardown(test_full_command_windows_with_args, setup_test_full_command, teardown_test_full_command),
-        cmocka_unit_test_setup_teardown(test_full_command_linux_no_args, setup_test_full_command, teardown_test_full_command)
+        cmocka_unit_test_setup_teardown(test_full_command_linux_no_args, setup_test_full_command, teardown_test_full_command),
+        cmocka_unit_test_setup_teardown(test_full_command_quoted_args, setup_test_full_command, teardown_test_full_command)
     };
     int result;
     result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -186,6 +186,16 @@ void * wm_command_main(wm_command_t * command) {
         // portion with the resolved full_path, preserving arguments verbatim.
         if (!command->full_command) {
             const char *p = command->command;
+            bool binary_was_quoted = false;
+
+            while (*p == ' ') {
+                p++;
+            }
+
+            if (*p == '"') {
+                binary_was_quoted = true;
+            }
+
             bool in_quotes = false;
             while (*p) {
                 if (*p == '\\' && p[1] != '\0') {
@@ -200,12 +210,17 @@ void * wm_command_main(wm_command_t * command) {
                 }
             }
 
+            bool need_quotes = !binary_was_quoted && strchr(full_path, ' ') != NULL;
+            const char *qc = (binary_was_quoted || need_quotes) ? "\"" : "";
+
             if (*p == ' ') {
-                size_t len = strlen(full_path) + strlen(p) + 1;
+                size_t len = strlen(full_path) + strlen(p) + strlen(qc) * 2 + 1;
                 os_malloc(len, command->full_command);
-                snprintf(command->full_command, len, "%s%s", full_path, p);
+                snprintf(command->full_command, len, "%s%s%s%s", qc, full_path, qc, p);
             } else {
-                os_strdup(full_path, command->full_command);
+                size_t len = strlen(full_path) + strlen(qc) * 2 + 1;
+                os_malloc(len, command->full_command);
+                snprintf(command->full_command, len, "%s%s%s", qc, full_path, qc);
             }
         }
         free_strarray(argv);

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -175,19 +175,29 @@ void * wm_command_main(wm_command_t * command) {
             pthread_exit(NULL);
         }
 
-        // Modify command with full path.
+        // Find end of first token in original command string using the same
+        // quoting/escaping rules as w_strtok, then replace only the binary
+        // portion with the resolved full_path, preserving arguments verbatim.
         if (!command->full_command) {
-            if (argv[1]) {
-                size_t len = strlen(full_path) + 1;
-                for (int k = 1; argv[k]; k++) {
-                    len += strlen(argv[k]) + 1;
+            const char *p = command->command;
+            bool in_quotes = false;
+            while (*p) {
+                if (*p == '\\' && p[1] != '\0') {
+                    p += 2;
+                } else if (*p == '"') {
+                    in_quotes = !in_quotes;
+                    p++;
+                } else if (*p == ' ' && !in_quotes) {
+                    break;
+                } else {
+                    p++;
                 }
+            }
+
+            if (*p == ' ') {
+                size_t len = strlen(full_path) + strlen(p) + 1;
                 os_malloc(len, command->full_command);
-                snprintf(command->full_command, len, "%s", full_path);
-                for (int k = 1; argv[k]; k++) {
-                    strcat(command->full_command, " ");
-                    strcat(command->full_command, argv[k]);
-                }
+                snprintf(command->full_command, len, "%s%s", full_path, p);
             } else {
                 os_strdup(full_path, command->full_command);
             }

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -18,6 +18,20 @@
 
 #ifdef WIN32
 #include <windows.h>
+
+// On Windows, the XML config convention uses double backslashes (C:\\Windows)
+// because w_strtok treats backslash as an escape character. Reduce consecutive
+// backslashes to single ones so the executed command receives valid paths.
+static void wm_command_reduce_win_backslashes(char *str) {
+    char *r = str, *w = str;
+    while (*r) {
+        if (r[0] == '\\' && r[1] == '\\') {
+            r++;
+        }
+        *w++ = *r++;
+    }
+    *w = '\0';
+}
 #endif
 
 static char *wm_command_build_event_payload(const char *event_start,
@@ -236,6 +250,12 @@ void * wm_command_main(wm_command_t * command) {
     } else {
         command->full_command = strdup(command->command);
     }
+
+#ifdef WIN32
+    if (command->full_command) {
+        wm_command_reduce_win_backslashes(command->full_command);
+    }
+#endif
 
     mtinfo(WM_COMMAND_LOGTAG, "Module command:%s started", command->tag);
 

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -177,9 +177,21 @@ void * wm_command_main(wm_command_t * command) {
 
         // Modify command with full path.
         if (!command->full_command) {
-            os_malloc(strlen(full_path) + strlen(command->command) - strlen(binary) + 1, command->full_command);
+            if (argv[1]) {
+                size_t len = strlen(full_path) + 1;
+                for (int k = 1; argv[k]; k++) {
+                    len += strlen(argv[k]) + 1;
+                }
+                os_malloc(len, command->full_command);
+                snprintf(command->full_command, len, "%s", full_path);
+                for (int k = 1; argv[k]; k++) {
+                    strcat(command->full_command, " ");
+                    strcat(command->full_command, argv[k]);
+                }
+            } else {
+                os_strdup(full_path, command->full_command);
+            }
         }
-        snprintf(command->full_command, strlen(full_path) + strlen(command->command) - strlen(binary) + 1, "%s %s", full_path, command->command + strlen(binary) + 1);
         free_strarray(argv);
 
         if (validate_command_checksums(command, full_path) != 0) {

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -152,6 +152,12 @@ void * wm_command_main(wm_command_t * command) {
         pthread_exit(0);
     }
 
+#ifdef WIN32
+    if (verify_command) {
+        SafeWow64DisableWow64FsRedirection(NULL);
+    }
+#endif
+
     if (verify_command) {
         command_cpy = strdup(command->command);
 

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -149,7 +149,9 @@ void * wm_command_main(wm_command_t * command) {
     char *command_cpy;
     char *binary;
     char *full_path = NULL;
+#ifndef WIN32
     char **argv;
+#endif
     char * timestamp = NULL;
     bool verify_command = command->md5_hash || command->sha1_hash || command->sha256_hash;
 
@@ -163,13 +165,10 @@ void * wm_command_main(wm_command_t * command) {
         pthread_exit(0);
     }
 
+    if (verify_command) {
 #ifdef WIN32
-    if (verify_command) {
         SafeWow64DisableWow64FsRedirection(NULL);
-    }
 #endif
-
-    if (verify_command) {
         command_cpy = strdup(command->command);
 
 #ifdef WIN32
@@ -288,13 +287,27 @@ void * wm_command_main(wm_command_t * command) {
 
     } else {
         command->full_command = strdup(command->command);
-    }
-
 #ifdef WIN32
-    if (command->full_command) {
-        wm_command_reduce_win_backslashes(command->full_command);
-    }
+        {
+            char *p = command->full_command;
+            while (*p == ' ') p++;
+            bool in_q = (*p == '"');
+            if (in_q) p++;
+            char *start = p;
+            while (*p) {
+                if (in_q && *p == '"') { p++; break; }
+                if (!in_q && *p == ' ') break;
+                p++;
+            }
+            char saved = *p;
+            *p = '\0';
+            wm_command_reduce_win_backslashes(start);
+            size_t new_len = strlen(start);
+            *p = saved;
+            memmove(start + new_len, p, strlen(p) + 1);
+        }
 #endif
+    }
 
     mtinfo(WM_COMMAND_LOGTAG, "Module command:%s started", command->tag);
 

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -19,9 +19,6 @@
 #ifdef WIN32
 #include <windows.h>
 
-// On Windows, the XML config convention uses double backslashes (C:\\Windows)
-// because w_strtok treats backslash as an escape character. Reduce consecutive
-// backslashes to single ones so the executed command receives valid paths.
 static void wm_command_reduce_win_backslashes(char *str) {
     char *r = str, *w = str;
     while (*r) {
@@ -175,6 +172,36 @@ void * wm_command_main(wm_command_t * command) {
     if (verify_command) {
         command_cpy = strdup(command->command);
 
+#ifdef WIN32
+        // On Windows, reduce \\\\ to \\ before extracting the binary token.
+        // This normalizes both conventions (single and double backslash) so
+        // that get_binary_path receives a valid Windows path and error
+        // messages show the path as the user intended.
+        wm_command_reduce_win_backslashes(command_cpy);
+
+        // Extract binary token without w_strtok (which treats \\ as escape
+        // and would strip the remaining single backslashes).
+        {
+            const char *s = command_cpy;
+            while (*s == ' ') s++;
+
+            char *bin_start = (char *)s;
+            if (*s == '"') {
+                s++;
+                bin_start = (char *)s;
+                while (*s && *s != '"') s++;
+                if (*s == '"') {
+                    *(char *)s = '\0';
+                }
+            } else {
+                while (*s && *s != ' ') s++;
+                if (*s == ' ') {
+                    *(char *)s = '\0';
+                }
+            }
+            os_strdup(bin_start, binary);
+        }
+#else
         argv = w_strtok(command_cpy);
     #ifndef __clang_analyzer__
         if (!argv) {
@@ -184,10 +211,15 @@ void * wm_command_main(wm_command_t * command) {
         }
     #endif
         binary = argv[0];
+#endif
 
         if (get_binary_path(binary, &full_path) == OS_INVALID) {
             mterror(WM_COMMAND_LOGTAG, "Cannot check binary: '%s'. Cannot stat binary file.", binary);
+#ifdef WIN32
+            os_free(binary);
+#else
             free_strarray(argv);
+#endif
             os_free(command_cpy);
         #ifndef __clang_analyzer__
             os_free(full_path);
@@ -196,8 +228,8 @@ void * wm_command_main(wm_command_t * command) {
         }
 
         // Find end of first token in original command string using the same
-        // quoting/escaping rules as w_strtok, then replace only the binary
-        // portion with the resolved full_path, preserving arguments verbatim.
+        // quoting rules, then replace only the binary portion with the
+        // resolved full_path, preserving arguments verbatim.
         if (!command->full_command) {
             const char *p = command->command;
             bool binary_was_quoted = false;
@@ -212,9 +244,12 @@ void * wm_command_main(wm_command_t * command) {
 
             bool in_quotes = false;
             while (*p) {
+#ifndef WIN32
                 if (*p == '\\' && p[1] != '\0') {
                     p += 2;
-                } else if (*p == '"') {
+                } else
+#endif
+                if (*p == '"') {
                     in_quotes = !in_quotes;
                     p++;
                 } else if (*p == ' ' && !in_quotes) {
@@ -237,7 +272,11 @@ void * wm_command_main(wm_command_t * command) {
                 snprintf(command->full_command, len, "%s%s%s", qc, full_path, qc);
             }
         }
+#ifdef WIN32
+        os_free(binary);
+#else
         free_strarray(argv);
+#endif
 
         if (validate_command_checksums(command, full_path) != 0) {
             os_free(command_cpy);


### PR DESCRIPTION
## Description

Closes #35955

This PR fixes the wodle command `verify_sha1` (and `verify_md5` / `verify_sha256`) failing on Windows agents when the command path contains backslashes. It also fixes a related issue where commands using the `\\` convention in arguments would fail at execution time because the raw config string was passed to the OS without normalizing double backslashes.

The original error manifests as a corrupted command string in the logs:

```sql
wazuh-modulesd:command: ERROR: SHA1 checksum verification failed for command 'C:\Windows\System32\whoami.exe xe'.
```

### Root cause

Two issues in the `wm_command_main()` function:

1. **Offset mismatch in `full_command` construction.** The original code used `strlen(binary)` (from `w_strtok()` output, where `\\` sequences are resolved to `\`) as an offset into the original `command->command` string (which still contains `\\`). Each `\\` pair (2 chars) becoming `\` (1 char) creates a cumulative offset mismatch, causing `snprintf` to read past the intended position and append garbage characters.

2. **`w_strtok` strips single backslashes on Windows.** `w_strtok()` treats `\` as a shell-style escape character and consumes it. On Windows, `\` is a path separator, not an escape. This caused single-backslash paths like `C:\Windows\System32\whoami.exe` to be mangled into `C:WindowsSystem32whoami.exe`, failing binary resolution and producing confusing error messages.

3. **Double backslashes not reduced before execution.** The `full_command` string used for execution was never normalized. When checksum verification was not configured, `full_command` was a direct copy of the raw config string, preserving `\\` sequences that caused `cmd.exe` to fail with "The specified path is invalid." when double backslashes appeared in command arguments.

## Proposed Changes

1. **Replace the offset-based `full_command` construction** with a proper token boundary scanner that locates the end of the binary token in the original command string (respecting quoting rules), then rebuilds `full_command` using the resolved `full_path` and the original arguments from the correct offset. This also handles quoted binaries with spaces and leading whitespace.

2. **Bypass `w_strtok` for binary extraction on Windows.** On WIN32, use a simple space/quote-aware tokenizer that treats `\` as a literal path separator. Before extraction, apply `\\` to `\` reduction so both single and double backslash conventions produce valid Windows paths. Error messages now show the path as the user intended.

3. **Disable WoW64 file system redirection** on Windows before resolving the binary path for checksum verification. Without this, 32-bit agents cannot locate binaries in `System32` because WoW64 silently redirects to `SysWOW64`.

4. **Reduce `\\` to `\` in `full_command` on Windows** after both the verify and no-verify code paths. A new `wm_command_reduce_win_backslashes()` helper performs a single in-place pass, scoped to WIN32 only. This ensures the executed command always contains valid single-backslash Windows paths regardless of which config convention the user chose.

### Results and Evidence

#### Test environment

| Component | Details |
|-----------|---------|
| Manager | Wazuh 5.0.0 (AIO install on Ubuntu 24.04 / WSL2) |
| Agent | Wazuh 5.0.0 custom build (cross-compiled with mingw from fix branch) |
| Agent OS | Windows Server 2016 (VirtualBox VM, host-only adapter via portproxy) |

#### Test configuration

Four wodle command blocks covering all backslash/verification combinations:

```xml
<wodle name="command">
  <disabled>no</disabled>
  <tag>case1-doublebs-sha1</tag>
  <command>C:\\Windows\\System32\\whoami.exe</command>
  <interval>2m</interval>
  <ignore_output>no</ignore_output>
  <run_on_start>yes</run_on_start>
  <timeout>30</timeout>
  <verify_sha1>9746e91bfc629d3a2e1fe6289b549c0452702004</verify_sha1>
</wodle>

<wodle name="command">
  <disabled>no</disabled>
  <tag>case2-doublebs-nosha1</tag>
  <command>C:\\Windows\\System32\\cmd.exe /c dir C:\\Windows\\Temp</command>
  <interval>2m</interval>
  <ignore_output>no</ignore_output>
  <run_on_start>yes</run_on_start>
  <timeout>30</timeout>
</wodle>

<wodle name="command">
  <disabled>no</disabled>
  <tag>case3-singlebs-sha1</tag>
  <command>C:\Windows\System32\whoami.exe</command>
  <interval>2m</interval>
  <ignore_output>no</ignore_output>
  <run_on_start>yes</run_on_start>
  <timeout>30</timeout>
  <verify_sha1>9746e91bfc629d3a2e1fe6289b549c0452702004</verify_sha1>
</wodle>

<wodle name="command">
  <disabled>no</disabled>
  <tag>case4-singlebs-nosha1</tag>
  <command>C:\Windows\System32\cmd.exe /c dir C:\Windows\Temp</command>
  <interval>2m</interval>
  <ignore_output>no</ignore_output>
  <run_on_start>yes</run_on_start>
  <timeout>30</timeout>
</wodle>
```

#### Test results summary

| Case | Config | Verification | Result | Notes |
|------|--------|:---:|:---:|-------|
| case1 | `C:\\...\\whoami.exe` + sha1 | yes | **pass** | All event fields correct, exit_code 0 |
| case2 | `C:\\...\\cmd.exe /c dir C:\\...\\Temp` | no | **pass** | exit_code 0, dir listing output. Was exit_code 1 before fix |
| case3 | `C:\...\whoami.exe` + sha1 | yes | **pass** | All event fields correct, exit_code 0. Was a fatal error before fix |
| case4 | `C:\...\cmd.exe /c dir C:\...\Temp` | no | **pass** | exit_code 0, dir listing output |

<details>
<summary>Agent logs (after fix, agent 006)</summary>

```sql
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Module command:case1-doublebs-sha1 started
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Verifying command checksum 'case1-doublebs-sha1'.
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Starting command 'case1-doublebs-sha1'.
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Module command:case3-singlebs-sha1 started
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Verifying command checksum 'case3-singlebs-sha1'.
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Starting command 'case3-singlebs-sha1'.
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Module command:case2-doublebs-nosha1 started
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Starting command 'case2-doublebs-nosha1'.
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Module command:case4-singlebs-nosha1 started
2026/05/12 16:57:52 wazuh-modulesd:command: INFO: Starting command 'case4-singlebs-nosha1'.
```

All four cases start and execute successfully. No errors.

</details>

<details>
<summary>case1-doublebs-sha1: Indexed event (decoded from event.original)</summary>

```json
{
  "event.module": "wazuh-wodle-cmd",
  "tags": ["case1-doublebs-sha1"],
  "process": {
    "args": [],
    "name": "whoami.exe",
    "path": "C:\\Windows\\System32\\whoami.exe",
    "command_line": "C:\\Windows\\System32\\whoami.exe",
    "hash": {
      "sha1": "9746e91bfc629d3a2e1fe6289b549c0452702004"
    },
    "exit_code": 0,
    "io": {
      "text": "nt authority\\system\r\n"
    }
  }
}
```

All fields correct. Binary path resolved, sha1 verified, single backslashes in path/command_line.

</details>

<details>
<summary>case3-singlebs-sha1: Indexed event (decoded from event.original)</summary>

```json
{
  "event.module": "wazuh-wodle-cmd",
  "tags": ["case3-singlebs-sha1"],
  "process": {
    "args": [],
    "name": "whoami.exe",
    "path": "C:\\Windows\\System32\\whoami.exe",
    "command_line": "C:\\Windows\\System32\\whoami.exe",
    "hash": {
      "sha1": "9746e91bfc629d3a2e1fe6289b549c0452702004"
    },
    "exit_code": 0,
    "io": {
      "text": "nt authority\\system\r\n"
    }
  }
}
```

Single backslash config now works with checksum verification. Previously this case produced `ERROR: Cannot check binary: 'C:WindowsSystem32whoami.exe'` because `w_strtok` stripped the backslashes. The WIN32 code path now bypasses `w_strtok` and preserves single backslashes as path separators.

</details>

<details>
<summary>case2-doublebs-nosha1: Indexed event (decoded from event.original)</summary>

```json
{
  "event.module": "wazuh-wodle-cmd",
  "tags": ["case2-doublebs-nosha1"],
  "process": {
    "args": ["/c", "dir", "C:WindowsTemp"],
    "name": "C:WindowsSystem32cmd.exe",
    "path": "",
    "command_line": "C:\\Windows\\System32\\cmd.exe /c dir C:\\Windows\\Temp",
    "exit_code": 0,
    "io": {
      "text": " Volume in drive C is Windows 2016\r\n ...\r\n"
    }
  }
}
```

Command executes successfully (exit_code 0) with correct dir listing output. The `command_line` field shows single backslashes after `\\` reduction. The `process.name` and `process.args` fields show mangled paths because the event metadata builder uses `w_strtok` internally (pre-existing limitation in the event building code path, separate from this fix).

**Before this fix**, this case failed with `exit_code: 1` and `"The specified path is invalid."` because `\\` was passed to `cmd.exe` without reduction.

</details>

<details>
<summary>case4-singlebs-nosha1: Indexed event (decoded from event.original)</summary>

```json
{
  "event.module": "wazuh-wodle-cmd",
  "tags": ["case4-singlebs-nosha1"],
  "process": {
    "args": ["/c", "dir", "C:WindowsTemp"],
    "name": "C:WindowsSystem32cmd.exe",
    "path": "",
    "command_line": "C:\\Windows\\System32\\cmd.exe /c dir C:\\Windows\\Temp",
    "exit_code": 0,
    "io": {
      "text": " Volume in drive C is Windows 2016\r\n ...\r\n"
    }
  }
}
```

Executes successfully. Same event metadata behavior as case2.

</details>

<details>
<summary>Before fix: indexed events from agent 004 (comparison)</summary>

**case1 equivalent (double backslash + sha1) on original code:**

```sql
wazuh-modulesd:command: ERROR: SHA1 checksum verification failed for command 'C:\Windows\System32\whoami.exe xe'.
```

Trailing ` xe` appended due to offset mismatch.

**case2 equivalent (double backslash + no sha1) on original code:**

```json
{
  "tags": ["verify-cmd-dir-with-doublebs"],
  "process": {
    "command_line": "C:\\\\Windows\\\\System32\\\\cmd.exe /c dir C:\\\\Windows\\\\Temp",
    "exit_code": 1,
    "io": { "text": "The specified path is invalid.\r\n" }
  }
}
```

Double backslashes in `command_line`, cmd.exe fails.

**case3 equivalent (single backslash + sha1) on original code:**

```sql
wazuh-modulesd:command: ERROR: Cannot check binary: 'C:WindowsSystem32whoami.exe'. Cannot stat binary file.
```

Backslashes stripped by `w_strtok`, path completely mangled.

</details>

#### Known limitations

- **Event metadata (`process.name`, `process.args`) for commands without checksum verification.** The event builder uses `w_strtok` to tokenize `full_command` for process metadata. After `\\` reduction, the command has single `\` which `w_strtok` then strips. This produces mangled values like `C:WindowsSystem32cmd.exe` in `process.name`. The `command_line` field (which uses `full_command` directly) is always correct. This is a pre-existing limitation in the event metadata code path, not introduced by this fix.

### Artifacts Affected

- `wazuh-modulesd` (all platforms: Windows, Linux, macOS)

### Configuration Changes

- None.

### Documentation Updates

This PR includes internal developer documentation for the command wodle module at `docs/ref/modules/command/README.md`. The document covers:

- Module overview and execution flow.
- Configuration reference (all XML options, scheduling, centralized configuration).
- Checksum verification behavior and Windows path handling.
- Event format specification with field descriptions.
- Troubleshooting guide with common error messages.

### Tests Introduced

Seven new unit tests in `src/unit_tests/wazuh_modules/command/test_wm_command.c`:

| Test | Description |
|------|-------------|
| `test_full_command_windows_no_args` | Windows path with `\\` escapes and no arguments (exact reproduction of the reported bug). |
| `test_full_command_windows_with_args` | Windows path with `\\` escapes and arguments (`/c dir`). |
| `test_full_command_linux_no_args` | Linux absolute path with no arguments. Regression test. |
| `test_full_command_quoted_args` | Linux path with quoted arguments containing spaces. |
| `test_full_command_quoted_binary_with_spaces` | Quoted Windows path with spaces in binary and arguments. |
| `test_full_command_leading_spaces` | Command string with leading whitespace. |
| `test_full_command_unquoted_path_with_spaces` | Unquoted Windows path with escaped space, verifying auto-quoting. |

Also added `--wrap=get_binary_path` to the test CMakeLists.txt, four new JSON payload tests for event format validation, and mock infrastructure for `wm_sendmsg`.

All 19 tests pass:

```
[PASSED] tests_with_startup: 1 test(s).
[PASSED] tests_without_startup: 5 test(s).
[PASSED] tests_validate_command_checksums: 2 test(s).
[PASSED] tests_payload_json: 4 test(s).
[PASSED] tests_full_command: 7 test(s).
```

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
