### PR TITLE
Remove unused Node.js 12 from arm deb agent builders (4.14.7)

### DIFF
--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
     autoconf libtool libaudit-dev selinux-basics \
-    libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2 \
+    libdb5.3 libssl1.0.2 gawk libsigsegv2 \
     libgmp-dev libmpfr-dev libmpc-dev libisl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \

--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -13,11 +13,6 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     autoconf libtool libaudit-dev selinux-basics \
     libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
 
-# Add Debian's source repository and, Install NodeJS 12
-RUN apt-get update &&  apt-get build-dep python3.5 -y --allow-change-held-packages
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install --allow-change-held-packages -y nodejs
-
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     ./contrib/download_prerequisites && \

--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
     autoconf libtool libaudit-dev selinux-basics \
-    libdb5.3 libssl1.0.2 gawk libsigsegv2 \
+    libdb5.3 libssl1.0.2 libssl-dev gawk libsigsegv2 \
     libgmp-dev libmpfr-dev libmpc-dev libisl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \

--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -11,11 +11,11 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
     autoconf libtool libaudit-dev selinux-basics \
-    libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
+    libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2 \
+    libgmp-dev libmpfr-dev libmpc-dev libisl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
-    ./contrib/download_prerequisites && \
     ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
         --disable-libsanitizer && \
     make -j$(nproc) && make install && \

--- a/packages/debs/armhf/agent/Dockerfile
+++ b/packages/debs/armhf/agent/Dockerfile
@@ -13,11 +13,6 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     libaudit-dev selinux-basics util-linux libdb5.1 \
     libssl1.1 libssl-dev gawk libsigsegv2 procps libc6-armel-cross g++
 
-# Add Debian's source repository and, Install NodeJS 12
-RUN apt-get build-dep python3.5 -y --allow-change-held-packages
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y --allow-change-held-packages nodejs
-
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
     linux32 ./contrib/download_prerequisites && \

--- a/packages/debs/armhf/agent/Dockerfile
+++ b/packages/debs/armhf/agent/Dockerfile
@@ -11,11 +11,11 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     perl libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake autoconf libtool \
     libaudit-dev selinux-basics util-linux libdb5.1 \
-    libssl1.1 libssl-dev gawk libsigsegv2 procps libc6-armel-cross g++
+    libssl1.1 libssl-dev gawk libsigsegv2 procps libc6-armel-cross g++ \
+    libgmp-dev libmpfr-dev libmpc-dev libisl-dev
 
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
-    linux32 ./contrib/download_prerequisites && \
     linux32 ./configure --prefix=/usr/local/gcc-9.4.0 --with-arch=armv7-a \
         --with-fpu=vfpv3-d16 --with-float=hard --enable-languages=c,c++ \
        --disable-multilib --disable-libsanitizer && \


### PR DESCRIPTION
## Description

Fixes broken Docker image builds for the ARM Debian agent builder images. Three issues fixed:

1. **NodeSource `setup_12.x` deprecated** — GPG key `1655A0AB68576280` is revoked. Node.js is not used in `build.sh` or `helper_function.sh`.
2. **`./contrib/download_prerequisites` removed** — GCC 9.4.0 build fetches GMP/MPFR/MPC/ISL from external mirrors at build time (fragile). Replaced with `libgmp-dev libmpfr-dev libmpc-dev libisl-dev` from apt.
3. **`libssl-dev` added to arm64** — CMake 3.18.3 bootstrap requires OpenSSL headers. arm64 had `libssl1.0.2` (runtime) but not `libssl-dev` (headers).
4. **Duplicate `libdb5.3` removed** from arm64 package list.

Note: `packages/debs/arm64/manager/Dockerfile` has the same NodeSource issue but is managed by the Server team — out of scope for this PR.

Closes #36163

## Proposed Changes

- **`packages/debs/arm64/agent/Dockerfile`** — Remove Node.js 12 block. Add `libgmp-dev libmpfr-dev libmpc-dev libisl-dev libssl-dev`. Remove `./contrib/download_prerequisites`. Remove duplicate `libdb5.3`.
- **`packages/debs/armhf/agent/Dockerfile`** — Remove Node.js 12 block. Add `libgmp-dev libmpfr-dev libmpc-dev libisl-dev`. Remove `linux32 ./contrib/download_prerequisites`.

## Tests and evidence

`4_builderpackage_upload-images-arm` triggered with `source_reference=fix/36053-remove-unused-nodejs-arm-deb-builder` and `docker_image_tag=testing-4758`:

| Arch | Run | Status |
|------|-----|--------|
| arm64 | https://github.com/wazuh/wazuh-agent-packages/actions/runs/26033017288 | ✅ |
| armhf | https://github.com/wazuh/wazuh-agent-packages/actions/runs/26282447708 | ✅ |

`4_builderpackage_agent-linux-arm` with `docker_image_tag=testing-4758` to validate image compiles packages:
- arm64 ✅ https://github.com/wazuh/wazuh-agent-packages/actions/runs/26150713815
- armhf ✅ https://github.com/wazuh/wazuh-agent-packages/actions/runs/26626838417

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided