### PR TITLE
Review agent info logs

### DIFF
--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -380,7 +380,7 @@ bool connect_server(int server_id, bool verbose)
     }
 
     if (verbose) {
-        mdebug1("Trying to connect to server ([%s]:%d/%s).",
+        minfo("Trying to connect to server ([%s]:%d/%s).",
             agt->server[server_id].rip,
             agt->server[server_id].port,
             "tcp");

--- a/src/logcollector/src/logcollector.c
+++ b/src/logcollector/src/logcollector.c
@@ -486,7 +486,7 @@ void LogCollectorStart()
 #endif
     set_can_read(1);
     atomic_int_set(&_startup_completed, 1);
-    mdebug1("Startup completed. Runtime-discovered files will be read from beginning.");
+    minfo("Startup completed. Runtime-discovered files will be read from beginning.");
     /* Daemon loop */
     while (1) {
 

--- a/src/rootcheck/src/rootcheck.c
+++ b/src/rootcheck/src/rootcheck.c
@@ -187,10 +187,7 @@ int rootcheck_init(int test_config)
 
 #ifdef OSSECHIDS
     /* Start up message */
-#ifdef WIN32
     mtinfo(ARGV0, STARTUP_MSG, getpid());
-#endif /* WIN32 */
-
 #endif /* OSSECHIDS */
 
     /* Initialize rk list */

--- a/src/rootcheck/src/run_rk_check.c
+++ b/src/rootcheck/src/run_rk_check.c
@@ -167,7 +167,7 @@ void run_rk_check()
     /* Send scan ending message */
     notify_rk(ALERT_POLICY_VIOLATION, "Ending rootcheck scan.");
     if (rootcheck.notify == QUEUE) {
-        mtinfo(ARGV0, "Ending rootcheck scan.");
+        mtinfo(ARGV0, "Rootcheck scan ended.");
     }
 
     mtdebug1(ARGV0, "Leaving run_rk_check");

--- a/src/shared/include/error_messages/debug_messages.h
+++ b/src/shared/include/error_messages/debug_messages.h
@@ -194,7 +194,6 @@
 /* Modules messages */
 #define WM_UPGRADE_RESULT_AGENT_INFO         "(8151): Agent Information obtained: '%s'"
 #define WM_UPGRADE_MODULE_DISABLED           "(8152): Module Agent Upgrade disabled. Exiting..."
-#define WM_UPGRADE_MODULE_STARTED            "(8153): Module Agent Upgrade started."
 #define WM_UPGRADE_MODULE_FINISHED           "(8154): Module Agent Upgrade finished."
 #define WM_UPGRADE_INCOMMING_MESSAGE         "(8155): Incomming message: '%s'"
 #define WM_UPGRADE_RESPONSE_MESSAGE          "(8156): Response message: '%s'"
@@ -215,7 +214,6 @@
 #define WM_UPGRADE_UNSUPPORTED_UPGRADE       "(8171): Agent '%d' with unsupported platform '%s' won't be upgraded without a default package."
 #define WM_UPGRADE_UNSUPPORTED_DEFAULT       "(8172): Agent '%d' with unsupported platform '%s' will be upgraded with package '%s'"
 
-#define MOD_TASK_START                      "(8200): Module Task Manager started."
 #define MOD_TASK_FINISH                     "(8201): Module Task Manager finished."
 #define MOD_TASK_DISABLED                   "(8202): Module disabled. Exiting..."
 #define MOD_TASK_EMPTY_MESSAGE              "(8203): Empty message from local client."

--- a/src/syscheckd/src/fim_scan.c
+++ b/src/syscheckd/src/fim_scan.c
@@ -58,7 +58,7 @@ time_t fim_scan() {
 #endif
     cputime_start = clock();
     gettime(&start);
-    mdebug1(FIM_FREQUENCY_STARTED);
+    minfo(FIM_FREQUENCY_STARTED);
 
     fim_diff_folder_size();
     syscheck.disk_quota_full_msg = true;

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -609,7 +609,7 @@ void start_daemon()
         return;
     }
 
-    mdebug1(FIM_DAEMON_STARTED);
+    minfo(FIM_DAEMON_STARTED);
 
     if (syscheck.file_limit_enabled) {
         mdebug2(FIM_FILE_LIMIT_VALUE, syscheck.file_entry_limit);
@@ -626,7 +626,7 @@ void start_daemon()
 #endif
 
     // Create File integrity monitoring base-line
-    mdebug1(FIM_FREQUENCY_TIME, syscheck.time);
+    minfo(FIM_FREQUENCY_TIME, syscheck.time);
     fim_scan();
 
 #ifndef WIN32

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -174,7 +174,7 @@ static int teardown_test(void **state) {
 /* connect_server */
 static void test_connect_server(void **state) {
     bool connected = false;
-    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
     /* Connect to first server (TCP)*/
     will_return(__wrap_getDefine_Int, 5);
     expect_string(__wrap_OS_GetHost, host, agt->server[0].rip);
@@ -201,7 +201,8 @@ static void test_connect_server(void **state) {
     expect_value(__wrap_OS_CloseSocket, sock, 11);
     will_return(__wrap_OS_CloseSocket, 0);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 2);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
 
     connected = connect_server(1, true);
     assert_int_equal(agt->rip_id, 1);
@@ -217,7 +218,8 @@ static void test_connect_server(void **state) {
     expect_value(__wrap_OS_CloseSocket, sock, 12);
     will_return(__wrap_OS_CloseSocket, 0);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 2);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
 
     connected = connect_server(2, true);
     assert_int_equal(agt->rip_id, 2);
@@ -242,7 +244,7 @@ static void test_connect_server(void **state) {
     expect_any(__wrap_OS_ConnectTCP, _ip);
     expect_any(__wrap_OS_ConnectTCP, ipv6);
     will_return(__wrap_OS_ConnectTCP, -1);
-    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
     expect_any(__wrap__merror, formatted_msg);
     connected = connect_server(0, true);
     assert_false(connected);
@@ -280,8 +282,8 @@ static void test_agent_handshake_to_server(void **state) {
 #endif
     will_return(__wrap_metadata_provider_update, 0);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 3);
-    expect_any(__wrap__minfo, formatted_msg);
+    expect_any_count(__wrap__mdebug1, formatted_msg, 2);
+    expect_any_count(__wrap__minfo, formatted_msg, 2);
 
     handshaked = agent_handshake_to_server(0, false);
     assert_true(handshaked);
@@ -315,8 +317,8 @@ static void test_agent_handshake_to_server(void **state) {
 #endif
     will_return(__wrap_metadata_provider_update, 0);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 4);
-    expect_any(__wrap__minfo, formatted_msg);
+    expect_any_count(__wrap__mdebug1, formatted_msg, 3);
+    expect_any_count(__wrap__minfo, formatted_msg, 2);
 
     handshaked = agent_handshake_to_server(1, false);
     assert_true(handshaked);
@@ -351,8 +353,8 @@ static void test_agent_handshake_to_server(void **state) {
 #endif
     will_return(__wrap_metadata_provider_update, 0);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 4);
-    expect_any(__wrap__minfo, formatted_msg);
+    expect_any_count(__wrap__mdebug1, formatted_msg, 3);
+    expect_any_count(__wrap__minfo, formatted_msg, 2);
 
     handshaked = agent_handshake_to_server(1, true);
     assert_true(handshaked);
@@ -368,7 +370,8 @@ static void test_agent_handshake_to_server(void **state) {
     expect_value(__wrap_OS_CloseSocket, sock, 23);
     will_return(__wrap_OS_CloseSocket, 0);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 2);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
     expect_any(__wrap__merror, formatted_msg);
 
     handshaked = agent_handshake_to_server(0, false);
@@ -385,7 +388,7 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_wnet_select, 0);
     expect_string(__wrap_send_msg, msg, "#!-agent startup {\"version\":\"v5.0.0\"}");
 
-    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
 
     handshaked = agent_handshake_to_server(0, false);
     assert_false(handshaked);
@@ -410,7 +413,8 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_ReadSecMSG, SERVER_WRONG_ACK);
     will_return(__wrap_ReadSecMSG, KS_CORRUPT);
 
-    expect_any_count(__wrap__mdebug1, formatted_msg, 2);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
     expect_any(__wrap__mwarn, formatted_msg);
 
     handshaked = agent_handshake_to_server(0, false);
@@ -440,7 +444,7 @@ static void test_agent_handshake_to_server_invalid_version(void **state) {
     will_return(__wrap_ReadSecMSG, "#!-err {\"message\": \"Agent version must be lower or equal to manager version\"}");
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
-    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
 
     expect_string(__wrap__mwarn, formatted_msg ,"Couldn't connect to server '127.0.0.1': 'Agent version must be lower or equal to manager version'");
 
@@ -469,7 +473,7 @@ static void test_agent_handshake_to_server_error_getting_msg1(void **state) {
     will_return(__wrap_ReadSecMSG, "#!-err \"message\": \"Agent version must be lower or equal to manager version\"}");
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
-    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
 
     expect_string(__wrap__merror, formatted_msg ,"Error getting message from server '127.0.0.1'");
 
@@ -498,7 +502,7 @@ static void test_agent_handshake_to_server_error_getting_msg2(void **state) {
     will_return(__wrap_ReadSecMSG, "#!-err {\"key\": \"Agent version must be lower or equal to manager version\"}");
     will_return(__wrap_ReadSecMSG, KS_VALID);
 
-    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_any(__wrap__minfo, formatted_msg);
 
     expect_string(__wrap__merror, formatted_msg ,"Error getting message from server '127.0.0.1'");
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -1789,7 +1789,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");
@@ -1877,7 +1877,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");
@@ -1941,7 +1941,7 @@ static void test_fim_scan_realtime_enabled(void **state) {
 
     syscheck.realtime = &realtime;
 
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");
@@ -2014,7 +2014,7 @@ static void test_fim_scan_no_limit(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");
@@ -2403,7 +2403,7 @@ static void test_fim_scan_db_full_double_scan(void **state) {
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     will_return(__wrap_fim_db_transaction_start, mock_handle);
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");
@@ -2469,7 +2469,7 @@ static void test_fim_scan_db_full_not_double_scan(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
 
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");
@@ -2532,7 +2532,7 @@ static void test_fim_scan_no_limit(void **state) {
     expect_function_call_any(__wrap_pthread_rwlock_rdlock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
-    expect_string(__wrap__mdebug1, formatted_msg, FIM_FREQUENCY_STARTED);
+    expect_string(__wrap__minfo, formatted_msg, FIM_FREQUENCY_STARTED);
 
     // fim_diff_folder_size
     expect_string(__wrap_IsDir, file, "queue/diff/local");

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
@@ -1050,7 +1050,7 @@ void test_wm_agent_upgrade_start_agent_module_enabled(void **state)
     allow_upgrades = false;
 
     expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8153): Module Agent Upgrade started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
 #ifndef TEST_WINAGENT
     expect_memory(__wrap_CreateThread, function_pointer, wm_agent_upgrade_listen_messages, sizeof(wm_agent_upgrade_listen_messages));

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_manager.c
@@ -885,7 +885,7 @@ void test_wm_agent_upgrade_start_manager_module_enabled(void **state)
     wm_manager_configs *config = *state;
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:agent-upgrade");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8153): Module Agent Upgrade started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     expect_string(__wrap_OS_BindUnixDomainWithPerms, path, WM_UPGRADE_SOCK);
     expect_value(__wrap_OS_BindUnixDomainWithPerms, type, SOCK_STREAM);

--- a/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager.c
+++ b/src/unit_tests/wazuh_modules/task_manager/test_wm_task_manager.c
@@ -628,7 +628,7 @@ void test_wm_task_manager_main_ok(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 1);
 
@@ -704,7 +704,7 @@ void test_wm_task_manager_main_recv_max_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 1);
 
@@ -754,7 +754,7 @@ void test_wm_task_manager_main_recv_empty_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 1);
 
@@ -804,7 +804,7 @@ void test_wm_task_manager_main_recv_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 1);
 
@@ -854,7 +854,7 @@ void test_wm_task_manager_main_sockterr_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 1);
 
@@ -904,7 +904,7 @@ void test_wm_task_manager_main_accept_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 1);
 
@@ -961,7 +961,7 @@ void test_wm_task_manager_main_select_empty_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, 0);
 
@@ -1013,7 +1013,7 @@ void test_wm_task_manager_main_select_err(void **state)
     will_return(__wrap_OS_BindUnixDomainWithPerms, sock);
 
     expect_string(__wrap__mtinfo, tag, "wazuh-manager-modulesd:task-manager");
-    expect_string(__wrap__mtinfo, formatted_msg, "(8200): Module Task Manager started.");
+    expect_any(__wrap__mtinfo, formatted_msg);
 
     will_return(__wrap_select, -1);
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -145,7 +145,7 @@ AgentInfoImpl::AgentInfoImpl(std::string dbPath,
         throw std::invalid_argument("Query module function must be provided");
     }
 
-    m_logFunction(LOG_INFO, "AgentInfo initialized.");
+    m_logFunction(LOG_DEBUG, "AgentInfo initialized.");
 }
 
 AgentInfoImpl::~AgentInfoImpl()
@@ -1188,7 +1188,7 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
                         return false;
                     }
 
-                    m_logFunction(LOG_INFO, moduleName + " pause completed successfully");
+                    m_logFunction(LOG_DEBUG, moduleName + " pause completed successfully");
                     return true;
                 }
             }
@@ -1391,7 +1391,7 @@ bool AgentInfoImpl::triggerModuleFlush(const std::set<std::string>& pausedModule
             return false;
         }
 
-        m_logFunction(LOG_INFO, "Triggering flush for " + module + " module");
+        m_logFunction(LOG_DEBUG, "Triggering flush for " + module + " module");
 
         std::string flushMessage = createJsonCommand("flush");
         ModuleResponse response = queryModuleWithRetry(module, flushMessage);

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1372,7 +1372,7 @@ public:
         // Init the socket server to attend keystore requests
         initializeKeystoreSocket();
 
-        logInfo(LOGGER_DEFAULT_TAG, "InventorySyncFacade started.");
+        logDebug1(LOGGER_DEFAULT_TAG, "InventorySyncFacade started.");
     }
 
     /**

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -87,7 +87,7 @@ SecurityConfigurationAssessment::SecurityConfigurationAssessment(std::string dbP
         LoggingHelper::getInstance().log(level, message);
     });
 
-    LoggingHelper::getInstance().log(LOG_INFO, "SCA initialized.");
+    LoggingHelper::getInstance().log(LOG_DEBUG, "SCA initialized.");
 }
 
 SecurityConfigurationAssessment::~SecurityConfigurationAssessment()
@@ -128,7 +128,7 @@ void SecurityConfigurationAssessment::Run()
         m_spSyncProtocol->reset();
     }
 
-    LoggingHelper::getInstance().log(LOG_INFO, "SCA module running.");
+    LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module running.");
 
     if (m_syncManager)
     {
@@ -205,7 +205,7 @@ void SecurityConfigurationAssessment::Run()
 
         if (firstScan && m_scanOnStart)
         {
-            LoggingHelper::getInstance().log(LOG_INFO, "SCA module scan on start.");
+            LoggingHelper::getInstance().log(LOG_DEBUG, "Module scan on start.");
         }
 
         // Mark scan as in progress
@@ -274,7 +274,7 @@ void SecurityConfigurationAssessment::Run()
                 checkResult.policyId, checkResult.checkId, checkResult.result, checkResult.reason);
         };
 
-        LoggingHelper::getInstance().log(LOG_INFO, "SCA scan started.");
+        LoggingHelper::getInstance().log(LOG_INFO, "Scan started.");
 
         for (auto& policy : m_policies)
         {
@@ -292,7 +292,7 @@ void SecurityConfigurationAssessment::Run()
 
         firstScan = false;
 
-        LoggingHelper::getInstance().log(LOG_INFO, "SCA scan ended.");
+        LoggingHelper::getInstance().log(LOG_INFO, "Scan ended.");
 
         // Mark scan as complete
         setScanInProgress(false);

--- a/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -99,7 +99,7 @@ void wm_agent_upgrade_start_agent_module(const wm_agent_configs* agent_config, c
     }
     else
     {
-        mtinfo(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_MODULE_STARTED);
+        mtinfo(WM_AGENT_UPGRADE_LOGTAG, STARTUP_MSG, (int)getpid());
     }
 
 #ifndef WIN32

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_manager.c
@@ -90,7 +90,7 @@ void wm_agent_upgrade_start_manager_module(const wm_manager_configs* manager_con
         pthread_exit(NULL);
     }
 
-    mtinfo(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_MODULE_STARTED);
+    mtinfo(WM_AGENT_UPGRADE_LOGTAG, STARTUP_MSG, (int)getpid());
 
     // Initialize task hashmap
     wm_agent_upgrade_init_task_map();

--- a/src/wazuh_modules/src/task_manager/wm_task_manager.c
+++ b/src/wazuh_modules/src/task_manager/wm_task_manager.c
@@ -138,7 +138,7 @@ STATIC void* wm_task_manager_main(wm_task_manager* task_config) {
     // Initial configuration
     sock = wm_task_manager_init(task_config);
 
-    mtinfo(WM_TASK_MANAGER_LOGTAG, MOD_TASK_START);
+    mtinfo(WM_TASK_MANAGER_LOGTAG, STARTUP_MSG, (int)getpid());
 
     while (!wm_shutdown_requested) {
 

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -580,7 +580,7 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
 #endif
     g_shutting_down = 0;
 
-    mdebug1("Starting agent-info module.");
+    mdebug1("Module enabled.");
 
     if (!agent_info)
     {
@@ -700,8 +700,7 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
     // This call will populate the agent metadata and send it to the queue
     if (agent_info_start_ptr)
     {
-        mdebug1("Starting agent-info module...");
-
+        minfo(STARTUP_MSG, (int)getpid());
         agent_info_start_ptr(agent_info);
     }
     else

--- a/src/wazuh_modules/src/wm_content_manager.c
+++ b/src/wazuh_modules/src/wm_content_manager.c
@@ -36,7 +36,7 @@ const wm_context WM_CONTENT_MANAGER_CONTEXT = {
 
 void* wm_content_manager_main()
 {
-    mtinfo(WM_CONTENT_MANAGER_LOGTAG, "Starting content_manager module.");
+    mtinfo(WM_CONTENT_MANAGER_LOGTAG, STARTUP_MSG, (int)getpid());
 
     if (content_manager_module = so_get_module_handle("content_manager"), content_manager_module)
     {
@@ -64,7 +64,7 @@ void wm_content_manager_destroy() {}
 
 void wm_content_manager_stop()
 {
-    mtinfo(WM_CONTENT_MANAGER_LOGTAG, "Stopping content_manager module.");
+    mtinfo(WM_CONTENT_MANAGER_LOGTAG, "Module finished.");
 
     if (content_manager_stop_ptr)
     {

--- a/src/wazuh_modules/src/wm_database.c
+++ b/src/wazuh_modules/src/wm_database.c
@@ -96,7 +96,7 @@ const wm_context WM_DATABASE_CONTEXT = {
 void* wm_database_main(wm_database *data) {
     module = data;
 
-    mtinfo(WM_DATABASE_LOGTAG, "Module started.");
+    mtinfo(WM_DATABASE_LOGTAG, STARTUP_MSG, (int)getpid());
 
     // Check if it is a worker node
     is_worker = w_is_worker();

--- a/src/wazuh_modules/src/wm_inventory_sync.c
+++ b/src/wazuh_modules/src/wm_inventory_sync.c
@@ -53,7 +53,7 @@
 
  void* wm_inventory_sync_main(__attribute__((unused))wm_inventory_sync_t* data)
  {
-     mtinfo(WM_INVENTORY_SYNC_LOGTAG, "Starting inventory_sync module.");
+     mtinfo(WM_INVENTORY_SYNC_LOGTAG, STARTUP_MSG, (int)getpid());
      if (inventory_sync_module = so_get_module_handle("inventory_sync"), inventory_sync_module)
      {
         inventory_sync_start_ptr = so_get_function_sym(inventory_sync_module, "inventory_sync_start");
@@ -115,7 +115,7 @@
 
  void wm_inventory_sync_stop(__attribute__((unused)) wm_inventory_sync_t* data)
  {
-     mtinfo(WM_INVENTORY_SYNC_LOGTAG, "Stopping inventory_sync module.");
+     mtinfo(WM_INVENTORY_SYNC_LOGTAG, "Module finished.");
      if (inventory_sync_stop_ptr)
      {
          inventory_sync_stop_ptr();

--- a/src/wazuh_modules/src/wm_router.c
+++ b/src/wazuh_modules/src/wm_router.c
@@ -37,7 +37,7 @@ const wm_context WM_ROUTER_CONTEXT = {
 
 void* wm_router_main()
 {
-    mtinfo(WM_ROUTER_LOGTAG, "Starting router module.");
+    mtinfo(WM_ROUTER_LOGTAG, STARTUP_MSG, (int)getpid());
     if (router_module = so_get_module_handle("router"), router_module)
     {
         router_start_ptr = so_get_function_sym(router_module, "router_start");
@@ -77,7 +77,7 @@ void wm_router_destroy() {}
 
 void wm_router_stop()
 {
-    mtinfo(WM_ROUTER_LOGTAG, "Stopping router module.");
+    mtinfo(WM_ROUTER_LOGTAG, "Module finished.");
     if (router_stop_ptr)
     {
         router_stop_ptr();

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -509,10 +509,10 @@ void * wm_sca_main(wm_sca_t * data) {
 #endif
     // If module is disabled, exit
     if (data->enabled) {
-        mdebug1("SCA module enabled.");
+        mdebug1("Module enabled.");
     } else {
         wm_handle_sca_disable_and_notify_data_clean();
-        mdebug1("SCA module disabled. Exiting.");
+        mdebug1("Module disabled. Exiting.");
         pthread_exit(NULL);
     }
 
@@ -612,7 +612,7 @@ void * wm_sca_main(wm_sca_t * data) {
         sca_set_sync_limit_ptr(sync_limit);
     }
 
-    mdebug1("Starting SCA module...");
+    mdebug1("Starting module.");
 
     wm_sca_start(data);
 

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -584,9 +584,11 @@ void* wm_sys_main(wm_sys_t* sys)
     if (!sys->flags.enabled)
     {
         wm_handle_sys_disabled_and_notify_data_clean(sys);
-        mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting...");
+        mtinfo(WM_SYS_LOGTAG, "Module disabled. Exiting.");
         pthread_exit(NULL);
     }
+
+    mtdebug1(WM_SYS_LOGTAG, "Module enabled.");
 
 #ifndef WIN32
     // Connect to socket
@@ -634,7 +636,7 @@ void* wm_sys_main(wm_sys_t* sys)
 
     if (syscollector_init_ptr && syscollector_start_ptr)
     {
-        mtdebug1(WM_SYS_LOGTAG, "Starting Syscollector.");
+        mtdebug1(WM_SYS_LOGTAG, "Starting module.");
         w_mutex_lock(&sys_stop_mutex);
         need_shutdown_wait = true;
         w_mutex_unlock(&sys_stop_mutex);
@@ -721,6 +723,7 @@ void* wm_sys_main(wm_sys_t* sys)
             mtdebug1(WM_SYS_LOGTAG, "Inventory synchronization is disabled or function not available");
         }
 
+        mtinfo(WM_SYS_LOGTAG, STARTUP_MSG, (int)getpid());
         syscollector_start_ptr();
     }
     else

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -49,7 +49,7 @@ static void wm_vulnerability_scanner_log_config(cJSON* config_json) {
 }
 
 void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
-    mtinfo(WM_VULNERABILITY_SCANNER_LOGTAG, "Starting vulnerability_scanner module.");
+    mtinfo(WM_VULNERABILITY_SCANNER_LOGTAG, STARTUP_MSG, (int)getpid());
     if (vulnerability_scanner_module = so_get_module_handle("vulnerability_scanner"), vulnerability_scanner_module) {
         vulnerability_scanner_start_ptr =
             so_get_function_sym(vulnerability_scanner_module, "vulnerability_scanner_start");
@@ -126,7 +126,7 @@ void wm_vulnerability_scanner_destroy(wm_vulnerability_scanner_t* data) {
 }
 
 void wm_vulnerability_scanner_stop(__attribute__((unused)) wm_vulnerability_scanner_t* data) {
-    mtinfo(WM_VULNERABILITY_SCANNER_LOGTAG, "Stopping vulnerability_scanner module.");
+    mtinfo(WM_VULNERABILITY_SCANNER_LOGTAG, "Module finished.");
     if (vulnerability_scanner_stop_ptr) {
         vulnerability_scanner_stop_ptr();
     }

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1891,8 +1891,6 @@ void Syscollector::scan()
 
 void Syscollector::syncLoop(std::unique_lock<std::mutex>& scan_lock)
 {
-    m_logFunction(LOG_INFO, "Module started.");
-
     if (m_scanOnStart)
     {
         scan();

--- a/tests/integration/test_sca/conftest.py
+++ b/tests/integration/test_sca/conftest.py
@@ -72,9 +72,9 @@ def wait_for_agent_gone():
 # limits_received to flip to true (src/client-agent/src/start_agent.c:142).
 _SCA_STARTUP_HIGHLIGHTS = {
     'SCA tagged lines': r':sca\b',
-    'SCA module enabled (DEBUG)': r'SCA module enabled',
-    'SCA module running (INFO)': r'SCA module running',
-    'Starting SCA module': r'Starting SCA module',
+    'SCA module enabled (DEBUG)': r'wazuh-modulesd:sca:.*Module enabled',
+    'SCA module running (DEBUG)': r'SCA module running',
+    'Starting SCA module': r'wazuh-modulesd:sca:.*Starting module',
     'agcom_dispatch failure': r'Failed to query agentd via agcom_dispatch',
     'AGCOM limits not configured': r'AGCOM Module limits not configured',
     'AGCOM err response': r'Agentd returned error',
@@ -85,6 +85,75 @@ _SCA_STARTUP_HIGHLIGHTS = {
     'Ruleset folder open fail': r'Could not open the default SCA ruleset folder',
     'Policy scan started': r'Starting Policy checks evaluation',
 }
+
+
+def _collect_service_diagnostics(log_path: str, highlight_patterns: dict) -> dict:
+    """Gather service state, processes and log highlights for failure messages.
+
+    Replacement for ``services.collect_service_diagnostics`` (which is not
+    exported by the installed ``wazuh_testing`` package). Kept local to avoid
+    swallowing the real timeout error with an ``AttributeError``.
+    """
+    diag: dict = {}
+
+    if sys.platform == WINDOWS:
+        try:
+            proc = subprocess.run(
+                ['sc', 'query', 'WazuhSvc'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
+            )
+            raw = proc.stdout.decode(errors='ignore')
+            state_match = re.search(r'STATE\s*:\s*\d+\s*(\S+)', raw)
+            diag['service_state'] = state_match.group(1) if state_match else 'UNKNOWN'
+            diag['service_raw'] = raw
+        except Exception as exc:
+            diag['service_state'] = 'UNKNOWN'
+            diag['service_raw'] = f"sc query failed: {exc}"
+    else:
+        try:
+            from wazuh_testing.constants.paths.binaries import WAZUH_CONTROL_PATH
+            proc = subprocess.run(
+                [WAZUH_CONTROL_PATH, 'status'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
+            )
+            raw = proc.stdout.decode(errors='ignore')
+            lines = [l for l in raw.splitlines() if l.strip()]
+            diag['service_state'] = (
+                'RUNNING' if lines and all('is running' in l for l in lines)
+                else 'STOPPED/PARTIAL'
+            )
+            diag['service_raw'] = raw
+        except Exception as exc:
+            diag['service_state'] = 'UNKNOWN'
+            diag['service_raw'] = f"wazuh-control status failed: {exc}"
+
+    procs = sorted({(p.info.get('name') or '') for p in psutil.process_iter(attrs=['name'])
+                    if (p.info.get('name') or '').lower().startswith('wazuh')})
+    diag['processes'] = ', '.join(procs) if procs else '(none)'
+
+    try:
+        with open(log_path, 'r', errors='ignore') as f:
+            log_lines = f.readlines()
+    except Exception:
+        log_lines = []
+
+    highlights: dict = {}
+    for label, pattern in (highlight_patterns or {}).items():
+        try:
+            regex = re.compile(pattern)
+        except re.error:
+            highlights[label] = {'count': 0, 'first': '', 'last': ''}
+            continue
+        matches = [line.strip() for line in log_lines if regex.search(line)]
+        highlights[label] = {
+            'count': len(matches),
+            'first': matches[0] if matches else '',
+            'last': matches[-1] if matches else '',
+        }
+    diag['highlights'] = highlights
+
+    diag['log_tail'] = ''.join(log_lines[-50:])
+    return diag
 
 
 def _wait_service_running(timeout: int) -> None:
@@ -220,13 +289,13 @@ def wait_for_sca_enabled():
           watching a file nobody is writing to.
 
       Phase 2 — SCA_ENABLED (DEBUG):
-          wm_sca_main emits "SCA module enabled." at the very start, BEFORE
+          wm_sca_main emits "Module enabled." at the very start, BEFORE
           loading the SCA shared object, resolving symbols, registering
           callbacks or doing any C++ setup. If this log never appears, the
           native wm_sca entrypoint is not being reached — the problem is
           upstream of the SCA module itself (config load, module registry).
 
-      Phase 3 — SCA_RUNNING (INFO):
+      Phase 3 — SCA_RUNNING (DEBUG):
           SecurityConfigurationAssessment::Run() emits "SCA module running."
           once the C++ implementation has finished initialising (sync manager,
           policy loader, scan loop). If Phase 2 passes but Phase 3 times out,
@@ -251,7 +320,7 @@ def wait_for_sca_enabled():
     try:
         _wait_service_running(service_timeout)
     except TimeoutError:
-        diag = services.collect_service_diagnostics(
+        diag = _collect_service_diagnostics(
             log_path=WAZUH_LOG_PATH, highlight_patterns=_SCA_STARTUP_HIGHLIGHTS)
         raise AssertionError(
             f"[Phase 1] Wazuh service did not reach RUNNING within {service_timeout}s.\n"
@@ -267,7 +336,7 @@ def wait_for_sca_enabled():
         only_new_events=False
     )
     if not log_monitor.callback_result:
-        diag = services.collect_service_diagnostics(
+        diag = _collect_service_diagnostics(
             log_path=WAZUH_LOG_PATH, highlight_patterns=_SCA_STARTUP_HIGHLIGHTS)
         raise AssertionError(
             f"[Phase 2] SCA module did not emit '{patterns.SCA_ENABLED}' within {enabled_timeout}s. "
@@ -283,7 +352,7 @@ def wait_for_sca_enabled():
         only_new_events=False
     )
     if not log_monitor.callback_result:
-        diag = services.collect_service_diagnostics(
+        diag = _collect_service_diagnostics(
             log_path=WAZUH_LOG_PATH, highlight_patterns=_SCA_STARTUP_HIGHLIGHTS)
         raise AssertionError(
             f"[Phase 3] SCA module did not emit '{patterns.SCA_RUNNING}' within {running_timeout}s. "
@@ -305,7 +374,7 @@ def wait_for_sca_enabled():
         only_new_events=False
     )
     if not log_monitor.callback_result:
-        diag = services.collect_service_diagnostics(
+        diag = _collect_service_diagnostics(
             log_path=WAZUH_LOG_PATH, highlight_patterns=_SCA_STARTUP_HIGHLIGHTS)
         raise AssertionError(
             f"[Phase 4] SCA scan did not start within {scan_start_timeout}s. "


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

The goal of this PR is to review the agent logs and determine which logs should be uploaded to `minfo` and which ones should be retained.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

We propose uploading the following logs to minfo: 

- From the `start_agent.c` file, upload the log entry “Trying to connect to server”
- From the `logcollector.c` file, upload the module's startup log
- From the `fim_scan.c` file, upload the log for `FIM_FREQUENCY_STARTED`
- From the `run_check.c` file, upload the log entries for `FIM_DAEMON_STARTED` and `FIM_FREQUENCY_TIME`
- From the `wm_agent_info.c` file, upload the startup log for the module and the library loading log
- From the `wm_sca.c` file, upload the module's start, enable, and disable logs
- From the `wm_syscollector.c` file, upload the module's startup log.

It is proposed to send the following logs to mdebug1:
- From the `agent_info_impl.cpp` file, download the pause and triggering log for the module
- From the `sca_impl.cpp` file, download the module's run log, the logs for the enabled, initialized, and starting modules.

The logs have been standardized so that the startup and shutdown logs have the same structure, and a duplicate “Start” log from the agent-info module has been removed. 

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

- Manager:

```
2026/05/25 08:12:05 wazuh-manager-authd: INFO: Started (pid: 140094).
2026/05/25 08:12:05 wazuh-manager-db: INFO: Started (pid: 140103).
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Store initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: IOC initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: GEO initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Schema initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: HLP initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Indexer Connector initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Stream logger initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Builder initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized (index: wazuh-events-raw-v5).
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: unlimited.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Dumper Events initialized.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Engine started and ready to process events.
2026/05/25 08:12:05 wazuh-manager-analysisd: INFO: Scheduler started.
2026/05/25 08:12:06 wazuh-manager-remoted: INFO: Started (pid: 140356). Listening on port 1514/TCP (secure).
2026/05/25 08:12:06 wazuh-manager-monitord: INFO: Started (pid: 140386).
2026/05/25 08:12:06 wazuh-manager-modulesd: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/05/25 08:12:06 wazuh-manager-modulesd:router: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:inventory-sync: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:content_manager: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:database: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:agent-upgrade: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:vulnerability-scanner: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:task-manager: INFO: Started (pid: 140392).
2026/05/25 08:12:06 wazuh-manager-modulesd:vulnerability-scanner (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/05/25 08:12:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/05/25 08:12:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting incremental update from offset 420064
2026/05/25 08:12:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Incremental update download phase complete — 0 documents, new cursor: '420064'
2026/05/25 08:12:06 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=false).
2026/05/25 08:12:06 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/05/25 08:12:16 wazuh-manager-monitord: INFO: wazuh: Manager started.

```

- Agent:
```
2026/05/25 08:13:57 wazuh-execd: INFO: Started (pid: 142027).
2026/05/25 08:13:57 wazuh-agentd: INFO: Started (pid: 142035).
2026/05/25 08:13:57 wazuh-agentd: INFO: Trying to connect to server ([192.168.72.166]:1514/tcp).
2026/05/25 08:13:57 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.72.166]:1514/tcp).
2026/05/25 08:13:58 wazuh-rootcheck: INFO: Started (pid: 142048).
2026/05/25 08:13:58 wazuh-syscheckd: INFO: Started (pid: 142050).
2026/05/25 08:13:58 wazuh-logcollector: INFO: Started (pid: 142058).
2026/05/25 08:13:58 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/05/25 08:13:58 wazuh-modulesd: INFO: Started (pid: 142072).
2026/05/25 08:13:58 wazuh-modulesd:control: INFO: Starting control thread.
2026/05/25 08:13:58 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 142072).
2026/05/25 08:13:58 wazuh-modulesd:agent-info: INFO: Started (pid: 142072).
2026/05/25 08:13:58 wazuh-modulesd:sca: INFO: Started (pid: 142072).
2026/05/25 08:13:58 wazuh-modulesd:syscollector: INFO: Started (pid: 142072).
2026/05/25 08:13:58 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/25 08:13:58 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/05/25 08:13:58 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/05/25 08:13:58 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/05/25 08:13:58 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/05/25 08:13:58 wazuh-modulesd:sca: INFO: Scan started.
2026/05/25 08:13:59 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/25 08:14:00 wazuh-modulesd:sca: INFO: Scan ended.
2026/05/25 08:14:00 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
```

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
