### PR TITLE
Cluster file processing parameter validation

### DIFF
--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -937,6 +937,16 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     # If the file is not 'merged' type, move it directly to the destination path.
                     else:
                         try:
+                            expected_base = safe_join(common.WAZUH_PATH, item_key)
+                            if not os.path.commonpath([full_path, expected_base]).startswith(expected_base):
+                                raise exception.WazuhClusterError(3022,
+                                    extra_message=f"File path outside allowed directory: {file_path}")
+
+                            file_basename = os.path.basename(file_path)
+                            if file_basename in cluster_items['files'].get('excluded_files', []):
+                                raise exception.WazuhClusterError(3022,
+                                    extra_message=f"File is in excluded list: {file_path}")
+
                             zip_path = safe_join(decompressed_files_path, file_path)
                             utils.safe_move(zip_path, full_path, ownership=(common.wazuh_uid(), common.wazuh_gid()),
                                             permissions=cluster_items['files'][item_key]['permissions'])

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1385,6 +1385,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
     assert result == {'errors_per_folder': defaultdict(list),
                       'generic_errors': [], 'total_updated': 0}
     path_join_mock.assert_has_calls([call(common.WAZUH_PATH, 'data'),
+                                     call(common.WAZUH_PATH, 'queue/testing/'),
                                      call(decompressed_files_path, 'data')])
 
     safe_move_mock.side_effect = TimeoutError
@@ -1832,3 +1833,51 @@ def test_master_handler_process_files_from_worker_validates_path_confinement(gid
             assert len(result['errors_per_folder']['queue/testing/']) > 0
             assert any('outside allowed directory' in str(e) or '3022' in str(e)
                       for e in result['errors_per_folder']['queue/testing/'])
+
+
+@patch("os.path.basename")
+@patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
+@patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
+@patch("wazuh.core.cluster.master.utils.safe_move")
+def test_master_handler_process_files_from_worker_validates_non_merged_path(safe_move_mock, gid_mock, uid_mock,
+                                                                             basename_mock):
+    """Test that process_files_from_worker validates path confinement for non-merged files."""
+    master_handler = get_master_handler()
+
+    basename_mock.return_value = "file.txt"
+    files_metadata = {"queue/testing/file.txt": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items,
+        worker_name='worker1',
+        timeout=0
+    )
+    assert result['errors_per_folder'] == defaultdict(list)
+
+    files_metadata = {"etc/ossec.conf": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items,
+        worker_name='worker1',
+        timeout=0
+    )
+    assert len(result['errors_per_folder']['queue/testing/']) > 0
+    assert any('outside allowed directory' in str(e) or '3022' in str(e)
+              for e in result['errors_per_folder']['queue/testing/'])
+
+    basename_mock.return_value = "excluded.txt"
+    cluster_items_with_excluded = dict(cluster_items)
+    cluster_items_with_excluded['files'] = {**cluster_items['files'], 'excluded_files': ['excluded.txt']}
+    files_metadata = {"queue/testing/excluded.txt": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items_with_excluded,
+        worker_name='worker1',
+        timeout=0
+    )
+    assert len(result['errors_per_folder']['queue/testing/']) > 0
+    assert any('excluded list' in str(e) or '3022' in str(e)
+              for e in result['errors_per_folder']['queue/testing/'])


### PR DESCRIPTION
## Description

This PR enhances the cluster synchronization process by adding parameter validation to the non-merged file processing path. Previously, the merged file path included checks to ensure proper directory confinement, but the non-merged path lacked this validation.

**Credits:** Issue reported by @moltenbit.

## Proposed Changes

- Add parameter validation in `process_files_from_worker` for non-merged files
- Ensure file paths match the directory specified by their cluster item key
- Apply consistent validation logic across both merged and non-merged code paths

### Results and Evidence

All existing tests pass, and new test coverage has been added to verify the parameter validation.

Test execution:
- `test_master_handler_process_files_from_worker_ok`: PASSED
- `test_master_handler_process_files_from_worker_validates_cluster_item_key`: PASSED
- `test_master_handler_process_files_from_worker_validates_path_confinement`: PASSED
- `test_master_handler_process_files_from_worker_validates_non_merged_path`: PASSED

### Artifacts Affected

- wazuh-clusterd

### Configuration Changes

None

### Documentation Updates

None

### Tests Introduced

New test case `test_master_handler_process_files_from_worker_validates_non_merged_path` validates:
- Files within allowed directories are processed correctly
- Files outside allowed directories are rejected with appropriate error

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
