### PR TITLE
Prevent Windows agent restart abort when service is already stopping

### DIFF
--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -576,9 +576,6 @@ void* wm_sys_main(wm_sys_t* sys)
 
     sys->flags.running = true;
 
-    w_cond_init(&sys_stop_condition, NULL);
-    w_mutex_init(&sys_stop_mutex, NULL);
-    w_mutex_init(&sys_reconnect_mutex, NULL);
     w_mutex_lock(&sys_stop_mutex);
     sys_main_thread = pthread_self();
     sys_main_thread_initialized = true;
@@ -753,10 +750,6 @@ void* wm_sys_main(wm_sys_t* sys)
 
 void wm_sys_destroy(wm_sys_t* data)
 {
-    w_cond_destroy(&sys_stop_condition);
-    w_mutex_destroy(&sys_stop_mutex);
-    w_mutex_destroy(&sys_reconnect_mutex);
-
     free(data);
 }
 

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -263,9 +263,18 @@ int UninstallService()
 /* "Signal" handler */
 VOID WINAPI OssecServiceCtrlHandler(DWORD dwOpcode)
 {
+    /* Re-entry guard: merror_exit() calls WinSetError() which re-enters this
+     * handler. Without the guard the second pass runs stop_wmodules a second
+     * time on top of the first, racing the SCM transitions. */
+    static volatile LONG stop_in_progress = 0;
+
     if (ossecServiceStatusHandle) {
         switch (dwOpcode) {
             case SERVICE_CONTROL_STOP:
+                if (InterlockedCompareExchange(&stop_in_progress, 1, 0) != 0) {
+                    return;
+                }
+
                 ossecServiceStatus.dwWin32ExitCode          = 0;
                 ossecServiceStatus.dwCheckPoint             = 0;
                 ossecServiceStatus.dwWaitHint               = 0;

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -84,6 +84,12 @@ int os_stop_service()
             else if (GetLastError() == ERROR_SERVICE_NOT_ACTIVE) {
                 rc = -1; /* already stopped — not a real error */
             }
+            else if (GetLastError() == ERROR_SERVICE_CANNOT_ACCEPT_CTRL) {
+                rc = -1; /* already stopping — wait and restart normally */
+            }
+            else {
+                plain_mdebug1("os_stop_service(): ControlService failed (error %lu).", GetLastError());
+            }
 
             CloseServiceHandle(schService);
         }


### PR DESCRIPTION
## Description

  When the Windows agent receives a `reload` command (e.g. after a shared-configuration change while a syscollector wodle is active), it crashes during shutdown with:

  ```
  wazuh-modulesd:syscollector: INFO: Module finished.
  wazuh-agent: CRITICAL: At pthread_cond_signal(): Invalid argument
  ```

  …and the subsequent detached restart fails with `Failure running stop service.`. Closes #35960.

  ### Root cause

  `wm_syscollector.c` is the only wmodule that still coordinates shutdown via C `pthread_cond_t` (SCA, agent-info and FIM all use C++ `std::condition_variable`). Its primitives are declared with **both** a static and a dynamic initializer:

  ```c
  /* src/wazuh_modules/src/wm_syscollector.c:51-56 */
  pthread_cond_t  sys_stop_condition  = PTHREAD_COND_INITIALIZER;
  pthread_mutex_t sys_stop_mutex      = PTHREAD_MUTEX_INITIALIZER;
  pthread_mutex_t sys_reconnect_mutex = PTHREAD_MUTEX_INITIALIZER;
  ...
  /* wm_sys_main, then redundantly: */
  w_cond_init(&sys_stop_condition, NULL);
  w_mutex_init(&sys_stop_mutex,    NULL);
  w_mutex_init(&sys_reconnect_mutex, NULL);
  ```

  Re-initializing an already-initialized cond/mutex is undefined behavior per POSIX. On MinGW winpthreads (`/usr/i686-w64-mingw32/include/pthread.h:269,278`), `pthread_cond_t` is an `intptr_t` and `PTHREAD_COND_INITIALIZER == -1`; `pthread_cond_init` always allocates a new `cond_t` and overwrites `*c`, leaving the previous sentinel/handle in a state where a later `pthread_cond_signal` can return `EINVAL` once the C++ stop path and the sync layer have interacted with the cond. The static initializer was added in #15575 (Jan 2023) without removing the dynamic init, so the UB has been latent for ~3 years and only surfaced now after the recent shutdown rework (`7cd0ab6bea`, `aa864634c9`) made the C↔C++ stop ordering more sensitive.

  When the EINVAL hits, the `w_cond_signal` macro (`src/shared/include/pthreads_op.h:25`) calls `merror_exit(...)`, which on Windows reaches `WinSetError()` → re-enters `OssecServiceCtrlHandler(SERVICE_CONTROL_STOP)` (`src/win32/win_service.c:296-299`). The handler had no re-entry guard, so it runs `stop_wmodules` / `fim_db_teardown` a second time on top of the first. That second pass transitions the service into `SERVICE_STOP_PENDING` before the detached restart process calls `os_stop_service()`, which is why `ControlService()` then fails with `ERROR_SERVICE_CANNOT_ACCEPT_CTRL` and the restart aborts (the symptom originally observed as `Failure running stop service.` and addressed in part by the early version of this PR).

  ### Proposed Changes

  - **`wazuh_modules/src/wm_syscollector.c`** — drop the dynamic re-initialization of `sys_stop_condition`, `sys_stop_mutex` and `sys_reconnect_mutex` at the top of `wm_sys_main`, and drop the matching `w_cond_destroy` / `w_mutex_destroy` calls in `wm_sys_destroy`. The static `PTHREAD_*_INITIALIZER` declarations are sufficient (and align with the pattern used by SCA, agent-info and FIM, which do not destroy stop primitives at all). This eliminates the undefined behavior that produces the `EINVAL` on `pthread_cond_signal`.

  - **`win32/win_service.c`** — add a re-entry guard at the top of `OssecServiceCtrlHandler`'s `SERVICE_CONTROL_STOP` case using `InterlockedCompareExchange` on a process-wide flag. If a `merror_exit` later in the shutdown path triggers `WinSetError()`, the second invocation returns immediately instead of running `stop_wmodules` / `fim_db_teardown` a second time and confusing the SCM. This is the structural fix that the previous `ERROR_SERVICE_CANNOT_ACCEPT_CTRL` workaround was masking.

  - **`win32/win_service.c`** — keep the `ERROR_SERVICE_CANNOT_ACCEPT_CTRL` handling already added to `os_stop_service()` (returning `rc = -1`, same as `ERROR_SERVICE_NOT_ACTIVE`) and the diagnostic `plain_mdebug1` fallback for unexpected `ControlService` failures. This is now a belt-and-suspenders measure rather than a workaround for the crash.

  ### Results and Evidence

  **Reproducer**

  Agent version

  ```
  Invoke-WebRequest -Uri https://packages-staging.xdrsiem.wazuh.info/pre-release/5.x/windows/wazuh-agent-5.0.0-beta1.msi -OutFile $env:tmp\wazuh-agent; msiexec.exe /i $env:tmp\wazuh-agent /q WAZUH_MANAGER='192.168.XXX.XXX' WAZUH_AGENT_NAME='win-agent'
  ```

  Shared configuration

  ```xml
  <agent_config>
    <!-- System inventory -->
    <wodle name="syscollector">
      <interval>1m</interval>
    </wodle>
  </agent_config>
  ```

  **Before the fix**

  Assigning the agent to a new group triggers a shared-config reload mid-flush and the agent crashes:

  ```log
  2026/05/08 19:31:25 wazuh-agent: INFO: Agent is reloading due to shared configuration changes.
  2026/05/08 19:31:25 wazuh-agent: INFO: Agent control: reload command received.
  2026/05/08 19:31:25 wazuh-agent: INFO: Agent control: 'reload' command received, detached restart process spawned.
  2026/05/08 19:31:26 wazuh-agent: INFO: Received exit signal. Starting exit process.
  2026/05/08 19:31:26 wazuh-agent: INFO: Set pending exit signal.
  2026/05/08 19:31:26 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
  2026/05/08 19:31:26 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
  2026/05/08 19:31:26 wazuh-modulesd:sca: INFO: SCA module stopped.
  2026/05/08 19:31:26 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
  2026/05/08 19:31:26 wazuh-modulesd:syscollector: INFO: Module finished.
  2026/05/08 19:31:26 wazuh-agent: CRITICAL: At pthread_cond_signal(): Invalid argument
  2026/05/08 19:31:26 wazuh-agent: INFO: Received exit signal. Starting exit process.
  2026/05/08 19:31:26 wazuh-agent: INFO: Set pending exit signal.
  2026/05/08 19:31:26 wazuh-modulesd:sca: INFO: SCA module stopped.
  2026/05/08 19:31:26 wazuh-agent: INFO: Exit completed successfully.
  2026/05/08 19:31:26 wazuh-agent: INFO: (1314): Shutdown received. Deleting responses.
  2026/05/08 19:31:26 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
  2026/05/08 19:31:26 wazuh-agent: ERROR: Failure running stop service.
  ```

  Notice the two `Received exit signal` / two `SCA module stopped` entries — that is the `OssecServiceCtrlHandler` re-entry described above.

  **After the fix**


```log
2026/05/12 19:19:33 wazuh-agent: INFO: Agent is reloading due to shared configuration changes.
2026/05/12 19:19:33 wazuh-agent: INFO: Agent control: reload command received.
2026/05/12 19:19:33 wazuh-agent: INFO: Agent control: 'reload' command received, detached restart process spawned.
2026/05/12 19:19:33 wazuh-modulesd:agent-info: INFO: Waiting for fim module to complete synchronization (180 seconds elapsed)
2026/05/12 19:19:33 wazuh-modulesd:agent-info: INFO: Waiting for syscollector module to complete synchronization (180 seconds elapsed)
2026/05/12 19:19:34 wazuh-agent: INFO: Received exit signal. Starting exit process.
2026/05/12 19:19:34 wazuh-agent: INFO: Set pending exit signal.
2026/05/12 19:19:34 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/05/12 19:19:34 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/05/12 19:19:34 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/05/12 19:19:34 wazuh-modulesd:syscollector: INFO: Sync End message retries exhausted because module is stopping.
2026/05/12 19:19:34 wazuh-modulesd:syscollector: INFO: Module finished.
2026/05/12 19:19:34 wazuh-modulesd:syscollector: INFO: syscollector_vd: Stop requested, aborting data message sending
2026/05/12 19:19:34 wazuh-modulesd:syscollector: INFO: Syscollector flush skipped: module is stopping
2026/05/12 19:19:34 wazuh-agent: INFO: Exit completed successfully.
2026/05/12 19:19:34 wazuh-agent: INFO: (1314): Shutdown received. Deleting responses.
2026/05/12 19:19:34 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\wazuh-agent.exe'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\wazuh-agent.exe': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\wazuh-agent.exe' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libagent_metadata.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libagent_metadata.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libagent_metadata.dll' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libagent_sync_protocol.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libagent_sync_protocol.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libagent_sync_protocol.dll' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libfimdb.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libfimdb.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libfimdb.dll' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\schema_validator.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\schema_validator.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\schema_validator.dll' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libwinpthread-1.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libwinpthread-1.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libwinpthread-1.dll' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libgcc_s_dw2-1.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libgcc_s_dw2-1.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libgcc_s_dw2-1.dll' is not signed or its signature is invalid.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libstdc++-6.dll'.
2026/05/12 19:19:35 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libstdc++-6.dll': No se ha encontrado el elemento.
2026/05/12 19:19:35 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libstdc++-6.dll' is not signed or its signature is invalid.
2026/05/12 19:19:36 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\libwazuhext.dll'.
2026/05/12 19:19:36 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\libwazuhext.dll': No se ha encontrado el elemento.
2026/05/12 19:19:36 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\libwazuhext.dll' is not signed or its signature is invalid.
2026/05/12 19:19:36 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\dbsync.dll'.
2026/05/12 19:19:36 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\dbsync.dll': No se ha encontrado el elemento.
2026/05/12 19:19:36 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\dbsync.dll' is not signed or its signature is invalid.
2026/05/12 19:19:36 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\sysinfo.dll'.
2026/05/12 19:19:36 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\sysinfo.dll': No se ha encontrado el elemento.
2026/05/12 19:19:36 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\sysinfo.dll' is not signed or its signature is invalid.
2026/05/12 19:19:36 wazuh-agent: INFO: (1410): Reading authentication keys file.
2026/05/12 19:19:36 wazuh-agent: INFO: Using notify time: 20 and max time to reconnect: 60
2026/05/12 19:19:36 wazuh-agent: INFO: Started (pid: 14196).
2026/05/12 19:19:36 wazuh-agent: INFO: (4102): Connected to the server ([192.168.100.232]:1514/tcp).
2026/05/12 19:19:37 wazuh-rootcheck: INFO: Started (pid: 14196).
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\batfile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\cmdfile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (1951): Analyzing event log: 'Application'.
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\comfile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\exefile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\piffile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (1951): Analyzing event log: 'Security'.
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\AllFilesystemObjects', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Directory', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (1951): Analyzing event log: 'System'.
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Folder', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Protocols [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Protocols', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Policies [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Policies', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Security', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\KnownDLLs', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\winreg', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256 | type'
2026/05/12 19:19:37 wazuh-agent: INFO: Started (pid: 14196).
2026/05/12 19:19:37 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\agent_info.dll'.
2026/05/12 19:19:37 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\agent_info.dll': No se ha encontrado el elemento.
2026/05/12 19:19:37 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\agent_info.dll' is not signed or its signature is invalid.
2026/05/12 19:19:37 wazuh-modulesd:agent-info: INFO: AgentInfo initialized.
2026/05/12 19:19:37 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\sca.dll'.
2026/05/12 19:19:37 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\sca.dll': No se ha encontrado el elemento.
2026/05/12 19:19:37 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\sca.dll' is not signed or its signature is invalid.
2026/05/12 19:19:37 wazuh-modulesd:sca: INFO: SCA initialized.
2026/05/12 19:19:37 wazuh-modulesd:sca: INFO: Started (pid: 14196).
2026/05/12 19:19:37 wazuh-modulesd:sca: INFO: SCA module running.
2026/05/12 19:19:37 wazuh-agent: WARNING: Trust verification of a module failed by using the signature method. No signature found for 'C:\Program Files (x86)\ossec-agent\syscollector.dll'.
2026/05/12 19:19:37 wazuh-agent: WARNING: Trust verification of a module failed by using the hash method. CryptCATAdminEnumCatalogFromHash failed with error 1168 for 'C:\Program Files (x86)\ossec-agent\syscollector.dll': No se ha encontrado el elemento.
2026/05/12 19:19:37 wazuh-agent: WARNING: The file 'C:\Program Files (x86)\ossec-agent\syscollector.dll' is not signed or its signature is invalid.
2026/05/12 19:19:37 wazuh-modulesd:sca: INFO: SCA module scan on start.
2026/05/12 19:19:37 wazuh-modulesd:syscollector: INFO: Module started.
2026/05/12 19:19:37 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/12 19:19:38 wazuh-agent: INFO: Started (pid: 14196).
2026/05/12 19:19:38 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/05/12 19:19:38 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/12 19:19:42 wazuh-modulesd:agent-info: INFO: Starting module coordination process
2026/05/12 19:19:42 wazuh-modulesd:agent-info: INFO: Pausing sca module for synchronization coordination
2026/05/12 19:19:43 wazuh-rootcheck: INFO: Ending rootcheck scan.
2026/05/12 19:19:46 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/12 19:20:17 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/05/12 19:20:17 wazuh-modulesd:agent-info: INFO: Pausing syscollector module for synchronization coordination
2026/05/12 19:20:17 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/05/12 19:20:17 wazuh-modulesd:agent-info: INFO: fim pause completed successfully
2026/05/12 19:20:21 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: Triggering flush for fim module
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: Triggering flush for sca module
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: Triggering flush for syscollector module
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: Resuming paused module: fim
2026/05/12 19:20:27 wazuh-modulesd:syscollector: INFO: Syscollector flush requested - syncing pending messages
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: Resuming paused module: sca
2026/05/12 19:20:27 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: Resuming paused module: syscollector
2026/05/12 19:20:27 wazuh-modulesd:syscollector: INFO: Resuming Syscollector module
2026/05/12 19:20:27 wazuh-modulesd:agent-info: INFO: sca pending operations completed with result: success (took 10 seconds)
2026/05/12 19:20:27 wazuh-agent: INFO: Starting FIM synchronization.
2026/05/12 19:20:46 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/12 19:20:54 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/12 19:21:17 wazuh-modulesd:agent-info: INFO: Waiting for fim module to complete synchronization (60 seconds elapsed)
2026/05/12 19:21:17 wazuh-modulesd:agent-info: INFO: Waiting for syscollector module to complete synchronization (60 seconds elapsed)
2026/05/12 19:21:54 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/12 19:22:03 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/12 19:22:17 wazuh-modulesd:agent-info: INFO: Waiting for fim module to complete synchronization (120 seconds elapsed)
2026/05/12 19:22:17 wazuh-modulesd:agent-info: INFO: Waiting for syscollector module to complete synchronization (120 seconds elapsed)
2026/05/12 19:23:03 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/12 19:23:11 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/12 19:23:17 wazuh-modulesd:agent-info: INFO: Waiting for fim module to complete synchronization (180 seconds elapsed)
2026/05/12 19:23:17 wazuh-modulesd:agent-info: INFO: Waiting for syscollector module to complete synchronization (180 seconds elapsed)
```

  ### Manual tests with their corresponding evidence

  - Compilation without warnings on every supported platform
    - [ ] Linux
    - [x] Windows
    - [ ] MAC OS X
  - [x] Log syntax and correct language review

  - Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer
  - Memory tests for Windows
    - [ ] Coverity
    - [ ] UMDH
  - Memory tests for macOS
    - [ ] Leaks
    - [ ] AddressSanitizer

  - Decoder/Rule tests _(Wazuh v4.x)_
    - [ ] Added unit testing files ".ini"
    - [ ] `runtests.py` executed without errors

  - Engine _(Wazuh v5.x and above)_
    - [ ] Test run in parallel
    - [ ] ASAN for test (utest/ctest)
    - [ ] TSAN for test and wazuh-engine.

  - Wazuh server API/Framework
    - [ ] Run API Integration Tests

  ### Artifacts Affected

  - `wazuh-agent.exe` (Windows)

  ### Configuration Changes

  N/A

  ### Tests Introduced

  N/A — the failure requires a live Windows Service Control Manager driving the reload→stop→restart sequence against a running syscollector wodle, which is outside the scope of the existing
  cmocka / wine unit-test environment. The change is a removal of dead/UB initialization plus a small re-entry guard, both verifiable by inspection.


## Fixed Package

- https://github.com/wazuh/wazuh-agent-packages/actions/runs/25765159064


  ## Review Checklist

  - [ ] Code changes reviewed
  - [ ] Relevant evidence provided
  - [ ] Tests cover the new functionality
  - [ ] Configuration changes documented
  - [ ] Developer documentation reflects the changes
  - [ ] Meets requirements and/or definition of done
  - [ ] No unresolved dependencies with other issues
