### PR TITLE
Propagate agent merged_sum after hot reload in cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fixed string buffer handling in version comparison function. ([#36059](https://github.com/wazuh/wazuh/pull/36059))
 - Improved cluster file synchronization security. ([#36060](https://github.com/wazuh/wazuh/pull/36060))
 - Fixed missing `agent.host.ip` in inventory documents when agent IP is empty. ([#35475](https://github.com/wazuh/wazuh/pull/35475))
+- Fixed stale agent `synced` status after hot reload on cluster worker nodes. ([#6726](https://github.com/wazuh/external-devel-requests/issues/6726))
 
 ### Agent
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -494,6 +494,11 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *pos
 
             os_strdup(msg, data->message);
 
+            /* Snapshot of the last merged_sum reported by the agent, used after
+             * unlocking to detect changes (e.g. after a hot reload). */
+            os_md5 prev_reported_merged_sum;
+            memcpy(prev_reported_merged_sum, data->last_reported_merged_sum, sizeof(os_md5));
+
             if (OS_SUCCESS == lookfor_agent_group(key->id, data->message, &data->group, wdb_sock)) {
                 group_t *aux = NULL;
 
@@ -554,13 +559,29 @@ void save_controlmsg(const keyentry * key, char *r_msg, int *wdb_sock, bool *pos
                 wm_strcat(&agent_data->labels, agent_data->version, 0);
             }
 
+            /* Detect a change in the merged_sum reported by the agent versus the
+             * previous keepalive. After a hot reload the agent does not send
+             * #!-agent startup, so on worker nodes the cluster sync would only
+             * propagate {id, last_keepalive} (syncreq_keepalive) and the master DB
+             * would keep the stale merged_sum. Escalating to syncreq triggers a
+             * full sync that includes merged_sum and group_config_status. */
+            bool agent_merged_sum_changed = agent_data->merged_sum &&
+                                            agent_data->merged_sum[0] &&
+                                            prev_reported_merged_sum[0] &&
+                                            strcmp(prev_reported_merged_sum, agent_data->merged_sum) != 0;
+
             agent_data->id = atoi(key->id);
             os_strdup(AGENT_CS_ACTIVE, agent_data->connection_status);
-            os_strdup(logr.worker_node ? (*post_startup ? "syncreq" : "syncreq_keepalive") : "synced", agent_data->sync_status);
+            os_strdup(logr.worker_node ? ((*post_startup || agent_merged_sum_changed) ? "syncreq" : "syncreq_keepalive") : "synced", agent_data->sync_status);
 
             *post_startup = false;
 
             w_mutex_lock(&lastmsg_mutex);
+
+            if (agent_data->merged_sum && agent_data->merged_sum[0]) {
+                strncpy(data->last_reported_merged_sum, agent_data->merged_sum, sizeof(os_md5) - 1);
+                data->last_reported_merged_sum[sizeof(os_md5) - 1] = '\0';
+            }
 
             if (data->merged_sum[0] && (!agent_data->merged_sum || (strcmp(data->merged_sum, agent_data->merged_sum) != 0))) {
                 /* Mark data as changed and insert into queue */

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -36,6 +36,7 @@ typedef struct pending_data_t {
     char *message;
     char *group;
     os_md5 merged_sum;
+    os_md5 last_reported_merged_sum;
     int changed;
 } pending_data_t;
 


### PR DESCRIPTION
## Summary

Fixes a stale `synced: false` reported by the API after an agent hot-reloads its shared configuration in a clustered deployment.

## Root cause

`save_controlmsg()` in `src/remoted/manager.c` sets the agent's `sync_status` based on a `post_startup` flag that only becomes `true` after a `#!-agent startup` control message (i.e., a full agent restart). Every other keepalive on a worker node lands as `syncreq_keepalive`.

The two sync statuses map to very different queries in `src/wazuh_db/wdb.c`:

```sql
-- syncreq → full sync, includes merged_sum and group_config_status
SELECT id, name, ..., merged_sum, ..., group_config_status, ...
-- syncreq_keepalive → minimal, master never sees the new merged_sum
SELECT id, last_keepalive
```

Since 4.14, the agent uses `reloadAgent()` (hot reload) instead of `restartAgent()` when shared configuration changes, so it keeps its TCP session and never sends `#!-agent startup`. The worker's `global.db` is updated with the new `merged_sum`, but the master's is not — and the API computes `synced` against the master's stale value:

```python
'synced': md5(group_merged_path) == agent_info['mergedSum']
```

AIO deployments are unaffected because `worker_node = false` writes `synced` directly without a cluster propagation step.

## Fix

Track the last `merged_sum` reported by each agent in `pending_data_t` and escalate `sync_status` to `syncreq` whenever it changes. This forces a full cluster sync that includes `merged_sum`, so the master's `global.db` stays consistent with what the agent reports after a hot reload.

- `pending_data_t` gets a new `last_reported_merged_sum` field.
- In `save_controlmsg()`, snapshot the previous value before releasing `lastmsg_mutex`, compare it against the freshly parsed `agent_data->merged_sum` after parsing, and use the result as an additional trigger for `syncreq` on worker nodes.
- Update the cached value inside the second critical section.

The existing `post_startup` path is preserved untouched, so restart-triggered syncs keep behaving the same.

## Evidences

- Environment: master ubuntu24 (192.168.72.166) | worker ubuntu24-2 (192.168.72.167) | agent ubuntu26
- Wazuh 4.14.6 with the fix included. Agent connected to the WORKER.

- Initial state:
```
$ sudo md5sum /var/ossec/etc/shared/default/merged.mg    # master
e15cd0c9f7dec03be7b82012b99d73bf
$ sudo md5sum /var/ossec/etc/shared/default/merged.mg    # worker
e15cd0c9f7dec03be7b82012b99d73bf
$ sudo md5sum /var/ossec/etc/shared/merged.mg            # agent
e15cd0c9f7dec03be7b82012b99d73bf
```

- Check merged.mg
```
$ curl -k -H "Authorization: Bearer $TOKEN" https://localhost:55000/agents/001/group/is_sync
{"id":"001","synced":true}
$ echo '<!-- test change -->' | sudo tee -a /var/ossec/etc/shared/default/agent.conf
$ sudo chown wazuh:wazuh /var/ossec/etc/shared/default/agent.conf
$ sudo md5sum /var/ossec/etc/shared/default/merged.mg    # master
d43476ce305e9a9aff9d82c3fcd43728
$ sudo md5sum /var/ossec/etc/shared/default/merged.mg    # worker
d43476ce305e9a9aff9d82c3fcd43728
$ sudo md5sum /var/ossec/etc/shared/merged.mg            # agent (hot reload, same PID)
d43476ce305e9a9aff9d82c3fcd43728
```
- Check fix:
```
$ sudo sqlite3 /var/ossec/queue/db/global.db \
    'SELECT id, sync_status, merged_sum FROM agent WHERE id=1;'
# master:
1|synced|d43476ce305e9a9aff9d82c3fcd43728
# worker (escalated to syncreq_keepalive as the fix predicts):
1|syncreq_keepalive|d43476ce305e9a9aff9d82c3fcd43728
$ curl -k -H "Authorization: Bearer $TOKEN" https://localhost:55000/agents/001/group/is_sync
{"id":"001","synced":true}     <-- API correct WITHOUT restarting the agent
$ sudo grep reload /var/ossec/logs/ossec.log | tail -1
wazuh-agentd[43488] agentd.c:18 at reload_handler(): INFO: SIGNAL [(10)-(User defined signal 1)] Received. Reload agentd.
$ sudo grep "Sending keep alive" /var/ossec/logs/ossec.log | tail -1
... Wazuh v4.14.5 / d43476ce305e9a9aff9d82c3fcd43728 merged.mg    <-- agent reports the NEW MD5
```