### PR TITLE
Expand Windows environment variables in SCA rule inputs

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -629,7 +629,11 @@ RuleEvaluatorFactory::CreateEvaluator(const std::string& input,
         sysInfo = std::make_unique<SysInfo>();
     }
 
+#ifdef _WIN32
+    auto ruleInput = Utils::trim(sca::win::ExpandEnvironmentVariables(input), " \t");
+#else
     auto ruleInput = Utils::trim(input, " \t");
+#endif
     auto isNegated = false;
 
     if (ruleInput.size() >= 4 && ruleInput.compare(0, 4, "not ") == 0)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -185,6 +185,14 @@ class RegistryRuleEvaluator : public RuleEvaluator
         GetValueFunc m_getValue = nullptr;
 };
 
+namespace sca::win
+{
+    /// @brief Expands Win32 environment variables (e.g. "%PROGRAMFILES%\\foo")
+    ///        in SCA rule inputs. Unknown %VAR% tokens are left literal.
+    ///        Returns the input unchanged on failure.
+    std::string ExpandEnvironmentVariables(const std::string& input);
+}
+
 class RuleEvaluatorFactory
 {
     public:

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -11,6 +11,39 @@
 
 #include "logging_helper.hpp"
 
+namespace sca::win
+{
+    // ExpandEnvironmentStringsA leaves unknown "%VAR%" tokens in place
+    std::string ExpandEnvironmentVariables(const std::string& input)
+    {
+        const auto requiredSize = ExpandEnvironmentStringsA(input.c_str(), nullptr, 0);
+
+        if (requiredSize == 0)
+        {
+            LoggingHelper::getInstance().log(
+                LOG_DEBUG,
+                "Error while getting length of expanded path in SCA rule: '" + input + "'");
+            return input;
+        }
+
+        std::string expanded(requiredSize, '\0');
+        const auto writtenSize = ExpandEnvironmentStringsA(input.c_str(), expanded.data(), requiredSize);
+
+        if (writtenSize == 0 || writtenSize > requiredSize)
+        {
+            LoggingHelper::getInstance().log(
+                LOG_DEBUG,
+                "Error while getting expanded path in SCA rule: '" + input + "'");
+            return input;
+        }
+
+        // ExpandEnvironmentStringsA returns the length including the
+        // terminating null character
+        expanded.resize(writtenSize - 1);
+        return expanded;
+    }
+}
+
 // LCOV_EXCL_START
 namespace
 {

--- a/src/wazuh_modules/sca/sca_impl/tests/CMakeLists.txt
+++ b/src/wazuh_modules/sca/sca_impl/tests/CMakeLists.txt
@@ -148,4 +148,10 @@ if(WIN32)
            COMMAND registry_rule_evaluator_unit_test)
 
   set_tests_properties(RegistryRuleEvaluatorTest PROPERTIES LABELS "sca")
+
+  add_executable(sca_win_helpers_unit_test sca_win_helpers_test.cpp)
+  target_link_libraries(sca_win_helpers_unit_test PRIVATE SCAImpl)
+  add_test(NAME SCAWinHelpersTest COMMAND sca_win_helpers_unit_test)
+
+  set_tests_properties(SCAWinHelpersTest PROPERTIES LABELS "sca")
 endif()

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_win_helpers_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_win_helpers_test.cpp
@@ -1,0 +1,139 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sca_policy_check.hpp>
+
+#include "logging_helper.hpp"
+
+#include <windows.h>
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+    // RAII guard that sets a process environment variable and restores its
+    // prior value (or absence) on destruction.
+    class ScopedEnvVar
+    {
+        public:
+            ScopedEnvVar(const char* name, const char* value)
+                : m_name(name)
+            {
+                if (const auto size = ::GetEnvironmentVariableA(m_name, nullptr, 0); size > 0)
+                {
+                    std::string prior(size, '\0');
+                    const auto read = ::GetEnvironmentVariableA(m_name, prior.data(), size);
+
+                    if (read > 0 && read < size)
+                    {
+                        prior.resize(read);
+                        m_prior = std::move(prior);
+                    }
+                }
+
+                if (!::SetEnvironmentVariableA(m_name, value))
+                {
+                    throw std::runtime_error("SetEnvironmentVariableA failed");
+                }
+            }
+
+            ~ScopedEnvVar()
+            {
+                ::SetEnvironmentVariableA(m_name, m_prior ? m_prior->c_str() : nullptr);
+            }
+
+            ScopedEnvVar(const ScopedEnvVar&) = delete;
+            ScopedEnvVar& operator=(const ScopedEnvVar&) = delete;
+            ScopedEnvVar(ScopedEnvVar&&) = delete;
+            ScopedEnvVar& operator=(ScopedEnvVar&&) = delete;
+
+        private:
+            const char* m_name;
+            std::optional<std::string> m_prior;
+    };
+
+    template<typename T>
+    bool IsInstanceOf(const IRuleEvaluator* evaluator)
+    {
+        return dynamic_cast<const T*>(evaluator) != nullptr;
+    }
+}
+
+class SCAWinHelpersTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            LoggingHelper::setLogCallback([](const modules_log_level_t /* level */, const char* /* log */)
+            {
+            });
+        }
+};
+
+// -----------------------------------------------------------------------------
+// Unit tests of sca::win::ExpandEnvironmentVariables
+// -----------------------------------------------------------------------------
+
+TEST_F(SCAWinHelpersTest, ExpandsKnownEnvironmentVariable)
+{
+    const ScopedEnvVar envVar("SCA_TEST_ROOT", "C:\\Windows");
+
+    EXPECT_EQ(sca::win::ExpandEnvironmentVariables("%SCA_TEST_ROOT%\\win.ini"),
+              "C:\\Windows\\win.ini");
+}
+
+TEST_F(SCAWinHelpersTest, LeavesUnknownEnvVarLiteral)
+{
+    // ExpandEnvironmentStringsA leaves unknown "%...%" tokens as literal text.
+    constexpr const char* kUnsetVar = "SCA_TEST_DEFINITELY_UNSET";
+    ASSERT_EQ(::GetEnvironmentVariableA(kUnsetVar, nullptr, 0), 0u);
+
+    const std::string input = "C:\\Apps\\%" + std::string(kUnsetVar) + "%\\app.cfg";
+
+    EXPECT_EQ(sca::win::ExpandEnvironmentVariables(input), input);
+}
+
+TEST_F(SCAWinHelpersTest, ReturnsInputUnchangedWhenNoTokensPresent)
+{
+    EXPECT_EQ(sca::win::ExpandEnvironmentVariables("C:\\Windows\\notepad.exe"),
+              "C:\\Windows\\notepad.exe");
+}
+
+TEST_F(SCAWinHelpersTest, ReturnsEmptyForEmptyInput)
+{
+    EXPECT_EQ(sca::win::ExpandEnvironmentVariables(""), "");
+}
+
+TEST_F(SCAWinHelpersTest, ExpandsMultipleVariablesInSingleInput)
+{
+    const ScopedEnvVar drive("SCA_TEST_DRIVE", "C:");
+    const ScopedEnvVar leaf("SCA_TEST_LEAF", "config.ini");
+
+    EXPECT_EQ(sca::win::ExpandEnvironmentVariables("%SCA_TEST_DRIVE%\\apps\\%SCA_TEST_LEAF%"),
+              "C:\\apps\\config.ini");
+}
+
+// -----------------------------------------------------------------------------
+// Integration test through RuleEvaluatorFactory
+// -----------------------------------------------------------------------------
+
+TEST_F(SCAWinHelpersTest, FactoryExpandsEnvironmentVariablesInRuleInput)
+{
+    const ScopedEnvVar envVar("SCA_TEST_ROOT", "C:\\Windows");
+
+    auto evaluator = RuleEvaluatorFactory::CreateEvaluator(
+                         "f:%SCA_TEST_ROOT%\\win.ini -> enabled", 30, false);
+
+    ASSERT_NE(evaluator, nullptr);
+    ASSERT_TRUE(IsInstanceOf<FileRuleEvaluator>(evaluator.get()));
+
+    const auto* base = dynamic_cast<const RuleEvaluator*>(evaluator.get());
+    ASSERT_NE(base, nullptr);
+
+    const auto& ctx = base->GetContext();
+    EXPECT_EQ(ctx.rule, "C:\\Windows\\win.ini");
+    ASSERT_TRUE(ctx.pattern.has_value());
+    EXPECT_EQ(ctx.pattern.value(), "enabled");
+}


### PR DESCRIPTION
## Description

In Wazuh 4.x the Windows SCA module expanded `%VAR%` environment variable tokens before evaluating policy rules. The 5.x SCA reimplementation (C++) was missing this step, so any rule whose input begins with a Windows environment variable (e.g. `%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell ...`) is forwarded to the OS, producing repeated warnings during scan:

```console
wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell ...': The system cannot find the file specified. (2)
```

This affects shipped Windows policies that rely on `%WINDIR%`, `%PROGRAMFILES%`, `%SYSTEMROOT%`, etc., and causes those checks to be reported as Not applicable.

Closes #36002

## Proposed Changes

- Add a `sca::win::ExpandEnvironmentVariables(const std::string&)` helper (Windows-only) that wraps `ExpandEnvironmentStringsA`. Unknown `%VAR%` tokens are left literal; the original input is returned on API failure (logged at DEBUG level).
  - Invoke the helper from `RuleEvaluatorFactory::CreateEvaluator` under `#ifdef _WIN32`, applied to the raw input prior to trim/`not` handling. The expansion therefore applies uniformly to all rule kinds (file, directory, registry, command, process).
  - Non-Windows builds are unchanged.

### Results and Evidence

#### **Before fix**
Windows Server 2019 -> `cis_win2019.yml`

```console
2026/05/12 23:48:07 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "MaximumPasswordAge"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "MaximumPasswordAge"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "MinimumPasswordAge"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "MinimumPasswordLength"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "LockoutDuration"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "LockoutBadCount"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "LockoutBadCount"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell secedit /export /cfg $env:TEMP\secpol.cfg; Get-Content $env:TEMP\secpol.cfg | Select-String "ResetLockoutCount"; Remove-Item $env:TEMP\secpol.cfg': The system cannot find the file specified. (2)
2026/05/12 23:48:07 wazuh-agent: WARNING: Cannot run '%WINDIR%\SysNative\WindowsPowerShell\v1.0\powershell -NoProfile -Command "[bool](Get-CimInstance -Query 'SELECT * FROM Win32_UserAccount WHERE LocalAccount = TRUE AND SID LIKE ''S-1-5-21-%-501''' | Where-Object -Property Disabled)"': The system cannot find the file specified. (2)
2026/05/12 23:48:15 wazuh-modulesd:sca: INFO: SCA scan ended.
```

<img width="2504" height="276" alt="Screenshot 2026-05-12 at 7 31 16 PM" src="https://github.com/user-attachments/assets/784aedfa-cea2-4674-bcd4-8f196b92d00a" />

Affected checks (Not applicable):
- 16500
- 16501
- 16502
- 16503
- 16504
- 16505
- 16507

#### **After fix**
Windows Server 2019 -> `cis_win2019.yml`

The affected policies now run without warnings in the log

```console
2026/05/13 00:14:46 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/13 00:14:52 wazuh-modulesd:sca: INFO: SCA scan ended.
```

<img width="2502" height="280" alt="Screenshot 2026-05-12 at 7 21 16 PM" src="https://github.com/user-attachments/assets/b9a28602-2c57-4bb5-b412-bf8cd5aeb660" />

#### **Other tests**
Windows Server 2012 R2 -> `cis_win2012r2.yml`

No warnings in logs

```console
2026/05/13 00:10:47 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/13 00:10:53 wazuh-modulesd:sca: INFO: SCA scan ended.
```

Windows Server 2025 -> `cis_win2025.yml`

No warnings in logs

```console
2026/05/13 00:14:44 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/13 00:14:55 wazuh-modulesd:sca: INFO: SCA scan ended.
```

### Artifacts Affected

- `wazuh-modulesd` (SCA module) on the Windows agent only.

### Configuration Changes

N/A

### Documentation Updates
  
N/A

### Tests Introduced

New test binary `sca_win_helpers_unit_test` (`src/wazuh_modules/sca/sca_impl/tests/sca_win_helpers_test.cpp`, Windows-only, label `sca`):
- Direct tests of `sca::win::ExpandEnvironmentVariables`:
    - Expands a known variable set via `SetEnvironmentVariableA`.
    - Leaves an unknown `%VAR%` token literal.
    - Returns the input unchanged when no tokens are present.
    - Handles empty input.
    - Expands multiple variables in a single string.
- Integration test through `RuleEvaluatorFactory::CreateEvaluator` verifying that a `f:%SCA_TEST_ROOT%\win.ini -> enabled` rule produces a `FileRuleEvaluator` whose context contains the expanded path and the parsed pattern.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
