### PR TITLE
fix: narrow bare except to OSError in WazuhQueue.send_msg_to_agent

### DIFF
--- a/framework/wazuh/core/tests/test_wazuh_queue.py
+++ b/framework/wazuh/core/tests/test_wazuh_queue.py
@@ -51,7 +51,7 @@ def test_BaseQueue_protected_connect(mock_set, mock_conn):
     mock_set.assert_called_once_with(1, 7, 6400)
 
 
-@patch('wazuh.core.wazuh_queue.socket.socket.connect', side_effect=Exception)
+@patch('wazuh.core.wazuh_queue.socket.socket.connect', side_effect=OSError)
 def test_BaseQueue_protected_connect_ko(mock_conn):
     """Test BaseQueue._connect function exceptions."""
 
@@ -154,7 +154,7 @@ def test_WazuhQueue_send_msg_to_agent(mock_send, mock_conn, msg, agent_id, msg_t
     ('force_reconnect', None, None, 1014),
 ])
 @patch('wazuh.core.wazuh_queue.socket.socket.connect')
-@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=Exception)
+@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=OSError)
 def test_WazuhQueue_send_msg_to_agent_ko(mock_send, mock_conn, msg, agent_id, msg_type, expected_exception):
     """Test WazuhQueue.send_msg_to_agent function exceptions.
 
@@ -176,3 +176,30 @@ def test_WazuhQueue_send_msg_to_agent_ko(mock_send, mock_conn, msg, agent_id, ms
         queue.send_msg_to_agent(msg, agent_id, msg_type)
 
     mock_conn.assert_called_once_with('test_path')
+
+
+@patch('wazuh.core.wazuh_queue.socket.socket.connect')
+@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=OSError("socket write failed"))
+def test_WazuhQueue_send_msg_oserror(mock_send, mock_conn):
+    """OSError from _send() should be wrapped as WazuhError(1014)."""
+    queue = WazuhQueue('test_path')
+    with pytest.raises(WazuhException, match='.* 1014 .*'):
+        queue.send_msg_to_agent('force_reconnect', None, None)
+
+
+@patch('wazuh.core.wazuh_queue.socket.socket.connect')
+@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=BrokenPipeError())
+def test_WazuhQueue_send_msg_broken_pipe(mock_send, mock_conn):
+    """BrokenPipeError (OSError subclass) should be wrapped as WazuhError(1014)."""
+    queue = WazuhQueue('test_path')
+    with pytest.raises(WazuhException, match='.* 1014 .*'):
+        queue.send_msg_to_agent('force_reconnect', None, None)
+
+
+@patch('wazuh.core.wazuh_queue.socket.socket.connect')
+@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=KeyboardInterrupt())
+def test_WazuhQueue_send_msg_keyboard_interrupt(mock_send, mock_conn):
+    """KeyboardInterrupt must NOT be caught — should propagate freely."""
+    queue = WazuhQueue('test_path')
+    with pytest.raises(KeyboardInterrupt):
+        queue.send_msg_to_agent('force_reconnect', None, None)

--- a/framework/wazuh/core/wazuh_queue.py
+++ b/framework/wazuh/core/wazuh_queue.py
@@ -169,7 +169,7 @@ class WazuhQueue(BaseQueue):
         try:
             # Send message
             self._send(socket_msg.encode())
-        except:
-            raise WazuhError(1014, extra_message=f": WazuhQueue socket with path {self.path}")
+        except OSError as e:
+            raise WazuhError(1014, extra_message=f": WazuhQueue socket with path {self.path}") from e
 
         return ret_msg


### PR DESCRIPTION
## Description

`send_msg_to_agent()` in `framework/wazuh/core/wazuh_queue.py` used a bare `except:` clause around `self._send()`. This silently catches `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` — none of which are socket errors — and re-raises them as `WazuhError(1014)`, masking the real signal and preventing clean process termination.

## Proposed Changes

- Narrowed `except:` to `except OSError as e:` in `send_msg_to_agent()` — covers all real socket-write failures (`BrokenPipeError`, `ConnectionResetError`, bad file descriptor, etc.) while letting non-OS signals propagate freely
- Added `from e` to preserve the original traceback for debuggability
- Fixed existing `test_WazuhQueue_send_msg_to_agent_ko` which used `side_effect=Exception` — updated to `OSError` to match the narrowed catch
- Added 3 new unit tests

### Results and Evidence

Before: `KeyboardInterrupt` raised inside `_send()` would be caught and re-raised as `WazuhError(1014)`, making it impossible to distinguish a socket failure from a process signal.

After: only `OSError` and its subclasses are caught. `KeyboardInterrupt` propagates freely.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [x] Log syntax and correct language review
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer
- Decoder/Rule tests: N/A
- Engine: N/A
- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `framework/wazuh/core/wazuh_queue.py`
- `framework/wazuh/core/tests/test_wazuh_queue.py`

### Configuration Changes

N/A

### Tests Introduced

Three new unit tests in `test_wazuh_queue.py`:

- `test_WazuhQueue_send_msg_oserror` — verifies `OSError` is wrapped as `WazuhError(1014)`
- `test_WazuhQueue_send_msg_broken_pipe` — verifies `BrokenPipeError` (OSError subclass) is also wrapped
- `test_WazuhQueue_send_msg_keyboard_interrupt` — verifies `KeyboardInterrupt` propagates freely and is not caught

All 3 pass. The pre-existing `test_BaseQueue_protected_connect` failure is unrelated — it fails due to changed socket option constants in Python 3.14 and was failing before this change.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [x] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues