### PR TITLE
Add support for 'authenticating' keyword in sshd-disconnect decoder

### DIFF
--- a/ruleset/decoders/0310-ssh_decoders.xml
+++ b/ruleset/decoders/0310-ssh_decoders.xml
@@ -230,9 +230,10 @@
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from user user 172.18.1.100 port 43042 -->
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnected from invalid user root 172.18.1.100 port 43042 -->
 <!-- 2020-03-24 08:38:47.230409-0700  localhost sshd[2531]: Disconnecting invalid user root 172.18.1.100 port 43042 -->
+<!-- Mar 31 12:32:30 localhost sshd[2548088]: Disconnecting authenticating user root 172.18.1.100 port 60158: Too many authentication failures [preauth] -->
 <decoder name="sshd-disconnect">
   <parent>sshd</parent>
-  <prematch type="pcre2">Disconnect(?:ed|ing) (?:from )?(?:invalid )?user </prematch>
+  <prematch type="pcre2">Disconnect(?:ed|ing) (?:authenticating )?(?:from )?(?:invalid )?user </prematch>
   <regex offset="after_prematch">^(\S+) (\S+) port (\d+)</regex>
   <order>srcuser,srcip,srcport</order>
 </decoder>

--- a/ruleset/testing/tests/sshd.ini
+++ b/ruleset/testing/tests/sshd.ini
@@ -170,6 +170,12 @@ rule = 5710
 alert = 5
 decoder = sshd
 
+[SSHD Disconnecting authenticating]
+log 1 pass = Mar 31 12:32:30 localhost sshd[2548088]: Disconnecting authenticating user root 172.18.1.100 port 60158: Too many authentication failures [preauth]
+rule = 2501
+alert = 5
+decoder = sshd
+
 [SSHD insecure connection attempt]
 log 1 pass = 2020-03-24 10:32:31.672920-0700  localhost sshd[5374]: Did not receive identification string from 172.18.1.1 port 45824
 rule = 5706


### PR DESCRIPTION
|Related issue|
|---|
|#28914|
## Description
The `sshd-disconnect` decoder's `prematch` PCRE2 pattern did not account for the `authenticating` keyword that OpenSSH includes in `Disconnecting authenticating user` log messages. As a result, those logs were not decoded and `srcuser`, `srcip`, and `srcport` fields were never extracted.
Added `(?:authenticating )?` as an optional non-capturing group to the prematch pattern:
**Before:**
```xml
<prematch type="pcre2">Disconnect(?:ed|ing) (?:from )?(?:invalid )?user </prematch>
```
**After:**
```xml
<prematch type="pcre2">Disconnect(?:ed|ing) (?:authenticating )?(?:from )?(?:invalid )?user </prematch>
```
## Configuration options
No new configuration parameters.
## Logs/Alerts example
**Before fix**: decoder does not match, no fields extracted:
```
**Phase 2: Completed decoding.
    No decoder matched.
```
**After fix**: decoder matches and correctly extracts all fields:
```
**Phase 2: Completed decoding.
    name: 'sshd'
    parent: 'sshd'
    srcip: '172.18.1.100'
    srcport: '60158'
    srcuser: 'root'
```
Tested with `wazuh-logtest` against the log from the issue:
```
Mar 31 12:32:30 localhost sshd[2548088]: Disconnecting authenticating user root 172.18.1.100 port 60158: Too many authentication failures [preauth]
```
All previously supported formats continue to decode correctly:
```
# Disconnected from user         -> Unit test OK
# Disconnected from invalid user -> Unit test OK
# Disconnecting invalid user     -> Unit test OK
```
## Tests
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors