### PR TITLE
Show sca timouts as Not Run

### DIFF
--- a/.github/test-modules-windows.json
+++ b/.github/test-modules-windows.json
@@ -126,6 +126,7 @@
         "src/config/src/wmodules-sca.c",
         "src/wazuh_modules/src/wm_sca.c",
         "src/wazuh_modules/src/wm_sca.h",
+        "src/wazuh_modules/sca/**",
         "src/win32/**",
         "src/Makefile",
         "tests/integration/conftest.py",

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -169,8 +169,10 @@ class SecurityConfigurationAssessment
         std::atomic<bool> m_firstSyncCompleted {false};
 
         /// @brief In-memory flag set after each complete scan iteration, cleared at Run() startup.
-        /// Polled by the C sync thread (via get_scan_completed query) to avoid triggering the first
-        /// snapshot while the DB still contains "Not run" placeholders. Non-zero means completed.
+        /// Polled by the C sync thread (via get_scan_completed query) to avoid triggering the
+        /// first snapshot before any check has had a chance to run. Note that "Not run" rows
+        /// are additionally filtered out of the snapshot SELECT to handle timeouts, which
+        /// legitimately leave checks in that state past scan completion. Non-zero means completed.
         std::atomic<int64_t> m_scanCompleted {0};
 
         /// @brief Condition variable for pause/resume coordination

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
@@ -41,12 +41,12 @@ void CheckConditionEvaluator::AddResult(const RuleEvaluationResult& result)
 
         if (!result.reason.empty())
         {
-            if (!m_invalidReason.empty())
+            if (!m_unresolvedReason.empty())
             {
-                m_invalidReason += "\n";
+                m_unresolvedReason += "\n";
             }
 
-            m_invalidReason += result.reason;
+            m_unresolvedReason += result.reason;
         }
     }
 
@@ -116,7 +116,7 @@ sca::CheckResult CheckConditionEvaluator::Result() const
     }
 }
 
-std::string CheckConditionEvaluator::GetInvalidReason() const
+std::string CheckConditionEvaluator::GetUnresolvedReason() const
 {
-    return m_invalidReason;
+    return m_unresolvedReason;
 }

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.cpp
@@ -34,9 +34,10 @@ void CheckConditionEvaluator::AddResult(const RuleEvaluationResult& result)
         return;
     }
 
-    if (result.result == RuleResult::Invalid)
+    if (result.result == RuleResult::Invalid || result.result == RuleResult::NotRun)
     {
-        m_hasInvalid = true;
+        m_hasInvalid = m_hasInvalid || (result.result == RuleResult::Invalid);
+        m_hasNotRun = m_hasNotRun || (result.result == RuleResult::NotRun);
 
         if (!result.reason.empty())
         {
@@ -85,6 +86,11 @@ sca::CheckResult CheckConditionEvaluator::Result() const
     if (m_result.has_value())
     {
         return *m_result ? sca::CheckResult::Passed : sca::CheckResult::Failed;
+    }
+
+    if (m_hasNotRun)
+    {
+        return sca::CheckResult::NotRun;
     }
 
     if (m_totalRules == 0 || m_hasInvalid)

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
@@ -23,7 +23,7 @@ class CheckConditionEvaluator
         void AddResult(const RuleEvaluationResult& result);
 
         sca::CheckResult Result() const;
-        std::string GetInvalidReason() const;
+        std::string GetUnresolvedReason() const;
 
     private:
         ConditionType m_type;
@@ -32,5 +32,9 @@ class CheckConditionEvaluator
         std::optional<bool> m_result;
         bool m_hasInvalid = false;
         bool m_hasNotRun = false;
-        std::string m_invalidReason;
+
+        /// Concatenated reasons from rules that didn't resolve to Found/NotFound,
+        /// covering both Invalid (e.g. missing file, disabled commands) and NotRun
+        /// (command timeout) cases.
+        std::string m_unresolvedReason;
 };

--- a/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/check_condition_evaluator.hpp
@@ -31,5 +31,6 @@ class CheckConditionEvaluator
         int m_passedRules {0};
         std::optional<bool> m_result;
         bool m_hasInvalid = false;
+        bool m_hasNotRun = false;
         std::string m_invalidReason;
 };

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -617,9 +617,10 @@ nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) co
                 check.erase("sync");
             }
 
-            // "Not run" is a DB placeholder — the check has not been executed yet in this
-            // scan cycle. Never emit a stateless event for a check in this state, regardless
-            // of the operation type (INSERTED, MODIFIED, DELETED).
+            // "Not run" means either (a) the check has not been executed yet in this
+            // scan cycle (DB placeholder), or (b) the check was attempted but did not
+            // complete (e.g. command timeout). Never emit a stateless event for a check
+            // in this state, regardless of the operation type (INSERTED, MODIFIED, DELETED).
             {
                 const auto resultIt = check.find("result");
 
@@ -635,10 +636,11 @@ nlohmann::json SCAEventHandler::ProcessStateless(const nlohmann::json& event) co
             {
                 const auto& old = event["check"]["old"];
 
-                // For MODIFIED events, stateless is only meaningful for valid result state
-                // transitions. "Not run" is a DB placeholder (not a real observable state),
-                // and metadata-only changes (no result change) don't constitute a state
-                // transition worth alerting on.
+                // For MODIFIED events, stateless is only meaningful for transitions
+                // between real executed results. Transitions where the old result was
+                // "Not run" (placeholder being replaced by first real result, or a
+                // timeout recovering) don't generate alerts. Metadata-only changes
+                // (no result change) also don't constitute a transition worth alerting on.
                 // Note: new result == "Not run" is already caught above.
                 if (static_cast<ReturnTypeCallback>(event["result"]) == MODIFIED)
                 {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1106,11 +1106,14 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
             m_dBSync->increaseEachEntryVersion("sca_check");
         }
 
+        // Exclude "Not run" rows from the snapshot. A timed-out check stays at "Not run"
+        // after the scan, and we don't want those rows leaking to the manager —
+        // it should keep the last known executed state instead.
         std::vector<nlohmann::json> checks;
         auto selectQuery = SelectQuery::builder()
                            .table("sca_check")
                            .columnList({"*"})
-                           .rowFilter("WHERE sync = 1")
+                           .rowFilter("WHERE sync = 1 AND result != 'Not run'")
                            .build();
 
         const auto selectCallback = [&checks](ReturnTypeCallback returnTypeCallback, const nlohmann::json & resultData)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy.cpp
@@ -32,6 +32,7 @@ void SCAPolicy::Scan(
     const std::function<void(const CheckResult&)>& reportCheckResult)
 {
     auto requirementsOk = sca::CheckResult::Passed;
+    std::string requirementsReason;
 
     if (!m_requirements.rules.empty())
     {
@@ -50,6 +51,11 @@ void SCAPolicy::Scan(
         }
 
         requirementsOk = resultEvaluator.Result();
+
+        if (requirementsOk == sca::CheckResult::NotRun)
+        {
+            requirementsReason = resultEvaluator.GetInvalidReason();
+        }
 
         LoggingHelper::getInstance().log(LOG_DEBUG, "Policy requirements evaluation completed for policy \"" + m_id + "\", result: " + sca::CheckResultToString(requirementsOk));
     }
@@ -73,7 +79,9 @@ void SCAPolicy::Scan(
             }
 
             const auto result = resultEvaluator.Result();
-            const auto& reason = (result == sca::CheckResult::NotApplicable) ? resultEvaluator.GetInvalidReason() : std::string{};
+            const auto& reason = (result == sca::CheckResult::NotApplicable || result == sca::CheckResult::NotRun)
+                                 ? resultEvaluator.GetInvalidReason()
+                                 : std::string{};
 
             // NOLINTBEGIN(bugprone-unchecked-optional-access)
             LoggingHelper::getInstance().log(
@@ -92,6 +100,16 @@ void SCAPolicy::Scan(
         }
 
         LoggingHelper::getInstance().log(LOG_DEBUG, "Policy checks evaluation completed for policy \"" + m_id + "\"");
+    }
+    else if (requirementsOk == sca::CheckResult::NotRun)
+    {
+        // A requirement rule timed out — we can't determine whether the policy applies,
+        // so don't overwrite the manager's last known state for any check in this policy.
+        for (const auto& check : m_checks)
+        {
+            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+            reportCheckResult({m_id, check.id.value(), sca::CheckResultToString(sca::CheckResult::NotRun), requirementsReason});
+        }
     }
     else
     {

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy.cpp
@@ -47,14 +47,14 @@ void SCAPolicy::Scan(
                 return;
             }
 
-            resultEvaluator.AddResult(RuleEvaluationResult(rule->Evaluate(), rule->GetInvalidReason()));
+            resultEvaluator.AddResult(RuleEvaluationResult(rule->Evaluate(), rule->GetUnresolvedReason()));
         }
 
         requirementsOk = resultEvaluator.Result();
 
         if (requirementsOk == sca::CheckResult::NotRun)
         {
-            requirementsReason = resultEvaluator.GetInvalidReason();
+            requirementsReason = resultEvaluator.GetUnresolvedReason();
         }
 
         LoggingHelper::getInstance().log(LOG_DEBUG, "Policy requirements evaluation completed for policy \"" + m_id + "\", result: " + sca::CheckResultToString(requirementsOk));
@@ -75,12 +75,12 @@ void SCAPolicy::Scan(
                     return;
                 }
 
-                resultEvaluator.AddResult(RuleEvaluationResult(rule->Evaluate(), rule->GetInvalidReason()));
+                resultEvaluator.AddResult(RuleEvaluationResult(rule->Evaluate(), rule->GetUnresolvedReason()));
             }
 
             const auto result = resultEvaluator.Result();
             const auto& reason = (result == sca::CheckResult::NotApplicable || result == sca::CheckResult::NotRun)
-                                 ? resultEvaluator.GetInvalidReason()
+                                 ? resultEvaluator.GetUnresolvedReason()
                                  : std::string{};
 
             // NOLINTBEGIN(bugprone-unchecked-optional-access)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -2,6 +2,7 @@
 
 #include <sca_utils.hpp>
 #include <sca_impl.hpp>
+#include <wmodules.h>
 
 #include <file_io_utils.hpp>
 #include <filesystem_wrapper.hpp>
@@ -218,6 +219,11 @@ CommandRuleEvaluator::CommandRuleEvaluator(PolicyEvaluationContext ctx,
             {
                 return execResult;
             }
+            else if (wmExecResult == WM_ERROR_TIMEOUT)
+            {
+                execResult.TimedOut = true;
+                return execResult;
+            }
             else
             {
                 return std::nullopt;
@@ -244,6 +250,15 @@ RuleResult CommandRuleEvaluator::Evaluate()
     {
         if (auto execResult = m_commandExecFunc(m_ctx.rule))
         {
+            if (execResult->TimedOut)
+            {
+                m_lastInvalidReason = "Command timed out after " + std::to_string(m_ctx.commandsTimeout) +
+                                      " seconds: " + m_ctx.rule;
+                LoggingHelper::getInstance().log(LOG_DEBUG, "Command rule '" + m_ctx.rule + "' timed out after " +
+                                                 std::to_string(m_ctx.commandsTimeout) + " seconds");
+                return RuleResult::NotRun;
+            }
+
             if (m_ctx.pattern)
             {
                 // Trim ending lines if any (command output may have trailing newlines)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.cpp
@@ -125,7 +125,7 @@ RuleResult FileRuleEvaluator::CheckFileForContents()
     .value_or(false))
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "File '" + m_ctx.rule + "' does not exist or is not a regular file");
-        m_lastInvalidReason = "File '" + m_ctx.rule + "' does not exist or is not a regular file";
+        m_lastUnresolvedReason = "File '" + m_ctx.rule + "' does not exist or is not a regular file";
         return RuleResult::Invalid; // Keep simple return for file not found - this is expected behavior
     }
 
@@ -144,7 +144,7 @@ RuleResult FileRuleEvaluator::CheckFileForContents()
     }
     else
     {
-        m_lastInvalidReason = "Failed to read file contents for '" + m_ctx.rule + "'";
+        m_lastUnresolvedReason = "Failed to read file contents for '" + m_ctx.rule + "'";
         return RuleResult::Invalid; // File access error or other exception
     }
 }
@@ -172,7 +172,7 @@ RuleResult FileRuleEvaluator::CheckFileExistence()
     else
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "An error occured and file rule '" + m_ctx.rule + "' could not be resolved");
-        m_lastInvalidReason = "File system access error for '" + m_ctx.rule + "'";
+        m_lastUnresolvedReason = "File system access error for '" + m_ctx.rule + "'";
         return RuleResult::Invalid; // File system access error
     }
 
@@ -239,7 +239,7 @@ RuleResult CommandRuleEvaluator::Evaluate()
 
     if (!m_ctx.commandsEnabled)
     {
-        m_lastInvalidReason = "Remote commands are disabled for this policy";
+        m_lastUnresolvedReason = "Remote commands are disabled for this policy";
         LoggingHelper::getInstance().log(LOG_DEBUG, "Policy is remote and remote commands are disabled. Skipping command rule.");
         return RuleResult::Invalid;
     }
@@ -252,8 +252,8 @@ RuleResult CommandRuleEvaluator::Evaluate()
         {
             if (execResult->TimedOut)
             {
-                m_lastInvalidReason = "Command timed out after " + std::to_string(m_ctx.commandsTimeout) +
-                                      " seconds: " + m_ctx.rule;
+                m_lastUnresolvedReason = "Command timed out after " + std::to_string(m_ctx.commandsTimeout) +
+                                         " seconds: " + m_ctx.rule;
                 LoggingHelper::getInstance().log(LOG_DEBUG, "Command rule '" + m_ctx.rule + "' timed out after " +
                                                  std::to_string(m_ctx.commandsTimeout) + " seconds");
                 return RuleResult::NotRun;
@@ -278,7 +278,7 @@ RuleResult CommandRuleEvaluator::Evaluate()
                     }
                     else
                     {
-                        m_lastInvalidReason = "Invalid pattern '" + *m_ctx.pattern + "' for command rule";
+                        m_lastUnresolvedReason = "Invalid pattern '" + *m_ctx.pattern + "' for command rule";
                         LoggingHelper::getInstance().log(LOG_DEBUG, "Invalid pattern '" + *m_ctx.pattern + "' for command rule evaluation");
                         return RuleResult::Invalid;
                     }
@@ -295,7 +295,7 @@ RuleResult CommandRuleEvaluator::Evaluate()
         }
         else
         {
-            m_lastInvalidReason = "Command execution failed: " + m_ctx.rule;
+            m_lastUnresolvedReason = "Command execution failed: " + m_ctx.rule;
             LoggingHelper::getInstance().log(LOG_DEBUG, "Command rule '" + m_ctx.rule + "' execution failed");
             return RuleResult::Invalid;
         }
@@ -336,7 +336,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
     if (!TryFunc([&] { return m_fileSystemWrapper->exists(m_ctx.rule); }).value_or(false))
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "Path '" + m_ctx.rule + "' does not exist");
-        m_lastInvalidReason = "Path '" + m_ctx.rule + "' does not exist";
+        m_lastUnresolvedReason = "Path '" + m_ctx.rule + "' does not exist";
         return RuleResult::Invalid;
     }
 
@@ -345,7 +345,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
     if (!resolved)
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "Directory '" + m_ctx.rule + "' could not be resolved");
-        m_lastInvalidReason = "Directory '" + m_ctx.rule + "' could not be resolved";
+        m_lastUnresolvedReason = "Directory '" + m_ctx.rule + "' could not be resolved";
         return RuleResult::Invalid;
     }
 
@@ -354,7 +354,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
     if (!TryFunc([&] { return m_fileSystemWrapper->is_directory(rootPath); }).value_or(false))
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "Path '" + rootPath.string() + "' is not a directory");
-        m_lastInvalidReason = "Path '" + rootPath.string() + "' is not a directory";
+        m_lastUnresolvedReason = "Path '" + rootPath.string() + "' is not a directory";
         return RuleResult::Invalid;
     }
 
@@ -373,7 +373,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
         if (!filesOpt)
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Directory '" + currentDir.string() + "' could not be listed");
-            m_lastInvalidReason = "Directory '" + currentDir.string() + "' could not be listed";
+            m_lastUnresolvedReason = "Directory '" + currentDir.string() + "' could not be listed";
             return RuleResult::Invalid;
         }
 
@@ -403,7 +403,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
             else
             {
                 LoggingHelper::getInstance().log(LOG_DEBUG, "Symlink check failed for file '" + file.string() + "'");
-                m_lastInvalidReason = "Symlink check failed for file '" + file.string() + "'";
+                m_lastUnresolvedReason = "Symlink check failed for file '" + file.string() + "'";
                 return RuleResult::Invalid;
             }
 
@@ -418,7 +418,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
             else
             {
                 LoggingHelper::getInstance().log(LOG_DEBUG,  "Directory check failed for file '" + file.string() + "'");
-                m_lastInvalidReason = "Directory check failed for file '" + file.string() + "'";
+                m_lastUnresolvedReason = "Directory check failed for file '" + file.string() + "'";
                 return RuleResult::Invalid;
             }
 
@@ -466,8 +466,8 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                             }
                             else
                             {
-                                m_lastInvalidReason = "Failed to read contents of file '" + file.string() +
-                                                      "' in directory '" + rootPath.string() + "'";
+                                m_lastUnresolvedReason = "Failed to read contents of file '" + file.string() +
+                                                         "' in directory '" + rootPath.string() + "'";
                                 return RuleResult::Invalid;
                             }
                         }
@@ -502,7 +502,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
                     }
                     else
                     {
-                        m_lastInvalidReason = "Failed to read contents of file '" + fileName + "' in directory '" + rootPath.string() + "'";
+                        m_lastUnresolvedReason = "Failed to read contents of file '" + fileName + "' in directory '" + rootPath.string() + "'";
                         return RuleResult::Invalid;
                     }
                 }
@@ -520,7 +520,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryForContents()
         if (isRegex && !hadValue)
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Invalid pattern '" + pattern + "' for directory '" + rootPath.string() + "'");
-            m_lastInvalidReason = "Invalid pattern '" + pattern + "' for directory '" + rootPath.string() + "'";
+            m_lastUnresolvedReason = "Invalid pattern '" + pattern + "' for directory '" + rootPath.string() + "'";
             return RuleResult::Invalid;
         }
     }
@@ -551,7 +551,7 @@ RuleResult DirRuleEvaluator::CheckDirectoryExistence()
     else
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "An error occured and file rule " + m_ctx.rule + " could not be resolved");
-        m_lastInvalidReason = "Directory access error for '" + m_ctx.rule + "'";
+        m_lastUnresolvedReason = "Directory access error for '" + m_ctx.rule + "'";
         return RuleResult::Invalid;
     }
 
@@ -612,7 +612,7 @@ RuleResult ProcessRuleEvaluator::Evaluate()
     else
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "Process rule '" + m_ctx.rule + "' execution failed");
-        m_lastInvalidReason = "Failed to get process list for rule '" + m_ctx.rule + "'";
+        m_lastUnresolvedReason = "Failed to get process list for rule '" + m_ctx.rule + "'";
         return RuleResult::Invalid;
     }
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -52,7 +52,7 @@ class IRuleEvaluator
 
         virtual const PolicyEvaluationContext& GetContext() const = 0;
 
-        virtual std::string GetInvalidReason() const = 0;
+        virtual std::string GetUnresolvedReason() const = 0;
 };
 
 class RuleEvaluator : public IRuleEvaluator
@@ -62,15 +62,15 @@ class RuleEvaluator : public IRuleEvaluator
 
         const PolicyEvaluationContext& GetContext() const override;
 
-        std::string GetInvalidReason() const override
+        std::string GetUnresolvedReason() const override
         {
-            return m_lastInvalidReason;
+            return m_lastUnresolvedReason;
         }
 
     protected:
         std::unique_ptr<IFileSystemWrapper> m_fileSystemWrapper = nullptr;
         PolicyEvaluationContext m_ctx = {};
-        std::string m_lastInvalidReason;
+        std::string m_lastUnresolvedReason;
 };
 
 class FileRuleEvaluator : public RuleEvaluator

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -15,7 +15,8 @@ enum class RuleResult
 {
     Invalid = -1,
     Found,
-    NotFound
+    NotFound,
+    NotRun
 };
 
 struct RuleEvaluationResult
@@ -97,6 +98,7 @@ class CommandRuleEvaluator : public RuleEvaluator
             std::string StdOut;
             std::string StdErr;
             int ExitCode;
+            bool TimedOut = false;
         };
 
         /// @brief Function that takes a command and returns the output and error as a pair of strings.

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -200,14 +200,14 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
         if (!m_isValidKey(m_ctx.rule))
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Key '" + m_ctx.rule + "' does not exist");
-            m_lastInvalidReason = "Registry key '" + m_ctx.rule + "' does not exist";
+            m_lastUnresolvedReason = "Registry key '" + m_ctx.rule + "' does not exist";
             return RuleResult::Invalid;
         }
     }
     catch (const std::exception& e)
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, std::string("RegistryRuleEvaluator::Evaluate: Exception: ") + e.what());
-        m_lastInvalidReason = "Exception accessing registry key '" + m_ctx.rule + "': " + e.what();
+        m_lastUnresolvedReason = "Exception accessing registry key '" + m_ctx.rule + "': " + e.what();
         return RuleResult::Invalid;
     }
 
@@ -223,7 +223,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyForContents()
         if (!obtainedValue.has_value())
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Value '" + valueName + "' does not exist");
-            m_lastInvalidReason = "Registry value '" + valueName + "' does not exist in key '" + m_ctx.rule + "'";
+            m_lastUnresolvedReason = "Registry value '" + valueName + "' does not exist in key '" + m_ctx.rule + "'";
             return RuleResult::Invalid;
         }
 
@@ -289,7 +289,7 @@ RuleResult RegistryRuleEvaluator::CheckKeyExistence()
     catch (const std::exception& e)
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, std::string("RegistryRuleEvaluator::Evaluate: Exception: ") + e.what());
-        m_lastInvalidReason = "Exception checking registry key existence '" + m_ctx.rule + "': " + e.what();
+        m_lastUnresolvedReason = "Exception checking registry key existence '" + m_ctx.rule + "': " + e.what();
         return RuleResult::Invalid;
     }
 

--- a/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
@@ -132,5 +132,5 @@ TEST(CheckConditionEvaluatorTest, NotRunSurfacesAsCheckResultNotRun)
     evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
     evaluator.AddResult(RuleEvaluationResult(RuleResult::NotRun, "Command timed out after 30 seconds: sleep 60"));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotRun);
-    EXPECT_NE(evaluator.GetInvalidReason().find("timed out"), std::string::npos);
+    EXPECT_NE(evaluator.GetUnresolvedReason().find("timed out"), std::string::npos);
 }

--- a/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/check_condition_evaluator_test.cpp
@@ -124,3 +124,13 @@ TEST(CheckConditionEvaluatorTest, AnyConditionWithInvalidCanBeTrueAsLongAsOnePas
     evaluator.AddResult(RuleEvaluationResult(RuleResult::Invalid));
     EXPECT_EQ(evaluator.Result(), sca::CheckResult::Passed);
 }
+
+TEST(CheckConditionEvaluatorTest, NotRunSurfacesAsCheckResultNotRun)
+{
+    auto evaluator = CheckConditionEvaluator::FromString("all");
+
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::Found));
+    evaluator.AddResult(RuleEvaluationResult(RuleResult::NotRun, "Command timed out after 30 seconds: sleep 60"));
+    EXPECT_EQ(evaluator.Result(), sca::CheckResult::NotRun);
+    EXPECT_NE(evaluator.GetInvalidReason().find("timed out"), std::string::npos);
+}

--- a/src/wazuh_modules/sca/sca_impl/tests/command_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/command_rule_evaluator_test.cpp
@@ -228,6 +228,28 @@ TEST_F(CommandRuleEvaluatorTest, CommandExecutionFailureHasReasonString)
     EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Command execution failed"));
 }
 
+TEST_F(CommandRuleEvaluatorTest, CommandTimedOutIsNotRunWithTimeoutReason)
+{
+    m_ctx.rule = "sleep 60";
+    m_ctx.pattern = std::string("something");
+    m_ctx.commandsTimeout = 5;
+
+    m_execMock = [](const std::string&) -> std::optional<CommandRuleEvaluator::ExecResult>
+    {
+        CommandRuleEvaluator::ExecResult result;
+        result.TimedOut = true;
+        return result;
+    };
+
+    auto evaluator = CreateEvaluator();
+    EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotRun);
+    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("timed out"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("5"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("sleep 60"));
+    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::Not(::testing::HasSubstr("Command execution failed")));
+}
+
 TEST_F(CommandRuleEvaluatorTest, InvalidPatternHasReasonString)
 {
     m_ctx.rule = "echo test";

--- a/src/wazuh_modules/sca/sca_impl/tests/command_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/command_rule_evaluator_test.cpp
@@ -207,8 +207,8 @@ TEST_F(CommandRuleEvaluatorTest, CommandsDisabledHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Remote commands are disabled"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Remote commands are disabled"));
 }
 
 TEST_F(CommandRuleEvaluatorTest, CommandExecutionFailureHasReasonString)
@@ -223,9 +223,9 @@ TEST_F(CommandRuleEvaluatorTest, CommandExecutionFailureHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("some command"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Command execution failed"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("some command"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Command execution failed"));
 }
 
 TEST_F(CommandRuleEvaluatorTest, CommandTimedOutIsNotRunWithTimeoutReason)
@@ -243,11 +243,11 @@ TEST_F(CommandRuleEvaluatorTest, CommandTimedOutIsNotRunWithTimeoutReason)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::NotRun);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("timed out"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("5"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("sleep 60"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::Not(::testing::HasSubstr("Command execution failed")));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("timed out"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("5"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("sleep 60"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::Not(::testing::HasSubstr("Command execution failed")));
 }
 
 TEST_F(CommandRuleEvaluatorTest, InvalidPatternHasReasonString)
@@ -266,7 +266,7 @@ TEST_F(CommandRuleEvaluatorTest, InvalidPatternHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("***invalid***"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Invalid pattern"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("***invalid***"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Invalid pattern"));
 }

--- a/src/wazuh_modules/sca/sca_impl/tests/directory_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/directory_rule_evaluator_test.cpp
@@ -400,9 +400,9 @@ TEST_F(DirRuleEvaluatorTest, PathDoesNotExistHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("nonexistent/"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("does not exist"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("nonexistent/"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("does not exist"));
 }
 
 TEST_F(DirRuleEvaluatorTest, CannotResolvePathHasReasonString)
@@ -416,9 +416,9 @@ TEST_F(DirRuleEvaluatorTest, CannotResolvePathHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("dir/"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("could not be resolved"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("dir/"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("could not be resolved"));
 }
 
 TEST_F(DirRuleEvaluatorTest, PathNotDirectoryHasReasonString)
@@ -431,9 +431,9 @@ TEST_F(DirRuleEvaluatorTest, PathNotDirectoryHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("notadir"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("not a directory"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("notadir"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("not a directory"));
 }
 
 TEST_F(DirRuleEvaluatorTest, CannotListDirectoryHasReasonString)
@@ -448,9 +448,9 @@ TEST_F(DirRuleEvaluatorTest, CannotListDirectoryHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("dir/"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("could not be listed"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("dir/"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("could not be listed"));
 }
 
 TEST_F(DirRuleEvaluatorTest, InvalidRegexPatternHasReasonString)
@@ -466,9 +466,9 @@ TEST_F(DirRuleEvaluatorTest, InvalidRegexPatternHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("dir/"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Invalid pattern"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("dir/"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Invalid pattern"));
 }
 
 

--- a/src/wazuh_modules/sca/sca_impl/tests/file_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/file_rule_evaluator_test.cpp
@@ -225,9 +225,9 @@ TEST_F(FileRuleEvaluatorTest, FileDoesNotExistHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("some/file"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("does not exist"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("some/file"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("does not exist"));
 }
 
 TEST_F(FileRuleEvaluatorTest, FileIsNotRegularFileHasReasonString)
@@ -240,9 +240,9 @@ TEST_F(FileRuleEvaluatorTest, FileIsNotRegularFileHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("some/file"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("not a regular file"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("some/file"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("not a regular file"));
 }
 
 TEST_F(FileRuleEvaluatorTest, FileContentReadFailureHasReasonString)
@@ -257,9 +257,9 @@ TEST_F(FileRuleEvaluatorTest, FileContentReadFailureHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("some/file"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Failed to read"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("some/file"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Failed to read"));
 }
 
 TEST_F(FileRuleEvaluatorTest, FileSystemAccessErrorHasReasonString)
@@ -273,9 +273,9 @@ TEST_F(FileRuleEvaluatorTest, FileSystemAccessErrorHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("some/file"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("access error"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("some/file"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("access error"));
 }
 
 TEST_F(FileRuleEvaluatorTest, NegatedPatternRegexMatchesContentReturnsNotFound)

--- a/src/wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/process_rule_evaluator_test.cpp
@@ -104,9 +104,9 @@ TEST_F(ProcessRuleEvaluatorTest, GetProcessesFailureHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("test_process"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Failed to get process list"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("test_process"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Failed to get process list"));
 }
 
 TEST_F(ProcessRuleEvaluatorTest, NegatedProcessFoundReturnsNotFound)

--- a/src/wazuh_modules/sca/sca_impl/tests/registry_rule_evaluator_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/registry_rule_evaluator_test.cpp
@@ -266,9 +266,9 @@ TEST_F(RegistryRuleEvaluatorTest, KeyDoesNotExistHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\NonExistentKey"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("does not exist"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("HKLM\\NonExistentKey"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("does not exist"));
 }
 
 TEST_F(RegistryRuleEvaluatorTest, KeyAccessExceptionHasReasonString)
@@ -283,10 +283,10 @@ TEST_F(RegistryRuleEvaluatorTest, KeyAccessExceptionHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Exception accessing registry"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Access denied to registry"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Exception accessing registry"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Access denied to registry"));
 }
 
 TEST_F(RegistryRuleEvaluatorTest, ValueDoesNotExistHasReasonString)
@@ -306,10 +306,10 @@ TEST_F(RegistryRuleEvaluatorTest, ValueDoesNotExistHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("NonExistentValue"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("does not exist"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("NonExistentValue"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("does not exist"));
 }
 
 TEST_F(RegistryRuleEvaluatorTest, KeyExistenceCheckExceptionHasReasonString)
@@ -323,8 +323,8 @@ TEST_F(RegistryRuleEvaluatorTest, KeyExistenceCheckExceptionHasReasonString)
 
     auto evaluator = CreateEvaluator();
     EXPECT_EQ(evaluator.Evaluate(), RuleResult::Invalid);
-    EXPECT_FALSE(evaluator.GetInvalidReason().empty());
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Exception checking registry key existence"));
-    EXPECT_THAT(evaluator.GetInvalidReason(), ::testing::HasSubstr("Registry access error"));
+    EXPECT_FALSE(evaluator.GetUnresolvedReason().empty());
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("HKLM\\SomeKey"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Exception checking registry key existence"));
+    EXPECT_THAT(evaluator.GetUnresolvedReason(), ::testing::HasSubstr("Registry access error"));
 }


### PR DESCRIPTION
## Description

SCA checks whose commands timed out were being reported as **Not applicable** with the generic reason `Command execution failed: <cmd>`, indistinguishable from other command-execution failures (binary not found, fork failure, etc.). This pull request introduces a distinct **Not run** outcome for timeouts and ensures those checks do **not** overwrite the last known executed state in the Manager/Indexer — so a transient timeout never clobbers a previously reported `Passed`/`Failed`/`Not applicable` result on the dashboard.

Closes #36125

Also fixes an issue where SCA ITs weren't being run on Windows in a separate commit.

## Proposed Changes

- A command rule that times out is now distinguished from other command failures and reported as **Not run** (instead of **Not applicable**), with a reason that states the configured timeout and the command.
- If a policy requirement times out, every check in that policy is reported as **Not run** rather than **Not applicable** — we can't tell whether the policy applies, so we don't misreport it.
- **Not run** is kept out of the Manager/Indexer entirely, so a timeout never overwrites a check's last known executed state on the dashboard. This closes a gap in the first-sync/recovery snapshot path that #35305 didn't cover for these new semantics.
- Renamed the "invalid reason" accessors/fields to "unresolved reason", since the reason now covers both invalid and timed-out rules. (Isolated in its own commit.)

> **Note for reviewers:** the rename above is isolated in its own commit (`fix: rename invalidReason to unresolvedReason`), which is purely mechanical and touches many files/tests. To review the actual behavior change, focus on the other commit (`feat: sca now reports timeouts as not run`) — it's much smaller and self-contained. The rename commit can be skimmed.

## Results and Evidence
All tests were performed on a Centos9 VM with the `Ensure sudo is installed` rule.
To simulate timeouts, I locked the dnf process during scans with `flock -x /var/cache/dnf/metadata_lock.pid sleep 300`
### First run - Timeout detected (logs) + 'Not Run' not appearing on dashboard
```
wm_sca.c:293 at sca_log_callback(): DEBUG: Processing command rule: 'dnf list sudo'
wm_sca.c:293 at sca_log_callback(): DEBUG: Command rule 'dnf list sudo' timed out after 30 seconds
wm_sca.c:293 at sca_log_callback(): DEBUG: Policy check "39179" evaluation completed for policy "cis_centos9_linux", result: Not run

wm_sca.c:299 at sca_log_callback(): INFO: Starting SCA synchronization.
wm_sca.c:293 at sca_log_callback(): DEBUG: SCA first synchronization is pending. Sending a full snapshot after scan completion.
wm_sca.c:293 at sca_log_callback(): DEBUG: Starting SCA initial synchronization full synchronization
wm_sca.c:293 at sca_log_callback(): DEBUG: SCA initial synchronization completed successfully
wm_sca.c:299 at sca_log_callback(): INFO: SCA synchronization finished successfully.
```
#### Inventory (SCA Stateful):
<img width="1906" height="231" alt="image" src="https://github.com/user-attachments/assets/1ed74741-a3b9-4c17-8ac6-94c3ae58be3b" />

#### Findings (SCA Stateless):
<img width="1906" height="231" alt="image" src="https://github.com/user-attachments/assets/5c2d5fd7-090e-442c-82ff-780fe86f6c73" />

### First run - Passed, no problems

#### Inventory (SCA Stateful):
<img width="1907" height="617" alt="image" src="https://github.com/user-attachments/assets/a22050df-1f49-4b09-86db-cb0f359c7d5f" />

#### Findings (SCA Stateless):
<img width="1906" height="231" alt="image" src="https://github.com/user-attachments/assets/44e2b3da-52c3-43e5-8e20-2c4581c01f4e" />

### Not first run - Timeout detected (logs) + Still show old state on dashboard
```
wm_sca.c:293 at sca_log_callback(): DEBUG: Processing command rule: 'dnf list sudo'
wm_sca.c:293 at sca_log_callback(): DEBUG: Command rule 'dnf list sudo' timed out after 30 seconds
wm_sca.c:293 at sca_log_callback(): DEBUG: Policy check "39179" evaluation completed for policy "cis_centos9_linux", result: Not run

wm_sca.c:299 at sca_log_callback(): INFO: Starting SCA synchronization.
wm_sca.c:299 at sca_log_callback(): INFO: SCA synchronization finished successfully.

```
Manager still shows 'Passed'

#### Inventory (SCA Stateful):
<img width="1907" height="617" alt="image" src="https://github.com/user-attachments/assets/a22050df-1f49-4b09-86db-cb0f359c7d5f" />

#### Findings (SCA Stateless):
<img width="1906" height="231" alt="image" src="https://github.com/user-attachments/assets/44e2b3da-52c3-43e5-8e20-2c4581c01f4e" />


### Artifacts Affected

- `wazuh-modulesd` (SCA module) — agent binary on all platforms.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `CommandRuleEvaluatorTest.CommandTimedOutIsNotRunWithTimeoutReason` — a timed-out command evaluates to `RuleResult::NotRun`, the reason contains `"timed out"`, the timeout value, and the command, and is distinct from the `Command execution failed` reason.
- `CheckConditionEvaluatorTest.NotRunSurfacesAsCheckResultNotRun` — a `RuleResult::NotRun` rule makes the check evaluate to `CheckResult::NotRun` and preserves the timeout reason through aggregation.
- Existing rule-evaluator tests updated for the `GetUnresolvedReason()` rename.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
