### PR TITLE
chore: refresh workflow registration on 4.10.4

### DIFF
--- a/.github/workflows/integration-tests-analysisd-tier-2.yml
+++ b/.github/workflows/integration-tests-analysisd-tier-2.yml
@@ -7,6 +7,17 @@ on:
         description: 'Base branch'
         required: true
         default: 'main'
+  pull_request:
+    paths:
+        - ".github/workflows/integration-tests-analysisd-tier-2.yml"
+        - "src/analysisd/**"
+        - "src/config/alerts-config.c"
+        - "src/config/global-config.c"
+        - "src/config/global-config.h"
+        - "src/config/rules-config.c"
+        - "src/Makefile"
+        - "tests/integration/conftest.py"
+        - "tests/integration/test_analysisd/**"
 
 jobs:
   build:
@@ -76,5 +87,3 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_analysisd/
-
-# noop

--- a/.github/workflows/integration-tests-analysisd-tier-2.yml
+++ b/.github/workflows/integration-tests-analysisd-tier-2.yml
@@ -76,3 +76,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_analysisd/
+
+# noop

--- a/.github/workflows/integration-tests-authd-tier-0-1.yml
+++ b/.github/workflows/integration-tests-authd-tier-0-1.yml
@@ -86,3 +86,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_authd/
+
+# noop

--- a/.github/workflows/integration-tests-integratord-tier-0-1.yml
+++ b/.github/workflows/integration-tests-integratord-tier-0-1.yml
@@ -85,3 +85,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_integratord/
+
+# noop

--- a/.github/workflows/integration-tests-logtest-tier-0-1.yml
+++ b/.github/workflows/integration-tests-logtest-tier-0-1.yml
@@ -86,3 +86,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_logtest/
+
+# noop

--- a/.github/workflows/integration-tests-remoted-tier-0-1.yml
+++ b/.github/workflows/integration-tests-remoted-tier-0-1.yml
@@ -85,3 +85,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_remoted/
+
+# noop

--- a/.github/workflows/integration-tests-remoted-tier-2.yml
+++ b/.github/workflows/integration-tests-remoted-tier-2.yml
@@ -7,6 +7,15 @@ on:
         description: 'Base branch'
         required: true
         default: 'main'
+  pull_request:
+    paths:
+        - ".github/workflows/integration-tests-remoted-tier-2.yml"
+        - "src/config/remote-config.c"
+        - "src/config/remote-config.h"
+        - "src/remoted/**"
+        - "src/Makefile"
+        - "tests/integration/conftest.py"
+        - "tests/integration/test_remoted/**"
 
 jobs:
   build:
@@ -76,5 +85,3 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_remoted/
-
-# noop

--- a/.github/workflows/integration-tests-remoted-tier-2.yml
+++ b/.github/workflows/integration-tests-remoted-tier-2.yml
@@ -76,3 +76,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_remoted/
+
+# noop

--- a/.github/workflows/integration-tests-wazuh_db-tier-0-1.yml
+++ b/.github/workflows/integration-tests-wazuh_db-tier-0-1.yml
@@ -85,3 +85,5 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_wazuh_db/
+
+# noop

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -320,3 +320,5 @@ jobs:
         with:
           name: QA log files
           path: ${{ github.workspace }}/qa_logs
+
+# noop


### PR DESCRIPTION
Dummy no-op change appending a comment line to integration-test workflow files so GitHub Actions re-indexes them as runnable on this branch.

Files touched:
- integration-tests-analysisd-tier-2.yml
- integration-tests-authd-tier-0-1.yml
- integration-tests-integratord-tier-0-1.yml
- integration-tests-logtest-tier-0-1.yml
- integration-tests-remoted-tier-0-1.yml
- integration-tests-remoted-tier-2.yml
- integration-tests-wazuh_db-tier-0-1.yml
- vulnerability-scanner-tests.yml

Not intended to be merged.