### PR TITLE
Fix Coverity findings in SCA, sync protocol, router init, and command cleanup

### DIFF
--- a/src/active-response/src/block-ip-unix.c
+++ b/src/active-response/src/block-ip-unix.c
@@ -173,8 +173,8 @@ firewall_result_t try_firewalld(const char *srcip, int action, int ip_version, c
                 wpclose(wfd);
             }
         }
-        os_free(systemctl_path);
     }
+    os_free(systemctl_path);
 
     // Acquire lock
     if (acquire_ar_lock(&lock_ctx) == OS_INVALID) {

--- a/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
@@ -52,7 +52,7 @@ enum class Option : int
 struct PersistedData
 {
     /// @brief Sequence number of the message (scoped per module).
-    uint64_t seq;
+    uint64_t seq{};
 
     /// @brief Unique identifier of the message.
     std::string id;
@@ -64,10 +64,10 @@ struct PersistedData
     std::string data;
 
     /// @brief Type of operation (CREATE, MODIFY, DELETE).
-    Operation operation;
+    Operation operation{Operation::NO_OP};
 
     /// @brief Version of the data.
-    uint64_t version;
+    uint64_t version{};
 
     /// @brief Flag indicating if this is DataContext (true) or DataValue (false).
     bool is_data_context = false;

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -4173,6 +4173,78 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanLogsErrorWithoutQueue)
     EXPECT_TRUE(foundError);
 }
 
+TEST_F(AgentSyncProtocolTest, NotifyDataCleanWithReqRetSuccess)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 1; },
+        .send_binary = [](int, const void*, size_t, const char*, char) { return 1; }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>(
+                   "test_module", ":memory:", mqFuncs, testLogger,
+                   std::chrono::seconds(0),
+                   std::chrono::seconds(min_timeout),
+                   retries, maxEps, mockQueue);
+
+    std::vector<std::string> indices = {"idx_a", "idx_b", "idx_c"};
+
+    EXPECT_CALL(*mockQueue, clearItemsByIndex("idx_a")).Times(1);
+    EXPECT_CALL(*mockQueue, clearItemsByIndex("idx_b")).Times(1);
+    EXPECT_CALL(*mockQueue, clearItemsByIndex("idx_c")).Times(1);
+
+    std::thread syncThread([this, &indices]()
+    {
+        bool result = protocol->notifyDataClean(indices);
+        EXPECT_TRUE(result);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+    {
+        flatbuffers::FlatBufferBuilder b;
+        Wazuh::SyncSchema::StartAckBuilder sab(b);
+        sab.add_status(Wazuh::SyncSchema::Status::Ok);
+        sab.add_session(session);
+        auto off = sab.Finish();
+        auto msg = Wazuh::SyncSchema::CreateMessage(
+                       b, Wazuh::SyncSchema::MessageType::StartAck, off.Union());
+        b.Finish(msg);
+        protocol->parseResponseBuffer(b.GetBufferPointer(), b.GetSize());
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+    {
+        flatbuffers::FlatBufferBuilder b;
+        std::vector<flatbuffers::Offset<Wazuh::SyncSchema::Pair>> ranges;
+        ranges.push_back(Wazuh::SyncSchema::CreatePair(b, 0, 2));
+        auto seqVec = b.CreateVector(ranges);
+        Wazuh::SyncSchema::ReqRetBuilder rb(b);
+        rb.add_session(session);
+        rb.add_seq(seqVec);
+        auto off = rb.Finish();
+        auto msg = Wazuh::SyncSchema::CreateMessage(
+                       b, Wazuh::SyncSchema::MessageType::ReqRet, off.Union());
+        b.Finish(msg);
+        protocol->parseResponseBuffer(b.GetBufferPointer(), b.GetSize());
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+    {
+        flatbuffers::FlatBufferBuilder b;
+        Wazuh::SyncSchema::EndAckBuilder eab(b);
+        eab.add_status(Wazuh::SyncSchema::Status::Ok);
+        eab.add_session(session);
+        auto off = eab.Finish();
+        auto msg = Wazuh::SyncSchema::CreateMessage(
+                       b, Wazuh::SyncSchema::MessageType::EndAck, off.Union());
+        b.Finish(msg);
+        protocol->parseResponseBuffer(b.GetBufferPointer(), b.GetSize());
+    }
+
+    syncThread.join();
+}
+
 TEST_F(AgentSyncProtocolTest, DeleteDatabaseLogsErrorWithoutQueue)
 {
     MQ_Functions mqFuncs =

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -190,7 +190,7 @@ CommandRuleEvaluator::CommandRuleEvaluator(PolicyEvaluationContext ctx,
     else
     {
         // LCOV_EXCL_START
-        m_commandExecFunc = [timeout = ctx.commandsTimeout](const std::string & command) -> std::optional<ExecResult>
+        m_commandExecFunc = [timeout = m_ctx.commandsTimeout](const std::string & command) -> std::optional<ExecResult>
         {
             auto wmExecCallback = SecurityConfigurationAssessment::GetGlobalWmExecFunction();
 

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -156,6 +156,7 @@ void * wm_command_main(wm_command_t * command) {
     #ifndef __clang_analyzer__
         if (!argv) {
             merror("Could not split command: %s", command_cpy);
+            os_free(command_cpy);
             pthread_exit(NULL);
         }
     #endif
@@ -163,7 +164,11 @@ void * wm_command_main(wm_command_t * command) {
 
         if (get_binary_path(binary, &full_path) == OS_INVALID) {
             mterror(WM_COMMAND_LOGTAG, "Cannot check binary: '%s'. Cannot stat binary file.", binary);
+            free_strarray(argv);
+            os_free(command_cpy);
+        #ifndef __clang_analyzer__
             os_free(full_path);
+        #endif
             pthread_exit(NULL);
         }
 
@@ -175,11 +180,12 @@ void * wm_command_main(wm_command_t * command) {
         free_strarray(argv);
 
         if (validate_command_checksums(command, full_path) != 0) {
+            os_free(command_cpy);
             os_free(full_path);
             pthread_exit(NULL);
         }
 
-        free(command_cpy);
+        os_free(command_cpy);
 
     } else {
         command->full_command = strdup(command->command);

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -163,6 +163,7 @@ void * wm_command_main(wm_command_t * command) {
 
         if (get_binary_path(binary, &full_path) == OS_INVALID) {
             mterror(WM_COMMAND_LOGTAG, "Cannot check binary: '%s'. Cannot stat binary file.", binary);
+            os_free(full_path);
             pthread_exit(NULL);
         }
 

--- a/src/wazuh_modules/src/wm_database.c
+++ b/src/wazuh_modules/src/wm_database.c
@@ -223,6 +223,7 @@ void wm_sync_agents() {
 
 static router_provider_create_func router_provider_create_ptr = NULL;
 static router_provider_send_func router_provider_send_ptr = NULL;
+static void *router_module = NULL;
 
 /**
  * @brief Initialize router functions for agent deletion notifications
@@ -230,7 +231,7 @@ static router_provider_send_func router_provider_send_ptr = NULL;
  * @return true if router functions were successfully loaded, false otherwise
  */
 static bool initialize_router_functions(void) {
-    void *router_module = so_get_module_handle("router");
+    router_module = so_get_module_handle("router");
     if (router_module) {
         router_provider_create_ptr = so_get_function_sym(router_module, "router_provider_create");
         router_provider_send_ptr = so_get_function_sym(router_module, "router_provider_send");


### PR DESCRIPTION
## Description

Fixes the Coverity findings investigated in #35884 across SCA, sync protocol, `wm_database`, active response, and `wm_command`.

Closes #35884

## Proposed Changes

- Fixed the `CommandRuleEvaluator` constructor to capture `m_ctx.commandsTimeout` instead of reading from moved-from `ctx`.
- Kept the router module handle alive in `wm_database` by promoting it to file scope, matching existing module-lifetime ownership used by sibling router consumers.
- Default-initialized scalar members in `PersistedData` to prevent undefined behavior on the `notifyDataClean()` ReqRet retransmission path.
- Fixed `try_firewalld()` cleanup so `systemctl_path` is released on both success and failure paths.
- Completed `wm_command_main()` early-exit cleanup for verification paths by releasing `full_path`, `command_cpy`, and `argv` allocations before `pthread_exit()`.

### Results and Evidence

- `sca_policy_check.cpp`: moved-from read removed with no behavior change.
  [[test](https://github.com/wazuh/wazuh/issues/35884#issuecomment-4393375973)] GDB confirmed the original `commandsTimeout` value was preserved after the move, and the fix keeps intent explicit.

> `CID 560679` no longer appears in latest Coverity scan

- `wm_database.c`: router handle promotion to file scope clarifies ownership model (not a leak). Aligns with pattern used by sibling router consumers.

<img width="1120" height="53" alt="image" src="https://github.com/user-attachments/assets/c48f4b28-362d-4549-857e-af512f99c4ea" />

- `agent_sync_protocol.cpp`: uninitialized `PersistedData` scalars no longer propagate through ReqRet/DataMessage handling.
  [[test](https://github.com/wazuh/wazuh/issues/35884#issuecomment-4400593985)] GDB confirmed uninitialized `PersistedData::version` could propagate into `DataMessage` serialization on the ReqRet path before the fix.

<img width="1121" height="50" alt="image" src="https://github.com/user-attachments/assets/b7f9047c-e66b-4996-b7c3-b8e6e3429451" />

- `block-ip-unix.c`: leak on missing-`systemctl` path removed.
  [[test](https://github.com/wazuh/wazuh/issues/35884#issuecomment-4400593985)] Valgrind confirmed the `try_firewalld()` leak before the fix and zero leaked bytes after the fix.

<img width="1120" height="49" alt="image" src="https://github.com/user-attachments/assets/5136a3a7-8727-46cb-8db4-21f760ec7bbc" />

- `wm_command.c`: verification failure paths no longer leak helper allocations.

> This is a similar scenario from `CID 560704` that was not yet flag by Coverity scan

### Artifacts Affected

- Manager modules / daemons:
  - `wazuh-modulesd`
  - active response firewall helper on Linux
- Shared sync protocol code and tests

### Configuration Changes

N/A

### Tests Introduced

- Added `NotifyDataCleanWithReqRetSuccess` in `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp` to test the StartAck -> ReqRet -> EndAck path and cover the uninitialized-read fix.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
