### PR TITLE
Update changelog for 4.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ### Manager
 
+#### Removed
+
+- Removed unused SSL/TLS transport option from cluster. ([#35648](https://github.com/wazuh/wazuh/pull/35648))
+
 #### Fixed
 
 - Improved message decompression handling in remoted. ([#35773](https://github.com/wazuh/wazuh/pull/35773))
@@ -12,6 +16,26 @@ All notable changes to this project will be documented in this file.
 - Fixed segfault in vulnerability scanner module shutdown when disabled. ([#36011](https://github.com/wazuh/wazuh/pull/36011))
 - Fixed string buffer handling in version comparison function. ([#36059](https://github.com/wazuh/wazuh/pull/36059))
 - Improved cluster file synchronization security. ([#36060](https://github.com/wazuh/wazuh/pull/36060))
+- Fixed missing `agent.host.ip` in inventory documents when agent IP is empty. ([#35475](https://github.com/wazuh/wazuh/pull/35475))
+
+### Agent
+
+#### Fixed
+
+- Fixed agent registration not running on reinstall after `apt-get remove`. ([#35727](https://github.com/wazuh/wazuh/pull/35727))
+
+### RESTful API
+
+#### Fixed
+
+- Escaped control characters in API usernames in access logs. ([#35866](https://github.com/wazuh/wazuh/pull/35866))
+- Added input validation in cluster result handling and authentication. ([#35757](https://github.com/wazuh/wazuh/pull/35757))
+
+### Other
+
+#### Changed
+
+- Updated `cryptography`, `urllib3` and `python-multipart` Python dependencies. ([#35982](https://github.com/wazuh/wazuh/pull/35982))
 
 
 ## [v4.14.5]


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh/issues/36107

This PR adds the missing entries to the `## [v4.14.6]` section in `CHANGELOG.md` for fixes that were merged into `4.14.6` without their own changelog entry.

## Entries added

| PR | Component | Category | Summary |
|----|-----------|----------|---------|
| [#35648](https://github.com/wazuh/wazuh/pull/35648) | Manager | Removed | Unused SSL/TLS transport option from cluster communication. |
| [#35475](https://github.com/wazuh/wazuh/pull/35475) | Manager | Fixed | Missing `agent.host.ip` in inventory documents when agent is enrolled without a fixed address. |
| [#35727](https://github.com/wazuh/wazuh/pull/35727) | Agent | Fixed | Debian agent reinstall after `apt-get remove` not substituting `WAZUH_MANAGER`. |
| [#35866](https://github.com/wazuh/wazuh/pull/35866) | RESTful API | Fixed | Control-character sanitization for usernames in access logs. |
| [#35757](https://github.com/wazuh/wazuh/pull/35757) | RESTful API | Fixed | Input validation in framework cluster result handling and authentication modules. |
| [#35982](https://github.com/wazuh/wazuh/pull/35982) | Other | Changed | Python dependency updates and embedded CPython build configuration. |
