### PR TITLE
[4.7] backport CVE-2025-62786: syscheck windows permissions parser fix

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1657,8 +1657,14 @@ char *decode_win_permissions(char *raw_perm) {
     int perm_size = MAX_WIN_PERM_SIZE;
     char *decoded_it = decoded_perm;
     char *perm_it = raw_perm;
+    char *perm_end = perm_it + strlen(raw_perm);
 
     while (perm_it = strchr(perm_it, '|'), perm_it) {
+        // Minimum size for the next permission
+        if (perm_end - perm_it < 3) {
+            goto error;
+        }
+
         // Get the account/group name
         base_it = ++perm_it;
         if (perm_it = strchr(perm_it, ','), !perm_it) {
@@ -1743,7 +1749,7 @@ char *decode_win_permissions(char *raw_perm) {
         }
     }
 
-    if (decoded_it && size > 1) {
+    if (decoded_it && decoded_it - 2 >= decoded_perm && size > 1) {
         *(decoded_it - 2) = '\0';
         // Adjusts the final size
         os_realloc(decoded_perm, written * sizeof(char), decoded_perm);
@@ -1751,8 +1757,8 @@ char *decode_win_permissions(char *raw_perm) {
 
     return decoded_perm;
 error:
-    free(decoded_perm);
-    free(account_name);
+    os_free(decoded_perm);
+    os_free(account_name);
     mdebug1("The file permissions could not be decoded: '%s'.", raw_perm);
     return NULL;
 }

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -2590,6 +2590,114 @@ static void test_decode_win_permissions_overrun_inner_buffer(void **state) {
     assert_true(strlen(output) < MAX_WIN_PERM_SIZE);
 }
 
+static void test_decode_win_permissions_empty_permissions(void **state) {
+    char *raw_perm = "";
+    char *output;
+
+    output = decode_win_permissions(raw_perm);
+
+    assert_string_equal(output, "");
+    os_free(output);
+}
+
+static void test_decode_win_permissions_single_pipe(void **state) {
+    char *raw_perm = "|";
+    char *output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "The file permissions could not be decoded: '|'.");
+    output = decode_win_permissions(raw_perm);
+
+    assert_null(output);
+}
+
+static void test_decode_win_permissions_bad_format_1(void **state) {
+    char *raw_perm = "|,";
+    char *output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "The file permissions could not be decoded: '|,'.");
+    output = decode_win_permissions(raw_perm);
+
+    assert_null(output);
+}
+
+
+static void test_decode_win_permissions_bad_format_2(void **state) {
+
+    char *raw_perm;
+    w_strdup("|,|", raw_perm);
+    char *output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "The file permissions could not be decoded: '|,|'.");
+    output = decode_win_permissions(raw_perm);
+
+    os_free(raw_perm);
+
+    assert_null(output);
+
+}
+
+static void test_decode_win_permissions_bad_format_3(void **state) {
+    char *raw_perm;
+    w_strdup("||", raw_perm);
+    char *output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "The file permissions could not be decoded: '||'.");
+    output = decode_win_permissions(raw_perm);
+    os_free(raw_perm);
+
+    assert_null(output);
+}
+
+static void test_decode_win_permissions_bad_format_4(void **state) {
+    char *raw_perm;
+    w_strdup("|,|,|,", raw_perm);
+    char *output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "The file permissions could not be decoded: '|,|,|,'.");
+    output = decode_win_permissions(raw_perm);
+    os_free(raw_perm);
+
+    assert_null(output);
+}
+
+static void test_decode_win_permissions_bad_format_5(void **state) {
+    char *raw_perm;
+    w_strdup("|account,0,123|", raw_perm);
+    char *output;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "The file permissions could not be decoded: '|account,0,123|'.");
+    output = decode_win_permissions(raw_perm);
+    os_free(raw_perm);
+
+    assert_null(output);
+}
+
+
+static void test_decode_win_permissions_incomplete_format_1(void **state) {
+    char *raw_perm;
+    w_strdup("|account,0,", raw_perm);
+    char *output;
+
+    output = decode_win_permissions(raw_perm);
+    os_free(raw_perm);
+
+    assert_string_equal(output, "account (allowed):");
+    os_free(output);
+}
+
+static void test_decode_win_permissions_incomplete_format_2(void **state) {
+    char *raw_perm;
+    w_strdup("|account,0,0", raw_perm);
+    char *output;
+
+    output = decode_win_permissions(raw_perm);
+    os_free(raw_perm);
+
+    assert_string_equal(output, "account (allowed):");
+    os_free(output);
+}
+
+
 /* compare_win_permissions */
 #define BASE_WIN_ALLOWED_ACE "[" \
     "\"delete\"," \
@@ -4756,6 +4864,17 @@ int main(int argc, char *argv[]) {
         cmocka_unit_test_teardown(test_decode_win_permissions_fail_no_access_type, teardown_string),
         cmocka_unit_test_teardown(test_decode_win_permissions_fail_wrong_format, teardown_string),
         cmocka_unit_test_teardown(test_decode_win_permissions_overrun_inner_buffer, teardown_string),
+        cmocka_unit_test(test_decode_win_permissions_empty_permissions),
+        cmocka_unit_test(test_decode_win_permissions_single_pipe),
+        cmocka_unit_test(test_decode_win_permissions_bad_format_1),
+        cmocka_unit_test(test_decode_win_permissions_bad_format_2),
+        cmocka_unit_test(test_decode_win_permissions_bad_format_3),
+        cmocka_unit_test(test_decode_win_permissions_bad_format_4),
+        cmocka_unit_test(test_decode_win_permissions_bad_format_5),
+        cmocka_unit_test(test_decode_win_permissions_incomplete_format_1),
+        cmocka_unit_test(test_decode_win_permissions_incomplete_format_2),
+
+
 
         /* compare_win_permissions */
         cmocka_unit_test(test_compare_win_permissions_equal_acls),


### PR DESCRIPTION
brings the CVE-2025-62786 fix `2257d7998aaf` onto `4.7` (refs #36182). same patch as the 4.4/4.5/4.6 PRs in this set.

only the parser fix in `src/shared/syscheck_op.c` (+9 -3) is the security-relevant hunk; the test file is a unit test for the same path.

upstream: https://github.com/wazuh/wazuh/commit/2257d7998aaff34263169d16f4afc491564a771c
CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-62786

clean cherry-pick. no local test run.