### PR TITLE
Remove /bin and /sbin from monitored directories on usrmerge distros

### DIFF
--- a/etc/templates/config/almalinux/syscheck.agent.template
+++ b/etc/templates/config/almalinux/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/amzn/2/syscheck.agent.template
+++ b/etc/templates/config/amzn/2/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/amzn/2023/syscheck.agent.template
+++ b/etc/templates/config/amzn/2023/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/centos/6/syscheck.agent.template
+++ b/etc/templates/config/centos/6/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/centos/syscheck.agent.template
+++ b/etc/templates/config/centos/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/debian/12/syscheck.agent.template
+++ b/etc/templates/config/debian/12/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/debian/13/syscheck.agent.template
+++ b/etc/templates/config/debian/13/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/fedora/syscheck.agent.template
+++ b/etc/templates/config/fedora/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ol/6/syscheck.agent.template
+++ b/etc/templates/config/ol/6/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ol/syscheck.agent.template
+++ b/etc/templates/config/ol/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/rhel/6/syscheck.agent.template
+++ b/etc/templates/config/rhel/6/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/rhel/syscheck.agent.template
+++ b/etc/templates/config/rhel/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/rocky/syscheck.agent.template
+++ b/etc/templates/config/rocky/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ubuntu/12/syscheck.agent.template
+++ b/etc/templates/config/ubuntu/12/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ubuntu/14/syscheck.agent.template
+++ b/etc/templates/config/ubuntu/14/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ubuntu/16/syscheck.agent.template
+++ b/etc/templates/config/ubuntu/16/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ubuntu/18/syscheck.agent.template
+++ b/etc/templates/config/ubuntu/18/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>

--- a/etc/templates/config/ubuntu/syscheck.agent.template
+++ b/etc/templates/config/ubuntu/syscheck.agent.template
@@ -1,0 +1,50 @@
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories>/etc,/usr/bin,/usr/sbin</directories>
+    <directories>/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- File types to ignore -->
+    <ignore type="sregex">.log$|.swp$</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+    <skip_dev>yes</skip_dev>
+    <skip_proc>yes</skip_proc>
+    <skip_sys>yes</skip_sys>
+
+    <!-- Nice value for Syscheck process -->
+    <process_priority>10</process_priority>
+
+    <!-- Maximum output throughput -->
+    <max_eps>50</max_eps>
+
+    <!-- Database synchronization settings -->
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_eps>75</max_eps>
+      <integrity_interval>24h</integrity_interval>
+    </synchronization>
+  </syscheck>


### PR DESCRIPTION
## Description

This PR fixes incorrect FIM monitoring of `/bin` and `/sbin` on Linux distributions that have adopted the usrmerge filesystem layout, where `/bin` and `/sbin` are symbolic links to `/usr/bin` and `/usr/sbin` respectively. On these systems, FIM was registering `/bin` as a separate monitored path instead of expanding it as a directory, causing duplicate and incomplete integrity monitoring.

The fix introduces distro-level `syscheck.agent.template` files for all confirmed usrmerge distros, monitoring `/usr/bin` and `/usr/sbin` directly and avoiding the symlink issue entirely. The generic template retains both paths as a safe fallback for systems without usrmerge. Version-specific fallback templates are provided for older distro versions (RHEL 6, CentOS 6, Oracle Linux 6) where `/bin` is still a real directory, ensuring the distro-level template does not override them incorrectly.

Note: this PR addresses the template configuration side of the issue only.
The FIM engine fix (auto-detection of symlinks pointing to directories)
is out of scope and will be handled separately.

**Proposed Release:** v5.0.0
**Issue:** wazuh/wazuh#35988
**Internal Reference:** N/A

## Proposed Changes

- Added distro-level `syscheck.agent.template` for all confirmed usrmerge distros, overriding the generic template. Replaced `<directories>/bin,/sbin,/boot</directories>` with `<directories>/boot</directories>`.
- Debian handled at version level (12 and 13 only) since Debian 10 and 11 still have `/bin` as a real directory.
- Amazon Linux handled at version level (2 and 2023 only) since Amazon Linux 1 still has `/bin` as a real directory.
- Added version-specific fallback templates for RHEL 6, CentOS 6, and Oracle Linux 6 that retain `/bin` and `/sbin` (real directories on those versions), preventing the distro-level usrmerge template from applying incorrectly.
- Added version-specific fallback templates for Ubuntu 12, 14, 16 and 18 that retain `/bin` and `/sbin` (real directories on those versions), preventing the distro-level usrmerge template from applying incorrectly.
- Generic template, Alpine, openSUSE Leap, SLES, Darwin and BSD left unchanged - `/bin` remains monitored where it is still a real directory.
- No `syscheck.manager.template` files created - syscheck has been removed from the manager.

### Results and Evidence

**Symlink verification - oldest and newest supported version per distro (Tier 1, 2 and 3):**

```bash
# Ubuntu 20.04 (oldest) and 24.04 (newest) - both symlinks
docker run --rm ubuntu:20.04 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Apr  4  2025 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Apr  4  2025 /sbin -> usr/sbin
docker run --rm ubuntu:24.04 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Apr 22  2024 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Apr 22  2024 /sbin -> usr/sbin

# Ubuntu 16.04 and 18.04 - real directories, fallback templates retain /bin
docker run --rm ubuntu:16.04 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 Aug  4 2021 .
docker run --rm ubuntu:18.04 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 May 30 2023 .

# Amazon Linux 1 - real directory, NO template created
docker run --rm amazonlinux:1 ls -la /bin
dr-xr-xr-x 2 root root 4096 Dec 18 2023 .

# Amazon Linux 2 (oldest with usrmerge) and 2023 (newest) - both symlinks
docker run --rm amazonlinux:2 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Apr  9  2019 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Apr  9  2019 /sbin -> usr/sbin
docker run --rm amazonlinux:2023 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Jan 30  2023 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Jan 30  2023 /sbin -> usr/sbin

# Debian 7, 8, 9, 10 - all real directories, NO template created
docker run --rm debian:7 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 Feb 28 2019 .
docker run --rm debian:8 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 Mar 26 2021 .
docker run --rm debian:9 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 Jun 22 2022 .
docker run --rm debian:10 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 Jun 12 2024 .

# Debian 12 and 13 - symlinks, templates created
docker run --rm debian:12 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 May  5 00:00 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 May  5 00:00 /sbin -> usr/sbin
docker run --rm debian:13 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Mar  2 21:50 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Mar  2 21:50 /sbin -> usr/sbin

# CentOS 6 - real directory, fallback template retains /bin
docker run --rm centos:6 ls -la /bin | head -1
dr-xr-xr-x 2 root root 4096 Oct  6 2018 .

# CentOS 7 and Stream 9 - both symlinks
docker run --rm centos:7 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Nov 13  2020 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Nov 13  2020 /sbin -> usr/sbin
docker run --rm quay.io/centos/centos:stream9 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Jun 25  2024 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Jun 25  2024 /sbin -> usr/sbin

# Fedora 42 (oldest) and 44 (newest) - both symlinks
docker run --rm fedora:42 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Jul 30  2025 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Jul 30  2025 /sbin -> usr/sbin
docker run --rm fedora:44 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Jan 16 00:00 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Jan 16 00:00 /sbin -> usr/sbin

# AlmaLinux 8 (oldest) and 10 (newest) - both symlinks
docker run --rm almalinux:8 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Oct  9  2021 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Oct  9  2021 /sbin -> usr/sbin
docker run --rm almalinux:10 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Apr  2  2025 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Apr  2  2025 /sbin -> usr/sbin

# Rocky 8 (oldest) and 9 (newest available) - both symlinks
docker run --rm rockylinux:8 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Oct 11  2021 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Oct 11  2021 /sbin -> usr/sbin
docker run --rm rockylinux:9 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 May 16  2022 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 May 16  2022 /sbin -> usr/sbin

# Oracle Linux 6 - real directory, fallback template retains /bin
docker run --rm oraclelinux:6 ls -la /bin | head -1
dr-xr-xr-x 2 root root 4096 Jan 29 2021 .

# Oracle Linux 7 (oldest with usrmerge) and 10 (newest) - both symlinks
docker run --rm oraclelinux:7 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Dec 10  2024 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Dec 10  2024 /sbin -> usr/sbin
docker run --rm oraclelinux:10 ls -la /bin /sbin
lrwxrwxrwx 1 root root 7 Apr  2  2025 /bin -> usr/bin
lrwxrwxrwx 1 root root 8 Apr  2  2025 /sbin -> usr/sbin

# openSUSE Leap 15 - real directory (individual symlinks inside), NO template
docker run --rm opensuse/leap:15 ls -la /bin | head -1
drwxr-xr-x 2 root root 4096 Apr 24 18:48 .
```

**FIM behavior before and after fix - Amazon Linux 2023 VM:**

```bash
# BEFORE (generic template with /bin,/sbin,/boot)
grep "/bin" /var/ossec/logs/ossec.log
2026/05/13 08:27:33 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin' ...
2026/05/13 08:27:33 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin' ...

# AFTER (fix applied, /boot only)
grep "/bin" /var/ossec/logs/ossec.log
2026/05/13 08:28:56 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin' ...
```

`/bin` is completely gone as a registered monitored path after the fix.

**Generic template unchanged:**

```bash
grep "directories" etc/templates/config/generic/syscheck.agent.template
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>
```

**No `/bin,/sbin` in any usrmerge distro-specific template:**

```bash
grep -r "/bin,/sbin" etc/templates/config/ --include="syscheck*"
etc/templates/config/darwin/syscheck.manager.template: ...
etc/templates/config/generic/syscheck.manager.template: ...
etc/templates/config/generic/syscheck.agent.template: ...
```

**Fallback templates for v6 retain /bin (confirmed real directory):**

```bash
grep "directories" etc/templates/config/rhel/6/syscheck.agent.template
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

grep "directories" etc/templates/config/centos/6/syscheck.agent.template
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>

grep "directories" etc/templates/config/ol/6/syscheck.agent.template
    <directories>/etc,/usr/bin,/usr/sbin</directories>
    <directories>/bin,/sbin,/boot</directories>
```

**Fallback templates for Ubuntu 12-18 retain /bin (confirmed real directory):**

```bash
grep "directories" etc/templates/config/ubuntu/18/syscheck.agent.template
    /etc,/usr/bin,/usr/sbin
    /bin,/sbin,/boot
```

### Artifacts Affected

New templates without `/bin,/sbin` (usrmerge distros):
- `etc/templates/config/ubuntu/syscheck.agent.template`
- `etc/templates/config/amzn/2/syscheck.agent.template`
- `etc/templates/config/amzn/2023/syscheck.agent.template`
- `etc/templates/config/debian/12/syscheck.agent.template`
- `etc/templates/config/debian/13/syscheck.agent.template`
- `etc/templates/config/fedora/syscheck.agent.template`
- `etc/templates/config/almalinux/syscheck.agent.template`
- `etc/templates/config/rocky/syscheck.agent.template`
- `etc/templates/config/ol/syscheck.agent.template`
- `etc/templates/config/rhel/syscheck.agent.template`
- `etc/templates/config/centos/syscheck.agent.template`

Fallback templates retaining `/bin,/sbin` (non-usrmerge versions):
- `etc/templates/config/rhel/6/syscheck.agent.template`
- `etc/templates/config/centos/6/syscheck.agent.template`
- `etc/templates/config/ol/6/syscheck.agent.template`
- `etc/templates/config/ubuntu/12/syscheck.agent.template`
- `etc/templates/config/ubuntu/14/syscheck.agent.template`
- `etc/templates/config/ubuntu/16/syscheck.agent.template`
- `etc/templates/config/ubuntu/18/syscheck.agent.template`

Unchanged (safe fallback and non-Linux):
- `etc/templates/config/generic/syscheck.agent.template`
- `etc/templates/config/generic/syscheck.manager.template`
- `etc/templates/config/darwin/syscheck.manager.template`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual verification
- **Details:** Verified `/bin` and `/sbin` symlink status using official Docker images on oldest and newest supported version of each affected distro across Tier 1, 2 and 3. FIM behavior validated before and after fix on Amazon Linux 2023 VM with wazuh-agent 4.14.5, confirming `/bin` is no longer registered as a monitored path after the template change. Confirmed fallback templates for RHEL 6, CentOS 6, Oracle Linux 6 and Ubuntu 12, 14, 16, 18 correctly retain `/bin` and `/sbin` monitoring for non-usrmerge systems.


## Review Checklist

**Manual tests with their corresponding evidence:**
- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues