### PR TITLE
Fix the wazuh-manager-modules crash that occurs while downloading the feed

### DIFF
--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -454,7 +454,7 @@ private:
                 {
                     syncConnector.deletePointInTime(*p);
                 }
-                catch (const IndexerConnectorException& e)
+                catch (const std::exception& e)
                 {
                     logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
                 }
@@ -543,7 +543,7 @@ private:
                 {
                     syncConnector.deletePointInTime(*p);
                 }
-                catch (const IndexerConnectorException& e)
+                catch (const std::exception& e)
                 {
                     logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
                 }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

`wazuh-manager-modulesd` was crashing silently during the vulnerability feed download, leaving a stale PID file and causing the manager to report the process as not running.

The root cause is a C++ exception type mismatch in the RAII pitGuard lambda inside `IndexerDownloader::fetchWithPit` and `IndexerDownloader::fetchWithSlicedPit`.


When the feed download fails (slices throw `std::runtime_error`), C++ begins stack unwinding. The pitGuard destructor fires to clean up the OpenSearch PIT. Inside the destructor, `deletePointInTime()` calls `m_selector->getNext()`, which throws `std::runtime_error("No available server")` when the monitoring thread has already marked all Indexer servers as unavailable. The pitGuard lambda only caught `IndexerConnectorException`, so the `std::runtime_error` escaped the destructor during stack unwinding and triggered `std::terminate()` which executes an  `abort()`. Because `abort()` does not invoke `atexit()` handlers, `wm_cleanup()` never ran, leaving the PID file on disk.

Closes #36328
<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

The fix changes both pitGuard catch blocks from `catch (const IndexerConnectorException& e)` to `catch (const std::exception& e)`, ensuring any exception thrown by `deletePointInTime()` , including the `std::runtime_error` from `getNext()`,  is absorbed and logged instead of propagating out of the destructor.


<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

I was able to reproduce the error by restarting the manager and indexer while the feed was downloading

- After applying the fix, the module no longer crashes

```
2026/05/25 07:42:34 wazuh-manager-modulesd: INFO: Started (pid: 1146352).
2026/05/25 07:42:34 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/05/25 07:42:34 wazuh-manager-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/25 07:42:34 wazuh-manager-modulesd:database: INFO: Module started.
2026/05/25 07:42:34 wazuh-manager-modulesd:task-manager: INFO: (8207): Module Task Manager only runs on Master nodes in cluster configuration.
2026/05/25 07:42:34 wazuh-manager-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/05/25 07:42:34 wazuh-manager-modulesd:inventory-sync: INFO: Starting inventory_sync module.
2026/05/25 07:42:34 wazuh-manager-modulesd:content_manager: INFO: Starting content_manager module.
2026/05/25 07:42:34 wazuh-manager-modulesd:router: INFO: Starting router module.
2026/05/25 07:42:35 logger-helper: INFO: InventorySyncFacade started.
2026/05/25 07:42:35 wazuh-manager-modulesd:vulnerability-scanner: WARNING: The local feed database is incomplete at startup: required global maps are missing. Clearing updater state to force a clean rebuild.
2026/05/25 07:42:35 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/05/25 07:42:35 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/05/25 07:42:35 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/05/25 07:42:35 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/05/25 07:42:39 wazuh-manager-analysisd: WARNING: [IOC::Sync] Get IOC type hashes from wazuh-indexer - Attempt 2/3: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
2026/05/25 07:42:44 wazuh-manager-analysisd: WARNING: [IOC::Sync] Get IOC type hashes from wazuh-indexer - Attempt 3/3: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
2026/05/25 07:42:44 wazuh-manager-analysisd: WARNING: [IOC::Sync] Synchronization cycle failed: Get IOC type hashes from wazuh-indexer::IOC::Sync failed after 3 attempts: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
2026/05/25 07:42:44 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/05/25 07:45:01 wazuh-manager-modulesd:content-updater: ERROR: IndexerDownloader: Slice 0 failed: Search request failed with status -1: Could not connect to server
2026/05/25 07:45:01 wazuh-manager-modulesd:content-updater: ERROR: IndexerDownloader: Slice 1 failed: Search request failed with status -1: Could not connect to server
2026/05/25 07:45:01 wazuh-manager-modulesd:content-updater: WARNING: IndexerDownloader: Initial load failed (IndexerDownloader: 2 slice(s) failed: Slice 0: Search request failed with status -1: Could not connect to server) — retrying in 30 s.

root@aio-ubuntu-24-amd64:/home/ubuntu# /var/wazuh-manager/bin/wazuh-manager-control status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid not running...

```

- If we keep waiting, the feed downloads successfully

```
2026/05/25 08:05:18 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 171336 docs in 593456ms
2026/05/25 08:05:19 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 171380 docs in 594275ms
2026/05/25 08:05:19 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 342716 documents, cursor: '420064'
2026/05/25 08:05:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/05/25 08:05:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/05/25 08:05:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/05/25 08:05:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=0, status=ok).
2026/05/25 08:07:04 wazuh-manager-analysisd: WARNING: [IOC::Sync] Get IOC type hashes from wazuh-indexer - Attempt 1/3: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
2026/05/25 08:07:09 wazuh-manager-analysisd: WARNING: [IOC::Sync] Get IOC type hashes from wazuh-indexer - Attempt 2/3: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
2026/05/25 08:07:14 wazuh-manager-analysisd: WARNING: [IOC::Sync] Get IOC type hashes from wazuh-indexer - Attempt 3/3: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
2026/05/25 08:07:14 wazuh-manager-analysisd: WARNING: [IOC::Sync] Synchronization cycle failed: Get IOC type hashes from wazuh-indexer::IOC::Sync failed after 3 attempts: Hash document '__ioc_type_hashes__' not found in index 'wazuh-threatintel-enrichments'
root@aio-ubuntu-24-amd64:/home/ubuntu#

```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
