### PR TITLE
 Make sync_end_delay interruptible to remove stale modulesd.pid

### DIFF
--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -924,13 +924,18 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         const size_t buffer_size = builder.GetSize();
         std::vector<uint8_t> messageVector(buffer_ptr, buffer_ptr + buffer_size);
 
+        // Wait for in-flight messages to settle before sending End.
+        // Interruptible: stop() notifies the cv so the wait wakes on shutdown.
         {
-            std::lock_guard<std::mutex> lock(m_syncState.mtx);
+            std::unique_lock<std::mutex> lock(m_syncState.mtx);
             m_syncState.phase = SyncPhase::WaitingEndAck;
-        }
 
-        // Configurable delay to wait for last messages to arrive before sending End
-        std::this_thread::sleep_for(m_syncEndDelay);
+            if (m_syncState.cv.wait_for(lock, m_syncEndDelay, [&] { return shouldStop(); }))
+            {
+                m_logger(LOG_DEBUG, "Stop requested during sync_end_delay; aborting End send.");
+                return false;
+            }
+        }
         m_logger(LOG_DEBUG, "Delayed " + std::to_string(m_syncEndDelay.count()) + " seconds before sending End message.");
 
         unsigned int attempt = 0;

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -788,6 +788,75 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendEndFails)
     syncThread.join();
 }
 
+TEST_F(AgentSyncProtocolTest, SendEndAbortedOnStopDuringSyncEndDelay)
+{
+    // syncEndDelay is intentionally large: without the cv.wait_for fix the
+    // sendEndAndWaitAck path would block here for the full duration, so a
+    // stop() call would never finish the sync inside this test's deadline.
+    constexpr unsigned int largeSyncEndDelay = 30;
+
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char) { return 0; }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger,
+                                                   std::chrono::seconds(largeSyncEndDelay),
+                                                   std::chrono::seconds(max_timeout),
+                                                   retries, maxEps, mockQueue);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    .WillOnce(Return(testData));
+
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(1);
+
+    auto syncFuture = std::async(std::launch::async, [&]()
+    {
+        return protocol->synchronizeModule(Mode::DELTA);
+    });
+
+    // Let the worker reach sendStartAndWaitAck and wait for StartAck.
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // Deliver StartAck so the worker continues into sendData and then into
+    // sendEndAndWaitAck's sync_end_delay wait.
+    flatbuffers::FlatBufferBuilder builder;
+    Wazuh::SyncSchema::StartAckBuilder startAckBuilder(builder);
+    startAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    startAckBuilder.add_session(session);
+    auto startAckOffset = startAckBuilder.Finish();
+    auto message = Wazuh::SyncSchema::CreateMessage(
+                       builder, Wazuh::SyncSchema::MessageType::StartAck, startAckOffset.Union());
+    builder.Finish(message);
+    protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
+
+    // Give the worker time to park inside cv.wait_for(m_syncEndDelay, ...).
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // stop() should wake the wait_for immediately via cv.notify_all().
+    protocol->stop();
+
+    // Without the fix this future would not be ready until largeSyncEndDelay
+    // seconds had elapsed. Give a generous bound to avoid CI flakiness.
+    constexpr auto testTimeout = std::chrono::seconds(5);
+
+    if (syncFuture.wait_for(testTimeout) == std::future_status::timeout)
+    {
+        FAIL() << "Sync thread did not respond to stop() during sync_end_delay; "
+               << "cv.wait_for may not be interruptible";
+    }
+
+    EXPECT_FALSE(syncFuture.get());
+}
+
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();


### PR DESCRIPTION
# Description

On macOS, `wazuh-modulesd-<pid>.pid` could be left in `/Library/Ossec/var/run` after `launchctl bootout` because syncing threads were parked in a non-interruptible `std::this_thread::sleep_for(m_syncEndDelay)` inside `AgentSyncProtocol::sendEndAndWaitAck`. When the wait crossed launchd's default 20 s `ExitTimeOut`, modulesd was SIGKILL'd before `atexit(wm_cleanup)` / `DeletePID()` could run. This PR replaces that sleep with `m_syncState.cv.wait_for(lock, m_syncEndDelay, [&]{ return shouldStop(); })` on the existing condition variable that `AgentSyncProtocol::stop()` already notifies, so the wait wakes immediately on shutdown and modulesd finishes cleanly within the supervisor's deadline. Resolves #36061.

## Proposed Changes

- Replace `std::this_thread::sleep_for(m_syncEndDelay)` in `AgentSyncProtocol::sendEndAndWaitAck` (`src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`, line 941) with an interruptible `m_syncState.cv.wait_for(lock, m_syncEndDelay, [&]{ return shouldStop(); })` on the existing `m_syncState.cv`.
- Hold the wait under a `std::unique_lock<std::mutex>(m_syncState.mtx)` so the same scope that sets `SyncPhase::WaitingEndAck` performs the wait, avoiding an unnecessary lock/unlock pair.
- On a stop request, `sendEndAndWaitAck` now returns `false` and `synchronizeModule` unwinds through its existing failure cleanup path (`m_persistentQueue->resetSyncingItems()` for DELTA, `m_inMemoryData.clear()` for FULL).
- Add unit test `SendEndAbortedOnStopDuringSyncEndDelay` in `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp` that configures a large `syncEndDelay`, drives the worker into `sendEndAndWaitAck`, calls `stop()`, and asserts that the synchronous call returns within 5 s (without the fix it would block for the full 30 s).

### Results and Evidence

Reproduced on macOS by looping `launchctl bootstrap` and `launchctl bootout` against the agent and inspecting `/Library/Ossec/var/run` after each stop. Logs before and after the fix:

<details><summary>Reproduction scaffolding — applied locally to force the bug, NOT included in this PR</summary>

To force `synchronizeModule` past the empty-data short-circuit and to make the pre-End wait long enough to cross launchd's 20 s `ExitTimeOut`, the following patch was applied locally over `main`. Both edits are pure test scaffolding (marked `STRESS-36061 / REMOVE BEFORE COMMITTING`). This block is recorded here so the temporary `test/36061-wazuh-modulesd-not-deleted-after-agent-stop` branch can be deleted.

```diff
diff --git a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -179,11 +179,21 @@ bool AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         }
     }

+    // TEMP — stress harness for #36061 verification. Ensure dataToSync is never
+    // empty so synchronizeModule continues into sendStartAndWaitAck and ultimately
+    // into sendEndAndWaitAck, where the 30s stress sleep lives. Without this, FIM
+    // events go through the events channel and the sync queue stays empty, so the
+    // pre-End sleep is never reached. REMOVE BEFORE COMMITTING.
     if (dataToSync.empty())
     {
-        const std::string modeStr = (mode == Mode::FULL) ? "FULL" : "DELTA";
-        m_logger(LOG_DEBUG, "No items to synchronize in " + modeStr + " mode");
-        return true;
+        m_logger(LOG_WARNING, "STRESS-36061: dataToSync empty, injecting stub item to reach sendEndAndWaitAck");
+        PersistedData stub{};
+        stub.id              = "stress-36061";
+        stub.index           = "stress-36061";
+        stub.data            = "{}";
+        stub.operation       = Operation::NO_OP;
+        stub.is_data_context = false;
+        dataToSync.push_back(std::move(stub));
     }

@@ -924,14 +934,35 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         const size_t buffer_size = builder.GetSize();
         std::vector<uint8_t> messageVector(buffer_ptr, buffer_ptr + buffer_size);

+        // TEMP — stress harness for #36061 verification (combined with the fix):
+        //   * Hard-codes the wait to 30 s instead of m_syncEndDelay so the
+        //     launchctl bootout (arriving ~10 s after agent start) lands while
+        //     this thread is parked here. Without the fix this would be a
+        //     non-interruptible sleep_for and modulesd would miss launchd's
+        //     20 s ExitTimeOut. With the fix the wait wakes immediately on
+        //     stop() and the function unwinds.
+        //   * REMOVE the STRESS-36061 log lines and the hard-coded 30 s before
+        //     committing — keep only the cv.wait_for(m_syncEndDelay, …) form.
         {
-            std::lock_guard<std::mutex> lock(m_syncState.mtx);
+            std::unique_lock<std::mutex> lock(m_syncState.mtx);
             m_syncState.phase = SyncPhase::WaitingEndAck;
-        }

-        std::this_thread::sleep_for(m_syncEndDelay);
-        m_logger(LOG_DEBUG, "Delayed " + std::to_string(m_syncEndDelay.count()) + " seconds before sending End message.");
+            m_logger(LOG_WARNING, "STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())");
+
+            if (m_syncState.cv.wait_for(lock, std::chrono::seconds(30), [&] { return shouldStop(); }))
+            {
+                m_logger(LOG_WARNING, "STRESS-36061: pre-End wait interrupted by stop(); aborting End send.");
+                return false;
+            }
+
+            m_logger(LOG_WARNING, "STRESS-36061: pre-End wait completed normally (no stop request within 30s).");
+        }
+        m_logger(LOG_DEBUG, "Delayed up to 30 seconds (stress) before sending End message.");
```

Validation procedure used:

1. Apply the patch above on top of `main` (without the fix) and rebuild the macOS agent → reproduce the leak (every iteration parks in a 30 s non-interruptible `sleep_for`, modulesd is SIGKILLed at the 20 s mark, `wazuh-modulesd-<pid>.pid` remains).
2. Replace the `sleep_for` with `cv.wait_for(lock, std::chrono::seconds(30), [&]{ return shouldStop(); })` (the fix's pattern, still with the hard-coded 30 s and `STRESS-36061` log lines for visibility), rebuild → leak disappears, every iteration logs `pre-End wait interrupted by stop()` ~5 s after SIGTERM.
3. Drop the `STRESS-36061` log lines, revert the hard-coded 30 s back to `m_syncEndDelay`, and remove the stub-data injection — leaving only the production fix shipped in this PR.

</details>


<details><summary>Before fix — `wazuh-modulesd-<pid>.pid` left on disk after `launchctl bootout` (two consecutive iterations)</summary>

```bash
Iteration: 1 / 10
Start agent
Sleeping 10s
Active PIDs in var/run:
total 120
-rwxrwx---  1 root   wazuh  35616 May 20 01:22 .wazuh_agent_metadata
-rw-r-----  1 wazuh  wazuh      6 May 20 01:22 wazuh-agentd-41351.pid
-rw-r--r--  1 wazuh  wazuh    641 May 20 01:23 wazuh-agentd.state
-rw-r-----  1 root   wazuh      6 May 20 01:22 wazuh-execd-41343.pid
-rw-r-----  1 root   wazuh      6 May 20 01:23 wazuh-logcollector-41384.pid
-rw-r-----  1 root   wazuh      6 May 20 01:23 wazuh-modulesd-41395.pid
-rw-r-----  1 root   wazuh      6 May 20 01:23 wazuh-syscheckd-41376.pid
Stop agent
Active PIDs in var/run after stop:
total 80
-rwxrwx---  1 root  wazuh  35616 May 20 01:23 .wazuh_agent_metadata
-rw-r-----  1 root  wazuh      6 May 20 01:23 wazuh-modulesd-41395.pid
===========================================
Iteration: 2 / 10
...
Active PIDs in var/run after stop:
total 80
-rwxrwx---  1 root  wazuh  35616 May 20 01:23 .wazuh_agent_metadata
-rw-r-----  1 root  wazuh      6 May 20 01:23 wazuh-modulesd-42010.pid
```

</details>

<details><summary>Before fix — non-interruptible sleep: wake comes 30 s after sleep_for starts regardless of SIGTERM (ossec.log, iter 1)</summary>

```bash
2026/05/20 01:23:00 wazuh-modulesd: INFO: Started (pid: 41395).
2026/05/20 01:23:06 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_metadata
2026/05/20 01:23:06 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End sleep, sleeping 30s
2026/05/20 01:23:06 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/05/20 01:23:06 wazuh-syscheckd:   INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/05/20 01:23:06 wazuh-agentd:      INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/05/20 01:23:07 wazuh-execd:       INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/05/20 01:23:08 wazuh-modulesd:syscollector: INFO: Module finished.
2026/05/20 01:23:36 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck wake after 30s sleep
2026/05/20 01:23:36 wazuh-modulesd: ERROR: socketerr (not available).
```

</details>

<details><summary>After fix — loop summary: zero modulesd `.pid` leaks</summary>

```bash
===========================================
Final cleanup...
===========================================
Summary
  Iterations run: 11
  Hits (stale modulesd PID): 0
```

</details>

<details><summary>After fix — interruptible wait: every `pre-End wait` is paired with `interrupted by stop()` ~5 s later (ossec.log)</summary>

```bash
2026/05/20 01:31:16 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:31:21 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:31:43 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:31:48 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:31:59 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:32:05 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:32:15 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:32:20 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:32:30 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:32:35 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:32:45 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:32:50 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:33:01 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:33:07 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
2026/05/20 01:33:16 wazuh-modulesd:agent-info: WARNING: STRESS-36061: sendEndAndWaitAck pre-End wait, up to 30s (interruptible by stop())
2026/05/20 01:33:21 wazuh-modulesd:agent-info: WARNING: STRESS-36061: pre-End wait interrupted by stop(); aborting End send.
```

</details>

<details><summary>After fix — one clean iteration end-to-end</summary>

```bash
Iteration: 3 / 300
Start agent
Sleeping 10s
Active PIDs in var/run:
total 120
-rwxrwx---  1 root   wazuh  35616 May 20 14:56 .wazuh_agent_metadata
-rw-r-----  1 wazuh  wazuh      6 May 20 14:56 wazuh-agentd-21931.pid
-rw-r--r--  1 wazuh  wazuh    639 May 20 14:56 wazuh-agentd.state
-rw-r-----  1 root   wazuh      6 May 20 14:56 wazuh-execd-21923.pid
-rw-r-----  1 root   wazuh      6 May 20 14:56 wazuh-logcollector-21964.pid
-rw-r-----  1 root   wazuh      6 May 20 14:56 wazuh-modulesd-21975.pid
-rw-r-----  1 root   wazuh      6 May 20 14:56 wazuh-syscheckd-21956.pid
Stop agent
Active PIDs in var/run after stop:
total 72
-rwxrwx---  1 root  wazuh  35616 May 20 14:56 .wazuh_agent_metadata
No PID files found, continuing...
```


[Full test evidence across 300 iterations](https://github.com/user-attachments/files/28066742/test_final_end.log)


</details>

### Artifacts Affected

`libsync_protocol` (modified library), `wazuh-modulesd` (the daemon whose `.pid` was leaking), `wazuh-syscheckd` (also calls `AgentSyncProtocol::synchronizeModule` via the FIM sync path and benefits from the same fix).

### Configuration Changes

_No configuration changes._ The `<sync_end_delay>` tag inside `<synchronization>` is pre-existing; this PR only changes how the agent honours it on shutdown.

### Documentation Updates

_No documentation changes required._

### Tests Introduced

- `SendEndAbortedOnStopDuringSyncEndDelay` in `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp` — drives `synchronizeModule` into `sendEndAndWaitAck`'s `sync_end_delay` wait (configured to 30 s), calls `protocol->stop()`, and asserts the call returns within 5 s. Without the fix, the future would block for the full 30 s and the test would `FAIL()` via the timeout.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
