### PR TITLE
Solve agent disconnect on direct 4.13→5.0 custom WPK upgrade

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -8,7 +8,33 @@ DIR="/var/ossec"
 WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 
 case "$1" in
-    remove|failed-upgrade|abort-install|abort-upgrade|disappear)
+    failed-upgrade|abort-upgrade)
+        # dpkg is rolling back to the previously installed package after a
+        # failed upgrade (for example, the new preinst rejected the version).
+        # The previous package's files are still on disk untouched, so the
+        # new postrm MUST NOT mutate ${DIR}/etc/ or any other agent state.
+        # Just point the operator at any preserve directory and restart
+        # the agent service that old-prerm stopped before the abort, so
+        # the agent can report upgrade_result back to the manager.
+
+        if [ -d "${WAZUH_TMP_DIR}" ]; then
+            echo "Wazuh upgrade recovery files were preserved at ${WAZUH_TMP_DIR}. Restore them manually if needed." >&2
+        fi
+
+        if [ -f ${WAZUH_TMP_DIR}/wazuh.restart ] ; then
+            rm -f ${WAZUH_TMP_DIR}/wazuh.restart
+            if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
+                systemctl daemon-reload > /dev/null 2>&1
+                systemctl restart wazuh-agent.service > /dev/null 2>&1 || true
+            elif command -v service > /dev/null 2>&1 ; then
+                service wazuh-agent restart > /dev/null 2>&1 || true
+            elif [ -x ${DIR}/bin/wazuh-control ]; then
+                ${DIR}/bin/wazuh-control restart > /dev/null 2>&1 || true
+            fi
+        fi
+        ;;
+
+    remove|abort-install|disappear)
 
         if [ -d ${WAZUH_TMP_DIR} ]; then
             rm -rf ${WAZUH_TMP_DIR}

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -1259,6 +1259,66 @@ void test_wm_agent_upgrade_validate_version_upgrade_custom_non_minimal(void **st
     assert_int_equal(ret, WM_UPGRADE_NOT_MINIMAL_VERSION_SUPPORTED);
 }
 
+void test_wm_agent_upgrade_validate_version_upgrade_custom_v5_from_413(void **state)
+{
+    (void) state;
+    wm_upgrade_custom_task *task = wm_agent_upgrade_init_upgrade_custom_task();
+    os_strdup("/tmp/wazuh_agent_v5.0.0_linux_amd64.deb.wpk", task->custom_file_path);
+    char *wazuh_version = "v4.13.0";
+    char *platform = "ubuntu";
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, platform, WM_UPGRADE_UPGRADE_CUSTOM, task);
+
+    assert_int_equal(ret, WM_UPGRADE_INTERMEDIATE_VERSION_REQUIRED);
+
+    wm_agent_upgrade_free_upgrade_custom_task(task);
+}
+
+void test_wm_agent_upgrade_validate_version_upgrade_custom_v5_from_414(void **state)
+{
+    (void) state;
+    wm_upgrade_custom_task *task = wm_agent_upgrade_init_upgrade_custom_task();
+    os_strdup("wazuh_agent_v5.0.0_linux_amd64.deb.wpk", task->custom_file_path);
+    char *wazuh_version = "v4.14.0";
+    char *platform = "ubuntu";
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, platform, WM_UPGRADE_UPGRADE_CUSTOM, task);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+
+    wm_agent_upgrade_free_upgrade_custom_task(task);
+}
+
+void test_wm_agent_upgrade_validate_version_upgrade_custom_v414_from_413(void **state)
+{
+    (void) state;
+    wm_upgrade_custom_task *task = wm_agent_upgrade_init_upgrade_custom_task();
+    os_strdup("wazuh_agent_v4.14.4_linux_amd64.deb.wpk", task->custom_file_path);
+    char *wazuh_version = "v4.13.0";
+    char *platform = "ubuntu";
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, platform, WM_UPGRADE_UPGRADE_CUSTOM, task);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+
+    wm_agent_upgrade_free_upgrade_custom_task(task);
+}
+
+void test_wm_agent_upgrade_validate_version_upgrade_custom_renamed_filename(void **state)
+{
+    (void) state;
+    wm_upgrade_custom_task *task = wm_agent_upgrade_init_upgrade_custom_task();
+    os_strdup("/tmp/myfile.wpk", task->custom_file_path);
+    char *wazuh_version = "v4.13.0";
+    char *platform = "ubuntu";
+
+    int ret = wm_agent_upgrade_validate_version(wazuh_version, platform, WM_UPGRADE_UPGRADE_CUSTOM, task);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+
+    wm_agent_upgrade_free_upgrade_custom_task(task);
+}
+
 void test_wm_agent_upgrade_validate_version_upgrade_older_version(void **state)
 {
     wm_upgrade_task *task = state[1];
@@ -1842,6 +1902,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_custom_ok, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_non_minimal, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_custom_non_minimal, setup_validate_wpk_version, teardown_validate_wpk_version),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_version_upgrade_custom_v5_from_413),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_version_upgrade_custom_v5_from_414),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_version_upgrade_custom_v414_from_413),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_version_upgrade_custom_renamed_filename),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_older_version, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_greater_version, setup_validate_wpk_version, teardown_validate_wpk_version),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_validate_version_upgrade_force, setup_validate_wpk_version, teardown_validate_wpk_version),

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -147,6 +147,45 @@ int wm_agent_upgrade_validate_system(const char *platform, const char *os_major,
     return return_code;
 }
 
+/**
+ * Extract the target version token from a canonical WPK filename of the form
+ * "wazuh_agent_v<VERSION>_<rest>.wpk". The extracted token is prefixed with 'v'
+ * so it can be compared directly with compare_wazuh_versions().
+ *
+ * @param file_path  Full path or basename of the WPK file.
+ * @param out        Output buffer for the version token (e.g. "v5.0.0").
+ * @param out_size   Capacity of out.
+ * @return true if a version token was found, false if the filename does not
+ *         follow the canonical pattern (renamed file, missing tokens, etc.).
+ */
+static bool wm_agent_upgrade_parse_wpk_custom_version(const char *file_path, char *out, size_t out_size) {
+    if (!file_path || !out || out_size == 0) {
+        return false;
+    }
+
+    const char *slash = strrchr(file_path, '/');
+    const char *fname = slash ? slash + 1 : file_path;
+    const char *vtag  = strstr(fname, "_v");
+    if (!vtag) {
+        return false;
+    }
+
+    const char *vstart = vtag + 1;
+    const char *vend   = strchr(vstart, '_');
+    if (!vend) {
+        return false;
+    }
+
+    size_t vlen = (size_t)(vend - vstart);
+    if (vlen == 0 || vlen >= out_size) {
+        return false;
+    }
+
+    memcpy(out, vstart, vlen);
+    out[vlen] = '\0';
+    return true;
+}
+
 int wm_agent_upgrade_validate_version(const char *wazuh_version, const char *platform, wm_upgrade_command command, void *task) {
     char *tmp_agent_version = NULL;
     char *manager_version = NULL;
@@ -179,7 +218,22 @@ int wm_agent_upgrade_validate_version(const char *wazuh_version, const char *pla
                     }
                 }
             } else if (WM_UPGRADE_UPGRADE_CUSTOM == command) {
+                wm_upgrade_custom_task *custom_task = (wm_upgrade_custom_task *)task;
+                char target_version[32] = {0};
                 return_code = WM_UPGRADE_SUCCESS;
+
+                // Mirror the repo-path rule when the WPK filename follows the
+                // canonical "wazuh_agent_v<VERSION>_<...>.wpk" pattern: direct
+                // upgrade to v5.0.0+ from agents older than v4.14.0 is not
+                // supported and cannot be forced. Non-canonical filenames fall
+                // through to the agent-side preinst check.
+                if (custom_task &&
+                    wm_agent_upgrade_parse_wpk_custom_version(custom_task->custom_file_path,
+                                                              target_version, sizeof(target_version)) &&
+                    compare_wazuh_versions(target_version, WM_UPGRADE_5X_MINIMUM_VERSION, true) >= 0 &&
+                    compare_wazuh_versions(tmp_agent_version, WM_UPGRADE_REQUIRED_INTERMEDIATE_VERSION, true) < 0) {
+                    return_code = WM_UPGRADE_INTERMEDIATE_VERSION_REQUIRED;
+                }
             }
         }
     }


### PR DESCRIPTION
# Description

Direct upgrade from a 4.13.x agent to v5.0.0 using `agent_upgrade -f <wpk>` left the manager hung on `Upgrading...` and the agent broken (only `ossec.conf.save` remained in `/var/ossec/etc/`). The custom-WPK code path in `wm_agent_upgrade_validate_version()` skipped the intermediate-version check that the repository path enforces, and on the agent side the new 5.0 DEB `postrm` ran its destructive `${DIR}/etc/` rename on the `abort-upgrade` rollback, wiping the configuration before the agent could report back. This PR adds a filename-aware version gate on the manager and isolates the DEB rollback path so `ossec.conf` is preserved and the service is restarted, allowing the agent's existing ACK to surface the correct `1822 - Direct upgrade to v5.0.0 is not supported` error in the dashboard. 

Resolves #35979.

## Proposed Changes

- `src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_validate.c`: add static helper `wm_agent_upgrade_parse_wpk_custom_version()` that extracts the target version from the canonical `wazuh_agent_v<VERSION>_<rest>.wpk` filename; extend the `WM_UPGRADE_UPGRADE_CUSTOM` branch of `wm_agent_upgrade_validate_version()` to apply the same intermediate-version rule used by the repo path (target ≥ `v5.0.0` + agent < `v4.14.0` → `WM_UPGRADE_INTERMEDIATE_VERSION_REQUIRED`, surfaced as API error `1822`). Non-canonical / renamed filenames fall through to the existing agent-side preinst as the safety net.
- `packages/debs/SPECS/wazuh-agent/debian/postrm`: split `failed-upgrade|abort-upgrade` out of the umbrella case that previously shared the destructive cleanup branch with `remove|abort-install|disappear`. The `find ${DIR}/etc/ -type f -exec mv {} {}.save \;` line no longer runs on aborted upgrades, so `ossec.conf` is preserved. Add the canonical service-restart block (mirroring `postinst:172-181`) gated on `${WAZUH_TMP_DIR}/wazuh.restart`, so when dpkg rolls back the failed upgrade the agent is restarted on its untouched config, reads `upgrade_result=1`, and the existing agent → manager ACK path delivers the user-visible error.
- `src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c`: add four new cases covering the custom-upgrade branch.
- RPM `%postun` is already guarded by `[ $1 = 0 ]`, and macOS `preinstall.sh` exits before any destructive `mv` — no change required for those platforms.

### Results and Evidence

<details><summary>Ubuntu (DEB) — agent 011</summary>

```bash
root@wazuh-aio-35979:~# /var/wazuh-manager/bin/agent_upgrade -a 011 -f /root/wazuh_agent_v5.0.0_linux_amd64.deb.wpk
Agents that cannot be upgraded:
    Agent 011 upgrade failed. Status: Error 1822 - Direct upgrade to v5.0.0 is not supported. Please upgrade to v4.14.x first


root@wazuh-aio-35979:~# /var/wazuh-manager/bin/agent_upgrade -a 011 -f /root/wazuh-agent_5.0.0-0_amd64_1fd4b31.deb.wpk

Upgrading...

Failed upgrades:
    Agent 011 status: Direct upgrade to v5.0.0 is not supported. Please upgrade to v4.14.x first
```

</details>

<details><summary>Windows (MSI) — agent 003</summary>

```bash
root@wazuh-aio-35979:~# /var/wazuh-manager/bin/agent_upgrade -a 003 -f /root/wazuh-agent_v5.0.0-0_windows.msi.wpk
Agents that cannot be upgraded:
    Agent 003 upgrade failed. Status: Error 1822 - Direct upgrade to v5.0.0 is not supported. Please upgrade to v4.14.x first


root@wazuh-aio-35979:~# /var/wazuh-manager/bin/agent_upgrade -a 003 -f /root/wazuh-agent_5.0.0-0_windows_1fd4b31.msi.wpk

Upgrading...

Failed upgrades:
    Agent 003 status: Direct upgrade to v5.0.0 is not supported. Please upgrade to v4.14.x first
```

</details>

<details><summary>CentOS (RPM) — agent 010</summary>

```bash
root@wazuh-aio-35979:~# /var/wazuh-manager/bin/agent_upgrade -a 010 -f /root/wazuh-agent_v5.0.0-0_x86_64_linux.rpm.wpk
Agents that cannot be upgraded:
    Agent 010 upgrade failed. Status: Error 1822 - Direct upgrade to v5.0.0 is not supported. Please upgrade to v4.14.x first


root@wazuh-aio-35979:~# /var/wazuh-manager/bin/agent_upgrade -a 010 -f /root/wazuh-agent_5.0.0-0_x86_64_1fd4b31.rpm.wpk

Upgrading...

Failed upgrades:
    Agent 010 status: Direct upgrade to v5.0.0 is not supported. Please upgrade to v4.14.x first
```

</details>

### Artifacts Affected

- `wazuh-modulesd` (manager side, `agent_upgrade` module) — new validation logic in `wm_agent_upgrade_validate_version()`.
- `wazuh-manager` package — ships the updated `wazuh-modulesd` binary.
- `wazuh-agent` DEB package — updated `postrm` maintainer script. RPM and macOS packages are unchanged.

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

- `test_wm_agent_upgrade_validate_version_upgrade_custom_v5_from_413` — agent on `v4.13.0` + canonical WPK `wazuh_agent_v5.0.0_linux_amd64.deb.wpk` → expects `WM_UPGRADE_INTERMEDIATE_VERSION_REQUIRED`.
- `test_wm_agent_upgrade_validate_version_upgrade_custom_v5_from_414` — agent on `v4.14.0` + canonical `v5.0.0` WPK → expects `WM_UPGRADE_SUCCESS`.
- `test_wm_agent_upgrade_validate_version_upgrade_custom_v414_from_413` — agent on `v4.13.0` + canonical `v4.14.4` WPK → expects `WM_UPGRADE_SUCCESS`.
- `test_wm_agent_upgrade_validate_version_upgrade_custom_renamed_filename` — agent on `v4.13.0` + non-canonical filename without the `_v` token → expects `WM_UPGRADE_SUCCESS` (fallback path).

All four added to `src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
