### PR TITLE
[4.9.0] backport CVE-2025-62787: malformed event handling

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -107,6 +107,10 @@ int DecodeWinevt(Eventinfo *lf){
     os_calloc(OS_MAXSTR, sizeof(char), msg_from_prov);
     os_calloc(OS_MAXSTR, sizeof(char), join_data);
 
+    // force a clean event
+    lf->program_name = NULL;
+    lf->dec_timestamp = NULL;
+
     const char *jsonErrPtr;
 
     if (received_event = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0), !received_event) {
@@ -141,6 +145,7 @@ int DecodeWinevt(Eventinfo *lf){
             } else {
                 mwarn("Could not read XML string: '%s'", event);
             }
+            OS_ClearXML(&xml);
         } else {
             node = OS_GetElementsbyNode(&xml, NULL);
 
@@ -245,7 +250,7 @@ int DecodeWinevt(Eventinfo *lf){
                                     } else if(child_attr[p]->content && strcmp(child_attr[p]->content, "(NULL)") != 0
                                             && strcmp(child_attr[p]->content, "-") != 0){
                                         filtered_string = replace_win_format(child_attr[p]->content, 0);
-                                        mdebug2("Unexpected attribute at EventData (%s).", child_attr[p]->attributes[j]);
+                                        mdebug2("Unexpected attribute at EventData (%s).", child_attr[p]->attributes[l]);
                                         *child_attr[p]->values[l] = tolower(*child_attr[p]->values[l]);
                                         cJSON_AddStringToObject(json_eventdata_in, child_attr[p]->values[l], filtered_string);
                                         os_free(filtered_string);


### PR DESCRIPTION
brings the CVE-2025-62787 fix (`267d5d55de49`) onto `4.9.0`. the change is in `src/analysisd/decoders/winevtchannel.c` — adds the malformed-event guard before further parsing. 6 lines added, 1 removed.

https://github.com/wazuh/wazuh/commit/267d5d55de49
https://nvd.nist.gov/vuln/detail/CVE-2025-62787

cherry-pick applied cleanly. didn't run the test suite locally — the diff is small enough to eyeball.