### PR TITLE
Remove obsolete configuration blocks from API upload_configuration setting

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -67,21 +67,6 @@ default_api_configuration = {
         "max_request_per_minute": 300
     },
     "upload_configuration": {
-        "remote_commands": {
-            "localfile": {
-                "allow": False,
-                "exceptions": []
-            },
-            "wodle_command": {
-                "allow": False,
-                "exceptions": []
-            }
-        },
-        "limits": {
-            "eps": {
-                "allow": False
-            }
-        },
         "agents": {
             "allow_higher_versions": {
                 "allow": False

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -69,11 +69,11 @@ default_api_configuration = {
     "upload_configuration": {
         "agents": {
             "allow_higher_versions": {
-                "allow": False
+                "allow": True
             }
         },
         "indexer": {
-            "allow": False
+            "allow": True
         }
     }
 }

--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -69,26 +69,26 @@ default_api_configuration = {
     "upload_configuration": {
         "remote_commands": {
             "localfile": {
-                "allow": True,
+                "allow": False,
                 "exceptions": []
             },
             "wodle_command": {
-                "allow": True,
+                "allow": False,
                 "exceptions": []
             }
         },
         "limits": {
             "eps": {
-                "allow": True
+                "allow": False
             }
         },
         "agents": {
             "allow_higher_versions": {
-                "allow": True
+                "allow": False
             }
         },
         "indexer": {
-            "allow": True
+            "allow": False
         }
     }
 }

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -55,6 +55,6 @@
 # upload_configuration:
 #   agents:
 #     allow_higher_versions:
-#       allow: no
+#       allow: yes
 #   indexer:
-#     allow: no
+#     allow: yes

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -53,16 +53,6 @@
 
 # Uploadable Wazuh configuration sections
 # upload_configuration:
-#   remote_commands:
-#     localfile:
-#       allow: no
-#       exceptions: []
-#     wodle_command:
-#       allow: no
-#       exceptions: []
-#   limits:
-#     eps:
-#       allow: no
 #   agents:
 #     allow_higher_versions:
 #       allow: no

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -54,14 +54,17 @@
 # Uploadable Wazuh configuration sections
 # upload_configuration:
 #   remote_commands:
+#     localfile:
+#       allow: no
+#       exceptions: []
 #     wodle_command:
-#       allow: yes
+#       allow: no
 #       exceptions: []
 #   limits:
 #     eps:
-#       allow: yes
+#       allow: no
 #   agents:
 #     allow_higher_versions:
-#       allow: yes
+#       allow: no
 #   indexer:
-#     allow: yes
+#     allow: no

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6822,21 +6822,11 @@ paths:
                           block_time: 300
                           max_request_per_minute: 300
                         upload_configuration:
-                          remote_commands:
-                            localfile:
-                              allow: true
-                              exceptions: []
-                            wodle_command:
-                              allow: true
-                              exceptions: []
-                          limits:
-                            eps:
-                              allow: true
                           agents:
                             allow_higher_versions:
-                              allow: true
+                              allow: false
                           indexer:
-                            allow: true
+                            allow: false
                     - node_name: "worker1"
                       node_api_config:
                         host: 0.0.0.0
@@ -6869,21 +6859,11 @@ paths:
                           block_time: 300
                           max_request_per_minute: 300
                         upload_configuration:
-                          remote_commands:
-                            localfile:
-                              allow: true
-                              exceptions: []
-                            wodle_command:
-                              allow: true
-                              exceptions: []
-                          limits:
-                            eps:
-                              allow: true
                           agents:
                             allow_higher_versions:
-                              allow: true
+                              allow: false
                           indexer:
-                            allow: true
+                            allow: false
                     - node_name: "worker2"
                       node_api_config:
                         host: 0.0.0.0
@@ -6916,21 +6896,11 @@ paths:
                           block_time: 300
                           max_request_per_minute: 300
                         upload_configuration:
-                          remote_commands:
-                            localfile:
-                              allow: true
-                              exceptions: []
-                            wodle_command:
-                              allow: true
-                              exceptions: []
-                          limits:
-                            eps:
-                              allow: true
                           agents:
                             allow_higher_versions:
-                              allow: true
+                              allow: false
                           indexer:
-                            allow: true
+                            allow: false
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6824,9 +6824,9 @@ paths:
                         upload_configuration:
                           agents:
                             allow_higher_versions:
-                              allow: false
+                              allow: true
                           indexer:
-                            allow: false
+                            allow: true
                     - node_name: "worker1"
                       node_api_config:
                         host: 0.0.0.0
@@ -6861,9 +6861,9 @@ paths:
                         upload_configuration:
                           agents:
                             allow_higher_versions:
-                              allow: false
+                              allow: true
                           indexer:
-                            allow: false
+                            allow: true
                     - node_name: "worker2"
                       node_api_config:
                         host: 0.0.0.0
@@ -6898,9 +6898,9 @@ paths:
                         upload_configuration:
                           agents:
                             allow_higher_versions:
-                              allow: false
+                              allow: true
                           indexer:
-                            allow: false
+                            allow: true
                   total_affected_items: 3
                   total_failed_items: 0
                   failed_items: []

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -41,21 +41,6 @@ custom_api_configuration = {
         "max_request_per_minute": 300
     },
     "upload_configuration": {
-        "remote_commands": {
-            "localfile": {
-                "allow": False,
-                "exceptions": []
-            },
-            "wodle_command": {
-                "allow": False,
-                "exceptions": []
-            }
-        },
-        "limits": {
-            "eps": {
-                "allow": False
-            }
-        },
         "agents": {
             "allow_higher_versions": {
                 "allow": False

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -43,21 +43,26 @@ custom_api_configuration = {
     "upload_configuration": {
         "remote_commands": {
             "localfile": {
-                "allow": True,
+                "allow": False,
                 "exceptions": []
             },
             "wodle_command": {
-                "allow": True,
+                "allow": False,
                 "exceptions": []
+            }
+        },
+        "limits": {
+            "eps": {
+                "allow": False
             }
         },
         "agents": {
             "allow_higher_versions": {
-                "allow": True
+                "allow": False
             }
         },
         "indexer": {
-            "allow": True
+            "allow": False
         }
     }
 }

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -43,11 +43,11 @@ custom_api_configuration = {
     "upload_configuration": {
         "agents": {
             "allow_higher_versions": {
-                "allow": False
+                "allow": True
             }
         },
         "indexer": {
-            "allow": False
+            "allow": True
         }
     }
 }
@@ -126,12 +126,6 @@ def test_read_configuration(mock_open, mock_exists, read_config):
     {'access': {'block_time': 'invalid_type'}},
     {'access': {'max_request_per_minute': 'invalid_type'}},
     {'access': {'invalid_subkey': 'invalid_type'}},
-    {'remote_commands': {'localfile': {'allow': 'invalid_type'}}},
-    {'remote_commands': {'localfile': {'exceptions': [0, 1, 2]}}},
-    {'remote_commands': {'localfile': {'invalid_subkey': 'invalid_type'}}},
-    {'remote_commands': {'wodle_command': {'allow': 'invalid_type'}}},
-    {'remote_commands': {'wodle_command': {'exceptions': [0, 1, 2]}}},
-    {'remote_commands': {'wodle_command': {'invalid_subkey': 'invalid_type'}}},
     {'agents': {'allow_higher_versions': {'allow': True}}},
     {'indexer': {'allow': True}},
 ])

--- a/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
+++ b/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
@@ -31,3 +31,11 @@ access:
 
 # Drop privileges (Run as wazuh-manager user)
 drop_privileges: yes
+
+# Uploadable Wazuh configuration sections (allow all for testing)
+upload_configuration:
+  agents:
+    allow_higher_versions:
+      allow: yes
+  indexer:
+    allow: yes

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -611,16 +611,6 @@ stages:
                 drop_privileges: !anybool
                 authentication_pool_size: !anyint
                 upload_configuration:
-                  remote_commands:
-                    localfile:
-                      allow: !anybool
-                      exceptions: !anything
-                    wodle_command:
-                      allow: !anybool
-                      exceptions: !anything
-                  limits:
-                    eps:
-                      allow: !anybool
                   agents:
                     allow_higher_versions:
                       allow: !anybool

--- a/docs/ref/modules/command/README.md
+++ b/docs/ref/modules/command/README.md
@@ -4,7 +4,7 @@
 
 The Wazuh command module executes configured operating system commands at scheduled intervals and can forward their output for analysis. It runs inside `wazuh-modulesd` as the `<wodle name="command">` module.
 
-Use this module for periodic command-based telemetry when a native collector is not available. The module executes the configured command locally on the agent or manager where the configuration is applied.
+Use this module for periodic command-based telemetry when a native collector is not available. The module executes the configured command locally on the agent where the configuration is applied.
 
 ## How it works
 

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -589,73 +589,6 @@ def test_plain_dict_to_nested_dict():
     assert result == mock_nested_dict
 
 
-@pytest.mark.parametrize('new_conf, original_conf, allow_config, should_raise', [
-    # Test case where localfile with command log_format is added (should raise when not allowed)
-    ("<wazuh_config><localfile><log_format>command</log_format><command>rm -rf /</command></localfile></wazuh_config>",
-     "<wazuh_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></wazuh_config>",
-     {'localfile': {'allow': False, 'exceptions': []},
-      'wodle_command': {'allow': True, 'exceptions': []}},
-     True),
-
-    # Test case where same command exists in both (should not raise)
-    ("<wazuh_config><localfile><log_format>command</log_format><command>echo test</command></localfile></wazuh_config>",
-     "<wazuh_config><localfile><log_format>command</log_format><command>echo test</command></localfile></wazuh_config>",
-     {'localfile': {'allow': False, 'exceptions': ['echo test']},
-      'wodle_command': {'allow': True, 'exceptions': []}},
-     False),
-
-    # Test case where wodle command is added (should raise when not allowed)
-    ('<wazuh_config><wodle name="command"><command>ls -la</command></wodle></wazuh_config>',
-     '<wazuh_config><wodle name="command"><tag>value</tag></wodle></wazuh_config>',
-     {'localfile': {'allow': True, 'exceptions': []},
-      'wodle_command': {'allow': False, 'exceptions': []}},
-     True),
-
-    # Test case where wodle command is in exceptions (should not raise)
-    ('<wazuh_config><wodle name="command"><command>test</command></wodle></wazuh_config>',
-     '<wazuh_config><wodle name="command"><command>test</command></wodle></wazuh_config>',
-     {'localfile': {'allow': True, 'exceptions': []},
-      'wodle_command': {'allow': False, 'exceptions': ['test']}},
-     False),
-
-    # Test case with no remote commands (should not raise)
-    ("<wazuh_config><other><value>test</value></other></wazuh_config>",
-     "<wazuh_config><other><value>test</value></other></wazuh_config>",
-     {'localfile': {'allow': False, 'exceptions': []},
-      'wodle_command': {'allow': False, 'exceptions': []}},
-     False),
-
-    # Test case where localfile with full_command log_format is added (should raise when not allowed)
-    ("<wazuh_config><localfile><log_format>full_command</log_format><command>cat /etc/passwd</command></localfile></wazuh_config>",
-     "<wazuh_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></wazuh_config>",
-     {'localfile': {'allow': False, 'exceptions': []},
-      'wodle_command': {'allow': True, 'exceptions': []}},
-     True),
-
-    # Test case where localfile without command log_format (should not raise)
-    ("<wazuh_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></wazuh_config>",
-     "<wazuh_config><localfile><log_format>apache</log_format><location>/var/log/apache.log</location></localfile></wazuh_config>",
-     {'localfile': {'allow': False, 'exceptions': []},
-      'wodle_command': {'allow': False, 'exceptions': []}},
-     False),
-])
-def test_check_remote_commands(new_conf, original_conf, allow_config, should_raise):
-    """Tests check_remote_commands with different remote command inputs."""
-    api_conf = utils.configuration.api_conf
-    api_conf['upload_configuration']['remote_commands'].update(allow_config)
-
-    # Convert string to XML Element for both new and original configurations
-    xml_new_conf = utils.load_wazuh_xml(None, new_conf)
-    xml_original_conf = utils.load_wazuh_xml(None, original_conf)
-
-    with patch('wazuh.core.utils.configuration.api_conf', new=api_conf):
-        if should_raise:
-            with pytest.raises(exception.WazuhError, match=r'.* 1124 .*'):
-                utils.check_remote_commands(xml_new_conf, xml_original_conf)
-        else:
-            utils.check_remote_commands(xml_new_conf, xml_original_conf)
-
-
 @patch('wazuh.core.utils.compile', return_value='Something')
 def test_basic_load_wazuh_xml(mock_compile):
     """Test basic load_wazuh_xml functionality."""
@@ -1703,13 +1636,10 @@ def test_select_array(select, required_fields, expected_result):
         assert e.code == 1724
 
 
-@patch('wazuh.core.utils.check_wazuh_limits_unchanged')
-@patch('wazuh.core.utils.check_remote_commands')
 @patch('wazuh.core.utils.check_agents_allow_higher_versions')
 @patch('wazuh.core.utils.check_indexer')
 @patch('wazuh.core.manager.common.WAZUH_PATH', new=test_files_path)
-def test_validate_wazuh_xml(mock_check_indexer,
-                            mock_agents_versions, mock_remote_commands, mock_unchanged_limits):
+def test_validate_wazuh_xml(mock_check_indexer, mock_agents_versions):
     """Test validate_wazuh_xml method works and methods inside are called with expected parameters"""
 
     with open(os.path.join(test_files_path, 'test_config.xml')) as f:
@@ -1719,10 +1649,8 @@ def test_validate_wazuh_xml(mock_check_indexer,
 
     with patch('builtins.open', m):
         utils.validate_wazuh_xml(xml_file)
-    mock_remote_commands.assert_called_once()
     mock_agents_versions.assert_called_once()
     mock_check_indexer.assert_called_once()
-    mock_unchanged_limits.assert_called_once()
 
 
 @pytest.mark.parametrize('effect, expected_exception', [

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -722,92 +722,6 @@ def plain_dict_to_nested_dict(data, nested=None, non_nested=None, force_fields=[
     return nested_dict
 
 
-def check_remote_commands(new_conf: Element, original_conf: Element):
-    """Check remote commands are allowed.
-
-    Parameters
-    ----------
-    new_conf : Element
-        New configuration file.
-    original_conf : Element
-        Original configuration file.
-
-    Raises
-    ------
-    WazuhError(1124)
-        Raised if remote command settings are modified in the configuration to upload.
-    """
-
-    def _filter_remote_commands(commands: list, exceptions: list) -> list:
-        """Keep only remote commands that are not part of the exception list.
-
-        Parameters
-        ----------
-        commands : list
-            List of commands to filter.
-        exceptions : list
-            List of exceptions to exclude from filtering.
-
-        Returns
-        -------
-        list
-            List of remote commands.
-        """
-        remote_commands = []
-
-        for command in commands:
-            if command['localfile']['log_format']['value'] in ['command', 'full_command'] \
-                and command['localfile']['command']['value'] not in exceptions:
-                remote_commands.append(command)
-
-        return remote_commands
-
-    def _filter_wodle_commands(commands: list, exceptions: list) -> list:
-        """Keep only wodle commands that are not part of the exception list.
-
-        Parameters
-        ----------
-        commands : list
-            List of commands to filter.
-        exceptions : list
-            List of exceptions to exclude from filtering.
-
-        Returns
-        -------
-        list
-            List of wodle commands.
-        """
-        wodle_commands = []
-
-        for command in commands:
-            if 'command' in command['wodle'] and command['wodle']['command']['value'] not in exceptions:
-                wodle_commands.append(command)
-
-        return wodle_commands
-
-    ALLOW_KEY = 'allow'
-    EXCEPTIONS_KEY = 'exceptions'
-    LOCALFILE_HIERARCHY = ['wazuh_config', 'localfile']
-    WODLE_HIERARCHY = ['wazuh_config', 'wodle']
-    LOCALFILE_SETTINGS = configuration.api_conf['upload_configuration']['remote_commands']['localfile']
-    WODLE_SETTINGS = configuration.api_conf['upload_configuration']['remote_commands']['wodle_command']
-
-    if not LOCALFILE_SETTINGS[ALLOW_KEY]:
-        new_localfile = xml_to_dict(new_conf, LOCALFILE_HIERARCHY)
-        original_localfile = xml_to_dict(original_conf, LOCALFILE_HIERARCHY)
-
-        if normalize(_filter_remote_commands(new_localfile, LOCALFILE_SETTINGS[EXCEPTIONS_KEY])) \
-            != normalize(_filter_remote_commands(original_localfile, LOCALFILE_SETTINGS[EXCEPTIONS_KEY])):
-            raise WazuhError(1124, extra_message="localfile")
-
-    if not WODLE_SETTINGS[ALLOW_KEY]:
-        new_wodle = xml_to_dict(new_conf, WODLE_HIERARCHY)
-        original_wodle = xml_to_dict(original_conf, WODLE_HIERARCHY)
-
-        if normalize(_filter_wodle_commands(new_wodle, WODLE_SETTINGS[EXCEPTIONS_KEY])) \
-            != normalize(_filter_wodle_commands(original_wodle, WODLE_SETTINGS[EXCEPTIONS_KEY])):
-            raise WazuhError(1124, extra_message="wodle")
-
 def xml_to_dict(root, section_path: list):
     """Extract configuration sections from an XML tree using dotted paths.
 
@@ -884,31 +798,6 @@ def normalize(data, preserve_root_order=True):
         return value
 
     return _normalize(data, True)
-
-
-def check_wazuh_limits_unchanged(new_conf, original_conf):
-    """Check if Wazuh limits remain unchanged.
-
-    Parameters
-    ----------
-    new_conf : Element
-        New configuration file.
-    original_conf : Element
-        Original configuration file.
-
-    Raises
-    -------
-    WazuhError(1127)
-        Raised if one of the protected limits is modified in the configuration to upload.
-    """
-    CONFIG_LIMITS_HIERARCHY = ['wazuh_config', 'global', 'limits']
-    limits_configuration = configuration.api_conf['upload_configuration']['limits']
-    for disabled_limit in [conf for conf, allowed in limits_configuration.items() if not allowed['allow']]:
-        new_limits = xml_to_dict(new_conf, CONFIG_LIMITS_HIERARCHY + [disabled_limit])
-        original_limits = xml_to_dict(original_conf, CONFIG_LIMITS_HIERARCHY + [disabled_limit])
-
-        if normalize(new_limits) != normalize(original_limits):
-            raise WazuhError(1127, extra_message=f"global > limits > {disabled_limit}")
 
 
 def check_agents_allow_higher_versions(new_conf: Element, original_conf: Element):
@@ -1904,11 +1793,9 @@ def validate_wazuh_xml(content: str):
         # Check xml format
         incoming_xml = load_wazuh_xml(xml_path='', data=final_xml)
         current_xml = load_wazuh_xml(xml_path=common.OSSEC_CONF)
-        # Check if remote commands are allowed
-        check_remote_commands(incoming_xml, current_xml)
+        # Check if configuration changes are allowed
         check_agents_allow_higher_versions(incoming_xml, current_xml)
         check_indexer(incoming_xml, current_xml)
-        check_wazuh_limits_unchanged(incoming_xml, current_xml)
 
     except ExpatError:
         raise WazuhError(1113)

--- a/tests/integration/test_api/test_config/test_upload_configuration/data/configuration_templates/configuration_upload_configuration.yaml
+++ b/tests/integration/test_api/test_config/test_upload_configuration/data/configuration_templates/configuration_upload_configuration.yaml
@@ -11,3 +11,5 @@
       agents:
         allow_higher_versions:
           allow: yes
+      indexer:
+        allow: yes

--- a/tests/integration/test_api/test_config/test_upload_configuration/data/configuration_templates/configuration_upload_configuration.yaml
+++ b/tests/integration/test_api/test_config/test_upload_configuration/data/configuration_templates/configuration_upload_configuration.yaml
@@ -1,13 +1,5 @@
 - blocks:
     upload_configuration:
-      remote_commands:
-        localfile:
-          allow: yes
-        wodle_command:
-          allow: yes
-      limits:
-        eps:
-          allow: yes
       agents:
         allow_higher_versions:
           allow: yes


### PR DESCRIPTION
## Description

This PR removes obsolete configuration blocks from the API's `upload_configuration` settings that are no longer applicable to Wazuh managers. The configuration previously contained settings for `remote_commands` (localfile/wodle_command) and `limits.eps` that were either agent-only or non-existent features.

With this change:
- Obsolete configuration blocks have been removed from the codebase
- The API now only protects configuration sections that actually exist and are relevant to managers
- Default settings remain permissive (`allow: True`) for valid features (`agents.allow_higher_versions` and `indexer`)

This cleanup improves code maintainability by removing 236 lines of obsolete validation logic and documentation.

## Proposed Changes

**Removed obsolete configuration blocks:**
- `remote_commands.localfile` - Agent-only feature (logcollector not built for managers)
- `remote_commands.wodle_command` - Agent-only feature (config parser explicitly rejects on managers with `mwarn("The 'command' module only works for the agent")`)
- `limits.eps` - Non-existent configuration (`<global><limits><eps>` doesn't exist in any configs)

### Results and Evidence

PR checks

https://jenkins-staging.qa.wazuh.info/job/5.0.0/job/Test_integration_endpoints/177/

### Artifacts Affected

API/Framework

### Configuration Changes

Disable `upload_configuration` in `api.yaml` by default.

### Tests Introduced

No new tests were introduced. This PR updates existing test fixtures to align with the new default values.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues