### PR TITLE
Add protection for double VDFirst scan

### DIFF
--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1128,30 +1128,66 @@ public:
                                     }
                                     else
                                     {
-                                        try
+                                        // Prevent duplicate VDFirst scans for the same agent from racing.
+                                        // This guards against agent retransmissions, stale sessions, or timing
+                                        // issues that could trigger multiple concurrent VDFirst scans and cause
+                                        // vulnerability cleanup races.
+                                        bool shouldRunScan = true;
+                                        if (res.context->option == Wazuh::SyncSchema::Option_VDFirst)
                                         {
-                                            VulnerabilityScannerFacade::instance().runScanner(*m_dataStore,
-                                                                                              *res.context);
-                                            if (res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                                            std::unique_lock vdFirstLock(m_activeVDFirstScansMutex);
+                                            auto [it, inserted] = m_activeVDFirstScans.insert(res.context->agentId);
+                                            if (!inserted)
                                             {
-                                                VulnerabilityScannerFacade::instance().registerFeedUpdateCoveredAgent(
-                                                    res.context->agentId);
+                                                logWarn(
+                                                    LOGGER_DEFAULT_TAG,
+                                                    "InventorySyncFacade: Duplicate VDFirst scan detected for agent "
+                                                    "%s - another VDFirst scan is already in progress. Skipping "
+                                                    "this scan to prevent race condition and duplicate vulnerability "
+                                                    "cleanup.",
+                                                    res.context->agentId.c_str());
+                                                shouldRunScan = false;
                                             }
                                         }
-                                        catch (const std::exception& e)
+
+                                        if (shouldRunScan)
                                         {
-                                            logError(LOGGER_DEFAULT_TAG,
-                                                     "InventorySyncFacade: Vulnerability scanner exception for "
-                                                     "agent %s: %s",
-                                                     res.context->agentId.c_str(),
-                                                     e.what());
-                                            m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                                             res.context->agentId,
-                                                                             res.context->sessionId,
-                                                                             res.context->moduleName);
-                                            m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
-                                            eraseSession(res.context->sessionId);
-                                            m_sessionCompletedCV.notify_all();
+                                            try
+                                            {
+                                                VulnerabilityScannerFacade::instance().runScanner(*m_dataStore,
+                                                                                                  *res.context);
+                                                if (res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                                                {
+                                                    VulnerabilityScannerFacade::instance()
+                                                        .registerFeedUpdateCoveredAgent(res.context->agentId);
+
+                                                    // Unregister VDFirst scan after successful completion
+                                                    std::unique_lock vdFirstLock(m_activeVDFirstScansMutex);
+                                                    m_activeVDFirstScans.erase(res.context->agentId);
+                                                }
+                                            }
+                                            catch (const std::exception& e)
+                                            {
+                                                // Cleanup VDFirst tracking on error
+                                                if (res.context->option == Wazuh::SyncSchema::Option_VDFirst)
+                                                {
+                                                    std::unique_lock vdFirstLock(m_activeVDFirstScansMutex);
+                                                    m_activeVDFirstScans.erase(res.context->agentId);
+                                                }
+
+                                                logError(LOGGER_DEFAULT_TAG,
+                                                         "InventorySyncFacade: Vulnerability scanner exception for "
+                                                         "agent %s: %s",
+                                                         res.context->agentId.c_str(),
+                                                         e.what());
+                                                m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
+                                                                                 res.context->agentId,
+                                                                                 res.context->sessionId,
+                                                                                 res.context->moduleName);
+                                                m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
+                                                eraseSession(res.context->sessionId);
+                                                m_sessionCompletedCV.notify_all();
+                                            }
                                         }
                                     }
                                 }
@@ -1754,6 +1790,12 @@ public:
             m_sessionTimeoutThread.join();
         }
 
+        // Clear VDFirst scan tracking
+        {
+            std::unique_lock lock(m_activeVDFirstScansMutex);
+            m_activeVDFirstScans.clear();
+        }
+
         m_inventorySubscription.reset();
         m_workersQueue.reset();
         m_indexerQueue.reset();
@@ -1891,6 +1933,10 @@ private:
     mutable std::shared_mutex m_blockedAgentsMutex;  ///< Mutex for blocked agents set
     std::atomic<bool> m_allAgentsLocked {false};     ///< Global lock for all agents
     std::unique_ptr<SocketServer<Socket<OSPrimitives, SizeHeaderProtocol>, EpollWrapper>> m_keystoreSocketServer;
+
+    // VDFirst scan deduplication mechanism
+    std::unordered_set<std::string> m_activeVDFirstScans; ///< Set of agents with active VDFirst scans
+    std::mutex m_activeVDFirstScansMutex;                 ///< Mutex for VDFirst scan tracking
 };
 
 using InventorySyncFacade = InventorySyncFacadeImpl<AgentSession,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -132,6 +132,22 @@ public:
                         scanType,
                         scanReason,
                         optionName);
+
+                // Prevent VDFirst scan with empty package inventory to avoid wiping valid vulnerability state.
+                // This guards against race conditions where:
+                // 1. Agent retransmits sync session END message
+                // 2. RocksDB session data was already deleted by a previous scan's cleanup callback
+                // 3. A duplicate/stale session triggers a second scan before the first completes
+                if (scanContext->packageCount() == 0)
+                {
+                    logWarn(WM_VULNSCAN_LOGTAG,
+                            "VDFirst scan aborted for agent '%s': no packages in inventory session. "
+                            "This may indicate a duplicate scan request or RocksDB cleanup race. "
+                            "Skipping deleteByQuery to preserve existing vulnerability state.",
+                            inventorySyncContext.agentId.c_str());
+                    break;
+                }
+
                 {
                     auto indexerLock = m_indexerConnector->scopeLock();
                     m_indexerConnector->deleteByQuery("wazuh-states-vulnerabilities", inventorySyncContext.agentId);
@@ -163,6 +179,16 @@ public:
                         scanType,
                         scanReason,
                         optionName);
+
+                // Warn about empty package inventory during VDSync - may indicate data race or stale session
+                if (scanContext->packageCount() == 0)
+                {
+                    logWarn(WM_VULNSCAN_LOGTAG,
+                            "VDSync scan for agent '%s' has no packages in inventory session. "
+                            "This may indicate a duplicate scan request or RocksDB cleanup race. "
+                            "Proceeding with scan (no-op for empty inventory).",
+                            inventorySyncContext.agentId.c_str());
+                }
 
                 {
                     auto indexerLock = m_indexerConnector->scopeLock();

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -224,62 +224,6 @@ void ScanOrchestratorTest::TearDown()
     Log::deassignLogFunction();
 }
 
-TEST_F(ScanOrchestratorTest, TestVDFirstFullScan)
-{
-    // Setup mocks - only 3 orchestration chains are created in constructor
-    auto spPackageDeltaOrchestration = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
-    EXPECT_CALL(*spPackageDeltaOrchestration, handleRequest(_)).Times(0);
-
-    auto spFirstFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
-    EXPECT_CALL(*spFirstFullScan, handleRequest(_)).Times(1);
-
-    auto spFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
-    EXPECT_CALL(*spFullScan, handleRequest(_)).Times(0);
-
-    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
-    EXPECT_CALL(*spFactoryOrchestratorMock, create())
-        .WillOnce(testing::Return(spPackageDeltaOrchestration))
-        .WillOnce(testing::Return(spFirstFullScan))
-        .WillOnce(testing::Return(spFullScan));
-
-    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
-    EXPECT_CALL(*spIndexerConnectorMock, deleteByQuery("wazuh-states-vulnerabilities", "001")).Times(1);
-
-    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-
-    std::shared_mutex mutexScanOrchestrator;
-
-    TScanOrchestrator<TrampolineTScanContext,
-                      TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
-                      MockIndexerConnector,
-                      MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, mutexScanOrchestrator);
-
-    // Create RocksDB data store
-    Utils::RocksDBWrapper dataStore("/tmp/test_vd_vdfirst");
-
-    uint64_t sessionId = 12345;
-
-    // Add package message
-    auto packageMessage = createDataValueMessage(
-        sessionId, TEST_PACKAGE_INDEX, "pkg001", PACKAGE_INSERTED_JSON, Wazuh::SyncSchema::Operation_Upsert);
-    dataStore.put(std::format("{}_{}", sessionId, "001"),
-                  rocksdb::Slice(reinterpret_cast<const char*>(packageMessage.data()), packageMessage.size()));
-
-    // Add OS context message
-    auto osMessage = createDataContextMessage(sessionId, TEST_OS_INDEX, "os001", OSINFO_JSON);
-    dataStore.put(std::format("{}_{}", sessionId, "002"),
-                  rocksdb::Slice(reinterpret_cast<const char*>(osMessage.data()), osMessage.size()));
-
-    // Create context for VDFirst
-    auto context = createTestContext(Wazuh::SyncSchema::Option_VDFirst, {TEST_PACKAGE_INDEX, TEST_OS_INDEX});
-    context.sessionId = sessionId;
-
-    // Run scan
-    EXPECT_NO_THROW(scanOrchestrator.runScan(dataStore, context));
-}
-
 TEST_F(ScanOrchestratorTest, RunScanAfterFeedUpdateNullContextSkipsHandler)
 {
     auto spPackageDeltaOrchestration = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
@@ -3433,4 +3377,107 @@ TEST_F(ScanOrchestratorTest, ExtractHotfixInfo_EmptyDocument)
     auto result = scanOrchestrator.extractHotfixInfo(doc);
 
     EXPECT_TRUE(result.hotfixName.empty());
+}
+
+TEST_F(ScanOrchestratorTest, VDFirstScan_EmptyPackageInventory_ShouldAbort)
+{
+    // Test for the fix: VDFirst scan with empty package inventory should abort
+    // without executing deleteByQuery to prevent wiping valid vulnerability state
+
+    auto spPackageDeltaOrchestration = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+
+    // First full scan should NOT be called when package count is 0
+    auto spFirstFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFirstFullScan, handleRequest(_)).Times(0);
+
+    auto spFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+
+    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
+    EXPECT_CALL(*spFactoryOrchestratorMock, create())
+        .WillOnce(testing::Return(spPackageDeltaOrchestration))
+        .WillOnce(testing::Return(spFirstFullScan))
+        .WillOnce(testing::Return(spFullScan));
+
+    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+
+    // deleteByQuery should NOT be called when package count is 0
+    EXPECT_CALL(*spIndexerConnectorMock, deleteByQuery(_, _)).Times(0);
+    EXPECT_CALL(*spIndexerConnectorMock, flush()).Times(0);
+    EXPECT_CALL(*spIndexerConnectorMock, scopeLock()).Times(0);
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    std::shared_mutex mutexScanOrchestrator;
+
+    TScanOrchestrator<TrampolineTScanContext,
+                      TrampolineFactoryOrchestrator,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
+                      MockIndexerConnector,
+                      MockDatabaseFeedManager>
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, mutexScanOrchestrator);
+
+    Utils::RocksDBWrapper dataStore("/tmp/test_vd_empty_first_scan");
+
+    uint64_t sessionId = 99999;
+
+    // Create context with VDFirst option but NO packages (simulating race condition scenario)
+    auto context = createTestContext(Wazuh::SyncSchema::Option_VDFirst, {TEST_PACKAGE_INDEX});
+    context.sessionId = sessionId;
+
+    // Only add OS context, no packages
+    auto osMessage = createDataContextMessage(sessionId, TEST_OS_INDEX, "os001", OSINFO_JSON);
+    dataStore.put(std::format("{}_{}", sessionId, "001"),
+                  rocksdb::Slice(reinterpret_cast<const char*>(osMessage.data()), osMessage.size()));
+
+    // This should abort early without calling deleteByQuery or handleRequest
+    EXPECT_NO_THROW(scanOrchestrator.runScan(dataStore, context));
+}
+
+TEST_F(ScanOrchestratorTest, VDSyncScan_EmptyPackageInventory_ShouldProceed)
+{
+    // VDSync with empty inventory should log warning but proceed (no-op)
+    // Unlike VDFirst, it doesn't do full deleteByQuery so it's safer
+
+    auto spPackageDeltaOrchestration = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spPackageDeltaOrchestration, handleRequest(_)).Times(1); // Should still be called
+
+    auto spFirstFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    auto spFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+
+    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
+    EXPECT_CALL(*spFactoryOrchestratorMock, create())
+        .WillOnce(testing::Return(spPackageDeltaOrchestration))
+        .WillOnce(testing::Return(spFirstFullScan))
+        .WillOnce(testing::Return(spFullScan));
+
+    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    EXPECT_CALL(*spIndexerConnectorMock, scopeLock()).Times(1);
+    EXPECT_CALL(*spIndexerConnectorMock, flush()).Times(1);
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    std::shared_mutex mutexScanOrchestrator;
+
+    TScanOrchestrator<TrampolineTScanContext,
+                      TrampolineFactoryOrchestrator,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
+                      MockIndexerConnector,
+                      MockDatabaseFeedManager>
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, mutexScanOrchestrator);
+
+    Utils::RocksDBWrapper dataStore("/tmp/test_vd_empty_sync_scan");
+
+    uint64_t sessionId = 99998;
+
+    // Create context with VDSync option and NO packages
+    auto context = createTestContext(Wazuh::SyncSchema::Option_VDSync, {TEST_PACKAGE_INDEX});
+    context.sessionId = sessionId;
+
+    // Only add OS context, no packages
+    auto osMessage = createDataContextMessage(sessionId, TEST_OS_INDEX, "os001", OSINFO_JSON);
+    dataStore.put(std::format("{}_{}", sessionId, "001"),
+                  rocksdb::Slice(reinterpret_cast<const char*>(osMessage.data()), osMessage.size()));
+
+    // VDSync should proceed even with empty inventory (logs warning but continues)
+    EXPECT_NO_THROW(scanOrchestrator.runScan(dataStore, context));
 }


### PR DESCRIPTION
## Description

Adds a protection mechanism to avoid triggering the Vulnerability Detection first scan (VDFirstScan) multiple times for the same agent or scan cycle.

Under certain conditions, the first vulnerability scan flow could be executed more than once, generating duplicated processing and inconsistent scan state handling. This PR introduces safeguards to ensure the initial VD scan is performed only once when appropriate.

The change improves the stability and consistency of the vulnerability scanning workflow, especially during agent synchronization and startup scenarios.

## Proposed Changes

- Add validation logic to prevent duplicated execution of VDFirstScan.
- Ensure the first vulnerability scan state is handled atomically and consistently.
- Avoid duplicated scan scheduling/processing for the same agent.
- Improve resilience of the Vulnerability Detection pipeline during initialization and synchronization events.
- Reduce the risk of duplicated vulnerability inventory generation and unnecessary processing overhead.

### Results and Evidence

<img width="1493" height="775" alt="image" src="https://github.com/user-attachments/assets/bfd91884-2ee2-4068-bae5-5506b9d9fb08" />

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

- `VDFirstScan_EmptyPackageInventory_ShouldAbort`
- `VDSyncScan_EmptyPackageInventory_ShouldProceed`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues