### PR TITLE
Serialize procps access to prevent modulesd crash

### DIFF
--- a/src/data_provider/src/procpsWrapperLinux.cpp
+++ b/src/data_provider/src/procpsWrapperLinux.cpp
@@ -1,0 +1,58 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#include "procpsWrapperLinux.hpp"
+
+#include <memory>
+#include <mutex>
+
+namespace
+{
+    std::mutex g_procpsMutex;
+
+    struct ProcTabDeleter
+    {
+        void operator()(PROCTAB* pt) const
+        {
+            if (pt)
+            {
+                closeproc(pt);
+            }
+        }
+    };
+
+    struct ProcDeleter
+    {
+        void operator()(proc_t* p) const
+        {
+            if (p)
+            {
+                freeproc(p);
+            }
+        }
+    };
+}
+
+void ProcpsWrapper::scanProcesses(int flags, const ProcCallback& callback)
+{
+    std::lock_guard<std::mutex> lock(g_procpsMutex);
+
+    std::unique_ptr<PROCTAB, ProcTabDeleter> proctab{openproc(flags)};
+
+    if (!proctab)
+    {
+        return;
+    }
+
+    while (auto* raw = readproc(proctab.get(), nullptr))
+    {
+        std::unique_ptr<proc_t, ProcDeleter> process{raw};
+        callback(process.get());
+    }
+}

--- a/src/data_provider/src/procpsWrapperLinux.hpp
+++ b/src/data_provider/src/procpsWrapperLinux.hpp
@@ -1,0 +1,29 @@
+/*
+ * Wazuh SysInfo
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#pragma once
+
+#include <functional>
+
+extern "C"
+{
+#include "readproc.h"
+}
+
+namespace ProcpsWrapper
+{
+    using ProcCallback = std::function<void(const proc_t*)>;
+
+    // Serializes a full openproc/readproc/closeproc iteration with a
+    // process-wide mutex. The vendored procps 2.8.3 keeps scratch buffers as
+    // `static` inside simple_readproc/simple_readtask/file2str/get_proc_stats,
+    // so concurrent iterations from different threads corrupt each other and
+    // can crash inside stat2proc (see issue #36166).
+    void scanProcesses(int flags, const ProcCallback& callback);
+}

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -20,7 +20,7 @@
 #include "cmdHelper.h"
 #include "osinfo/sysOsParsers.h"
 #include "sysInfo.hpp"
-#include "readproc.h"
+#include "procpsWrapperLinux.hpp"
 #include "networkUnixHelper.h"
 #include "networkHelper.h"
 #include "network/networkLinuxWrapper.h"
@@ -42,21 +42,6 @@
 #include "firefox.hpp"
 
 using ProcessInfo = std::unordered_map<int64_t, std::pair<int32_t, std::string>>;
-
-struct ProcTableDeleter
-{
-    void operator()(PROCTAB* proc)
-    {
-        closeproc(proc);
-    }
-    void operator()(proc_t* proc)
-    {
-        freeproc(proc);
-    }
-};
-
-using SysInfoProcessesTable = std::unique_ptr<PROCTAB, ProcTableDeleter>;
-using SysInfoProcess        = std::unique_ptr<proc_t, ProcTableDeleter>;
 
 static void parseLineAndFillMap(const std::string& line, const std::string& separator, std::map<std::string, std::string>& systemInfo)
 {
@@ -90,7 +75,7 @@ static bool getSystemInfo(const std::string& fileName, const std::string& separa
     return ret;
 }
 
-static nlohmann::json getProcessInfo(const SysInfoProcess& process)
+static nlohmann::json getProcessInfo(const proc_t* process)
 {
     nlohmann::json jsProcessInfo{};
     // Current process information
@@ -610,21 +595,14 @@ nlohmann::json SysInfo::getPorts() const
 
 void SysInfo::getProcessesInfo(std::function<void(nlohmann::json&)> callback) const
 {
+    const int flags = PROC_FILLMEM | PROC_FILLSTAT | PROC_FILLSTATUS | PROC_FILLARG
+                      | PROC_FILLGRP | PROC_FILLUSR | PROC_FILLCOM | PROC_FILLENV;
 
-    const SysInfoProcessesTable spProcTable
+    ProcpsWrapper::scanProcesses(flags, [&callback](const proc_t* process)
     {
-        openproc(PROC_FILLMEM | PROC_FILLSTAT | PROC_FILLSTATUS | PROC_FILLARG | PROC_FILLGRP | PROC_FILLUSR | PROC_FILLCOM | PROC_FILLENV)
-    };
-
-    SysInfoProcess spProcInfo { readproc(spProcTable.get(), nullptr) };
-
-    while (nullptr != spProcInfo)
-    {
-        // Get process information object and push it to the caller
-        auto processInfo = getProcessInfo(spProcInfo);
+        auto processInfo = getProcessInfo(process);
         callback(processInfo);
-        spProcInfo.reset(readproc(spProcTable.get(), nullptr));
-    }
+    });
 }
 
 void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const


### PR DESCRIPTION
  ## Description

  `wazuh-modulesd` randomly SIGSEGVs on Fedora 43 aarch64 (and any platform with glibc ≥ 2.38 on ARM) during the first process scan after an agent restart. The top frames are always  `__GI_strrchr → stat2proc → simple_readproc → readproc → SysInfo::getProcessesInfo`. The root cause is a thread-safety violation in the vendored `procps 2.8.3`: `simple_readproc`,
  `simple_readtask`, `file2str` and `get_proc_stats` keep their scratch buffers (`sbuf[1024]`, `struct stat sb`, `filename[80]`, `path`) declared as `static`. Those buffers are a single instance per process, shared across every thread. The Syscollector module and SCA's `ProcessRuleEvaluator` both call `SysInfo::getProcessesInfo` from independent threads, so they corrupt
  each other mid-parse. On aarch64 the vectorized `strrchr` reads past the corrupted boundary and dereferences an unmapped page; on x86_64 the byte-by-byte path masks the bug and produces wrong process names instead of a crash. Upgrading the vendored copy to `procps-ng 3.3.x` does **not** fix this — upstream keeps the same `static` buffers; only the 4.x `libproc-2` API is thread-safe.

  Closes #36166

  ## Proposed Changes

  Introduces a thin C++ wrapper around procps that serializes every `openproc → readproc → closeproc` session with a process-wide `std::mutex`. All consumers in `libsysinfo.so` (Syscollector and SCA) go through the wrapper, so concurrent scans are queued instead of trampling the shared `static` buffers inside the vendored library. The wrapper lives in `data_provider/` next to
   the only call site that needs it; the vendored procps sources are left untouched, which is required because `src/external/procps/` is gitignored and rebuilt from the externals tarball on every CI run.

  - New `data_provider/src/procpsWrapperLinux.hpp` exposing `ProcpsWrapper::scanProcesses(flags, callback)`.
  - New `data_provider/src/procpsWrapperLinux.cpp` with the static mutex and RAII handles for `PROCTAB`/`proc_t`.
  - `data_provider/src/sysInfoLinux.cpp` now includes the wrapper header instead of `readproc.h`, replaces the manual `openproc`/`readproc`/`closeproc` loop in `SysInfo::getProcessesInfo`, and drops the now-unused `ProcTableDeleter`, `SysInfoProcessesTable` and `SysInfoProcess` aliases. `getProcessInfo` takes `const proc_t*` directly.

  ### Results and Evidence

https://github.com/wazuh/wazuh/pull/36261#issuecomment-4511574863
https://github.com/wazuh/wazuh/pull/36261#issuecomment-4511807495

  ### Manual tests with their corresponding evidence

  - Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
  - [ ] Log syntax and correct language review

  - Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer
  - Memory tests for Windows
    - [ ] Coverity
    - [ ] UMDH
  - Memory tests for macOS
    - [ ] Leaks
    - [ ] AddressSanitizer

  - Decoder/Rule tests _(Wazuh v4.x)_
    - [ ] Added unit testing files ".ini"
    - [ ] `runtests.py` executed without errors

  - Engine _(Wazuh v5.x and above)_
    - [ ] Test run in parallel
    - [ ] ASAN for test (utest/ctest)
    - [ ] TSAN for test and wazuh-engine.

  - Wazuh server API/Framework
    - [ ] Run API Integration Tests

  ### Artifacts Affected

  - `libsysinfo.so` (Linux agent and manager). No changes to public headers, no ABI changes — `SysInfo::getProcessesInfo` keeps its signature and behavior. Windows, macOS and BSD builds are unaffected because the wrapper is Linux-only (`procpsWrapperLinux.cpp` matches the existing `*Linux.cpp` glob in `data_provider/CMakeLists.txt`). The vendored `src/external/procps/` tree is left intact.

  ### Configuration Changes

  N/A. No new settings, no defaults changed, no on-disk format impact.

  ### Tests Introduced

  N/A. 

  ## Review Checklist

  - [ ] Code changes reviewed
  - [ ] Relevant evidence provided
  - [ ] Tests cover the new functionality
  - [ ] Configuration changes documented
  - [ ] Developer documentation reflects the changes
  - [ ] Meets requirements and/or definition of done
  - [ ] No unresolved dependencies with other issues
