### PR TITLE
Build binutils 2.41 in the deb-agent amd64 builder image

### DIFF
--- a/packages/debs/amd64/agent/Dockerfile
+++ b/packages/debs/amd64/agent/Dockerfile
@@ -51,6 +51,23 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     cd / && rm -rf gcc-9.4.0*
 
 # -------------------------------------------------------------------
+# Binutils 2.41 (stock debian:7 ships 2.22, which predates
+# R_X86_64_REX_GOTPCRELX and .note.gnu.property — both emitted by
+# GCC 14.3 and required to link externals built on this image).
+# -------------------------------------------------------------------
+RUN apt-get install -y --force-yes flex bison && \
+    curl -OL https://github.com/bminor/binutils-gdb/archive/refs/tags/binutils-2_41.tar.gz && \
+    tar xzf binutils-2_41.tar.gz && rm -f binutils-2_41.tar.gz && \
+    cd binutils-gdb-binutils-2_41 && mkdir build && cd build && \
+    ../configure --disable-gdb --disable-werror --disable-zlib \
+        --disable-gprofng --disable-gdbserver --disable-gdbsupport \
+        --disable-gnulib --disable-gold --disable-gprof --disable-texinfo \
+        --disable-binutils --disable-sim && \
+    make MAKEINFO=true -j$(nproc) && make MAKEINFO=true install && \
+    cd / && rm -rf binutils-gdb-binutils-2_41 && \
+    ln -fs /usr/local/bin/ld /usr/bin/ld
+
+# -------------------------------------------------------------------
 # GCC 14.3.0 (set as final compiler)
 # -------------------------------------------------------------------
 RUN curl -OL https://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-14.3.0/gcc-14.3.0.tar.gz && \


### PR DESCRIPTION
## Description

Closes #36127.

The `pkg_deb_agent_builder_amd64` image (debian:7) was modernized to GCC 14.3 in September 2025 but kept its stock `binutils 2.22`. That binutils version predates two things GCC 14.3 emits unconditionally on x86_64:

- The `R_X86_64_REX_GOTPCRELX` relocation (added in binutils **2.26**).
- The `.note.gnu.property` section used to carry CET metadata.

So any object produced by this image with GCC 14.3 can fail to link with a `bfd_get_reloc_size internal error`. The same modernization wave already bumped the equivalent piece in `pkg_deb_manager_builder_amd64` (binutils 2.38 from a prebuilt `.deb`) and `pkg_rpm_agent_builder_amd64` (binutils 2.41 from source); deb-agent amd64 is the one that was missed.

## Proposed Changes

- `packages/debs/amd64/agent/Dockerfile`: add a binutils 2.41 from-source build step between the GCC 9.4.0 bootstrap and the GCC 14.3 final compiler. Recipe mirrors the existing one in `packages/rpms/amd64/agent/Dockerfile`. After install, `/usr/bin/ld` is repointed at `/usr/local/bin/ld` so GCC 14.3 finds it.

The prebuilt `binutils_2.38-1_amd64.deb` that deb-manager uses is not an option here: it was packaged on debian:8 (glibc 2.19) and would not run on debian:7 (glibc 2.13). Building from source matches what rpm-agent already does for centos:6.

### Results and Evidence

The build break this fixes was captured while reworking the externals build (#36063):

```
[...]/x86_64-pc-linux-gnu/bin/ld: BFD (GNU Binutils for Debian) 2.22 internal error,
aborting at /build/buildd/binutils-2.22/bfd/reloc.c line 444 in bfd_get_reloc_size
```

Fleet status after this change:

| Image | OS base | binutils | Status |
|---|---|---|---|
| `pkg_rpm_agent_builder_amd64` | centos:6 | 2.41 (built from source) | unchanged |
| `pkg_rpm_manager_builder_amd64` | centos:7 | 2.30 (distro) | unchanged |
| `pkg_deb_manager_builder_amd64` | debian:8 | 2.38 (prebuilt `.deb`) | unchanged |
| `pkg_deb_agent_builder_amd64` | debian:7 | **2.22 → 2.41 (this PR)** | fixed |
| `pkg_deb_agent_builder_arm64` | debian:stretch | 2.28 (distro) | unchanged |

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — covered indirectly: the builder-image pipeline rebuilds this image, and the externals rebuild on top of the new image will link cleanly. To be reconfirmed after the GHCR image is republished.
  - [ ] Windows — N/A (Windows agent uses a separate MinGW cross-compile path).
  - [ ] MAC OS X — N/A (macOS uses its own Xcode toolchain).
- [ ] Log syntax and correct language review — N/A (no runtime code changes).

Memory tests, decoder/rule tests, engine tests, API tests — N/A. The change is build-environment only; runtime behavior of the agent is unaffected.

### Artifacts Affected

- `pkg_deb_agent_builder_amd64` GHCR image. Once republished by the builder-image pipeline, subsequent agent package builds and any externals rebuild on amd64 deb pick up the new linker.
- No runtime artifact (the agent binary itself, glibc requirements, default config) is altered.

### Configuration Changes

N/A. binutils is a build-time tool; the runtime ABI of artifacts produced by this image is unchanged. The glibc 2.12 floor of debian:7 still defines the agent's runtime portability surface.

### Tests Introduced

N/A.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — N/A
- [ ] Configuration changes documented — N/A
- [ ] Developer documentation reflects the changes — N/A
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues