### PR TITLE
Improve cluster file handling path validation in end_receiving_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Improved agent name validation to reject names starting with dot. ([#4503](https://github.com/wazuh/internal-devel-requests/issues/4503))
 - Fixed segfault in vulnerability scanner module shutdown when disabled. ([#36011](https://github.com/wazuh/wazuh/pull/36011))
 - Fixed string buffer handling in version comparison function. ([#36059](https://github.com/wazuh/wazuh/pull/36059))
+- Improved cluster file synchronization security. ([#36060](https://github.com/wazuh/wazuh/pull/36060))
 
 
 ## [v4.14.5]

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1351,18 +1351,23 @@ class WazuhCommon:
             Response message.
         """
         task_id, filename = task_and_file_names.split(' ', 1)
+
+        safe_path = os.path.realpath(os.path.join(common.WAZUH_PATH, filename.lstrip("/")))
+
+        if not any(os.path.commonpath([safe_path, root]) == root for root in _ALLOWED_PREFIXES):
+            self.get_logger(logger_tag).error(f"Write path not allowed")
+            raise exception.WazuhClusterError(3027, extra_message=task_id)
+
         if task_id not in self.sync_tasks:
-            # Remove filename if task_id does not exist, before raising exception.
-            if os.path.exists(os.path.join(common.WAZUH_PATH, filename)):
+            if os.path.exists(safe_path):
                 try:
-                    os.remove(os.path.join(common.WAZUH_PATH, filename))
+                    os.remove(safe_path)
                 except Exception as e:
-                    self.get_logger(logger_tag).error(
-                        f"Attempt to delete file {os.path.join(common.WAZUH_PATH, filename)} failed: {e}")
+                    self.get_logger(logger_tag).error(f"Attempt to delete file {safe_path} failed: {e}")
             raise exception.WazuhClusterError(3027, extra_message=task_id)
 
         # Set full path to file for task 'task_id' and notify it is ready to be read, so the lock is released.
-        self.sync_tasks[task_id].filename = os.path.join(common.WAZUH_PATH, filename)
+        self.sync_tasks[task_id].filename = safe_path
         self.sync_tasks[task_id].received_information.set()
         return b'ok', b'File correctly received'
 

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1493,9 +1493,11 @@ def test_wazuh_common_end_receiving_file_ok(logger_mock, wazuh_common_mock):
         with patch('asyncio.create_task'):
             file_task = cluster_common.ReceiveFileTask(wazuh_common_mock, logger_mock, b"task")
 
-    wazuh_common.sync_tasks = {'task_ID': file_task}
-    assert wazuh_common.end_receiving_file("task_ID filepath") == (b'ok', b'File correctly received')
-    assert isinstance(wazuh_common.sync_tasks["task_ID"], cluster_common.ReceiveFileTask)
+    with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
+        wazuh_common.sync_tasks = {'task_ID': file_task}
+        # Use a path within queue/cluster to pass validation
+        assert wazuh_common.end_receiving_file("task_ID queue/cluster/filepath") == (b'ok', b'File correctly received')
+        assert isinstance(wazuh_common.sync_tasks["task_ID"], cluster_common.ReceiveFileTask)
 
 
 @patch('os.remove')
@@ -1503,14 +1505,14 @@ def test_wazuh_common_end_receiving_file_ok(logger_mock, wazuh_common_mock):
 def test_wazuh_common_end_receiving_file_ko(path_exists_mock, os_remove_mock):
     """Test the 'end_receiving_file' correct functioning in a failure scenario."""
 
-    with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
-        wazuh_common.end_receiving_file("not_task_ID filepath")
-
     with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
         with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
+            wazuh_common.end_receiving_file("not_task_ID queue/cluster/filepath")
+
+        with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
             os_remove_mock.side_effect = Exception
-            wazuh_common.end_receiving_file("not_task_ID filepath")
-    assert os_remove_mock.call_count == 2
+            wazuh_common.end_receiving_file("not_task_ID queue/cluster/filepath")
+        assert os_remove_mock.call_count == 2
 
 
 @patch('json.loads')
@@ -1535,6 +1537,48 @@ def test_wazuh_common_error_receiving_file_ko():
             with patch('os.remove', side_effect=Exception):
                 with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
                     assert wazuh_common.error_receiving_file("task_ID error_details") == (b'ok', b'Error received')
+
+
+def test_wazuh_common_end_receiving_file_invalid_absolute_path():
+    """Test that end_receiving_file rejects absolute paths."""
+
+    with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
+        with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
+            wazuh_common.end_receiving_file("not_task_ID /etc/passwd")
+
+
+def test_wazuh_common_end_receiving_file_invalid_relative_path():
+    """Test that end_receiving_file rejects paths outside allowed prefix."""
+
+    with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
+        with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
+            wazuh_common.end_receiving_file("not_task_ID ../../../../etc/passwd")
+
+
+def test_wazuh_common_end_receiving_file_invalid_nested_path():
+    """Test that end_receiving_file validates nested path components."""
+
+    with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
+        with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
+            wazuh_common.end_receiving_file("not_task_ID ../../../tmp/evil.sh")
+
+
+@patch('os.path.exists', return_value=False)
+def test_wazuh_common_end_receiving_file_path_validation_with_valid_task(path_exists_mock):
+    """Test that path validation is applied regardless of task_id validity."""
+
+    from unittest.mock import MagicMock
+
+    with patch('wazuh.core.cluster.common.ReceiveFileTask.set_up_coro'):
+        with patch('asyncio.create_task'):
+            with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
+                file_task = cluster_common.ReceiveFileTask(wazuh_common, MagicMock(), b"task")
+
+    wazuh_common.sync_tasks = {'valid_task_id': file_task}
+
+    with patch('wazuh.core.cluster.common.WazuhCommon.get_logger'):
+        with pytest.raises(exception.WazuhClusterError, match=r'.* 3027 .*'):
+            wazuh_common.end_receiving_file("valid_task_id /etc/passwd")
 
 
 def test_wazuh_common_get_node():


### PR DESCRIPTION
## Description

Applies consistent path validation to `end_receiving_file()` in the cluster protocol, matching the protection pattern established in `receive_file()` by PR #33705.

**Credit**: Thanks to @mikecole-mg for identifying this issue.

## Proposed Changes

The `WazuhCommon.end_receiving_file()` function now validates file paths before processing, preventing operations outside the allowed cluster directory prefix.

**Changed file**: `framework/wazuh/core/cluster/common.py` (lines 1353-1370)

**Key changes**:
- Normalize paths using `os.path.realpath()` and `lstrip("/")`
- Validate resolved paths against `_ALLOWED_PREFIXES`
- Use validated path consistently throughout the function

### Results and Evidence

Path validation logic matches the implementation in `receive_file()` (line 1000-1003), which was introduced in https://github.com/wazuh/wazuh/pull/33705:

```python
# Pattern from receive_file() (PR #33705)
dst = os.path.realpath(os.path.join(common.WAZUH_PATH, rel.lstrip("/")))
if not any(os.path.commonpath([dst, root]) == root for root in _ALLOWED_PREFIXES):
    return b"err", b"Write path not allowed"
```

Now applied to `end_receiving_file()`:
```python
safe_path = os.path.realpath(os.path.join(common.WAZUH_PATH, filename.lstrip("/")))
if not any(os.path.commonpath([safe_path, root]) == root for root in _ALLOWED_PREFIXES):
    self.get_logger(logger_tag).error(f"Write path not allowed")
    raise exception.WazuhClusterError(3027, extra_message=task_id)
```

### Artifacts Affected

- wazuh-apid
- wazuh-clusterd

### Configuration Changes

No configuration changes required.

### Documentation Updates

No documentation updates required.

### Tests Introduced

Added regression tests in `framework/wazuh/core/cluster/tests/test_common.py`:
- `test_wazuh_common_end_receiving_file_invalid_absolute_path`
- `test_wazuh_common_end_receiving_file_invalid_relative_path`
- `test_wazuh_common_end_receiving_file_invalid_nested_path`
- `test_wazuh_common_end_receiving_file_path_validation_with_valid_task`

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
