### PR TITLE
Added new CVE5 fields

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -37,6 +37,8 @@ table CVSS_V4_0 {
     valueDensity: string;
     vulnerabilityResponseEffort: string;
     providerUrgency: string;
+    x_source: string;
+    x_type: string;
 }
 
 table CVSS_V3_1 {
@@ -70,6 +72,8 @@ table CVSS_V3_1 {
     modifiedAvailabilityImpact: string;
     environmentalScore: float;
     environmentalSeverity: string;
+    x_source: string;
+    x_type: string;
 }
 
 table CVSS_V3_0 {
@@ -103,6 +107,8 @@ table CVSS_V3_0 {
     modifiedAvailabilityImpact: string;
     environmentalScore: float;
     environmentalSeverity: string;
+    x_source: string;
+    x_type: string;
 }
 
 table CVSS_V2_0 {
@@ -125,6 +131,8 @@ table CVSS_V2_0 {
     integrityRequirement: string;
     availabilityRequirement: string;
     environmentalScore: float;
+    x_source: string;
+    x_type: string;
 }
 
 table StringifiedObject {
@@ -244,6 +252,7 @@ table Remediations {
 table ProviderMetadata {
     orgId: string;
     shortName: string;
+    datePublished: string;
     dateUpdated: string;
     x_subShortName: string;
 }
@@ -279,6 +288,7 @@ table Adp {
     source: StringifiedObject;
     tags: [string];
     taxonomyMappings: [TaxonomyMapping];
+    x_cveStatus: string;
 }
 
 table Cna {
@@ -304,6 +314,7 @@ table Cna {
     x_remediations: Remediations;
     rejectedReasons: [Description];
     replacedBy: [string];
+    x_cveStatus: string;
 }
 
 table CveMetadata {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -337,3 +337,29 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV4_0FromMultipleMetrics)
     EXPECT_EQ(vulnerabilityDescription->scope()->str(), "");
     EXPECT_EQ(vulnerabilityDescription->userInteraction()->str(), "NONE");
 }
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionNewCVE5Fields)
+{
+    std::string vulnerabilityDescriptionFBStr;
+    processMetricHelper(JSON_STR_NEW_CVE5_FIELDS, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
+
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "4.0");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "HIGH");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)8.1);
+    EXPECT_EQ(vulnerabilityDescription->accessComplexity()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->assignerShortName()->str(), "GitHub_M");
+    EXPECT_EQ(vulnerabilityDescription->attackVector()->str(), "NETWORK");
+    EXPECT_EQ(vulnerabilityDescription->authentication()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->availabilityImpact()->str(), "HIGH");
+    EXPECT_EQ(vulnerabilityDescription->confidentialityImpact()->str(), "HIGH");
+    EXPECT_EQ(vulnerabilityDescription->cweId()->str(), "CWE-121");
+    EXPECT_EQ(vulnerabilityDescription->datePublished()->str(), "2026-04-24T18:16:29Z");
+    EXPECT_EQ(vulnerabilityDescription->dateUpdated()->str(), "2026-04-28T17:44:16Z");
+    EXPECT_EQ(vulnerabilityDescription->integrityImpact()->str(), "HIGH");
+    EXPECT_EQ(vulnerabilityDescription->privilegesRequired()->str(), "NONE");
+    EXPECT_EQ(vulnerabilityDescription->scope()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->userInteraction()->str(), "NONE");
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.hpp
@@ -1054,6 +1054,272 @@ namespace NSUpdateCVEDescriptionTest
             }
          )"};
 
+    // CVE-2026-41681
+    const std::string JSON_STR_NEW_CVE5_FIELDS {
+        R"(
+            {
+        "containers":
+        {
+            "adp":
+            [
+                {
+                    "affected":
+                    [
+                        {
+                            "defaultStatus": "unaffected",
+                            "modules":
+                            [
+                                "rust:3.3"
+                            ],
+                            "platforms":
+                            [
+                                "cpe:/o:fedoraproject:fedora:42"
+                            ],
+                            "product": "rust-openssl",
+                            "vendor": "fedora",
+                            "versions":
+                            [
+                                {
+                                    "lessThan": "0:0.10.78-1.fc42",
+                                    "status": "affected",
+                                    "version": "0",
+                                    "versionType": "rpm"
+                                }
+                            ]
+                        },
+                        {
+                            "defaultStatus": "unaffected",
+                            "platforms":
+                            [
+                                "cpe:/o:fedoraproject:fedora:42"
+                            ],
+                            "product": "rust-openssl-sys",
+                            "vendor": "fedora",
+                            "versions":
+                            [
+                                {
+                                    "lessThan": "0:0.9.114-1.fc42",
+                                    "status": "affected",
+                                    "version": "0",
+                                    "versionType": "rpm"
+                                }
+                            ]
+                        }
+                    ],
+                    "descriptions":
+                    [
+                        {
+                            "lang": "en",
+                            "value": "Update the openssl crate to version 0.10.78 and the openssl-sys crate to version 0.9.114.\n\nRelease notes:\n\n- openssl 0.10.77 / openssl-sys 0.9.113: https://github.com/rust-openssl/rust-openssl/releases/tag/openssl-v0.10.77\n- openssl 0.10.78 / openssl-sys 0.9.114: https://github.com/rust-openssl/rust-openssl/releases/tag/openssl-v0.10.78\n\nThis addresses the following security advisories:\n\n- GHSA-pqf5-4pqq-29f5 / CVE-2026-41676: https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-pqf5-4pqq-29f5\n- GHSA-xmgf-hq76-4vx2 / CVE-2026-41677: https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-xmgf-hq76-4vx2\n- GHSA-8c75-8mhr-p7r9 / CVE-2026-41678: https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-8c75-8mhr-p7r9\n- GHSA-ghm9-cr32-g9qj / CVE-2026-41681: https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-ghm9-cr32-g9qj\n- GHSA-hppc-g8h3-xhp3 (no CVE entry): https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-hppc-g8h3-xhp3\n\nAffected applications still need to be rebuilt to pick up these fixes.\n"
+                        }
+                    ],
+                    "metrics":
+                    [
+                        {
+                            "other":
+                            {
+                                "content":
+                                {
+                                    "data": "{\"description\":\"medium\"}"
+                                },
+                                "type": "Unknown"
+                            }
+                        }
+                    ],
+                    "providerMetadata":
+                    {
+                        "dateUpdated": "2026-04-24T17:42:54Z",
+                        "datePublished": "2026-04-23T13:02:56Z",
+                        "orgId": "92fb86c3-55a5-4fb5-9c3f-4757b9e96dc5",
+                        "shortName": "fedora",
+                        "x_subShortName": "fedora"
+                    },
+                    "references":
+                    [
+                        {
+                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2026-16a3cea414"
+                        },
+                        {
+                            "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2026-76f57efeef"
+                        }
+                    ]
+                }
+            ],
+            "cna":
+            {
+                "affected":
+                [
+                    {
+                        "cpes":
+                        [
+                            "cpe:2.3:a:rust-openssl_project:rust-openssl:*:*:*:*:*:rust:*:*"
+                        ],
+                        "defaultStatus": "unaffected",
+                        "platforms":
+                        [
+                            "rust"
+                        ],
+                        "product": "rust-openssl",
+                        "vendor": "rust-openssl_project",
+                        "versions":
+                        [
+                            {
+                                "lessThan": "0.10.78",
+                                "status": "affected",
+                                "version": "0.10.39",
+                                "versionType": "custom"
+                            }
+                        ]
+                    }
+                ],
+                "descriptions":
+                [
+                    {
+                        "lang": "en",
+                        "value": "rust-openssl provides OpenSSL bindings for the Rust programming language.  From 0.10.39 to before 0.10.78, EVP_DigestFinal() always writes EVP_MD_CTX_size(ctx) to the out buffer. If out is smaller than that, MdCtxRef::digest_final() writes past its end, usually corrupting the stack. This is reachable from safe Rust. This vulnerability is fixed in 0.10.78."
+                    }
+                ],
+                "metrics":
+                [
+                    {
+                        "cvssV3_1":
+                        {
+                            "attackComplexity": "LOW",
+                            "attackVector": "NETWORK",
+                            "availabilityImpact": "HIGH",
+                            "baseScore": 9.8,
+                            "baseSeverity": "CRITICAL",
+                            "confidentialityImpact": "HIGH",
+                            "integrityImpact": "HIGH",
+                            "privilegesRequired": "NONE",
+                            "scope": "UNCHANGED",
+                            "userInteraction": "NONE",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                            "version": "3.1",
+                            "x_source": "nvd",
+                            "x_type": "primary"
+                        },
+                        "format": "CVSS"
+                    },
+                    {
+                        "cvssV4_0":
+                        {
+                            "Automatable": "NOT_DEFINED",
+                            "Recovery": "NOT_DEFINED",
+                            "Safety": "NOT_DEFINED",
+                            "attackComplexity": "LOW",
+                            "attackRequirements": "NONE",
+                            "attackVector": "NETWORK",
+                            "availabilityRequirement": "NOT_DEFINED",
+                            "baseScore": 8.1,
+                            "baseSeverity": "HIGH",
+                            "confidentialityRequirement": "NOT_DEFINED",
+                            "exploitMaturity": "UNREPORTED",
+                            "integrityRequirement": "NOT_DEFINED",
+                            "modifiedAttackComplexity": "NOT_DEFINED",
+                            "modifiedAttackRequirements": "NOT_DEFINED",
+                            "modifiedAttackVector": "NOT_DEFINED",
+                            "modifiedPrivilegesRequired": "NOT_DEFINED",
+                            "modifiedSubAvailabilityImpact": "NOT_DEFINED",
+                            "modifiedSubConfidentialityImpact": "NOT_DEFINED",
+                            "modifiedSubIntegrityImpact": "NOT_DEFINED",
+                            "modifiedUserInteraction": "NOT_DEFINED",
+                            "modifiedVulnAvailabilityImpact": "NOT_DEFINED",
+                            "modifiedVulnConfidentialityImpact": "NOT_DEFINED",
+                            "modifiedVulnIntegrityImpact": "NOT_DEFINED",
+                            "privilegesRequired": "NONE",
+                            "providerUrgency": "NOT_DEFINED",
+                            "subAvailabilityImpact": "NONE",
+                            "subConfidentialityImpact": "NONE",
+                            "subIntegrityImpact": "NONE",
+                            "userInteraction": "NONE",
+                            "valueDensity": "NOT_DEFINED",
+                            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:U/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X",
+                            "version": "4.0",
+                            "vulnAvailabilityImpact": "HIGH",
+                            "vulnConfidentialityImpact": "HIGH",
+                            "vulnIntegrityImpact": "HIGH",
+                            "vulnerabilityResponseEffort": "NOT_DEFINED",
+                            "x_source": "nvd",
+                            "x_type": "primary"
+                        },
+                        "format": "CVSS"
+                    },
+                    {
+                        "other":
+                        {
+                            "type": "epss",
+                            "content":
+                            {
+                                "data": "{\"epss\":\"0.000560000\",\"percentile\":\"0.174730000\",\"date\":\"2026-05-07T00:00:00Z\"}"
+                            }
+                        }
+                    },
+                    {
+                        "other":
+                        {
+                            "type": "kev",
+                            "content":
+                            {
+                                "data": "{\"listed\":true,\"vendorProject\":\"dummy_data_for_test\",\"product\":\"dummy_data_for_test\",\"vulnerabilityName\":\"dummy_data_for_test\",\"dateAdded\":\"2026-05-01T00:00:00Z\",\"shortDescription\":\"dummy_data_for_test\",\"requiredAction\":\"dummy_data_for_test\",\"knownRansomwareCampaignUse\":\"Unknown\",\"notes\":\"dummy_data_for_test\"}"
+                            }
+                        }
+                    }
+                ],
+                "problemTypes":
+                [
+                    {
+                        "descriptions":
+                        [
+                            {
+                                "cweId": "CWE-121",
+                                "description": "CWE-121",
+                                "lang": "en"
+                            }
+                        ]
+                    }
+                ],
+                "providerMetadata":
+                {
+                    "dateUpdated": "2026-04-28T17:44:16Z",
+                    "datePublished": "2026-04-24T18:16:29Z",
+                    "orgId": "00000000-0000-4000-A000-000000000003",
+                    "shortName": "nvd",
+                    "x_subShortName": "nvd"
+                },
+                "references":
+                [
+                    {
+                        "tags":
+                        [
+                            "issue-tracking"
+                        ],
+                        "url": "https://github.com/rust-openssl/rust-openssl/pull/2608"
+                    },
+                    {
+                        "tags":
+                        [
+                            "patch"
+                        ],
+                        "url": "https://github.com/rust-openssl/rust-openssl/commit/826c3888b77add418b394770e2b2e3a72d9f92fe"
+                    }
+                ],
+                "x_cveStatus": "Analyzed"
+            }
+        },
+        "cveMetadata":
+        {
+            "assignerOrgId": "a0819718-46f1-4df5-94e2-005712e83aaa",
+            "assignerShortName": "GitHub_M",
+            "cveId": "CVE-2026-41681",
+            "datePublished": "2026-04-24T18:16:29Z",
+            "dateUpdated": "2026-04-28T17:44:16Z",
+            "state": "PUBLISHED"
+        },
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0"
+    })"};
+
     const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
 } // namespace NSUpdateCVEDescriptionTest
 


### PR DESCRIPTION
## Description

As part of the support for new CVSSV4.0, some new fields where added to the CVE5 schema to accept the new format. 

## Proposed Changes

- x_source, x_type string values to each CVSSVx score information 
- Added datePublished string value to providerMetadata
- Added x_cveStatus string value to adp and cna


