### PR TITLE
Fix string handling in version comparison function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Improved message decompression handling in remoted. ([#35773](https://github.com/wazuh/wazuh/pull/35773))
 - Improved agent name validation to reject names starting with dot. ([#4503](https://github.com/wazuh/internal-devel-requests/issues/4503))
 - Fixed segfault in vulnerability scanner module shutdown when disabled. ([#36011](https://github.com/wazuh/wazuh/pull/36011))
+- Fixed string buffer handling in version comparison function. ([#36059](https://github.com/wazuh/wazuh/pull/36059))
 
 
 ## [v4.14.5]

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -1063,7 +1063,8 @@ int compare_wazuh_versions(const char *version1, const char *version2, bool comp
     int result = 0;
 
     if (version1) {
-        strncpy(ver1, version1, 9);
+        strncpy(ver1, version1, sizeof(ver1) - 1);
+        ver1[sizeof(ver1) - 1] = '\0';
 
         if (tmp_v1 = strchr(ver1, 'v'), tmp_v1) {
             tmp_v1++;
@@ -1085,7 +1086,8 @@ int compare_wazuh_versions(const char *version1, const char *version2, bool comp
     }
 
     if (version2) {
-        strncpy(ver2, version2, 9);
+        strncpy(ver2, version2, sizeof(ver2) - 1);
+        ver2[sizeof(ver2) - 1] = '\0';
 
         if (tmp_v2 = strchr(ver2, 'v'), tmp_v2) {
             tmp_v2++;

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -2311,6 +2311,50 @@ void test_compare_wazuh_versions_null(void **state)
     assert_int_equal(ret, 0);
 }
 
+void test_compare_wazuh_versions_long_string_v1(void **state)
+{
+    (void) state;
+    char *v1 = "AAAAAAAAA";
+    char *v2 = "v4.0.0";
+
+    int ret = compare_wazuh_versions(v1, v2, true);
+
+    assert_int_equal(ret, -1);
+}
+
+void test_compare_wazuh_versions_long_string_v2(void **state)
+{
+    (void) state;
+    char *v1 = "v4.0.0";
+    char *v2 = "AAAAAAAAA";
+
+    int ret = compare_wazuh_versions(v1, v2, true);
+
+    assert_int_equal(ret, 1);
+}
+
+void test_compare_wazuh_versions_long_string_both(void **state)
+{
+    (void) state;
+    char *v1 = "BBBBBBBBB";
+    char *v2 = "AAAAAAAAA";
+
+    int ret = compare_wazuh_versions(v1, v2, true);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_compare_wazuh_versions_truncated_version(void **state)
+{
+    (void) state;
+    char *v1 = "v5.123456";
+    char *v2 = "v4.0.0";
+
+    int ret = compare_wazuh_versions(v1, v2, true);
+
+    assert_int_equal(ret, 1);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
 #ifdef __linux__
@@ -2357,7 +2401,11 @@ int main(void) {
             cmocka_unit_test(test_compare_wazuh_versions_lower_patch),
             cmocka_unit_test(test_compare_wazuh_versions_lower_minor),
             cmocka_unit_test(test_compare_wazuh_versions_lower_major),
-            cmocka_unit_test(test_compare_wazuh_versions_null)
+            cmocka_unit_test(test_compare_wazuh_versions_null),
+            cmocka_unit_test(test_compare_wazuh_versions_long_string_v1),
+            cmocka_unit_test(test_compare_wazuh_versions_long_string_v2),
+            cmocka_unit_test(test_compare_wazuh_versions_long_string_both),
+            cmocka_unit_test(test_compare_wazuh_versions_truncated_version)
     };
     return cmocka_run_group_tests(tests, setup_group, teardown_group);
 }


### PR DESCRIPTION
## Description

This PR addresses a string handling issue in the `compare_wazuh_versions()` function where `strncpy()` was used without ensuring proper NUL-termination of the destination buffers. When the source string length equals or exceeds the copy limit, `strncpy()` does not append a NUL terminator, which could lead to undefined behavior in subsequent string operations (`strchr()`, `strtok()`).

The issue was identified and reported by @TarPeg007, who provided detailed analysis and reproduction steps showing how certain input patterns could trigger the vulnerability through the authd enrollment process.

## Proposed Changes

### Results and Evidence

- Modified `compare_wazuh_versions()` in `src/shared/version_op.c` to guarantee NUL-termination of both `ver1` and `ver2` buffers
- Changed `strncpy(ver1, version1, 9)` to `strncpy(ver1, version1, sizeof(ver1) - 1)` followed by explicit `ver1[sizeof(ver1) - 1] = '\0'`
- Applied the same fix to `ver2` buffer handling
- Added comprehensive unit tests to cover edge cases with long input strings that previously could cause issues

### Artifacts Affected

- wazuh-authd

### Configuration Changes

None. This is a code-level fix with no configuration impact.

### Documentation Updates

None required. Internal function behavior remains unchanged for valid inputs.

### Tests Introduced

Added unit tests to verify proper handling of:
- Long strings without version delimiters (9+ characters)
- Truncated version strings at buffer boundary
- Mixed scenarios with one valid and one edge-case input
- Comparison behavior when both inputs are at boundary length

> 100% tests passed, 0 tests failed out of 189

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
