### PR TITLE
Adapted curl call for old system on wazuh-control

### DIFF
--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -285,7 +285,7 @@ get_wazuh_engine_pid()
 wait_for_wazuh_engine_ready()
 {
     local attempts=0
-    local max_attempts=240 # TODO Improve this value
+    local max_attempts=120
 
     ENGINE_PID=$(get_wazuh_engine_pid)
     if [ $? -ne 0 ]; then
@@ -294,7 +294,7 @@ wait_for_wazuh_engine_ready()
     fi
 
     while [ $attempts -lt $max_attempts ]; do
-        curl --silent --fail-with-body --unix-socket ${DIR}/queue/sockets/analysis \
+        curl --silent --fail --unix-socket ${DIR}/queue/sockets/analysis \
             -X POST -H "Content-Type: application/json" \
             -d '{}' \
             http://localhost/_internal/event-dumper/status \


### PR DESCRIPTION

## Description

The `wazuh-manager-control` script (source: `src/init/wazuh-server.sh`, installed at `/var/wazuh-manager/bin/wazuh-manager-control`) was failing to start `wazuh-manager-analysisd` on CentOS 8. The readiness probe relied on `curl --fail-with-body`, a flag introduced in curl 7.76.0. CentOS 8 ships curl 7.61.1, so the option is not recognized and every probe attempt failed, causing the start sequence to abort after the configured number of attempts.

Closes #36091

## Proposed Changes

- Replaced `curl --fail-with-body` with `curl --fail` in the engine readiness probe of `wazuh-manager-control`, restoring compatibility with curl < 7.76.0 (e.g. CentOS 8 / curl 7.61.1).
- Independent minor adjustment: reduced `max_attempts` from 240 to 120 in `wait_for_wazuh_engine_ready` (removes a previous `TODO` placeholder value); not related to the curl fix.

### Results and Evidence

**Before fix**
```bash
[root@128-centos-8 vagrant]# /var/wazuh-manager/bin/wazuh-manager-control start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
wazuh-manager-analysisd did not respond correctly after 240 attempts.
wazuh-manager-analysisd did not start correctly.
```

**After fix**
```bash
[root@128-centos-8 vagrant]# /var/wazuh-manager/bin/wazuh-manager-control start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
[root@128-centos-8 vagrant]#
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-manager-control` script, installed at `/var/wazuh-manager/bin/wazuh-manager-control` (source: `src/init/wazuh-server.sh`). Used by the services unit and journald to manage the manager lifecycle.

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
