### PR TITLE
Update JSON property names in Wodle event

### DIFF
--- a/src/unit_tests/wazuh_modules/command/test_wm_command.c
+++ b/src/unit_tests/wazuh_modules/command/test_wm_command.c
@@ -92,11 +92,14 @@ static int check_wm_sendmsg_message_is_valid_command_json(const LargestIntegralT
     cJSON *root = cJSON_Parse(message);
     assert_non_null(root);
 
-    const char *event_module = wm_command_json_get_string(root, "event.module");
+    const cJSON *event_obj = wm_command_json_get_object(root, "event");
+    assert_non_null(event_obj);
+
+    const char *event_module = wm_command_json_get_string(event_obj, "module");
     assert_non_null(event_module);
     assert_string_equal(event_module, "wazuh-wodle-cmd");
 
-    const char *event_start = wm_command_json_get_string(root, "event.start");
+    const char *event_start = wm_command_json_get_string(event_obj, "start");
     assert_non_null(event_start);
 
     if (g_payload_expectation.tag) {
@@ -222,8 +225,11 @@ static size_t wm_command_build_base_len_for_test(const char *event_start,
     cJSON *json_event = cJSON_CreateObject();
     assert_non_null(json_event);
 
-    cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
-    cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
+    cJSON *event_obj = cJSON_AddObjectToObject(json_event, "event");
+    if (event_obj) {
+        cJSON_AddStringToObject(event_obj, "module", "wazuh-wodle-cmd");
+        cJSON_AddStringToObject(event_obj, "start", event_start ? event_start : "");
+    }
     if (tag) {
         cJSON *tags_array = cJSON_AddArrayToObject(json_event, "tags");
         if (tags_array) {
@@ -270,8 +276,11 @@ static size_t wm_command_build_payload_len_for_test(const char *event_start,
     cJSON *json_event = cJSON_CreateObject();
     assert_non_null(json_event);
 
-    cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
-    cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
+    cJSON *event_obj = cJSON_AddObjectToObject(json_event, "event");
+    if (event_obj) {
+        cJSON_AddStringToObject(event_obj, "module", "wazuh-wodle-cmd");
+        cJSON_AddStringToObject(event_obj, "start", event_start ? event_start : "");
+    }
     if (tag) {
         cJSON *tags_array = cJSON_AddArrayToObject(json_event, "tags");
         if (tags_array) {

--- a/src/wazuh_modules/src/wm_command.c
+++ b/src/wazuh_modules/src/wm_command.c
@@ -56,8 +56,11 @@ static char *wm_command_build_event_payload(const char *event_start,
         return NULL;
     }
 
-    cJSON_AddStringToObject(json_event, "event.module", "wazuh-wodle-cmd");
-    cJSON_AddStringToObject(json_event, "event.start", event_start ? event_start : "");
+    cJSON *event_obj = cJSON_AddObjectToObject(json_event, "event");
+    if (event_obj) {
+        cJSON_AddStringToObject(event_obj, "module", "wazuh-wodle-cmd");
+        cJSON_AddStringToObject(event_obj, "start", event_start ? event_start : "");
+    }
     if (tag) {
         cJSON *tags_array = cJSON_AddArrayToObject(json_event, "tags");
         if (tags_array) {


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes #35992 

After merging https://github.com/wazuh/wazuh/pull/35703, the event.module and the event.start properties were set at root level of the wodle command json events.

It was requested that they should be properties of the event property, for example:

```
"event": {
    "module": "wazuh-wodle-cmd",
    "start": "2026-05-11T17:47:07.078Z"
}
```
## Proposed Changes
Modify the json event to reflect the above mentioned format and adjust the unit tests accordingly.
<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence
Before these changes:
```
{
    "event.module": "wazuh-wodle-cmd",
    "event.start": "2026-05-11T13:01:30.145Z",
    "tags": [
        "echo-test"
    ],
    "process": {
        "args": [
            "-la"
        ],
        "name": "ls",
        "path": "/usr/bin/ls",
        "command_line": "ls -la ",
        "exit_code": 0,
        "io": {
            "text": "total 56\ndrwxr-x--- 13 root  wazuh 4096 May 11 09:14 .\ndrwxr-xr-x 13 root  root  4096 May 11 09:14 ..\ndrwxr-x---  3 root  wazuh 4096 May 11 09:14 active-response\ndrwxr-x---  2 root  wazuh 4096 May 11 09:14 backup\ndrwxr-x---  2 root  root  4096 May 11 09:14 bin\ndrwxrwx---  3 root  wazuh 4096 May 11 09:58 etc\ndrwxr-x---  2 root  wazuh 4096 May 11 09:14 lib\ndrwxrwx---  3 wazuh wazuh 4096 May 11 09:14 logs\ndrwxrwx--- 10 wazuh wazuh 4096 May 11 09:14 queue\ndrwxr-x---  3 root  wazuh 4096 May 11 09:14 ruleset\ndrwxrwx--T  2 root  wazuh 4096 May 11 09:14 tmp\ndrwxr-x---  7 root  wazuh 4096 May 11 09:58 var\n-r--r-----  1 root  wazuh   48 May 11 09:14 VERSION.json\ndrwxr-x---  6 root  wazuh 4096 May 11 09:14 wodles\n"
        }
    }
}
```

After these changes:
```
{
    "event": {
        "module": "wazuh-wodle-cmd",
        "start": "2026-05-11T17:47:07.078Z"
    },
    "tags": [
        "echo-test"
    ],
    "process": {
        "args": [
            "-la"
        ],
        "name": "ls",
        "path": "/usr/bin/ls",
        "command_line": "ls -la ",
        "exit_code": 0,
        "io": {
            "text": "total 56\ndrwxr-x--- 13 root  wazuh 4096 May 11 14:46 .\ndrwxr-xr-x 13 root  root  4096 May 11 09:14 ..\ndrwxr-x---  3 root  wazuh 4096 May 11 09:14 active-response\ndrwxr-x---  2 root  wazuh 4096 May 11 09:14 backup\ndrwxr-x---  2 root  root  4096 May 11 14:46 bin\ndrwxrwx---  3 root  wazuh 4096 May 11 14:46 etc\ndrwxr-x---  2 root  wazuh 4096 May 11 14:46 lib\ndrwxrwx---  3 wazuh wazuh 4096 May 11 14:46 logs\ndrwxrwx--- 10 wazuh wazuh 4096 May 11 09:14 queue\ndrwxr-x---  3 root  wazuh 4096 May 11 09:14 ruleset\ndrwxrwx--T  2 root  wazuh 4096 May 11 09:14 tmp\ndrwxr-x---  7 root  wazuh 4096 May 11 14:46 var\n-r--r-----  1 root  wazuh   48 May 11 14:46 VERSION.json\ndrwxr-x---  6 root  wazuh 4096 May 11 14:46 wodles\n"
        }
    }
}
```
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
- Wodle commands
### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
 - N/A
### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
 - N/A
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
