### PR TITLE
Revert the changes that preserve all configuration files when upgrading an agent

### DIFF
--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -222,17 +222,6 @@ jobs:
           expected_upgrade_version: ${{ env.VERSION }}
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
 
-      - name: Test agent upgrade rule checks
-        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
-        with:
-          mode: run
-          component: agent
-          system: ${{ env.SYSTEM }}
-          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
-          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
-          package_mount: /tmp
-          package_path: /packages/${{ env.PACKAGE_NAME }}
-
   upload-deb-arm64-to-s3:
     needs: [build-deb-arm64, test-deb-arm64]
     if: success()
@@ -482,17 +471,6 @@ jobs:
           old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
           expected_upgrade_version: ${{ env.VERSION }}
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
-
-      - name: Test agent upgrade rule checks
-        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
-        with:
-          mode: run
-          component: agent
-          system: ${{ env.SYSTEM }}
-          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
-          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
-          package_mount: /tmp
-          package_path: /packages/${{ env.PACKAGE_NAME }}
 
   upload-rpm-arm64-to-s3:
     needs: [build-rpm-arm64, test-rpm-arm64]

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -263,17 +263,6 @@ jobs:
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
           package_path: /tmp/upgrade_test
 
-      - name: Test agent upgrade rule checks
-        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
-        with:
-          mode: run
-          component: agent
-          system: ${{ env.SYSTEM }}
-          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
-          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
-          package_mount: /tmp/upgrade_test
-          package_path: /packages/${{ env.PACKAGE_NAME }}
-
   upload-deb-to-s3:
     needs: [build-deb, test-deb]
     if: success()
@@ -558,17 +547,6 @@ jobs:
           expected_upgrade_version: ${{ env.VERSION }}
           tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
           package_path: /tmp/upgrade_test
-
-      - name: Test agent upgrade rule checks
-        uses: ./.github/actions/5_builderpackage_manager-upgrade-rules-test
-        with:
-          mode: run
-          component: agent
-          system: ${{ env.SYSTEM }}
-          tested_docker: "${{ env.CONTAINER_NAME }}:${{ env.TAG }}"
-          old_package_url: ${{ steps.upgrade-package-url.outputs.testing_package_url }}
-          package_mount: /tmp/upgrade_test
-          package_path: /packages/${{ env.PACKAGE_NAME }}
 
   upload-rpm-to-s3:
     needs: [build-rpm, test-rpm]

--- a/install.sh
+++ b/install.sh
@@ -257,7 +257,7 @@ Install()
         UpdateStopWAZUH
     fi
 
-    if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ] || [ "X${INSTYPE}" = "Xagent" ]; }; then
+    if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ]; }; then
         PrepareUpgradePreserve || PrepareErrorExit "Could not prepare ${INSTYPE} upgrade preserve backup."
         trap 'HandleUpgradeInterrupt' HUP INT TERM
         trap 'HandleUpgradeExit' 0
@@ -268,14 +268,14 @@ Install()
     INSTALL_STATUS=$?
 
     if [ "${INSTALL_STATUS}" != "0" ]; then
-        if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ] || [ "X${INSTYPE}" = "Xagent" ]; }; then
+        if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ]; }; then
             trap - HUP INT TERM 0
             AttemptUpgradePreserveRestore "ERROR: Upgrade failed"
         fi
         exit "${INSTALL_STATUS}"
     fi
 
-    if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ] || [ "X${INSTYPE}" = "Xagent" ]; }; then
+    if [ "X${update_only}" = "Xyes" ] && { [ "X${INSTYPE}" = "Xmanager" ]; }; then
         trap - HUP INT TERM 0
         RestoreUpgradePreserve || RestoreErrorExit "Could not restore ${INSTYPE} upgrade preserve backup."
     fi

--- a/packages/debs/SPECS/wazuh-agent/debian/postinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/postinst
@@ -14,22 +14,10 @@ case "$1" in
     GROUP="wazuh"
     WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
     WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_config_files"
-    WAZUH_PRESERVE_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_upgrade_preserve"
     SCRIPTS_DIR="${WAZUH_GLOBAL_TMP_DIR}/agent_installation_scripts"
     SCA_BASE_DIR="${SCRIPTS_DIR}/sca"
 
     OSMYSHELL="/sbin/nologin"
-
-    restore_upgrade_preserve() {
-        if [ -d "${WAZUH_PRESERVE_DIR}/etc" ]; then
-            mkdir -p "${DIR}/etc"
-            cp -a "${WAZUH_PRESERVE_DIR}/etc/." "${DIR}/etc/"
-        fi
-
-        if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
-            rm -rf "${WAZUH_PRESERVE_DIR}"
-        fi
-    }
 
     if [ -d /run/systemd/system ]; then
         rm -f /etc/init.d/wazuh-agent
@@ -58,18 +46,30 @@ case "$1" in
         chmod 640 ${DIR}/etc/ossec.conf.new
     fi
 
-    if [ -z "$2" ]; then
-        # For the etc dir
-        if [ -f /etc/localtime ]; then
-            cp -pL /etc/localtime ${DIR}/etc/;
-            chmod 640 ${DIR}/etc/localtime
-            chown root:${GROUP} ${DIR}/etc/localtime
-        fi
+    # For the etc dir
+    if [ -f /etc/localtime ]; then
+        cp -pL /etc/localtime ${DIR}/etc/;
+        chmod 640 ${DIR}/etc/localtime
+        chown root:${GROUP} ${DIR}/etc/localtime
     fi
 
     # Remove deprecated binaries
     if [ -f ${DIR}/bin/agent-auth ]; then
         rm -f ${DIR}/bin/agent-auth
+    fi
+
+    # Restore the local rules, client.keys and local_decoder
+    if [ -f ${WAZUH_TMP_DIR}/client.keys ]; then
+        cp ${WAZUH_TMP_DIR}/client.keys ${DIR}/etc/client.keys
+    fi
+    # Restore ossec.conf configuration
+    if [ -f ${WAZUH_TMP_DIR}/ossec.conf ]; then
+        mv ${WAZUH_TMP_DIR}/ossec.conf ${DIR}/etc/ossec.conf
+        chmod 640 ${DIR}/etc/ossec.conf
+    fi
+    # Restore internal options configuration
+    if [ -f ${WAZUH_TMP_DIR}/local_internal_options.conf ]; then
+        mv ${WAZUH_TMP_DIR}/local_internal_options.conf ${DIR}/etc/local_internal_options.conf
     fi
 
     # Install the SCA files
@@ -112,6 +112,12 @@ case "$1" in
 
     fi
 
+    # Restore group files
+    if [ -d ${WAZUH_TMP_DIR}/group ]; then
+        cp -rfp ${WAZUH_TMP_DIR}/group/* ${DIR}/etc/shared
+        rm -rf ${WAZUH_TMP_DIR}/group
+    fi
+
     touch ${DIR}/logs/active-responses.log
     chown wazuh:wazuh ${DIR}/logs/active-responses.log
     chmod 0660 ${DIR}/logs/active-responses.log
@@ -128,12 +134,6 @@ case "$1" in
     if [ -z "$2" ] ; then
         ${SCRIPTS_DIR}/src/init/register_configure_agent.sh ${DIR} > /dev/null || :
     fi
-
-    # Restore preserved etc/ as the last content-restore/overwrite
-    # step for that tree, matching the RPM %posttrans ordering and the
-    # strict "etc/ MUST NOT be overwritten" contract from the upgrade rules.
-    # Permission normalization may still follow afterwards.
-    restore_upgrade_preserve
 
     # Restoring file permissions
     ${SCRIPTS_DIR}/restore-permissions.sh > /dev/null 2>&1 || :

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -6,29 +6,13 @@ set -e
 
 DIR="/var/ossec"
 WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
-WAZUH_PRESERVE_DIR="${DIR}/packages_files/agent_upgrade_preserve"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
 
-        case "$1" in
-            failed-upgrade|abort-upgrade)
-                if [ -d "${WAZUH_TMP_DIR}" ]; then
-                    echo "Wazuh upgrade recovery files were preserved at ${WAZUH_TMP_DIR}. Restore them manually if needed." >&2
-                fi
-                if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
-                    echo "Wazuh upgrade recovery files were preserved at ${WAZUH_PRESERVE_DIR}. Restore them manually if needed." >&2
-                fi
-                ;;
-            *)
-                if [ -d ${WAZUH_TMP_DIR} ]; then
-                    rm -rf ${WAZUH_TMP_DIR}
-                fi
-                if [ -d "${WAZUH_PRESERVE_DIR}" ]; then
-                    rm -rf "${WAZUH_PRESERVE_DIR}"
-                fi
-                ;;
-        esac
+        if [ -d ${WAZUH_TMP_DIR} ]; then
+            rm -rf ${WAZUH_TMP_DIR}
+        fi
 
         # Back up the old configuration files as .save
         if [ ! -d ${DIR}/etc ]; then

--- a/packages/debs/SPECS/wazuh-agent/debian/preinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/preinst
@@ -6,23 +6,9 @@ set -e
 # configuration variables
 DIR="/var/ossec"
 WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
-WAZUH_PRESERVE_DIR="${DIR}/packages_files/agent_upgrade_preserve"
 
 # environment configuration
 mkdir -p ${WAZUH_TMP_DIR}
-
-backup_upgrade_preserve() {
-    if [ -e "${WAZUH_PRESERVE_DIR}" ]; then
-        echo "ERROR: Existing agent upgrade preserve backup found at ${WAZUH_PRESERVE_DIR}." >&2
-        echo "ERROR: Recover or move this directory before retrying the upgrade." >&2
-        exit 1
-    fi
-    mkdir -p "${WAZUH_PRESERVE_DIR}"
-
-    if [ -d "${DIR}/etc" ]; then
-        cp -a "${DIR}/etc" "${WAZUH_PRESERVE_DIR}/"
-    fi
-}
 
 case "$1" in
     install|upgrade)
@@ -94,8 +80,6 @@ EOF
             fi
             ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 
-            backup_upgrade_preserve
-
             # Remove old databases if upgrading from pre 5.X to 5.X
             if [ $MAJOR -lt 5 ]; then
                 if [ -f ${DIR}/queue/syscollector/db/local.db ]; then
@@ -134,6 +118,32 @@ EOF
             touch ${WAZUH_TMP_DIR}/create_conf
         fi
 
+        # Delete old service
+        if [ -f /etc/init.d/ossec ]; then
+            rm /etc/init.d/ossec
+        fi
+
+        # back up the current user rules
+        if [ -f ${DIR}/etc/client.keys ]; then
+            cp ${DIR}/etc/client.keys ${WAZUH_TMP_DIR}/client.keys
+        fi
+        if [ -f ${DIR}/etc/local_internal_options.conf ]; then
+            cp -p ${DIR}/etc/local_internal_options.conf ${WAZUH_TMP_DIR}/local_internal_options.conf
+        fi
+        if [ -f ${DIR}/etc/ossec.conf ]; then
+            cp -p ${DIR}/etc/ossec.conf ${WAZUH_TMP_DIR}/ossec.conf
+        fi
+
+        if [ -d "${DIR}/etc/shared" ]; then
+            if [ "$(ls -A "${DIR}/etc/shared")" ]; then
+                files="$(ls -A ${DIR}/etc/shared/*)"
+            fi
+        fi
+
+        if [ ! -z "$files" ]; then
+            mkdir -p ${WAZUH_TMP_DIR}/group
+            cp -rp ${DIR}/etc/shared/* ${WAZUH_TMP_DIR}/group/
+        fi
     ;;
 
     abort-upgrade)

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -209,7 +209,7 @@ elif [ -f %{_localstatedir}/VERSION.json ]; then
 fi
 
 # Validate upgrade constraints for Agent (only during upgrade)
-if [ "$1" -eq 2 ]; then
+if [ $1 = 2 ]; then
   ERROR_TYPE=""
 
   # Determine if upgrade should be blocked
@@ -249,7 +249,7 @@ EOF
 fi
 
 # Stop the services to upgrade the package
-if [ "$1" -eq 2 ]; then
+if [ $1 = 2 ]; then
   if [ ! -d "%{_localstatedir}" ]; then
     echo "Error: Directory %{_localstatedir} does not exist. Cannot perform upgrade" >&2
     exit 1
@@ -266,24 +266,6 @@ if [ "$1" -eq 2 ]; then
     touch %{_localstatedir}/tmp/wazuh.restart
   fi
   %{_localstatedir}/bin/wazuh-control stop > /dev/null 2>&1
-
-  UPGRADE_PRESERVE_DIR="%{_localstatedir}/tmp/agent_upgrade_preserve"
-  (
-    set -e
-    if [ -e "${UPGRADE_PRESERVE_DIR}" ]; then
-      echo "ERROR: Existing agent upgrade preserve backup found at ${UPGRADE_PRESERVE_DIR}." >&2
-      echo "ERROR: Recover or move this directory before retrying the upgrade." >&2
-      exit 1
-    fi
-    mkdir -p "${UPGRADE_PRESERVE_DIR}"
-
-    if [ -d "%{_localstatedir}/etc" ]; then
-      cp -a "%{_localstatedir}/etc" "${UPGRADE_PRESERVE_DIR}/"
-    fi
-  ) || {
-    echo "ERROR: Could not prepare agent upgrade preserve backup at ${UPGRADE_PRESERVE_DIR}." >&2
-    exit 1
-  }
 fi
 
 # Remove old databases if upgrading from pre 5.X to 5.X
@@ -298,7 +280,7 @@ fi
 
 %post
 
-if [ "$1" -eq 2 ]; then
+if [ $1 = 2 ]; then
   if [ -d %{_localstatedir}/logs/ossec ]; then
     rm -rf %{_localstatedir}/logs/wazuh
     cp -rp %{_localstatedir}/logs/ossec %{_localstatedir}/logs/wazuh
@@ -310,7 +292,7 @@ if [ "$1" -eq 2 ]; then
   fi
 fi
 # If the package is being installed
-if [ "$1" -eq 1 ]; then
+if [ $1 = 1 ]; then
 
   touch %{_localstatedir}/logs/active-responses.log
   chown wazuh:wazuh %{_localstatedir}/logs/active-responses.log
@@ -341,6 +323,9 @@ fi
 
 # Delete the installation files used to configure the agent
 rm -rf %{_localstatedir}/packages_files
+
+# Remove unnecessary files from shared directory
+rm -f %{_localstatedir}/etc/shared/*.rpmnew
 
 #AlmaLinux
 if [ -r "/etc/almalinux-release" ]; then
@@ -609,6 +594,16 @@ fi
 
 DELETE_WAZUH_USER_AND_GROUP=0
 
+if [ $1 = 1 ]; then
+  if [ ! -f %{_localstatedir}/etc/client.keys ]; then
+    if [ -f %{_localstatedir}/etc/client.keys.rpmsave ]; then
+      mv %{_localstatedir}/etc/client.keys.rpmsave %{_localstatedir}/etc/client.keys
+    elif [ -f %{_localstatedir}/etc/client.keys.rpmnew ]; then
+      mv %{_localstatedir}/etc/client.keys.rpmnew %{_localstatedir}/etc/client.keys
+    fi
+  fi
+fi
+
 # If the package is been uninstalled or we want to delete wazuh user and group
 if [ $1 = 0 ] || [ $DELETE_WAZUH_USER_AND_GROUP = 1 ]; then
   # Remove the wazuh user if it exists
@@ -637,22 +632,6 @@ fi
 
 # posttrans code is the last thing executed in a install/upgrade
 %posttrans
-UPGRADE_PRESERVE_DIR="%{_localstatedir}/tmp/agent_upgrade_preserve"
-
-if [ -d "${UPGRADE_PRESERVE_DIR}" ]; then
-  (
-    set -e
-    if [ -d "${UPGRADE_PRESERVE_DIR}/etc" ]; then
-      mkdir -p "%{_localstatedir}/etc"
-      cp -a "${UPGRADE_PRESERVE_DIR}/etc/." "%{_localstatedir}/etc/"
-    fi
-  ) || {
-    echo "ERROR: Could not restore agent upgrade preserve backup; contents left at ${UPGRADE_PRESERVE_DIR}." >&2
-    exit 1
-  }
-  rm -rf "${UPGRADE_PRESERVE_DIR}"
-fi
-
 if [ -f %{_sysconfdir}/systemd/system/wazuh-agent.service ]; then
   rm -rf %{_sysconfdir}/systemd/system/wazuh-agent.service
   systemctl daemon-reload > /dev/null 2>&1
@@ -706,10 +685,10 @@ rm -fr %{buildroot}
 %attr(750, root, root) %{_localstatedir}/bin/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/backup
 %dir %attr(770, wazuh, wazuh) %{_localstatedir}/etc
-%attr(640, root, wazuh) %{_localstatedir}/etc/client.keys
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/client.keys
 %attr(640, root, wazuh) %{_localstatedir}/etc/internal_options*
 %attr(640, root, wazuh) %{_localstatedir}/etc/localtime
-%attr(640, root, wazuh) %{_localstatedir}/etc/local_internal_options.conf
+%attr(640, root, wazuh) %config(noreplace) %{_localstatedir}/etc/local_internal_options.conf
 %attr(640, root, wazuh) %ghost %{_localstatedir}/etc/ossec.conf
 %attr(640, root, wazuh) %{_localstatedir}/etc/wpk_root.pem
 %dir %attr(770, root, wazuh) %{_localstatedir}/etc/shared


### PR DESCRIPTION
## Description


With this change, we retain the functionality of preserving only those configuration files that we consider necessary in the agent following an upgrade, namely: `ossec.conf`, `local_internal_options.conf` and `client.keys`.

This avoids the _`CRITICAL`_ error caused by retaining deprecated options from the 4.X `internal_options.conf`.

## Proposed Changes

- Revert the changes to the agent side made in the following PR:
  - https://github.com/wazuh/wazuh/pull/35580

### Results and Evidence

Before:
```
root@debian13:/home/vagrant# dpkg -i ./wazuh-agent_4.14.5-1_amd64.deb
Selecting previously unselected package wazuh-agent.
(Reading database ... 38929 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.14.5-1_amd64.deb ...
Unpacking wazuh-agent (4.14.5-1) ...
Setting up wazuh-agent (4.14.5-1) ...
root@debian13:/home/vagrant# dpkg -i --force-confold ./wazuh-agent_5.0.0-latest_amd64.deb
(Reading database ... 39385 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-latest_amd64.deb ...
Unpacking wazuh-agent (5.0.0-latest) over (4.14.5-1) ...
Setting up wazuh-agent (5.0.0-latest) ...

Configuration file '/etc/init.d/wazuh-agent'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
 ==> Using current old file as you requested.
root@debian13:/home/vagrant# ls -lah /var/ossec/etc/
total 56K
drwxrwx---  3 root wazuh 4.0K May 12 17:06 .
drwxr-x--- 13 root wazuh 4.0K May 12 17:06 ..
-rw-r-----  1 root wazuh    0 Apr 16 12:49 client.keys
-rw-r-----  1 root wazuh  15K Apr 16 12:49 internal_options.conf
-rw-r-----  1 root wazuh  320 Apr 16 12:49 local_internal_options.conf
-rw-r-----  1 root wazuh  114 Aug 24  2025 localtime
-rw-r-----  1 root wazuh 5.5K May 12 17:06 ossec.conf
-rw-r-----  1 root root  4.7K May 12 17:06 ossec.conf.new
drwxrwx---  2 root wazuh 4.0K May 12 17:06 shared
-rw-r-----  1 root wazuh 1.4K Apr 16 12:49 wpk_root.pem
```

After:
```
root@debian13:/home/vagrant# dpkg -i ./wazuh-agent_4.14.5-1_amd64.deb
Selecting previously unselected package wazuh-agent.
(Reading database ... 38929 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.14.5-1_amd64.deb ...
Unpacking wazuh-agent (4.14.5-1) ...
Setting up wazuh-agent (4.14.5-1) ...
root@debian13:/home/vagrant# dpkg -i --force-confold ./wazuh-agent_5.0.0-
wazuh-agent_5.0.0-0_amd64_ec0cbe0.deb  wazuh-agent_5.0.0-latest_amd64.deb
root@debian13:/home/vagrant# dpkg -i --force-confold ./wazuh-agent_5.0.0-0_amd64_ec0cbe0.deb 
(Reading database ... 39385 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_amd64_ec0cbe0.deb ...
Unpacking wazuh-agent (5.0.0-0) over (4.14.5-1) ...
Setting up wazuh-agent (5.0.0-0) ...

Configuration file '/etc/init.d/wazuh-agent'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
 ==> Using current old file as you requested.
root@debian13:/home/vagrant# ls -lah /var/ossec/etc/
total 48K
drwxrwx---  3 root wazuh 4.0K May 12 17:09 .
drwxr-x--- 13 root wazuh 4.0K May 12 17:09 ..
-rw-r-----  1 root wazuh    0 May 12 17:09 client.keys
-rw-r-----  1 root wazuh 6.2K May 12 17:04 internal_options.conf
-rw-r-----  1 root wazuh  320 Apr 16 12:49 local_internal_options.conf
-rw-r-----  1 root wazuh  114 Aug 24  2025 localtime
-rw-r-----  1 root wazuh 5.5K May 12 17:09 ossec.conf
-rw-r-----  1 root root  4.7K May 12 17:09 ossec.conf.new
drwxrwx---  2 root wazuh 4.0K May 12 17:09 shared
-rw-r-----  1 root wazuh 1.4K May 12 17:04 wpk_root.pem
```


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

