### PR TITLE
Restore working vulnerability scanner database workflow

### DIFF
--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -3,7 +3,6 @@ name: 4.X - Vulnerability Scanner - Database Generation
 on:
   schedule:
     - cron: '20 0 * * *'
-
   pull_request:
     paths:
       - ".github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml"
@@ -19,9 +18,15 @@ on:
         required: true
         type: string
 
+      upload_to_s3:
+        description: 'Upload the generated content to S3'
+        required: false
+        default: false
+        type: boolean
+
 jobs:
   vulnerability_scanner_database_scheduled_update:
-    if: github.event_name == 'schedule'
+    if: ${{ (github.event_name == 'schedule') || (github.event_name == 'pull_request') }}
 
     runs-on: ubuntu-24.04
 
@@ -32,29 +37,47 @@ jobs:
           content_version: ["4.8.0", "4.10.0", "4.11.0", "4.13.0"]
 
     steps:
-      # Checkout to the branch
-      - name: Checkout to branch
+      # Checkout repository to the default branch
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 0
-          ref: ${{ matrix.content_version }}
 
       # Checkout to the tag. If it doesn't exist, continue with the branch
-      - name: Checkout to tag
+      - name: Checkout to ${{ matrix.content_version }}
         run: |
           if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.content_version }}"; then
             git checkout --quiet "tags/v${{ matrix.content_version }}"
           else
             echo "Warning: Unable to find tag v${{ matrix.content_version }}. Continuing with branch ${{ matrix.content_version }}"
+            git show-ref --quiet "refs/remotes/origin/${{ matrix.content_version }}"
+            if [ $? -eq 0 ]; then
+              git checkout --quiet "${{ matrix.content_version }}"
+            else
+              echo "Warning: Unable to find branch ${{ matrix.content_version }}. Exiting"
+              exit 1
+            fi
+          fi
+          echo "Git branch: $(git branch | grep "*")"
+
+          # Replace all occurrences of 'wazuh_version' with 'content_version' in all .yml files
+          find .github/actions .github/workflows -type f -name "*.yml" -exec sed -i 's/wazuh_version/content_version/g' {} +
+
+      # Restore missing template file.
+      - name: Restore missing template file
+        run: |
+          # Previous version (4.8.0) expects the template file to be in templates/vd_states_template.json location
+          template=src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+          if [ -f "$template" ]; then
+            if [ ! -d "templates" ]; then
+              mkdir templates
+            fi
+            cp "$template" templates/vd_states_template.json
           fi
 
       ########################
       # Compilation          #
       ########################
-      - name: "Install a compatible CMake"
-        uses: ./.github/actions/reinstall_cmake
-
       - name: Compile
         uses: ./.github/actions/vulnerability_scanner/compile
 
@@ -83,35 +106,6 @@ jobs:
           AWS_DEFAULT_REGION: 'us-west-1'
         shell: bash
 
-  vulnerability_scanner_database_workflow_changes:
-    if: github.event_name == 'pull_request'
-
-    runs-on: wz-linux-amd64
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      ########################
-      # Compilation          #
-      ########################
-      - name: "Install a compatible CMake"
-        uses: ./.github/actions/reinstall_cmake
-
-      - name: Compile
-        uses: ./.github/actions/vulnerability_scanner/compile
-
-      ########################
-      # Content generation   #
-      ########################
-      - name: Generate vulnerability database
-        uses: ./.github/actions/vulnerability_scanner/content_generation
-        with:
-          content_version: "pull_request"
-
   vulnerability_scanner_database_manual_update:
       if: ${{ github.event_name == 'workflow_dispatch' }}
 
@@ -121,15 +115,11 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v3
           with:
-            submodules: recursive
             fetch-depth: 0
 
         ########################
         # Compilation          #
         ########################
-        - name: "Install a compatible CMake"
-          uses: ./.github/actions/reinstall_cmake
-
         - name: Compile
           uses: ./.github/actions/vulnerability_scanner/compile
 
@@ -145,6 +135,7 @@ jobs:
         # Content upload       #
         ########################
         - name: Upload database to S3
+          if: ${{ inputs.upload_to_s3 }}
           run: |
             root_folder=$(pwd)
             bucket="${{ secrets.FEED_AWS_BUCKET }}"


### PR DESCRIPTION
The previous restore (PR #36246) brought the workflow from branch 4.14.6, which is missing two compatibility steps required to build the vulnerability database for older versions (4.8.0, 4.10.0, 4.11.0, 4.13.0):

- Renaming `wazuh_version` to `content_version` in composite actions of older branches.
- Restoring the missing template file expected by 4.8.0 at `templates/vd_states_template.json`.

This PR replaces the workflow with the version that was in `main` before its deprecation in PR #36044, which includes both steps and was the last known working version.