### PR TITLE
Update support new OSs issue template for devOps team

### DIFF
--- a/.github/ISSUE_TEMPLATE/planned--specific-support-new-oss.md
+++ b/.github/ISSUE_TEMPLATE/planned--specific-support-new-oss.md
@@ -75,6 +75,7 @@ assignees: ''
 - [ ] Adapt Puppet.
 - [ ] Adapt Ansible.
 - [ ] Update AMI, OVA, or Docker images if needed.
+- [ ] Update the compatibility matrix in the installation assistant if needed.
 -->
 
 <!-- Uncomment for DASHBOARD issue


### PR DESCRIPTION
## Description

As a result of [this issue](https://github.com/wazuh/wazuh-installation-assistant/issues/793), the DevOps team has added another task to update the OS compatibility matrix if necessary.

### Related issue

- https://github.com/wazuh/wazuh-installation-assistant/issues/793