### PR TITLE
DockerListener messages as log

### DIFF
--- a/src/wazuh_modules/src/wm_docker.c
+++ b/src/wazuh_modules/src/wm_docker.c
@@ -87,7 +87,11 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
                 *end = '\0';
             }
 
-            mtinfo(WM_DOCKER_LOGTAG, "%s", buffer);
+            if (strncmp(buffer, "INFO ", 5) == 0) {
+                mtinfo(WM_DOCKER_LOGTAG, "%s", buffer + 5);
+            } else {
+                mterror(WM_DOCKER_LOGTAG, "%s", buffer);
+            }
         }
 
         // At this point, DockerListener terminated

--- a/src/wazuh_modules/src/wm_docker.c
+++ b/src/wazuh_modules/src/wm_docker.c
@@ -125,7 +125,6 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 }
 
 
-
 // Get read data
 
 cJSON *wm_docker_dump(const wm_docker_t *docker_conf) {

--- a/src/wazuh_modules/src/wm_docker.c
+++ b/src/wazuh_modules/src/wm_docker.c
@@ -89,6 +89,8 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
             if (strncmp(buffer, "INFO ", 5) == 0) {
                 mtinfo(WM_DOCKER_LOGTAG, "%s", buffer + 5);
+            } else if (strncmp(buffer, "WARN ", 5) == 0) {
+                mtwarn(WM_DOCKER_LOGTAG, "%s", buffer + 5);
             } else {
                 mterror(WM_DOCKER_LOGTAG, "%s", buffer);
             }

--- a/src/wazuh_modules/src/wm_docker.c
+++ b/src/wazuh_modules/src/wm_docker.c
@@ -87,7 +87,7 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
                 *end = '\0';
             }
 
-            mterror(WM_DOCKER_LOGTAG, "%s", buffer);
+            mtinfo(WM_DOCKER_LOGTAG, "%s", buffer);
         }
 
         // At this point, DockerListener terminated
@@ -117,6 +117,7 @@ void* wm_docker_main(wm_docker_t *docker_conf) {
 
     return NULL;
 }
+
 
 
 // Get read data

--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -26,8 +26,10 @@ except:
 
 
 def log(msg):
+    if not msg.endswith("\n"):
+        msg += "\n"
     sys.stderr.write("INFO " + msg)
-
+    sys.stderr.flush()
 
 class DockerListener:
     wait_time = 5
@@ -107,7 +109,7 @@ class DockerListener:
         self.connect()
 
     def process(self, event):
-        """"
+        """
         Processes a main Docker event
 
         :param event: Docker event.

--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -26,15 +26,14 @@ except:
 
 
 def log(msg):
-    sys.stderr.write(msg)
+    sys.stderr.write("INFO " + msg)
 
 
 class DockerListener:
     wait_time = 5
 
     def __init__(self):
-        """"
-        
+        """
         DockerListener constructor
 
         """

--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -25,6 +25,10 @@ except:
     exit(1)
 
 
+def log(msg):
+    sys.stderr.write(msg)
+
+
 class DockerListener:
     wait_time = 5
 
@@ -47,7 +51,7 @@ class DockerListener:
         self.thread2 = None
 
     def start(self):
-        sys.stderr.write("Wodle started.\n")
+        log("Wodle started.\n")
         self.thread1 = threading.Thread(target=self.listen)
         self.thread2 = threading.Thread(target=self.listen)
         self.connect(first_time=True)
@@ -68,12 +72,12 @@ class DockerListener:
                     self.thread1.start()
             else:
                 self.thread1.start()
-            sys.stderr.write("Docker service was started.\n")
+            log("Docker service was started.\n")
         else:
             if first_time:
-                sys.stderr.write("Docker service is not running.\n")
+                log("Docker service is not running.\n")
             while not self.check_docker_service():
-                sys.stderr.write("Reconnecting...\n")
+                log("Reconnecting...\n")
                 time.sleep(self.wait_time)
             self.connect()
 
@@ -100,7 +104,7 @@ class DockerListener:
                 self.process(event)
         except Exception as e:
             raise e
-        sys.stderr.write("Docker service was stopped.\n")
+        log("Docker service was stopped.\n")
         self.connect()
 
     def process(self, event):

--- a/wodles/docker-listener/DockerListener.py
+++ b/wodles/docker-listener/DockerListener.py
@@ -27,10 +27,10 @@ except:
 
 class DockerListener:
     wait_time = 5
-    field_debug_name = "Wodle event"
 
     def __init__(self):
         """"
+        
         DockerListener constructor
 
         """
@@ -47,7 +47,7 @@ class DockerListener:
         self.thread2 = None
 
     def start(self):
-        self.send_msg(json.dumps({self.field_debug_name: "Started"}))
+        sys.stderr.write("Wodle started.\n")
         self.thread1 = threading.Thread(target=self.listen)
         self.thread2 = threading.Thread(target=self.listen)
         self.connect(first_time=True)
@@ -68,14 +68,12 @@ class DockerListener:
                     self.thread1.start()
             else:
                 self.thread1.start()
-            print("Docker service was started.")
-            self.send_msg(json.dumps({self.field_debug_name: "Connected to Docker service"}))
+            sys.stderr.write("Docker service was started.\n")
         else:
             if first_time:
-                print("Docker service is not running.")
-                self.send_msg(json.dumps({self.field_debug_name: "Docker service is not running"}))
+                sys.stderr.write("Docker service is not running.\n")
             while not self.check_docker_service():
-                print("Reconnecting...")
+                sys.stderr.write("Reconnecting...\n")
                 time.sleep(self.wait_time)
             self.connect()
 
@@ -102,8 +100,7 @@ class DockerListener:
                 self.process(event)
         except Exception as e:
             raise e
-        print("Docker service was stopped.")
-        self.send_msg(json.dumps({self.field_debug_name: "Disconnected from the Docker service"}))
+        sys.stderr.write("Docker service was stopped.\n")
         self.connect()
 
     def process(self, event):
@@ -131,7 +128,6 @@ class DockerListener:
         """
         try:
             json_msg = json.dumps(self.format_msg(msg))
-            print(json_msg)
             s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
             s.connect(self.wazuh_queue)
 

--- a/wodles/docker-listener/tests/test_docker_listener.py
+++ b/wodles/docker-listener/tests/test_docker_listener.py
@@ -33,12 +33,12 @@ def test_DockerListener__init__ko(mock_stderr):
 
 @patch('DockerListener.threading.Thread')
 @patch('DockerListener.DockerListener.connect')
-@patch('DockerListener.DockerListener.send_msg')
-def test_DockerListener_start(mock_send, mock_connect, mock_thread):
+@patch('DockerListener.log')
+def test_DockerListener_start(mock_log, mock_connect, mock_thread):
     """Test if start creates the expected Threads and calls to the connect function."""
     dl = docker_listener.DockerListener()
     dl.start()
-    mock_send.assert_called_once()
+    mock_log.assert_called_once()
     mock_connect.assert_called_with(first_time=True)
     mock_thread.assert_has_calls([call(target=dl.listen), call(target=dl.listen)])
     assert dl.thread1
@@ -48,9 +48,9 @@ def test_DockerListener_start(mock_send, mock_connect, mock_thread):
 @pytest.mark.parametrize('first_time', [True, False])
 @pytest.mark.parametrize('alive', [True, False])
 @patch('DockerListener.threading.Thread')
-@patch('DockerListener.DockerListener.send_msg')
+@patch('DockerListener.log')
 @patch('DockerListener.DockerListener.check_docker_service', return_value=True)
-def test_DockerListener_connect(mock_service, mock_send, mock_thread, first_time, alive):
+def test_DockerListener_connect(mock_service, mock_log, mock_thread, first_time, alive):
     """Test DockerListener successfully connects to the Docker service by starting the expected thread."""
     dl = docker_listener.DockerListener()
     m = MagicMock()
@@ -70,15 +70,15 @@ def test_DockerListener_connect(mock_service, mock_send, mock_thread, first_time
         mock_thread.assert_called_with(target=dl.listen)
         dl.thread1.start.assert_called_once()
 
-    mock_send.assert_called_once()
+    mock_log.assert_called_once()
 
 
 @pytest.mark.parametrize('first_time', [True, False])
 @patch('DockerListener.threading.Thread')
 @patch('DockerListener.time.sleep')
 @patch('DockerListener.DockerListener.check_docker_service')
-@patch('DockerListener.DockerListener.send_msg')
-def test_DockerListener_connect_ko(mock_send, mock_service, mock_time, mock_thread, first_time):
+@patch('DockerListener.log')
+def test_DockerListener_connect_ko(mock_log, mock_service, mock_time, mock_thread, first_time):
     """Test connect function will attempt to reconnect to the docker service until accomplished."""
     docker_service_values = [False, False, True, True]
     mock_service.side_effect = docker_service_values
@@ -90,7 +90,7 @@ def test_DockerListener_connect_ko(mock_send, mock_service, mock_time, mock_thre
     dl.connect(first_time=first_time)
 
     assert mock_service.call_count == len(docker_service_values)
-    assert mock_send.call_count == 2 if first_time else 1
+    assert mock_log.call_count == (3 if first_time else 2)
     mock_time.assert_called_with(dl.wait_time)
     mock_thread.assert_called_with(target=dl.listen)
     dl.thread1.start.assert_called_once()
@@ -114,9 +114,9 @@ def test_DockerListener_check_docker_service_ko():
 
 
 @patch('DockerListener.DockerListener.connect')
-@patch('DockerListener.DockerListener.send_msg')
+@patch('DockerListener.log')
 @patch('DockerListener.DockerListener.process')
-def test_DockerListener_listen(mock_process, mock_send, mock_connect):
+def test_DockerListener_listen(mock_process, mock_log, mock_connect):
     """Test listen function process every event received from the client."""
     event_list = [1, 2, 3]
     dl = docker_listener.DockerListener()
@@ -124,7 +124,7 @@ def test_DockerListener_listen(mock_process, mock_send, mock_connect):
     dl.client.events.return_value = event_list
     dl.listen()
     mock_process.assert_has_calls([call(x) for x in event_list])
-    mock_send.assert_called_once()
+    mock_log.assert_called_once()
     mock_connect.assert_called_once()
 
 


### PR DESCRIPTION
## Description

Docker listener wodle lifecycle messages (startup, connection, disconnection) were incorrectly sent as Docker events through the Wazuh queue via `send_msg`, causing them to appear as actual Docker event alerts. Additionally, the C module (`wm_docker.c`) was logging all stderr output from the Python script at a single severity level, making it impossible to distinguish informational lifecycle messages from actionable error conditions.

Closes #36126

## Proposed Changes

- Removed `field_debug_name` and the associated `send_msg` calls that were dispatching lifecycle status strings (`"Started"`, `"Connected to Docker service"`, `"Docker service is not running"`, `"Disconnected from the Docker service"`) as Docker events through the Wazuh queue.
- Added a `log(msg)` helper function in `DockerListener.py` that writes `"INFO " + msg` to `sys.stderr`, and replaced all lifecycle `sys.stderr.write()` calls with `log()` to centralise logging and make it easily testable.
- Removed spurious `print(json_msg)` debug output from `send_msg()`.
- Updated `wm_docker.c` to parse the `"INFO "` prefix from each stderr line: lines produced by `log()` are forwarded to `ossec.log` via `mtinfo` (prefix stripped); all other lines — real error conditions such as missing docker module or socket failures — are forwarded via `mterror`.
- Updated unit tests in `test_docker_listener.py` to patch `DockerListener.log` instead of `DockerListener.DockerListener.send_msg` for lifecycle message assertions.

### Results and Evidence

Before: lifecycle messages did not appear in `ossec.log`; status strings were emitted as Docker event alerts through the Wazuh queue.

<img width="1878" height="1288" alt="Image" src="https://github.com/user-attachments/assets/2c4e475b-f525-4a7d-a501-db4a1abec2e5" />

After: lifecycle messages (`"Wodle started."`, `"Docker service was started."`, `"Reconnecting..."`, `"Docker service was stopped."`) appear in `ossec.log` at `INFO` level. Real error conditions (`"Wazuh must be running."`, socket send failures, missing docker module) appear at `ERROR` level, making them actionable and distinguishable from normal operation.


<img width="1186" height="447" alt="imagen" src="https://github.com/user-attachments/assets/b51a339d-b99c-4578-8e71-e0339637b006" />

<img width="3816" height="935" alt="imagen" src="https://github.com/user-attachments/assets/81eb6c44-611a-4cd1-b8dd-0ddf714f5ab8" />

### Artifacts Affected

- `wodles/docker-listener/DockerListener.py`
- `src/wazuh_modules/src/wm_docker.c` (Linux/macOS agent and manager)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Existing unit tests in `wodles/docker-listener/tests/test_docker_listener.py` were updated to reflect the new logging approach: `send_msg` lifecycle mocks replaced with `DockerListener.log` mocks in `test_DockerListener_start`, `test_DockerListener_connect`, `test_DockerListener_connect_ko`, and `test_DockerListener_listen`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
