### PR TITLE
Draft: SCA: Updating 33136,33137 and 33138 for Debian 12 and 13

### DIFF
--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -2270,7 +2270,7 @@ checks:
     condition: all
     rules:
       - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/iif(name)? \"lo\"/''" -> r:accept'
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> r:drop'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0|::1)/''" -> r:drop'
 
   # 4.3.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 

--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -2195,10 +2195,10 @@ checks:
   # 4.3.4 Ensure a nftables table exists. (Automated)
   - id: 33136
     name: "Ensure a nftables table exists."
-    description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
+    description: "Tables hold chains. Each table only has one address family and only applies to packets of this family."
     rationale: "nftables doesn't have any default tables. Without a table being built, nftables will not filter network traffic."
     impact: "Adding rules to a running nftables can cause loss of connectivity to the system."
-    remediation: "Run the following command to create a table in nftables # nft create table inet <table name> Example: # nft create table inet filter."
+    remediation: "Run the following command to create a table in nftables # nft create table <table family> <table name> Example: # nft create table inet filter."
     compliance:
       cmmc: ["AC.L2-3.1.20", "CM.L2-3.4.7", "SC.L2-3.13.1", "SC.L2-3.13.6"]
       fedramp: ["SC-7"]
@@ -2216,15 +2216,15 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - "c:nft list tables -> r:table inet"
+      - "c:nft list tables -> r:table"
 
   # 4.3.5 Ensure nftables base chains exist. (Automated)
   - id: 33137
     name: "Ensure nftables base chains exist."
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
-    rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
+    rationale: "If a base chain doesn't exist with a hook for input, forward, and output, packets that would flow through those chains will not be touched by nftables."
     impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
-    remediation: "Run the following command to create the base chains: # nft create chain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }."
+    remediation: "Run the following command to create the base chains: # nft create chain <table family> <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }."
     compliance:
       cmmc: ["AC.L2-3.1.20", "CM.L2-3.4.7", "SC.L2-3.13.1", "SC.L2-3.13.6"]
       fedramp: ["SC-7"]
@@ -2242,9 +2242,9 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - "c:nft list ruleset -> r:type filter hook input priority 0"
-      - "c:nft list ruleset -> r:type filter hook forward priority 0"
-      - "c:nft list ruleset -> r:type filter hook output priority 0"
+      - "c:nft --numeric list chains -> r:type filter hook input priority 0"
+      - "c:nft --numeric list chains -> r:type filter hook forward priority 0"
+      - "c:nft --numeric list chains -> r:type filter hook output priority 0"
 
   # 4.3.6 Ensure nftables loopback traffic is configured. (Automated)
   - id: 33138
@@ -2269,8 +2269,8 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/''" -> r:iif "lo" accept'
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/''" -> r:ip saddr|ip6 saddr'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/iif(name)? \"lo\"/''" -> r:accept'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> !r:accept'
 
   # 4.3.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 

--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -2270,7 +2270,7 @@ checks:
     condition: all
     rules:
       - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/iif(name)? \"lo\"/''" -> r:accept'
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> !r:accept'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> r:drop'
 
   # 4.3.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 

--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -2270,7 +2270,7 @@ checks:
     condition: all
     rules:
       - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/iif(name)? \"lo\"/''" -> r:accept'
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> r:drop'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0|::1)/''" -> r:drop'
 
   # 4.3.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 

--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -2195,10 +2195,10 @@ checks:
   # 4.3.4 Ensure a nftables table exists. (Automated)
   - id: 33136
     name: "Ensure a nftables table exists."
-    description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
+    description: "Tables hold chains. Each table only has one address family and only applies to packets of this family."
     rationale: "nftables doesn't have any default tables. Without a table being built, nftables will not filter network traffic."
     impact: "Adding rules to a running nftables can cause loss of connectivity to the system."
-    remediation: "Run the following command to create a table in nftables # nft create table inet <table name> Example: # nft create table inet filter."
+    remediation: "Run the following command to create a table in nftables # nft create table <table family> <table name> Example: # nft create table inet filter."
     compliance:
       cmmc: ["AC.L2-3.1.20", "CM.L2-3.4.7", "SC.L2-3.13.1", "SC.L2-3.13.6"]
       fedramp: ["SC-7"]
@@ -2216,15 +2216,15 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - "c:nft list tables -> r:table inet"
+      - "c:nft list tables -> r:table"
 
   # 4.3.5 Ensure nftables base chains exist. (Automated)
   - id: 33137
     name: "Ensure nftables base chains exist."
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
-    rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
+    rationale: "If a base chain doesn't exist with a hook for input, forward, and output, packets that would flow through those chains will not be touched by nftables."
     impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
-    remediation: "Run the following command to create the base chains: # nft create chain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }."
+    remediation: "Run the following command to create the base chains: # nft create chain <table family> <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }."
     compliance:
       cmmc: ["AC.L2-3.1.20", "CM.L2-3.4.7", "SC.L2-3.13.1", "SC.L2-3.13.6"]
       fedramp: ["SC-7"]
@@ -2242,9 +2242,9 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - "c:nft list ruleset -> r:type filter hook input priority 0"
-      - "c:nft list ruleset -> r:type filter hook forward priority 0"
-      - "c:nft list ruleset -> r:type filter hook output priority 0"
+      - "c:nft --numeric list chains -> r:type filter hook input priority 0"
+      - "c:nft --numeric list chains -> r:type filter hook forward priority 0"
+      - "c:nft --numeric list chains -> r:type filter hook output priority 0"
 
   # 4.3.6 Ensure nftables loopback traffic is configured. (Automated)
   - id: 33138
@@ -2269,8 +2269,8 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/''" -> r:iif "lo" accept'
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/''" -> r:ip saddr|ip6 saddr'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/iif(name)? \"lo\"/''" -> r:accept'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> !r:accept'
 
   # 4.3.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 

--- a/ruleset/sca/debian/cis_debian13.yml
+++ b/ruleset/sca/debian/cis_debian13.yml
@@ -2270,7 +2270,7 @@ checks:
     condition: all
     rules:
       - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/iif(name)? \"lo\"/''" -> r:accept'
-      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> !r:accept'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/'' | awk ''/ip(6)? saddr (127.0.0.0\/8|::1)/''" -> r:drop'
 
   # 4.3.7 Ensure nftables outbound and established connections are configured. (Manual) - Not Implemented
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Fixing Debian 12 and 13 CSA items for Id's: 33136,33137 and 33138 relating to nftables

## Proposed Changes

* **ID: 33136:**
  *  Allow rule check to validate nftables table exist, irrespective of table address family
* **ID: 33137:**
  *  Fix check to force numerical output to validate priority values
* **ID: 33138:**
  * Fix loopback nftables rule validation, catering for IPv4 and Ipv6 addresses

### Results and Evidence

#### Before (current master rules):
* **ID: 33136:**
<img width="1403" height="628" alt="Screenshot from 2026-05-08 15-31-03" src="https://github.com/user-attachments/assets/2b6221b7-0187-4100-b5d7-4f9f9a69a10a" />

* **ID: 33137:**
<img width="1386" height="705" alt="Screenshot from 2026-05-08 15-31-14" src="https://github.com/user-attachments/assets/d5bf1ddb-94fe-439f-8144-4cfb74a4dbca" />

* **ID: 33138:**
<img width="1385" height="663" alt="Screenshot from 2026-05-08 15-31-23" src="https://github.com/user-attachments/assets/aa44f939-b6d3-481b-98ef-b6f9b19417ba" />

#### After:
* **ID: 33136:**
<img width="1395" height="628" alt="image" src="https://github.com/user-attachments/assets/99807b89-4ec7-4b92-8e53-9cdd147b5814" />

* **ID: 33137:**
<img width="1398" height="708" alt="image" src="https://github.com/user-attachments/assets/80287aa3-ec18-46b9-80fa-bff6b24c6959" />

* **ID: 33138:**
<img width="1396" height="708" alt="image" src="https://github.com/user-attachments/assets/51133814-9d78-4554-80c6-b0ce4ae04f7e" />

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

Ruleset SCA

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
