### PR TITLE
Create a backup of local_rules.xml during execution of IT analysisd tier 0 1

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,6 +19,7 @@ from wazuh_testing.constants.paths.logs import (
     ACTIVE_RESPONSE_LOG_PATH,
     WAZUH_LOG_PATH,
     ALERTS_JSON_PATH,
+    ARCHIVES_LOG_PATH,
     WAZUH_API_LOG_FILE_PATH,
     WAZUH_API_JSON_LOG_FILE_PATH,
 )
@@ -289,6 +290,7 @@ def truncate_monitored_files_implementation() -> None:
         log_files = [
             WAZUH_LOG_PATH,
             ALERTS_JSON_PATH,
+            ARCHIVES_LOG_PATH,
             WAZUH_API_LOG_FILE_PATH,
             WAZUH_API_JSON_LOG_FILE_PATH,
             WAZUH_CLIENT_KEYS_PATH,

--- a/tests/integration/test_analysisd/conftest.py
+++ b/tests/integration/test_analysisd/conftest.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 import pytest
 
 from wazuh_testing.constants.paths.configurations import CUSTOM_RULES_PATH, CUSTOM_RULES_FILE, WAZUH_CONF_PATH
-from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, ARCHIVES_LOG_PATH, WAZUH_LOG_PATH
 from wazuh_testing.constants.users import WAZUH_UNIX_GROUP, WAZUH_UNIX_USER
 from wazuh_testing.modules.analysisd import patterns
 from wazuh_testing.tools.monitors import file_monitor
@@ -26,6 +26,12 @@ def prepare_custom_rules_file(request, test_metadata):
     data_dir = getattr(request.module, 'RULES_SAMPLE_PATH')
     source_rule = os.path.join(data_dir, test_metadata['rules_file'])
     target_rule = os.path.join(CUSTOM_RULES_PATH, test_metadata['rules_file'])
+    backup_rule = target_rule + '.cpy'
+
+    # back up the original target if it already exists (e.g. local_rules.xml)
+    target_existed = os.path.isfile(target_rule)
+    if target_existed:
+        shutil.copy(target_rule, backup_rule)
 
     # copy custom rule with specific privileges
     shutil.copy(source_rule, target_rule)
@@ -33,8 +39,12 @@ def prepare_custom_rules_file(request, test_metadata):
 
     yield
 
-    # remove custom rule
-    os.remove(target_rule)
+    # restore the original rule if it existed, otherwise drop the test copy
+    if target_existed:
+        shutil.move(backup_rule, target_rule)
+        shutil.chown(target_rule, WAZUH_UNIX_USER, WAZUH_UNIX_GROUP)
+    else:
+        os.remove(target_rule)
 
 
 @pytest.fixture()
@@ -52,6 +62,23 @@ def configure_local_rules(request, test_configuration):
 
     # restore previous configuration
     shutil.move(CUSTOM_RULES_FILE + '.cpy', CUSTOM_RULES_FILE)
+
+
+@pytest.fixture()
+def truncate_archives_log():
+    """Truncate /var/ossec/logs/archives/archives.log before and after the test.
+
+    The general `truncate_monitored_files` fixture does not cover this file, but
+    tests that assert on event ordering inside archives.log need a clean slate
+    between executions to avoid IDs from prior runs breaking the assertion.
+    """
+    if os.path.isfile(ARCHIVES_LOG_PATH):
+        file.truncate_file(ARCHIVES_LOG_PATH)
+
+    yield
+
+    if os.path.isfile(ARCHIVES_LOG_PATH):
+        file.truncate_file(ARCHIVES_LOG_PATH)
 
 
 @pytest.fixture()

--- a/tests/integration/test_analysisd/conftest.py
+++ b/tests/integration/test_analysisd/conftest.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 import pytest
 
 from wazuh_testing.constants.paths.configurations import CUSTOM_RULES_PATH, CUSTOM_RULES_FILE, WAZUH_CONF_PATH
-from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, ARCHIVES_LOG_PATH, WAZUH_LOG_PATH
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
 from wazuh_testing.constants.users import WAZUH_UNIX_GROUP, WAZUH_UNIX_USER
 from wazuh_testing.modules.analysisd import patterns
 from wazuh_testing.tools.monitors import file_monitor
@@ -28,7 +28,7 @@ def prepare_custom_rules_file(request, test_metadata):
     target_rule = os.path.join(CUSTOM_RULES_PATH, test_metadata['rules_file'])
     backup_rule = target_rule + '.cpy'
 
-    # back up the original target if it already exists (e.g. local_rules.xml)
+    # back up the original target if it already exists
     target_existed = os.path.isfile(target_rule)
     if target_existed:
         shutil.copy(target_rule, backup_rule)
@@ -39,7 +39,7 @@ def prepare_custom_rules_file(request, test_metadata):
 
     yield
 
-    # restore the original rule if it existed, otherwise drop the test copy
+    # restore the original rule if it existed
     if target_existed:
         shutil.move(backup_rule, target_rule)
         shutil.chown(target_rule, WAZUH_UNIX_USER, WAZUH_UNIX_GROUP)
@@ -62,23 +62,6 @@ def configure_local_rules(request, test_configuration):
 
     # restore previous configuration
     shutil.move(CUSTOM_RULES_FILE + '.cpy', CUSTOM_RULES_FILE)
-
-
-@pytest.fixture()
-def truncate_archives_log():
-    """Truncate /var/ossec/logs/archives/archives.log before and after the test.
-
-    The general `truncate_monitored_files` fixture does not cover this file, but
-    tests that assert on event ordering inside archives.log need a clean slate
-    between executions to avoid IDs from prior runs breaking the assertion.
-    """
-    if os.path.isfile(ARCHIVES_LOG_PATH):
-        file.truncate_file(ARCHIVES_LOG_PATH)
-
-    yield
-
-    if os.path.isfile(ARCHIVES_LOG_PATH):
-        file.truncate_file(ARCHIVES_LOG_PATH)
 
 
 @pytest.fixture()

--- a/tests/integration/test_analysisd/test_limit_eps/test_event_processing.py
+++ b/tests/integration/test_analysisd/test_limit_eps/test_event_processing.py
@@ -427,8 +427,7 @@ def test_dropping_events_when_queue_is_full(test_configuration, test_metadata, l
 @pytest.mark.parametrize('test_configuration, test_metadata', zip(test4_configuration, test4_metadata), ids=test4_cases_ids)
 @pytest.mark.parametrize('configure_local_internal_options', [t4_local_internal_options], indirect=True)
 def test_event_processing_in_order_single_thread(test_configuration, test_metadata, load_wazuh_basic_configuration, set_wazuh_configuration,
-                                                 configure_local_internal_options, truncate_monitored_files,
-                                                 truncate_archives_log, daemons_handler):
+                                                 configure_local_internal_options, truncate_monitored_files, daemons_handler):
     """
     description: Check that events are processed in order according to the position within the queue, and
         that events that are being received during the blocking phase are being added to the end of the queue when
@@ -536,8 +535,7 @@ def test_event_processing_in_order_single_thread(test_configuration, test_metada
 
 @pytest.mark.parametrize('test_configuration, test_metadata', zip(test5_configuration, test5_metadata), ids=test5_cases_ids)
 def test_event_processing_in_order_multi_thread(test_configuration, test_metadata, load_wazuh_basic_configuration, set_wazuh_configuration,
-                                                configure_local_internal_options, truncate_monitored_files,
-                                                truncate_archives_log, daemons_handler):
+                                                configure_local_internal_options, truncate_monitored_files, daemons_handler):
     """
     description: Check that events are processed in order according to the position within the queue, and
         that events that are being received during the blocking phase are being added to the end of the queue when

--- a/tests/integration/test_analysisd/test_limit_eps/test_event_processing.py
+++ b/tests/integration/test_analysisd/test_limit_eps/test_event_processing.py
@@ -427,7 +427,8 @@ def test_dropping_events_when_queue_is_full(test_configuration, test_metadata, l
 @pytest.mark.parametrize('test_configuration, test_metadata', zip(test4_configuration, test4_metadata), ids=test4_cases_ids)
 @pytest.mark.parametrize('configure_local_internal_options', [t4_local_internal_options], indirect=True)
 def test_event_processing_in_order_single_thread(test_configuration, test_metadata, load_wazuh_basic_configuration, set_wazuh_configuration,
-                                                 configure_local_internal_options, truncate_monitored_files, daemons_handler):
+                                                 configure_local_internal_options, truncate_monitored_files,
+                                                 truncate_archives_log, daemons_handler):
     """
     description: Check that events are processed in order according to the position within the queue, and
         that events that are being received during the blocking phase are being added to the end of the queue when
@@ -535,7 +536,8 @@ def test_event_processing_in_order_single_thread(test_configuration, test_metada
 
 @pytest.mark.parametrize('test_configuration, test_metadata', zip(test5_configuration, test5_metadata), ids=test5_cases_ids)
 def test_event_processing_in_order_multi_thread(test_configuration, test_metadata, load_wazuh_basic_configuration, set_wazuh_configuration,
-                                                configure_local_internal_options, truncate_monitored_files, daemons_handler):
+                                                configure_local_internal_options, truncate_monitored_files,
+                                                truncate_archives_log, daemons_handler):
     """
     description: Check that events are processed in order according to the position within the queue, and
         that events that are being received during the blocking phase are being added to the end of the queue when


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Two integration test fixtures in the `analysisd` tier 0/1 suite caused intermittent failures when tests were executed sequentially on the same host.

1. `prepare_custom_rules_file` always deleted the destination rule file during teardown, even when that file (e.g. `local_rules.xml`) existed on the system before the test started. This left the system without the file, breaking subsequent tests that depended on it.

2. `truncate_monitored_files` did not cover `archives.log`. Tests like `test_event_processing_in_order_single_thread` that assert on event ordering by reading that file accumulated events from previous runs, causing false ordering failures.

## Proposed Changes

### `tests/integration/test_analysisd/conftest.py` — `prepare_custom_rules_file` fixture

- Before copying the test rule file to the destination path, the fixture now checks whether the destination file already exists.
- If it does, a backup copy (`.cpy`) is saved before overwriting.
- In teardown, if the file existed previously, the backup is restored and ownership is set to `wazuh:wazuh`. If the file did not exist before the test, it is deleted as before.

**Before:**
```python
shutil.copy(source_rule, target_rule)
shutil.chown(target_rule, WAZUH_UNIX_USER, WAZUH_UNIX_GROUP)
yield
os.remove(target_rule)  # always deleted, even if target was a pre-existing system file
```

**After:**
```python
target_existed = os.path.isfile(target_rule)
if target_existed:
    shutil.copy(target_rule, backup_rule)   # save original
shutil.copy(source_rule, target_rule)
shutil.chown(target_rule, WAZUH_UNIX_USER, WAZUH_UNIX_GROUP)
yield
if target_existed:
    shutil.move(backup_rule, target_rule)   # restore original
    shutil.chown(target_rule, WAZUH_UNIX_USER, WAZUH_UNIX_GROUP)
else:
    os.remove(target_rule)
```

### `tests/integration/conftest.py` — `truncate_monitored_files_implementation`

- Added `ARCHIVES_LOG_PATH` (`/var/ossec/logs/archives/archives.log`) to the list of files truncated by `truncate_monitored_files` and `truncate_monitored_files_module`.
- This ensures a clean slate for every test that reads `archives.log` to assert on event ordering, preventing IDs from prior runs from appearing in the file and causing false failures.

### Results and Evidence

 

<details>
<summary> Before the changes, the result of the second execution </summary>

```
=============================================================================== short test summary info ===============================================================================
FAILED test_analysisd/test_limit_eps/test_event_processing.py::test_event_processing_in_order_single_thread[configure_local_internal_options0-messages events order - single-thread] - AssertionError: Events have not been processed in the expected order
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test1.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test2.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test3.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test4.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test5.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test6.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test7.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test8.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test9.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test10.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test11.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test12.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test13.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'
ERROR test_analysisd/test_mitre/test_mitre_check_alert.py::test_mitre_check_alert[/home/vagrant/git/4.14.6/wazuh/tests/integration/test_analysisd/test_mitre/data/rules_samples/test14.xml] - FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/etc/rules/local_rules.xml'

```

</details>


- After the changes

```
============= 85 passed, 57142 deselected, 74 warnings in 2102.94s
```

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues