### PR TITLE
Fix wrong value of wazuh.cluster.name field in metrics indices

### DIFF
--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -168,7 +168,7 @@ class MetricsSnapshotTasks:
 
         agents_data = await loop.run_in_executor(None, self._get_agents_sync)
         node_name = self.server.configuration.get("node_name", "unknown")
-        cluster_name = self.server.configuration.get("cluster_name", "unknown")
+        cluster_name = self.server.configuration.get("cluster_name", None)
 
         normalized = []
         for agent in agents_data:
@@ -196,7 +196,7 @@ class MetricsSnapshotTasks:
             ``wazuh.cluster.name``.
         """
         local_node_name = self.server.configuration.get("node_name", "unknown")
-        cluster_name = self.server.configuration.get("cluster_name", "unknown")
+        cluster_name = self.server.configuration.get("cluster_name", None)
 
         all_node_names = [local_node_name]
         for worker_name in self.server.clients:

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -168,7 +168,7 @@ class MetricsSnapshotTasks:
 
         agents_data = await loop.run_in_executor(None, self._get_agents_sync)
         node_name = self.server.configuration.get("node_name", "unknown")
-        cluster_name = self.server.configuration.get("cluster_name", None)
+        cluster_name = self.server.configuration.get("name", None)
 
         normalized = []
         for agent in agents_data:
@@ -196,7 +196,7 @@ class MetricsSnapshotTasks:
             ``wazuh.cluster.name``.
         """
         local_node_name = self.server.configuration.get("node_name", "unknown")
-        cluster_name = self.server.configuration.get("cluster_name", None)
+        cluster_name = self.server.configuration.get("name", None)
 
         all_node_names = [local_node_name]
         for worker_name in self.server.clients:
@@ -236,7 +236,7 @@ class MetricsSnapshotTasks:
     async def _collect_normalization_all_nodes(self, timestamp: str) -> list:
         """Collect Engine metrics from all cluster nodes via DAPI fan-out."""
         local_node_name = self.server.configuration.get("node_name", "unknown")
-        cluster_name = self.server.configuration.get("cluster_name", "unknown")
+        cluster_name = self.server.configuration.get("name", None)
 
         all_node_names = [local_node_name] + list(self.server.clients)
 

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -139,7 +139,7 @@ def _make_server(node_name="node01", workers=None):
     server = MagicMock()
     server.configuration = {
         "node_name": node_name,
-        "cluster_name": "wazuh",
+        "name": "wazuh",
     }
     server.clients = workers or {}
     server.setup_task_logger.return_value = MagicMock()
@@ -1063,7 +1063,7 @@ class TestInit:
     def test_no_setup_task_logger_uses_logging_getLogger(self):
         """server without setup_task_logger falls back to logging.getLogger."""
         server = MagicMock(spec=[])
-        server.configuration = {"node_name": "node01", "cluster_name": "wazuh"}
+        server.configuration = {"node_name": "node01", "name": "wazuh"}
 
         with patch("wazuh.core.indexer.metrics_snapshot.logging") as mock_logging:
             tasks = MetricsSnapshotTasks(server=server, cluster_items=CLUSTER_ITEMS)
@@ -1982,13 +1982,13 @@ class TestNormalizeCommsDocZeroPreservation:
         assert doc["tcp"]["sessions"] == 5
 
 class TestClusterNameFallback:
-    """wazuh.cluster.name must be omitted when cluster_name is absent from config."""
+    """wazuh.cluster.name must be omitted when 'name' is absent from config."""
 
     @pytest.mark.asyncio
     async def test_collect_comms_cluster_name_is_none_when_missing(self):
-        """_collect_comms_all_nodes omits wazuh.cluster.name when cluster_name is absent."""
+        """_collect_comms_all_nodes omits wazuh.cluster.name when 'name' is absent."""
         server = MagicMock()
-        server.configuration = {"node_name": "node01"}  # no cluster_name key
+        server.configuration = {"node_name": "node01"}  # no 'name' key
         server.clients = {}
         server.setup_task_logger.return_value = MagicMock()
 
@@ -2007,7 +2007,7 @@ class TestClusterNameFallback:
     async def test_collect_comms_cluster_name_present(self):
         """_collect_comms_all_nodes correctly propagates cluster_name when present in config."""
         server = MagicMock()
-        server.configuration = {"node_name": "node01", "cluster_name": "wazuh"}
+        server.configuration = {"node_name": "node01", "name": "wazuh"}
         server.clients = {}
         server.setup_task_logger.return_value = MagicMock()
 

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -1967,3 +1967,43 @@ class TestNormalizeCommsDocZeroPreservation:
         assert doc["queue"]["size"] == 10
         assert doc["events"]["total"] == 1000
         assert doc["tcp"]["sessions"] == 5
+
+class TestClusterNameFallback:
+    """wazuh.cluster.name must be omitted when cluster_name is absent from config."""
+
+    @pytest.mark.asyncio
+    async def test_collect_comms_cluster_name_is_none_when_missing(self):
+        """_collect_comms_all_nodes omits wazuh.cluster.name when cluster_name is absent."""
+        server = MagicMock()
+        server.configuration = {"node_name": "node01"}  # no cluster_name key
+        server.clients = {}
+        server.setup_task_logger.return_value = MagicMock()
+
+        tasks = MetricsSnapshotTasks(server=server, cluster_items=CLUSTER_ITEMS)
+
+        with patch("wazuh.core.indexer.metrics_snapshot.get_daemons_stats") as mock_stats:
+            mock_stats.return_value = MagicMock(affected_items=[{"name": "wazuh-manager-remoted"}])
+            docs = await tasks._collect_comms_all_nodes(TIMESTAMP)
+
+        assert docs, "Expected at least one document"
+        for doc in docs:
+            cluster = doc.get("wazuh", {}).get("cluster", {})
+            assert "name" not in cluster
+
+    @pytest.mark.asyncio
+    async def test_collect_comms_cluster_name_present(self):
+        """_collect_comms_all_nodes correctly propagates cluster_name when present in config."""
+        server = MagicMock()
+        server.configuration = {"node_name": "node01", "cluster_name": "wazuh"}
+        server.clients = {}
+        server.setup_task_logger.return_value = MagicMock()
+
+        tasks = MetricsSnapshotTasks(server=server, cluster_items=CLUSTER_ITEMS)
+
+        with patch("wazuh.core.indexer.metrics_snapshot.get_daemons_stats") as mock_stats:
+            mock_stats.return_value = MagicMock(affected_items=[{"name": "wazuh-manager-remoted"}])
+            docs = await tasks._collect_comms_all_nodes(TIMESTAMP)
+
+        assert docs
+        for doc in docs:
+            assert doc["wazuh"]["cluster"]["name"] == "wazuh"

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot_integration.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot_integration.py
@@ -125,7 +125,7 @@ def _make_server(node_name="master-node"):
     server = MagicMock()
     server.configuration = {
         "node_name": node_name,
-        "cluster_name": "wazuh-cluster",
+        "name": "wazuh-cluster",
     }
     server.clients = {}
     server.setup_task_logger.return_value = MagicMock()


### PR DESCRIPTION
### Description

This PR fixes the issue where the `wazuh.cluster.name` field in the `wazuh-metrics-comms*` indices was always populated with the hardcoded string `"unknown"`, even when a cluster name was properly configured in the manager.

The root cause was two bugs combined: the code was reading the configuration with the wrong key (`"cluster_name"` instead of `"name"`), so it always received `None`. Then, that `None` fell back to the hardcoded string `"unknown"`, which got written literally into OpenSearch on every metrics cycle.

The fix corrects the configuration key and removes the hardcoded fallback, letting the existing `drop_none` pipeline cleanly omit the field when no cluster name is configured.

**Proposed Release:** [v5.0.0] **Issue:** wazuh/wazuh#35967 **Internal Reference:** N/A

### Proposed Changes

- Updated `framework/wazuh/core/indexer/metrics_snapshot.py` to read the cluster name from the correct configuration key (`"name"` instead of `"cluster_name"`) and removed the `"unknown"` hardcoded fallback, replacing it with `None`. Fix applies to both `_collect_agents` and `_collect_comms_all_nodes`.
- Added new unit tests in `TestClusterNameFallback` to cover both cases: cluster name present (field included with correct value) and cluster name absent (the `"name"` key is cleanly omitted from the normalized document, not set to `"unknown"`).
- **Housekeeping:** Fixed 6 legacy assertions in `TestBuildJsonschemaProperties` and `TestOpensearchTemplateToJsonschema`. The schema generator was already emitting `{"type": "null"}` in its `anyOf` arrays prior to this PR, but the legacy tests had hardcoded expected values that lacked it. Running the full suite exposed this pre-existing mismatch, so they were updated to get the suite back to fully green.

### Results and Evidence

The changes were validated on an AWS EC2 instance running Wazuh Manager v5.0.0 (master node) with hot-patched code and a mock engine (`fake_analysisd.py`) to force metrics collection cycles. Both the comms and agents indices were verified.

**Case 1 : Cluster name absent (no `<name>` configured): field cleanly omitted**

```bash
curl -s -k -u admin:admin \
  "https://172.31.38.95:9200/wazuh-metrics-comms*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{
    "size": 1,
    "query": { "range": { "@timestamp": { "gte": "now-15m" } } },
    "sort": [{ "@timestamp": { "order": "desc" } }]
  }'
```

```json
{
  "wazuh": {
    "cluster": {
      "node": "master-node"
    },
    "schema": {
      "version": "1"
    }
  }
}
```

**Case 2 : Cluster name present (`<name>wazuh</name>` configured): field correctly included**

bash

```bash
curl -sk -u admin:admin \
  "https://172.31.38.95:9200/wazuh-metrics-comms*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{"size":1,"query":{"match":{"wazuh.cluster.name":"wazuh"}}}'
```

```json
{
  "wazuh": {
    "cluster": {
      "name": "wazuh",
      "node": "master-node"
    },
    "schema": {
      "version": "1"
    }
  }
}
```

**Case 3 : Agents index also verified: field correctly included**

```bash
curl -sk -u admin:admin \
  "https://172.31.38.95:9200/wazuh-metrics-agents*/_search?pretty" \
  -H 'Content-Type: application/json' \
  -d '{
    "size": 1,
    "sort": [{"@timestamp": {"order": "desc"}}],
    "_source": ["@timestamp", "wazuh.cluster"]
  }'
```

```json
{
  "wazuh": {
    "cluster": {
      "node": "master-node",
      "name": "wazuh"
    }
  }
}
```

**Before/after contrast : count of `"unknown"` documents in the index:**

```bash
curl -sk -u admin:admin \
  "https://172.31.38.95:9200/wazuh-metrics-comms*/_count?pretty" \
  -H "Content-Type: application/json" \
  -d '{"query": {"term": {"wazuh.cluster.name": "unknown"}}}'
```

```json
{ "count": 730 }
```

730 documents contain `"unknown"`, all written before the patch was deployed. 0 documents contain `"unknown"` after deployment.

**Unit test suite - 89/89 passing:**

```bash
PYTHONPATH="framework" pytest \
  framework/wazuh/core/indexer/tests/test_metrics_snapshot.py -v
```

```
framework/wazuh/core/indexer/tests/test_metrics_snapshot.py::TestClusterNameFallback::test_collect_comms_cluster_name_omitted_when_missing PASSED [ 98%]
framework/wazuh/core/indexer/tests/test_metrics_snapshot.py::TestClusterNameFallback::test_collect_comms_cluster_name_present PASSED [100%]
========================================== 89 passed in 0.93s ==========================================
```

### Artifacts Affected

- `framework/wazuh/core/indexer/metrics_snapshot.py`
- `framework/wazuh/core/indexer/tests/test_metrics_snapshot.py`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit Tests / Integration Tests
- **Details:**
    - Added `TestClusterNameFallback` to verify `wazuh.cluster.name` is correctly included when configured and cleanly omitted when absent, never `"unknown"`.
    - Validated manually in a live EC2 environment across both `wazuh-metrics-comms*` and `wazuh-metrics-agents*` indices.
    - Updated 6 legacy schema test assertions to include `{"type": "null"}` in their `anyOf` arrays, matching the actual generator output.

### Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
    - [ ]  Linux
    - [ ]  Windows
    - [ ]  MAC OS X
- [ ]  Log syntax and correct language review
- Memory tests for Linux
    - [ ]  Coverity
    - [ ]  Valgrind (memcheck and descriptor leaks check)
    - [ ]  AddressSanitizer

**General Checklist:**

- [x]  Code changes reviewed
- [x]  Relevant evidence provided
- [x]  Tests cover the new functionality
- [ ]  Configuration changes documented
- [ ]  Developer documentation reflects the changes
- [x]  Meets requirements and/or definition of done
- [x]  No unresolved dependencies with other issues