### PR TITLE
Improve tmp_file path validation in cluster DAPI

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -411,12 +411,22 @@ class DistributedAPI:
     async def send_tmp_file(self, node_name=None):
         # POST/agent/group/:group_id/configuration and POST/agent/group/:group_id/file/:file_name API calls write
         # a temporary file in /var/ossec/tmp which needs to be sent to the master before forwarding the request
+        tmp_file = self.f_kwargs.get('tmp_file', '')
+        if not tmp_file:
+            raise exception.WazuhClusterError(3034, extra_message='tmp_file parameter is required')
+
+        tmp_path = os.path.join(common.OSSEC_TMP_PATH, tmp_file)
+        resolved_path = os.path.realpath(tmp_path)
+
+        allowed_tmp_dir = os.path.realpath(common.OSSEC_TMP_PATH)
+        if not resolved_path.startswith(allowed_tmp_dir + os.sep) and resolved_path != allowed_tmp_dir:
+            raise exception.WazuhClusterError(3034,
+                extra_message=f'Invalid tmp_file path: {tmp_file}. Path must be within tmp directory')
+
         client = self.get_client()
-        res = json.loads(await client.send_file(os.path.join(common.WAZUH_PATH,
-                                                             self.f_kwargs['tmp_file']),
-                                                node_name),
+        res = json.loads(await client.send_file(resolved_path, node_name),
                          object_hook=c_common.as_wazuh_object)
-        os.remove(os.path.join(common.WAZUH_PATH, self.f_kwargs['tmp_file']))
+        os.remove(resolved_path)
 
     async def execute_remote_request(self) -> Dict:
         """Execute a remote request. This function is used by worker nodes to execute master_only API requests.

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -425,15 +425,17 @@ def test_DistributedAPI_logger():
 @patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 def test_DistributedAPI_tmp_file(mock_cluster_status):
     """Test the behaviour when processing temporal files to be send. Master node and unknown node."""
-    open('/tmp/dapi_file.txt', 'a').close()
+    tmp_file_path = os.path.join(common.OSSEC_TMP_PATH, 'dapi_file.txt')
+    os.makedirs(common.OSSEC_TMP_PATH, exist_ok=True)
+    open(tmp_file_path, 'a').close()
     with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'unknown'}):
         with patch('wazuh.core.cluster.dapi.dapi.get_node_wrapper',
                    return_value=AffectedItemsWazuhResult(affected_items=[{'type': 'master', 'node': 'unknown'}])):
             dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
-                           'f_kwargs': {'tmp_file': '/tmp/dapi_file.txt'}}
+                           'f_kwargs': {'tmp_file': 'dapi_file.txt'}}
             raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
-    open('/tmp/dapi_file.txt', 'a').close()
+    open(tmp_file_path, 'a').close()
     with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'unk', 'node': 'master'}):
         raise_if_exc_routine(dapi_kwargs=dapi_kwargs)
 
@@ -444,21 +446,23 @@ def test_DistributedAPI_tmp_file(mock_cluster_status):
 @patch('wazuh.core.cluster.dapi.dapi.check_cluster_status', return_value=True)
 def test_DistributedAPI_tmp_file_cluster_error(mock_cluster_status):
     """Test the behaviour when an error raises with temporal files function."""
-    open('/tmp/dapi_file.txt', 'a').close()
+    tmp_file_path = os.path.join(common.OSSEC_TMP_PATH, 'dapi_file.txt')
+    os.makedirs(common.OSSEC_TMP_PATH, exist_ok=True)
+    open(tmp_file_path, 'a').close()
     with patch('wazuh.core.cluster.cluster.get_node', return_value={'type': 'master', 'node': 'unknown'}):
         with patch('wazuh.core.cluster.dapi.dapi.get_node_wrapper',
                    return_value=AffectedItemsWazuhResult(affected_items=[{'type': 'master', 'node': 'unknown'}])):
             with patch('wazuh.core.cluster.local_client.LocalClient.execute',
                        new=AsyncMock(side_effect=WazuhClusterError(3022))):
                 dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
-                               'f_kwargs': {'tmp_file': '/tmp/dapi_file.txt'}}
+                               'f_kwargs': {'tmp_file': 'dapi_file.txt'}}
                 raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=3022)
 
-            open('/tmp/dapi_file.txt', 'a').close()
+            open(tmp_file_path, 'a').close()
             with patch('wazuh.core.cluster.local_client.LocalClient.execute',
                        new=AsyncMock(side_effect=WazuhClusterError(1000))):
                 dapi_kwargs = {'f': manager.status, 'logger': logger, 'request_type': 'distributed_master',
-                               'f_kwargs': {'tmp_file': '/tmp/dapi_file.txt'}}
+                               'f_kwargs': {'tmp_file': 'dapi_file.txt'}}
                 raise_if_exc_routine(dapi_kwargs=dapi_kwargs, expected_error=1000)
 
 
@@ -852,3 +856,101 @@ async def test_SendSyncRequestQueue_run(loop_mock, contexlib_mock):
             with patch("wazuh.core.cluster.dapi.dapi.wazuh_sendsync", side_effect="noerror"):
                 with pytest.raises(Exception):
                     await sendsync.run()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('tmp_file, expected_error', [
+    ('../../etc/ossec.conf', WazuhClusterError),
+    ('../../../etc/passwd', WazuhClusterError),
+    ('/etc/passwd', WazuhClusterError),
+    ('../api/configuration/security/private_key.pem', WazuhClusterError),
+    ('/var/ossec/api/configuration/security/private_key.pem', WazuhClusterError),
+    ('valid_file.txt', None),
+    ('subdir/valid_file.txt', None),
+])
+async def test_send_tmp_file_path_validation(tmp_file, expected_error):
+    """Test send_tmp_file with various path formats."""
+    with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
+        dapi = DistributedAPI()
+        dapi.f_kwargs = {'tmp_file': tmp_file}
+        dapi.logger = TestingLogger('test')
+
+        mock_client = MagicMock()
+
+        with patch.object(dapi, 'get_client', return_value=mock_client):
+            if expected_error:
+                with pytest.raises(expected_error):
+                    await dapi.send_tmp_file()
+            else:
+                with patch('os.path.realpath') as mock_realpath:
+                    with patch('os.remove'):
+                        def mock_realpath_func(p):
+                            if common.OSSEC_TMP_PATH in p:
+                                return os.path.join(common.OSSEC_TMP_PATH, tmp_file)
+                            return p
+
+                        mock_realpath.side_effect = mock_realpath_func
+                        mock_client.send_file = AsyncMock(return_value=json.dumps(123))
+
+                        await dapi.send_tmp_file()
+
+                        assert mock_client.send_file.mock.called
+
+
+@pytest.mark.asyncio
+async def test_send_tmp_file_empty_parameter():
+    """Test send_tmp_file with missing tmp_file parameter."""
+    with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
+        dapi = DistributedAPI()
+        dapi.f_kwargs = {}
+        dapi.logger = TestingLogger('test')
+
+        with pytest.raises(WazuhClusterError) as exc_info:
+            await dapi.send_tmp_file()
+
+        assert 'tmp_file parameter is required' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_send_tmp_file_absolute_path():
+    """Test send_tmp_file with absolute path."""
+    with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
+        dapi = DistributedAPI()
+        dapi.f_kwargs = {'tmp_file': '/var/ossec/api/configuration/security/private_key.pem'}
+        dapi.logger = TestingLogger('test')
+
+        with pytest.raises(WazuhClusterError) as exc_info:
+            await dapi.send_tmp_file()
+
+        assert 'Invalid tmp_file path' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_send_tmp_file_parent_directory():
+    """Test send_tmp_file with parent directory reference."""
+    with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
+        dapi = DistributedAPI()
+        dapi.f_kwargs = {'tmp_file': '../etc/ossec.conf'}
+        dapi.logger = TestingLogger('test')
+
+        with pytest.raises(WazuhClusterError) as exc_info:
+            await dapi.send_tmp_file()
+
+        assert 'Invalid tmp_file path' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_send_tmp_file_symlink_resolution():
+    """Test send_tmp_file with symlink resolution."""
+    with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
+        dapi = DistributedAPI()
+        dapi.f_kwargs = {'tmp_file': 'symlink_to_file'}
+        dapi.logger = TestingLogger('test')
+
+        with patch('os.path.realpath') as mock_realpath:
+            mock_realpath.side_effect = lambda p: '/var/ossec/api/configuration/security/private_key.pem' if 'symlink' in p else p
+
+            with pytest.raises(WazuhClusterError) as exc_info:
+                await dapi.send_tmp_file()
+
+            assert 'Invalid tmp_file path' in str(exc_info.value)


### PR DESCRIPTION
## Description

Enhanced path validation in the `send_tmp_file` method of the cluster DAPI to ensure temporary files are properly constrained to the designated temporary directory.

**Credits:** Thanks to @moltenbit for reporting this issue.

## Proposed Changes

- Modified `DistributedAPI.send_tmp_file()` to validate that `tmp_file` parameter points to files within `OSSEC_TMP_PATH`
- Added path resolution using `os.path.realpath()` to handle symbolic links and relative paths correctly
- Changed base directory from `WAZUH_PATH` to `OSSEC_TMP_PATH` for stricter containment
- Updated existing tests to use relative paths within the tmp directory

### Results and Evidence

All tests passing:
```
======================== 47 passed, 8 warnings in 0.87s ========================
```

New tests validate:
- Invalid path formats are rejected
- Absolute paths are rejected
- Parent directory references are rejected
- Symbolic link resolution is handled correctly
- Valid relative paths within tmp directory work as expected

### Artifacts Affected

- wazuh-clusterd

### Configuration Changes

No configuration changes required.

### Documentation Updates

No documentation updates required.

### Tests Introduced

- `test_send_tmp_file_path_validation`: Parametrized test with 7 cases for various path formats
- `test_send_tmp_file_empty_parameter`: Tests missing parameter handling
- `test_send_tmp_file_absolute_path`: Tests absolute path rejection
- `test_send_tmp_file_parent_directory`: Tests parent directory reference rejection
- `test_send_tmp_file_symlink_resolution`: Tests symlink resolution handling

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
