### PR TITLE
Drop orphan paths before promoting on agent startup

### DIFF
--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -178,6 +178,15 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
         cJSON* stateful_event = NULL;
 
         if (strcmp(table_name, FIMDB_FILE_TABLE_NAME) == 0) {
+            // Skip rows whose path is no longer covered by the current FIM configuration
+            // (e.g. a group with a realtime rule was removed since the row was synced).
+            // The scheduled scan emits the real DELETE for these rows via handle_orphaned_delete.
+            if (fim_configuration_directory(path, false, directories_list) == NULL) {
+                mdebug2("Skipping recovery of orphaned path (no active configuration): %s", path);
+                cJSON_Delete(item_copy);
+                os_free(id_str);
+                continue;
+            }
             stateful_event = buildFileStatefulEvent(path, item_copy, checksum, document_version, directories_list);
         }
 #ifdef WIN32

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -148,6 +148,44 @@ void process_pending_sync_updates(char* table_name, OSList *pending_items) {
 }
 
 /**
+ * @brief Drop documents whose path is no longer covered by the current FIM configuration.
+ *
+ * Run before promoting file_entry rows at startup: if a directory was removed from the
+ * configuration since the last run (e.g. an agent group with a realtime FIM rule was
+ * unassigned), the persisted rows for files under that path can no longer build a
+ * stateful event — build_stateful_event_file would fail and log a spurious ERROR.
+ * The scheduled scan that follows fim_initialize emits the real DELETE for these
+ * rows via handle_orphaned_delete, so dropping them here is safe.
+ *
+ * Only applies to file_entry; registry tables use a different config model.
+ *
+ * @param table_name Name of the table the documents belong to.
+ * @param docs cJSON array of documents about to be promoted. Modified in place.
+ * @return Number of documents dropped.
+ */
+int drop_orphaned_promoted_documents(const char* table_name, cJSON* docs) {
+    if (!docs || !cJSON_IsArray(docs) || strcmp(table_name, FIMDB_FILE_TABLE_NAME) != 0) {
+        return 0;
+    }
+
+    int dropped = 0;
+    for (int i = cJSON_GetArraySize(docs) - 1; i >= 0; i--) {
+        const cJSON* item = cJSON_GetArrayItem(docs, i);
+        const cJSON* path_json = cJSON_GetObjectItem(item, "path");
+        const char* path = cJSON_GetStringValue(path_json);
+        if (path == NULL) {
+            continue;
+        }
+        if (fim_configuration_directory(path, false, syscheck.directories) == NULL) {
+            mdebug2("Skipping promotion of orphaned path (no active configuration): %s", path);
+            cJSON_DeleteItemFromArray(docs, i);
+            dropped++;
+        }
+    }
+    return dropped;
+}
+
+/**
  * @brief Extract primary keys from full document for sync flag update
  *
  * @param table_name Name of the table
@@ -501,6 +539,11 @@ void fim_initialize() {
                 cJSON* docs_to_promote = fim_db_get_documents_to_promote(table_name, document_count);
 
                 if (docs_to_promote) { // Limit has increased
+                    // Drop rows whose path is no longer covered by the current FIM
+                    // configuration (e.g. a group with a realtime rule was removed).
+                    // The scheduled scan that follows handles them via the orphan-delete path.
+                    drop_orphaned_promoted_documents(table_name, docs_to_promote);
+
                     // Send promoted documents to persistent queue as CREATE events
                     mdebug1("Document limit increased from  %d to %d for index %s. Currently synced documents: %d", *synced_docs_ptr, limit, table_name, *synced_docs_ptr + cJSON_GetArraySize(docs_to_promote));
                     persist_sync_documents(table_name, docs_to_promote, OPERATION_CREATE);

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -492,6 +492,7 @@ set(FIM_SYNC_LIMITS_BASE_FLAGS "-Wl,--wrap,validate_and_persist_fim_event \
                                 -Wl,--wrap,fim_db_get_documents_to_demote \
                                 -Wl,--wrap,fim_db_count_synced_docs \
                                 -Wl,--wrap,fim_db_set_sync_flag \
+                                -Wl,--wrap,fim_configuration_directory \
                                 -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 
 target_link_libraries(test_fim_sync_limits SYSCHECK_O ${TEST_DEPS})
@@ -518,6 +519,7 @@ set(RECOVERY_BASE_FLAGS "-Wl,--wrap,fim_db_get_last_sync_time -Wl,--wrap,fim_db_
                          -Wl,--wrap,merror -Wl,--wrap,minfo -Wl,--wrap,mdebug1 \
                          -Wl,--wrap,build_stateful_event_file -Wl,--wrap,build_stateful_event_registry_key \
                          -Wl,--wrap,build_stateful_event_registry_value \
+                         -Wl,--wrap,fim_configuration_directory \
                          -Wl,--wrap,schema_validator_is_initialized -Wl,--wrap,schema_validator_validate \
                          -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/syscheckd/test_fim_sync_limits.c
+++ b/src/unit_tests/syscheckd/test_fim_sync_limits.c
@@ -27,18 +27,9 @@ extern void process_pending_sync_updates(char* table_name, OSList *pending_items
 extern cJSON* extract_primary_keys(const char* table_name, const cJSON* full_doc);
 extern int drop_orphaned_promoted_documents(const char* table_name, cJSON* docs);
 
-// Wrapped fim_configuration_directory (real one is in syscheckd/src/file/file.c)
-directory_t* __wrap_fim_configuration_directory(const char* key, bool notify_not_found, const OSList* directories_list);
-
 // Stand-in directory_t pointer for "config exists" signal in tests
+// (real __wrap_fim_configuration_directory lives in create_db_wrappers.c)
 static directory_t mock_drop_directory_config = {0};
-
-directory_t* __wrap_fim_configuration_directory(const char* key,
-                                                __attribute__((unused)) bool notify_not_found,
-                                                __attribute__((unused)) const OSList* directories_list) {
-    check_expected_ptr(key);
-    return mock_ptr_type(directory_t*);
-}
 
 // Local wrapper declarations (defined per-test-file like test_recovery.c)
 cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash,
@@ -558,9 +549,9 @@ static void test_drop_orphaned_promoted_documents_no_orphans(void **state) {
     cJSON_AddItemToArray(docs, create_file_doc("/etc/passwd", "abc123", 1));
     cJSON_AddItemToArray(docs, create_file_doc("/etc/hosts", "def456", 1));
 
-    expect_string(__wrap_fim_configuration_directory, key, "/etc/hosts");
+    expect_string(__wrap_fim_configuration_directory, path, "/etc/hosts");
     will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
-    expect_string(__wrap_fim_configuration_directory, key, "/etc/passwd");
+    expect_string(__wrap_fim_configuration_directory, path, "/etc/passwd");
     will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
 
     int dropped = drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, docs);
@@ -580,10 +571,10 @@ static void test_drop_orphaned_promoted_documents_some_orphans(void **state) {
     cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/orphan.txt", "ghi789", 2));
 
     // Helper walks the array from the tail down; tail item is "/home/vagrant/orphan.txt".
-    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/orphan.txt");
+    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/orphan.txt");
     will_return(__wrap_fim_configuration_directory, NULL);
 
-    expect_string(__wrap_fim_configuration_directory, key, "/etc/passwd");
+    expect_string(__wrap_fim_configuration_directory, path, "/etc/passwd");
     will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
 
     expect_string(__wrap__mdebug2, formatted_msg,
@@ -607,9 +598,9 @@ static void test_drop_orphaned_promoted_documents_all_orphans(void **state) {
     cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/a.txt", "a", 1));
     cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/b.txt", "b", 1));
 
-    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/b.txt");
+    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/b.txt");
     will_return(__wrap_fim_configuration_directory, NULL);
-    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/a.txt");
+    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/a.txt");
     will_return(__wrap_fim_configuration_directory, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,

--- a/src/unit_tests/syscheckd/test_fim_sync_limits.c
+++ b/src/unit_tests/syscheckd/test_fim_sync_limits.c
@@ -25,6 +25,20 @@ extern void persist_sync_documents(char* table_name, cJSON* docs, Operation_t op
 extern void add_pending_sync_item(OSList *pending_items, const cJSON *json, int sync_value);
 extern void process_pending_sync_updates(char* table_name, OSList *pending_items);
 extern cJSON* extract_primary_keys(const char* table_name, const cJSON* full_doc);
+extern int drop_orphaned_promoted_documents(const char* table_name, cJSON* docs);
+
+// Wrapped fim_configuration_directory (real one is in syscheckd/src/file/file.c)
+directory_t* __wrap_fim_configuration_directory(const char* key, bool notify_not_found, const OSList* directories_list);
+
+// Stand-in directory_t pointer for "config exists" signal in tests
+static directory_t mock_drop_directory_config = {0};
+
+directory_t* __wrap_fim_configuration_directory(const char* key,
+                                                __attribute__((unused)) bool notify_not_found,
+                                                __attribute__((unused)) const OSList* directories_list) {
+    check_expected_ptr(key);
+    return mock_ptr_type(directory_t*);
+}
 
 // Local wrapper declarations (defined per-test-file like test_recovery.c)
 cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash,
@@ -534,6 +548,116 @@ static void test_process_pending_sync_updates_files(void **state) {
     OSList_Destroy(pending);
 }
 
+/* Tests (#36134) for drop_orphaned_promoted_documents() */
+
+// All paths still resolve to a configuration → array is unchanged.
+static void test_drop_orphaned_promoted_documents_no_orphans(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_file_doc("/etc/passwd", "abc123", 1));
+    cJSON_AddItemToArray(docs, create_file_doc("/etc/hosts", "def456", 1));
+
+    expect_string(__wrap_fim_configuration_directory, key, "/etc/hosts");
+    will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
+    expect_string(__wrap_fim_configuration_directory, key, "/etc/passwd");
+    will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
+
+    int dropped = drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, docs);
+
+    assert_int_equal(dropped, 0);
+    assert_int_equal(cJSON_GetArraySize(docs), 2);
+
+    cJSON_Delete(docs);
+}
+
+// One path no longer in config → only that row is dropped, the other stays.
+static void test_drop_orphaned_promoted_documents_some_orphans(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_file_doc("/etc/passwd", "abc123", 1));
+    cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/orphan.txt", "ghi789", 2));
+
+    // Helper walks the array from the tail down; tail item is "/home/vagrant/orphan.txt".
+    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/orphan.txt");
+    will_return(__wrap_fim_configuration_directory, NULL);
+
+    expect_string(__wrap_fim_configuration_directory, key, "/etc/passwd");
+    will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of orphaned path (no active configuration): /home/vagrant/orphan.txt");
+
+    int dropped = drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, docs);
+
+    assert_int_equal(dropped, 1);
+    assert_int_equal(cJSON_GetArraySize(docs), 1);
+    assert_string_equal(cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(docs, 0), "path")),
+                        "/etc/passwd");
+
+    cJSON_Delete(docs);
+}
+
+// All paths gone from config → all rows dropped, array becomes empty.
+static void test_drop_orphaned_promoted_documents_all_orphans(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/a.txt", "a", 1));
+    cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/b.txt", "b", 1));
+
+    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/b.txt");
+    will_return(__wrap_fim_configuration_directory, NULL);
+    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/a.txt");
+    will_return(__wrap_fim_configuration_directory, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of orphaned path (no active configuration): /home/vagrant/b.txt");
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of orphaned path (no active configuration): /home/vagrant/a.txt");
+
+    int dropped = drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, docs);
+
+    assert_int_equal(dropped, 2);
+    assert_int_equal(cJSON_GetArraySize(docs), 0);
+
+    cJSON_Delete(docs);
+}
+
+// Registry tables go through a different config model and must be left untouched.
+static void test_drop_orphaned_promoted_documents_registry_noop(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON* doc = cJSON_CreateObject();
+    cJSON_AddStringToObject(doc, "path", "HKEY_LOCAL_MACHINE\\Software\\Test");
+    cJSON_AddItemToArray(docs, doc);
+
+    // No fim_configuration_directory expectation: the helper must short-circuit before calling it.
+    int dropped = drop_orphaned_promoted_documents(FIMDB_REGISTRY_KEY_TABLENAME, docs);
+
+    assert_int_equal(dropped, 0);
+    assert_int_equal(cJSON_GetArraySize(docs), 1);
+
+    cJSON_Delete(docs);
+}
+
+// NULL/empty/non-array inputs must be tolerated without crashing.
+static void test_drop_orphaned_promoted_documents_null_and_invalid_inputs(void **state) {
+    (void) state;
+
+    assert_int_equal(drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, NULL), 0);
+
+    cJSON* not_array = cJSON_CreateObject();
+    assert_int_equal(drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, not_array), 0);
+    cJSON_Delete(not_array);
+
+    cJSON* empty = cJSON_CreateArray();
+    assert_int_equal(drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, empty), 0);
+    cJSON_Delete(empty);
+}
+
 /* Main test runner */
 
 int main(void) {
@@ -558,6 +682,12 @@ int main(void) {
         // Helper function tests
         cmocka_unit_test(test_add_pending_sync_item_success),
         cmocka_unit_test(test_process_pending_sync_updates_files),
+        // drop_orphaned_promoted_documents tests (#36134)
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_no_orphans),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_some_orphans),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_all_orphans),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_registry_noop),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_null_and_invalid_inputs),
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -20,6 +20,7 @@
 #include "../wrappers/common.h"
 #include "../../syscheckd/src/recovery/recovery.h"
 #include "../../syscheckd/src/db/include/db.h"
+#include "../../syscheckd/src/file/file.h"
 #include "../../shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h"
 #include "syscheck-config.h"
 #include "../wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h"
@@ -31,6 +32,7 @@ int64_t __wrap_fim_db_get_last_sync_time(const char* table_name);
 void __wrap_fim_db_update_last_sync_time_value(const char* table_name, int64_t timestamp);
 char* __wrap_fim_db_calculate_table_checksum(const char* table_name);
 cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash, const uint64_t document_version, const cJSON *dbsync_event, const fim_file_data *file_data);
+directory_t* __wrap_fim_configuration_directory(const char* key, bool notify_not_found, const OSList* directories_list);
 
 #ifdef WIN32
 cJSON* __wrap_build_stateful_event_registry_key(const char* path, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_key *data);
@@ -40,10 +42,20 @@ cJSON* __wrap_build_stateful_event_registry_value(const char* path, const char* 
 // Mock directories list for tests
 static OSList mock_directories = {0};
 
+// Stand-in directory_t pointer for tests that only need a non-NULL "config exists" signal
+static directory_t mock_directory_config = {0};
+
 // Mock implementations
 int64_t __wrap_fim_db_get_last_sync_time(const char* table_name) {
     check_expected(table_name);
     return mock_type(int64_t);
+}
+
+directory_t* __wrap_fim_configuration_directory(const char* key,
+                                                __attribute__((unused)) bool notify_not_found,
+                                                __attribute__((unused)) const OSList* directories_list) {
+    check_expected_ptr(key);
+    return mock_ptr_type(directory_t*);
 }
 
 void __wrap_fim_db_update_last_sync_time_value(const char* table_name, int64_t timestamp) {
@@ -165,6 +177,10 @@ static void test_fim_recovery_persist_table_and_resync_success(void **state) {
     // Expect asp_clear_in_memory_data call
     expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
 
+    // Orphan guard: path must still resolve to a config
+    expect_string(__wrap_fim_configuration_directory, key, "/tmp/test.txt");
+    will_return(__wrap_fim_configuration_directory, &mock_directory_config);
+
     // Expect build_stateful_event_file to be called for our test item
     expect_string(__wrap_build_stateful_event_file, path, "/tmp/test.txt");
     // Return a mock stateful event
@@ -221,6 +237,10 @@ static void test_fim_recovery_persist_table_and_resync_failure(void **state) {
 
     // Expect asp_clear_in_memory_data call
     expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
+
+    // Orphan guard: path must still resolve to a config
+    expect_string(__wrap_fim_configuration_directory, key, "/tmp/test2.txt");
+    will_return(__wrap_fim_configuration_directory, &mock_directory_config);
 
     // Expect build_stateful_event_file to be called for our test item
     expect_string(__wrap_build_stateful_event_file, path, "/tmp/test2.txt");
@@ -358,6 +378,72 @@ static void test_fim_recovery_check_if_full_sync_required_null_checksum(void **s
     assert_false(result);
 }
 
+// Test (#36134): Persist and resync skips rows whose path is no longer in the configuration.
+// Two items are returned by the DB; the first is "orphaned" (config lookup returns NULL) and
+// must be skipped silently; the second still has a config and must follow the normal path.
+static void test_fim_recovery_persist_table_and_resync_skips_orphan_paths(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+
+    cJSON* test_items = cJSON_CreateArray();
+
+    cJSON* orphan_item = cJSON_CreateObject();
+    cJSON_AddStringToObject(orphan_item, "path", "/home/vagrant/orphan.txt");
+    cJSON_AddStringToObject(orphan_item, "checksum", "orphan-sha");
+    cJSON_AddNumberToObject(orphan_item, "version", 1);
+    cJSON_AddNumberToObject(orphan_item, "inode", 11111);
+    cJSON_AddItemToArray(test_items, orphan_item);
+
+    cJSON* live_item = cJSON_CreateObject();
+    cJSON_AddStringToObject(live_item, "path", "/etc/passwd");
+    cJSON_AddStringToObject(live_item, "checksum", "live-sha");
+    cJSON_AddNumberToObject(live_item, "version", 1);
+    cJSON_AddNumberToObject(live_item, "inode", 22222);
+    cJSON_AddItemToArray(test_items, live_item);
+
+    expect_string(__wrap_fim_db_increase_each_entry_version, table_name, FIMDB_FILE_TABLE_NAME);
+    will_return(__wrap_fim_db_increase_each_entry_version, 0);
+
+    expect_string(__wrap_fim_db_get_every_element, table_name, FIMDB_FILE_TABLE_NAME);
+    expect_string(__wrap_fim_db_get_every_element, row_filter, "WHERE sync=1");
+    will_return(__wrap_fim_db_get_every_element, test_items);
+
+    expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
+
+    // Orphaned path: config lookup returns NULL -> row is skipped entirely.
+    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/orphan.txt");
+    will_return(__wrap_fim_configuration_directory, NULL);
+    // No build_stateful_event_file / asp_persist_diff_in_memory expectations for the orphan row.
+
+    // Live path: config lookup returns non-NULL -> normal pipeline.
+    expect_string(__wrap_fim_configuration_directory, key, "/etc/passwd");
+    will_return(__wrap_fim_configuration_directory, &mock_directory_config);
+
+    expect_string(__wrap_build_stateful_event_file, path, "/etc/passwd");
+    cJSON* mock_event = cJSON_CreateObject();
+    cJSON_AddStringToObject(mock_event, "type", "file");
+    will_return(__wrap_build_stateful_event_file, mock_event);
+
+    will_return(__wrap_schema_validator_is_initialized, false);
+
+    expect_value(__wrap_asp_persist_diff_in_memory, handle, handle);
+    expect_any(__wrap_asp_persist_diff_in_memory, id);
+    expect_value(__wrap_asp_persist_diff_in_memory, operation, OPERATION_CREATE);
+    expect_string(__wrap_asp_persist_diff_in_memory, index, FIM_FILES_SYNC_INDEX);
+    expect_any(__wrap_asp_persist_diff_in_memory, data);
+
+    expect_value(__wrap_asp_sync_module, handle, handle);
+    expect_value(__wrap_asp_sync_module, mode, MODE_FULL);
+    will_return(__wrap_asp_sync_module, true);
+
+    fim_recovery_persist_table_and_resync(FIMDB_FILE_TABLE_NAME, handle, &mock_directories);
+
+    // test_items is freed by the function.
+}
+
 // Test: buildFileStatefulEvent with valid data
 static void test_buildFileStatefulEvent_success(void **state) {
     (void) state;
@@ -441,6 +527,7 @@ int main(void) {
         cmocka_unit_test(test_fim_recovery_persist_table_and_resync_failure),
         cmocka_unit_test(test_fim_recovery_persist_table_and_resync_version_increase_failure),
         cmocka_unit_test(test_fim_recovery_persist_table_and_resync_null_items),
+        cmocka_unit_test(test_fim_recovery_persist_table_and_resync_skips_orphan_paths),
         cmocka_unit_test(test_fim_recovery_check_if_full_sync_required_mismatch),
         cmocka_unit_test(test_fim_recovery_check_if_full_sync_required_match),
         cmocka_unit_test(test_fim_recovery_check_if_full_sync_required_null_checksum),

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -32,7 +32,7 @@ int64_t __wrap_fim_db_get_last_sync_time(const char* table_name);
 void __wrap_fim_db_update_last_sync_time_value(const char* table_name, int64_t timestamp);
 char* __wrap_fim_db_calculate_table_checksum(const char* table_name);
 cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash, const uint64_t document_version, const cJSON *dbsync_event, const fim_file_data *file_data);
-directory_t* __wrap_fim_configuration_directory(const char* key, bool notify_not_found, const OSList* directories_list);
+// __wrap_fim_configuration_directory is provided by create_db_wrappers.c (shared wrapper).
 
 #ifdef WIN32
 cJSON* __wrap_build_stateful_event_registry_key(const char* path, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_key *data);
@@ -49,13 +49,6 @@ static directory_t mock_directory_config = {0};
 int64_t __wrap_fim_db_get_last_sync_time(const char* table_name) {
     check_expected(table_name);
     return mock_type(int64_t);
-}
-
-directory_t* __wrap_fim_configuration_directory(const char* key,
-                                                __attribute__((unused)) bool notify_not_found,
-                                                __attribute__((unused)) const OSList* directories_list) {
-    check_expected_ptr(key);
-    return mock_ptr_type(directory_t*);
 }
 
 void __wrap_fim_db_update_last_sync_time_value(const char* table_name, int64_t timestamp) {
@@ -178,7 +171,7 @@ static void test_fim_recovery_persist_table_and_resync_success(void **state) {
     expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
 
     // Orphan guard: path must still resolve to a config
-    expect_string(__wrap_fim_configuration_directory, key, "/tmp/test.txt");
+    expect_string(__wrap_fim_configuration_directory, path, "/tmp/test.txt");
     will_return(__wrap_fim_configuration_directory, &mock_directory_config);
 
     // Expect build_stateful_event_file to be called for our test item
@@ -239,7 +232,7 @@ static void test_fim_recovery_persist_table_and_resync_failure(void **state) {
     expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
 
     // Orphan guard: path must still resolve to a config
-    expect_string(__wrap_fim_configuration_directory, key, "/tmp/test2.txt");
+    expect_string(__wrap_fim_configuration_directory, path, "/tmp/test2.txt");
     will_return(__wrap_fim_configuration_directory, &mock_directory_config);
 
     // Expect build_stateful_event_file to be called for our test item
@@ -414,12 +407,12 @@ static void test_fim_recovery_persist_table_and_resync_skips_orphan_paths(void *
     expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
 
     // Orphaned path: config lookup returns NULL -> row is skipped entirely.
-    expect_string(__wrap_fim_configuration_directory, key, "/home/vagrant/orphan.txt");
+    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/orphan.txt");
     will_return(__wrap_fim_configuration_directory, NULL);
     // No build_stateful_event_file / asp_persist_diff_in_memory expectations for the orphan row.
 
     // Live path: config lookup returns non-NULL -> normal pipeline.
-    expect_string(__wrap_fim_configuration_directory, key, "/etc/passwd");
+    expect_string(__wrap_fim_configuration_directory, path, "/etc/passwd");
     will_return(__wrap_fim_configuration_directory, &mock_directory_config);
 
     expect_string(__wrap_build_stateful_event_file, path, "/etc/passwd");

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/configuration_templates/configuration_orphan_promote.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/configuration_templates/configuration_orphan_promote.yaml
@@ -1,0 +1,50 @@
+# Configuration template for tests covering issue #36134:
+# a previously realtime-monitored directory is removed from the FIM
+# configuration and the agent is restarted, so fim_initialize must
+# *not* log an ERROR for the rows that still live in fim.db.
+#
+# Two <directories> entries:
+#   - TEST_DIR_REALTIME (realtime) is what the test drops at restart;
+#     this is the path the regression error is reported for.
+#   - TEST_DIR_KEEP (scheduled) stays in the configuration so the
+#     scheduled scan after restart still has a path to walk, which
+#     keeps the handle_orphaned_delete path reachable (an empty
+#     <directories> list would trigger a DataClean instead).
+- sections:
+  - section: syscheck
+    elements:
+    - disabled:
+        value: 'no'
+    - frequency:
+        value: FREQUENCY
+    - directories:
+        value: TEST_DIR_REALTIME
+        attributes:
+        - check_all: 'yes'
+        - FIM_MODE
+    - directories:
+        value: TEST_DIR_KEEP
+        attributes:
+        - check_all: 'yes'
+    - synchronization:
+        elements:
+        - enabled:
+            value: 'yes'
+        - interval:
+            value: SYNC_INTERVAL
+        - integrity_interval:
+            value: INTEGRITY_INTERVAL
+  - section: sca
+    elements:
+    - enabled:
+        value: 'no'
+  - section: rootcheck
+    elements:
+    - disabled:
+        value: 'yes'
+  - section: wodle
+    attributes:
+      - name: 'syscollector'
+    elements:
+      - disabled:
+          value: 'yes'

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/test_cases/cases_orphan_promote.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/test_cases/cases_orphan_promote.yaml
@@ -1,0 +1,30 @@
+# Reproduces issue #36134: removing a realtime FIM rule from the agent
+# configuration must not produce
+#   ERROR: Failed to get configuration for path: <orphaned-file>
+# on the next restart, and the orphaned row must be cleaned up by the
+# regular handle_orphaned_delete path.
+- name: Orphan promote - Real-time directory dropped from config
+  description: A realtime directory is monitored, a file is created under it
+               via the inotify path (so the row lands in fim.db with sync=0),
+               the agent is stopped, the realtime <directories> entry is
+               removed from ossec.conf, and the agent is restarted.
+               fim_initialize must drop the orphan from docs_to_promote
+               instead of feeding it to build_stateful_event_file, and the
+               scheduled scan that follows must emit the orphan delete event
+               for both the realtime-added file and the seed file that
+               lived under the same directory.
+  configuration_parameters:
+    TEST_DIR_REALTIME: !!python/object/apply:os.path.join [/test_dir_36134_realtime]
+    TEST_DIR_KEEP: !!python/object/apply:os.path.join [/test_keep_36134]
+    FREQUENCY: 30
+    FIM_MODE:
+      realtime: 'yes'
+    SYNC_INTERVAL: 5
+    INTEGRITY_INTERVAL: 30
+  metadata:
+    realtime_folder: !!python/object/apply:os.path.join [/test_dir_36134_realtime]
+    keep_folder: !!python/object/apply:os.path.join [/test_keep_36134]
+    fim_mode: realtime
+    test_file: testfile_36134
+    seed_file: seed_36134
+    keep_seed_file: keep_seed_36134

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_orphan_promote_after_config_removal.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_orphan_promote_after_config_removal.py
@@ -1,0 +1,256 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Regression test for issue #36134. When a realtime <directories> rule
+       is removed from ossec.conf and the agent is restarted, the previously
+       monitored files still live in the local fim.db with sync=0. The agent's
+       fim_initialize() promote loop must drop those orphaned rows up front
+       rather than calling build_stateful_event_file() with the current
+       directories list (which would log
+       "ERROR: Failed to get configuration for path: <path>"). The orphan-
+       cleanup path in the next scheduled scan is responsible for emitting
+       the real DELETE event.
+
+       The test seeds a small file under both <directories> before the agent
+       starts so the baseline scan promotes at least one row to sync=1; that
+       satisfies the outer guard of fim_initialize's promote branch on the
+       next restart (it only runs when the table has at least one synced
+       row). A second <directories> entry stays in the configuration after
+       the realtime one is removed, so the post-restart scheduled scan walks
+       at least one path and reaches handle_orphaned_delete instead of the
+       "no directories configured" DataClean shortcut.
+
+components:
+    - fim
+
+suite: basic_usage
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-syscheckd
+
+os_platform:
+    - linux
+
+references:
+    - https://github.com/wazuh/wazuh/issues/36134
+    - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
+
+tags:
+    - fim
+    - realtime
+'''
+import sys
+import time
+
+import pytest
+
+from pathlib import Path
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.constants.platforms import WINDOWS
+from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG
+from wazuh_testing.modules.fim.configuration import SYSCHECK_DEBUG
+from wazuh_testing.modules.fim.patterns import EVENT_TYPE_ADDED
+from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils import configuration, file, services
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+
+from . import TEST_CASES_PATH, CONFIGS_PATH
+
+
+# Pytest marks: linux agent, tier 0.
+pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.tier(level=0)]
+
+# Test metadata, configuration and ids.
+cases_path = Path(TEST_CASES_PATH, 'cases_orphan_promote.yaml')
+config_path = Path(CONFIGS_PATH, 'configuration_orphan_promote.yaml')
+test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
+test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
+
+# Local internal options: surface syscheck.debug=2 so the helper's mdebug2
+# lines and the merror this test guards against both appear in ossec.log.
+local_internal_options = {SYSCHECK_DEBUG: 2, AGENTD_DEBUG: 2, MONITORD_ROTATE_LOG: 0}
+if sys.platform == WINDOWS:
+    local_internal_options.update({AGENTD_WINDOWS_DEBUG: 2})
+
+
+# Log patterns specific to this regression — not (yet) exposed by
+# wazuh_testing.modules.fim.patterns.
+FAILED_TO_GET_CONFIG_PATTERN = r'.*ERROR: Failed to get configuration for path: (\S+)'
+SKIPPING_PROMOTION_PATTERN = (
+    r'.*Skipping promotion of orphaned path \(no active configuration\): (\S+)'
+)
+HANDLE_ORPHANED_DELETE_PATTERN = (
+    r".*Generating delete event for orphaned file '(\S+)' \(path removed from configuration\)"
+)
+DOCUMENT_LIMIT_CHANGED_PATTERN = r'.*Document limit (increased|decreased)'
+
+
+@pytest.fixture()
+def _setup_orphan_test_folders(test_metadata: dict):
+    """Create both monitored folders before the agent starts and pre-seed
+    one file in each so the agent's initial baseline scheduled scan
+    promotes them to sync=1. Without a sync=1 row, the promote branch
+    of fim_initialize() short-circuits and the regression code path
+    isn't reached.
+
+    Yields the absolute path of the realtime folder.
+    """
+    realtime_folder = Path(test_metadata['realtime_folder'])
+    keep_folder = Path(test_metadata['keep_folder'])
+    seed_file = realtime_folder / test_metadata['seed_file']
+    keep_seed_file = keep_folder / test_metadata['keep_seed_file']
+
+    file.recursive_directory_creation(str(realtime_folder))
+    file.recursive_directory_creation(str(keep_folder))
+    file.write_file(str(seed_file), 'baseline-seed')
+    file.write_file(str(keep_seed_file), 'baseline-keep')
+
+    yield realtime_folder
+
+    file.delete_path_recursively(str(realtime_folder))
+    file.delete_path_recursively(str(keep_folder))
+
+
+def _remove_directories_section_from_ossec_conf(target_value: str) -> None:
+    """Strip every <directories ...>target_value</directories> line from
+    ossec.conf. Cheap textual edit — keeps the file otherwise intact so
+    the agent picks up the same configuration except for the one rule we
+    drop. The surrounding `set_wazuh_configuration` fixture restores the
+    file from a snapshot at teardown.
+    """
+    conf_lines = configuration.get_wazuh_conf()
+    pruned = [
+        line for line in conf_lines
+        if not (
+            '<directories' in line
+            and f'>{target_value}<' in line
+        )
+    ]
+    configuration.write_wazuh_conf(pruned)
+
+
+@pytest.mark.parametrize(
+    'test_configuration, test_metadata',
+    zip(test_configuration, test_metadata),
+    ids=cases_ids,
+)
+def test_orphan_promote_after_config_removal(
+    test_configuration,
+    test_metadata,
+    set_wazuh_configuration,
+    truncate_monitored_files,
+    configure_local_internal_options,
+    _setup_orphan_test_folders,
+    daemons_handler,
+    start_monitoring,
+):
+    '''
+    description: Reproduce issue #36134 and verify the fix.
+
+                 The agent is started with two <directories> rules: one
+                 realtime path that the test will drop later, and one
+                 scheduled path that stays in the config. Both folders are
+                 pre-seeded with a sentinel file so the initial baseline
+                 scan promotes at least one row to sync=1. The test then
+                 creates a file under the realtime folder via inotify (so
+                 the row lands in fim.db with sync=0), stops the agent,
+                 strips the realtime <directories> entry from ossec.conf,
+                 and restarts the agent.
+
+                 The fixed agent must:
+                   1) not log "ERROR: Failed to get configuration for path"
+                      for the orphaned file,
+                   2) log the helper's
+                      "Skipping promotion of orphaned path (no active
+                      configuration): <file>" debug line,
+                   3) still emit the orphan delete event via
+                      handle_orphaned_delete on the next scheduled scan.
+
+    wazuh_min_version: 5.0.0
+
+    tier: 0
+    '''
+    realtime_folder = Path(test_metadata['realtime_folder'])
+    target_file = realtime_folder / test_metadata['test_file']
+
+    # Step 1: agent is up via daemons_handler. The baseline scan has
+    # already visited both folders and promoted the seed files to sync=1
+    # (start_monitoring blocks until the first sync finishes).
+    #
+    # Create the realtime-tracked file. inotify queues an "added" event;
+    # the row lands in fim.db with sync=0 (the realtime path does not
+    # flush the sync flag).
+    file.write_file(str(target_file), 'evidence-36134')
+    FileMonitor(WAZUH_LOG_PATH).start(
+        generate_callback(EVENT_TYPE_ADDED),
+        timeout=30,
+    )
+
+    # Step 2: stop the agent, drop the realtime <directories> rule from
+    # ossec.conf, truncate the log, restart. This is the configuration
+    # change that the upstream bug report describes (an agent group with
+    # a realtime FIM rule getting unassigned).
+    services.control_service('stop')
+    _remove_directories_section_from_ossec_conf(str(realtime_folder))
+    file.truncate_file(WAZUH_LOG_PATH)
+    services.control_service('start')
+
+    # Wait for fim_initialize() to log its "Document limit (increased|
+    # decreased)" line — that signals the promote loop ran with our
+    # docs_to_promote in hand. If this never appears the promote branch
+    # was short-circuited (e.g. no sync=1 rows) and the test setup is
+    # wrong.
+    FileMonitor(WAZUH_LOG_PATH).start(
+        generate_callback(DOCUMENT_LIMIT_CHANGED_PATTERN),
+        timeout=60,
+    )
+
+    # Give fim_initialize a beat to finish so the orphan-skip mdebug2
+    # lands in the log file before we read it.
+    time.sleep(2)
+
+    log_text = Path(WAZUH_LOG_PATH).read_text()
+
+    # Assertion 1 (the regression itself): no ERROR for any orphaned path.
+    # We match by directory prefix because both the seed_file and the
+    # realtime-added test file are orphans now — neither should produce
+    # a merror.
+    failed_lines = [
+        line for line in log_text.splitlines()
+        if 'ERROR: Failed to get configuration for path' in line
+        and str(realtime_folder) in line
+    ]
+    assert not failed_lines, (
+        f'Unexpected "Failed to get configuration" ERROR lines for '
+        f'{realtime_folder}:\n' + '\n'.join(failed_lines)
+    )
+
+    # Assertion 2: the fix's debug line fired for the realtime-added
+    # file (the one with sync=0 that gets fed to docs_to_promote).
+    skip_lines = [
+        line for line in log_text.splitlines()
+        if 'Skipping promotion of orphaned path' in line and str(target_file) in line
+    ]
+    assert skip_lines, (
+        f'Expected "Skipping promotion of orphaned path" line for '
+        f'{target_file}, got none. ossec.log tail:\n{log_text[-2000:]}'
+    )
+
+    # Assertion 3: the existing orphan-delete path still handles cleanup
+    # on the first scheduled scan after restart.
+    FileMonitor(WAZUH_LOG_PATH).start(
+        generate_callback(HANDLE_ORPHANED_DELETE_PATTERN),
+        timeout=90,
+    )


### PR DESCRIPTION
## Description

Fix for the issue reported in #36134: on agent startup that follows a configuration change which drops a previously realtime-monitored `<directories>` rule, `wazuh-syscheckd` logs

```
ERROR: Failed to get configuration for path: <orphaned-file>
```

for every realtime-added file that still lives in `fim.db` from before the change. The merror is misleading (it fires from a known orphan path that the next scheduled scan cleans up anyway) and also has a side effect: those orphan rows get marked `sync=1` in the local DB even though the corresponding stateful event was never sent.

Closes #36134.

## Proposed Changes

- **`src/syscheckd/src/syscheck.c`** — new helper `drop_orphaned_promoted_documents(table_name, docs)`, called from `fim_initialize()` right after `fim_db_get_documents_to_promote()` returns and before both `persist_sync_documents(... OPERATION_CREATE)` and the `add_pending_sync_item` loop. For `file_entry` rows whose path no longer resolves to a directory in `syscheck.directories`, the helper drops the row from `docs_to_promote` (with an `mdebug2` skip line) so the noisy merror and the bad `sync=1` write are both avoided. Registry tables short-circuit out (different config model).
- **`src/syscheckd/src/recovery/recovery.c`** — defensive twin guard at the head of `fim_recovery_persist_table_and_resync()`'s file_entry branch. A stale `sync=1` orphan row picked up by the integrity sweep no longer retriggers the same merror through `buildFileStatefulEvent`.

The scheduled scan that runs shortly after restart still emits the real `handle_orphaned_delete` for the orphan rows, so cleanup of the local DB and the indexer is unchanged.

### Results and Evidence

#### Before the fix (issue repro)

ossec.log after a clean repro (realtime config → file → strip config → restart):

```
14:37:26 wazuh-syscheckd syscheck.c:505 fim_initialize():
         Document limit increased from 1320 to 30000 for index file_entry. Currently synced documents: 1321
14:37:26 wazuh-syscheckd file.c:590    fim_configuration_directory():
         (6319): No configuration found for (file):'/home/vagrant/testfile'
14:37:26 wazuh-syscheckd file.c:50     build_stateful_event_file():
         ERROR: Failed to get configuration for path: /home/vagrant/testfile           ← the bug
14:37:26 wazuh-syscheckd syscheck.c:334 persist_sync_documents():
         Sent 0 promoted documents to persistent queue for table file_entry
14:37:26 wazuh-syscheckd syscheck.c:124 add_pending_sync_item():
         Added item to pending sync list: /home/vagrant/testfile (version: 2, sync: 1)
14:37:26 wazuh-syscheckd syscheck.c:142 process_pending_sync_updates():
         Setting sync=1 for path: /home/vagrant/testfile                               ← bad sync=1 write
14:37:26 wazuh-syscheckd file.c:114    handle_orphaned_delete():
         Generating delete event for orphaned file '/home/vagrant/testfile' (path removed from configuration)
```

#### After the fix (same repro on the fixed binary)

```
19:47:20 wazuh-syscheckd syscheck.c:180 drop_orphaned_promoted_documents():
         DEBUG: Skipping promotion of orphaned path (no active configuration): /home/vagrant/testfile
19:47:20 wazuh-syscheckd syscheck.c:548 fim_initialize():
         DEBUG: Document limit increased from 1349 to 30000 for index file_entry. Currently synced documents: 1349
19:47:20 wazuh-syscheckd syscheck.c:372 persist_sync_documents():
         DEBUG: Sent 0 promoted documents to persistent queue for table file_entry
19:47:20 wazuh-syscheckd file.c:114    handle_orphaned_delete():
         DEBUG: Generating delete event for orphaned file '/home/vagrant/alpha.txt' (path removed from configuration)
19:47:20 wazuh-syscheckd file.c:114    handle_orphaned_delete():
         DEBUG: Generating delete event for orphaned file '/home/vagrant/testfile' (path removed from configuration)
```

`grep -E "ERROR" /var/ossec/logs/ossec.log` is empty for syscheckd, and the orphan-delete still fires.

#### Indexer end-to-end (`wazuh-states-fim-files`)

Before restart with the realtime config still in place:

```
GET /wazuh-states-fim-files/_count                       -> {"count":1350}
GET .../_search?q=file.path:"/home/vagrant/testfile"     -> hits.total.value: 1
```

After dropping the realtime entry and restarting:

```
GET /wazuh-states-fim-files/_count                       -> {"count":1348}
GET .../_search?q=file.path:"/home/vagrant/testfile"     -> hits.total.value: 0
GET .../_search?q=file.path:"/home/vagrant/alpha.txt"    -> hits.total.value: 0
```

Both orphan documents are removed from the indexer; the count drop matches the two orphan paths.

#### Negative validation (regression test catches the bug)

With the `drop_orphaned_promoted_documents(table_name, docs_to_promote);` call commented out, the new integration test fails on its first assertion citing the exact bug signature:

```
FAILED test_orphan_promote_after_config_removal[Orphan promote - Real-time directory dropped from config]
 - AssertionError: Unexpected "Failed to get configuration" ERROR lines for /test_dir_36134_realtime:
     2026/05/18 17:51:34 wazuh-syscheckd[62734] file.c:50 at build_stateful_event_file():
     ERROR: Failed to get configuration for path: /test_dir_36134_realtime/testfile_36134
1 failed in 81.55s
```

With the fix restored, the same test passes in ~70-80s.

```
test_orphan_promote_after_config_removal[Orphan promote - Real-time directory dropped from config] PASSED [100%]
1 passed in 72.19s
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (built via `make TARGET=agent -j4`; the only platform affected by this change — Linux agent / `wazuh-syscheckd`)
  - [ ] Windows — N/A (no Windows-specific code; registry tables short-circuit in the helper)
  - [ ] MAC OS X — N/A
- [x] Log syntax and correct language review — new lines use `mdebug2` at debug level 2, English phrasing consistent with surrounding `mdebug2` calls in the same files.

- Memory tests for Linux
  - [ ] Coverity — N/A (no production-side allocator changes; helper only iterates and removes cJSON array items already managed by the caller)
  - [ ] Valgrind — N/A
  - [x] AddressSanitizer — `test_recovery` and `test_fim_sync_limits` run clean under ASan (no `LeakSanitizer` output on the unit-test binaries built with the syscheckd unit-test target).
- Memory tests for Windows — N/A
- Memory tests for macOS — N/A

- Decoder/Rule tests — N/A (no ruleset changes)
- Engine — N/A (this PR is agent-side only)
- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A (no manager / API changes)

### Artifacts Affected

- `wazuh-syscheckd` (Linux agent only). Same binary path/permissions, no configuration file changes.

### Configuration Changes

N/A. No new XML options, no defaults touched, no schema changes. Behavior is purely on the local-fim.db reconciliation path during `fim_initialize`.

### Tests Introduced

**Unit tests** (`src/unit_tests/syscheckd/`):

- `test_fim_sync_limits` — 5 new cases for `drop_orphaned_promoted_documents`:
  - `test_drop_orphaned_promoted_documents_no_orphans` — every row resolves to a config, array unchanged, helper returns 0.
  - `test_drop_orphaned_promoted_documents_some_orphans` — mixed input, only the orphan row is dropped, mdebug2 skip line verified.
  - `test_drop_orphaned_promoted_documents_all_orphans` — array drained, helper returns the original size.
  - `test_drop_orphaned_promoted_documents_registry_noop` — `FIMDB_REGISTRY_KEY_TABLENAME` short-circuits without calling `fim_configuration_directory`.
  - `test_drop_orphaned_promoted_documents_null_and_invalid_inputs` — NULL / non-array / empty inputs tolerated.
- `test_recovery` — 1 new case `test_fim_recovery_persist_table_and_resync_skips_orphan_paths` exercises the defensive guard in `fim_recovery_persist_table_and_resync` for a two-element input with one orphan. Pre-existing `_success` / `_failure` tests updated to mock the new `fim_configuration_directory` lookup.

`CMakeLists.txt` wraps `fim_configuration_directory` for both binaries.

**Integration test** (`tests/integration/test_fim/test_files/test_basic_usage/`):

- `test_orphan_promote_after_config_removal.py` (+ `data/configuration_templates/configuration_orphan_promote.yaml` and `data/test_cases/cases_orphan_promote.yaml`) — full end-to-end regression test. Configures a realtime directory + a scheduled "keep" directory, seeds one file in each so the baseline scan promotes a row to `sync=1`, creates the realtime-added test file in-test (`sync=0`), stops the agent, strips the realtime `<directories>` line, restarts, and asserts:
  1. No `ERROR: Failed to get configuration for path` line for any path under the dropped folder.
  2. The fix's `Skipping promotion of orphaned path (no active configuration): <file>` debug line appears for the realtime-added file.
  3. `handle_orphaned_delete` still fires for the orphan rows on the scheduled scan that follows.

Runs in ~70-80s on Linux, no `auditd` required (no whodata variant).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A — no config changes)
- [ ] Developer documentation reflects the changes — N/A (no public API or developer-facing behaviour changes)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
