### PR TITLE
Refresh apt index before installing flex/bison for binutils 2.41

### DIFF
--- a/packages/debs/amd64/agent/Dockerfile
+++ b/packages/debs/amd64/agent/Dockerfile
@@ -57,15 +57,15 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
 # -------------------------------------------------------------------
 RUN apt-get update -y && \
     apt-get install -y --force-yes flex bison && \
-    curl -OL https://github.com/bminor/binutils-gdb/archive/refs/tags/binutils-2_41.tar.gz && \
-    tar xzf binutils-2_41.tar.gz && rm -f binutils-2_41.tar.gz && \
-    cd binutils-gdb-binutils-2_41 && mkdir build && cd build && \
+    curl -OL https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.gz && \
+    tar xzf binutils-2.41.tar.gz && rm -f binutils-2.41.tar.gz && \
+    cd binutils-2.41 && mkdir build && cd build && \
     ../configure --disable-gdb --disable-werror --disable-zlib \
         --disable-gprofng --disable-gdbserver --disable-gdbsupport \
         --disable-gnulib --disable-gold --disable-gprof --disable-texinfo \
         --disable-binutils --disable-sim && \
     make MAKEINFO=true -j$(nproc) && make MAKEINFO=true install && \
-    cd / && rm -rf binutils-gdb-binutils-2_41 && \
+    cd / && rm -rf binutils-2.41 && \
     ln -fs /usr/local/bin/ld /usr/bin/ld
 
 # -------------------------------------------------------------------

--- a/packages/debs/amd64/agent/Dockerfile
+++ b/packages/debs/amd64/agent/Dockerfile
@@ -55,7 +55,8 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
 # R_X86_64_REX_GOTPCRELX and .note.gnu.property — both emitted by
 # GCC 14.3 and required to link externals built on this image).
 # -------------------------------------------------------------------
-RUN apt-get install -y --force-yes flex bison && \
+RUN apt-get update -y && \
+    apt-get install -y --force-yes flex bison && \
     curl -OL https://github.com/bminor/binutils-gdb/archive/refs/tags/binutils-2_41.tar.gz && \
     tar xzf binutils-2_41.tar.gz && rm -f binutils-2_41.tar.gz && \
     cd binutils-gdb-binutils-2_41 && mkdir build && cd build && \


### PR DESCRIPTION
## Description

Closes #36132. Follow-up to #36127 / #36128.

The binutils 2.41 RUN block added to `packages/debs/amd64/agent/Dockerfile` in #36128 starts with `apt-get install -y --force-yes flex bison`, but an earlier RUN (line 23 of the same Dockerfile) ends with `rm -rf /var/lib/apt/lists/*`. By the time the binutils block runs, the apt package index is empty and the install fails:

```
E: Package 'flex' has no installation candidate
E: Package 'bison' has no installation candidate
ERROR: process "/bin/sh -c apt-get install -y --force-yes flex bison && curl -OL ..."
       did not complete successfully: exit code: 100
```

## Proposed Changes

- `packages/debs/amd64/agent/Dockerfile`: prepend `apt-get update -y &&` to the binutils RUN block. Matches the pattern in the deb-manager Dockerfile (which also re-runs `apt-get update` before each install that follows a list-wipe).

### Results and Evidence

Failure log captured from the builder-image pipeline run that processed #36128 on `main`:

```
#13 0.149 E: Package 'flex' has no installation candidate
#13 0.149 E: Package 'bison' has no installation candidate
#13 ERROR: process "/bin/sh -c apt-get install -y --force-yes flex bison && ..."
          did not complete successfully: exit code: 100
[retry] Build image ghcr.io/wazuh/pkg_deb_agent_builder_amd64:5.0.0: failed after 2 attempts (exit code 1).
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — the builder-image pipeline will rebuild `pkg_deb_agent_builder_amd64` with this fix; that's the same image that failed before, so a green build of that image is the test.
  - [ ] Windows — N/A
  - [ ] MAC OS X — N/A
- [ ] Log syntax and correct language review — N/A

Memory tests, decoder/rule tests, engine tests, API tests — N/A. Build-environment-only change.

### Artifacts Affected

- `pkg_deb_agent_builder_amd64` GHCR image. No runtime artifact is altered.

### Configuration Changes

N/A.

### Tests Introduced

N/A.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — N/A
- [ ] Configuration changes documented — N/A
- [ ] Developer documentation reflects the changes — N/A
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues