### PR TITLE
Prevent segfault when stopping disabled vulnerability scanner module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Improved message decompression handling in remoted. ([#35773](https://github.com/wazuh/wazuh/pull/35773))
 - Improved agent name validation to reject names starting with dot. ([#4503](https://github.com/wazuh/internal-devel-requests/issues/4503))
+- Fixed segfault in vulnerability scanner module shutdown when disabled. ([#36011](https://github.com/wazuh/wazuh/pull/36011))
 
 
 ## [v4.14.5]

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -605,6 +605,9 @@ void VulnerabilityScannerFacade::start(
         // Event dispatcher initialization.
         initEventDispatcher();
 
+        // Mark as fully initialized
+        m_fullyInitialized = true;
+
         logInfo(WM_VULNSCAN_LOGTAG, "Vulnerability scanner module started.");
     }
     catch (const std::exception& e)
@@ -639,10 +642,21 @@ void VulnerabilityScannerFacade::stop()
         m_managerThread.join();
     }
 
+    // Always cleanup m_databaseFeedManager if it exists, even on partial initialization
+    if (m_databaseFeedManager)
+    {
+        m_databaseFeedManager->teardown();
+        m_databaseFeedManager.reset();
+    }
+
+    // Only perform full cleanup if the module was fully initialized
+    if (!m_fullyInitialized)
+    {
+        return;
+    }
+
     // Reset shared pointers
     m_indexerConnector.reset();
-    m_databaseFeedManager->teardown();
-    m_databaseFeedManager.reset();
     m_syscollectorRsyncSubscription.reset();
     m_syscollectorDeltasSubscription.reset();
     m_wdbAgentEventsSubscription.reset();
@@ -654,4 +668,7 @@ void VulnerabilityScannerFacade::stop()
 
     // Destroy socketDbWrapper
     SocketDBWrapper::instance().teardown();
+
+    // Reset initialization flag
+    m_fullyInitialized = false;
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -238,6 +238,7 @@ private:
     std::shared_mutex m_internalMutex;
     std::condition_variable m_retryWait;
     std::mutex m_retryMutex;
+    bool m_fullyInitialized {false};
 };
 
 #endif // _VULNERABILITY_SCANNER_FACADE_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp
@@ -60,3 +60,22 @@ TEST_F(VulnerabilityScannerFacadeTest, TestStartToEndMethod)
 
     EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());
 }
+
+/*
+ * @brief Test stop method when module is disabled (start returns early).
+ */
+TEST_F(VulnerabilityScannerFacadeTest, TestStopAfterDisabledModuleStart)
+{
+    // Configure with vulnerability detection disabled
+    nlohmann::json configuration;
+    configuration["vulnerability-detection"]["enabled"] = "no";
+
+    auto& vulnerabilityScannerFacade {VulnerabilityScannerFacade::instance()};
+
+    // Start with disabled configuration - this returns early without initializing m_databaseFeedManager
+    EXPECT_NO_THROW(vulnerabilityScannerFacade.start(logFunction, configuration));
+
+    // Stop should not crash even though m_databaseFeedManager was never initialized
+    // Before fix: this would segfault with null pointer dereference at offset 0xacd86
+    EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());
+}


### PR DESCRIPTION
## Description

Fixes a deterministic segfault (null pointer dereference) in `wazuh-modulesd` when the vulnerability scanner module is disabled. The crash occurs at a fixed offset (0xacd86) within `libvulnerability_scanner.so` during module shutdown.

Thanks to @imaginacrea for reporting this bug.

### Root cause

When `<vulnerability-detection><enabled>no</enabled>` is set in `ossec.conf`, the `VulnerabilityScannerFacade::start()` method returns early before initializing `m_databaseFeedManager`. However, the `stop()` method unconditionally calls `m_databaseFeedManager->teardown()`, causing a null pointer dereference.

**Regression introduced in:** https://github.com/wazuh/wazuh/pull/30627

## Proposed Changes

### Code Changes

Added initialization tracking to prevent cleanup of uninitialized resources when the module is disabled:

**Files modified:**
- `src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp`
- `src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp`
- `src/wazuh_modules/vulnerability_scanner/tests/component/vulnerabilityScannerFacade_test.cpp`

**1. Added initialization flag (`vulnerabilityScannerFacade.hpp`):**
```cpp
bool m_fullyInitialized {false};
```

**2. Set flag after successful initialization (`vulnerabilityScannerFacade.cpp:608`):**
```cpp
// Event dispatcher initialization.
initEventDispatcher();

// Mark as fully initialized
m_fullyInitialized = true;
```

**3. Early return in stop() if not fully initialized (`vulnerabilityScannerFacade.cpp:645`):**
```cpp
void VulnerabilityScannerFacade::stop()
{
    // ... thread cleanup ...

    // Only perform full cleanup if the module was fully initialized
    if (!m_fullyInitialized)
    {
        return;
    }

    // ... resource cleanup (m_databaseFeedManager, SocketDBWrapper, etc.) ...

    // Reset initialization flag
    m_fullyInitialized = false;
}
```

**4. Added regression test (`vulnerabilityScannerFacade_test.cpp`):**
```cpp
TEST_F(VulnerabilityScannerFacadeTest, TestStopAfterDisabledModuleStart)
{
    nlohmann::json configuration;
    configuration["vulnerability-detection"]["enabled"] = "no";

    auto& vulnerabilityScannerFacade {VulnerabilityScannerFacade::instance()};

    EXPECT_NO_THROW(vulnerabilityScannerFacade.start(logFunction, configuration));
    EXPECT_NO_THROW(vulnerabilityScannerFacade.stop());  // Should not crash
}
```

### Results and Evidence

**Before the fix:**
- Segfaults occurred ~5.4 times per day on average with vulnerability scanner disabled
- All 35 crashes observed at deterministic offset 0xacd86 (null pointer dereference)
- Error signature: `segfault at 50 ip ... error 6 in libvulnerability_scanner.so[acd86,...]`
- GDB backtrace confirms: `TDatabaseFeedManager::teardown (this=0x0)` at line 798, called from `VulnerabilityScannerFacade::stop()` at line 644

**Crash analysis:**
```
Frame #0: TDatabaseFeedManager::teardown (this=0x0)
          at databaseFeedManager.hpp:798
          798   m_shouldStop = true;  // Writing to offset 0x50 through nullptr

Frame #1: VulnerabilityScannerFacade::stop()
          at vulnerabilityScannerFacade.cpp:644
          644   m_databaseFeedManager->teardown();  // No null check!
```

**After the fix:**
- ✅ Graceful shutdown works correctly with vulnerability scanner **disabled**
- ✅ Graceful shutdown preserved when module is **enabled**
- ✅ No segfaults in kernel logs after multiple restarts
- ✅ Clean stop sequence logged in `ossec.log`:

```
2026/05/11 10:04:38 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2026/05/11 10:04:38 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/05/11 10:04:38 wazuh-modulesd:syscollector: INFO: Module finished.
2026/05/11 10:04:38 wazuh-modulesd:vulnerability-scanner: INFO: Stopping vulnerability_scanner module.
2026/05/11 10:04:38 wazuh-modulesd:router: INFO: Stopping router module.
2026/05/11 10:04:38 wazuh-modulesd:content_manager: INFO: Stopping content_manager module.
2026/05/11 10:04:38 wazuh-modulesd:inventory-harvester: INFO: Stopping inventory_harvester module.
2026/05/11 10:04:38 logger-helper: INFO: Inventory harvester module stopped.
```

### Artifacts Affected

- Vulnerability Scanner Module `libvulnerability_scanner.so`

### Configuration Changes

None. The fix allows the existing configuration with `<vulnerability-detection><enabled>no</enabled>` to work correctly without segfaults.

### Documentation Updates

None required. This fix restores expected behavior when the module is disabled as documented.

### Tests Introduced

**Automated regression test:**

Added component test `VulnerabilityScannerFacadeTest.TestStopAfterDisabledModuleStart` in `vulnerabilityScannerFacade_test.cpp` that verifies the fix:

**Test description:**
- Configures vulnerability scanner as disabled (`enabled=no`)
- Calls `start()` which returns early without full initialization
- Calls `stop()` and verifies no segfault occurs
- **Result:** ✅ Test passes with the fix, ❌ fails with SEGV without the fix

**How to run:**
```bash
cd src/build
make vulnerability_scanner_component_tests
./wazuh_modules/vulnerability_scanner/tests/component/vulnerability_scanner_component_tests \
  --gtest_filter=VulnerabilityScannerFacadeTest.TestStopAfterDisabledModuleStart
```

**Test results:**
```
[==========] Running 5 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 2 tests from DatabaseFeedManagerTest
[ RUN      ] DatabaseFeedManagerTest.TestInstantiationOfTheDatabaseFeedManagerClass
[  SKIPPED ] DatabaseFeedManagerTest.TestInstantiationOfTheDatabaseFeedManagerClass (0 ms)
[ RUN      ] DatabaseFeedManagerTest.TestUpdateOfTheDatabaseFeedManagerClass
[  SKIPPED ] DatabaseFeedManagerTest.TestUpdateOfTheDatabaseFeedManagerClass (0 ms)
[----------] 2 tests from DatabaseFeedManagerTest (0 ms total)

[----------] 3 tests from VulnerabilityScannerFacadeTest
[ RUN      ] VulnerabilityScannerFacadeTest.TestSingletonOfTheVulnerabilityScannerFacadeClass
[       OK ] VulnerabilityScannerFacadeTest.TestSingletonOfTheVulnerabilityScannerFacadeClass (0 ms)
[ RUN      ] VulnerabilityScannerFacadeTest.TestStartToEndMethod
[  SKIPPED ] VulnerabilityScannerFacadeTest.TestStartToEndMethod (0 ms)
[ RUN      ] VulnerabilityScannerFacadeTest.TestStopAfterDisabledModuleStart
[       OK ] VulnerabilityScannerFacadeTest.TestStopAfterDisabledModuleStart (0 ms)
[----------] 3 tests from VulnerabilityScannerFacadeTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 2 tests.
[  SKIPPED ] 3 tests, listed below:
[  SKIPPED ] DatabaseFeedManagerTest.TestInstantiationOfTheDatabaseFeedManagerClass
[  SKIPPED ] DatabaseFeedManagerTest.TestUpdateOfTheDatabaseFeedManagerClass
[  SKIPPED ] VulnerabilityScannerFacadeTest.TestStartToEndMethod
```

**Manual verification with GDB:**

The fix was verified by reproducing the segfault in affected versions and confirming it's resolved with the fix:

1. **Reproduce on v4.14.5 (before fix):**
   ```bash
   # Configure with vulnerability detection disabled
   vim /var/ossec/etc/ossec.conf  # Set <enabled>no</enabled>

   # Run under GDB
   gdb --args /var/ossec/bin/wazuh-modulesd -f
   (gdb) run
   # ... wait for startup ...
   # Send SIGTERM (Ctrl+C)

   # Result: SEGFAULT
   Thread 1 "wazuh-modulesd" received signal SIGSEGV, Segmentation fault.
   0x00007fffe4531a8c in TDatabaseFeedManager::teardown (this=0x0)
   ```

2. **Reproduce on v4.14.6 (before fix):**
   - Same procedure, same result: SEGFAULT at `TDatabaseFeedManager::teardown (this=0x0)`

3. **Verify fix (this branch):**
   ```bash
   # Apply fix and rebuild
   cd src/build
   make vulnerability_scanner

   # Run under GDB with same configuration
   gdb --args /var/ossec/bin/wazuh-modulesd -f
   (gdb) run
   # ... wait for startup ...
   # Send SIGTERM (Ctrl+C)

   # Result: CLEAN SHUTDOWN (no segfault)
   2026/05/11 10:04:38 wazuh-modulesd: INFO: Shutting down Wazuh modules.
   2026/05/11 10:04:38 wazuh-modulesd:vulnerability-scanner: INFO: Stopping vulnerability_scanner module.
   [Inferior 1 (process xxx) exited normally]
   ```

**Verified on versions:**
- ❌ v4.14.5: Segfaults on shutdown with disabled module
- ❌ v4.14.6: Segfaults on shutdown with disabled module
- ✅ With fix applied: Clean shutdown, no segfault

## Review Checklist

- [ ] Code changes reviewed - Added initialization tracking flag and early return in stop() to prevent cleanup of uninitialized resources
- [ ] Relevant evidence provided - Issue #36008 contains detailed crash analysis with 35 segfault samples at deterministic offset, plus GDB backtrace confirmation
- [ ] Tests cover the new functionality - Automated regression test added and passing
- [ ] Configuration changes documented - No configuration changes required
- [ ] Developer documentation reflects the changes - No documentation updates needed (bug fix restores documented behavior)
- [ ] Meets requirements and/or definition of done - Fixes the reported segfault when module is disabled
- [ ] No unresolved dependencies with other issues - Standalone fix