### PR TITLE
Build windows externals inside compile_windows_agent image

### DIFF
--- a/.github/workflows/5_builderpackage_externals.yml
+++ b/.github/workflows/5_builderpackage_externals.yml
@@ -16,8 +16,11 @@ name: 5.X - Package - Build external dependencies
 #                           denominator — its glibc is forward-compatible
 #                           with deb, so we don't build deb separately)
 #   - 2 macOS native legs:  macos-intel64, macos-arm64
-#   - 1 Windows leg:        windows-i686 (MinGW cross-compile on a Linux
-#                                         runner, no Docker)
+#   - 1 Windows leg:        windows-i686 (MinGW cross-compile inside the
+#                                         compile_windows_agent image —
+#                                         ubuntu:22.04 with mingw pre-baked,
+#                                         the same image used by the official
+#                                         windows agent build)
 # macOS and Windows are agent-only (no manager binaries exist for them).
 # To re-run a single broken leg, use Actions' "Re-run failed jobs" rather
 # than reintroducing a per-leg dispatch input.
@@ -63,7 +66,8 @@ jobs:
       matrix:
         # Linux legs run twice (agent image + manager image); macOS and
         # Windows have no manager builder image so they run agent-only.
-        # windows-i686 is MinGW cross-compile on the Linux amd64 runner.
+        # windows-i686 is MinGW cross-compile inside the compile_windows_agent
+        # container on the Linux amd64 runner — see "Resolve image tag" below.
         include:
           - { system: rpm,     architecture: amd64,   runner: wz-linux-amd64, leg: rpm-amd64,     target: agent }
           - { system: rpm,     architecture: arm64,   runner: wz-linux-arm64, leg: rpm-arm64,     target: agent }
@@ -80,7 +84,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Resolve image tag
-        if: matrix.system == 'rpm'
+        if: matrix.system == 'rpm' || matrix.system == 'windows'
         run: |
           VERSION="$(grep '"version"' "${GITHUB_WORKSPACE}/VERSION.json" | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
           if [ "${{ inputs.docker_image_tag }}" = "auto" ]; then
@@ -90,10 +94,19 @@ jobs:
           else
             echo "TAG=${{ inputs.docker_image_tag }}" >> "${GITHUB_ENV}"
           fi
-          echo "CONTAINER_NAME=pkg_${{ matrix.system }}_${{ matrix.target }}_builder_${{ matrix.architecture }}" >> "${GITHUB_ENV}"
+          # rpm legs use one builder image per (system, target, arch). The
+          # windows leg uses compile_windows_agent — the same ubuntu:22.04 +
+          # MinGW image 5_builderpackage_agent-windows.yml builds the agent
+          # in, so the host glibc the externals link against matches what
+          # downstream windows agent consumers see.
+          if [ "${{ matrix.system }}" = "windows" ]; then
+            echo "CONTAINER_NAME=compile_windows_agent" >> "${GITHUB_ENV}"
+          else
+            echo "CONTAINER_NAME=pkg_${{ matrix.system }}_${{ matrix.target }}_builder_${{ matrix.architecture }}" >> "${GITHUB_ENV}"
+          fi
 
       - name: Pull builder image from GHCR
-        if: matrix.system == 'rpm'
+        if: matrix.system == 'rpm' || matrix.system == 'windows'
         timeout-minutes: 20
         run: |
           bash "${GITHUB_WORKSPACE}/.github/actions/ghcr-pull-and-push/pull_image_from_ghcr.sh" \
@@ -105,16 +118,6 @@ jobs:
         # --owner/--group/--no-same-owner, which we use to keep the packed
         # tarballs reproducible across runners.
         run: brew install bash automake gnu-tar
-
-      - name: Install MinGW cross-compiler (windows leg)
-        if: matrix.system == 'windows'
-        run: |
-          # Mirrors what 5_builderpackage_agent-windows.yml does: cross-compile
-          # the Windows agent on a Linux runner using MinGW. The Wazuh CMake
-          # external recipes detect IS_WINDOWS via CMAKE_SYSTEM_NAME (set by
-          # TARGET=winagent) and switch to the i686-w64-mingw32-* toolchain.
-          sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64 make
 
       - name: Build externals
         timeout-minutes: 60

--- a/.github/workflows/5_builderpackage_externals.yml
+++ b/.github/workflows/5_builderpackage_externals.yml
@@ -289,11 +289,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `image` is the builder image to consume the consolidated deps inside.
+        # For agent/manager that's the same rpm builder build-externals used;
+        # for winagent it's compile_windows_agent (ubuntu:22.04) so the windows
+        # binaries shipped in libraries/windows/ are exercised against the same
+        # glibc baseline the downstream windows agent build sees. Without this,
+        # a host-side tool packed in the windows externals (e.g. flatbuffers'
+        # `flatc`) that was built on a newer glibc than the consumer slips
+        # through the smoke check.
         include:
-          - { architecture: amd64, runner: wz-linux-amd64, target: agent }
-          - { architecture: amd64, runner: wz-linux-amd64, target: manager }
-          - { architecture: arm64, runner: wz-linux-arm64, target: agent }
-          - { architecture: arm64, runner: wz-linux-arm64, target: manager }
+          - { architecture: amd64, runner: wz-linux-amd64, target: agent,    image: pkg_rpm_agent_builder_amd64 }
+          - { architecture: amd64, runner: wz-linux-amd64, target: manager,  image: pkg_rpm_manager_builder_amd64 }
+          - { architecture: arm64, runner: wz-linux-arm64, target: agent,    image: pkg_rpm_agent_builder_arm64 }
+          - { architecture: arm64, runner: wz-linux-arm64, target: manager,  image: pkg_rpm_manager_builder_arm64 }
+          - { architecture: i686,  runner: wz-linux-amd64, target: winagent, image: compile_windows_agent }
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     name: Smoke build (${{ matrix.target }}-${{ matrix.architecture }})
@@ -311,7 +320,7 @@ jobs:
           else
             echo "TAG=${{ inputs.docker_image_tag }}" >> "${GITHUB_ENV}"
           fi
-          echo "CONTAINER_NAME=pkg_rpm_${{ matrix.target }}_builder_${{ matrix.architecture }}" >> "${GITHUB_ENV}"
+          echo "CONTAINER_NAME=${{ matrix.image }}" >> "${GITHUB_ENV}"
 
       - name: Pull builder image from GHCR
         timeout-minutes: 20

--- a/docs/dev/build-external-dependencies.md
+++ b/docs/dev/build-external-dependencies.md
@@ -68,12 +68,12 @@ We don't build separate `deb` legs because rpm glibc is forward-compatible with 
 ```
 build-externals (matrix, 7 jobs)
        │
-       └─► consolidate ──► smoke-build (4 jobs, Linux-only)
+       └─► consolidate ──► smoke-build (5 jobs)
 ```
 
 - **`build-externals`** — each leg seeds `src/external/`, applies `--dependencies` overrides, runs the build, and uploads `externals-<leg>-<target>.tar.gz`.
 - **`consolidate`** — downloads every per-leg tarball, merges into the canonical `libraries/{linux,darwin,windows,sources}/` layout, and uploads `externals-all.tar.gz` (the artifact you publish to `packages.wazuh.com/deps/<version>/`).
-- **`smoke-build`** — for each of the 4 Linux combinations (amd64/arm64 × agent/manager), pulls `externals-all.tar.gz`, points `make deps RESOURCES_URL=file://…` at the local tree, then runs the real Wazuh build. Confirms the precompiled tarballs you just packed actually get consumed. Emits `::warning::` for any dep that fell back to source compile — that means the binary was packed at a path `src/external/CMakeLists.txt` doesn't expect.
+- **`smoke-build`** — for each of the 4 Linux combinations (amd64/arm64 × agent/manager) plus a windows-i686 leg, pulls `externals-all.tar.gz`, points `make deps RESOURCES_URL=file://…` at the local tree, then runs the real Wazuh build inside the matching builder image (`pkg_rpm_<target>_builder_<arch>` for Linux, `compile_windows_agent` for windows). Confirms the precompiled tarballs you just packed actually get consumed. Emits `::warning::` for any dep that fell back to source compile — that means the binary was packed at a path `src/external/CMakeLists.txt` doesn't expect. The windows leg is what catches host-side tools shipped in `libraries/windows/<dep>.tar.gz` (e.g. flatbuffers' `flatc`, invoked during `make TARGET=winagent` schema codegen) that were built against a newer glibc/libstdc++ than the consumer image — without it, that mismatch only surfaces downstream when the windows agent build runs.
 
 ## Output
 

--- a/docs/dev/build-external-dependencies.md
+++ b/docs/dev/build-external-dependencies.md
@@ -55,7 +55,7 @@ The matrix is fixed at 7 entries:
 | `rpm-arm64` | agent | `wz-linux-arm64` | CentOS 6 agent builder image. |
 | `macos-intel64` | agent | `macos-14-large` | Native macOS build. Agent-only. |
 | `macos-arm64` | agent | `macos-14` | Native macOS build. Agent-only. |
-| `windows-i686` | agent | `wz-linux-amd64` | MinGW cross-compile on Linux. Agent-only. |
+| `windows-i686` | agent | `wz-linux-amd64` | MinGW cross-compile inside the `compile_windows_agent` image (ubuntu:22.04, same one the official windows agent build uses). Agent-only. |
 | `rpm-amd64` | manager | `wz-linux-amd64` | CentOS 7 manager builder image (glibc 2.17). |
 | `rpm-arm64` | manager | `wz-linux-arm64` | CentOS 7 manager builder image. |
 

--- a/packages/externals/generate_external.sh
+++ b/packages/externals/generate_external.sh
@@ -7,9 +7,10 @@
 # packages/externals/build_external.sh inside the container, and exposes the
 # per-dep zip artifacts on the host.
 #
-# Currently supports the 4 Linux Docker legs (deb/rpm x amd64/arm64).
-# macOS (native) and Windows (MinGW cross-compile) legs are added in
-# follow-up commits.
+# Linux deb/rpm legs run inside the pkg_<sys>_<target>_builder_<arch> image.
+# The Windows MinGW cross-compile leg runs inside compile_windows_agent
+# (ubuntu:22.04 with the mingw toolchain pre-baked — same image the official
+# Windows agent build uses). macOS legs run natively on the macOS runner.
 
 set -e
 
@@ -110,12 +111,20 @@ echo "[generate_external] target=${TARGET} system=${SYSTEM} arch=${ARCHITECTURE}
 echo "[generate_external] deps='${DEPS_TO_UPDATE}'"
 echo "[generate_external] output=${OUTDIR}"
 
-# Linux deb/rpm uses the existing builder Docker images. macOS runs natively
-# on the macOS runner; Windows runs natively on a Linux runner with MinGW
-# installed (the cross-compile target is i686-w64-mingw32, build artifacts
-# are .a/.lib files for Windows). Neither macOS nor Windows uses a Wazuh
-# package builder image.
-if [ "${SYSTEM}" = "macos" ] || [ "${SYSTEM}" = "windows" ]; then
+# macOS runs natively on the macOS runner (no Docker available, host toolchain
+# is what we ship against). Every other leg runs inside a pinned Wazuh builder
+# image so the host glibc the build was produced against is the image's, not
+# the runner's:
+#   - deb/rpm   -> pkg_<sys>_<target>_builder_<arch>      (centos:6/7 era)
+#   - windows   -> compile_windows_agent                   (ubuntu:22.04, the
+#                                                          same image used by
+#                                                          5_builderpackage_agent-windows.yml's
+#                                                          downstream consumers)
+# Without the compile_windows_agent pin, the windows leg picked up whatever
+# glibc the wz-linux-amd64 runner happened to ship; downstream agent builds
+# that re-consumed the packed windows externals on the 22.04 image then
+# missed the newer symbols.
+if [ "${SYSTEM}" = "macos" ]; then
     echo "[generate_external] mode=native (no docker)"
     env \
         WAZUH_SRC="${WAZUH_PATH}" \
@@ -128,15 +137,20 @@ if [ "${SYSTEM}" = "macos" ] || [ "${SYSTEM}" = "windows" ]; then
         WAZUH_VERBOSE="${VERBOSE}" \
         bash "${WAZUH_PATH}/packages/externals/build_external.sh"
 else
-    CONTAINER_NAME="pkg_${SYSTEM}_${TARGET}_builder_${ARCHITECTURE}"
+    if [ "${SYSTEM}" = "windows" ]; then
+        CONTAINER_NAME="compile_windows_agent"
+    else
+        CONTAINER_NAME="pkg_${SYSTEM}_${TARGET}_builder_${ARCHITECTURE}"
+    fi
     echo "[generate_external] image=${CONTAINER_NAME}:${DOCKER_TAG}"
 
-    # Run build_external.sh inside the existing builder image.
+    # Run build_external.sh inside the builder image.
     # - /wazuh-local-src    working tree (read-write so we can replace src/external/)
     # - /var/local/wazuh    artifact output (build_external.sh writes
     #                       external_artifacts/ subdir here, we pull from there)
-    # We override the image entrypoint because the default entrypoint
-    # (docker_builder.sh) drives a full package build.
+    # We override the image entrypoint because each image's default entrypoint
+    # drives a full package build (docker_builder.sh on the rpm/deb images,
+    # entrypoint.sh on compile_windows_agent).
     docker run --rm -t \
         -v "${WAZUH_PATH}:/wazuh-local-src:Z" \
         -v "${OUTDIR}:/var/local/wazuh:Z" \

--- a/packages/externals/smoke_build.sh
+++ b/packages/externals/smoke_build.sh
@@ -38,11 +38,17 @@ err() { echo "[smoke][ERROR] $*" >&2; }
 
 # src/Makefile builds the manager under TARGET=server (the `server` target is
 # the one that pulls in build_python and the manager-only externals). The
-# agent target passes through unchanged.
+# agent and winagent targets pass through unchanged — winagent is the windows
+# cross-compile, and we run this smoke build inside compile_windows_agent so
+# the host-side tools shipped in libraries/windows/<dep>.tar.gz (notably
+# flatbuffers' `flatc`, which `make TARGET=winagent` invokes during schema
+# codegen) get exercised against the same glibc/libstdc++ the downstream
+# windows agent build sees.
 case "${BUILD_TARGET}" in
-    agent)   MAKE_TARGET="agent" ;;
-    manager) MAKE_TARGET="server" ;;
-    *)       err "BUILD_TARGET must be 'agent' or 'manager' (got '${BUILD_TARGET}')"; exit 2 ;;
+    agent)    MAKE_TARGET="agent" ;;
+    manager)  MAKE_TARGET="server" ;;
+    winagent) MAKE_TARGET="winagent" ;;
+    *)        err "BUILD_TARGET must be 'agent', 'manager' or 'winagent' (got '${BUILD_TARGET}')"; exit 2 ;;
 esac
 
 if [ ! -d "${DEPS_DIR}/libraries" ]; then

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -251,11 +251,18 @@ add_dependencies(ext_libyaml libyaml_external)
 # ------------------------------------------------------------------------------
 
 if(IS_WINDOWS)
+  # _WIN32_WINNT=0x0600 (Vista) is the rest of the project's target — see
+  # src/syscheckd/CMakeLists.txt, src/wazuh_modules/CMakeLists.txt, etc.
+  # Curl ≥ 8.x's configure refuses to build for anything older. MinGW 12+
+  # already defaults to 0x0A00 (Win10) and would pass the configure check
+  # implicitly, but the compile_windows_agent image (ubuntu:22.04) ships
+  # MinGW 10, which still defaults to 0x0501 (XP). Set it explicitly so the
+  # build is portable across MinGW versions.
   set(CURL_CONFIGURE_CMD
       ${CMAKE_COMMAND}
       -E
       env
-      CFLAGS=-fPIC
+      "CFLAGS=-fPIC -D_WIN32_WINNT=0x0600"
       CC=${MINGW_CC}
       ${EXTERNAL_DIR}/curl/configure
       --host=${MINGW_HOST}


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-agent-packages/issues/788 

The `windows-i686` leg of `5_builderpackage_externals.yml` (introduced in #36048) installed MinGW on the bare `wz-linux-amd64` runner via `apt-get install gcc-mingw-w64 g++-mingw-w64 make` instead of running inside a pinned Docker builder image. As a result, whichever glibc and libstdc++ the runner shipped is what host-side tools in the windows externals tarball (in particular flatbuffers' `flatc`) linked against. A downstream consumer running inside `ghcr.io/wazuh/compile_windows_agent:5.0.0` (ubuntu:22.04) then hit:

```
external/flatbuffers/build/flatc: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found
external/flatbuffers/build/flatc: /lib/x86_64-linux-gnu/libc.so.6:    version `GLIBC_2.38' not found
make[4]: *** [shared_modules/sync_protocol/CMakeFiles/generate_flatbuffers.dir/build.make:80: shared_modules/sync_protocol/inventorySync_generated.h] Error 1
```

The smoke-build job did not catch the regression because its matrix only consumed the consolidated externals against the rpm agent and manager images — the windows slice of `libraries/` was never extracted/used in CI.

Related: #36048 (the workflow this fixes).

## Proposed Changes

### Fix — windows externals build inside the right image

- `.github/workflows/5_builderpackage_externals.yml`
  - Extend the **Resolve image tag** and **Pull builder image from GHCR** steps to also fire for `matrix.system == 'windows'`.
  - Map `SYSTEM=windows` to `CONTAINER_NAME=compile_windows_agent`; rpm legs keep `pkg_<sys>_<target>_builder_<arch>`. The image tag still comes from `VERSION.json`, so pulls land on `ghcr.io/wazuh/compile_windows_agent:<VERSION>` via the existing `pull_image_from_ghcr.sh` action.
  - Drop the **Install MinGW cross-compiler (windows leg)** step — the toolchain is baked into `compile_windows_agent`.
- `packages/externals/generate_external.sh`
  - Split the previous "macOS or windows → native, no docker" branch in two. macOS stays native; windows now goes through the existing `docker run --rm -t` invocation with `CONTAINER_NAME=compile_windows_agent`.

### Curl configure — pin `_WIN32_WINNT=0x0600`

- `src/external/CMakeLists.txt` — the curl windows recipe now passes `-D_WIN32_WINNT=0x0600` in `CFLAGS`. MinGW 12+ defaults to `0x0A00` (Win10) so this was implicit before, but `compile_windows_agent` ships MinGW 10 (ubuntu:22.04 baseline), which defaults to `0x0501` (XP). curl ≥ 8.x's configure rejects anything below Vista — without this define the windows leg fails at `checking if building for Windows Vista or newer... no`. The rest of the project already targets Vista (`src/syscheckd`, `src/wazuh_modules`, `src/data_provider`, `src/addagent`).

### Smoke-build coverage that would have caught it

- `.github/workflows/5_builderpackage_externals.yml` — add a fifth matrix entry to the `smoke-build` job for `target=winagent`, `image=compile_windows_agent`. Lift the per-row `CONTAINER_NAME` out into an explicit `image` field so the rpm and windows legs can carry different images without an if-ladder.
- `packages/externals/smoke_build.sh` — accept `BUILD_TARGET=winagent` (passes through to `make TARGET=winagent`). Running this inside `compile_windows_agent` exercises the windows host-side tools (notably `flatc`) against the same glibc baseline downstream consumers see, so a future glibc regression in the windows leg fails the smoke check instead of surfacing only when someone runs the full agent-windows build.

### Docs

- `docs/dev/build-external-dependencies.md` — update the matrix table for the windows leg's new runtime; bump smoke-build job count from 4 to 5 and spell out what the new winagent smoke entry catches.

### Results and Evidence

**1. CI workflow validation — externals workflow on this branch**

Run [`26097247838`](https://github.com/wazuh/wazuh/actions/runs/26097247838) at SHA `eb5c4464dd`: all green.

- 7/7 `build-externals` matrix legs ✅ — `windows-i686-agent` now runs inside `ghcr.io/wazuh/compile_windows_agent:5.0.0`.
- `consolidate` ✅.
- 5/5 `smoke-build` legs ✅ including the new `winagent-i686` entry that runs `make deps TARGET=winagent && make TARGET=winagent` inside `compile_windows_agent`. This is the path that previously emitted `flatc: GLIBC_2.38 not found`; it now completes cleanly.

(The previous dispatch [`26096732232`](https://github.com/wazuh/wazuh/actions/runs/26096732232) on the same branch failed at curl's configure step with `Building for Windows Vista or newer is required.` — that's how we found the missing `_WIN32_WINNT=0x0600` define, which is the second fix in this PR.)

**2. End-to-end local consumption — Windows MSI built off this branch's externals**

To confirm the fix doesn't only look right in CI but actually delivers a consumable externals tarball, I built a Windows MSI locally:

- Downloaded the `externals-all` artifact from run `26097247838`.
- Cross-compiled the agent inside a clean ubuntu:22.04 container (same glibc baseline as `compile_windows_agent` — 2.35), pointing `make deps` at the local externals tree via `RESOURCES_URL=file://...`.
- `make TARGET=winagent` completed cleanly. 14 `.exe` files produced. No `Exec format error` from `flatc` (the smoking-gun symptom of the original bug).
- Glibc / libstdc++ baseline of the host-side `flatc` shipped in `libraries/windows/flatbuffers.tar.gz` (this is what the original bug report was about):

```
GLIBC requirements:   GLIBC_2.2.5  GLIBC_2.3    GLIBC_2.3.3  GLIBC_2.3.4
                      GLIBC_2.4    GLIBC_2.14   GLIBC_2.32   GLIBC_2.33   GLIBC_2.34
GLIBCXX requirements: GLIBCXX_3.4       GLIBCXX_3.4.9    GLIBCXX_3.4.11
                      GLIBCXX_3.4.14    GLIBCXX_3.4.15   GLIBCXX_3.4.18
                      GLIBCXX_3.4.20    GLIBCXX_3.4.21   GLIBCXX_3.4.26
                      GLIBCXX_3.4.29
```

Compare to the original failure: `GLIBC_2.38` / `GLIBCXX_3.4.32`. The fix lowers `flatc`'s required baseline by ~one Ubuntu LTS, landing it squarely on ubuntu:22.04 (which `compile_windows_agent` runs).

- Transferred to a Windows VM, packaged with WiX 3.14 (`candle.exe` + `light.exe`), produced `wazuh-agent-5.0.0-0.msi` (33 MB). The local pipeline mirrors CI's structure (`5_builderpackage_agent-windows.yml` → cross-compile inside `compile_windows_agent` → Windows runner for WiX), just on a developer machine.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `5_builderpackage_externals.yml` workflow:
  - `windows-i686-agent` per-leg tarball.
  - The windows slice (`libraries/windows/<dep>.tar.gz`) of the consolidated `externals-all.tar.gz`.
  - `smoke-build` job — one additional matrix entry, no behaviour change for the existing four.
- `src/external/CMakeLists.txt` — only the windows branch of the curl recipe changes (`CFLAGS` gets `-D_WIN32_WINNT=0x0600`). Linux/macOS curl flags unchanged.

### Configuration Changes

N/A.

### Tests Introduced

The new `smoke-build (winagent-i686)` matrix entry. Builds Wazuh against the consolidated dep tree inside `compile_windows_agent` and fails if the windows externals can't actually be consumed there.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
