### PR TITLE
Improve Unit test's readme

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -159,7 +159,7 @@ endif
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)
 		PRECOMPILED_OS:=linux
-		CC=gcc
+		CC?=gcc
 else
 ifeq (${uname_S},Darwin)
 	PRECOMPILED_OS:=darwin

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1161,10 +1161,10 @@ if(UNIT_TEST OR WAZUH_ENGINE_TEST)
 endif()
 
 # ------------------------------------------------------------------------------
-# Google Benchmark (test builds only)
+# Google Benchmark (test builds only; server/manager targets)
 # ------------------------------------------------------------------------------
 
-if(UNIT_TEST OR WAZUH_ENGINE_TEST)
+if((UNIT_TEST OR WAZUH_ENGINE_TEST) AND NOT IS_AGENT)
   if(EXISTS ${EXTERNAL_DIR}/benchmark/build/src/libbenchmark.a)
     message(STATUS "Using precompiled benchmark library")
     add_custom_target(benchmark_external)

--- a/src/unit_tests/Readme.md
+++ b/src/unit_tests/Readme.md
@@ -1,197 +1,340 @@
 # Unit Tests
+
+This document explains how to compile and run the Wazuh unit tests for the supported targets (Linux server/agent, Windows agent, macOS agent). The high-level flow is the same for every target:
+
+1. Install the required toolchain and libraries (GCC 14, CMake, CMocka, and — for the Windows agent — MinGW and wine).
+2. Fetch the external sources with `make TARGET=… deps`.
+3. Compile Wazuh with `TEST=1` so internal symbols and test hooks are exposed.
+4. Configure and build the unit-test binaries under `src/unit_tests` with CMake.
+5. Run them — either all at once with `ctest`, with coverage via `make coverage`, or one binary at a time.
+
+The sections below walk through each target end-to-end. The one appendix at the bottom covers cleanup when switching between targets.
+
+> **Tip:** every `make` invocation in this document accepts `-j$(nproc)` to parallelize across all your CPU cores, which makes a big difference on the C++ link-heavy steps. For example: `make -j$(nproc) TARGET=agent TEST=1`.
+
 ## Index
 1. [Requirements](#requirements)
-2. [Compile Wazuh](#compile-wazuh)
-3. [Compile and run unit tests for Linux targets](#compile-and-run-unit-tests-for-linux-targets)
-4. [Compile and run unit tests for Windows agent](#compile-and-run-unit-tests-for-windows-agent)
-5. [Compile and run unit tests for macOS agent](#compile-and-run-unit-tests-for-macos-agent)
-6. [Installing CMake](#installing-cmake)
-7. [Installing cmocka](#installing-cmocka)
-8. [Intalling wine](#installing-wine)
+2. [Compile and run unit tests for Linux targets](#compile-and-run-unit-tests-for-linux-targets)
+3. [Compile and run unit tests for Windows agent](#compile-and-run-unit-tests-for-windows-agent)
+4. [Compile and run unit tests for macOS agent](#compile-and-run-unit-tests-for-macos-agent)
+5. [Appendix: Cleaning the environment before building a different target](#appendix-cleaning-the-environment-before-building-a-different-target)
 
-## Requirements:
-1. Compiling tools (GCC and/or mingw)
-2. CMake (version 3.10 or higher)
-3. Wine (For executing winagent tests)
-4. CMocka (C Unit Testing Framework)
+## Requirements
+1. **GCC 14** (`gcc-14` / `g++-14`) — required on Linux for all targets. On macOS the build uses Apple Clang from Xcode Command Line Tools (Apple Clang 16 on macos-15).
+2. **MinGW** (`i686-w64-mingw32-gcc` / `g++-posix`) — required for the Windows agent.
+3. **CMake** 3.22.1 or higher. Ubuntu 22.04+ and macOS Homebrew both ship a recent enough version by default.
+4. **CMocka** (C unit testing framework). For Linux/macOS targets the distribution package is enough; for the Windows agent it must be cross-built with MinGW (step 0.2 of the [Windows agent section](#compile-and-run-unit-tests-for-windows-agent)).
+5. **Wine** (32 bit) — required for the Windows agent.
 
-Additional dependencies can be installed on Ubuntu by running the following commands.
+### Installing dependencies on Ubuntu
+Base packages (Linux server/agent + unit tests):
 ```
 sudo apt-get update -y
-sudo apt-get install -y gcc-mingw-w64 make python3 gcc g++ cmake libc6-dev curl policycoreutils automake autoconf libtool libssl-dev lcov
+sudo apt-get install -y \
+    gcc-14 g++-14 \
+    make cmake python3 libc6-dev \
+    automake autoconf libtool \
+    libcmocka-dev lcov
 ```
 
-To install the additional dependencies on macOS run the following commands.
-```
-$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-$ brew install cmake
-$ brew install cmocka
-$ brew install lcov
-```
+For the Windows agent there are additional packages (mingw, wine, a cross-compiled cmocka) — they're installed as part of step 0 in the [Windows agent section](#compile-and-run-unit-tests-for-windows-agent).
 
-## Compile Wazuh
-In order to run unit tests on a specific wazuh target, the project needs to be built with the `TEST` option as shown below:
-```
-make TARGET=server|agent|winagent TEST=1
-```
+### Installing dependencies on macOS
+Handled in step 0 of the [macOS agent section](#compile-and-run-unit-tests-for-macos-agent) — macOS prereqs are non-trivial (cmocka 1.1.7 from source rather than Homebrew, plus several env vars at build time) and live with the rest of that target's flow.
 
 ## Compile and run unit tests for Linux targets
-In order to run unit tests for either the Wazuh server or Linux agents, these need to be built using [CMake](#installing-cmake) version 3.10 or higher and [cmocka](#installing-cmocka).
 
-Navigate into `wazuh/src/unit_tests` and run the following commands:
+### 0. Point the build at GCC 14
+On a fresh Ubuntu install the unversioned `gcc`/`g++` typically resolve to an older GCC (13.x on Ubuntu 24.04) and `g++` may not even be installed — installing `gcc-14`/`g++-14` does **not** by itself change what `make`/CMake pick up. The `Makefile` honors `CC` and `CXX` from the environment, so export them in the shell where you run `make`:
+```
+export CC=gcc-14
+export CXX=g++-14
+```
+Add the two `export` lines to your `~/.bashrc` if you want them to persist across sessions.
+
+If you'd rather make GCC 14 the system default (e.g. on a VM dedicated to Wazuh dev) so you can drop the exports entirely, you can swap `gcc`/`g++` system-wide with `update-alternatives`:
+```
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-14
+```
+
+### 1. Fetch the external dependencies
+The repo only checks in `src/external/CMakeLists.txt`; OpenSSL, libcurl, audit-userspace, libplist, jemalloc, msgpack, sqlite, etc. are downloaded and extracted on demand. The exact list is target-dependent, so pass the same `TARGET=` you intend to build (one-time per checkout — re-run after `make clean-deps` or a fresh clone):
+```
+make TARGET=manager|agent deps
+```
+
+### 2. Compile Wazuh with the test flag
+From `wazuh/src`:
+```
+make TARGET=manager|agent TEST=1
+```
+
+### 3. Build the unit tests
+Navigate into `wazuh/src/unit_tests` and run:
 ```
 mkdir build
 cd build
-cmake -DTARGET=server|agent ..
+cmake -DTARGET=manager|agent ..
 make
 ```
-Notice that when running the cmake command we need to specify the target on which we will run the unit tests, this target needs to match the wazuh target used for compilation and wazuh needs to be previously compiled.
 
-There are several ways to run unit tests:
+### 4. Run the tests
+There are several ways to run them:
 
-### Batch run
-In order to run all unit tests and get a global result for all of them you can run the `ctest` command inside the `build` directory. CTest will run all available tests and display their results on the console. If more details on the tests are required, you can inspect the `LastTest.log` located inside `build/Testing/Temporary` after running this command.
+#### Batch run
+Run `ctest` inside the `build` directory to execute all tests and get a global result. For more detail, inspect `build/Testing/Temporary/LastTest.log` after the run.
 
-### Coverage run
-You can get a coverage report from the unit tests run by running `make coverage` inside the `build` directory. Tests will be run and if they all pass a `coverage-report` directory will be created with an html report.
+#### Coverage run
+Point cmake at the matching `gcov-14` before running `make coverage` (the default picks up the unversioned system gcov, which on Ubuntu 24.04 is 13.3 and can't read gcc-14's `.gcno` files):
+```
+cmake -DGCOV_PATH=$(which gcov-14) ..
+make coverage
+```
+If all tests pass, a `coverage-report/` directory with an HTML report will be generated.
 
-### Running a specific test
-In case you need to run a specific test, navigate into the subdirectory where the test resides and run it as you would any other Linux binary. As an example, if you want to run tests on `create_db.c`
+**Note:** To get more accurate coverage mapping on the report, you'll have to add the `DEBUG=1` flag to the `make TARGET=manager|agent` command, so that it compiles without optimizations. Note that this build configuration can take twice as long as the regular test build.
+
+#### Running a specific test
+Navigate into the subdirectory where the test resides and run the binary directly. For example, to run tests on `create_db.c`:
 ```
 cd syscheckd
 ./test_create_db
 ```
-The output of the test will be written directly into the console.
 
 ## Compile and run unit tests for Windows agent
-Similarly to compiling unit tests for server or Linux agent configurations, [CMake](#installing-cmake) 3.10 or higher and [cmocka](#installing-cmocka) are required, as well as a 32 bit [wine installation](#installing-wine) in order to run the tests.
 
-Navigate into `wazuh/src/unit_tests` and run the following commands:
+> **Note:** the Windows agent is **cross-compiled from a Linux host** — there is no native Windows build path. The MinGW toolchain (`i686-w64-mingw32-…`) produces Windows binaries on Linux, and the resulting `.exe` test binaries are executed under wine on the same Linux host. You don't need a Windows machine at any point.
+
+### 0. Install winagent-specific prerequisites
+
+#### 0.1 Install the MinGW toolchain
+```
+sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64
+```
+Stock Ubuntu 24.04 ships GCC 13.2 in these packages, which is sufficient.
+
+#### 0.2 Build cmocka cross-compiled for MinGW
+Wazuh's `libwazuh_test.a` (built as part of `make TARGET=winagent TEST=1`) `#include <cmocka.h>` from the test wrappers, so the cmocka headers and a static `.a` must live under `/usr/i686-w64-mingw32/` before the compile step. Ubuntu doesn't package a mingw build of cmocka, so build it from source — pinned to the upstream `stable-1.1` branch (Wazuh's wrappers are written against the 1.1 API):
+
+```
+curl -L --retry 3 --retry-delay 2 \
+    -o /tmp/cmocka-stable-1.1.tar.gz \
+    https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
+tar -zxf /tmp/cmocka-stable-1.1.tar.gz -C /tmp/
+mkdir /tmp/stable-1.1/build && cd /tmp/stable-1.1/build
+cmake -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc \
+      -DCMAKE_C_LINK_EXECUTABLE=i686-w64-mingw32-ld \
+      -DCMAKE_INSTALL_PREFIX=/usr/i686-w64-mingw32/ \
+      -DCMAKE_SYSTEM_NAME=Windows \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DUNIT_TESTING=OFF \
+      -DWITH_EXAMPLES=OFF \
+      -DPICKY_DEVELOPER=OFF ..
+make
+sudo make install
+```
+After this, `/usr/i686-w64-mingw32/include/cmocka.h` and `/usr/i686-w64-mingw32/lib/libcmocka.a` should exist. The four `-D…=OFF` flags disable cmocka's shared-library build (we want the static `.a`), its own test suite, its examples, and some other things.
+
+Forgetting this step surfaces as `fatal error: cmocka.h: No such file or directory` during the compile.
+
+#### 0.3 Install wine
+Wine is needed at **build time** (cmake invokes it as the cross-compile emulator for try-runs in externals — missing wine surfaces as *"compiled but failed to run"* or *"Failed to determine the source files for the regular expression backend"*) and at **test time** to execute the `.exe` binaries. The runtime configuration (`WINEPATH`/`WINEARCH`) is covered in step 3.
+
+The install recipe matches is pinned to wine `10.0.0.0~noble-1`. On Ubuntu 24.04 (noble):
+
+```
+# Enable 32-bit packages (Wazuh's wine targets win32)
+sudo dpkg --add-architecture i386
+
+# Register WineHQ's signing key and noble repository
+sudo mkdir -pm755 /etc/apt/keyrings
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources
+
+# Install wine + its 32-bit runtime deps
+sudo apt-get update
+sudo apt-get install -y --allow-downgrades \
+    libc6:i386 libgcc-s1:i386 libstdc++6:i386 \
+    wine-stable=10.0.0.0~noble-1 \
+    wine-stable-i386=10.0.0.0~noble-1 \
+    wine-stable-amd64=10.0.0.0~noble-1 \
+    winehq-stable=10.0.0.0~noble-1
+
+# Sanity check
+wine --version
+```
+
+For other Ubuntu releases swap `noble` for the matching codename (`jammy` for 22.04, etc.) in both the `.sources` URL and the version-pin suffix; see the [WineHQ install guide](https://gitlab.winehq.org/wine/wine/-/wikis/Debian-Ubuntu) for the current list.
+
+**Troubleshooting:** if a later `wine` invocation errors with *"wineserver: WINEARCH set to win32 but '/home/…/.wine' is a 64-bit installation"*, a previous `wine` run (possibly from another tool) created a 64-bit prefix at `~/.wine`. Wine can't downgrade a prefix from 64- to 32-bit, so move it aside and let wine create a fresh 32-bit one on the next run:
+```
+mv ~/.wine ~/.wine.bak
+```
+
+#### 0.4 Clear native `CC`/`CXX` before the cross-compile
+If you've been doing Linux builds in this shell, you likely have `CC=gcc-14` and `CXX=g++-14` exported (per the [Pointing the build at GCC 14](#pointing-the-build-at-gcc-14) section). Those need to be **unset** before `make TARGET=winagent`
+
+Just unset them and let the Makefile's defaults select the mingw cross-compiler:
+```
+unset CC CXX
+```
+
+### 1. Fetch the external dependencies
+The repo only checks in `src/external/CMakeLists.txt`; OpenSSL, libcurl, audit-userspace, libplist, msgpack, sqlite, etc. are downloaded and extracted on demand. From `wazuh/src` (one-time per checkout — re-run after `make clean-deps` or a fresh clone):
+```
+make TARGET=winagent deps
+```
+
+### 2. Compile the Windows agent with the test flag
+From `wazuh/src`:
+```
+make TARGET=winagent TEST=1
+```
+
+### 3. Build the unit tests
+Navigate into `wazuh/src/unit_tests` and run:
 ```
 mkdir build
 cd build
 cmake -DTARGET=winagent -DCMAKE_TOOLCHAIN_FILE=../Toolchain-win32.cmake ..
 make
 ```
-Just as when compiling server and Linux agent unit tests, the winagent target for Wazuh must be compiled previously.
+`CMAKE_TOOLCHAIN_FILE` configures CMake for cross-compilation.
 
-The `CMAKE_TOOLCHAIN_FILE` option is added so crosscompiling of the unit tests can be properly configured by cmake.
+### 4. Run the tests (via wine)
+Wine needs two env vars before it can run the `.exe` test binaries:
 
-There are several ways to run the tests:
+- `WINEPATH` — **semicolon-separated, Windows-style** list of directories wine searches for DLLs at runtime. The test binaries need the mingw runtime (`libstdc++-6.dll`, `libgcc_s_*.dll`, `libwinpthread-1.dll`, etc.) and Wazuh's own built libraries (`libagent_metadata.dll`, `libwazuhext.dll`, etc., emitted under `src/build/bin/`).
+- `WINEARCH=win32` — pins the wine prefix to 32-bit. Without it, the first run creates a 64-bit prefix at `~/.wine` and subsequent 32-bit runs fail (see the troubleshooting note at the end of step 0.3).
 
-### Batch run
-In order to run all unit tests and get a global result for all of them you can run the `ctest` command inside the `build` directory. CTest will run all available tests by using wine and display their results on the console. If more details on the tests are required, you can inspect the `LastTest.log` located inside `build/Testing/Temporary` after running this command.
-
-### Coverage run
-You can get a coverage report from the unit tests run by running `make coverage` inside the `build` directory. Tests will be run and if they all pass a `coverage-report` directory will be created with an html report.
-
-### Running a specific test
-In case you need to run a specific test, navigate into the subdirectory where the test resides and run it by using wine. As an example, if you want to run tests on `create_db.c`
+**Recommended:** scope both env vars to the test invocation so they apply only to the run and don't pollute your shell. From `wazuh/src/unit_tests/build`:
 ```
-cd syscheckd
-wine test_create_db.exe
+WAZUH_SRC=$(realpath ../..)
+WINEARCH=win32 \
+WINEPATH="/usr/i686-w64-mingw32/lib;/usr/lib/gcc/i686-w64-mingw32/13-posix;${WAZUH_SRC};${WAZUH_SRC}/build/bin" \
+ctest --output-on-failure
 ```
-The output of the test will be written directly into the console.
+`realpath ../..` derives the absolute path to `wazuh/src` on the fly, so you don't have to hardcode it.
+
+**Alternative — persistent shell exports.** Add to `~/.bashrc`, substituting your wazuh checkout's absolute path for `<WAZUH_SRC>`:
+```
+export WINEARCH=win32
+export WINEPATH="/usr/i686-w64-mingw32/lib;/usr/lib/gcc/i686-w64-mingw32/13-posix;<WAZUH_SRC>;<WAZUH_SRC>/build/bin"
+```
+The `13-posix` path matches the GCC 13.x mingw shipped by Ubuntu 24.04. On other distros run `ls /usr/lib/gcc/i686-w64-mingw32/` to find the right directory.
+
+#### Batch run
+Run `ctest` with the env above. CTest invokes wine on each test binary and displays the results; detailed output goes to `build/Testing/Temporary/LastTest.log`.
+
+#### Coverage run
+Winagent coverage needs a small gcov wrapper to bridge a version-string incompatibility between `i686-w64-mingw32-gcov-posix` and lcov 2.x — lcov reads `--version` from the gcov tool to decide compatibility, and mingw's gcov reports a string lcov rejects. Generate the wrapper alongside `unit_tests/build/`, point cmake at it, then run `make coverage` with the same wine env as the test run:
+
+```
+cat > winagent-gcov-wrapper.sh <<'EOF'
+#!/bin/bash
+if [[ "$1" == "-v" || "$1" == "--version" ]]; then
+    echo "gcov (GCC) 10.3.0"
+    echo "Copyright (C) 2020 Free Software Foundation, Inc."
+    echo "This is free software; see the source for copying conditions."
+    exit 0
+fi
+exec /usr/bin/i686-w64-mingw32-gcov-posix "$@"
+EOF
+chmod +x winagent-gcov-wrapper.sh
+
+cmake -DGCOV_PATH=$PWD/winagent-gcov-wrapper.sh ..
+
+WAZUH_SRC=$(realpath ../..)
+WINEARCH=win32 \
+WINEPATH="/usr/i686-w64-mingw32/lib;/usr/lib/gcc/i686-w64-mingw32/13-posix;${WAZUH_SRC};${WAZUH_SRC}/build/bin" \
+make coverage
+```
+The wrapper intercepts `--version` queries from lcov and reports a known-compatible string; every other invocation passes through to the real mingw gcov. `.github/actions/legacy_unit_tests.sh` generates the same wrapper inline in CI. If `make coverage` succeeds, the HTML report lands under `coverage-report/`.
+
+**Note:** To get more accurate coverage mapping on the report, you'll have to add the `DEBUG=1` flag to the `make TARGET=agent` command, so that it compiles without optimizations. Note that this build configuration can take twice as long as the regular test build.
+
+#### Running a specific test
+Useful for iterating on a single failure. From `wazuh/src/unit_tests/build`:
+```
+WAZUH_SRC=$(realpath ../..)
+WINEARCH=win32 \
+WINEPATH="/usr/i686-w64-mingw32/lib;/usr/lib/gcc/i686-w64-mingw32/13-posix;${WAZUH_SRC};${WAZUH_SRC}/build/bin" \
+wine ./client-agent/test_start_agent.exe
+```
 
 ## Compile and run unit tests for macOS agent
-Similarly to compiling unit tests for server or Linux agent configurations, [CMake](#installing-cmake) 3.10 or higher and [cmocka](#installing-cmocka) are required.
 
-Navigate into `wazuh/src/unit_tests` and run the following commands:
+### 0. Install prerequisites
+**Homebrew** (if not already installed):
 ```
-export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib
-mkdir build
-cd build
-cmake -DTARGET=agent ..
-make
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
-The agent target for Wazuh must be compiled previously. The tests are run in the same way as Linux systems.
 
-## Installing CMake
-If installing cmake using `apt-get` or `yum` yields a version lower the 3.10, remove it and run these commands to install from sources.
-
+**lcov** (CMake is pre-installed on the macos-15 runner / via Xcode Command Line Tools):
 ```
-mkdir ~/temp
-cd ~/temp
-wget https://cmake.org/files/v3.17/cmake-3.17.0-rc1.tar.gz
-tar -xzvf cmake-3.17.0-rc1.tar.gz
-cd cmake-3.17.0-rc1/
-./bootstrap
-make
+brew install lcov
+```
+
+**CMocka 1.1.7 from source.** Wazuh's test wrappers are written against the cmocka 1.1 API. Homebrew's current `cmocka` formula is newer and not what CI builds against, so install 1.1.7 directly.
+```
+curl -LO https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz
+tar -xf cmocka-1.1.7.tar.xz
+cd cmocka-1.1.7
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
+make -j$(sysctl -n hw.ncpu)
 sudo make install
 ```
+Headers land at `/usr/local/include/cmocka.h`, the static lib at `/usr/local/lib/libcmocka.a`.
 
-## Installing cmocka
-The cmocka unit tests framework is required in order to compile and run the Wazuh unit tests suite. For server and Linux agent tests, a binary installation of cmocka using a package manager is enough. If you want to run the Windows agent tests, you will need to build cmocka using the MinGW compiler.
-
-1. Clone cmocka repository:
+### 1. Fetch the external dependencies
+The repo only checks in `src/external/CMakeLists.txt`; OpenSSL, libcurl, msgpack, sqlite, etc. are downloaded and extracted on demand. From `wazuh/src` (one-time per checkout — re-run after `make clean-deps` or a fresh clone):
 ```
-git clone https://git.cryptomilk.org/projects/cmocka.git
+make TARGET=agent deps
 ```
 
-2. Checkout the `stable-1.1` branch
+### 2. Compile Wazuh with the test flag
+Set the env vars and run from `wazuh/src`. There's no separate "build the unit tests" step — `make TARGET=agent TEST=1` produces the test binaries in `src/build/` alongside the main wazuh build:
 
-3. Modify `DefineOptions.cmake` file and set `BUILD_SHARED_LIBS` to `OFF`
-
-4. Build CMocka by running the following commands inside the repository directory:
 ```
-mkdir build
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+export C_INCLUDE_PATH="$C_INCLUDE_PATH:$(brew --prefix)/include"
+export LIBRARY_PATH="/usr/local/lib:$(brew --prefix)/lib"
+make TARGET=agent TEST=1
+```
+
+What each env var does:
+- `CMAKE_POLICY_VERSION_MINIMUM=3.5` — the macos-15 runner (and Homebrew on a fresh user box) ships cmake 4.x, which refuses to honor vendored externals declaring `cmake_minimum_required(VERSION 2.8)` (notably googletest). This var tells cmake to behave as if every project declared at least 3.5.
+- `C_INCLUDE_PATH=$(brew --prefix)/include` — adds Homebrew's include dir to clang's system header search. `brew --prefix` resolves to `/opt/homebrew` on Apple Silicon and `/usr/local` on Intel, so the same line works on both archs.
+- `LIBRARY_PATH=/usr/local/lib:$(brew --prefix)/lib` — `/usr/local/lib` for the cmocka you just installed there; `$(brew --prefix)/lib` for everything else brew installs (on Apple Silicon these are different directories; on Intel they're the same `/usr/local/lib` and the duplicate is harmless).
+
+### 3. Run the tests
+The test binaries are under `src/build/`. From `wazuh/src`:
+```
+export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"
 cd build
-cmake -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_C_LINK_EXECUTABLE=i686-w64-mingw32-ld -DCMAKE_INSTALL_PREFIX=/usr/i686-w64-mingw32/ -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_BUILD_TYPE=Release ..
-make
-sudo make install
+ctest -V
+```
+`DYLD_LIBRARY_PATH` is the Apple equivalent of Linux's `LD_LIBRARY_PATH` — Apple's runtime linker needs to find cmocka's dylib at test execution time.
+
+#### Running a specific test
+Test binaries live under `src/build/<module>/`. For example:
+```
+cd src/build
+export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"
+./shared/test_url    # or wherever the binary you care about lives
 ```
 
-If you need to build cmocka for the Linux targets, keep `BUILD_SHARED_LIBS` as `ON` and run the following commands
+## Appendix: Cleaning the environment before building a different target
+Build artifacts produced by `make TARGET=…` are not interchangeable across targets. Three things go stale when you switch (e.g. agent → winagent or agent → server) and will cause confusing link errors or compiler-mismatch problems if you don't wipe them first:
+
+Run these from `src/` before starting the per-target steps for the new target:
 ```
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make
-sudo make install
-```
-If you need to rebuild cmocka, remember to remove all files from the `build` directory first.
-
-## Installing wine
-On Ubuntu, run the following commands:
-```
-# Add 32 bit architecture
-sudo dpkg --add-architecture i386
-
-# Add key
-wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
-
-###  Add repository (Ubuntu 19.10)
-sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ eoan main'
-
-###  Add repository (Ubuntu 18.04)
-sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main'
-sudo add-apt-repository ppa:cybermax-dexter/sdl2-backport
-
-
-###  Add repository (Ubuntu 16.04)
-sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ xenial main'
-
-# Install
-sudo apt update
-sudo apt install --install-recommends winehq-stable
-
-### If unmet dependencies error, use aptitude
-sudo apt install aptitude
-sudo aptitude install winehq-stable
-
-# Check version
-wine --version
-
-# Link wine binary
-sudo ln -s /opt/wine-stable/bin/wine /usr/bin/
+make clean        # build/, unit_tests/build*, generated headers, *.gcda/*.gcno, autotools distclean
+make clean-deps   # external/* sources + tarballs (no TARGET needed — wipes the superset)
 ```
 
-Commands above have been taken from the following guide: https://tecadmin.net/install-wine-on-ubuntu/
-If you need to run the tests on a CentOS 7 machine, you can follow these instructions in order to build a 32 bit wine: https://www.systutorials.com/239913/install-32-bit-wine-1-8-centos-7/
+Then start the new target's per-target section from step 1 (fetch external dependencies).
 
-After installing wine, the `WINEPATH` and `WINEARCH` variables need to be created in order for it to know it should run on 32 bit mode and find all required dlls for the tests. On an Ubuntu system, the following commands need to be executed and/or added into the user's `.bashrc` file.
-```
-export WINEPATH="/usr/i686-w64-mingw32/lib;/usr/lib/gcc/i686-w64-mingw32/13-posix;/path/to/wazuh/src;/path/to/wazuh/src/build/bin"
-export WINEARCH=win32
-```
-If wine complains about being a 64 bit installation, remove/rename the directory `~/.wine` and run it again.


### PR DESCRIPTION
## Description

Rewrites `src/unit_tests/Readme.md` so a developer can follow it on a fresh Ubuntu 24.04 or macOS 15 box and end up with a working unit-test build. The previous version had outdated install commands (Ruby-based Homebrew install, `apt-key` for wine, EOL Ubuntu releases), broken instructions for switching targets, a fictional macOS unit-test step that didn't match what CI runs, and per-target sections that drifted from the actual workflow files. This branch updates the doc end-to-end and adds two small supporting changes in build files to close real issues the new doc exposes.

Closes #35974
Closes #35975

## Proposed Changes

### `src/unit_tests/Readme.md` — full rewrite

### `src/Makefile` — one-line env-respect fix
- Line 163: `CC=gcc` → `CC?=gcc` (Linux non-winagent branch).

Previously the Makefile silently overrode any `CC` the user exported in their shell, forcing the system unversioned `gcc` (13.3 on Ubuntu 24.04) and producing confusing `std::format`/C++20 compile errors in the coverage build. With `?=`, `export CC=gcc-14` (the canonical Linux setup per the new doc) actually reaches cmake. CI lanes that don't set `CC` are unaffected — `?=` falls back to `gcc`, identical to current behavior.

Without this change you'd get this error when running `make coverage`:
```
  /vagrant/unit_test_docu/wazuh/src/build/shared/CMakeFiles/wazuh_test.dir/os_crypto/signature/signature.c.gcno:version 'B33*', prefer 'B42*'
geninfo: ERROR: Incompatible GCC/GCOV version found while processing /vagrant/unit_test_docu/wazuh/src/build/shared/CMakeFiles/wazuh_test.dir/os_crypto/signature/signature.c.gcno:
        Your test was built with 'B33*'.
        You are trying to capture with gcov tool '/usr/bin/gcov-14' which is version 'B42*'.
        (use "geninfo --ignore-errors version ..." to bypass this error)
```


### `src/external/CMakeLists.txt` — benchmark guard for agent targets
- `if(UNIT_TEST OR WAZUH_ENGINE_TEST)` → `if((UNIT_TEST OR WAZUH_ENGINE_TEST) AND NOT IS_AGENT)` on the Google Benchmark `ExternalProject_Add` block.

`benchmark_external` was being configured for every test build, including agent and winagent, even though nothing in the agent/winagent code paths links `benchmark::`. CI never noticed because its `make deps` lands a precompiled `libbenchmark.a` from `packages.wazuh.com`, which short-circuits the source-build branch. A fresh local clone hits the source-build fallback.

Without it we get this error, which is related to the CMakeLists's minimum version of this package not being supported by gcc 14:
```
[  1%] Performing configure step for 'benchmark_external'
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:16 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.

```

### Results and Evidence

End-to-end build + test verified on Ubuntu 24.04 (Linux agent + manager, Windows agent cross-compile) and macOS 15 / Intel EC2 (macOS agent) following the new doc step by step.

### Artifacts Affected

- No binary or package output changes.

### Configuration Changes

- None.

### Documentation Updates

- `src/unit_tests/Readme.md` — rewritten end-to-end. See "Proposed Changes" above for the section-by-section breakdown.

### Tests Introduced

No automated tests added — this is a docs + minor build-config change. Manual end-to-end verification documented below.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

---

## Manual Testing

The new doc was walked through end-to-end on each platform. Each row was followed straight from the README (no off-script steps).

| Target | Single test binary | `ctest` batch run | `make coverage` |
|---|---|---|---|
| **Linux agent** (Ubuntu 24.04, GCC 14 via `export`) | ✅ | ✅ | ✅ (`-DGCOV_PATH=$(which gcov-14)` per the doc) |
| **Linux manager** (Ubuntu 24.04, GCC 14 via `export`) | ✅ | ✅ | ✅ (`-DGCOV_PATH=$(which gcov-14)` per the doc) |
| **Windows agent** (cross-compile from Ubuntu 24.04, mingw 13.2, wine 10.0) | ✅ (`wine ./test_*.exe`) | ✅ | ✅ (mingw-gcov wrapper per the coverage subsection) |
| **macOS agent** (macOS 15 / Sequoia, **Intel** EC2 instance) | ✅ (`./<module>/test_*` from `src/build/`) | ✅ (`ctest -V` from `src/build/`) | ⬜ Not part of CI's macOS lane |

### Target-switching scenarios

The "Cleaning the environment before building a different target" appendix recipe was verified by switching directions in both ways on the same checkout:

| Switch | Followed the appendix recipe → built clean | Confirmed no leftover `.gcno`/`.gcda` version-mismatch or stale `CMakeCache.txt` issues |
|---|---|---|
| Linux agent → Windows agent | ✅ | ✅ |
| Windows agent → Linux agent | ✅ | ✅ |
| Linux agent → Linux server | ✅ | ✅ |
| Linux server → Linux agent | ✅ | ✅ |
