### PR TITLE
wazuh-engine: Architecture doc

### DIFF
--- a/docs/ref/modules/engine/README.md
+++ b/docs/ref/modules/engine/README.md
@@ -840,11 +840,6 @@ flowchart TD
     linkStyle 2,3 stroke:#D50000,fill:none
 ```
 
-> [!WARNING]
-> The output files in `default/` are **replaced on every installation or update** of `wazuh-manager`.
-> Modifications to those files will be overwritten. To preserve custom outputs across updates, place
-> them in a space-specific folder (`standard/` or `custom/`) instead of `default/`.
-
 #### Unclassified events
 
 An event is considered **unclassified** when it was only processed by the root decoder and no other decoder

--- a/docs/ref/modules/engine/architecture.md
+++ b/docs/ref/modules/engine/architecture.md
@@ -2,9 +2,13 @@
 
 ## Introduction
 
-The **Wazuh Engine** is the decoding, enrichment and routing engine of the Wazuh manager (it ships as the `wazuh-manager-analysisd` daemon). It receives raw events from `wazuh-manager-remoted`, normalizes them to the Wazuh Common Schema using user-defined decoders, enriches them (GeoIP, IOC, key-value lookups), evaluates them against one or more security policies, and forwards the resulting documents to `wazuh-indexer`.
+The **Wazuh Engine** is the decoding, enrichment and routing events of the Wazuh manager (it ships as the `wazuh-manager-analysisd` daemon). It receives raw events from `wazuh-manager-remoted`, normalizes them to the Wazuh Common Schema using user-defined decoders, enriches them (GeoIP, IOC, key-value lookups), evaluates them against one or more security policies, and forwards the resulting documents to `wazuh-indexer`.
 
-The engine never communicates with agents or with Wazuh CTI directly. Its only inbound peer for events is `remoted`, and its only outbound peer is `wazuh-indexer`. Content (decoders, integrations, policies, IOC databases) is also pulled from `wazuh-indexer` rather than from a CTI feed. For the runtime concepts referenced throughout this document — events, decoders, security policies, spaces, helper functions, assets — see the [quick-start](./README.md). For the API surface, see [api-reference.md](./api-reference.md).
+The engine never communicates with agents or with Wazuh CTI directly. Its only inbound peer for events is `remoted` and `vd`, and its only outbound peer for event/content flows is `wazuh-indexer`. The only external Internet connectivity it requires is downloading GeoIP/ASN databases from official Wazuh servers for geolocation updates. Content (decoders, integrations, policies, IOC databases) is also pulled from `wazuh-indexer` rather than from a CTI feed. For the runtime concepts referenced throughout this document — events, decoders, security policies, spaces, helper functions, assets — see the [quick-start](./README.md). For the API surface, see [api-reference.md](./api-reference.md).
+
+
+> [!NOTE]
+> When this document mentions "Content Management" it is referring to the engine's internal content management system, which is separate from the Wazuh manager's external content management used by vulnerability detector.
 
 ---
 
@@ -22,8 +26,8 @@ classDef ExternalClass font-size:14px,stroke-width:2px,fill:#3f51b5,color:#fff,r
 classDef ModuleClass font-size:14px,stroke-width:2px,rx:10,ry:10
 classDef HubClass font-size:14px,stroke-width:2px,fill:#e8eaf6,rx:10,ry:10
 
-remoted["wazuh-manager-remoted"]:::ExternalClass
-operator["Operator / CLI"]:::ExternalClass
+remoted["wazuh-manager-remoted / vulnerability detector"]:::ExternalClass
+operator["Wazuh-indexer / Internal CLI"]:::ExternalClass
 indexer["wazuh-indexer"]:::ExternalClass
 
 subgraph engine["Wazuh Engine"]
@@ -34,7 +38,7 @@ subgraph engine["Wazuh Engine"]
   backend["Backend"]:::ModuleClass
   builder["Builder"]:::ModuleClass
   schema["Schema"]:::ModuleClass
-  cm["Content Manager"]:::HubClass
+  cm["Engine Content Manager"]:::HubClass
   kvdb["KVDB"]:::ModuleClass
   ioc["IOC"]:::ModuleClass
   geo["Geo"]:::ModuleClass
@@ -63,7 +67,7 @@ ic --> indexer
 indexer --> ic
 ```
 
-The diagram shows the engine boundary and its relationships with the outside world. Events enter through the **Server** module, are routed by the **Orchestrator** to the active security policies, and are processed by the **Backend** using the executable graph produced by the **Builder**. Content (decoders, integrations, policies, KVDBs) is pulled from `wazuh-indexer` by the **Content Manager** through the **Indexer Connector**, which is also the channel for outbound processed events.
+The diagram shows the engine boundary and its relationships with the outside world. Events enter through the **Server** module, are routed by the **Orchestrator** to the active security policies, and are processed by the **Backend** using the executable graph produced by the **Builder**. Content (decoders, integrations, policies, KVDBs) is pulled from `wazuh-indexer` by the **Engine Content Manager** through the **Indexer Connector**, which is also the channel for outbound processed events.
 
 ---
 
@@ -75,7 +79,7 @@ The diagram shows the engine boundary and its relationships with the outside wor
 | Orchestrator | Routes incoming events to active security policies; runs the tester | [Policy processing](./README.md#policy-processing) |
 | Builder | Compiles assets and policies into an executable graph | [Assets](./README.md#assets), [Execution Graph Summary](./README.md#execution-graph-summary) |
 | Backend | Runtime that executes the compiled graph for each event | [Policy processing](./README.md#policy-processing) |
-| Content Manager | Mirrors policies, integrations, decoders, filters and KVDBs from `wazuh-indexer` | [Content Management](./README.md#content-management-managing-the-engines-processing), [Spaces](./README.md#spaces) |
+| Engine Content Manager | Mirrors policies, integrations, decoders, filters and KVDBs from `wazuh-indexer` | [Content Management](./README.md#content-management-managing-the-engines-processing), [Spaces](./README.md#spaces) |
 | Schema | Validates events against the Wazuh Common Schema | [Schema](./README.md#schema) |
 | KVDB | Per-space key-value lookups used by decoders and filters | [Key Value Databases (KVDBs)](./README.md#key-value-databases-kvdbs) |
 | IOC | Global Indicator-of-Compromise databases consumed by enrichment | [IOC enrichment](./README.md#ioc-enrichment) |
@@ -90,7 +94,7 @@ The diagram shows the engine boundary and its relationships with the outside wor
 
 ### Server
 
-Two HTTP servers running on Unix Domain Sockets. The **events** socket receives raw events from `wazuh-manager-remoted`. The **management API** socket exposes the operations used by CLI tools and the rest of the Wazuh manager: managing routes, running tester sessions, applying content changes, querying GeoIP/IOC state, toggling raw event indexing, and reading metrics. Both sockets speak HTTP with JSON bodies; the schema for every request and response is defined in protobuf.
+Two HTTP servers running on Unix Domain Sockets. The **events** socket receives raw events from `wazuh-manager-remoted` or `vulnerability dectector`. The **management API** socket exposes the operations used by internal client dev tools and the rest of the Wazuh manager: managing routes, running tester sessions, applying content changes, querying GeoIP/IOC state, toggling raw event indexing, and reading metrics. Both sockets speak HTTP with JSON bodies; the schema for every request and response is defined in protobuf.
 
 ### Orchestrator
 
@@ -98,15 +102,15 @@ The runtime hub. It owns the **routes** table that maps each space to the active
 
 ### Builder
 
-The Builder turns the declarative content stored in the Content Manager — policies, integrations, decoders, filters, KVDB references — into an executable graph that the Backend can run. It validates field types against the Schema, resolves variables and definitions, and links every helper function used in `check`, `parse` and `normalize` stages. The Content Manager calls the Builder whenever content changes; the resulting graph is what the Orchestrator ultimately registers as a route.
+The Builder turns the declarative content stored in the Engine Content Manager — policies, integrations, decoders, filters, KVDB references — into an executable graph that the Backend can run. It validates field types against the Schema, resolves variables and definitions, and links every helper function used in `check`, `parse` and `normalize` stages. The Engine Content Manager calls the Builder whenever content changes; the resulting graph is what the Orchestrator ultimately registers as a route.
 
 ### Backend
 
 The Backend is the runtime that executes the compiled graph for every event. It walks the stages described in [Policy processing](./README.md#policy-processing): pre-filter, decoders (including KVDB lookups), enrichment (Geo and IOC), post-filter, and outputs. The Backend is policy-agnostic — it has no domain knowledge of decoders or rules; it only knows how to evaluate the graph the Builder produced.
 
-### Content Manager
+### Engine Content Manager
 
-Local mirror of the content managed in `wazuh-indexer`. It is organized by **space** — Standard (Wazuh-curated) and Custom (user-defined) — exactly mirroring the layout in the indexer. The Content Manager has three responsibilities: **storage** of decoders, filters, KVDBs, integrations and policies on the engine host; **synchronization** with the indexer (CMSync), which periodically compares per-space content hashes and pulls the full content when they differ — see [Synchronization process](./README.md#synchronization-process); and **CRUD**, which validates and applies any mutations issued through the management API. After every applied change, the Content Manager hands the affected policies to the Builder and asks the Orchestrator to swap the corresponding routes.
+Local mirror of the content managed in `wazuh-indexer`. It is organized by **space** — Standard (Wazuh-curated) and Custom (user-defined) — exactly mirroring the layout in the indexer. The Engine Content Manager has three responsibilities: **storage** of decoders, filters, KVDBs, integrations and policies on the engine host; **synchronization** with the indexer (CMSync), which periodically compares per-space content hashes and pulls the full content when they differ — see [Synchronization process](./README.md#synchronization-process); and **CRUD**, which validates and applies any mutations issued through the management API. After every applied change, the Engine Content Manager hands the affected policies to the Builder and asks the Orchestrator to swap the corresponding routes.
 
 ### Schema
 
@@ -126,7 +130,7 @@ The Geo module performs GeoIP and ASN lookups using MaxMind MMDB databases. Like
 
 ### Indexer Connector
 
-The Indexer Connector is the single component that talks to `wazuh-indexer`. It carries three flows: **outbound** processed events (driven by policy outputs), **inbound** content (consumed by the Content Manager and the IOC synchronizer), and **inbound** runtime configuration (consumed by the Configuration module). Concentrating all `wazuh-indexer` traffic in one place is what allows the rest of the engine to stay independent of the indexer's transport details.
+The Indexer Connector is the single component that talks to `wazuh-indexer`. It carries three flows: **outbound** processed events (driven by policy outputs), **inbound** content (consumed by the Engine Content Manager and the IOC synchronizer), and **inbound** runtime configuration (consumed by the Configuration module). Concentrating all `wazuh-indexer` traffic in one place is what allows the rest of the engine to stay independent of the indexer's transport details.
 
 ### Stream Log
 
@@ -134,7 +138,7 @@ Stream Log provides asynchronous, rotating log channels with size-based and time
 
 ### Configuration
 
-The local configuration is loaded from the Wazuh manager's YAML at startup; every module reads from it. A subset of runtime parameters is also pulled periodically from `wazuh-indexer` as **remote configuration**, so operators can tune behaviour without restarting the engine. Remote configuration changes are applied with rollback if a module rejects the new values.
+The local configuration is loaded from the Wazuh manager's XML/ini at startup; every module reads from it. A subset of runtime parameters is also pulled periodically from `wazuh-indexer` as **remote configuration**, so operators can tune behaviour without restarting the engine. Remote configuration changes are applied with rollback if a module rejects the new values.
 
 ---
 
@@ -183,7 +187,7 @@ classDef ModuleClass stroke-width:2px,rx:10,ry:10
 operator["Operator"]:::ExternalClass
 indexer["wazuh-indexer"]:::ExternalClass
 ic["Indexer Connector"]:::ModuleClass
-cm["Content Manager (CMSync)"]:::ModuleClass
+cm["Engine Content Manager (CMSync)"]:::ModuleClass
 builder["Builder"]:::ModuleClass
 orchestrator["Orchestrator"]:::ModuleClass
 

--- a/docs/ref/modules/engine/architecture.md
+++ b/docs/ref/modules/engine/architecture.md
@@ -2,288 +2,207 @@
 
 ## Introduction
 
+The **Wazuh Engine** is the decoding, enrichment and routing engine of the Wazuh manager (it ships as the `wazuh-manager-analysisd` daemon). It receives raw events from `wazuh-manager-remoted`, normalizes them to the Wazuh Common Schema using user-defined decoders, enriches them (GeoIP, IOC, key-value lookups), evaluates them against one or more security policies, and forwards the resulting documents to `wazuh-indexer`.
+
+The engine never communicates with agents or with Wazuh CTI directly. Its only inbound peer for events is `remoted`, and its only outbound peer is `wazuh-indexer`. Content (decoders, integrations, policies, IOC databases) is also pulled from `wazuh-indexer` rather than from a CTI feed. For the runtime concepts referenced throughout this document — events, decoders, security policies, spaces, helper functions, assets — see the [quick-start](./README.md). For the API surface, see [api-reference.md](./api-reference.md).
+
+---
+
+## High-level view
+
 ```mermaid
 ---
 config:
-  title: "Simplified architecture"
-  nodeSpacing: 30
-  rankSpacing: 25
   flowchart:
     curve: stepAfter
-    subGraphTitleMargin:
-      top: 20
-      bottom: 20
 ---
 flowchart LR
 
-classDef SubmoduleClass font-size:15px,stroke-width:2px,stroke-dasharray:10px,rx:15,ry:15
-classDef ModuleClass  font-size:15px,stroke-width:2px,rx:15,ry:15
+classDef ExternalClass font-size:14px,stroke-width:2px,fill:#3f51b5,color:#fff,rx:6,ry:6
+classDef ModuleClass font-size:14px,stroke-width:2px,rx:10,ry:10
+classDef HubClass font-size:14px,stroke-width:2px,fill:#e8eaf6,rx:10,ry:10
 
-%% ----------------------------------
-%%                  API
-%% ----------------------------------
+remoted["wazuh-manager-remoted"]:::ExternalClass
+operator["Operator / CLI"]:::ExternalClass
+indexer["wazuh-indexer"]:::ExternalClass
 
-subgraph apiModule["API"]
-   direction LR
-   api_orchestrator@{ shape: stadium, label: "Orchestrator manager" }
-   api_kvdb@{ shape: stadium, label: "KVDB manager" }
-   api_metrics@{ shape: stadium, label: "Metric manager" }
-   api_geo@{ shape: stadium, label: "Geo manager" }
-   api_orchestrator ~~~ api_kvdb
-   api_metrics ~~~ api_geo
+subgraph engine["Wazuh Engine"]
+  direction LR
 
-   api_catalog@{ shape: disk, label: "Catalog of assets" }
-   api_policies@{ shape: disk, label: "Policies" }
-   api_policies ~~~ api_catalog
-end
-apiModule:::ModuleClass
+  server["Server (UDS HTTP)"]:::HubClass
+  orchestrator["Orchestrator"]:::HubClass
+  backend["Backend"]:::ModuleClass
+  builder["Builder"]:::ModuleClass
+  schema["Schema"]:::ModuleClass
+  cm["Content Manager"]:::HubClass
+  kvdb["KVDB"]:::ModuleClass
+  ioc["IOC"]:::ModuleClass
+  geo["Geo"]:::ModuleClass
+  ic["Indexer Connector"]:::HubClass
+  streamlog["Stream Log"]:::ModuleClass
+  conf["Configuration"]:::ModuleClass
 
-
-%% ----------------------------------
-%%                  Geo module
-%% ----------------------------------
-subgraph geoModule["Geolocator"]
-  geo_mmdb@{ shape: disk, label: "MaxMind DBs" }
-end
-geoModule:::ModuleClass
-
-%% ----------------------------------
-%%                  KVDB
-%% ----------------------------------
-subgraph kvdbModule["KVDB"]
-    direction TB
-    kvdb_db_2@{ shape: docs, label: "Key-Value DataBases" }
-end
-kvdbModule:::ModuleClass
-
-%% ----------------------------------
-%%              Global module
-%% ----------------------------------
-subgraph globalModule["Global"]
-    global_metrics("Metrics")
-    global_logger("Logger")
-end
-globalModule:::ModuleClass
-
-%% ----------------------------------
-%%                  Server
-%% ----------------------------------
-
-subgraph serverModule["Server"]
-   direction RL
-   server_API>Server API]
-   server_engine>Server engine]
-end
-serverModule:::ModuleClass
-
-%% ----------------------------------
-%%           Storage
-%% ----------------------------------
-storageModule@{ shape: cyl, label: "Persistent</br>Storage" }
-storageModule:::ModuleClass
-
-%% ----------------------------------
-%%           Builder
-%% ----------------------------------
-subgraph builderModule["Builder"]
- builder_asset@{ shape: stadium, label: "Builder asset" }
- builder_policy@{ shape: stadium, label: "Builder policy" }
- builder_parser@{ shape: stadium, label: "Builder parser" }
- builder_hp@{ shape: stadium, label: "Builder helper function" }
-
- builder_policy ~~~ builder_asset --- builder_parser & builder_hp
- builder_parser --- builder_catalog_hf@{ shape: disk, label: "Catalog of helper functions" }
- builder_hp --- builder_catalog_parser@{ shape: disk, label: "Catalog of parser" }
-
-end
-builderModule:::ModuleClass
-
-%% ----------------------------------
-%%           Orchestrator
-%% ----------------------------------
-subgraph orchestratorModule["Orchestrator"]
-   direction RL
-   orchestrator_router@{ shape: stadium, label: "Router" }
-   orchestrator_tester@{ shape: stadium, label: "Tester" }
-   orchestrator_routerTable@{ shape: disk, label: "Routes" }
-   orchestrator_sessionTable@{ shape: disk, label: "Session" }
-   orchestrator_router --- orchestrator_routerTable
-   orchestrator_tester --- orchestrator_sessionTable
-end
-orchestratorModule:::ModuleClass
-
-subgraph backendModule["Backend"]
-
+  server --> orchestrator
+  server --> cm
+  orchestrator --> backend
+  cm --> builder
+  builder --> backend
+  builder --> schema
+  backend --> kvdb
+  backend --> ioc
+  backend --> geo
+  backend --> ic
+  backend --> streamlog
+  cm --> ic
+  conf --> ic
 end
 
-%% ----------------------------------
-%%           Modules conexion
-%% ----------------------------------
-serverModule ------- orchestratorModule & apiModule
-orchestratorModule ---- backendModule
-builderModule & apiModule --- geoModule & kvdbModule
-apiModule --- storageModule
-
-apiModule ------ builderModule
-
-orchestratorModule  ------ builderModule
-orchestratorModule ----- apiModule
-storageModule --- builderModule
-
+remoted --> server
+operator --> server
+ic --> indexer
+indexer --> ic
 ```
-<center><i>Simplified architecture of the Wazuh engine</i></center>
 
-The **Wazuh-Engine** is composed of multiple modules that work together to provide all engine functionality. Below is a summary of each module’s responsibilities and interactions.
-
----
-
-## Main Modules
-
-1. **Server**
-   The Server module exposes the Wazuh-Engine to the rest of the Wazuh-Server system. It creates two Unix stream sockets:
-   - **engine.socket**: Receives events from Wazuh agents and forwards them to the Orchestrator module for processing.
-   - **api.socket**: Exposes the engine’s REST API, forwarding requests to the API module. These requests manage engine state (policies, assets, routes, DB updates, etc.).
-
-2. **Orchestrator**
-   The Orchestrator module manages runtime routes and policy testing:
-   - **Router**: Decides which policy to apply for each incoming event. It refers to a **Routes Table** that defines priorities and mappings to specific policies.
-   - **Tester**: Evaluates events against the assigned policies. It uses a **Session Table** to store context/state of session. The Tester returns the outcome of policy checks (e.g., alerts and traces).
-
-3. **Backend**
-   While Orchestrator handles routing and policy instantiation, the Backend module executes the code produced by the Builder module. The Backend is effectively the runtime environment for those policies.
-
-4. **Builder**
-   The Builder module generates executable code based on policies and assets. It has four components:
-   - **Policy**: Constructs code representing policy logic.
-   - **Asset**: Constructs code for asset definitions.
-   - **Parser**: Constructs code for any parsing functionalities.
-   - **Helper Functions**: Builds code for auxiliary or common utility functions.
-
-5. **API**
-   The API module manages interactions between the Wazuh-Engine and external modules or services via a REST interface. Its major components include:
-   - **Orchestrator Manager**: Handles orchestrator-related tasks.
-   - **KVDB Manager**: Manages access to the KVDB module.
-   - **Metric Manager**: Interfaces with the metrics system in the Global module.
-   - **Geo Manager**: Manages the Geo module.
-   - **Catalog of Assets**: Maintains definitions of assets used across the engine.
-   - **Policies**: Maintains definitions of policies used across the engine.
-
-6. **KVDB**
-   The KVDB module provides key-value database functionality, using [RocksDB](https://rocksdb.org/) under the hood. It is typically employed by helper functions.
-
-7. **Geo**
-   The Geo module manages geolocation data, relying on [MaxMind](https://www.maxmind.com/) databases. It exposes an internal API for updating and querying geolocation information.
-
-8. **Persistent Storage**
-   The Storage module oversees long-term persistence for policies, assets, sessions, and other data (e.g., routes, schemas, configurations). It currently uses the local file system.
-
-9. **Global**
-   The Global module offers cross-cutting engine resources:
-   - **Metrics**: Tracks performance and usage statistics for Wazuh-Engine.
-   - **Logger**: Centralizes logging features for all modules.
+The diagram shows the engine boundary and its relationships with the outside world. Events enter through the **Server** module, are routed by the **Orchestrator** to the active security policies, and are processed by the **Backend** using the executable graph produced by the **Builder**. Content (decoders, integrations, policies, KVDBs) is pulled from `wazuh-indexer` by the **Content Manager** through the **Indexer Connector**, which is also the channel for outbound processed events.
 
 ---
 
-## Module: Server
+## Module overview
 
-The **Server** module provides the primary interface for both incoming agent events and external API requests:
-
-- **engine.socket**:
-  - Receives raw events from Wazuh agents.
-  - Forwards these events to the Orchestrator for routing and policy application.
-
-- **api.socket**:
-  - Exposes the REST API of the Wazuh-Engine.
-  - Forwards requests to the API module, which then manages tasks such as policy updates, asset management, and configuration changes.
-
----
-
-## Module: Orchestrator
-
-The **Orchestrator** determines how incoming events are routed and tested against policies:
-
-- **Router**:
-  - Uses a **Routes Table** to map events to policies based on defined priorities.
-  - Example of a routes table:
-
-    | Route name (ID)   | Priority | Policy                   |
-    |-------------------|----------|--------------------------|
-    | router_example    | 1        | policy_1                 |
-    | ...               | ...      | policy_2                 |
-    | default           | 255      | wazuh-default-policy     |
-
-- **Tester**:
-  - Uses a **Session Table** to maintain session state.
-  - Receives an event and a sesion, then produces a result (alerts sample and traces).
+| Module | Role | Related quick-start sections |
+|--------|------|------------------------------|
+| Server | HTTP-over-UDS entry: event ingestion socket and management API socket | [Data flow](./README.md#data-flow) |
+| Orchestrator | Routes incoming events to active security policies; runs the tester | [Policy processing](./README.md#policy-processing) |
+| Builder | Compiles assets and policies into an executable graph | [Assets](./README.md#assets), [Execution Graph Summary](./README.md#execution-graph-summary) |
+| Backend | Runtime that executes the compiled graph for each event | [Policy processing](./README.md#policy-processing) |
+| Content Manager | Mirrors policies, integrations, decoders, filters and KVDBs from `wazuh-indexer` | [Content Management](./README.md#content-management-managing-the-engines-processing), [Spaces](./README.md#spaces) |
+| Schema | Validates events against the Wazuh Common Schema | [Schema](./README.md#schema) |
+| KVDB | Per-space key-value lookups used by decoders and filters | [Key Value Databases (KVDBs)](./README.md#key-value-databases-kvdbs) |
+| IOC | Global Indicator-of-Compromise databases consumed by enrichment | [IOC enrichment](./README.md#ioc-enrichment) |
+| Geo | GeoIP/ASN enrichment using MaxMind databases | [Geo enrichment](./README.md#geo-enrichment) |
+| Indexer Connector | Sole channel to `wazuh-indexer`: outbound events, inbound content, inbound configuration | [Output process](./README.md#output-process) |
+| Stream Log | Async rotating log channels backing file outputs and the event dumper | [Output directory structure](./README.md#output-directory-structure) |
+| Configuration | Local YAML configuration plus runtime settings pulled from `wazuh-indexer` | — |
 
 ---
 
-## Module: Backend
+## Module details
 
-The **Backend** executes the compiled policy and routing code generated by the Builder module. It effectively serves as the runtime environment for custom logic crafted by the Builder and orchestrated by the Orchestrator.
+### Server
 
----
+Two HTTP servers running on Unix Domain Sockets. The **events** socket receives raw events from `wazuh-manager-remoted`. The **management API** socket exposes the operations used by CLI tools and the rest of the Wazuh manager: managing routes, running tester sessions, applying content changes, querying GeoIP/IOC state, toggling raw event indexing, and reading metrics. Both sockets speak HTTP with JSON bodies; the schema for every request and response is defined in protobuf.
 
-## Module: Geo
+### Orchestrator
 
-The **Geo** module offers geolocation capabilities:
+The runtime hub. It owns the **routes** table that maps each space to the active security policy and the priority at which events are evaluated, plus the session table used by the tester. When an event arrives the Orchestrator forwards an independent copy to each active policy, so a single incoming event can produce multiple output documents — one per active policy. Routes can be added, replaced or removed at runtime without restarting the engine, which is what makes hot-swapping of synchronized content possible.
 
-- Relies on [MaxMind](https://www.maxmind.com/) databases.
-- Provides an internal interface for updating these databases and querying geolocation data.
+### Builder
 
----
+The Builder turns the declarative content stored in the Content Manager — policies, integrations, decoders, filters, KVDB references — into an executable graph that the Backend can run. It validates field types against the Schema, resolves variables and definitions, and links every helper function used in `check`, `parse` and `normalize` stages. The Content Manager calls the Builder whenever content changes; the resulting graph is what the Orchestrator ultimately registers as a route.
 
-## Module: KVDB
+### Backend
 
-The **KVDB** module manages key-value databases for various engine operations:
+The Backend is the runtime that executes the compiled graph for every event. It walks the stages described in [Policy processing](./README.md#policy-processing): pre-filter, decoders (including KVDB lookups), enrichment (Geo and IOC), post-filter, and outputs. The Backend is policy-agnostic — it has no domain knowledge of decoders or rules; it only knows how to evaluate the graph the Builder produced.
 
-- Primarily used by helper functions.
-- Internally uses [RocksDB](https://rocksdb.org/) for data management.
+### Content Manager
 
----
+Local mirror of the content managed in `wazuh-indexer`. It is organized by **space** — Standard (Wazuh-curated) and Custom (user-defined) — exactly mirroring the layout in the indexer. The Content Manager has three responsibilities: **storage** of decoders, filters, KVDBs, integrations and policies on the engine host; **synchronization** with the indexer (CMSync), which periodically compares per-space content hashes and pulls the full content when they differ — see [Synchronization process](./README.md#synchronization-process); and **CRUD**, which validates and applies any mutations issued through the management API. After every applied change, the Content Manager hands the affected policies to the Builder and asks the Orchestrator to swap the corresponding routes.
 
-## Module: Persistent Storage
+### Schema
 
-The **Persistent Storage** module handles local storage for:
+The Schema module loads the Wazuh Common Schema document at startup and exposes it to the Builder for build-time field validation and to the Backend for runtime validation of dynamic values. It guarantees that every document the engine emits is type-consistent with the mappings configured in `wazuh-indexer`. See [Schema](./README.md#schema).
 
-- Policies, routes, assets, sessions, configurations, and other engine-related data.
-- Uses the file system for data persistence.
+### KVDB
 
----
+Per-space key-value databases that decoders and filters consult during processing — for example to map identifiers to canonical names or to merge default values into events. Regular KVDBs are part of the per-space content: they are synchronized along with the rest of the space's assets and rebuilt on the engine when their source changes. See [Key Value Databases (KVDBs)](./README.md#key-value-databases-kvdbs).
 
-## Module: Global
+### IOC
 
-The **Global** module unifies core engine-wide features:
+Indicator-of-Compromise databases used by the IOC enrichment stage to match fields in incoming events against threat intelligence. These databases are **shared across spaces** and are **independent of the regular content sync**: they are kept up to date by a dedicated IOC synchronizer that downloads updates into a temporary database and then atomically swaps it in, so readers never observe a partially-updated database. See [IOC enrichment](./README.md#ioc-enrichment).
 
-- **Metrics**: Collects real-time performance statistics and usage data.
-- **Logger**: Centralizes logging, enabling consistent log output for all modules.
+### Geo
 
----
+The Geo module performs GeoIP and ASN lookups using MaxMind MMDB databases. Like the IOC databases, the Geo databases are global rather than per-space; they are refreshed in the background and hot-reloaded without restarting the engine. See [Geo enrichment](./README.md#geo-enrichment).
 
-## Module: Builder
+### Indexer Connector
 
-The **Builder** module translates high-level definitions of policies, assets, parsers, and helper functions into executable code:
+The Indexer Connector is the single component that talks to `wazuh-indexer`. It carries three flows: **outbound** processed events (driven by policy outputs), **inbound** content (consumed by the Content Manager and the IOC synchronizer), and **inbound** runtime configuration (consumed by the Configuration module). Concentrating all `wazuh-indexer` traffic in one place is what allows the rest of the engine to stay independent of the indexer's transport details.
 
-1. **Policy**: Generates policy-related logic.
-2. **Asset**: Defines and compiles asset representation.
-3. **Parser**: Builds parser logic.
-4. **Helper Functions**: Compiles shared utility code used by assets.
+### Stream Log
 
----
+Stream Log provides asynchronous, rotating log channels with size-based and time-based rotation, gzip compression and retention by file count and total size. It backs the file outputs that policies can configure, and it is also what the optional event dumper uses to persist raw events for forensic investigation. Hot-path writes never block on disk I/O.
 
-## Module: API
+### Configuration
 
-The **API** module offers a REST interface for external tools and internal modules:
-
-- **Orchestrator Manager**: Oversees orchestrator tasks (e.g., route administration).
-- **KVDB Manager**: Interfaces with KVDB for data operations.
-- **Metric Manager**: Exposes engine metrics for monitoring.
-- **Geo Manager**: Manages geolocation data updates and queries.
-- **Catalog of Assets**: Maintains a registry of asset definitions.
-- **Policies**: Maintains a registry of policies used throughout the engine.
+The local configuration is loaded from the Wazuh manager's YAML at startup; every module reads from it. A subset of runtime parameters is also pulled periodically from `wazuh-indexer` as **remote configuration**, so operators can tune behaviour without restarting the engine. Remote configuration changes are applied with rollback if a module rejects the new values.
 
 ---
 
-**Note**: This architecture is intentionally simplified to illustrate high-level relationships and flows. For more specific implementation details (such as internal data structures, APIs, or design patterns), please refer to the respective module documentation or source code.
+## Event lifecycle
+
+The diagram below shows the journey of a single event through the engine, with each step labelled by the module that owns it.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Remoted as wazuh-manager-remoted
+    participant Server
+    participant Orchestrator
+    participant Backend
+    participant Geo
+    participant IOC
+    participant KVDB
+    participant IC as Indexer Connector
+    participant Indexer as wazuh-indexer
+
+    Remoted->>Server: Raw event (HTTP/UDS, JSON)
+    Server->>Orchestrator: Forward event
+    Orchestrator->>Backend: Fan-out (one copy per active policy)
+    Note over Backend: pre-filter → decoders → enrichment → post-filter → outputs
+    Backend->>KVDB: Lookups during decoding
+    Backend->>Geo: Geo enrichment
+    Backend->>IOC: IOC enrichment
+    Backend->>IC: Output (processed event)
+    IC->>Indexer: Index document
+```
+
+The Backend executes the same five stages described in the quick-start's [Data flow](./README.md#data-flow) and [Policy processing](./README.md#policy-processing) sections; this diagram only shows which module is responsible for each step. File outputs follow the same path but reach **Stream Log** instead of (or in addition to) the **Indexer Connector**.
 
 ---
+
+## Content lifecycle
+
+Content does not originate in the engine. The single source of truth for decoders, integrations, filters, KVDBs and policies is `wazuh-indexer`; the engine pulls and mirrors it locally. The diagram below shows that flow.
+
+```mermaid
+flowchart LR
+
+classDef ExternalClass fill:#3f51b5,color:#fff,stroke-width:2px,rx:6,ry:6
+classDef ModuleClass stroke-width:2px,rx:10,ry:10
+
+operator["Operator"]:::ExternalClass
+indexer["wazuh-indexer"]:::ExternalClass
+ic["Indexer Connector"]:::ModuleClass
+cm["Content Manager (CMSync)"]:::ModuleClass
+builder["Builder"]:::ModuleClass
+orchestrator["Orchestrator"]:::ModuleClass
+
+operator -- "Edits content per space" --> indexer
+indexer -- "Hash + content" --> ic
+ic --> cm
+cm -- "Per-space hash compare<br/>full fetch on change" --> cm
+cm -- "Updated policies/assets" --> builder
+builder -- "Compiled graph" --> orchestrator
+orchestrator -- "Hot-swap routes" --> orchestrator
+```
+
+CMSync runs periodically per space (Standard and Custom). For each space it compares the indexer's content hash with the local one; when they differ it downloads the full content for the space, applies it to the local store and notifies the Builder, which recompiles the affected policy graphs. The Orchestrator then swaps the routes atomically, so events that arrive during the change always see either the previous or the new graph — never a partial one. See [Synchronization process](./README.md#synchronization-process) for the per-space details and [Spaces](./README.md#spaces) for what each space contains.
+
+IOC databases follow a parallel, independent pipeline: their own synchronizer pulls from `wazuh-indexer`, writes into a temporary database, and atomically hot-swaps it in. There is no per-space split for IOCs, and they are not part of CMSync.
+
+---
+
+## Notes
+
+- This document covers the structure of the engine and the contracts between its modules. For runtime semantics — stages, helpers, asset structure, examples — read the [quick-start](./README.md). For the API surface, read [api-reference.md](./api-reference.md).
+- The diagrams are intentionally simplified. Cross-cutting facilities such as logging, metrics and configuration loading are not drawn but are described in the corresponding module subsection above.

--- a/src/engine/source/README.md
+++ b/src/engine/source/README.md
@@ -2,7 +2,7 @@
 
 `wazuh-engine` is the decoding, enrichment and routing engine of the Wazuh manager (it ships as the `wazuh-manager-analysisd` daemon). It receives raw security events from `remoted` and external producers, parses them into the **Wazuh Common Schema (WCS)** using user-defined **decoders**, enriches them (GeoIP, IOC, KVDB lookups), runs them through one or more **policies**, and forwards the resulting normalized JSON documents to the Wazuh Indexer (and optional file outputs).
 
-The engine can also run standalone (`WAZUH_ENGINE_STANDALONE=true`) for development and testing.
+The engine can also run standalone (`WAZUH_ENGINE_STANDALONE=true`) for development, testing or if run inside wazuh-indexer as a standalone content processor/validator.
 
 This README is the **developer / source-tree** view: what each directory does, how modules depend on each other, and how the process is wired together at startup. For operator-facing documentation (configuration, ruleset authoring, CLI usage), see the [user manual](../../../docs/ref/modules/engine/README.md).
 
@@ -11,9 +11,9 @@ This README is the **developer / source-tree** view: what each directory does, h
 ## Event pipeline (data flow)
 
 ```
-                          +----------------------+
-   remoted / agents ─────►│   httpsrv (events)   │  UDS HTTP ingestion
-                          +----------┬-----------+
+                           +----------------------+
+   remoted / VD / Others ─►│   httpsrv (events)   │  UDS HTTP ingestion
+                           +---------┬------------+
                                      │ JSON event
                                      ▼
                           +----------------------+
@@ -46,7 +46,7 @@ This README is the **developer / source-tree** view: what each directory does, h
 
 ## Architectural layers
 
-`source/` contains 33 modules. Below they are grouped by their role; arrows point in the direction of the dependency (a layer depends on the layers above it). Each entry links to that module's own README — the deep dive lives there, this index does not duplicate it.
+`source/` contains the modules. Below they are grouped by their role; arrows point in the direction of the dependency (a layer depends on the layers above it). Each entry links to that module's own README — the deep dive lives there, this index does not duplicate it.
 
 ### Foundation
 
@@ -55,7 +55,7 @@ Used by virtually every other module.
 - [base/](base/) — Shared primitives: logging (spdlog), JSON wrappers, error types (`base::Error`, `RespOrError`), expression trees (`base::Term`, `base::Event`), process and time utilities. No README; see [base/include/base/](base/include/base/).
 - [proto/](proto/) — Protobuf (`*.proto`) schema for the API. Wire format is JSON, but protobuf is the single source of truth shared by C++ handlers and the Python clients. No README; the `.proto` files in this directory are the contract.
 - [yml/](yml/) — yaml-cpp ↔ RapidJSON conversion used during config and content loading.
-- [conf/](conf/README.md) — Three-tier config (env → YAML file → defaults) with typed validation. Read by every module at startup.
+- [conf/](conf/README.md) — Three-tier config (env → json file → defaults) with typed validation. Read by every module at startup.
 - [hlp/](hlp/README.md) — Type-specific parsers (IP, date, JSON, CSV, …). The parser library that decoders are built from.
 - [parsec/](parsec/README.md) — Header-only parser-combinator library that underlies `logpar` and `logicexpr`.
 - [logicexpr/](logicexpr/README.md) — Boolean expression parser/evaluator (Shunting-Yard) used in `check` stages.
@@ -164,7 +164,7 @@ Key relationships:
 Modules are wired together in [main.cpp](main.cpp) using `std::shared_ptr` and a `StackExecutor` that records teardown callbacks for LIFO shutdown. Construction is staged so each phase only depends on phases above it. Some phases are gated by `conf::key::SERVER_ENABLE_EVENT_PROCESSING`.
 
 1. **Process bootstrap** — option parsing, logging (standalone vs `libwazuhshared`), signal handlers (`SIGINT`, `SIGTERM`, `SIGPIPE` → ignore), optional `goDaemon()`.
-2. **Configuration** — `conf::Conf` loads from YAML; every later module reads it via `confManager.get<T>(key::…)`.
+2. **Configuration** — `conf::Conf` loads from ini file; every later module reads it via `confManager.get<T>(key::…)`.
 3. **Core data layer** — `store::Store` (with `FileDriver`) → `cmstore::CMStore` → `kvdbstore::KVDBManager` → `iockvdb::KVDBManager(store)` → `geo::Manager(store, downloader)` → `fastmetrics::registerManager()` → `schemf::Schema` (loads `schema/engine-schema/0` from `store`).
 4. **Parsing** — `hlp::initTZDB(...)` then `logpar::Logpar` (uses `schema/wazuh-logpar-overrides/0` from `store` and the schema validator); `hlp::registerParsers(logpar)`.
 5. **Scheduler & I/O** (always, but most consumers gated on `enableProcessing`) — `scheduler::Scheduler` (registered for early shutdown). When `enableProcessing` is on: `wiconnector::WIndexerConnector` (queue metrics registered as pull callbacks) and `streamlog::LogManager(store, scheduler)`.
@@ -202,7 +202,6 @@ The engine uses a small but specific vocabulary, mirrored across the codebase, t
 - Each module exposes an `I<Module>` interface in `include/<module>/`, implementations in `src/`, GoogleTest unit tests in `test/src/unit/`, and mocks for use by other modules' tests in `test/mocks/`.
 - Dependencies are injected as `std::shared_ptr` and wired exclusively in [main.cpp](main.cpp); modules never instantiate their own dependencies.
 - API handlers follow a factory pattern; see [api/README.md](api/README.md) for the contract.
-- Build commands, sanitizers and environment variables are documented in [CLAUDE.md](../../../../.claude/CLAUDE.md) at the repository root.
 
 ---
 

--- a/src/engine/source/README.md
+++ b/src/engine/source/README.md
@@ -1,0 +1,215 @@
+# Wazuh Engine — Source Tree Architecture
+
+`wazuh-engine` is the decoding, enrichment and routing engine of the Wazuh manager (it ships as the `wazuh-manager-analysisd` daemon). It receives raw security events from `remoted` and external producers, parses them into the **Wazuh Common Schema (WCS)** using user-defined **decoders**, enriches them (GeoIP, IOC, KVDB lookups), runs them through one or more **policies**, and forwards the resulting normalized JSON documents to the Wazuh Indexer (and optional file outputs).
+
+The engine can also run standalone (`WAZUH_ENGINE_STANDALONE=true`) for development and testing.
+
+This README is the **developer / source-tree** view: what each directory does, how modules depend on each other, and how the process is wired together at startup. For operator-facing documentation (configuration, ruleset authoring, CLI usage), see the [user manual](../../../docs/ref/modules/engine/README.md).
+
+---
+
+## Event pipeline (data flow)
+
+```
+                          +----------------------+
+   remoted / agents ─────►│   httpsrv (events)   │  UDS HTTP ingestion
+                          +----------┬-----------+
+                                     │ JSON event
+                                     ▼
+                          +----------------------+
+                          │  router/Orchestrator │  fan-out per active policy
+                          +----------┬-----------+
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              ▼                      ▼                      ▼
+        Policy A (std)         Policy B (custom)       Tester session
+              │                      │                      │
+              └──────────┬───────────┴──────────┬───────────┘
+                         ▼                      ▼
+        ┌────────────────────────────────────────────────┐
+        │     bk::IController  (Rx or Taskflow)          │
+        │                                                │
+        │   pre-filter → decoders → pre-enrichment       │
+        │             → enrichment (geo, ioc, kvdb)      │
+        │             → post-filter → outputs            │
+        └────────────────────┬───────────────────────────┘
+                             │
+                             ▼
+              wazuh-indexer  /  file outputs (streamlog)
+```
+
+- One incoming event ⇒ one independent traversal **per active policy**.
+- Inside a policy, decoders are arranged hierarchically (a root decoder dispatches to children), and decoders are grouped into **integrations**.
+- The `builder` module compiles policy assets into an expression tree; the `bk` backend materializes that tree into a runnable pipeline (Rx or Taskflow).
+
+---
+
+## Architectural layers
+
+`source/` contains 33 modules. Below they are grouped by their role; arrows point in the direction of the dependency (a layer depends on the layers above it). Each entry links to that module's own README — the deep dive lives there, this index does not duplicate it.
+
+### Foundation
+
+Used by virtually every other module.
+
+- [base/](base/) — Shared primitives: logging (spdlog), JSON wrappers, error types (`base::Error`, `RespOrError`), expression trees (`base::Term`, `base::Event`), process and time utilities. No README; see [base/include/base/](base/include/base/).
+- [proto/](proto/) — Protobuf (`*.proto`) schema for the API. Wire format is JSON, but protobuf is the single source of truth shared by C++ handlers and the Python clients. No README; the `.proto` files in this directory are the contract.
+- [yml/](yml/) — yaml-cpp ↔ RapidJSON conversion used during config and content loading.
+- [conf/](conf/README.md) — Three-tier config (env → YAML file → defaults) with typed validation. Read by every module at startup.
+- [hlp/](hlp/README.md) — Type-specific parsers (IP, date, JSON, CSV, …). The parser library that decoders are built from.
+- [parsec/](parsec/README.md) — Header-only parser-combinator library that underlies `logpar` and `logicexpr`.
+- [logicexpr/](logicexpr/README.md) — Boolean expression parser/evaluator (Shunting-Yard) used in `check` stages.
+- [logpar/](logpar/README.md) — Compiles declarative log-format strings into composed `hlp` parsers.
+- [defs/](defs/README.md) — `$variable` substitution with cycle detection, used in asset definitions.
+- [schemf/](schemf/README.md) — WCS schema and field-type validation (build-time and runtime).
+- [fastqueue/](fastqueue/README.md) — Bounded thread-safe queues (lock-free `CQueue`, mutex `StdQueue`) with optional rate limiting.
+- [fastmetrics/](fastmetrics/README.md) — Lock-free counters/gauges/pull-callbacks with periodic JSON dump.
+
+### Storage
+
+- [store/](store/README.md) — JSON document store with pluggable driver (`FileDriver` ships in tree). The engine's persistent KV.
+- [cmstore/](cmstore/README.md) — Content repository: namespaces holding decoders, filters, outputs, integrations, KVDBs and policies, with bidirectional UUID↔name caches.
+- [kvdbstore/](kvdbstore/README.md) — In-memory KVDB cache materialized from `cmstore` for decoder/filter lookups; entries expire when no handler holds them.
+- [iockvdb/](iockvdb/README.md) — RocksDB-backed IOC database with RCU-style atomic hot-swap of the whole database instance.
+
+### Compilation & execution backend
+
+- [builder/](builder/) — The compilation hub. Reads assets from `cmstore` and produces executable `IPolicy` expression trees, pulling in `logpar`, `schemf`, `kvdbstore`, `iockvdb`, `geo`, `streamlog` and `wiconnector` via a `BuilderDeps` struct. No README; the public interface is in [builder/include/builder/](builder/include/builder/).
+- [bk/](bk/README.md) — Two interchangeable execution backends (RxCpp observable graph or Taskflow DAG) for the compiled expression. Provides node-tracing and hot-reload.
+
+### Enrichment & I/O services
+
+- [geo/](geo/README.md) — MaxMind GeoIP/ASN lookups with hash-based hot-reload.
+- [streamlog/](streamlog/README.md) — Async rotating log channels (size+time, gzip, retention) used by file outputs and `dumper`.
+- [dumper/](dumper/README.md) — Toggleable raw-event dumper that writes via `streamlog` when active.
+- [scheduler/](scheduler/README.md) — Priority thread-pool task scheduler for periodic syncs and metric flushes.
+- [wiconnector/](wiconnector/README.md) — Thread-safe client for the Wazuh Indexer: events, policy resources, IOCs and remote config. Sole egress to the indexer.
+
+### Synchronization & remote configuration
+
+- [confremote/](confremote/README.md) — Pulls remote runtime configuration from the indexer with rollback on rejection.
+- [cmcrud/](cmcrud/README.md) — Validation/adapter layer between the API and `cmstore` mutations; enforces canonical ordering and namespace import atomicity.
+- [cmsync/](cmsync/README.md) — Periodic content sync from indexer; hot-swaps router routes when policies change.
+- [iocsync/](iocsync/README.md) — Periodic IOC sync into `iockvdb` with atomic hot-swap.
+- [rawevtindexer/](rawevtindexer/README.md) — Toggleable forensic indexing of raw (pre-processing) events.
+
+### Routing & runtime
+
+- [router/](router/README.md) — Production `Router` (worker pool) + synchronous `Tester` + `Orchestrator` façade. Owns event queues, policy `Environment`s, and route hot-swap.
+
+### API gateway
+
+- [httpsrv/](httpsrv/README.md) — UDS HTTP server (cpp-httplib). Two instances are created in `main`: the management API and the optional remote-event-receiver.
+- [api/](api/README.md) — Per-domain handler factories: `router`, `tester`, `cmcrud`, `geo`, `ioccrud`, `dumper`, `rawevtindexer`, `metrics`, `event`. They translate JSON↔protobuf and delegate to the corresponding domain interface.
+
+### Entry point
+
+- [main.cpp](main.cpp) — Process entry. Signal/daemon handling, dependency-injection wiring, `StackExecutor` for LIFO shutdown.
+- [stackExecutor.hpp](stackExecutor.hpp) — Records shutdown callbacks at construction order and runs them in reverse.
+
+---
+
+## Module dependency graph (high level)
+
+`base`, `conf`, `proto` and other foundation libraries are omitted — they are used everywhere. The graph emphasizes the runtime hubs.
+
+```
+                                  ┌──────────────┐
+                                  │     api      │   (handlers per domain)
+                                  └──────┬───────┘
+                                         │
+                                  ┌──────▼───────┐
+                                  │   httpsrv    │
+                                  └──────────────┘
+
+      ┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+      │   cmsync     │───►│     router      │◄───│  fastqueue   │
+      └──────┬───────┘    │  (Orchestrator) │    └──────────────┘
+             │            └────────┬────────┘
+             │                     │
+             ▼                     ▼
+      ┌──────────────┐     ┌──────────────┐
+      │   cmcrud     │     │   builder    │ ─── compilation hub
+      └──────┬───────┘     └──┬───┬───┬───┘
+             │                │   │   │
+             ▼                │   │   └────────────► geo, streamlog
+      ┌──────────────┐        │   │
+      │   cmstore    │◄───────┘   └────► logpar ──► hlp ──► parsec
+      └──────┬───────┘                   schemf
+             │                           kvdbstore
+             ▼                           iockvdb ◄── iocsync
+        ┌────────┐
+        │ store  │◄── confremote, rawevtindexer
+        └────────┘
+
+                  ┌────────────────┐
+                  │  wiconnector   │ ──► wazuh-indexer    (sole egress)
+                  └────────────────┘
+                          ▲
+              cmsync, iocsync, confremote,
+              rawevtindexer, streamlog, builder
+```
+
+Key relationships:
+
+- **`router` is the runtime hub.** It owns event queues, worker threads and route lifecycle; `cmsync` hot-swaps its routes.
+- **`builder` is the compilation hub.** Every dependency that contributes to event processing is funneled into it via `BuilderDeps`.
+- **`store` and `cmstore` are the data hubs.** Persisted state (schemas, allowed fields, ruleset, sync state) flows through them.
+- **`wiconnector` is the only egress to the indexer.** All outbound traffic to OpenSearch goes through it.
+
+---
+
+## Startup & dependency injection (`main.cpp`)
+
+Modules are wired together in [main.cpp](main.cpp) using `std::shared_ptr` and a `StackExecutor` that records teardown callbacks for LIFO shutdown. Construction is staged so each phase only depends on phases above it. Some phases are gated by `conf::key::SERVER_ENABLE_EVENT_PROCESSING`.
+
+1. **Process bootstrap** — option parsing, logging (standalone vs `libwazuhshared`), signal handlers (`SIGINT`, `SIGTERM`, `SIGPIPE` → ignore), optional `goDaemon()`.
+2. **Configuration** — `conf::Conf` loads from YAML; every later module reads it via `confManager.get<T>(key::…)`.
+3. **Core data layer** — `store::Store` (with `FileDriver`) → `cmstore::CMStore` → `kvdbstore::KVDBManager` → `iockvdb::KVDBManager(store)` → `geo::Manager(store, downloader)` → `fastmetrics::registerManager()` → `schemf::Schema` (loads `schema/engine-schema/0` from `store`).
+4. **Parsing** — `hlp::initTZDB(...)` then `logpar::Logpar` (uses `schema/wazuh-logpar-overrides/0` from `store` and the schema validator); `hlp::registerParsers(logpar)`.
+5. **Scheduler & I/O** (always, but most consumers gated on `enableProcessing`) — `scheduler::Scheduler` (registered for early shutdown). When `enableProcessing` is on: `wiconnector::WIndexerConnector` (queue metrics registered as pull callbacks) and `streamlog::LogManager(store, scheduler)`.
+6. **Compilation hub** — `builder::Builder(cmStore, schemaValidator, defs, allowedFields, builderDeps, store)` where `BuilderDeps` carries `logpar`, `kvdbManager`, `IOCkvdb`, `geoManager`, `streamLogger`, `indexerConnector` and the file-output rotation config. Then `cmcrud::CrudService(cmStore, builder)`.
+7. **Background services** (gated) — `confremote::ConfRemoteManager`, `rawevtindexer::RawEventIndexer`, `router::Orchestrator(...)` (started immediately and registered for shutdown), `cmsync::CMSync`, `iocsync::IocSync` (scheduled via `scheduler`), `dumper::Dumper(streamLogger)`.
+8. **API surface** — `httpsrv::Server` is created, then per-domain handlers register their routes against it: metrics, geo, router, tester, dumper, rawevtindexer, cmcrud, ioccrud. Finally `apiServer->start(socketPath)`. An optional second `httpsrv::Server` is created for the remote-event-receiver (event ingestion).
+
+Shutdown is the exact reverse: `StackExecutor` drains callbacks in LIFO. The API server stops first (it joins client connections), background services request shutdown and join, the orchestrator drains queues, `streamlog` and `wiconnector` flush, the scheduler stops, and logging is the last thing torn down.
+
+---
+
+## Domain glossary
+
+The engine uses a small but specific vocabulary, mirrored across the codebase, the API and the user manual.
+
+- **Event** — JSON document representing a security log line, carrying agent/cluster metadata. The unit of work flowing through the engine.
+- **Wazuh Common Schema (WCS)** — Authoritative typed field schema all output events must conform to. Owned by the indexer; the engine fetches `schema/engine-schema/0` from `store` at startup.
+- **Asset** — Smallest content unit (decoder, filter, output, integration, KVDB, schema). Addressed as `<type>/<name>/<version>` (e.g. `decoder/aws-cloudtrail/0`).
+- **Decoder** — Asset that parses and normalizes events into WCS fields. Decoders are arranged hierarchically (root → children) and grouped into integrations.
+- **Integration** — Ordered group of decoders + KVDBs that belong to one product or log source. Every decoder lives in exactly one integration.
+- **Filter** — Boolean predicate over an event. Pre-filters drop events before decoding; post-filters drop events before they reach outputs.
+- **Output** — Destination for processed events (Wazuh Indexer, file). Bundled with the manager, not synced from content.
+- **Policy** — Named pipeline `pre-filter → decoders → pre-enrichment → enrichment → post-filter → outputs`. Multiple policies run concurrently.
+- **Namespace / Space** — Logical content partition. Two spaces ship: **standard** (Wazuh-maintained) and **custom** (user). The indexer is the source of truth; the engine mirrors it locally.
+- **KVDB** — Lightweight key-value store consulted by decoders/filters during processing. Regular KVDBs are per-space; IOC and Geo databases are global.
+- **Helper** — Reusable function callable from decoder/filter stages: condition helpers (in `check`) and mapping helpers (in `map`).
+- **Stage** — Operation block inside a decoder: `check` (boolean), `parse|<field>` (extraction), `normalize` (with nested `map`).
+- **Route / Environment** — Runtime instance of a compiled policy held by the orchestrator. Routes can be hot-swapped without restart.
+
+---
+
+## Conventions
+
+- **C++17** across the engine; `clang-format` and `clang-tidy` configured at `engine/`.
+- Each module exposes an `I<Module>` interface in `include/<module>/`, implementations in `src/`, GoogleTest unit tests in `test/src/unit/`, and mocks for use by other modules' tests in `test/mocks/`.
+- Dependencies are injected as `std::shared_ptr` and wired exclusively in [main.cpp](main.cpp); modules never instantiate their own dependencies.
+- API handlers follow a factory pattern; see [api/README.md](api/README.md) for the contract.
+- Build commands, sanitizers and environment variables are documented in [CLAUDE.md](../../../../.claude/CLAUDE.md) at the repository root.
+
+---
+
+## Further reading
+
+- [User manual / quick-start](../../../docs/ref/modules/engine/README.md) — operator-facing documentation.
+- [api/README.md](api/README.md) — API handler conventions.
+- [router/README.md](router/README.md) — runtime orchestration, route lifecycle and tester semantics.
+- [builder/](builder/) — policy compilation (no README; start at [builder/include/builder/builder.hpp](builder/include/builder/builder.hpp)).
+- [bk/README.md](bk/README.md) — execution backends.

--- a/src/engine/source/confremote/README.md
+++ b/src/engine/source/confremote/README.md
@@ -1,0 +1,230 @@
+# ConfRemote Module
+
+## Overview
+
+The **confremote** module manages runtime remote configuration for the Wazuh engine. It periodically fetches settings from `wazuh-indexer`, applies them to registered modules via callbacks, and persists the accepted state to the internal store for crash/restart resilience.
+
+The module follows an observer pattern: other modules register per-key callbacks (`addTrigger`), and the manager invokes them whenever the remote value changes. Callbacks can reject values by throwing an exception, in which case the previous value is preserved.
+
+## Architecture
+
+```
+                     wazuh-indexer
+                    (.wazuh-settings)
+                          │
+                 getEngineRemoteConfig()
+                          │
+              ┌───────────▼────────────────────────────────────┐
+              │          ConfRemoteManager                      │
+              │                                                 │
+              │  synchronize()  ◄── scheduler (periodic task)   │
+              │       │                                         │
+              │       ▼                                         │
+              │  Fetch remote JSON ──► Compare with lastConfig  │
+              │                              │                  │
+              │                    changed?  │  unchanged?      │
+              │                      │              │           │
+              │              invoke callback     skip           │
+              │                 │         │                     │
+              │            accepted    rejected (throws)        │
+              │                │              │                 │
+              │         update lastConfig   keep current        │
+              │                │                                │
+              │         saveSettingsToStore()                    │
+              │                │                                │
+              │      ┌────────▼─────────┐                      │
+              │      │   store (IStore)  │                      │
+              │      │ "remote-config/   │                      │
+              │      │  engine-cnf/0"    │                      │
+              │      └──────────────────┘                      │
+              └─────────────────────────────────────────────────┘
+                          │
+                  addTrigger("key", callback, default)
+                          │
+              ┌───────────▼───────────┐
+              │   Consumer modules    │
+              │  (e.g. RawEventIndexer│
+              │   hotReloadConf)      │
+              └───────────────────────┘
+```
+
+## Key Concepts
+
+### Interface (`IConfRemote`)
+
+Defined in `interface/confremote/iconfremote.hpp`. Exposes two methods:
+
+| Method | Description |
+|--------|-------------|
+| `synchronize()` | Fetches settings from wazuh-indexer and applies changes. Non-throwing: failures are handled internally |
+| `requestShutdown()` | Signals graceful shutdown; aborts in-flight or future sync operations |
+
+### Trigger Registration (`addTrigger`)
+
+Modules register interest in a specific configuration key via `addTrigger()`:
+
+```cpp
+json::Json addTrigger(
+    std::string_view key,                              // setting key (e.g. "index_raw_events")
+    std::function<void(const json::Json&)> callback,   // invoked on value change
+    const json::Json& defaultValue                     // fallback when no persisted value exists
+);
+```
+
+**Return value**: The last persisted value for the key (from store), or `defaultValue` if no cached state exists. This allows the consumer to initialize itself immediately.
+
+**Rules**:
+- Each key can only be registered once. Duplicate registration throws `std::invalid_argument`.
+- The callback receives the candidate value. If it throws, the change is **rejected** and the previous value is kept.
+- Callbacks are invoked under a unique lock (`m_mutex`), so they must not call back into the manager.
+
+### Synchronization Cycle
+
+Each call to `synchronize()` executes the following steps:
+
+1. **Check shutdown flag** — abort early if shutdown was requested.
+2. **Fetch remote settings** — call `IWIndexerConnector::getEngineRemoteConfig()` with retry logic (`m_attempts` retries, `m_waitSeconds` delay between attempts).
+3. **Iterate remote keys** — for each key in the fetched JSON object:
+   - Skip if no callback is registered for the key.
+   - Skip if the value equals `lastConfig` (no change).
+   - Invoke the registered callback.
+   - If the callback throws, log a warning and keep the previous value.
+   - If the callback succeeds, update `lastConfig`.
+4. **Persist** — if any value changed, save all `lastConfig` entries to the store via `upsertDoc`.
+
+The synchronization is **non-destructive**: network failures, invalid payloads, or rejected callbacks never corrupt existing state.
+
+### Persistence
+
+Settings are persisted to the store under the document path `remote-config/engine-cnf/0`. The stored document is a flat JSON object mapping keys to their last accepted values:
+
+```json
+{
+  "index_raw_events": true
+}
+```
+
+On construction, the manager loads this document (if it exists) to restore `lastConfig` for all previously known keys. This ensures that after a restart, `addTrigger()` returns the last known good value even before the first `synchronize()` completes.
+
+### Shutdown
+
+`requestShutdown()` sets an atomic flag that is checked:
+- Before starting synchronization.
+- Before each retry attempt during remote fetch (via `executeWithRetry`).
+- Between processing individual settings.
+
+This ensures prompt cancellation without leaving partial state.
+
+## Dependencies
+
+| Dependency | CMake Target | Role |
+|------------|-------------|------|
+| `base` | `base` | Logging, JSON, error handling, `executeWithRetry` |
+| `store` | `store::istore` | Persisting/loading cached settings (`IStore`) |
+| `wiconnector` | `wIndexerConnector::iwIndexerConnector` | Fetching remote config from wazuh-indexer (`IWIndexerConnector`) |
+
+## Configuration
+
+Controlled by three configuration keys (defined in `conf/include/conf/keys.hpp`):
+
+| Key | Env Override | Default | Description |
+|-----|-------------|---------|-------------|
+| `analysisd.remote_conf_indexer_connector_max_retries` | `WAZUH_REMOTE_CONF_INDEXER_CONNECTOR_MAX_RETRIES` | `3` | Max retry attempts when fetching remote config |
+| `analysisd.remote_conf_indexer_connector_retry_interval` | `WAZUH_REMOTE_CONF_INDEXER_CONNECTOR_RETRY_INTERVAL` | `5` | Seconds between retry attempts |
+| `analysisd.remote_conf_sync_interval` | `WAZUH_REMOTE_CONF_SYNC_INTERVAL` | `120` | Seconds between periodic synchronization calls |
+
+## Integration in `main.cpp`
+
+The module is wired in the engine entry point with the following lifecycle:
+
+```cpp
+// 1. Construction — injected with indexer connector, store, and retry config
+remoteConf = std::make_shared<confremote::ConfRemoteManager>(
+    indexerConnector, store, maxRetries, retryInterval);
+
+// 2. Shutdown hook
+exitHandler.add([remoteConf]() { remoteConf->requestShutdown(); });
+
+// 3. Register consumers
+const auto initialValue = remoteConf->addTrigger(
+    "index_raw_events",
+    [rawEventIndexer](const json::Json& v) { rawEventIndexer->hotReloadConf(v); },
+    json::Json("false"));
+rawEventIndexer->hotReloadConf(initialValue);
+
+// 4. Schedule periodic sync
+scheduler->scheduleTask("remote-conf-sync",
+    {.interval = remoteConfSyncInterval, .runImmediately = true, ...},
+    [remoteConf]() { remoteConf->synchronize(); });
+```
+
+Currently, the only registered setting is `"index_raw_events"`, which controls whether the `RawEventIndexer` module forwards raw events to the indexer.
+
+## Thread Safety
+
+- `m_mutex` (`std::shared_mutex`) protects `m_settings`. Both `synchronize()` and `addTrigger()` acquire a unique lock.
+- `m_shutdownRequested` is an `std::atomic<bool>` with relaxed ordering, sufficient for signaling intent.
+- `m_indexerConnector` and `m_store` are held as `std::weak_ptr` to avoid preventing destruction of shared resources.
+
+## File Structure
+
+```
+confremote/
+├── CMakeLists.txt                                    # Build targets: iconfremote (INTERFACE), confremote (STATIC)
+├── interface/confremote/
+│   └── iconfremote.hpp                               # IConfRemote interface (synchronize, requestShutdown)
+├── include/confremote/
+│   └── confremotemanager.hpp                         # ConfRemoteManager class declaration
+├── src/
+│   └── confremotemanager.cpp                         # Full implementation
+└── test/src/
+    ├── unit/
+    │   └── confremotemanager_test.cpp                # Unit tests (mocked store + connector)
+    └── component/
+        └── confremote_refresh_test.cpp               # Component tests (with real RawEventIndexer)
+```
+
+## Testing
+
+### Unit Tests (`confremote_utest`)
+
+Test the manager in isolation with mocked `IStore` and `IWIndexerConnector`:
+
+| Test | Verifies |
+|------|----------|
+| `CanConstructWithStoreAndNullConnector` | Null connector is accepted (sync will fail gracefully) |
+| `AddTriggerReturnsDefaultWhenStoreIsEmpty` | Default value returned when no cache exists |
+| `AddTriggerReturnsPersistedValueWhenStoreHasCache` | Cached value returned over default |
+| `AddTriggerThrowsWhenKeyIsAlreadyRegistered` | Duplicate key throws `std::invalid_argument` |
+| `SynchronizeSkipsCallbackWhenValueDoesNotChange` | No callback invoked when remote == lastConfig |
+| `SynchronizeNotifiesWhenValueChanges` | Callback invoked and value persisted on change |
+| `RejectedCallbackDoesNotCommitValue` | Throwing callback keeps previous state |
+| `SynchronizeCallbackRejectsWrongTypeAndPreservesCurrentState` | Type validation via callback works |
+| `SynchronizeWithFetchFailureKeepsCurrentState` | Network failure leaves state unchanged |
+| `SynchronizeIgnoresUnregisteredKeys` | Keys without callbacks are skipped |
+| `SynchronizeWithNullConnectorDoesNotThrow` | Graceful handling of expired connector |
+
+### Component Tests (`confremote_ctest`)
+
+Test integration with the real `RawEventIndexer` module:
+
+| Test | Verifies |
+|------|----------|
+| `SynchronizePropagatesChangedValue` | End-to-end value change propagation |
+| `PersistedValueIsReturnedByAddTriggerOnRecreation` | Restart resilience via store persistence |
+| `FreshInstallKeepsRawEventIndexerDisabled` | Default behavior when indexer is unreachable |
+| `RestartWithCachedSettingsWhenRemoteUnavailableUsesLastValidValue` | Cached state survives outage |
+| `SynchronizeTogglesRawEventIndexer` | Toggle from disabled to enabled |
+
+Build tests with `ENGINE_TEST=y`:
+
+```bash
+make --directory=$WAZUH_REPO/src -j TARGET=manager ENGINE_TEST=y DEBUG=yes
+```
+
+Run:
+
+```bash
+$ENGINE_BUILD/source/confremote/confremote_utest
+$ENGINE_BUILD/source/confremote/confremote_ctest
+```

--- a/src/engine/source/dumper/README.md
+++ b/src/engine/source/dumper/README.md
@@ -1,0 +1,227 @@
+# Dumper Module
+
+## Overview
+
+The **dumper** module provides an activatable event-dumping mechanism for the Wazuh engine. When active, it writes incoming event data to rotating log files via the `streamlog` subsystem. When inactive, all `dump()` calls are silently discarded (no-op). The module can be toggled at runtime through API endpoints, enabling on-demand event capture for debugging and diagnostics without restarting the engine.
+
+## Architecture
+
+```
+                  Incoming events (NDJSON batches)
+                          │
+              ┌───────────▼───────────────────────────────┐
+              │      api/event – pushEvent handler         │
+              │                                            │
+              │   dumpRef->dump(batchToDump)               │
+              └───────────┬───────────────────────────────┘
+                          │
+              ┌───────────▼───────────────────────────────┐
+              │           IDumper                          │
+              │   dump(string | char* | string_view)       │
+              │   activate() / deactivate() / isActive()   │
+              └───────────┬───────────────────────────────┘
+                          │
+              ┌───────────▼───────────────────────────────┐
+              │            Dumper                           │
+              │                                            │
+              │   m_logWriter ──► streamlog::WriterEvent    │
+              │      (null when inactive)                   │
+              │                                            │
+              │   active:   (*m_logWriter)(data)            │
+              │   inactive: return (no-op)                  │
+              └───────────┬───────────────────────────────┘
+                          │
+              ┌───────────▼───────────────────────────────┐
+              │     streamlog::ILogManager                  │
+              │   ensureAndGetWriter("event-dumps", cfg)    │
+              │                                            │
+              │   → rotating log files on disk              │
+              │     (async, buffered, compressible)         │
+              └────────────────────────────────────────────┘
+
+              ┌────────────────────────────────────────────┐
+              │   API Endpoints (api/dumper)                │
+              │                                            │
+              │   POST /_internal/event-dumper/activate     │
+              │   POST /_internal/event-dumper/deactivate   │
+              │   POST /_internal/event-dumper/status       │
+              └────────────────────────────────────────────┘
+```
+
+## Key Concepts
+
+### Interface (`IDumper`)
+
+Defined in `interface/dumper/idumper.hpp`. All methods are virtual:
+
+| Method | Description |
+|--------|-------------|
+| `dump(const std::string&)` | Write data to the log channel (no-op if inactive) |
+| `dump(const char*)` | Write data from C-string; returns early on `nullptr` or empty string |
+| `dump(std::string_view)` | Write data from zero-copy view; returns early on empty view |
+| `activate()` | Enable the dumper (creates the streamlog writer) |
+| `deactivate()` | Disable the dumper (releases the writer) |
+| `isActive()` | Returns `true` if the dumper currently holds an active writer |
+
+All `dump()` overloads are **non-throwing**: if the dumper is inactive, calls are silently ignored.
+
+### Active/Inactive State
+
+The dumper's state is determined by whether `m_logWriter` is non-null:
+
+- **Active**: `m_logWriter` points to a `streamlog::WriterEvent` bound to the `"event-dumps"` channel. Data passed to `dump()` is forwarded to `(*m_logWriter)(data)`, which asynchronously writes to rotating log files.
+- **Inactive**: `m_logWriter` is null. All `dump()` calls check for null and return immediately.
+
+State transitions:
+
+| Operation | From → To | Effect |
+|-----------|-----------|--------|
+| `activate()` | inactive → active | Calls `ILogManager::ensureAndGetWriter()` to obtain a writer. No-op if already active |
+| `deactivate()` | active → inactive | Resets `m_logWriter` to null. No-op if already inactive |
+
+### Streamlog Channel
+
+The dumper writes to a channel named `"event-dumps"` with extension `"log"` (constants `CHANNEL_NAME` and `CHANNEL_EXTENSION`). The channel is configured via `streamlog::RotationConfig`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `basePath` | `std::string` | Base directory for log files |
+| `pattern` | `std::string` | File naming pattern (supports `${YYYY}`, `${MMM}`, `${DD}`, `${name}`) |
+| `maxSize` | `size_t` | Max size per file before rotation (`0` = unlimited) |
+| `bufferSize` | `size_t` | In-memory write buffer size |
+| `shouldCompress` | `bool` | Whether to compress rotated files |
+| `compressionLevel` | `size_t` | Compression level (if enabled) |
+| `maxFiles` | `size_t` | Max number of rotated files to keep |
+| `maxAccumulatedSize` | `size_t` | Max total size across all rotated files |
+
+## Dependencies
+
+| Dependency | CMake Target | Role |
+|------------|-------------|------|
+| `base` | `base` | Error handling, JSON |
+| `streamlog` | `streamlogger::istreamlogger` | `ILogManager` and `WriterEvent` for file-based async logging |
+
+## Configuration
+
+The dumper configuration is sourced from `conf` keys (passed via `RotationConfig` at construction):
+
+| Key prefix | Description |
+|-----------|-------------|
+| `STREAMLOG_BASE_PATH` | Base directory for dump log files |
+| `STREAMLOG_DUMPER_PATTERN` | File naming pattern for the dumper channel |
+| `STREAMLOG_DUMPER_MAX_SIZE` | Max file size before rotation |
+| `STREAMLOG_DUMPER_BUFFER_SIZE` | Write buffer size |
+| `STREAMLOG_SHOULD_COMPRESS` | Enable compression of rotated files |
+| `STREAMLOG_COMPRESSION_LEVEL` | Compression level |
+| `STREAMLOG_MAX_FILES` | Max rotated file count |
+| `STREAMLOG_MAX_ACCUMULATED_SIZE` | Max total rotated file size |
+| `DUMPER_ENABLED` | Initial active state (`true`/`false`) |
+
+## Integration in `main.cpp`
+
+```cpp
+// 1. Build rotation config from conf keys
+const auto dumperConfig = streamlog::RotationConfig {
+    .basePath = confManager.get<std::string>(conf::key::STREAMLOG_BASE_PATH),
+    .pattern  = confManager.get<std::string>(conf::key::STREAMLOG_DUMPER_PATTERN),
+    // ... remaining RotationConfig fields ...
+};
+
+// 2. Construct dumper with streamlog manager, config, and initial enabled state
+dumper = std::make_shared<dumper::Dumper>(
+    streamLogger, dumperConfig, confManager.get<bool>(conf::key::DUMPER_ENABLED));
+
+// 3. Register exit handler to deactivate on shutdown
+exitHandler.add([dumper]() { dumper->deactivate(); });
+```
+
+### Consumer: Event Ingestion (`api/event`)
+
+The `pushEvent` HTTP handler receives a `weak_ptr<IDumper>` and dumps each incoming NDJSON batch before parsing:
+
+```cpp
+if (auto dumpRef = weakDump.lock(); dumpRef)
+{
+    std::string_view batchToDump = req.body;
+    if (!batchToDump.empty() && batchToDump.back() == '\n')
+        batchToDump.remove_suffix(1);
+    dumpRef->dump(batchToDump);
+}
+```
+
+### Consumer: Runtime Control (`api/dumper`)
+
+Three HTTP endpoints allow runtime toggling:
+
+| Endpoint | Method | Action |
+|----------|--------|--------|
+| `/_internal/event-dumper/activate` | POST | `dumper->activate()` |
+| `/_internal/event-dumper/deactivate` | POST | `dumper->deactivate()` |
+| `/_internal/event-dumper/status` | POST | `dumper->isActive()` |
+
+## Thread Safety
+
+- `m_loggerMutex` (`std::shared_mutex`) protects all access to `m_logWriter`:
+  - `dump()` acquires a **shared lock** — multiple threads can dump concurrently.
+  - `activate()`, `deactivate()`, and the destructor acquire a **unique lock**.
+  - `isActive()` acquires a **shared lock**.
+- `m_logger` is held as `std::weak_ptr` to avoid preventing destruction of the log manager.
+
+## File Structure
+
+```
+dumper/
+├── CMakeLists.txt                              # Build: iface (INTERFACE), dumper (STATIC), mocks, utest
+├── interface/dumper/
+│   └── idumper.hpp                             # IDumper interface (dump, activate, deactivate, isActive)
+├── include/dumper/
+│   └── dumper.hpp                              # Dumper class declaration + inline activate/deactivate/isActive
+├── src/
+│   └── dumper.cpp                              # dump() overloads implementation
+├── test/
+│   ├── mocks/dumper/
+│   │   └── mockDumper.hpp                      # GMock mock for IDumper (used by other modules' tests)
+│   └── src/unit/
+│       └── dumper_test.cpp                     # Unit tests with mocked streamlog
+```
+
+## Testing
+
+### Unit Tests (`dumper_utest`)
+
+Test the dumper with mocked `ILogManager` and `WriterEvent`:
+
+| Test | Verifies |
+|------|----------|
+| `ConstructorWithInvalidLogger` | Null logger throws `std::runtime_error` |
+| `ConstructorInactive` | Default state is inactive |
+| `ConstructorActive` | Active construction creates writer |
+| `Activate` | Transition from inactive to active |
+| `ActivateWhenAlreadyActive` | No duplicate writer creation |
+| `ActivateWithInvalidLogger` | Expired logger throws on activate |
+| `Deactivate` | Transition from active to inactive |
+| `DeactivateWhenAlreadyInactive` | No-op on double deactivate |
+| `DumpStringWhenActive` | Data forwarded to writer |
+| `DumpStringWhenInactive` | Data silently discarded |
+| `DumpCStringWhenActive` | C-string forwarded to writer |
+| `DumpNullCString` | `nullptr` returns early without writing |
+| `DumpEmptyCString` | Empty string returns early without writing |
+| `DumpWriterReturnsFalse` | No throw even if writer fails |
+| `ThreadSafety` | Concurrent `isActive()` calls are safe |
+| `DestructorCleansUp` | Destructor releases writer cleanly |
+
+Build tests with `ENGINE_TEST=y`:
+
+```bash
+make --directory=$WAZUH_REPO/src -j TARGET=manager ENGINE_TEST=y DEBUG=yes
+```
+
+Run:
+
+```bash
+$ENGINE_BUILD/source/dumper/dumper_utest
+```
+
+## Mock
+
+A GMock mock is provided at `test/mocks/dumper/mockDumper.hpp` (`dumper::mocks::MockDumper`) for use by other modules that depend on `IDumper`. CMake target: `dumper::mocks`.

--- a/src/engine/source/fastmetrics/README.md
+++ b/src/engine/source/fastmetrics/README.md
@@ -1,0 +1,272 @@
+# FastMetrics Module
+
+## Overview
+
+The **fastmetrics** module provides a high-performance, lock-free metrics system for the Wazuh engine. It is designed for ultra-low-overhead instrumentation of hot paths (event processing loops, queue operations) using `std::atomic` with `memory_order_relaxed`. Metrics are registered in a thread-safe registry and accessed globally via a singleton pattern (`SingletonLocator`).
+
+The module supports three metric types: **counters** (monotonically increasing), **gauges** (bidirectional integers), and **pull metrics** (on-demand callbacks). All metrics are periodically serialized as JSON lines and written to rotating log files via the `streamlog` subsystem.
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────────────────────┐
+                    │                  Producers                          │
+                    │                                                     │
+                    │  router/worker:    counter.add(1)    (hot path)     │
+                    │  router/orch:      FASTMETRICS_PULL(...)            │
+                    │  api/event:        counter.add(bytes) (hot path)    │
+                    │  builder/policy:   counter.add(1)                   │
+                    │  main.cpp:         FASTMETRICS_PULL(...)            │
+                    └───────────────┬─────────────────────────────────────┘
+                                    │
+                         lock-free atomic ops
+                                    │
+                    ┌───────────────▼─────────────────────────────────────┐
+                    │              IManager (singleton)                    │
+                    │                                                     │
+                    │  getOrCreateCounter(name)  → shared_ptr<ICounter>   │
+                    │  getOrCreateGaugeInt(name) → shared_ptr<IGaugeInt>  │
+                    │  registerPullMetric(name, getter)                   │
+                    │                                                     │
+                    │  ┌────────────────────────────────────────────────┐ │
+                    │  │         Manager (registry)                     │ │
+                    │  │  m_metrics: unordered_map<string, IMetric>     │ │
+                    │  │                                                │ │
+                    │  │  Registration: unique_lock    (cold path)      │ │
+                    │  │  Lookup:       shared_lock    (warm path)      │ │
+                    │  │  Update:       lock-free      (hot path)       │ │
+                    │  └────────────────────────────────────────────────┘ │
+                    └───────────────┬─────────────────────────────────────┘
+                                    │
+                          writeAllMetrics(writer)
+                           (scheduled task)
+                                    │
+                    ┌───────────────▼──────────────────┐
+                    │   streamlog::WriterEvent          │
+                    │   channel: "engine-metrics"       │
+                    │   → JSON lines to rotating files  │
+                    └──────────────────────────────────┘
+
+                    ┌──────────────────────────────────┐
+                    │   API Endpoints (api/metrics)     │
+                    │                                   │
+                    │   GET  /metrics/{name}             │
+                    │   GET  /metrics                    │
+                    │   POST /metrics/enable             │
+                    │   POST /metrics/dump               │
+                    └──────────────────────────────────┘
+```
+
+## Key Concepts
+
+### Metric Types
+
+| Type | Interface | Implementation | Storage | Use Case |
+|------|-----------|---------------|---------|----------|
+| `COUNTER` | `ICounter` | `AtomicCounter` | `atomic<uint64_t>` | Monotonically increasing values (events processed, bytes received) |
+| `GAUGE_INT` | `IGaugeInt` | `AtomicGaugeInt` | `atomic<int64_t>` | Values that go up/down (queue sizes, active connections) |
+| `PULL` | `IMetric` | `PullMetric<T>` | `std::function<T()>` | On-demand callbacks that read existing state (queue usage %, EPS rates) |
+
+### Performance Model
+
+The module is designed around three performance tiers:
+
+1. **Hot path** (lock-free): `counter.add()`, `gauge.set()`, `gauge.add()`, `gauge.sub()` — all use `atomic::fetch_add` / `atomic::store` with `memory_order_relaxed`. Zero contention.
+2. **Warm path** (shared lock): `manager().get()`, `manager().exists()`, `manager().getAllNames()` — read-only lookups on the registry map with `shared_lock`.
+3. **Cold path** (unique lock): `getOrCreateCounter()`, `getOrCreateGaugeInt()`, `registerPullMetric()` — registration with double-checked locking pattern.
+
+### Enable/Disable
+
+Each metric has an individual `m_enabled` atomic flag. When disabled, all mutation operations (`add`, `set`, `sub`) become no-ops and `value()` returns 0.0. The manager provides `enableAll()` / `disableAll()` to toggle all metrics globally via `m_globalEnabled`.
+
+### Singleton Access Pattern
+
+The manager is registered once via `fastmetrics::registerManager()` and accessed globally through `fastmetrics::manager()`, which resolves to `SingletonLocator::instance<IManager>()`. This avoids passing the manager through dependency injection in hot paths.
+
+```cpp
+// Registration (once in main.cpp)
+fastmetrics::registerManager();
+
+// Access from anywhere
+auto counter = fastmetrics::manager().getOrCreateCounter("router.events.processed");
+counter->add(1);  // lock-free, hot path
+```
+
+### Pull Metrics and the `FASTMETRICS_PULL` Macro
+
+Pull metrics avoid state duplication by executing a callback on read:
+
+```cpp
+FASTMETRICS_PULL(uint64_t, "indexer.queue.size", [wIndexer]() { return wIndexer->queueSize(); });
+FASTMETRICS_PULL(double, "router.eps.1m", [rate]() { return rate->getRate(std::chrono::seconds(60)); });
+```
+
+The macro expands to `fastmetrics::registerPullMetric(name, std::function<type()>(getter))`.
+
+### Sliding Window Rate (`SlidingWindowRate`)
+
+A lock-free circular buffer for computing events-per-second (EPS) over configurable time windows (up to 31 minutes). Used by the router to compute `router.eps.1m`, `router.eps.5m`, and `router.eps.30m`.
+
+- Resolution: 1 second per bucket.
+- Buffer size: 1860 buckets (31 × 60 seconds).
+- Each bucket has an atomic timestamp and atomic count.
+- Bucket recycling uses a CAS-based protocol with a sentinel timestamp (`RECYCLING_TS`) to prevent data races.
+- Reads use a double-check pattern (read timestamp, read count, re-read timestamp) for consistency.
+
+### Metric Output Format
+
+`writeAllMetrics()` serializes all metrics as JSON lines:
+
+```json
+{"timestamp":1715270400000,"name":"router.events.processed","value":42}
+{"timestamp":1715270400000,"name":"indexer.queue.size","value":100}
+```
+
+Timestamp is milliseconds since epoch. Value is always `double`.
+
+## Registered Metric Names
+
+Predefined names in `metric_names.hpp`:
+
+| Name | Type | Source |
+|------|------|--------|
+| `indexer.queue.size` | PULL | main.cpp (indexer connector) |
+| `indexer.queue.usage.percent` | PULL | main.cpp (indexer connector) |
+| `indexer.events.dropped` | PULL | main.cpp (indexer connector) |
+| `router.queue.size` | PULL | router/orchestrator |
+| `router.queue.usage.percent` | PULL | router/orchestrator |
+| `router.events.processed` | COUNTER | router/worker |
+| `router.events.dropped` | COUNTER | router/orchestrator |
+| `router.eps.1m` | PULL | router/orchestrator (SlidingWindowRate) |
+| `router.eps.5m` | PULL | router/orchestrator (SlidingWindowRate) |
+| `router.eps.30m` | PULL | router/orchestrator (SlidingWindowRate) |
+| `server.bytes.received` | COUNTER | api/event |
+| `server.events.received` | COUNTER | api/event |
+| `space.{name}.events.unclassified` | COUNTER | builder/policy (per-space) |
+| `space.{name}.events.discarded` | COUNTER | builder/policy (per-space) |
+| `space.{name}.events.discarded.prefilter` | COUNTER | builder/policy (per-space) |
+| `space.{name}.events.discarded.postfilter` | COUNTER | builder/policy (per-space) |
+
+## Dependencies
+
+| Dependency | CMake Target | Role |
+|------------|-------------|------|
+| `base` | `base` | `SingletonLocator`, logging |
+| `streamlog` | `streamlogger::streamlogger` | `WriterEvent` and `ILogManager` for `writeAllMetrics()` |
+
+## Integration in `main.cpp`
+
+```cpp
+// 1. Register singleton manager (early startup)
+fastmetrics::registerManager();
+
+// 2. Register pull metrics for indexer
+FASTMETRICS_PULL(uint64_t, fastmetrics::names::INDEXER_QUEUE_SIZE, [wIndexer]() { ... });
+FASTMETRICS_PULL(double, fastmetrics::names::INDEXER_QUEUE_USAGE_PERCENT, indexerQueueUsageGetter);
+
+// 3. Wrap singleton as shared_ptr for API handlers
+metricsManager = std::shared_ptr<fastmetrics::IManager>(&fastmetrics::manager(), [](auto*) {});
+
+// 4. Register API endpoints
+api::metrics::handlers::registerHandlers(metricsManager, apiServer, ...);
+
+// 5. Schedule periodic metrics dump to streamlog
+scheduler->scheduleTask("MetricsLogger", {
+    .interval = metricsLogInterval,
+    .taskFunction = [metricsWriter, metricsManager]() {
+        metricsManager->writeAllMetrics(metricsWriter);
+    }
+});
+```
+
+## Consumers
+
+| Module | What it does |
+|--------|-------------|
+| **router** | Creates counters for processed/dropped events, registers EPS pull metrics via `SlidingWindowRate`, increments counters in the worker event loop |
+| **builder** | Creates per-space counters for unclassified/discarded events in policy pipelines |
+| **api/event** | Creates counters for bytes/events received on the ingest endpoint |
+| **api/metrics** | Exposes metrics via HTTP API (get, list, enable/disable, dump) |
+| **main.cpp** | Registers indexer pull metrics, schedules periodic JSON dump to `streamlog` |
+
+## Thread Safety
+
+- **Registry (`Manager`)**: `std::shared_mutex` — shared lock for reads, unique lock for registration. Double-checked locking on `getOrCreate*` methods.
+- **Counters/Gauges**: Lock-free via `std::atomic` with `memory_order_relaxed`. No contention on the hot path.
+- **Pull Metrics**: Callback is invoked under no lock. The caller must ensure captured references remain valid.
+- **SlidingWindowRate**: Lock-free with CAS-based bucket recycling. Reads are best-effort (consistent enough for metrics, not exact accounting).
+- **Global enable**: `std::atomic<bool>` with relaxed ordering.
+
+## File Structure
+
+```
+fastmetrics/
+├── CMakeLists.txt                                          # Build: ifastmetrics (INTERFACE), fastmetrics (STATIC)
+├── interface/fastmetrics/
+│   ├── iMetric.hpp                                         # IMetric, ICounter, IGaugeInt interfaces
+│   ├── iManager.hpp                                        # IManager interface (registry + writeAllMetrics)
+│   ├── registry.hpp                                        # Singleton access: manager(), registerManager(), FASTMETRICS_PULL
+│   ├── metric_names.hpp                                    # Predefined metric name constants and formatters
+│   └── slidingWindowRate.hpp                               # Lock-free EPS calculator (circular buffer)
+├── include/fastmetrics/
+│   ├── atomicCounter.hpp                                   # AtomicCounter (ICounter implementation)
+│   ├── atomicGauge.hpp                                     # AtomicGaugeInt (IGaugeInt implementation)
+│   ├── pullMetric.hpp                                      # PullMetric<T> (callback-based IMetric)
+│   └── manager.hpp                                         # Manager class (IManager implementation)
+├── src/
+│   ├── manager.cpp                                         # Manager methods (get, exists, writeAllMetrics, etc.)
+│   └── registry.cpp                                        # registerManager() — SingletonLocator wiring
+├── test/
+│   ├── mocks/fastmetrics/
+│   │   ├── mockCounter.hpp                                 # GMock mock for ICounter
+│   │   ├── mockGauge.hpp                                   # GMock mock for IGaugeInt
+│   │   └── mockManager.hpp                                 # GMock mock for IManager
+│   └── src/
+│       ├── unit/
+│       │   ├── main.cpp                                    # Test main (registers singleton for tests)
+│       │   ├── counter_test.cpp                            # AtomicCounter tests
+│       │   ├── gauge_test.cpp                              # AtomicGaugeInt tests
+│       │   ├── pullMetric_test.cpp                         # PullMetric tests
+│       │   ├── registry_test.cpp                           # Manager/registry tests
+│       │   └── slidingWindowRate_test.cpp                  # SlidingWindowRate tests
+│       └── component/
+│           └── realistic_scenarios_test.cpp                # End-to-end realistic workload tests
+```
+
+## Testing
+
+### Unit Tests (`fastmetrics_utest`)
+
+| Test File | Covers |
+|-----------|--------|
+| `counter_test.cpp` | AtomicCounter: add, increment, reset, enable/disable, concurrent access |
+| `gauge_test.cpp` | AtomicGaugeInt: set, add, sub, reset, enable/disable |
+| `pullMetric_test.cpp` | PullMetric: callback invocation, disable behavior, exception safety |
+| `registry_test.cpp` | Manager: getOrCreate, type conflicts, exists, getAllNames, count, clear, enableAll/disableAll |
+| `slidingWindowRate_test.cpp` | SlidingWindowRate: increment, getRate over windows, bucket recycling |
+
+### Component Tests (`fastmetrics_ctest`)
+
+| Test File | Covers |
+|-----------|--------|
+| `realistic_scenarios_test.cpp` | Realistic multi-threaded workloads with counters, gauges, and pull metrics |
+
+Build and run:
+
+```bash
+make --directory=$WAZUH_REPO/src -j TARGET=manager ENGINE_TEST=y DEBUG=yes
+$ENGINE_BUILD/source/fastmetrics/fastmetrics_utest
+$ENGINE_BUILD/source/fastmetrics/fastmetrics_ctest
+```
+
+## Mocks
+
+Available at `test/mocks/fastmetrics/` (CMake target: `fastmetrics::mocks`):
+
+| Mock | Class |
+|------|-------|
+| `mockCounter.hpp` | `fastmetrics::mocks::MockCounter` — mocks `ICounter` |
+| `mockGauge.hpp` | `fastmetrics::mocks::MockGauge` — mocks `IGaugeInt` |
+| `mockManager.hpp` | `fastmetrics::mocks::MockManager` — mocks `IManager` |
+
+Used by `router` and `builder` test targets.

--- a/src/engine/source/geo/README.md
+++ b/src/engine/source/geo/README.md
@@ -1,0 +1,293 @@
+# Geo Module
+
+## Overview
+
+The **geo** module provides GeoIP enrichment capabilities for the Wazuh engine using MaxMind MMDB databases. It manages the lifecycle of GeoLite2 databases (City and ASN), including automatic downloading from a remote manifest, hash-based update detection, hot-reloading without restart, and persistent state tracking via the internal store. At query time, it provides `ILocator` instances for resolving IP addresses to geographic and network information.
+
+## Architecture
+
+```
+              ┌──────────────────────────────────────────────────────────┐
+              │                Remote Manifest (S3)                       │
+              │  { "generated_at": ...,                                   │
+              │    "city": { "url": "...gz", "md5": "..." },             │
+              │    "asn":  { "url": "...gz", "md5": "..." } }            │
+              └──────────────────┬────────────────────────────────────────┘
+                                 │  downloadManifest()
+                                 │  downloadHTTPS() + extractMmdbFromGz()
+              ┌──────────────────▼────────────────────────────────────────┐
+              │              Manager (IManager)                           │
+              │                                                           │
+              │  remoteUpsert(manifestUrl, cityPath, asnPath)             │
+              │       ◄── scheduler (periodic, default 6 min)             │
+              │                                                           │
+              │  ┌─────────────────────────────────────────────────┐      │
+              │  │  m_dbs: map<name, shared_ptr<DbHandle>>        │      │
+              │  │  m_dbTypes: map<Type, name>                    │      │
+              │  │                                                 │      │
+              │  │  DbHandle ──► atomic<shared_ptr<DbInstance>>    │      │
+              │  │                    │                             │      │
+              │  │              DbInstance (immutable)              │      │
+              │  │                MMDB_s (mmap'd .mmdb file)       │      │
+              │  │                path, hash, createdAt, type      │      │
+              │  └─────────────────────────────────────────────────┘      │
+              │                                                           │
+              │  getLocator(Type) → shared_ptr<ILocator>                  │
+              │                                                           │
+              │  ┌────────────────┐     ┌────────────────────────┐       │
+              │  │   IStore       │     │   IDownloader          │       │
+              │  │ "geo/mmdb/0"   │     │   HTTPS + gz extract   │       │
+              │  └────────────────┘     └────────────────────────┘       │
+              └──────────────────────────────────────────────────────────┘
+                         │
+                getLocator(CITY/ASN)
+                         │
+              ┌──────────▼───────────────────────────────────────────────┐
+              │              Locator (ILocator)                           │
+              │                                                           │
+              │   getString(ip, path)   → Result<string>                  │
+              │   getUint32(ip, path)   → Result<uint32_t>                │
+              │   getDouble(ip, path)   → Result<double>                  │
+              │   getAsJson(ip, path)   → Result<json::Json>              │
+              │   getAll(ip)            → Result<json::Json>              │
+              │                                                           │
+              │   Caches: last IP lookup result + DB instance ref          │
+              └──────────────────────────────────────────────────────────┘
+                         │
+                    Consumers
+                         │
+              ┌──────────▼──────────────────────┐
+              │  builder/enrichment/geo.cpp       │  GeoIP enrichment expressions
+              │  builder/opmap/mmdb.cpp           │  MMDB helper map operations
+              │  api/geo (HTTP endpoints)         │  On-demand IP lookup API
+              └──────────────────────────────────┘
+```
+
+## Key Concepts
+
+### Database Types
+
+| Type | Enum | Database File | Data |
+|------|------|---------------|------|
+| City | `geo::Type::CITY` | `GeoLite2-City.mmdb` | Country, city, continent, location (lat/lon), postal code, timezone |
+| ASN | `geo::Type::ASN` | `GeoLite2-ASN.mmdb` | Autonomous System Number, organization name |
+
+Only one database per type is allowed at any time.
+
+### Internal Classes (private to `src/`)
+
+| Class | File | Purpose |
+|-------|------|---------|
+| `DbInstance` | `dbInstance.hpp` | Immutable RAII wrapper around `MMDB_s`. Opens the `.mmdb` file via `MMDB_open` (memory-mapped) on construction, calls `MMDB_close` on destruction. Holds path, hash, createdAt, type. |
+| `DbHandle` | `dbHandle.hpp` | Atomic pointer holder (`std::atomic_load`/`std::atomic_store` on `shared_ptr<const DbInstance>`). Enables lock-free hot-reload: new `DbInstance` is swapped in atomically while existing `Locator` instances continue using the old one. |
+| `Locator` | `locator.hpp` | Implements `ILocator`. Holds a `weak_ptr<DbHandle>` and caches the last IP lookup result (`MMDB_lookup_result_s`). Automatically invalidates cache when the underlying `DbInstance` changes (hot-reload). |
+
+### Hot-Reload Mechanism
+
+Database updates are applied without restarting the engine:
+
+1. New `.mmdb` is written to a temp file, then atomically renamed to the final path.
+2. A new `DbInstance` is created (opens the renamed file via mmap).
+3. `DbHandle::store()` atomically swaps the `shared_ptr`, publishing the new instance.
+4. Existing `Locator` instances detect the change on next query (their cached `DbInstance` pointer differs from `DbHandle::load()`), invalidate their IP cache, and switch to the new instance.
+5. The old `DbInstance` is destroyed when all references are released.
+
+### Remote Update Flow (`remoteUpsert`)
+
+1. Download and parse manifest JSON from URL.
+2. For each database type (City, ASN):
+   - Compare manifest MD5 hash with stored hash → skip if unchanged.
+   - Download `.gz` file from manifest URL.
+   - Validate MD5 of downloaded content (retry up to 3 times on mismatch).
+   - Extract `.mmdb` from gz via `zlibHelper`.
+   - Atomic rename temp file → final path (permissions set to 640).
+   - Hot-load new `DbInstance` into `DbHandle`.
+   - Persist metadata (path, hash, generated_at) to internal store.
+3. Shutdown flag (`m_shouldRun`) is checked between operations for graceful cancellation.
+
+### Error Handling (`Result<T>` and `ErrorCode`)
+
+The module uses a custom `Result<T>` type (similar to `std::expected`) with typed `ErrorCode` enum instead of string errors. Error categories:
+
+| Category | Codes |
+|----------|-------|
+| Database | `DB_NOT_AVAILABLE`, `DB_HANDLE_EXPIRED`, `DB_TYPE_NOT_AVAILABLE` |
+| IP/Network | `IP_TRANSLATION`, `IP_NOT_FOUND` |
+| Data access | `DATA_TYPE_MISMATCH`, `DATA_TYPE_MISMATCH_STRING`, `DATA_TYPE_MISMATCH_UINT32`, `DATA_TYPE_MISMATCH_DOUBLE`, `DATA_ENTRY_EMPTY` |
+| MMDB library | `MMDB_VALUE_ERROR`, `MMDB_LIBMMDB_ERROR`, `MMDB_RETRIEVAL_ENTRY_LIST`, `MMDB_DUMP_ENTRY` |
+
+### ILocator Query Interface
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `getString(ip, path)` | `Result<string>` | Get string value at dot-path (e.g., `"country.names.en"`) |
+| `getUint32(ip, path)` | `Result<uint32_t>` | Get uint32 value (e.g., ASN number) |
+| `getDouble(ip, path)` | `Result<double>` | Get double value (e.g., latitude/longitude) |
+| `getAsJson(ip, path)` | `Result<json::Json>` | Get value as JSON at specific path |
+| `getAll(ip)` | `Result<json::Json>` | Get complete record for IP as JSON |
+
+The `path` parameter uses dot notation matching the MMDB internal structure (e.g., `"city.names.en"`, `"location.latitude"`).
+
+## Dependencies
+
+| Dependency | CMake Target | Role |
+|------------|-------------|------|
+| `base` | `base` | Logging, JSON, error handling, hash utilities |
+| `store` | `store::istore` | Persisting database metadata (hash, path, generated_at) |
+| `maxminddb` | `maxminddb::maxminddb` | libmaxminddb C library for MMDB file reading |
+| `urlrequest` | `urlrequest` | HTTP client for downloading manifests and databases |
+| `zlibHelper` | (via urlrequest) | Gz decompression for downloaded database archives |
+
+## Configuration
+
+| Key | Env Override | Default | Description |
+|-----|-------------|---------|-------------|
+| `analysisd.geo_sync_interval` | `WAZUH_GEO_SYNC_INTERVAL` | `360` | Seconds between sync checks (`0` = disabled) |
+| `analysisd.geo_db_path` | `WAZUH_GEO_DB_PATH` | `{wazuhRoot}/data/mmdb` | Directory for `.mmdb` files |
+| `analysisd.geo_manifest_url` | `WAZUH_GEO_MANIFEST_URL` | S3 URL | Manifest JSON URL |
+| `analysisd.geo_download_timeout` | `WAZUH_GEO_DOWNLOAD_TIMEOUT` | `60000` | HTTP download timeout (ms) |
+
+## Integration in `main.cpp`
+
+```cpp
+// 1. Create downloader with timeout and manager with store
+auto geoDownloader = std::make_shared<geo::Downloader>(geoDownloadTimeout);
+geoManager = std::make_shared<geo::Manager>(store, geoDownloader);
+geoDownloader->setShouldRun(geoManager->shouldRunFlag());
+
+// 2. Shutdown hook
+exitHandler.add([geoManager]() { geoManager->requestShutdown(); });
+
+// 3. Register API endpoints
+api::geo::handlers::registerHandlers(geoManager, apiServer);
+
+// 4. Inject into builder for enrichment
+builderDeps.geoManager = geoManager;
+
+// 5. Schedule periodic sync
+scheduler->scheduleTask("geo-sync-task", {
+    .interval = geoSyncInterval,
+    .runImmediately = true,
+    .taskFunction = [geoManager, manifestUrl, cityPath, asnPath]() {
+        geoManager->remoteUpsert(manifestUrl, cityPath, asnPath);
+    }
+});
+```
+
+## Consumers
+
+| Module | Usage |
+|--------|-------|
+| **builder/enrichment** | `getLocator(CITY)` + `getLocator(ASN)` to build GeoIP enrichment expressions in decoder/rule pipelines |
+| **builder/opmap** | `getLocator()` in MMDB map operations for event field enrichment |
+| **api/geo** | `POST /_internal/geo/db/get` (IP lookup) and `POST /_internal/geo/db/list` (list loaded DBs) |
+| **main.cpp** | Periodic `remoteUpsert` via scheduler |
+
+## Thread Safety
+
+- **Registry maps** (`m_dbs`, `m_dbTypes`): Protected by `std::shared_mutex` — shared lock for `getLocator()` / `listDbs()`, unique lock for `processDbEntry()`.
+- **DbHandle**: Lock-free atomic swap of `shared_ptr<const DbInstance>` via `std::atomic_load`/`std::atomic_store`.
+- **Locator**: Not thread-safe per-instance (each consumer should hold its own `Locator`). IP lookup result is cached per-locator.
+- **Shutdown**: `std::atomic<bool>` flag shared between Manager and Downloader for mid-transfer cancellation.
+
+## Persistence
+
+Database metadata is stored in a single document at `geo/mmdb/0` in the internal store:
+
+```json
+{
+  "city": {
+    "path": "/var/wazuh-manager/data/mmdb/GeoLite2-City.mmdb",
+    "hash": "abc123...",
+    "generated_at": 1715270400
+  },
+  "asn": {
+    "path": "/var/wazuh-manager/data/mmdb/GeoLite2-ASN.mmdb",
+    "hash": "def456...",
+    "generated_at": 1715270400
+  }
+}
+```
+
+On construction, the manager loads this document and opens any `.mmdb` files found. On update, only the changed type's fields are updated.
+
+## File Structure
+
+```
+geo/
+├── CMakeLists.txt                                  # Build: igeo (INTERFACE), geo (STATIC), mocks, tests, benchmark
+├── interface/geo/
+│   ├── imanager.hpp                                # IManager interface (listDbs, remoteUpsert, getLocator, requestShutdown)
+│   ├── ilocator.hpp                                # ILocator interface (getString, getUint32, getDouble, getAsJson, getAll)
+│   ├── idownloader.hpp                             # IDownloader interface (downloadHTTPS, downloadManifest, extractMmdbFromGz)
+│   └── errorCodes.hpp                              # ErrorCode enum + Result<T> type
+├── include/geo/
+│   ├── manager.hpp                                 # Manager class declaration
+│   └── downloader.hpp                              # Downloader class declaration
+├── src/
+│   ├── manager.cpp                                 # Manager implementation (remoteUpsert, processDbEntry, store persistence)
+│   ├── downloader.cpp                              # HTTP download + gz extraction
+│   ├── locator.cpp                                 # Locator implementation (MMDB lookups)
+│   ├── locator.hpp                                 # Locator class declaration (private)
+│   ├── dbHandle.hpp                                # Atomic shared_ptr holder for hot-reload (private)
+│   └── dbInstance.hpp                              # Immutable MMDB_s RAII wrapper (private)
+├── test/
+│   ├── mocks/geo/
+│   │   ├── mockManager.hpp                         # GMock mock for IManager
+│   │   └── mockLocator.hpp                         # GMock mock for ILocator
+│   └── src/
+│       ├── testdb.mmdb                             # Test MMDB database file
+│       ├── generateTestDB.pl                       # Script to regenerate test database
+│       ├── mockDownloader.hpp                      # Mock for IDownloader (used in tests)
+│       ├── unit/
+│       │   ├── manager_test.cpp                    # Manager unit tests (mocked store + downloader)
+│       │   └── locator_test.cpp                    # Locator unit tests (with test MMDB)
+│       └── component/
+│           └── manager_test.cpp                    # Component tests (end-to-end update flow)
+└── benchmark/src/
+    └── geo_bench.cpp                               # MMDB lookup benchmarks
+```
+
+## Testing
+
+### Unit Tests (`geo_utest`)
+
+| File | Covers |
+|------|--------|
+| `manager_test.cpp` | Construction from store, addDb, remoteUpsert with mocked downloader, hash comparison, error handling |
+| `locator_test.cpp` | IP lookup (getString, getUint32, getDouble, getAsJson, getAll), cache invalidation, error codes for invalid IPs/paths |
+
+### Component Tests (`geo_ctest`)
+
+| File | Covers |
+|------|--------|
+| `manager_test.cpp` | End-to-end update flow with real MMDB file operations |
+
+### Benchmarks (`geo_benchmark`)
+
+| File | Covers |
+|------|--------|
+| `geo_bench.cpp` | MMDB lookup performance (latency per query) |
+
+Build and run:
+
+```bash
+# Tests
+make --directory=$WAZUH_REPO/src -j TARGET=manager ENGINE_TEST=y DEBUG=yes
+$ENGINE_BUILD/source/geo/geo_utest
+$ENGINE_BUILD/source/geo/geo_ctest
+
+# Benchmarks (requires ENGINE_BUILD_BENCHMARK=ON)
+$ENGINE_BUILD/source/geo/geo_benchmark
+```
+
+## Mocks
+
+Available at `test/mocks/geo/` (CMake target: `geo::mocks`):
+
+| Mock | Class |
+|------|-------|
+| `mockManager.hpp` | `geo::mocks::MockManager` — mocks `IManager` |
+| `mockLocator.hpp` | `geo::mocks::MockLocator` — mocks `ILocator` |
+
+Used by `builder` and `api/geo` test targets.

--- a/src/engine/source/httpsrv/README.md
+++ b/src/engine/source/httpsrv/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The **httpsrv** module provides an HTTP server over Unix Domain Sockets (UDS) for the Wazuh engine's internal API. Built on top of [cpp-httplib](https://github.com/yhiber/cpp-httplib), it handles route registration, request dispatching, payload size enforcement, and lifecycle management (start/stop with optional background thread). The engine runs two server instances: one for API services (management, metrics, geo, etc.) and one for event ingestion.
+The **httpsrv** module provides an HTTP server over Unix Domain Sockets (UDS) for the Wazuh engine's internal API. Built on top of [cpp-httplib](https://github.com/yhirose/cpp-httplib), it handles route registration, request dispatching, payload size enforcement, and lifecycle management (start/stop with optional background thread). The engine runs two server instances: one for API services (management, metrics, geo, etc.) and one for event ingestion.
 
 ## Architecture
 
@@ -21,7 +21,7 @@ The **httpsrv** module provides an HTTP server over Unix Domain Sockets (UDS) fo
                 │   │  POST /events/enriched      → pushEvent        │   │
                 │   │  POST /_internal/router/*    → router handlers  │   │
                 │   │  POST /_internal/geo/db/*    → geo handlers     │   │
-                │   │  POST /_internal/metrics/*   → metrics handlers │   │
+                │   │  POST /metrics/*             → metrics handlers │   │
                 │   │  POST /_internal/event-*     → dumper handlers  │   │
                 │   │  ...                                           │   │
                 │   └───────────────────────────────────────────────┘   │
@@ -132,7 +132,7 @@ Eight API sub-modules register handlers on the API server, plus one direct route
 
 | Sub-module | Routes | Server |
 |------------|--------|--------|
-| `api::metrics` | `/_internal/metrics/{enable,get,list,dump}` | API |
+| `api::metrics` | `/metrics/{enable,get,list,dump}` | API |
 | `api::geo` | `/_internal/geo/db/{get,list}` | API |
 | `api::router` | `/_internal/router/route/*`, `/_internal/router/table/get` | API |
 | `api::tester` | `/_internal/tester/*` | API |

--- a/src/engine/source/httpsrv/README.md
+++ b/src/engine/source/httpsrv/README.md
@@ -1,0 +1,248 @@
+# HttpSrv Module
+
+## Overview
+
+The **httpsrv** module provides an HTTP server over Unix Domain Sockets (UDS) for the Wazuh engine's internal API. Built on top of [cpp-httplib](https://github.com/yhiber/cpp-httplib), it handles route registration, request dispatching, payload size enforcement, and lifecycle management (start/stop with optional background thread). The engine runs two server instances: one for API services (management, metrics, geo, etc.) and one for event ingestion.
+
+## Architecture
+
+```
+                      Unix Domain Socket
+                    (AF_UNIX, .sock file)
+                            │
+                ┌───────────▼───────────────────────────────────────────┐
+                │            httpsrv::Server                            │
+                │                                                       │
+                │   httplib::Server (thread pool: 8–16 workers)         │
+                │                                                       │
+                │   ┌───────────────────────────────────────────────┐   │
+                │   │  Route Table                                   │   │
+                │   │                                                │   │
+                │   │  POST /events/enriched      → pushEvent        │   │
+                │   │  POST /_internal/router/*    → router handlers  │   │
+                │   │  POST /_internal/geo/db/*    → geo handlers     │   │
+                │   │  POST /_internal/metrics/*   → metrics handlers │   │
+                │   │  POST /_internal/event-*     → dumper handlers  │   │
+                │   │  ...                                           │   │
+                │   └───────────────────────────────────────────────┘   │
+                │                                                       │
+                │   Features:                                           │
+                │   • Payload size limit (413 response)                 │
+                │   • Exception handler (500 on uncaught exceptions)    │
+                │   • Request/response logging (TRACE level)            │
+                │   • Socket permission set to 660                      │
+                └───────────────────────────────────────────────────────┘
+                            │
+                    addRoute(Method, path, handler)
+                            │
+                ┌───────────▼───────────────────────────────────────────┐
+                │         api::adapter (separate module)                 │
+                │                                                       │
+                │   httplib::Request/Response ←→ Protobuf domain types   │
+                │                                                       │
+                │   parseRequest<Req>()     → deserialize proto from JSON│
+                │   userResponse<Res>()     → serialize proto + 200 OK   │
+                │   userErrorResponse<Res>()→ serialize error + 400      │
+                │   internalErrorResponse() → serialize error + 500      │
+                └───────────────────────────────────────────────────────┘
+                            │
+                     RouteHandler = std::function<void(
+                         const httplib::Request&,
+                         httplib::Response&)>
+                            │
+                ┌───────────▼───────────────────────────────────────────┐
+                │           API Sub-modules                              │
+                │                                                       │
+                │   api/metrics    api/geo      api/router               │
+                │   api/tester     api/dumper   api/rawevtindexer         │
+                │   api/cmcrud     api/ioccrud  api/event                 │
+                └───────────────────────────────────────────────────────┘
+```
+
+## Key Concepts
+
+### Interface (`IServer<ServerImpl>`)
+
+CRTP interface in `interface/httpsrv/iserver.hpp`:
+
+| Method | Description |
+|--------|-------------|
+| `start(socketPath, useThread)` | Bind to UDS and start listening. If `useThread=true`, runs in a background thread |
+| `stop()` | Stop the server, join thread, remove socket file |
+| `addRoute(method, route, handler)` | Register an HTTP handler for a method+path combination |
+| `isRunning()` | Check if the server is currently listening |
+
+### HTTP Methods
+
+```cpp
+enum class Method { GET, POST, PUT, DELETE, ERROR_METHOD };
+```
+
+Utility functions `methodToStr()` and `strToMethod()` convert between enum and string.
+
+### Server Implementation
+
+`Server` wraps `httplib::Server` and adds:
+
+| Feature | Implementation |
+|---------|----------------|
+| **Unix Domain Socket** | `set_address_family(AF_UNIX)`, binds to file path |
+| **Thread pool** | `CPPHTTPLIB_THREAD_POOL_COUNT` clamped to `[8, 16]` based on `hardware_concurrency()` |
+| **Payload limit** | `set_payload_max_length()` — returns `413 Payload Too Large` when exceeded |
+| **Exception safety** | `set_exception_handler()` catches all route handler exceptions → `500 Internal Server Error` |
+| **Logging** | `set_logger()` logs every request/response at TRACE level (truncated to 1024 chars) |
+| **Socket permissions** | `chmod(660)` after bind for group-readable access |
+| **Threaded start** | Waits up to 10s for server to become ready, throws on failure |
+| **Clean shutdown** | `stop()` is noexcept, removes socket file, joins thread |
+
+### Constructor Parameters
+
+```cpp
+Server(const std::string& id, size_t payloadMaxBytes = 0, bool enableDetailedLogging = true);
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `id` | String identifier for log messages (e.g., `"API services"`, `"Event services"`) |
+| `payloadMaxBytes` | Maximum request body size in bytes. `0` = unlimited |
+| `enableDetailedLogging` | If `true`, logs full request method/path/body and response status. If `false`, logs only that a request was received |
+
+### Route Handler Signature
+
+All handlers must match the `httplib` callback signature:
+
+```cpp
+std::function<void(const httplib::Request&, httplib::Response&)>
+```
+
+The `api::adapter` module (separate from httpsrv) wraps this into `adapter::RouteHandler` and provides protobuf serialization/deserialization helpers.
+
+## Server Instances
+
+The engine creates two separate server instances in `main.cpp`:
+
+| Instance | ID | Socket | Payload Limit | Logging | Purpose |
+|----------|-----|--------|---------------|---------|---------|
+| `apiServer` | `"API services"` | `SERVER_API_SOCKET` | Configurable | Detailed | Management API (routes, metrics, geo, content, etc.) |
+| `engineRemoteServer` | `"Event services"` | `SERVER_ENRICHED_EVENTS_SOCKET` | Unlimited (`0`) | Minimal | Event ingestion (`/events/enriched`) |
+
+## API Route Registration
+
+Eight API sub-modules register handlers on the API server, plus one direct route on the event server:
+
+| Sub-module | Routes | Server |
+|------------|--------|--------|
+| `api::metrics` | `/_internal/metrics/{enable,get,list,dump}` | API |
+| `api::geo` | `/_internal/geo/db/{get,list}` | API |
+| `api::router` | `/_internal/router/route/*`, `/_internal/router/table/get` | API |
+| `api::tester` | `/_internal/tester/*` | API |
+| `api::dumper` | `/_internal/event-dumper/{activate,deactivate,status}` | API |
+| `api::rawevtindexer` | `/_internal/raweventindexer/status` | API |
+| `api::cmcrud` | `/_internal/content/{namespace,policy,resource}/*` | API |
+| `api::ioccrud` | `/content/ioc/{update,state}` | API |
+| `api::event` | `POST /events/enriched` | Event |
+
+## Dependencies
+
+| Dependency | CMake Target | Role |
+|------------|-------------|------|
+| `base` | `base` | Logging, process utilities |
+| `httplib` | (header-only, via `eMessages`) | HTTP server implementation |
+| `eMessages` | `eMessages` | Protobuf definitions (transitive) |
+
+## Configuration
+
+| Key | Env Override | Default | Description |
+|-----|-------------|---------|-------------|
+| `analysisd.server_api_socket` | `WAZUH_SERVER_API_SOCKET` | `$WAZUH_HOME/queue/sockets/analysis` | UDS path for API server |
+| `analysisd.server_api_timeout` | `WAZUH_SERVER_API_TIMEOUT` | `5000` | Server timeout (ms) |
+| `analysisd.server_api_payload_max_bytes` | `WAZUH_SERVER_API_PAYLOAD_MAX_BYTES` | `0` (unlimited) | Max payload size for API server |
+| `analysisd.server_enriched_events_socket` | `WAZUH_SERVER_ENRICHED_EVENTS_SOCKET` | `$WAZUH_HOME/queue/sockets/queue-http.sock` | UDS path for event server |
+
+## Integration in `main.cpp`
+
+```cpp
+// 1. Create API server with payload limit
+apiServer = std::make_shared<httpsrv::Server>(
+    "API services", serverApiPayloadMaxBytes, true);
+
+// 2. Register all API route handlers
+api::metrics::handlers::registerHandlers(metricsManager, apiServer, ...);
+api::geo::handlers::registerHandlers(geoManager, apiServer);
+api::router::handlers::registerHandlers(orchestrator, cmStore, apiServer);
+// ... 5 more sub-modules ...
+
+// 3. Start API server (threaded)
+apiServer->start(confManager.get<std::string>(conf::key::SERVER_API_SOCKET));
+
+// 4. Create event server (unlimited payload, minimal logging)
+engineRemoteServer = std::make_shared<httpsrv::Server>("Event services", 0, false);
+
+// 5. Register event ingestion route
+engineRemoteServer->addRoute(
+    httpsrv::Method::POST, "/events/enriched",
+    api::event::handlers::pushEvent(orchestrator, dumper));
+
+// 6. Start event server (threaded)
+engineRemoteServer->start(confManager.get<std::string>(conf::key::SERVER_ENRICHED_EVENTS_SOCKET));
+
+// 7. Shutdown hooks
+exitHandler.add([apiServer]() { apiServer->stop(); });
+exitHandler.add([engineRemoteServer]() { engineRemoteServer->stop(); });
+```
+
+## Thread Safety
+
+- Route registration (`addRoute`) must happen **before** `start()`. The underlying `httplib::Server` is not safe for concurrent route addition while running.
+- Request handling is thread-safe: `httplib` dispatches requests across its thread pool (8–16 workers).
+- `stop()` is noexcept and safe to call from any thread. It signals the server, joins the background thread, and cleans up the socket file.
+
+## File Structure
+
+```
+httpsrv/
+├── CMakeLists.txt                                   # Build: ihttpsrv (INTERFACE), httpsrv (STATIC)
+├── interface/httpsrv/
+│   └── iserver.hpp                                  # IServer<> CRTP interface (start, stop, addRoute, isRunning)
+├── include/httpsrv/
+│   └── server.hpp                                   # Server class declaration (httplib wrapper)
+├── src/
+│   └── server.cpp                                   # Server implementation (bind, listen, route dispatch, logging)
+└── test/src/
+    ├── generic_request.proto                        # Test protobuf definition
+    ├── generic_request.pb.h                         # Generated protobuf header
+    ├── generic_request.pb.cc                        # Generated protobuf source
+    ├── unit/
+    │   └── server_test.cpp                          # Unit tests (create, start/stop, socket paths)
+    └── component/
+        └── server_test.cpp                          # Component tests (route handling, payload limits, protobuf)
+```
+
+## Testing
+
+### Unit Tests (`httpsrv_utest`)
+
+| Test | Verifies |
+|------|----------|
+| `Create` | Server construction succeeds |
+| `StartEmptySocketPath` | Empty path throws `std::runtime_error` |
+| `StartInvalidSocketPath` | Non-existent parent directory throws |
+| `StartStop` | Normal start/stop lifecycle |
+| `StartStopCurrentThread` | Blocking start mode (no background thread) |
+
+### Component Tests (`httpsrv_ctest`)
+
+| Test | Verifies |
+|------|----------|
+| `ServerStart` | Server starts and listens on UDS |
+| `ServerStartTwice` | Double start throws |
+| `ServerStop` | Clean shutdown |
+| Route tests | GET/POST/PUT/DELETE route handling, protobuf serialization, payload limit enforcement (413) |
+
+Build and run:
+
+```bash
+make --directory=$WAZUH_REPO/src -j TARGET=manager ENGINE_TEST=y DEBUG=yes
+$ENGINE_BUILD/source/httpsrv/httpsrv_utest
+$ENGINE_BUILD/source/httpsrv/httpsrv_ctest
+```


### PR DESCRIPTION
## Description

Adds architecture documentation for the Wazuh Engine and per-module READMEs for several engine modules. This PR is documentation-only: no source code, build system, configuration, or runtime behavior is modified.

Closes #33937

## Proposed Changes

- Refines the top-level engine documentation under `docs/ref/modules/engine/`:
  - `README.md`: minor edits.
  - `architecture.md`: substantial rewrite/restructure of the engine architecture overview.
- Adds a new index README at `src/engine/source/README.md` describing every engine module and how they relate.
- Adds new per-module READMEs documenting purpose, architecture, key concepts and interfaces for:
  - `src/engine/source/confremote/README.md`
  - `src/engine/source/dumper/README.md`
  - `src/engine/source/fastmetrics/README.md`
  - `src/engine/source/geo/README.md`
  - `src/engine/source/httpsrv/README.md`

No code, headers, build files, tests or configuration are modified.

### Results and Evidence

<img width="3521" height="1568" alt="image" src="https://github.com/user-attachments/assets/e968b5c1-392a-4d25-82cd-f45994a9f9b4" />

**No error en mdbook**
```
╰─# mdbook serve -n 127.0.0.1
 INFO Book building has started
 INFO Running the html backend
 WARN unclosed HTML tag `<data>` found in `ref/modules/engine/ref-parser.md` while exiting Item
HTML tags must be closed before exiting a markdown element.
 WARN unclosed HTML tag `<event>` found in `ref/modules/engine/ref-parser.md` while exiting Item
HTML tags must be closed before exiting a markdown element.
 INFO HTML book written to `/workspaces/wazuh-5.x/wazuh/docs/book`
 INFO Serving on: http://127.0.0.1:3000
 INFO Watching for changes...
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected



### Configuration Changes



### Tests Introduced



## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
