### PR TITLE
Restore vulnerability scanner database workflow

### DIFF
--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -2,24 +2,157 @@ name: 4.X - Vulnerability Scanner - Database Generation
 
 on:
   schedule:
-    - cron: "20 0 * * *"
+    - cron: '20 0 * * *'
+
+  pull_request:
+    paths:
+      - ".github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml"
+      - ".github/actions/compile_and_test/action.yml"
+      - ".github/actions/vulnerability_scanner_deps/action.yml"
+      - ".github/actions/vulnerability_scanner/content_generation/action.yml"
+      - ".github/actions/vulnerability_scanner/compile/action.yml"
 
   workflow_dispatch:
     inputs:
       content_version:
-        description: "Identifier of the generated content. The generated file will be named vd_1.0.0_vd_<content_version>.tar.xz"
+        description: 'Identifier of the generated content. The generated file will be named vd_1.0.0_vd_<content_version>.tar.xz'
         required: true
         type: string
 
-      upload_to_s3:
-        description: "Upload the generated content to S3"
-        required: false
-        default: false
-        type: boolean
-
 jobs:
-  deprecated:
+  vulnerability_scanner_database_scheduled_update:
+    if: github.event_name == 'schedule'
+
     runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<content_version>.tar.xz
+          content_version: ["4.8.0", "4.10.0", "4.11.0", "4.13.0"]
+
     steps:
-      - name: Warning
-        run: echo "This workflow is deprecated. Be careful, you have just run it from main."
+      # Checkout to the branch
+      - name: Checkout to branch
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          ref: ${{ matrix.content_version }}
+
+      # Checkout to the tag. If it doesn't exist, continue with the branch
+      - name: Checkout to tag
+        run: |
+          if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.content_version }}"; then
+            git checkout --quiet "tags/v${{ matrix.content_version }}"
+          else
+            echo "Warning: Unable to find tag v${{ matrix.content_version }}. Continuing with branch ${{ matrix.content_version }}"
+          fi
+
+      ########################
+      # Compilation          #
+      ########################
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
+
+      - name: Compile
+        uses: ./.github/actions/vulnerability_scanner/compile
+
+      ########################
+      # Content generation   #
+      ########################
+      - name: Generate vulnerability database
+        uses: ./.github/actions/vulnerability_scanner/content_generation
+        with:
+          content_version: ${{ matrix.content_version }}
+
+      ########################
+      # Content upload       #
+      ########################
+      - name: Upload database to S3
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          root_folder=$(pwd)
+          bucket="${{ secrets.FEED_AWS_BUCKET }}"
+          file="vd_1.0.0_vd_${{ matrix.content_version }}.tar.xz"
+          dest_dir="deps/vulnerability_model_database"
+          aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.FEED_AWS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.FEED_AWS_SECRET_ACCESS_KEY}}
+          AWS_DEFAULT_REGION: 'us-west-1'
+        shell: bash
+
+  vulnerability_scanner_database_workflow_changes:
+    if: github.event_name == 'pull_request'
+
+    runs-on: wz-linux-amd64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      ########################
+      # Compilation          #
+      ########################
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
+
+      - name: Compile
+        uses: ./.github/actions/vulnerability_scanner/compile
+
+      ########################
+      # Content generation   #
+      ########################
+      - name: Generate vulnerability database
+        uses: ./.github/actions/vulnerability_scanner/content_generation
+        with:
+          content_version: "pull_request"
+
+  vulnerability_scanner_database_manual_update:
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+
+      runs-on: ubuntu-24.04
+
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+          with:
+            submodules: recursive
+            fetch-depth: 0
+
+        ########################
+        # Compilation          #
+        ########################
+        - name: "Install a compatible CMake"
+          uses: ./.github/actions/reinstall_cmake
+
+        - name: Compile
+          uses: ./.github/actions/vulnerability_scanner/compile
+
+        ########################
+        # Content generation   #
+        ########################
+        - name: Generate vulnerability database
+          uses: ./.github/actions/vulnerability_scanner/content_generation
+          with:
+            content_version: ${{ inputs.content_version }}
+
+        ########################
+        # Content upload       #
+        ########################
+        - name: Upload database to S3
+          run: |
+            root_folder=$(pwd)
+            bucket="${{ secrets.FEED_AWS_BUCKET }}"
+            file="vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz"
+            dest_dir="deps/vulnerability_model_database"
+            aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file}
+          env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.FEED_AWS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.FEED_AWS_SECRET_ACCESS_KEY}}
+            AWS_DEFAULT_REGION: 'us-west-1'
+          shell: bash


### PR DESCRIPTION
Restore the workflow on main so the scheduled cron (`20 0 * * *`) fires. GitHub Actions only runs schedules from the default branch; while main held the deprecated stub, the daily run never triggered.

File contents synced with branch 4.14.6.