### PR TITLE
Remove unused Node.js 12 from arm64 deb agent builder

### DIFF
--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -16,13 +16,6 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
 # -------------------------------------------------------------------
-# Add Debian's source repository and, Install NodeJS 12
-# -------------------------------------------------------------------
-RUN apt-get update &&  apt-get build-dep python3.5 -y --allow-change-held-packages
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install --allow-change-held-packages -y nodejs
-
-# -------------------------------------------------------------------
 # CMake
 # -------------------------------------------------------------------
 RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-Linux-aarch64.sh && \


### PR DESCRIPTION
## Description

Removes the unused Node.js 12 install block from `packages/debs/arm64/agent/Dockerfile`. The NodeSource `setup_12.x` script is deprecated and its GPG key (`1655A0AB68576280`) is revoked, causing the Docker image build to fail. Node.js is not referenced in `build.sh`, `helper_function.sh`, or any other script executed inside this image.

Closes #36163

## Proposed Changes

- `packages/debs/arm64/agent/Dockerfile` — Remove unused Node.js 12 install block.

## Tests and evidence

Issue confirmed on `main` (commit `5906fd0`): [run #26557928710](https://github.com/wazuh/wazuh/actions/runs/26557928710) ❌

Fix verified on this branch: [run #26559588703](https://github.com/wazuh/wazuh-agent-packages/actions/runs/26559588703) ✅

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided