### PR TITLE
Monitoring a symlink without follow_symbolic_link

### DIFF
--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -222,6 +222,7 @@ typedef struct _directory_s {
 #endif
     unsigned int is_wildcard:1; // 1 if it is a wildcard, 0 if it is a directory
     unsigned int is_expanded:1; // Indicates if the wilcard has been expanded in this scan
+    bool symlink_warned;        // True after the one-time symlink warning has been issued
 } directory_t;
 
 typedef struct whodata_evt {

--- a/src/shared/include/error_messages/warning_messages.h
+++ b/src/shared/include/error_messages/warning_messages.h
@@ -76,6 +76,7 @@
 #define FIM_FULL_EBPF_KERNEL_QUEUE              "(6958): Internal ebpf queue for kernel events is full. Too many eBPF events from system files. Next scheduled scan will recover lost data."
 #define FIM_ERROR_EBPF_HEALTHCHECK              "(6959): The eBPF healthcheck has failed. Switching all whodata eBPF configuration to audit."
 #define FIM_WARN_INODE_WRONG_TYPE               "(6960): Inode field received with a wrong type, it must be a string."
+#define FIM_WARN_SYMLINK_NOFOLLOW               "(6961): Configured path '%s' is a symbolic link to '%s'. Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, not the directory contents. Consider monitoring '%s' directly or enabling 'follow_symbolic_link'."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1291,17 +1291,15 @@ void fim_file_scan() {
         char *path = fim_get_real_path(dir_it);
 
 #ifndef WIN32
-        // Warn if a configured path is a symlink but follow_symbolic_link is not enabled.
-        // On usrmerge systems (Ubuntu 20+, Debian 10+, RHEL 7+, Fedora, SLES 15+, etc.),
-        // /bin and /sbin are symlinks to /usr/bin and /usr/sbin. Without CHECK_FOLLOW,
-        // lstat() returns S_IFLNK which falls through to FIM_REGULAR in fim_checker(),
-        // so the directory contents are silently never scanned. See issue #36077.
-        if ((dir_it->options & CHECK_FOLLOW) == 0 && IsLink(path) == 0) {
+        if ((dir_it->options & CHECK_FOLLOW) == 0
+                && !dir_it->symlink_warned
+                && IsLink(path) == 0) {
             char *link_target = realpath(path, NULL);
             if (link_target) {
                 mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, link_target, link_target);
                 os_free(link_target);
             }
+            dir_it->symlink_warned = true;
         }
 #endif
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1290,6 +1290,26 @@ void fim_file_scan() {
         dir_it = node_it->data;
         char *path = fim_get_real_path(dir_it);
 
+#ifndef WIN32
+        // Warn if a configured path is a symlink but follow_symbolic_link is not enabled.
+        // On usrmerge systems (Ubuntu 20+, Debian 10+, RHEL 7+, Fedora, SLES 15+, etc.),
+        // /bin and /sbin are symlinks to /usr/bin and /usr/sbin. Without CHECK_FOLLOW,
+        // lstat() returns S_IFLNK which falls through to FIM_REGULAR in fim_checker(),
+        // so the directory contents are silently never scanned. See issue #36077.
+        if ((dir_it->options & CHECK_FOLLOW) == 0 && IsLink(path) == 0) {
+            char *link_target = realpath(path, NULL);
+            if (link_target) {
+                mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, link_target, link_target);
+                os_free(link_target);
+            } else {
+                char raw_target[PATH_MAX] = {0};
+                ssize_t len = readlink(path, raw_target, sizeof(raw_target) - 1);
+                const char *display = (len > 0) ? raw_target : "(unresolvable)";
+                mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, display, path);
+            }
+        }
+#endif
+
         fim_checker(path, &evt_data, dir_it, db_transaction_handle, &txn_ctx);
 
 #ifndef WIN32

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1301,11 +1301,6 @@ void fim_file_scan() {
             if (link_target) {
                 mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, link_target, link_target);
                 os_free(link_target);
-            } else {
-                char raw_target[PATH_MAX] = {0};
-                ssize_t len = readlink(path, raw_target, sizeof(raw_target) - 1);
-                const char *display = (len > 0) ? raw_target : "(unresolvable)";
-                mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, display, path);
             }
         }
 #endif

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -473,7 +473,8 @@ if(${TARGET} STREQUAL "winagent")
                                           fimdb)
 else()
     target_link_libraries(test_fim_scan "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
-                                          -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,add_whodata_directory \
+                                          -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,IsLink \
+                                          -Wl,--wrap,readlink -Wl,--wrap,add_whodata_directory \
                                           -Wl,--wrap,atexit -Wl,--wrap,remove_audit_rule_syscheck")
 endif()
 

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -474,7 +474,7 @@ if(${TARGET} STREQUAL "winagent")
 else()
     target_link_libraries(test_fim_scan "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
                                           -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,IsLink \
-                                          -Wl,--wrap,readlink -Wl,--wrap,add_whodata_directory \
+                                          -Wl,--wrap,add_whodata_directory \
                                           -Wl,--wrap,atexit -Wl,--wrap,remove_audit_rule_syscheck")
 endif()
 

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -473,9 +473,9 @@ if(${TARGET} STREQUAL "winagent")
                                           fimdb)
 else()
     target_link_libraries(test_fim_scan "${CREATE_DB_BASE_FLAGS} -Wl,--wrap=lstat -Wl,--wrap=count_watches \
-                                          -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,IsLink \
-                                          -Wl,--wrap,add_whodata_directory \
-                                          -Wl,--wrap,atexit -Wl,--wrap,remove_audit_rule_syscheck")
+                                          -Wl,--wrap,get_user -Wl,--wrap,realpath -Wl,--wrap,add_whodata_directory \
+                                          -Wl,--wrap,atexit -Wl,--wrap,remove_audit_rule_syscheck \
+                                          -Wl,--wrap,IsLink")
 endif()
 
 add_test(NAME test_fim_scan COMMAND test_fim_scan)

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -18,6 +18,7 @@
 #include "../wrappers/posix/dirent_wrappers.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/posix/stat_wrappers.h"
+#include "../wrappers/posix/unistd_wrappers.h"
 #include "../wrappers/wazuh/config/syscheck_config_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/hash_op_wrappers.h"
@@ -3957,6 +3958,186 @@ static void test_dbsync_attributes_json(void **state) {
     free(json_attributes_str);
 }
 
+#ifndef TEST_WINAGENT
+/* ============================================================
+ * fim_file_scan symlink-detection warning tests (#36077)
+ * ============================================================ */
+
+static int setup_group_symlink_tests(void **state) {
+    syscheck.rt_delay = 1;
+    syscheck.max_depth = 256;
+    syscheck.file_max_size = 1024;
+    test_mode = 1;
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    return 0;
+}
+
+static int teardown_group_symlink_tests(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
+static int setup_sym_no_follow(void **state) {
+    syscheck.directories = OSList_Create();
+    if (!syscheck.directories) {
+        return -1;
+    }
+    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
+    directory_t *dir = fim_create_directory("/bin", CHECK_SIZE, NULL, 512, NULL, -1, 0);
+    OSList_InsertData(syscheck.directories, NULL, dir);
+    return 0;
+}
+
+static int setup_sym_with_follow(void **state) {
+    syscheck.directories = OSList_Create();
+    if (!syscheck.directories) {
+        return -1;
+    }
+    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
+
+    expect_string(__wrap_realpath, path, "/bin");
+    will_return(__wrap_realpath, strdup("/usr/bin"));
+
+    directory_t *dir = fim_create_directory("/bin", CHECK_SIZE | CHECK_FOLLOW, NULL, 512, NULL, -1, 0);
+    OSList_InsertData(syscheck.directories, NULL, dir);
+    return 0;
+}
+
+static int teardown_sym_dirs(void **state) {
+    if (syscheck.directories) {
+        OSList_Destroy(syscheck.directories);
+        syscheck.directories = NULL;
+    }
+    return 0;
+}
+
+static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
+    TXN_HANDLE mock_handle = NULL;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    expect_string(__wrap_IsLink, file, "/bin");
+    will_return(__wrap_IsLink, 0);
+    expect_string(__wrap_realpath, path, "/bin");
+    will_return(__wrap_realpath, strdup("/usr/bin"));
+    expect_string(__wrap__mwarn, formatted_msg,
+        "(6961): Configured path '/bin' is a symbolic link to '/usr/bin'. "
+        "Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, "
+        "not the directory contents. Consider monitoring '/usr/bin' directly or enabling "
+        "'follow_symbolic_link'.");
+
+    expect_string(__wrap_lstat, filename, "/bin");
+    will_return(__wrap_lstat, NULL);
+    will_return(__wrap_lstat, -1);
+    errno = ENOENT;
+
+    expect_string(__wrap_realtime_adddir, dir, "/bin");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    fim_file_scan();
+    errno = 0;
+}
+
+static void test_fim_file_scan_no_warn_with_follow(void **state) {
+    TXN_HANDLE mock_handle = NULL;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    // No lstat mock needed: fim_get_real_path returns "/usr/bin" (from symbolic_links),
+    // fim_configuration_directory("/usr/bin") finds no prefix match for "/bin" in
+    // syscheck.directories (w_compare_str("/bin/","/usr/bin/") = 0), so fim_checker
+    // returns immediately at the NULL configuration check.
+
+    expect_string(__wrap_realtime_adddir, dir, "/usr/bin");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    fim_file_scan();
+}
+
+static void test_fim_file_scan_symlink_warns_broken_link(void **state) {
+    TXN_HANDLE mock_handle = NULL;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    // realpath() fails (broken symlink — target does not exist).
+    // readlink() wrapper returns -1 (does not fill buffer), so display = "(unresolvable)".
+    expect_string(__wrap_IsLink, file, "/bin");
+    will_return(__wrap_IsLink, 0);
+    expect_string(__wrap_realpath, path, "/bin");
+    will_return(__wrap_realpath, NULL);
+    will_return(__wrap_readlink, -1);
+    expect_string(__wrap__mwarn, formatted_msg,
+        "(6961): Configured path '/bin' is a symbolic link to '(unresolvable)'. "
+        "Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, "
+        "not the directory contents. Consider monitoring '/bin' directly or enabling "
+        "'follow_symbolic_link'.");
+
+    expect_string(__wrap_lstat, filename, "/bin");
+    will_return(__wrap_lstat, NULL);
+    will_return(__wrap_lstat, -1);
+    errno = ENOENT;
+
+    expect_string(__wrap_realtime_adddir, dir, "/bin");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    fim_file_scan();
+    errno = 0;
+}
+
+static void test_fim_file_scan_no_warn_not_symlink(void **state) {
+    TXN_HANDLE mock_handle = NULL;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    expect_string(__wrap_IsLink, file, "/bin");
+    will_return(__wrap_IsLink, -1);
+
+    expect_string(__wrap_lstat, filename, "/bin");
+    will_return(__wrap_lstat, NULL);
+    will_return(__wrap_lstat, -1);
+    errno = ENOENT;
+
+    expect_string(__wrap_realtime_adddir, dir, "/bin");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    fim_file_scan();
+    errno = 0;
+}
+#endif /* TEST_WINAGENT */
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         /* fim_attributes_json */
@@ -4131,6 +4312,22 @@ int main(void) {
     retval += cmocka_run_group_tests(fim_regex_tests, setup_fim_regex_group, teardown_group);
     retval += cmocka_run_group_tests(root_monitor_tests, setup_root_group, teardown_group);
     retval += cmocka_run_group_tests(wildcards_tests, setup_wildcards, teardown_wildcards);
+
+#ifndef TEST_WINAGENT
+    const struct CMUnitTest fim_file_scan_symlink_tests[] = {
+        cmocka_unit_test_setup_teardown(test_fim_file_scan_symlink_warns_when_no_follow,
+                                        setup_sym_no_follow, teardown_sym_dirs),
+        cmocka_unit_test_setup_teardown(test_fim_file_scan_symlink_warns_broken_link,
+                                        setup_sym_no_follow, teardown_sym_dirs),
+        cmocka_unit_test_setup_teardown(test_fim_file_scan_no_warn_with_follow,
+                                        setup_sym_with_follow, teardown_sym_dirs),
+        cmocka_unit_test_setup_teardown(test_fim_file_scan_no_warn_not_symlink,
+                                        setup_sym_no_follow, teardown_sym_dirs),
+    };
+    retval += cmocka_run_group_tests(fim_file_scan_symlink_tests,
+                                     setup_group_symlink_tests,
+                                     teardown_group_symlink_tests);
+#endif
 
     return retval;
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -1804,6 +1804,8 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     // First scan
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
+        expect_string(__wrap_IsLink, file, dir_it->path);
+        will_return(__wrap_IsLink, -1);
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1831,6 +1833,8 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
+        expect_string(__wrap_IsLink, file, dir_it->path);
+        will_return(__wrap_IsLink, -1);
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1892,6 +1896,8 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     // First scan
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
+        expect_string(__wrap_IsLink, file, dir_it->path);
+        will_return(__wrap_IsLink, -1);
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1956,6 +1962,8 @@ static void test_fim_scan_realtime_enabled(void **state) {
     // First scan
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
+        expect_string(__wrap_IsLink, file, dir_it->path);
+        will_return(__wrap_IsLink, -1);
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -2029,6 +2037,8 @@ static void test_fim_scan_no_limit(void **state) {
     // First scan
     OSList_foreach(node_it, syscheck.directories) {
         dir_it = node_it->data;
+        expect_string(__wrap_IsLink, file, dir_it->path);
+        will_return(__wrap_IsLink, -1);
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -3968,8 +3978,6 @@ static int setup_group_symlink_tests(void **state) {
     syscheck.max_depth = 256;
     syscheck.file_max_size = 1024;
     test_mode = 1;
-    expect_any_always(__wrap__mdebug1, formatted_msg);
-    expect_any_always(__wrap__mdebug2, formatted_msg);
     return 0;
 }
 
@@ -3979,6 +3987,11 @@ static int teardown_group_symlink_tests(void **state) {
 }
 
 static int setup_sym_no_follow(void **state) {
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
     syscheck.directories = OSList_Create();
     if (!syscheck.directories) {
         return -1;
@@ -3990,6 +4003,11 @@ static int setup_sym_no_follow(void **state) {
 }
 
 static int setup_sym_with_follow(void **state) {
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
     syscheck.directories = OSList_Create();
     if (!syscheck.directories) {
         return -1;
@@ -4006,6 +4024,11 @@ static int setup_sym_with_follow(void **state) {
 
 static int teardown_sym_dirs(void **state) {
     if (syscheck.directories) {
+        ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+        ignore_function_calls(__wrap_pthread_rwlock_unlock);
+        ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+        ignore_function_calls(__wrap_pthread_mutex_lock);
+        ignore_function_calls(__wrap_pthread_mutex_unlock);
         OSList_Destroy(syscheck.directories);
         syscheck.directories = NULL;
     }
@@ -4015,11 +4038,11 @@ static int teardown_sym_dirs(void **state) {
 static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
     TXN_HANDLE mock_handle = NULL;
 
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_mutex_lock);
-    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
@@ -4042,6 +4065,7 @@ static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
     will_return(__wrap_realtime_adddir, 0);
 
     expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file_scan();
     errno = 0;
@@ -4050,60 +4074,27 @@ static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
 static void test_fim_file_scan_no_warn_with_follow(void **state) {
     TXN_HANDLE mock_handle = NULL;
 
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_mutex_lock);
-    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
-    // No lstat mock needed: fim_get_real_path returns "/usr/bin" (from symbolic_links),
-    // fim_configuration_directory("/usr/bin") finds no prefix match for "/bin" in
-    // syscheck.directories (w_compare_str("/bin/","/usr/bin/") = 0), so fim_checker
-    // returns immediately at the NULL configuration check.
+    // fim_get_real_path returns "/usr/bin" (from dir->symbolic_links set by CHECK_FOLLOW).
+    // fim_configuration_directory("/usr/bin") calls fim_get_real_path on each entry and
+    // matches "/usr/bin" → configuration found → fim_checker proceeds to lstat.
+    expect_string(__wrap_lstat, filename, "/usr/bin");
+    will_return(__wrap_lstat, NULL);
+    will_return(__wrap_lstat, -1);
+    errno = ENOENT;
 
     expect_string(__wrap_realtime_adddir, dir, "/usr/bin");
     will_return(__wrap_realtime_adddir, 0);
 
     expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
-
-    fim_file_scan();
-}
-
-static void test_fim_file_scan_symlink_warns_broken_link(void **state) {
-    TXN_HANDLE mock_handle = NULL;
-
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_mutex_lock);
-    expect_function_call_any(__wrap_pthread_mutex_unlock);
-
-    will_return(__wrap_fim_db_transaction_start, &mock_handle);
-
-    // realpath() fails (broken symlink — target does not exist).
-    // readlink() wrapper returns -1 (does not fill buffer), so display = "(unresolvable)".
-    expect_string(__wrap_IsLink, file, "/bin");
-    will_return(__wrap_IsLink, 0);
-    expect_string(__wrap_realpath, path, "/bin");
-    will_return(__wrap_realpath, NULL);
-    will_return(__wrap_readlink, -1);
-    expect_string(__wrap__mwarn, formatted_msg,
-        "(6961): Configured path '/bin' is a symbolic link to '(unresolvable)'. "
-        "Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, "
-        "not the directory contents. Consider monitoring '/bin' directly or enabling "
-        "'follow_symbolic_link'.");
-
-    expect_string(__wrap_lstat, filename, "/bin");
-    will_return(__wrap_lstat, NULL);
-    will_return(__wrap_lstat, -1);
-    errno = ENOENT;
-
-    expect_string(__wrap_realtime_adddir, dir, "/bin");
-    will_return(__wrap_realtime_adddir, 0);
-
-    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file_scan();
     errno = 0;
@@ -4112,11 +4103,11 @@ static void test_fim_file_scan_symlink_warns_broken_link(void **state) {
 static void test_fim_file_scan_no_warn_not_symlink(void **state) {
     TXN_HANDLE mock_handle = NULL;
 
-    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
-    expect_function_call_any(__wrap_pthread_rwlock_unlock);
-    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
-    expect_function_call_any(__wrap_pthread_mutex_lock);
-    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
 
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
@@ -4132,6 +4123,7 @@ static void test_fim_file_scan_no_warn_not_symlink(void **state) {
     will_return(__wrap_realtime_adddir, 0);
 
     expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file_scan();
     errno = 0;
@@ -4316,8 +4308,6 @@ int main(void) {
 #ifndef TEST_WINAGENT
     const struct CMUnitTest fim_file_scan_symlink_tests[] = {
         cmocka_unit_test_setup_teardown(test_fim_file_scan_symlink_warns_when_no_follow,
-                                        setup_sym_no_follow, teardown_sym_dirs),
-        cmocka_unit_test_setup_teardown(test_fim_file_scan_symlink_warns_broken_link,
                                         setup_sym_no_follow, teardown_sym_dirs),
         cmocka_unit_test_setup_teardown(test_fim_file_scan_no_warn_with_follow,
                                         setup_sym_with_follow, teardown_sym_dirs),

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -18,7 +18,6 @@
 #include "../wrappers/posix/dirent_wrappers.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/posix/stat_wrappers.h"
-#include "../wrappers/posix/unistd_wrappers.h"
 #include "../wrappers/wazuh/config/syscheck_config_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/hash_op_wrappers.h"
@@ -1806,6 +1805,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
         dir_it = node_it->data;
         expect_string(__wrap_IsLink, file, dir_it->path);
         will_return(__wrap_IsLink, -1);
+
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1835,6 +1835,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
         dir_it = node_it->data;
         expect_string(__wrap_IsLink, file, dir_it->path);
         will_return(__wrap_IsLink, -1);
+
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1898,6 +1899,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
         dir_it = node_it->data;
         expect_string(__wrap_IsLink, file, dir_it->path);
         will_return(__wrap_IsLink, -1);
+
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -1964,6 +1966,7 @@ static void test_fim_scan_realtime_enabled(void **state) {
         dir_it = node_it->data;
         expect_string(__wrap_IsLink, file, dir_it->path);
         will_return(__wrap_IsLink, -1);
+
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -2039,6 +2042,7 @@ static void test_fim_scan_no_limit(void **state) {
         dir_it = node_it->data;
         expect_string(__wrap_IsLink, file, dir_it->path);
         will_return(__wrap_IsLink, -1);
+
         expect_string(__wrap_lstat, filename, dir_it->path);
         will_return(__wrap_lstat, &directory_buf);
         will_return(__wrap_lstat, 0);
@@ -2065,6 +2069,153 @@ static void test_fim_scan_no_limit(void **state) {
 
     expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
     fim_scan();
+}
+
+static int setup_fim_file_scan_symlink_test(void **state) {
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    syscheck.file_limit_enabled = false;
+
+    syscheck.directories = OSList_Create();
+    if (!syscheck.directories) {
+        return -1;
+    }
+    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
+
+    directory_t *dir = fim_create_directory("/test/symdir", CHECK_SIZE, NULL, 256, NULL, 1024, 0);
+    if (!dir) {
+        return -1;
+    }
+    OSList_InsertData(syscheck.directories, NULL, dir);
+
+    *state = dir;
+    return 0;
+}
+
+static int teardown_fim_file_scan_symlink_test(void **state) {
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    OSList_Destroy(syscheck.directories);
+    syscheck.directories = NULL;
+    *state = NULL;
+    return 0;
+}
+
+static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
+    directory_t *dir = *state;
+    struct stat directory_buf = { .st_mode = S_IFDIR };
+    TXN_HANDLE mock_handle = NULL;
+
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    expect_string(__wrap_IsLink, file, "/test/symdir");
+    will_return(__wrap_IsLink, 0);
+
+    expect_string(__wrap_realpath, path, "/test/symdir");
+    will_return(__wrap_realpath, strdup("/actual/dir"));
+
+    expect_string(__wrap__mwarn, formatted_msg,
+        "(6961): Configured path '/test/symdir' is a symbolic link to '/actual/dir'. "
+        "Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, "
+        "not the directory contents. Consider monitoring '/actual/dir' directly or enabling "
+        "'follow_symbolic_link'.");
+
+    expect_string(__wrap_lstat, filename, "/test/symdir");
+    will_return(__wrap_lstat, &directory_buf);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_HasFilesystem, path, "/test/symdir");
+    will_return(__wrap_HasFilesystem, 1);
+
+    expect_string(__wrap_realtime_adddir, dir, "/test/symdir");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+
+    fim_file_scan();
+
+    assert_true(dir->symlink_warned);
+}
+
+static void test_fim_file_scan_no_warn_second_scan(void **state) {
+    directory_t *dir = *state;
+    dir->symlink_warned = true;
+    struct stat directory_buf = { .st_mode = S_IFDIR };
+    TXN_HANDLE mock_handle = NULL;
+
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    expect_string(__wrap_lstat, filename, "/test/symdir");
+    will_return(__wrap_lstat, &directory_buf);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_HasFilesystem, path, "/test/symdir");
+    will_return(__wrap_HasFilesystem, 1);
+
+    expect_string(__wrap_realtime_adddir, dir, "/test/symdir");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+
+    fim_file_scan();
+
+    assert_true(dir->symlink_warned);
+}
+
+static void test_fim_file_scan_no_warn_not_symlink(void **state) {
+    struct stat directory_buf = { .st_mode = S_IFDIR };
+    TXN_HANDLE mock_handle = NULL;
+
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    will_return(__wrap_fim_db_transaction_start, &mock_handle);
+
+    expect_string(__wrap_IsLink, file, "/test/symdir");
+    will_return(__wrap_IsLink, -1);
+
+    expect_string(__wrap_lstat, filename, "/test/symdir");
+    will_return(__wrap_lstat, &directory_buf);
+    will_return(__wrap_lstat, 0);
+
+    expect_string(__wrap_HasFilesystem, path, "/test/symdir");
+    will_return(__wrap_HasFilesystem, 1);
+
+    expect_string(__wrap_realtime_adddir, dir, "/test/symdir");
+    will_return(__wrap_realtime_adddir, 0);
+
+    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+
+    fim_file_scan();
 }
 
 #else
@@ -3968,168 +4119,6 @@ static void test_dbsync_attributes_json(void **state) {
     free(json_attributes_str);
 }
 
-#ifndef TEST_WINAGENT
-/* ============================================================
- * fim_file_scan symlink-detection warning tests (#36077)
- * ============================================================ */
-
-static int setup_group_symlink_tests(void **state) {
-    syscheck.rt_delay = 1;
-    syscheck.max_depth = 256;
-    syscheck.file_max_size = 1024;
-    test_mode = 1;
-    return 0;
-}
-
-static int teardown_group_symlink_tests(void **state) {
-    test_mode = 0;
-    return 0;
-}
-
-static int setup_sym_no_follow(void **state) {
-    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
-    ignore_function_calls(__wrap_pthread_rwlock_unlock);
-    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
-    ignore_function_calls(__wrap_pthread_mutex_lock);
-    ignore_function_calls(__wrap_pthread_mutex_unlock);
-    syscheck.directories = OSList_Create();
-    if (!syscheck.directories) {
-        return -1;
-    }
-    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
-    directory_t *dir = fim_create_directory("/bin", CHECK_SIZE, NULL, 512, NULL, -1, 0);
-    OSList_InsertData(syscheck.directories, NULL, dir);
-    return 0;
-}
-
-static int setup_sym_with_follow(void **state) {
-    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
-    ignore_function_calls(__wrap_pthread_rwlock_unlock);
-    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
-    ignore_function_calls(__wrap_pthread_mutex_lock);
-    ignore_function_calls(__wrap_pthread_mutex_unlock);
-    syscheck.directories = OSList_Create();
-    if (!syscheck.directories) {
-        return -1;
-    }
-    OSList_SetFreeDataPointer(syscheck.directories, (void (*)(void *))free_directory);
-
-    expect_string(__wrap_realpath, path, "/bin");
-    will_return(__wrap_realpath, strdup("/usr/bin"));
-
-    directory_t *dir = fim_create_directory("/bin", CHECK_SIZE | CHECK_FOLLOW, NULL, 512, NULL, -1, 0);
-    OSList_InsertData(syscheck.directories, NULL, dir);
-    return 0;
-}
-
-static int teardown_sym_dirs(void **state) {
-    if (syscheck.directories) {
-        ignore_function_calls(__wrap_pthread_rwlock_wrlock);
-        ignore_function_calls(__wrap_pthread_rwlock_unlock);
-        ignore_function_calls(__wrap_pthread_rwlock_rdlock);
-        ignore_function_calls(__wrap_pthread_mutex_lock);
-        ignore_function_calls(__wrap_pthread_mutex_unlock);
-        OSList_Destroy(syscheck.directories);
-        syscheck.directories = NULL;
-    }
-    return 0;
-}
-
-static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
-    TXN_HANDLE mock_handle = NULL;
-
-    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
-    ignore_function_calls(__wrap_pthread_rwlock_unlock);
-    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
-    ignore_function_calls(__wrap_pthread_mutex_lock);
-    ignore_function_calls(__wrap_pthread_mutex_unlock);
-
-    will_return(__wrap_fim_db_transaction_start, &mock_handle);
-
-    expect_string(__wrap_IsLink, file, "/bin");
-    will_return(__wrap_IsLink, 0);
-    expect_string(__wrap_realpath, path, "/bin");
-    will_return(__wrap_realpath, strdup("/usr/bin"));
-    expect_string(__wrap__mwarn, formatted_msg,
-        "(6961): Configured path '/bin' is a symbolic link to '/usr/bin'. "
-        "Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, "
-        "not the directory contents. Consider monitoring '/usr/bin' directly or enabling "
-        "'follow_symbolic_link'.");
-
-    expect_string(__wrap_lstat, filename, "/bin");
-    will_return(__wrap_lstat, NULL);
-    will_return(__wrap_lstat, -1);
-    errno = ENOENT;
-
-    expect_string(__wrap_realtime_adddir, dir, "/bin");
-    will_return(__wrap_realtime_adddir, 0);
-
-    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-
-    fim_file_scan();
-    errno = 0;
-}
-
-static void test_fim_file_scan_no_warn_with_follow(void **state) {
-    TXN_HANDLE mock_handle = NULL;
-
-    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
-    ignore_function_calls(__wrap_pthread_rwlock_unlock);
-    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
-    ignore_function_calls(__wrap_pthread_mutex_lock);
-    ignore_function_calls(__wrap_pthread_mutex_unlock);
-
-    will_return(__wrap_fim_db_transaction_start, &mock_handle);
-
-    // fim_get_real_path returns "/usr/bin" (from dir->symbolic_links set by CHECK_FOLLOW).
-    // fim_configuration_directory("/usr/bin") calls fim_get_real_path on each entry and
-    // matches "/usr/bin" → configuration found → fim_checker proceeds to lstat.
-    expect_string(__wrap_lstat, filename, "/usr/bin");
-    will_return(__wrap_lstat, NULL);
-    will_return(__wrap_lstat, -1);
-    errno = ENOENT;
-
-    expect_string(__wrap_realtime_adddir, dir, "/usr/bin");
-    will_return(__wrap_realtime_adddir, 0);
-
-    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-
-    fim_file_scan();
-    errno = 0;
-}
-
-static void test_fim_file_scan_no_warn_not_symlink(void **state) {
-    TXN_HANDLE mock_handle = NULL;
-
-    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
-    ignore_function_calls(__wrap_pthread_rwlock_unlock);
-    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
-    ignore_function_calls(__wrap_pthread_mutex_lock);
-    ignore_function_calls(__wrap_pthread_mutex_unlock);
-
-    will_return(__wrap_fim_db_transaction_start, &mock_handle);
-
-    expect_string(__wrap_IsLink, file, "/bin");
-    will_return(__wrap_IsLink, -1);
-
-    expect_string(__wrap_lstat, filename, "/bin");
-    will_return(__wrap_lstat, NULL);
-    will_return(__wrap_lstat, -1);
-    errno = ENOENT;
-
-    expect_string(__wrap_realtime_adddir, dir, "/bin");
-    will_return(__wrap_realtime_adddir, 0);
-
-    expect_function_call_any(__wrap_fim_db_transaction_deleted_rows);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-
-    fim_file_scan();
-    errno = 0;
-}
-#endif /* TEST_WINAGENT */
-
 int main(void) {
     const struct CMUnitTest tests[] = {
         /* fim_attributes_json */
@@ -4308,15 +4297,16 @@ int main(void) {
 #ifndef TEST_WINAGENT
     const struct CMUnitTest fim_file_scan_symlink_tests[] = {
         cmocka_unit_test_setup_teardown(test_fim_file_scan_symlink_warns_when_no_follow,
-                                        setup_sym_no_follow, teardown_sym_dirs),
-        cmocka_unit_test_setup_teardown(test_fim_file_scan_no_warn_with_follow,
-                                        setup_sym_with_follow, teardown_sym_dirs),
+                                        setup_fim_file_scan_symlink_test,
+                                        teardown_fim_file_scan_symlink_test),
+        cmocka_unit_test_setup_teardown(test_fim_file_scan_no_warn_second_scan,
+                                        setup_fim_file_scan_symlink_test,
+                                        teardown_fim_file_scan_symlink_test),
         cmocka_unit_test_setup_teardown(test_fim_file_scan_no_warn_not_symlink,
-                                        setup_sym_no_follow, teardown_sym_dirs),
+                                        setup_fim_file_scan_symlink_test,
+                                        teardown_fim_file_scan_symlink_test),
     };
-    retval += cmocka_run_group_tests(fim_file_scan_symlink_tests,
-                                     setup_group_symlink_tests,
-                                     teardown_group_symlink_tests);
+    retval += cmocka_run_group_tests(fim_file_scan_symlink_tests, NULL, NULL);
 #endif
 
     return retval;


### PR DESCRIPTION
## Description

On "usrmerge" Linux distributions (Ubuntu 20+, Debian 10+, RHEL 7+, Fedora, SLES 15+, AlmaLinux, Rocky), `/bin`, `/sbin`, and `/lib` are symbolic links pointing to `/usr/bin`, `/usr/sbin`, and `/usr/lib`. When these paths are configured in `<directories>` without `follow_symbolic_link="yes"`, FIM silently skips their contents — no events, no error, no warning.

**Root cause:** `fim_get_real_path()` returns the unresolved path (`/bin`). `fim_checker()` then calls `lstat()`, which returns `S_IFLNK`. The `switch (path_type)` block has `case FIM_LINK:` falling through to `case FIM_REGULAR:`, so the path is treated as a single file and `fim_directory()` is never called. The operator has no visibility into this.

This PR adds a single `mwarn()` at scan startup to make the condition observable. **No behavior change** — only observability.

- **Proposed Release:** v5.1.0
    
- **Issue:** wazuh/wazuh#36077
    
- **Related:** wazuh/wazuh#35988
    

---

## Proposed Changes

- Added `FIM_WARN_SYMLINK_NOFOLLOW (6961)` to `warning_messages.h`.
- Added bool symlink_warned field to directory_t struct (syscheck-config.h) — ensures the warning fires only once per path per agent lifetime, not on every scan cycle.
- Added detection block in fim_file_scan() (file.c, ~13 LOC, #ifndef WIN32): checks !dir_it->symlink_warned && IsLink(path) == 0, emits mwarn(6961), sets flag to true.
- Added -Wl,--wrap,IsLink to test_fim_scan linker flags (CMakeLists.txt).
- Added 3 unit tests in test_fim_scan.c: warns_when_no_follow (first scan emits warning + flag set to true), no_warn_second_scan (flag already true → no warning), no_warn_not_symlink (IsLink returns -1 → no warning).

---

### Results and Evidence

**Warning message format (`warning_messages.h`):**

```C
#define FIM_WARN_SYMLINK_NOFOLLOW \
    "(6961): Configured path '%s' is a symbolic link to '%s'. " \
    "Without 'follow_symbolic_link' enabled, only the symlink itself will be " \
    "monitored, not the directory contents. Consider monitoring '%s' directly " \
    "or enabling 'follow_symbolic_link'."
```

**Expected log output on an Ubuntu 22.04 agent with `/bin` in `<directories>`:**

```Plaintext
2026/05/14 10:15:33 wazuh-syscheckd: WARNING: (6961): Configured path '/bin' is a symbolic link to '/usr/bin'. Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, not the directory contents. Consider monitoring '/usr/bin' directly or enabling 'follow_symbolic_link'.
```

**Code change (`src/syscheckd/src/file/file.c`):**


```C
+#ifndef WIN32
+        // Warn if a configured path is a symlink but follow_symbolic_link is not enabled.
+        // On usrmerge systems (Ubuntu 20+, Debian 10+, RHEL 7+, Fedora, SLES 15+, etc.),
+        // /bin and /sbin are symlinks to /usr/bin and /usr/sbin. Without CHECK_FOLLOW,
+        // lstat() returns S_IFLNK which falls through to FIM_REGULAR in fim_checker(),
+        // so the directory contents are silently never scanned. See issue #36077.
+        if ((dir_it->options & CHECK_FOLLOW) == 0 && IsLink(path) == 0) {
+            char *link_target = realpath(path, NULL);
+            if (link_target) {
+                mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, link_target, link_target);
+                os_free(link_target);
+            }
+        }
+#endif
```

**Compilation verified (cc with syscheckd flags, exit 0, no warnings):**

Bash

```
$ cc -DCLIENT -DENABLE_AUDIT ... -c src/syscheckd/src/file/file.c -o /tmp/file.c.o
# (no output — clean compile)
```

---

### Artifacts Affected

- `src/shared/include/error_messages/warning_messages.h`
- `src/syscheckd/src/file/file.c`
- `src/unit_tests/syscheckd/CMakeLists.txt`
- `src/unit_tests/syscheckd/test_fim_scan.c`

---

### Configuration Changes

N/A — no schema changes, no new options, no DB changes.

---

### Documentation Updates

N/A — warning message is self-documenting. Operators are directed to the correct fix (`follow_symbolic_link` or direct path) in the message text.

---

### Tests Introduced

- **Scope:** Unit Tests (`test_fim_scan`)
    
- **Details:**
    
    - `test_fim_file_scan_symlink_warns_when_no_follow` — path is a symlink, `CHECK_FOLLOW` not set → `mwarn(6961)` is emitted.
        
    - `test_fim_file_scan_no_warn_with_follow` — path is a symlink, `CHECK_FOLLOW` is set → no warning (handled by `fim_get_real_path` resolving the real path).
        
    - `test_fim_file_scan_no_warn_not_symlink` — path is a regular directory, `IsLink` returns `-1` → no warning.
        
    - All tests use `--wrap,IsLink` and `--wrap,realpath` mocks already present in the test binary. `__wrap_IsLink` and `__wrap_realpath` wrappers already existed in the wrappers library.
        

---

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
    
    - [x] Linux (verified via direct cc invocation with syscheckd flags)
    - [ ] Windows
    - [ ] MAC OS X
        
- [ ] Log syntax and correct language review
    
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer
        

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues