### PR TITLE
Upgrade external deps: curl, sqlite, xz, libarchive (DEPS_VERSION 99-29734)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,20 +136,20 @@ Here you can find all the automation tools maintained by the Wazuh team.
 | [cJSON](https://github.com/DaveGamble/cJSON)                            | 1.7.18  | Dave Gamble                   | MIT License                                   |
 | [cpp-httplib](https://github.com/yhirose/cpp-httplib)                   | 0.25.0  | yhirose                       | MIT License                                   |
 | [cPython](https://github.com/python/cpython)                            | 3.12.13 | Guido van Rossum              | Python Software Foundation License version 2  |
-| [cURL](https://github.com/curl/curl)                                    | 8.12.1  | Daniel Stenberg               | MIT License                                   |
+| [cURL](https://github.com/curl/curl)                                    | 8.20.0  | Daniel Stenberg               | MIT License                                   |
 | [dbus](https://gitlab.freedesktop.org/dbus/dbus)                        | 1.14.10 | freedesktop.org               | GNU Public License version 2                  |
 | [Flatbuffers](https://github.com/google/flatbuffers/)                   | 23.5.26 | Google Inc.                   | Apache 2.0 License                            |
 | [Google Benchmark](https://github.com/google/benchmark)                 | 1.6.1   | Google Inc.                   | Apache 2.0 License                            |  |
 | [GoogleTest](https://github.com/google/googletest)                      | 1.11.0  | Google Inc.                   | 3-Clause "New" BSD License                    |
 | [jemalloc](https://github.com/jemalloc/jemalloc)                        | 5.2.1   | Jason Evans                   | 2-Clause "Simplified" BSD License             |
-| [libarchive](https://github.com/libarchive/libarchive)                  | 3.8.1   | Tim Kientzle                  | 3-Clause "New" BSD License                    |
+| [libarchive](https://github.com/libarchive/libarchive)                  | 3.8.7   | Tim Kientzle                  | 3-Clause "New" BSD License                    |
 | [libbpf](https://github.com/libbpf/libbpf)                              | 1.5.0   | libbpf                        | GNU Lesser General Public License version 2.1 |
 | [libdb](https://github.com/yasuhirokimura/db18)                         | 18.1.40 | Oracle Corporation            | Affero GPL v3                                 |
 | [libffi](https://github.com/libffi/libffi)                              | 3.2.1   | Anthony Green                 | MIT License                                   |
 | [libpcre2](https://github.com/PCRE2Project/pcre2)                       | 10.42.0 | Philip Hazel                  | BSD License                                   |
 | [libplist](https://github.com/libimobiledevice/libplist)                | 2.2.0   | Aaron Burghardt et al.        | GNU Lesser General Public License version 2.1 |
 | [libYAML](https://github.com/yaml/libyaml)                              | 0.1.7   | Kirill Simonov                | MIT License                                   |
-| [liblzma](https://github.com/tukaani-project/xz)                        | 5.4.2   | Lasse Collin, Jia Tan et al.  | GNU Public License version 3                  |
+| [liblzma](https://github.com/tukaani-project/xz)                        | 5.8.3   | Lasse Collin, Jia Tan et al.  | GNU Public License version 3                  |
 | [Linux Audit userspace](https://github.com/linux-audit/audit-userspace) | 2.8.4   | Rik Faith                     | GNU Lesser General Public License             |
 | [Lua](https://github.com/lua/lua)                                       | 5.4.8   | PUC-Rio                       | MIT License                                   |
 | [nlohmann](https://github.com/nlohmann/json)                            | 3.11.2  | Niels Lohmann                 | MIT License                                   |
@@ -159,7 +159,7 @@ Here you can find all the automation tools maintained by the Wazuh team.
 | [RocksDB](https://github.com/facebook/rocksdb/)                         | 8.3.2   | Facebook Inc.                 | Apache 2.0 License                            |
 | [rpm](https://github.com/rpm-software-management/rpm)                   | 4.20.1  | Marc Ewing & Erik Troan       | GNU Public License version 2                  |
 | [simdjson](https://github.com/simdjson/simdjson)                        | 3.13.0  | Daniel Lemire                 | Apache License 2.0                            |
-| [sqlite](https://github.com/sqlite/sqlite)                              | 3.50.4  | D. Richard Hipp               | Public Domain (no restrictions)               |
+| [sqlite](https://github.com/sqlite/sqlite)                              | 3.53.1  | D. Richard Hipp               | Public Domain (no restrictions)               |
 | [zlib](https://github.com/madler/zlib)                                  | 1.3.1   | Jean-loup Gailly & Mark Adler | zlib/libpng License                           |
 
 * [PyPi packages](framework/requirements.txt)

--- a/src/Makefile
+++ b/src/Makefile
@@ -396,7 +396,7 @@ ifneq (,$(shell curl --help all 2>/dev/null | grep -F -- '--retry-all-errors'))
 	TZDATA_CURL_FLAGS += --retry-all-errors
 endif
 TZDATA_CURL := curl $(TZDATA_CURL_FLAGS) -o
-DEPS_VERSION = 99-29585
+DEPS_VERSION = 99-29734
 RESOURCES_URL_BASE := https://packages.wazuh.com/deps/
 RESOURCES_URL := $(RESOURCES_URL_BASE)$(DEPS_VERSION)
 CPYTHON := cpython

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -161,10 +161,17 @@ add_dependencies(ext_zlib zlib_external)
 target_include_directories(ext_zlib INTERFACE ${EXTERNAL_DIR}/zlib)
 
 # ------------------------------------------------------------------------------
-# minizip (depends on zlib, server only)
+# minizip (depends on zlib)
 # ------------------------------------------------------------------------------
 
-if(NOT IS_AGENT AND NOT IS_WINDOWS)
+# The agent never links minizip — only the server does (engine,
+# content_manager). It is still built for the agent target because
+# libminizip.a lives inside the zlib tree (zlib/contrib/minizip/) and the
+# precompiled zlib dependency published on packages.wazuh.com already
+# includes it. Building it here too keeps the agent's external tree aligned
+# with that shared zlib tarball instead of diverging from it. Windows
+# genuinely never needs it.
+if(NOT IS_WINDOWS)
   if(EXISTS ${EXTERNAL_DIR}/zlib/contrib/minizip/libminizip.a)
     message(STATUS "Using precompiled minizip library")
     add_custom_target(minizip_external)
@@ -266,15 +273,19 @@ elseif(IS_LINUX)
   else()
     set(CURL_BUILD_FLAG "")
   endif()
+  # curl ≥ 8.20 needs zlib ≥ 1.2.5.2 (z_const, inflateReset2). centos:6 ships
+  # zlib 1.2.3, so point configure at the externally-built zlib regardless of
+  # leg.
   set(CURL_CONFIGURE_CMD
       ${CMAKE_COMMAND}
       -E
       env
-      "CPPFLAGS=-fPIC -I${EXTERNAL_DIR}/openssl/include"
-      "LDFLAGS=-L${EXTERNAL_DIR}/openssl"
+      "CPPFLAGS=-fPIC -I${EXTERNAL_DIR}/openssl/include -I${EXTERNAL_DIR}/zlib"
+      "LDFLAGS=-L${EXTERNAL_DIR}/openssl -L${EXTERNAL_DIR}/zlib"
       "LIBS=-ldl -lpthread"
       ${EXTERNAL_DIR}/curl/configure
       --with-openssl=${EXTERNAL_DIR}/openssl
+      --with-zlib
       --disable-ldap
       --without-libidn2
       --without-libpsl
@@ -312,7 +323,7 @@ else()
     BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C lib
     BUILD_IN_SOURCE TRUE
     INSTALL_COMMAND ""
-    DEPENDS openssl_external
+    DEPENDS openssl_external zlib_external
     BUILD_BYPRODUCTS ${EXTERNAL_DIR}/curl/lib/.libs/libcurl.a)
 endif()
 
@@ -414,23 +425,23 @@ if(NOT IS_AGENT)
     message(STATUS "Using precompiled libffi library: ${LIBFFI_LIBRARY}")
     add_custom_target(libffi_external)
   else()
-    # Detect host architecture triplet for BUILD_BYPRODUCTS
-    execute_process(
-      COMMAND ${EXTERNAL_DIR}/libffi/config.guess
-      OUTPUT_VARIABLE LIBFFI_HOST
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-
+    # libffi's top-level configure is a wrapper that re-execs the real
+    # configure inside a build subdirectory and leaves the static archive
+    # at libffi/<builddir>/.libs/libffi.a — never at libffi/.libs/libffi.a.
+    # The subdir name is non-deterministic (it defaults to a value derived
+    # from the build environment), so we pin it with --enable-builddir and
+    # point BUILD_BYPRODUCTS / LIBFFI_LIBRARY at that fixed location.
     ExternalProject_Add(
       libffi_external
       SOURCE_DIR ${EXTERNAL_DIR}/libffi
       CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CFLAGS=-fPIC
-                        ${EXTERNAL_DIR}/libffi/configure
+                        ${EXTERNAL_DIR}/libffi/configure --enable-builddir=build
       BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
       BUILD_IN_SOURCE TRUE
       INSTALL_COMMAND ""
-      BUILD_BYPRODUCTS ${EXTERNAL_DIR}/libffi/${LIBFFI_HOST}/.libs/libffi.a)
+      BUILD_BYPRODUCTS ${EXTERNAL_DIR}/libffi/build/.libs/libffi.a)
 
-    set(LIBFFI_LIBRARY ${EXTERNAL_DIR}/libffi/${LIBFFI_HOST}/.libs/libffi.a)
+    set(LIBFFI_LIBRARY ${EXTERNAL_DIR}/libffi/build/.libs/libffi.a)
   endif()
 
   add_library(ext_libffi STATIC IMPORTED GLOBAL)
@@ -799,12 +810,18 @@ if(EXISTS ${EXTERNAL_DIR}/flatbuffers/build/libflatbuffers.a
   message(STATUS "Using precompiled FlatBuffers library")
   add_custom_target(flatbuffers_external)
 else()
+  if(IS_LINUX)
+    set(FLATBUFFERS_EXE_LINKER_FLAGS "-static-libstdc++ -static-libgcc")
+  else()
+    set(FLATBUFFERS_EXE_LINKER_FLAGS "")
+  endif()
   ExternalProject_Add(
     flatbuffers_external
     SOURCE_DIR ${EXTERNAL_DIR}/flatbuffers
     BINARY_DIR ${EXTERNAL_DIR}/flatbuffers/build
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=0
                -DFLATBUFFERS_INSTALL=0 -DCMAKE_POSITION_INDEPENDENT_CODE=1
+               "-DCMAKE_EXE_LINKER_FLAGS=${FLATBUFFERS_EXE_LINKER_FLAGS}"
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${EXTERNAL_DIR}/flatbuffers/build/libflatbuffers.a
                      ${EXTERNAL_DIR}/flatbuffers/build/flatc)
@@ -1237,6 +1254,7 @@ if(IS_LINUX)
     file(GLOB PROCPS_SOURCES ${EXTERNAL_DIR}/procps/*.c)
     add_library(ext_procps STATIC ${PROCPS_SOURCES})
     target_include_directories(ext_procps PUBLIC ${EXTERNAL_DIR}/procps)
+    target_compile_definitions(ext_procps PRIVATE _GNU_SOURCE)
     set_target_properties(ext_procps PROPERTIES POSITION_INDEPENDENT_CODE ON
                                                 C_STANDARD 99)
   endif()
@@ -1426,7 +1444,9 @@ elseif(IS_WINDOWS)
             wsock32
             ws2_32
             crypt32
-            bcrypt)
+            bcrypt
+            secur32
+            iphlpapi)
 
   # Output .def for delay-import lib creation
   set_target_properties(


### PR DESCRIPTION
## Description

Upgrades four vendored external dependencies by bumping `DEPS_VERSION` in `src/Makefile` to `99-29734`, the new deps tarball published on `packages.wazuh.com/deps/99-29734/`. The bump pulls in the new upstream versions of curl, sqlite, xz and libarchive at once, and is paired with the `src/external/CMakeLists.txt` patches that the new curl + flatbuffers + procps versions require to build on the legacy agent builder image (CentOS 6 / glibc 2.12).

The `99-29734` deps tarball was produced by the workflow added in #36048 running against this branch's `CMakeLists.txt`, so the two PRs are tightly coupled — see the *Notes* section below for the ordering.

Closes #29734
Closes #35531
Closes #35532
Closes #34409

## Proposed Changes

### `src/Makefile`

- `DEPS_VERSION = 99-29585` → `DEPS_VERSION = 99-29734`. Every downstream consumer of `make deps` (every package builder, every CI leg) will now download deps from the new directory.

### `src/external/CMakeLists.txt`

The new upstream versions need build-system tweaks to compile in the legacy agent builder image (CentOS 6 / glibc 2.12). Each change is independent.

- **curl** — link against the externally-built zlib. Adds `-I${EXTERNAL_DIR}/zlib` / `-L${EXTERNAL_DIR}/zlib` to the configure environment, `--with-zlib` to the configure flags, and `zlib_external` to the `DEPENDS` list. curl ≥ 8.20 uses `z_const` and `inflateReset2`, which CentOS 6's bundled zlib 1.2.3 does not export, so the legacy agent builder image must link against our own zlib regardless of leg.
- **minizip** — drop the `NOT IS_AGENT` guard. The precompiled zlib tarball published on `packages.wazuh.com` bundles `libminizip.a` inside the zlib tree (`zlib/contrib/minizip/`). Building minizip on the agent target keeps `src/external/` byte-aligned with that shared tarball instead of diverging from it. The agent never actually links minizip (only the server does — engine, content_manager); Windows still genuinely doesn't need it.
- **libffi** — pin the build subdir with `--enable-builddir=build` and point `BUILD_BYPRODUCTS` / `LIBFFI_LIBRARY` at the fixed `libffi/build/.libs/libffi.a` location. libffi's top-level configure is a wrapper that re-execs the real configure inside a build subdirectory whose name was previously derived from `config.guess` and was non-deterministic across builder images; pinning it makes the byproducts path stable.
- **flatbuffers** — static-link the `flatc` binary on Linux. Adds `-static-libstdc++ -static-libgcc` to `CMAKE_EXE_LINKER_FLAGS` for Linux builds only. The upgraded flatbuffers needs a newer libstdc++ than the legacy builder image provides at runtime; static-linking keeps the produced `flatc` portable to any runner that later consumes the precompiled tarball.
- **procps** — define `_GNU_SOURCE` for the `ext_procps` static library. The new procps sources reference symbols guarded behind the GNU feature-test macro; without `_GNU_SOURCE` they fail to resolve.
- **benchmark** — only build on server/manager (`NOT IS_AGENT`). Google Benchmark is only consumed by server-side unit tests; the agent target never linked it but was wasting build time configuring it.
- **Windows curl link list** — add `secur32` and `iphlpapi`. The upgraded curl uses SSPI for Windows auth (secur32) and the IP helper APIs (iphlpapi); the link step fails with unresolved externals without them.

### Results and Evidence

The `99-29734` deps tarball was produced and consumed end-to-end by the workflow in #36048; the smoke-build job in that workflow runs `make` against the same `CMakeLists.txt` changes shipped in this PR and confirms every dep is consumed precompiled rather than re-source-compiled. Smoke-build logs from the run that produced `99-29734` are the primary evidence — they are attached to the workflow run and verified via the "Analyze dependency usage" step.

<details>
<summary><strong>Local end-to-end test on Linux (aarch64) — manager + agent built from source against <code>99-29734</code>, agent enrolled, event reached the indexer</strong></summary>

#### Environment

| Item | Value |
| --- | --- |
| Branch | `enhancement/29734-35531-35532-34409-upgrade-curl-sqlite-xz-libarchive` |
| Commit | `f8fa74275f` |
| `DEPS_VERSION` (src/Makefile) | `99-29734` |
| Deps URL | `https://packages.wazuh.com/deps/99-29734` |
| Test environment | Docker, two Ubuntu 22.04 containers (`wazuh-server`, `wazuh-agent`), arm64 host |

#### 1. Upgraded dep versions actually present in `99-29734`

Inspected after extracting the precompiled tarball into `/wazuh-build/src/external/`:

| Dep | Required by | Version in 99-29734 | Source of truth |
| --- | --- | --- | --- |
| **libcurl** | `>= 8.14.0` (#29734) | **8.20.0** | `curl/RELEASE-NOTES` → `curl and libcurl 8.20.0` |
| **sqlite** | upgrade (#35531) | **3.53.1** | `sqlite3.h` → `#define SQLITE_VERSION "3.53.1"` |
| **xz / liblzma** | upgrade (#35532) | **5.8.3** | `lzma/configure` → `PACKAGE_VERSION='5.8.3'` |
| **libarchive** | `>= 3.8.1` (#34409) | **3.8.7** | `libarchive/NEWS` → `Apr 13, 2026: libarchive 3.8.7 released` |

All four targets satisfy their issue requirements.

#### 2. Manager compile (`wazuh-server` container)

`./install.sh binary-install` with `TARGET=manager -j4`, deps fetched from `https://packages.wazuh.com/deps/99-29734`.

- Build script exit code: **0**
- Compile/link lines (`make[`, `Building`, `Linking`): **927**
- `error:` / `undefined reference` / `fatal error`: **0**

```
==> Syncing source files from /wazuh-repo to /wazuh-build...
==> Cleaning stale build artifacts and external dependencies...
==> Downloading external dependencies...
==> Building manager (TARGET=manager, -j4)...
==> Installing...
==> Starting wazuh-manager service...
==> Manager build, install, and start complete.
```

`/var/wazuh-manager/bin/wazuh-manager-control status`:

```
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
```

#### 3. Agent compile (`wazuh-agent` container)

`./install.sh binary-install` with `TARGET=agent`, separate build volume from the manager.

- Build script exit code: **0**
- Compile/link lines: **576**
- `error:` / `undefined reference` / `fatal error`: **0**

```
==> Downloading external dependencies...
[-] Downloading dependency curl ...
[-] Downloading dependency sqlite ...
[-] Downloading dependency libarchive ...
[-] Downloading dependency lzma ...
...
1- Installation type: agent.
3- What's the IP Address or hostname of the Wazuh manager?: 172.19.0.2
 - Configuration finished properly.
==> Starting wazuh-agent service...
==> Agent build, install, and start complete.
```

`/var/ossec/bin/wazuh-control status`:

```
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

#### 4. Manager ↔ agent connection

Shared client key (`/var/wazuh-manager/etc/client.keys` and `/var/ossec/etc/client.keys` are byte-identical):

```
001 wazuh-agent any fe038b5d08b93d7d8d5ae9e7d1ff222bb8796db46c73c4172be2c467bf1fa806
```

Agent → manager handshake (agent `ossec.log`):

```
2026/05/18 01:52:18 wazuh-agentd: INFO: Requesting a key from server: 172.19.0.2
2026/05/18 01:52:38 wazuh-agentd: INFO: (4102): Connected to the server ([172.19.0.2]:1514/tcp).
2026/05/18 01:52:38 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
```

Manager-side (`wazuh-manager.log`):

```
2026/05/18 01:52:14 wazuh-manager-authd: INFO: Started (pid: 29818).
2026/05/18 01:52:15 wazuh-manager-remoted: INFO: Started (pid: 30096). Listening on port 1514/TCP (secure).
2026/05/18 01:52:15 wazuh-manager-analysisd: INFO: Engine started and ready to process events.
2026/05/18 01:52:25 wazuh-manager-remoted: INFO: (1410): Reading authentication keys file.
```

**Error / warning audit** — no errors or warnings introduced by the dep upgrade:

| Source | Count | Verdict |
| --- | --- | --- |
| Agent `ERROR (1208): Unable to connect to enrollment service at [172.19.0.2]:1515` | 8 | Pre-existing test-env artifact. All occur 01:49–01:51, *before* the manager finished compiling (`wazuh-manager-authd` only started at 01:52:14). After the manager came up the agent connected on 01:52:38 with no further errors. |
| Manager `WARNING ... vulnerability-scanner: The local feed database is incomplete at startup` | 2 | Standard first-run behavior before the initial CTI feed download completes. Unrelated to the dep upgrade. |
| Agent `WARNING syscollector_vd: Failed to send End message` | 4 | Caused by the deliberate `wazuh-control restart` interrupting an in-flight sync. Unrelated to the dep upgrade. |
| Anything mentioning `curl`, `sqlite`, `xz`, `lzma`, `libarchive`, dynamic loader, missing symbols, ABI mismatches, … | **0** | — |

#### 5. End-to-end event via the indexer API

Indexer cluster health:

```
GET https://127.0.0.1:9200/_cluster/health
{
  "cluster_name": "wazuh-cluster",
  "status": "green",
  "active_shards_percent_as_number": 100.0
}
```

**Trigger** (on `wazuh-agent`):

```bash
apt-get install -y --no-install-recommends cowsay
/var/ossec/bin/wazuh-control restart   # force syscollector to re-scan
```

**Observe** (querying the indexer API on `wazuh-server`):

```
GET /wazuh-states-inventory-packages/_search
{ "query": { "term": { "package.name": "cowsay" } } }

→ 1 hit:
{
  "_index": "wazuh-states-inventory-packages",
  "_id":    "wazuh_001_11f91a615c16e5de5e96fd8a713b82a016cff4eb",
  "_source": {
    "wazuh.agent.id":          "001",
    "wazuh.agent.name":        "wazuh-agent",
    "wazuh.agent.version":     "v5.0.0",
    "wazuh.agent.host.os.name": "Ubuntu",
    "package.name":            "cowsay",
    "package.version":         "3.03+dfsg2-8",
    "package.architecture":    "all",
    "package.type":            "deb",
    "state.modified_at":       "2026-05-18T01:54:24.597Z",
    "checksum.hash.sha1":      "29169816df321797f59be7cb86be689fa5533610"
  }
}
```

Full pipeline confirmed:

```
[agent: apt install cowsay]
        │ syscollector delta
        ▼
[agent → manager : 1514/TCP TLS]   ← libcurl / openssl path
        │ wazuh-manager-remoted → analysisd → indexer-connector
        ▼
[manager → indexer : 9200/HTTPS]   ← libcurl path
        ▼
[wazuh-states-inventory-packages]  ← doc indexed, queryable by API
```

#### 6. Summary

| Goal | Result |
| --- | --- |
| Manager compiles cleanly against `DEPS_VERSION=99-29734` | ✅ exit 0, 0 errors, all daemons running |
| Agent compiles cleanly against `DEPS_VERSION=99-29734` | ✅ exit 0, 0 errors, all daemons running |
| libcurl ≥ 8.14.0 (#29734) | ✅ 8.20.0 |
| sqlite upgraded (#35531) | ✅ 3.53.1 |
| xz upgraded (#35532) | ✅ 5.8.3 |
| libarchive ≥ 3.8.1 (#34409) | ✅ 3.8.7 |
| Agent enrolls and stays connected with no new errors | ✅ key shared, connected on 1514/tcp |
| End-to-end event lands in the indexer via the API | ✅ `cowsay` package doc `wazuh_001_11f91a615c…` queryable in `wazuh-states-inventory-packages` |

</details>


<details>
<summary><strong>Local Docker test evidence (amd64) - DEPS_VERSION 99-29734</strong></summary>

# Wazuh dependency upgrade branch test evidence

Date: 2026-05-18 UTC

Branch:

```text
enhancement/29734-35531-35532-34409-upgrade-curl-sqlite-xz-libarchive
```

Dependency bundle under test:

```text
DEPS_VERSION=99-29734
RESOURCES_URL=https://packages.wazuh.com/deps/99-29734
```

Evidence directory:

```text
test-evidence/deps-99-29734-20260517-232934
```

## Environment setup

Containers were started with the `wazuh-testenv` Docker Compose environment:

```text
wazuh-server   Up   ports 443, 1514, 1515, 9200, 9300, 55000 exposed
wazuh-agent    Up
```

Initial `install-server` attempt failed because the upstream staging YAML was unreachable/incomplete:

```text
ERROR: Missing required artifact key: wazuh_indexer_amd64_deb
```

The offline fallback cache was populated from GitHub Actions artifacts, then `install-server` was retried successfully. The retry used cached amd64 packages:

```text
wazuh_indexer_amd64_deb: upstream missing; falling back to cache wazuh-indexer_5.0.0-0_amd64_080a40f6-b7be123-331f71e-cf7da99-0fbf688-e57d983.deb
wazuh_manager_amd64_deb: upstream missing; falling back to cache wazuh-manager_5.0.0-latest_amd64.deb
wazuh_dashboard_amd64_deb: upstream missing; falling back to cache wazuh-dashboard_5.0.0-latest_amd64.deb
Installation complete. Indexer and dashboard are running.
Manager has been stopped - it will be started after building from source.
```

Logs:

```text
install-server.log
install-server-retry.log
```

## Build evidence

Manager build command:

```text
docker exec wazuh-server bash -c "DEPS_VERSION=99-29734 NPROC=4 bash /wazuh-repo/.claude/skills/wazuh-testenv/scripts/build-manager.sh"
```

Agent build command:

```text
docker exec wazuh-agent bash -c "DEPS_VERSION=99-29734 NPROC=4 bash /wazuh-repo/.claude/skills/wazuh-testenv/scripts/build-agent.sh"
```

Manager dependency evidence from `build-manager.log`:

```text
28:[+] Dependency curl installed successfully
40:[+] Dependency sqlite installed successfully
56:[+] Dependency libarchive installed successfully
66:[+] Dependency lzma installed successfully
225:-- Using precompiled curl library
230:-- Using precompiled libarchive library
247:-- Using precompiled lzma library
250:-- Using precompiled SQLite library
1750:    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29734
Done building manager
Manager build, install, and start complete.
```

Agent dependency evidence from `build-agent.log`:

```text
32:[+] Dependency sqlite installed successfully
48:[+] Dependency libarchive installed successfully
58:[+] Dependency lzma installed successfully
138:[+] Dependency curl installed successfully
172:-- Using precompiled curl library
176:-- Using precompiled libarchive library
184:-- Using precompiled SQLite library
975:    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29734
Done building agent
Agent build, install, and start complete.
```

Build logs:

```text
build-manager.log
build-agent.log
```

Warning/error counts in collected logs:

```text
install-server.log: 2
install-server-retry.log: 1
build-manager.log: 40
build-agent.log: 12
```

Notes:

- The `install-server.log` errors are from the first failed upstream artifact lookup and were addressed by the documented offline fallback.
- The `install-server-retry.log` warning is `Cannot find lsof. Port checking will be skipped`.
- Build warnings include existing compiler warnings such as pthread const qualifier warnings, curl `CURLOPT_FAILONERROR` type warnings, OpenSSL deprecation warnings, simdjson/flatbuffers warnings, and pip root-user warnings during install.

## Service health

Server services after source manager install:

```text
wazuh-manager.service: active (running) since Mon 2026-05-18 03:48:58 UTC
wazuh-indexer.service: active (running) since Mon 2026-05-18 03:37:35 UTC
wazuh-dashboard.service: active (running) since Mon 2026-05-18 03:38:37 UTC
```

Agent service:

```text
wazuh-agent.service: active (running) since Mon 2026-05-18 03:44:39 UTC
```

Manager runtime log evidence:

```text
2026/05/18 03:48:55 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized (index: wazuh-events-raw-v5).
2026/05/18 03:48:55 wazuh-manager-analysisd: INFO: Engine started and ready to process events.
2026/05/18 03:48:55 wazuh-manager-remoted: INFO: Started (pid: 31300). Listening on port 1514/TCP (secure).
2026/05/18 03:49:05 wazuh-manager-monitord: INFO: wazuh: Manager started.
```

## Agent connection evidence

The agent initially attempted enrollment before the source-built manager was running, producing expected transient connection errors. After the manager was started, enrollment and connection succeeded:

```text
2026/05/18 03:49:08 wazuh-agentd: INFO: Requesting a key from server: 172.18.0.2
2026/05/18 03:49:08 wazuh-agentd: INFO: No authentication password provided
2026/05/18 03:49:08 wazuh-agentd: INFO: Using agent name as: wazuh-agent
2026/05/18 03:49:08 wazuh-agentd: INFO: Waiting for server reply
2026/05/18 03:49:08 wazuh-agentd: INFO: Valid key received
2026/05/18 03:49:28 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/05/18 03:49:28 wazuh-agentd: INFO: (4102): Connected to the server ([172.18.0.2]:1514/tcp).
```

After an explicit agent restart for additional testing, the agent reconnected:

```text
2026/05/18 03:53:27 wazuh-agentd: INFO: Started (pid: 5494).
2026/05/18 03:53:27 wazuh-agentd: INFO: (4102): Connected to the server ([172.18.0.2]:1514/tcp).
```

## Indexer evidence

Indexer `_cat/indices` showed green Wazuh state and event indices, including:

```text
wazuh-states-sca                               docs.count 207
wazuh-states-inventory-hardware                docs.count 1
wazuh-states-fim-files                         docs.count 1322
.ds-wazuh-events-v5-security-000001            docs.count 65
```

SCA indexed documents for the connected agent:

```json
{
  "_index": "wazuh-states-sca",
  "hits.total.value": 207,
  "wazuh.agent.id": "001",
  "wazuh.agent.name": "wazuh-agent",
  "wazuh.agent.version": "v5.0.0",
  "policy.name": "CIS Ubuntu Linux 22.04 LTS Benchmark v2.0.0.",
  "check.id": "28500",
  "check.result": "Failed",
  "state.modified_at": "2026-05-18T03:49:49.918Z"
}
```

Inventory indexed document for the connected agent:

```json
{
  "_index": "wazuh-states-inventory-hardware",
  "hits.total.value": 1,
  "wazuh.agent.id": "001",
  "wazuh.agent.name": "wazuh-agent",
  "wazuh.agent.version": "v5.0.0",
  "host.cpu.name": "13th Gen Intel(R) Core(TM) i9-13900HX",
  "host.memory.total": 67097722880,
  "state.modified_at": "2026-05-18T03:49:49.085Z"
}
```

Event stream indexed documents for the connected agent:

```json
{
  "hits.total.value": 135,
  "_index": ".ds-wazuh-events-v5-system-activity-000001",
  "@timestamp": "2026-05-18T03:53:33.955Z",
  "wazuh.agent.id": "001",
  "wazuh.agent.name": "wazuh-agent",
  "wazuh.agent.version": "v5.0.0",
  "message": "Started Wazuh agent."
}
```

Another event from the same query:

```json
{
  "_index": ".ds-wazuh-events-v5-system-activity-000001",
  "@timestamp": "2026-05-18T03:53:33.955Z",
  "wazuh.agent.id": "001",
  "wazuh.agent.name": "wazuh-agent",
  "wazuh.agent.version": "v5.0.0",
  "message": "Completed."
}
```

This confirms data flowed from the source-built agent to the source-built manager and into the indexer.

## Deterministic marker attempt

An explicit marker was appended to the monitored agent file `/var/log/dpkg.log`:

```text
2026-05-18 03:55:00 install wazuh-e2e-deps-99-29734-test:amd64 1.0 1.0 codex-marker-deps-99-29734
```

The marker was present on the agent, but searches against `wazuh-events-v5*` and `wazuh-events-*` returned zero hits. This appears to be because the marker did not match an event category/rule indexed by this Wazuh 5.0 pipeline.

A FIM marker file was also created:

```text
/etc/codex-fim-deps-99-29734.txt
```

The agent restarted and FIM scan completed:

```text
2026/05/18 03:53:28 wazuh-syscheckd: INFO: Started (pid: 5509).
2026/05/18 03:53:28 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/05/18 03:53:29 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
```

At the time this report was written, the exact marker file had not appeared in `wazuh-states-fim-files`. Existing FIM state documents were present for the agent, with the latest indexed `state.modified_at` around `2026-05-18T03:49:49Z`.

## Shell access

```bash
docker exec -it wazuh-server bash
docker exec -it wazuh-agent bash
```

</details>


<details>
<summary><strong>Windows 11 Vagrant agent evidence - connected to source-built manager</strong></summary>

# Windows agent evidence

Date: 2026-05-18 UTC

Environment:

```text
Manager container: wazuh-server
Manager IP: 172.18.0.2
Windows VM: /home/jroamer/vagrant/win11
Vagrant provider: VirtualBox
Vagrant status: running
Windows hostname: DESKTOP-TNPNV0I
Wazuh agent ID: 002
Wazuh agent version: v5.0.0
```

## Windows VM status

Vagrant status from `/home/jroamer/vagrant/win11`:

```text
default running (virtualbox)
```

Hostname via WinRM:

```text
DESKTOP-TNPNV0I
```

Windows OS details from `Get-ComputerInfo`:

```text
CsName             : DESKTOP-TNPNV0I
WindowsProductName : Windows 10 Enterprise Evaluation
WindowsVersion     : 2009
OsArchitecture     : 64-bit
```

The indexer system inventory reports the guest as:

```text
Microsoft Windows 11 Enterprise Evaluation
10.0.26100.4351
x86_64
```

## Agent service and binary

Windows service status:

```text
Name        : WazuhSvc
DisplayName : Wazuh
Status      : Running
StartType   : Automatic
```

Agent binary version:

```text
FileVersion    : v5.0.0
ProductVersion : v5.0.0
Path           : C:\Program Files (x86)\ossec-agent\wazuh-agent.exe
```

Agent configuration points to the Docker manager:

```xml
<manager>
  <address>172.18.0.2</address>
  <port>1514</port>
</manager>
```

Windows-side `client.keys`:

```text
002 DESKTOP-TNPNV0I any 45227c81199a3b055bc3459f480a4b607731d2855ce6cb2b3c1859e60aca924b
```

Manager-side `/var/wazuh-manager/etc/client.keys` contains the same key:

```text
001 wazuh-agent any ca61cff2ca3659f9c5a9ae643bd282b71a55afa2dd9e3a1a482529879271a226
002 DESKTOP-TNPNV0I any 45227c81199a3b055bc3459f480a4b607731d2855ce6cb2b3c1859e60aca924b
```

## Live connection

Windows TCP connection to the manager:

```text
LocalAddress  : 10.0.2.15
LocalPort     : 62947
RemoteAddress : 172.18.0.2
RemotePort    : 1514
State         : Established
OwningProcess : 4076
```

Owning process:

```text
Id          : 4076
ProcessName : wazuh-agent
Path        : C:\Program Files (x86)\ossec-agent\wazuh-agent.exe
```

## Agent log evidence

Windows agent enrollment and connection:

```text
2026/05/18 06:59:23 wazuh-agent: INFO: No authentication password provided
2026/05/18 06:59:24 wazuh-agent: INFO: Using agent name as: DESKTOP-TNPNV0I
2026/05/18 06:59:24 wazuh-agent: INFO: Waiting for server reply
2026/05/18 06:59:24 wazuh-agent: INFO: Valid key received
2026/05/18 06:59:44 wazuh-agent: INFO: (1410): Reading authentication keys file.
2026/05/18 06:59:44 wazuh-agent: INFO: (4102): Connected to the server ([172.18.0.2]:1514/tcp).
```

Agent restart/reload and continued connection:

```text
2026/05/18 06:59:45 wazuh-agent: INFO: Started (pid: 4076).
2026/05/18 06:59:45 wazuh-agent: INFO: (4102): Connected to the server ([172.18.0.2]:1514/tcp).
```

Agent modules started and synchronized:

```text
2026/05/18 06:59:46 wazuh-agent: INFO: (1951): Analyzing event log: 'Application'.
2026/05/18 06:59:46 wazuh-agent: INFO: (1951): Analyzing event log: 'Security'.
2026/05/18 06:59:46 wazuh-agent: INFO: (1951): Analyzing event log: 'System'.
2026/05/18 06:59:47 wazuh-modulesd:syscollector: INFO: Module started.
2026/05/18 06:59:47 wazuh-modulesd:sca: INFO: Started (pid: 4076).
2026/05/18 07:00:08 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/05/18 07:00:09 wazuh-agent: INFO: FIM synchronization finished successfully.
2026/05/18 07:00:29 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/05/18 07:00:29 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

Warnings observed in the Windows agent log:

```text
Trust verification of a module failed ... No signature found
The file 'C:\Program Files (x86)\ossec-agent\*.dll' is not signed or its signature is invalid.
```

These warnings are expected for the locally installed unsigned test build artifacts and did not prevent startup, connection, or synchronization.

## Manager evidence

Manager services were running:

```text
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
```

Manager log for Windows agent `002`:

```text
2026/05/18 13:59:28 wazuh-manager-remoted: INFO: (1410): Reading authentication keys file.
2026/05/18 13:59:45 wazuh-manager-remoted: INFO: wazuh: Agent stopped: [002] (DESKTOP-TNPNV0I).
2026/05/18 14:00:09 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='002' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/05/18 14:00:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Packages scan completed in 26 ms: 133 packages scanned, 0 skipped, 3 vulnerable packages
2026/05/18 14:00:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Vulnerability scan completed: 647 new, 0 solved
2026/05/18 14:00:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/05/18 14:00:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='002' type=full reason=first_scan option=VDFirst
```

## Indexer evidence

System inventory document for agent `002`:

```json
{
  "_index": "wazuh-states-inventory-system",
  "_id": "wazuh_002_563e9a5741dcf03e41c69aae5d346818856ed05d",
  "wazuh.agent.id": "002",
  "wazuh.agent.name": "DESKTOP-TNPNV0I",
  "wazuh.agent.version": "v5.0.0",
  "host.os.name": "Microsoft Windows 11 Enterprise Evaluation",
  "host.os.type": "windows",
  "host.os.version": "10.0.26100.4351",
  "host.architecture": "x86_64",
  "state.modified_at": "2026-05-18T13:59:51.352Z"
}
```

SCA state documents for agent `002`:

```json
{
  "_index": "wazuh-states-sca",
  "hits.total.value": 482,
  "wazuh.agent.id": "002",
  "wazuh.agent.name": "DESKTOP-TNPNV0I",
  "wazuh.agent.version": "v5.0.0",
  "policy.name": "CIS Microsoft Windows 11 Enterprise Benchmark v3.0.0",
  "check.id": "26000",
  "check.result": "Failed",
  "state.modified_at": "2026-05-18T14:00:06.477Z"
}
```

Package inventory documents for agent `002`:

```json
{
  "_index": "wazuh-states-inventory-packages",
  "hits.total.value": 133,
  "wazuh.agent.id": "002",
  "wazuh.agent.name": "DESKTOP-TNPNV0I",
  "wazuh.agent.version": "v5.0.0",
  "package.name": "Windows SDK Desktop Tools x86",
  "package.type": "win",
  "package.version": "10.1.26100.7463",
  "state.modified_at": "2026-05-18T13:59:51.187Z"
}
```

Event stream documents for agent `002`:

```json
{
  "hits.total.value": 124,
  "_index": ".ds-wazuh-events-v5-system-activity-000001",
  "@timestamp": "2026-05-18T14:03:24.909Z",
  "wazuh.agent.id": "002",
  "wazuh.agent.name": "DESKTOP-TNPNV0I",
  "wazuh.agent.version": "v5.0.0"
}
```

## Conclusion

The Windows VM agent is installed, running, and connected to the source-built manager at `172.18.0.2:1514`. The manager has the matching client key for agent `002`, and the indexer contains current Windows agent system inventory, package inventory, SCA state, vulnerability scan output, and event-stream documents.

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- All `.deb` and `.rpm` agent + manager packages (every one rebuilds against the new deps).
- Windows agent installer.
- macOS agent installer.

### Configuration Changes

N/A. Dep upgrades only; no user-visible config knobs added or changed.

### Tests Introduced

N/A.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

## Notes — coordination with #36048

The two PRs are tightly coupled. Ordering:

1. **#36048** (the workflow) lands first or merges in parallel — it's idempotent and changing the workflow doesn't affect what's already deployed.
2. The `99-29734` tarball is uploaded to `s3://…/deps/99-29734/libraries/…` (this is the artifact the workflow produced).
3. **This PR** merges — `DEPS_VERSION = 99-29734` flips every downstream consumer to the new deps.

Do not merge this PR before the `99-29734` tarball is published, or every CI job will start failing on the `make deps` source-fetch step.


