### PR TITLE
Improve json schema for optional time

### DIFF
--- a/src/engine/ruleset/schemas/wazuh-decoders.json
+++ b/src/engine/ruleset/schemas/wazuh-decoders.json
@@ -15574,9 +15574,8 @@
           "type": "array"
         },
         "date": {
-          "description": "Creation date in ISO 8601 date-time format",
-          "format": "date-time",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "description": "Creation date in ISO 8601 date or date-time format",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$",
           "type": "string"
         },
         "description": {
@@ -15586,9 +15585,8 @@
           "type": "string"
         },
         "modified": {
-          "description": "Last modification date in ISO 8601 date-time format",
-          "format": "date-time",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "description": "Last modification date in ISO 8601 date or date-time format",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$",
           "type": "string"
         },
         "references": {

--- a/src/engine/ruleset/schemas/wazuh-decoders.template.json
+++ b/src/engine/ruleset/schemas/wazuh-decoders.template.json
@@ -41,15 +41,13 @@
         "author": { "type": "string" },
         "date": {
           "type": "string",
-          "format": "date-time",
-          "description": "Creation date in ISO 8601 date-time format",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+          "description": "Creation date in ISO 8601 date or date-time format",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
         },
         "modified": {
           "type": "string",
-          "format": "date-time",
-          "description": "Last modification date in ISO 8601 date-time format",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+          "description": "Last modification date in ISO 8601 date or date-time format",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
         },
         "description": { "type": "string" },
         "references": { "type": "array", "items": { "type": "string" } },


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

The JSON schemas used to validate decoder metadata only accepted ISO 8601 **date-time** values (e.g. `2025-09-30T12:00:00Z`) for the `metadata.date` and `metadata.modified` fields. Authors needed to be able to provide a date-only value (e.g. `2025-09-30`) without a time component.

This is a schema-only change. No binary is affected and no runtime behavior is modified.

Closes #36135

## Proposed Changes

- Updated `src/engine/ruleset/schemas/wazuh-decoders.json` and `src/engine/ruleset/schemas/wazuh-decoders.template.json`:
  - `metadata.date` and `metadata.modified` now accept either `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ`.
  - Regex updated to `^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$`.
  - Removed the `"format": "date-time"` keyword, as the field is no longer strictly a date-time.
  - Updated the `description` of both fields to reflect that date-only is allowed.
- Previously accepted date-time values remain valid (backward compatible).

### Results and Evidence

Schema validation matrix for the new pattern `^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$`:

| Input value              | Before | After |
|--------------------------|--------|-------|
| `2025-09-30T12:00:00Z`   | valid  | valid |
| `2025-09-30`             | invalid | valid |
| `2025-09-30T12:00:00`    | invalid | invalid |
| `25-09-30`               | invalid | invalid |
| `2025/09/30`             | invalid | invalid |

**Before**

<img width="2294" height="1383" alt="image" src="https://github.com/user-attachments/assets/24ea75fd-4f03-4046-aebe-72c11f8909cf" />

**After**
<img width="1476" height="873" alt="image" src="https://github.com/user-attachments/assets/2aed9894-b814-4ee6-8aef-6a10162e4215" />


### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `src/engine/ruleset/schemas/wazuh-decoders.json`
- `src/engine/ruleset/schemas/wazuh-decoders.template.json`

No executables, packages or default configuration files are modified.

### Configuration Changes

N/A



## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
