### PR TITLE
Dependency Reduction Evidence — Debian/Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - Updated logcollector file-tailing initial read strategy for more consistent behavior across log rotation scenarios. ([#33382](https://github.com/wazuh/wazuh/issues/33382))
 - Updated Windows Event Channel log collection to emit native XML from `EvtRender()` without an XML declaration header. ([#34462](https://github.com/wazuh/wazuh/issues/34462))
 - Increased default limits for agent event throughput and inventory message sizes. ([#35330](https://github.com/wazuh/wazuh/issues/35330))
+- Reduced `wazuh-agent` Debian package dependencies, removed `adduser`, `lsb-release`, and `debconf`. ([#35880](https://github.com/wazuh/wazuh/issues/35880))
 
 #### Removed
 
@@ -65,12 +66,6 @@ All notable changes to this project will be documented in this file.
 - Fixed FIM inventory reporting file modification time as 1970-01-01. ([#35162](https://github.com/wazuh/wazuh/issues/35162))
 - Fixed agent automatic reload failing after receiving centralized configuration. ([#35169](https://github.com/wazuh/wazuh/issues/35169))
 - Fixed syscollector false positive package detection on macOS. ([#35248](https://github.com/wazuh/wazuh/issues/35248))
-
-### Packages
-
-#### Changed
-
-- Reduced `wazuh-agent` Debian package dependencies by removing `adduser`, `lsb-release`, and `debconf`, replacing them with POSIX-standard utilities from `passwd` (`useradd`, `groupadd`, `userdel`, `groupdel`) and `/etc/os-release` from `base-files`, both guaranteed present on any Debian-based system. ([#35880](https://github.com/wazuh/wazuh/issues/35880))
 
 ## [v4.14.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ All notable changes to this project will be documented in this file.
 - Fixed agent automatic reload failing after receiving centralized configuration. ([#35169](https://github.com/wazuh/wazuh/issues/35169))
 - Fixed syscollector false positive package detection on macOS. ([#35248](https://github.com/wazuh/wazuh/issues/35248))
 
+### Packages
+
+#### Changed
+
+- Reduced `wazuh-agent` Debian package dependencies by removing `adduser`, `lsb-release`, and `debconf`, replacing them with POSIX-standard utilities from `passwd` (`useradd`, `groupadd`, `userdel`, `groupdel`) and `/etc/os-release` from `base-files`, both guaranteed present on any Debian-based system. ([#35880](https://github.com/wazuh/wazuh/issues/35880))
+
 ## [v4.14.6]
 
 ## [v4.14.5]

--- a/packages/debs/SPECS/wazuh-agent/debian/control
+++ b/packages/debs/SPECS/wazuh-agent/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.wazuh.com
 
 Package: wazuh-agent
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser, procps
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), procps
 Conflicts: ossec-hids-agent, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, ossec-hids
 Description: Wazuh agent

--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -7,8 +7,8 @@ set -e
 case "$1" in
     configure)
 
-    OS=$(lsb_release -si)
-    VER=$(lsb_release -sr)
+    OS=$(. /etc/os-release && printf '%s\n' "$ID" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+    VER=$(. /etc/os-release && echo "${VERSION_ID}")
     DIR="/var/ossec"
     USER="wazuh"
     GROUP="wazuh"
@@ -42,10 +42,10 @@ case "$1" in
     fi
 
     if ! getent group ${GROUP} > /dev/null 2>&1; then
-        addgroup --system ${GROUP} > /dev/null 2>&1
+        groupadd --system ${GROUP} > /dev/null 2>&1
     fi
     if ! getent passwd ${USER} > /dev/null 2>&1; then
-        adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
+        useradd --system --home-dir ${DIR} --shell ${OSMYSHELL} --gid ${GROUP} --no-create-home ${USER} > /dev/null 2>&1
     fi
 
     if [ -z "$2" ] || [ -f ${WAZUH_TMP_DIR}/create_conf ] ; then
@@ -150,18 +150,18 @@ case "$1" in
         find ${DIR}/ -group ossec -user root -exec chown root:wazuh {} \; > /dev/null 2>&1 || true
         if getent passwd ossec > /dev/null 2>&1; then
             find ${DIR}/ -group ossec -user ossec -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossec > /dev/null 2>&1
+            userdel ossec > /dev/null 2>&1
         fi
         if getent passwd ossecm > /dev/null 2>&1; then
             find ${DIR}/ -group ossec -user ossecm -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossecm > /dev/null 2>&1
+            userdel ossecm > /dev/null 2>&1
         fi
         if getent passwd ossecr > /dev/null 2>&1; then
             find ${DIR}/ -group ossec -user ossecr -exec chown wazuh:wazuh {} \; > /dev/null 2>&1 || true
-            deluser ossecr > /dev/null 2>&1
+            userdel ossecr > /dev/null 2>&1
         fi
         if getent group ossec > /dev/null 2>&1; then
-            delgroup ossec > /dev/null 2>&1
+            groupdel ossec > /dev/null 2>&1
         fi
     fi
 

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -67,10 +67,10 @@ case "$1" in
         purge)
 
         if getent passwd wazuh >/dev/null 2>&1; then
-            deluser wazuh > /dev/null 2>&1
+            userdel wazuh > /dev/null 2>&1
         fi
         if getent group wazuh >/dev/null 2>&1; then
-            delgroup wazuh > /dev/null 2>&1
+            groupdel wazuh > /dev/null 2>&1
         fi
         rm -rf ${DIR}/*
 


### PR DESCRIPTION
**Environments tested:**
- Debian GNU/Linux 13 (trixie) — fresh `incus` container (`images:debian/13`)
- Ubuntu 24.04.4 LTS (Noble) — fresh `incus` container (`images:ubuntu/noble`)

**Test date:** 2026-05-11

---

## Summary of changes

| Dependency | Action | Justification |
|---|---|---|
| `adduser` | **Removed** → replaced by `useradd`/`groupadd`/`userdel`/`groupdel` | `passwd` pkg (Priority: **required**) always ships these binaries |
| `lsb-release` | **Removed** → replaced by `/etc/os-release` parsing | Priority: optional/important; not installed by default on Debian 13; `base-files` (Essential: yes) always provides `/etc/os-release` |
| `debconf` | **Removed** | Priority: **required** on both Debian and Ubuntu — guaranteed present, no explicit dep needed |
| `procps` | **Kept** | Used directly in wazuh source code (`pkill`, `kill`, etc.) |

---

## Official references

- **Debian Policy Manual — Priority levels (§2.5):**
  https://www.debian.org/doc/debian-policy/ch-archive.html#s-priorities

  > **Required:** "Packages which are necessary for the proper functioning of the system. Removing such packages risks complete system failure and may prevent using dpkg for recovery."

- **Debian package tracker — `passwd`:** https://packages.debian.org/trixie/passwd
- **Debian package tracker — `base-files`:** https://packages.debian.org/trixie/base-files
- **Debian package tracker — `debconf`:** https://packages.debian.org/trixie/debconf
- **Ubuntu package tracker — `passwd`:** https://packages.ubuntu.com/noble/passwd
- **Ubuntu package tracker — `base-files`:** https://packages.ubuntu.com/noble/base-files
- **Ubuntu package tracker — `debconf`:** https://packages.ubuntu.com/noble/debconf

---

## Package priorities across distros

```
apt-cache show <package> | grep -E "^(Package|Version|Priority|Essential):"
```

| Package | Debian 13 Priority | Ubuntu 24.04 Priority | Notes |
|---|---|---|---|
| `passwd` | **required** | **required** | Provides `useradd`, `groupadd`, `userdel`, `groupdel` |
| `base-files` | **required** + Essential: yes | **required** + Essential: yes | Provides `/etc/os-release` |
| `debconf` | **required** | **required** | Always installed — no explicit dep needed |
| `procps` | important | **required** | Kept as explicit dep |
| `adduser` | important | important | **Removable** — not required/essential |
| `lsb-release` | optional — **NOT installed** | important — installed | **Removable** — `/etc/os-release` replaces it |

### Debian 13 raw output
```
Package: passwd       Version: 1:4.17.4-2           Priority: required
Package: base-files   Version: 13.8+deb13u4          Priority: required    Essential: yes
Package: debconf      Version: 1.5.91                Priority: required
Package: procps       Version: 2:4.0.4-9             Priority: important
Package: adduser      Version: 3.152                 Priority: important
Package: lsb-release  Version: 12.1-1                Priority: optional    (NOT installed on fresh system)
```

### Ubuntu 24.04 raw output
```
Package: passwd       Version: 1:4.13+dfsg1-4ubuntu3 Priority: required
Package: base-files   Version: 13ubuntu10.4           Priority: required    Essential: yes
Package: debconf      Version: 1.5.86ubuntu1          Priority: required
Package: procps       Version: 2:4.0.4-4ubuntu3       Priority: required
Package: adduser      Version: 3.137ubuntu1            Priority: important
Package: lsb-release  Version: 12.0-2                 Priority: important
```

---

## Test 1 — `useradd`/`groupadd` provided by `passwd`

```console
# Both distros
root@container:~# dpkg -S /usr/sbin/useradd
passwd: /usr/sbin/useradd

root@container:~# which useradd groupadd userdel groupdel
/usr/sbin/useradd
/usr/sbin/groupadd
/usr/sbin/userdel
/usr/sbin/groupdel
```

---

## Test 2 — OS detection via `/etc/os-release` replaces `lsb_release`

`base-files` (Essential: yes) always provides `/etc/os-release`. The replacements below run under POSIX `sh` (matching the `#!/bin/sh` shebang in `postinst`):

### Debian 13
```console
root@wazuh-deb13:~# . /etc/os-release && printf '%s\n' "$ID" | awk '{print toupper(substr($0,1,1)) substr($0,2)}'
Debian
root@wazuh-deb13:~# . /etc/os-release && echo "${VERSION_ID}"
13
```

Equivalent to: `lsb_release -si` → `Debian`, `lsb_release -sr` → `13`

### Ubuntu 24.04
```console
root@wazuh-ubuntu24:~# . /etc/os-release && printf '%s\n' "$ID" | awk '{print toupper(substr($0,1,1)) substr($0,2)}'
Ubuntu
root@wazuh-ubuntu24:~# . /etc/os-release && echo "${VERSION_ID}"
24.04
```

Equivalent to: `lsb_release -si` → `Ubuntu`, `lsb_release -sr` → `24.04`

---

## Test 3 — `groupadd --system` and `useradd --system` (replacing `addgroup`/`adduser`)

```console
root@wazuh-deb13:~# groupadd --system wazuh
root@wazuh-deb13:~# getent group wazuh
wazuh:x:989:

root@wazuh-deb13:~# useradd --system --home-dir /var/ossec --shell /sbin/nologin --gid wazuh --no-create-home wazuh
root@wazuh-deb13:~# getent passwd wazuh
wazuh:x:989:989::/var/ossec:/sbin/nologin

root@wazuh-deb13:~# getent passwd wazuh | cut -d: -f7
/sbin/nologin
```

`--no-create-home` ensures `/var/ossec` (created by the package) is not overwritten.

---

## Test 4 — `userdel`/`groupdel` replaces `deluser`/`delgroup` (ossec legacy cleanup)

The existing `if getent group ossec` guard handles `userdel` auto-removing the primary group:

```console
root@wazuh-deb13:~# userdel ossec   # also removes primary group
root@wazuh-deb13:~# if getent group ossec > /dev/null 2>&1; then
>     groupdel ossec && echo "groupdel: OK"
> else
>     echo "group already removed by userdel — guard prevents error: OK"
> fi
group already removed by userdel — guard prevents error: OK
```

No change required to the guard logic in `postinst`.

---

## Test 5 — `adduser` removable without breaking system

```console
root@wazuh-deb13:~# apt-get remove --purge -y adduser
Removing adduser (3.152) ...

root@wazuh-deb13:~# useradd --help > /dev/null && echo "useradd still available (from passwd)"
useradd still available (from passwd)

root@wazuh-deb13:~# groupadd --help > /dev/null && echo "groupadd still available (from passwd)"
groupadd still available (from passwd)
```

---

## Test 6 — `postinst` syntax check

```console
root@wazuh-deb13:~# sh -n /tmp/postinst && echo "syntax OK"
syntax OK
```

---

## Files changed

- `packages/debs/SPECS/wazuh-agent/debian/control` — removed `lsb-release`, `debconf`, `adduser` from `Depends:`
- `packages/debs/SPECS/wazuh-agent/debian/postinst` — replaced `lsb_release`, `addgroup`/`adduser`, `deluser`/`delgroup` with POSIX-compatible equivalents from `passwd`
