### PR TITLE
wazuh-engine: Improve wic index deteccion

### DIFF
--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -73,11 +73,11 @@ IndexResourceType fromIndexName(std::string_view indexName)
 {
     // Static regex patterns compiled once
     static const std::array<std::pair<std::regex, IndexResourceType>, 5> patterns = {
-        {{std::regex(R"(.*-kvdbs$)"), IndexResourceType::KVDB},
-         {std::regex(R"(.*-decoders$)"), IndexResourceType::DECODER},
-         {std::regex(R"(.*-filters$)"), IndexResourceType::FILTER},
-         {std::regex(R"(.*-integrations$)"), IndexResourceType::INTEGRATION_DECODER},
-         {std::regex(R"(.*-policies$)"), IndexResourceType::POLICY}}};
+        {{std::regex(R"(.*kvdbs.*)"), IndexResourceType::KVDB},
+         {std::regex(R"(.*decoders.*)"), IndexResourceType::DECODER},
+         {std::regex(R"(.*filters.*)"), IndexResourceType::FILTER},
+         {std::regex(R"(.*integrations.*)"), IndexResourceType::INTEGRATION_DECODER},
+         {std::regex(R"(.*policies.*)"), IndexResourceType::POLICY}}};
 
     for (const auto& [pattern, resourceType] : patterns)
     {


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR proposes simplifying the regular expression that windexer-connector uses to filter documents based on the security policy. When performing the PIT, it is necessary to know the type of each document; to do this, we filter by the name of the index to which they belong.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

Manager logs:

```log
footprint●› 
╰─# tail -f  /var/wazuh-manager/logs/wazuh-manager.log                                 130 ↵
2026/05/14 14:18:50 wazuh-manager-modulesd: ERROR: File 'etc/certs/root-ca.pem' not found for 'indexer.ssl.certificate_authorities' in module 'indexer'. Check configuration
2026/05/14 14:18:50 wazuh-manager-modulesd: ERROR: (1202): Configuration error at 'etc/wazuh-manager.conf'.
2026/05/14 14:29:56 wazuh-manager-authd: INFO: Started (pid: 40001).
2026/05/14 14:29:56 wazuh-manager-db: INFO: Started (pid: 40010).
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Store initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: IOC initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: GEO initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Schema initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: HLP initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Indexer Connector initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Stream logger initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Builder initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized (index: wazuh-events-raw-v5).
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: unlimited.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] First setup detected, initializing default IOC types to sync
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'connection' to the sync list
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'url_full' to the sync list
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'url_domain' to the sync list
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'hash_md5' to the sync list
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'hash_sha1' to the sync list
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'hash_sha256' to the sync list
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Dumper Events initialized.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Engine started and ready to process events.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: Scheduler started.
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [CMSync] Changes detected for space 'standard', updating...
2026/05/14 14:29:56 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'connection', updating...
2026/05/14 14:29:57 wazuh-manager-remoted: INFO: Started (pid: 40380). Listening on port 1514/TCP (secure).
2026/05/14 14:29:57 wazuh-manager-monitord: INFO: Started (pid: 40410).
2026/05/14 14:29:57 wazuh-manager-modulesd: INFO: Started (pid: 40416).
2026/05/14 14:29:57 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/05/14 14:29:57 wazuh-manager-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2026/05/14 14:29:57 wazuh-manager-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/14 14:29:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/05/14 14:29:57 wazuh-manager-modulesd:router: INFO: Starting router module.
2026/05/14 14:29:57 wazuh-manager-modulesd:database: INFO: Module started.
2026/05/14 14:29:57 wazuh-manager-modulesd:inventory-sync: INFO: Starting inventory_sync module.
2026/05/14 14:29:57 wazuh-manager-modulesd:content_manager: INFO: Starting content_manager module.
2026/05/14 14:29:57 wazuh-manager-modulesd:vulnerability-scanner (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/05/14 14:29:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: No existing local vulnerability feed detected at startup. A full feed will be downloaded.
2026/05/14 14:29:57 logger-helper: INFO: InventorySyncFacade started.
2026/05/14 14:29:57 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/05/14 14:29:57 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/05/14 14:29:57 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/05/14 14:29:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/05/14 14:30:00 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'connection'
2026/05/14 14:30:00 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_full', updating...
2026/05/14 14:30:01 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_full'
2026/05/14 14:30:01 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_domain', updating...
2026/05/14 14:30:05 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_domain'
2026/05/14 14:30:05 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_md5', updating...
2026/05/14 14:30:05 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_md5'
2026/05/14 14:30:05 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha1', updating...
2026/05/14 14:30:06 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha1'
2026/05/14 14:30:06 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha256', updating...
2026/05/14 14:30:06 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha256'
2026/05/14 14:30:07 wazuh-manager-analysisd: INFO: [Geo::Manager] Changes detected for CITY database 'GeoLite2-City.mmdb', updating...
2026/05/14 14:30:07 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/05/14 14:30:08 wazuh-manager-analysisd: INFO: [CMSync] Successfully synchronized space 'standard'
2026/05/14 14:30:08 wazuh-manager-analysisd: INFO: Remote settings synchronized: changes detected and applied.
2026/05/14 14:30:11 wazuh-manager-analysisd: INFO: [Geo::Manager] Successfully updated CITY database 'GeoLite2-City.mmdb'
2026/05/14 14:30:11 wazuh-manager-analysisd: INFO: [Geo::Manager] Changes detected for ASN database 'GeoLite2-ASN.mmdb', updating...
2026/05/14 14:30:12 wazuh-manager-analysisd: INFO: [Geo::Manager] Successfully updated ASN database 'GeoLite2-ASN.mmdb'
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
