### PR TITLE
Removal of unused dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Adapted Vulnerability Detector input pipeline to the new Wazuh 5.0 synchronization algorithm, covering first-scan, inventory-change, and feed-update scenarios. ([#30535](https://github.com/wazuh/wazuh/issues/30535))
 - Revamped Role-Based Access Control (RBAC) management and introduced an upgrade mechanism for existing RBAC configurations. ([#27706](https://github.com/wazuh/wazuh/issues/27706))
 - Removed legacy configuration surfaces, database schemas, build targets, and compatibility layers in the second server cleanup phase. ([#34608](https://github.com/wazuh/wazuh/issues/34608))
+- Reduced `wazuh-manager` Debian package dependencies, removed `adduser`, `lsb-release`, `debconf`, and `libc6`. ([#35881](https://github.com/wazuh/wazuh/issues/35881))
 
 #### Removed
 

--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.wazuh.com
 
 Package: wazuh-manager
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser, curl
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), curl
 Suggests: expect
 Conflicts: ossec-hids-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR intends to remove debian packaging dependencies that are either unused or do not make sense for them to be there because there are better alternatives. The dependencies audition and the research process is in the linked issue.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

View https://github.com/wazuh/wazuh/issues/35881#issuecomment-4419090554 to see the changes and justification of each change.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Manual tests with their corresponding evidence

<details> 
<summary> Clean install</summary>

```
root@Linux-Manager-3:/home/vagrant# dpkg -i wazuh-agent_5.0.0-0_amd64_00e9408.deb 
Selecting previously unselected package wazuh-agent.
(Reading database ... 166734 files and directories currently installed.)
Preparing to unpack wazuh-agent_5.0.0-0_amd64_00e9408.deb ...
Unpacking wazuh-agent (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...

● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/lib/systemd/system/wazuh-manager.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2026-05-11 10:56:54 UTC; 1min 31s ago
      Tasks: 166 (limit: 7056)
     Memory: 346.5M
        CPU: 17.303s
     CGroup: /system.slice/wazuh-manager.service
             ├─22632 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─22646 /var/wazuh-manager/bin/wazuh-manager-authd
             ├─22655 /var/wazuh-manager/bin/wazuh-manager-db
             ├─22672 /var/wazuh-manager/bin/wazuh-manager-analysisd
             ├─22888 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─22889 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─22892 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
             ├─22902 /var/wazuh-manager/bin/wazuh-manager-remoted
             ├─22932 /var/wazuh-manager/bin/wazuh-manager-monitord
             ├─22938 /var/wazuh-manager/bin/wazuh-manager-modulesd
             ├─23104 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/framework/scripts/wazuh_manager_clusterd.…
             ├─23111 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/framework/scripts/wazuh_manager_clusterd.…
             └─23113 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/framework/scripts/wazuh_manager_clusterd.…

May 11 10:56:50 Linux-Manager-3 env[22571]: Started wazuh-manager-apid...
May 11 10:56:50 Linux-Manager-3 env[22571]: Started wazuh-manager-authd...
May 11 10:56:50 Linux-Manager-3 env[22571]: Started wazuh-manager-db...
May 11 10:56:51 Linux-Manager-3 env[22571]: Started wazuh-manager-analysisd...
May 11 10:56:52 Linux-Manager-3 env[22571]: Started wazuh-manager-remoted...
May 11 10:56:52 Linux-Manager-3 env[22571]: Started wazuh-manager-monitord...
May 11 10:56:52 Linux-Manager-3 env[22571]: Started wazuh-manager-modulesd...
May 11 10:56:52 Linux-Manager-3 env[22571]: Started wazuh-manager-clusterd...
May 11 10:56:54 Linux-Manager-3 env[22571]: Completed.
May 11 10:56:54 Linux-Manager-3 systemd[1]: Started Wazuh manager.

● wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2026-05-11 10:56:23 UTC; 2min 22s ago
       Docs: https://documentation.wazuh.com
   Main PID: 22040 (java)
      Tasks: 193 (limit: 7056)
     Memory: 1.6G
        CPU: 2min 57.088s
     CGroup: /system.slice/wazuh-indexer.service
             ├─22040 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.net…
             └─22041 /usr/share/wazuh-indexer/engine/bin/wazuh-engine -f

May 11 10:56:04 Linux-Manager-3 wazuh-indexer[22040]: WARNING: Unknown module: org.apache.arrow.memory.core specified to -…d-opens
May 11 10:56:04 Linux-Manager-3 wazuh-indexer[22040]: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
May 11 10:56:04 Linux-Manager-3 wazuh-indexer[22040]: WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.b…nAction
May 11 10:56:04 Linux-Manager-3 wazuh-indexer[22040]: WARNING: Please consider reporting this to the maintainers of class …nAction
May 11 10:56:04 Linux-Manager-3 wazuh-indexer[22040]: WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a fut…release
May 11 10:56:06 Linux-Manager-3 wazuh-indexer[22040]: WARNING: A restricted method in java.lang.System has been called
May 11 10:56:06 Linux-Manager-3 wazuh-indexer[22040]: WARNING: java.lang.System::load has been called by org.bouncycastle.….2.jar)
May 11 10:56:06 Linux-Manager-3 wazuh-indexer[22040]: WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning f… module
May 11 10:56:06 Linux-Manager-3 wazuh-indexer[22040]: WARNING: Restricted methods will be blocked in a future release unle…enabled
May 11 10:56:23 Linux-Manager-3 systemd[1]: Started wazuh-indexer.
Hint: Some lines were ellipsized, use -l to show in full.

● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/lib/systemd/system/wazuh-dashboard.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2026-05-11 10:56:55 UTC; 2min 9s ago
   Main PID: 23468 (node)
      Tasks: 11 (limit: 7056)
     Memory: 190.4M
        CPU: 9.948s
     CGroup: /system.slice/wazuh-dashboard.service
             └─23468 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=w…

May 11 10:57:07 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:07Z","tags":["i… task"}
May 11 10:57:07 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:07Z","tags":["i…nts*]"}
May 11 10:57:14 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:14Z","tags":["i…re ok"}
May 11 10:57:14 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:14Z","tags":["i…000ms"}
May 11 10:57:14 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:14Z","tags":["i…savedOb
May 11 10:57:14 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:14Z","tags":["i…ibana"}
May 11 10:57:14 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:14Z","tags":["i…n: 01"}
May 11 10:57:14 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:14Z","tags":["i…921MB"}
May 11 10:57:15 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:15Z","tags":["l…0:443"}
May 11 10:57:15 Linux-Manager-3 opensearch-dashboards[23468]: {"type":"log","@timestamp":"2026-05-11T10:57:15Z","tags":["i…0:443"}
Hint: Some lines were ellipsized, use -l to show in full.

● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/lib/systemd/system/wazuh-agent.service; disabled; vendor preset: enabled)
     Active: active (running) since Mon 2026-05-11 11:09:09 UTC; 47s ago
    Process: 28252 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
    Process: 28337 ExecReload=/usr/bin/env /var/ossec/bin/wazuh-control reload (code=exited, status=0/SUCCESS)
      Tasks: 29 (limit: 7056)
     Memory: 189.8M
        CPU: 7.239s
     CGroup: /system.slice/wazuh-agent.service
             ├─28282 /var/ossec/bin/wazuh-agentd
             ├─28402 /var/ossec/bin/wazuh-execd
             ├─28413 /var/ossec/bin/wazuh-syscheckd
             ├─28421 /var/ossec/bin/wazuh-logcollector
             └─28431 /var/ossec/bin/wazuh-modulesd

May 11 11:09:24 Linux-Manager-3 env[28337]: Killing wazuh-execd...
May 11 11:09:25 Linux-Manager-3 env[28337]: Wazuh v5.0.0 Stopped
May 11 11:09:26 Linux-Manager-3 env[28337]: Starting Wazuh v5.0.0...
May 11 11:09:26 Linux-Manager-3 env[28337]: Started wazuh-execd...
May 11 11:09:26 Linux-Manager-3 env[28337]: wazuh-agentd already running...
May 11 11:09:26 Linux-Manager-3 env[28337]: Started wazuh-syscheckd...
May 11 11:09:27 Linux-Manager-3 env[28337]: Started wazuh-logcollector...
May 11 11:09:28 Linux-Manager-3 env[28337]: Started wazuh-modulesd...
May 11 11:09:30 Linux-Manager-3 env[28337]: Completed.
May 11 11:09:30 Linux-Manager-3 systemd[1]: Reloaded Wazuh agent.
```

---

```
root@Linux-Manager-3:/home/vagrant# curl -k -X GET "https://localhost:55000/agents?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "os": {
               "arch": "x86_64",
               "major": "22",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "type": "linux",
               "version": "22.04.5 LTS (Jammy Jellyfish)"
            },
            "ip": "192.168.56.15",
            "version": "v5.0.0",
            "node_name": "node01",
            "status_code": 0,
            "mergedSum": "ca35f9148a3273413eccb79f149f4757",
            "dateAdd": "2026-05-11T11:41:11+00:00",
            "lastKeepAlive": "2026-05-11T12:05:52+00:00",
            "name": "Linux-Manager-3",
            "id": "001",
            "registerIP": "any",
            "group": [
               "default"
            ],
            "group_config_status": "synced",
            "status": "active"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected agents information was returned",
   "error": 0
}

root@Linux-Manager-3:/home/vagrant# ls -la /var/ossec/
total 56
drwxr-x--- 13 root  wazuh 4096 May 11 11:40 .
drwxr-xr-x 15 root  root  4096 May 11 11:40 ..
-r--r-----  1 root  wazuh   73 May 11 08:54 VERSION.json
drwxr-x---  3 root  wazuh 4096 May 11 11:40 active-response
drwxr-x---  2 root  wazuh 4096 May 11 08:54 backup
drwxr-x---  2 root  root  4096 May 11 11:40 bin
drwxrwx---  3 root  wazuh 4096 May 11 11:41 etc
drwxr-x---  2 root  wazuh 4096 May 11 11:40 lib
drwxrwx---  3 wazuh wazuh 4096 May 11 11:41 logs
drwxrwx--- 10 wazuh wazuh 4096 May 11 11:40 queue
drwxr-x---  3 root  wazuh 4096 May 11 11:40 ruleset
drwxrwx--T  2 root  wazuh 4096 May 11 08:54 tmp
drwxr-x---  7 root  wazuh 4096 May 11 11:41 var
drwxr-x---  6 root  wazuh 4096 May 11 11:40 wodles

root@Linux-Manager-3:/home/vagrant# ls -la /var/wazuh-manager/
total 56
drwxr-x--- 13 root          wazuh-manager 4096 May 11 11:38 .
drwxr-xr-x 15 root          root          4096 May 11 11:40 ..
-r--r-----  1 root          wazuh-manager   73 May 11 09:59 VERSION.json
drwxr-x---  4 root          wazuh-manager 4096 May 11 11:37 api
drwxr-x---  3 root          wazuh-manager 4096 May 11 11:37 backup
drwxr-x---  2 root          wazuh-manager 4096 May 11 11:37 bin
drwxr-x---  7 wazuh-manager wazuh-manager 4096 May 11 11:37 data
drwxrwx---  5 root          wazuh-manager 4096 May 11 11:41 etc
drwxr-x---  5 root          wazuh-manager 4096 May 11 11:37 framework
drwxr-x---  2 root          wazuh-manager 4096 May 11 11:37 lib
drwxrwx---  5 wazuh-manager wazuh-manager 4096 May 11 11:40 logs
drwxrwx--- 13 wazuh-manager wazuh-manager 4096 May 11 11:41 queue
drwxrwx--T  2 root          wazuh-manager 4096 May 11 09:59 tmp
drwxr-x---  8 root          wazuh-manager 4096 May 11 11:40 var
```

<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/79cc1a92-79f3-46f1-b515-464d7013eac7" />

---

<img width="1915" height="865" alt="image" src="https://github.com/user-attachments/assets/376398a4-8768-4f3a-af03-d42a194fc4d9" />

<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/ba8fa4fe-0b17-4980-be98-6b64fe9bb3cd" />


---

<img width="1916" height="869" alt="image" src="https://github.com/user-attachments/assets/6b455d4a-005e-412b-b2a9-a8b3ea906a4e" />

<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/10c9f302-5251-4ab6-9501-64eafb998eeb" />

</details>

<details> 
<summary> Agent upgrade from previous version (4.14.5 -> 5.0)</summary>

```
root@Linux-Agent:/home/vagrant# dpkg -i wazuh-agent_5.0.0-0_amd64_213d43a.deb 
(Reading database ... 64374 files and directories currently installed.)
Preparing to unpack wazuh-agent_5.0.0-0_amd64_213d43a.deb ...
Unpacking wazuh-agent (5.0.0-0) over (4.14.5-1) ...
Setting up wazuh-agent (5.0.0-0) ...

Configuration file '/etc/init.d/wazuh-agent'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** wazuh-agent (Y/I/N/O/D/Z) [default=N] ? y
Installing new version of config file /etc/init.d/wazuh-agent ...
Processing triggers for systemd (245.4-4ubuntu3.24) ...

root@Linux-Agent:/home/vagrant# ls -la /var/ossec/
total 56
drwxr-x--- 13 root  wazuh 4096 May 13 10:13 .
drwxr-xr-x 14 root  root  4096 May 13 10:12 ..
-r--r-----  1 root  wazuh   73 May 13 09:52 VERSION.json
drwxr-x---  3 root  wazuh 4096 May 13 10:12 active-response
drwxr-x---  2 root  wazuh 4096 Apr 16 12:49 backup
drwxr-x---  2 root  root  4096 May 13 10:13 bin
drwxrwx---  3 root  wazuh 4096 May 13 10:13 etc
drwxr-x---  2 root  wazuh 4096 May 13 10:13 lib
drwxrwx---  3 wazuh wazuh 4096 May 13 10:12 logs
drwxrwx--- 10 wazuh wazuh 4096 May 13 10:13 queue
drwxr-x---  3 root  wazuh 4096 May 13 10:12 ruleset
drwxrwx--T  2 root  wazuh 4096 Apr 16 12:49 tmp
drwxr-x---  7 root  wazuh 4096 May 13 10:13 var
drwxr-x---  6 root  wazuh 4096 May 13 10:13 wodles

root@Linux-Agent:/home/vagrant# systemctl status wazuh-agent --no-pager -l
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/lib/systemd/system/wazuh-agent.service; disabled; vendor preset: enabled)
     Active: active (running) since Wed 2026-05-13 10:13:34 UTC; 6s ago
    Process: 5002 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exited, status=0/SUCCESS)
      Tasks: 11 (limit: 3531)
     Memory: 10.4M
     CGroup: /system.slice/wazuh-agent.service
             ├─5038 /var/ossec/bin/wazuh-execd
             ├─5048 /var/ossec/bin/wazuh-agentd
             ├─5061 /var/ossec/bin/wazuh-syscheckd
             ├─5074 /var/ossec/bin/wazuh-logcollector
             └─5086 /var/ossec/bin/wazuh-modulesd

May 13 10:13:29 Linux-Agent env[5058]: 2026/05/13 10:13:29 wazuh-syscheckd: WARNING: (1202): Configuration error at 'etc/ossec.conf'.
May 13 10:13:29 Linux-Agent env[5058]: 2026/05/13 10:13:29 wazuh-syscheckd: WARNING: (1207): wazuh-rootcheck remote configuration in 'etc/ossec.conf' is corrupted.
May 13 10:13:30 Linux-Agent env[5002]: Started wazuh-syscheckd...
May 13 10:13:31 Linux-Agent env[5002]: Started wazuh-logcollector...
May 13 10:13:31 Linux-Agent env[5083]: 2026/05/13 10:13:31 wazuh-modulesd: ERROR: Unknown module 'cis-cat'
May 13 10:13:31 Linux-Agent env[5083]: 2026/05/13 10:13:31 wazuh-modulesd: ERROR: Unknown module 'osquery'
May 13 10:13:31 Linux-Agent env[5083]: 2026/05/13 10:13:31 wazuh-modulesd:sca: WARNING: Detected a deprecated configuration for SCA: 'skip_nfs' is no longer available.
May 13 10:13:32 Linux-Agent env[5002]: Started wazuh-modulesd...
May 13 10:13:34 Linux-Agent env[5002]: Completed.
May 13 10:13:34 Linux-Agent systemd[1]: Started Wazuh agent.

root@Linux-Manager-3:/home/vagrant# curl -k -X GET "https://localhost:55000/agents?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "os": {
               "arch": "x86_64",
               "major": "22",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "type": "linux",
               "version": "22.04.5 LTS (Jammy Jellyfish)"
            },
            "version": "v5.0.0",
            "dateAdd": "2026-05-13T10:29:33+00:00",
            "registerIP": "any",
            "node_name": "node01",
            "group_config_status": "synced",
            "group": [
               "default"
            ],
            "lastKeepAlive": "2026-05-13T10:32:53+00:00",
            "mergedSum": "ca35f9148a3273413eccb79f149f4757",
            "status": "active",
            "name": "Linux-Manager-3",
            "ip": "192.168.56.15",
            "status_code": 0,
            "id": "001"
         },
         {
            "os": {
               "arch": "x86_64",
               "major": "20",
               "minor": "04",
               "name": "Ubuntu",
               "platform": "ubuntu",
               "type": "linux",
               "version": "20.04.6 LTS (Focal Fossa)"
            },
            "version": "v5.0.0",
            "dateAdd": "2026-05-13T10:30:09+00:00",
            "registerIP": "any",
            "node_name": "node01",
            "group_config_status": "synced",
            "group": [
               "default"
            ],
            "lastKeepAlive": "2026-05-13T10:32:37+00:00",
            "mergedSum": "ca35f9148a3273413eccb79f149f4757",
            "status": "active",
            "name": "Linux-Agent",
            "ip": "192.168.56.10",
            "status_code": 0,
            "id": "002"
         }
      ],
      "total_affected_items": 2,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected agents information was returned",
   "error": 0
}
```

<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/26606f69-a92b-4b9d-b8bb-0a0fcaba9450" />

---

<img width="1916" height="867" alt="image" src="https://github.com/user-attachments/assets/fa85ef12-1416-400f-bf9e-94a633178418" />

<img width="1916" height="864" alt="image" src="https://github.com/user-attachments/assets/393da0b7-6b93-4548-b58d-f0adce051773" />


---

<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/6322049b-893e-47d3-bb28-27fca6843f0b" />

<img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/71137bec-19c0-422c-baaa-8f43de50541d" />


</details>

<details>
<summary> Purge/remove clean 5.0 agent</summary>

```
root@Linux-Manager-3:/home/vagrant# dpkg -r wazuh-agent
(Reading database ... 174361 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
root@Linux-Manager-3:/home/vagrant# ls /var/ossec/
etc  packages_files

root@Linux-Manager-3:/home/vagrant# dpkg --purge wazuh-agent
(Reading database ... 173999 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...

root@Linux-Manager-3:/home/vagrant# ls /var/ossec/
ls: cannot access '/var/ossec/': No such file or directory
```


</details>

<details>
<summary> Purge/remove upgraded agent</summary>

```
root@Linux-Agent:/home/vagrant# dpkg -r wazuh-agent
(Reading database ... 70415 files and directories currently installed.)
Removing wazuh-agent (5.0.0-0) ...
root@Linux-Agent:/home/vagrant# ls /var/ossec/
etc  packages_files
root@Linux-Agent:/home/vagrant# dpkg --purge wazuh-agent
(Reading database ... 70053 files and directories currently installed.)
Purging configuration files for wazuh-agent (5.0.0-0) ...
dpkg: warning: while removing wazuh-agent, directory '/usr/lib/systemd/system' not empty so not removed
Processing triggers for systemd (245.4-4ubuntu3.24) ...
root@Linux-Agent:/home/vagrant# ls /var/ossec/
ls: cannot access '/var/ossec/': No such file or directory
```

</details>

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

### Artifacts Affected

See https://github.com/wazuh/wazuh/issues/35881#issuecomment-4405686407 (excluding curl section) to check all artifacts that have changed.

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
