### PR TITLE
Fix agent keepalive scheduling after system clock rollback

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2704,10 +2704,10 @@ win32/ui/%.o: win32/ui/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -UOSSECHIDS -DARGV0=\"wazuh-win32ui\" -c $^ -o $@
 
 win32/wazuh-agent.exe: win32/wazuh_agent_resource.o win32/version-app.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main.o, ${os_logcollector_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
-	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd -l:libfimdb.lib libwazuh.a -o $@
+	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd -l:libfimdb.lib libwazuh.a -lkernel32 -o $@
 
 win32/wazuh-agent-eventchannel.exe: win32/wazuh_agent_eventchannel_resource.o win32/version-app.o win32/icon.o win32/win_agent.o win32/win_service.o win32/win_utils.o os_crypto/md5_sha1_sha256/md5_sha1_sha256_op.o ${rootcheck_o} $(filter-out wazuh_modules/main.o, ${wmodulesd_o}) $(filter-out client-agent/main.o, $(filter-out client-agent/agentd.o, $(filter-out client-agent/event-forward.o, ${client_agent_o}))) $(filter-out logcollector/main-event.o, ${os_logcollector_eventchannel_o}) $(filter-out os_execd/main.o, ${os_execd_o}) active-response/active_responses.o monitord/rotate_log.o monitord/compress_log.o
-	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd-event -l:libfimdb.lib libwazuh.a -lwevtapi -o $@
+	${OSSEC_CCBIN} -DARGV0=\"wazuh-agent\" -DOSSECHIDS -DEVENTCHANNEL_SUPPORT ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} ${DBSYNC_LIB} ${RSYNC_LIB} -lwazuh-syscheckd-event -l:libfimdb.lib libwazuh.a -lwevtapi -lkernel32 -o $@
 
 win32/manage_agents.exe: win32/manage_agents_resource.o win32/version-app.o win32/win_service_rk.o ${addagent_o}
 	${OSSEC_CCBIN} -DARGV0=\"manage-agents\" -DMA ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -888,8 +888,8 @@ endif
 .PHONY: winagent
 winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME} win32/version-dll.o win32/version-app.o
 	${MAKE} ${WAZUHEXT_LIB} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lws2_32 -lcrypt32"
-	${MAKE} ${WINDOWS_LIBS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1"
-	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
+	${MAKE} ${WINDOWS_LIBS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1 -D_WIN32_WINNT=0x600"
+	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1 -D_WIN32_WINNT=0x600" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -75,6 +75,12 @@ void clear_merged_hash_cache() {
     os_free(g_shared_mg_file_hash);
 }
 
+#ifdef WAZUH_UNIT_TESTING
+void notify_reset_saved_time(void) {
+    g_saved_time = 0;
+}
+#endif
+
 /* Periodically send notification to server */
 void run_notify()
 {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -88,7 +88,12 @@ void run_notify()
     static const char no_hash_value[] = "x merged.mg\n";
 
     tmp_msg[OS_MAXSTR - OS_HEADER_SIZE + 1] = '\0';
+    time_t mono_now = w_get_monotonic_time();
     curr_time = time(0);
+
+    if (g_saved_time == 0) {
+        g_saved_time = mono_now;
+    }
 
 #ifndef ONEWAY_ENABLED
     /* Check if the server has responded */
@@ -121,11 +126,11 @@ void run_notify()
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
     }
 
-    /* Check if time has elapsed */
-    if ((curr_time - g_saved_time) < agt->notify_time) {
+    /* Check if time has elapsed (monotonic — immune to clock changes) */
+    if ((mono_now - g_saved_time) < agt->notify_time) {
         return;
     }
-    g_saved_time = curr_time;
+    g_saved_time = mono_now;
 
     mdebug1("Sending agent notification.");
 
@@ -161,10 +166,8 @@ void run_notify()
         clear_merged_hash_cache();
     }
 
-    time_t now = time(NULL);
-    if ((now - last_update) >= agt->main_ip_update_interval) {
-        // Update agent_ip considering main_ip_update_interval value
-        last_update = now;
+    if ((mono_now - last_update) >= agt->main_ip_update_interval) {
+        last_update = mono_now;
         char *tmp_agent_ip = get_agent_ip();
 
         if (tmp_agent_ip) {

--- a/src/headers/time_op.h
+++ b/src/headers/time_op.h
@@ -88,4 +88,15 @@ long long int get_windows_file_time_epoch(FILETIME ft);
  */
 bool is_leap_year(int year);
 
+/**
+ * @brief Get monotonic elapsed seconds since an arbitrary fixed point.
+ *
+ * Uses CLOCK_MONOTONIC on Linux, Mach SYSTEM_CLOCK on macOS,
+ * and GetTickCount64 on Windows. Never goes backwards regardless of
+ * system clock changes (NTP sync, manual adjustment, VM time warp).
+ *
+ * @return Seconds since an unspecified epoch (not wall-clock time).
+ */
+time_t w_get_monotonic_time(void);
+
 #endif // TIME_OP_H

--- a/src/shared/time_op.c
+++ b/src/shared/time_op.c
@@ -79,6 +79,23 @@ void gettime(struct timespec * ts) {
 
 #endif
 
+time_t w_get_monotonic_time(void) {
+#ifdef WIN32
+    return (time_t)(GetTickCount64() / 1000);
+#elif defined(__MACH__)
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    return (time_t)mts.tv_sec;
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec;
+#endif
+}
+
 char *w_get_timestamp(time_t time) {
     struct tm localtm;
     char *timestamp;

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -53,11 +53,13 @@ list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_Se
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=fim_db_teardown \
                                 -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize \
                                 -Wl,--wrap=getsockname -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \
-                                -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time ${DEBUG_OP_WRAPPERS}")
+                                -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time ${DEBUG_OP_WRAPPERS} \
+                                -Wl,--wrap,w_get_monotonic_time,--wrap,send_msg,--wrap,w_agentd_state_update")
 else()
 list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_SendUnix,--wrap,OS_RecvUnix \
                                 -Wl,--wrap=getsockname -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \
-                                -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time ${DEBUG_OP_WRAPPERS}")
+                                -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time ${DEBUG_OP_WRAPPERS} \
+                                -Wl,--wrap,w_get_monotonic_time,--wrap,send_msg,--wrap,w_agentd_state_update")
 endif()
 
 list(APPEND client-agent_names "test_agentd_state")

--- a/src/unit_tests/client-agent/test_notify.c
+++ b/src/unit_tests/client-agent/test_notify.c
@@ -11,11 +11,32 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <string.h>
 
 #include "../client-agent/agentd.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 
 #define DUMMY_VALID_SOCKET_FD 1
+
+/* Inline wrappers for run_notify dependencies — defined here to avoid
+ * pulling in file_op.c.o via __real_getuname, which transitively
+ * requires __wrap__merror_exit from libwazuh_test.a. */
+
+time_t __wrap_w_get_monotonic_time(void) {
+    return mock_type(time_t);
+}
+
+int __wrap_send_msg(const char *msg, ssize_t msg_length) {
+    check_expected(msg);
+    return 0;
+}
+
+void __wrap_w_agentd_state_update(w_agentd_state_update_t type, void *data) {
+    check_expected(type);
+}
+
+/* Reset file-scope statics in notify.c for test isolation */
+extern void notify_reset_saved_time(void);
 
 static int setup(void **state) {
     static agent global_config;
@@ -23,6 +44,23 @@ static int setup(void **state) {
     // force init value on every call
     agt->sock = DUMMY_VALID_SOCKET_FD;
     errno = 0;
+    return 0;
+}
+
+static int setup_run_notify(void **state) {
+    static agent global_config;
+    memset(&global_config, 0, sizeof(global_config));
+    agt = &global_config;
+    agt->sock = DUMMY_VALID_SOCKET_FD;
+    agt->notify_time = 60;
+    agt->max_time_reconnect_try = 3600;
+    agt->force_reconnect_interval = 0;
+    agt->main_ip_update_interval = 3600;
+    agt->labels = NULL;
+    available_server = 2000;
+    errno = 0;
+    notify_reset_saved_time();
+    clear_merged_hash_cache();
     return 0;
 }
 
@@ -112,6 +150,35 @@ static void get_agent_ip_ipv6_updated_successfully(void **state) {
 
 #endif // TEST_AGENT
 
+#ifdef TEST_AGENT
+
+/* run_notify scheduling tests — monotonic clock fix (issue #36260) */
+
+static void test_run_notify_skips_when_not_enough_time(void **state) {
+    /* First call: g_saved_time is 0, gets set to mono_now=1000.
+     * Elapsed = 0 < notify_time=60 → early return, no keepalive. */
+    will_return(__wrap_w_get_monotonic_time, (time_t)1000);
+    will_return(__wrap_time, (time_t)2000);
+
+    run_notify();
+}
+
+static void test_run_notify_skips_on_clock_rollback(void **state) {
+    /* Initialize g_saved_time to 1000. */
+    will_return(__wrap_w_get_monotonic_time, (time_t)1000);
+    will_return(__wrap_time, (time_t)2000);
+    run_notify();
+
+    /* Simulate wall-clock rollback: w_get_monotonic_time() returns 500 < 1000.
+     * (mono_now - g_saved_time) = -500 < notify_time=60 → early return.
+     * This proves the guard is safe against backwards values. */
+    will_return(__wrap_w_get_monotonic_time, (time_t)500);
+    will_return(__wrap_time, (time_t)2000);
+    run_notify();
+}
+
+#endif // TEST_AGENT (run_notify tests)
+
 int main(void) {
     const struct CMUnitTest tests[] = {
 #ifdef TEST_AGENT
@@ -119,7 +186,9 @@ int main(void) {
         cmocka_unit_test_setup(get_agent_ip_invalid_socket, setup),
         cmocka_unit_test_setup(get_agent_ip_unknown_address_family, setup),
         cmocka_unit_test_setup(get_agent_ip_ipv4_updated_successfully, setup),
-        cmocka_unit_test_setup(get_agent_ip_ipv6_updated_successfully, setup)
+        cmocka_unit_test_setup(get_agent_ip_ipv6_updated_successfully, setup),
+        cmocka_unit_test_setup(test_run_notify_skips_when_not_enough_time, setup_run_notify),
+        cmocka_unit_test_setup(test_run_notify_skips_on_clock_rollback, setup_run_notify),
 #endif // TEST_AGENT
     };
 

--- a/src/unit_tests/shared/test_time_op.c
+++ b/src/unit_tests/shared/test_time_op.c
@@ -21,6 +21,21 @@
 
 /* tests */
 
+void test_w_get_monotonic_time_is_positive(void **state)
+{
+    (void) state;
+    time_t t = w_get_monotonic_time();
+    assert_true(t > 0);
+}
+
+void test_w_get_monotonic_time_is_nondecreasing(void **state)
+{
+    (void) state;
+    time_t t1 = w_get_monotonic_time();
+    time_t t2 = w_get_monotonic_time();
+    assert_true(t2 >= t1);
+}
+
 void test_is_leap_year_two(void **state)
 {
     (void) state;
@@ -84,6 +99,8 @@ void test_is_leap_year_four_hundred(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_w_get_monotonic_time_is_positive),
+        cmocka_unit_test(test_w_get_monotonic_time_is_nondecreasing),
         cmocka_unit_test(test_is_leap_year_two),
         cmocka_unit_test(test_is_leap_year_four),
         cmocka_unit_test(test_is_leap_year_one_hundred),


### PR DESCRIPTION
## Description
This PR fixes an issue where the Wazuh agent stops sending keepalives and is incorrectly marked as `Disconnected` after a system clock rollback (NTP sync, VM time sync, manual adjustment).

**Proposed Release:** v4.14.7
**Issue:** wazuh/wazuh#36260

## Proposed Changes
- Updated `src/client-agent/notify.c` to use monotonic time for keepalive interval calculations.
- Added `w_get_monotonic_time()` to `src/shared/time_op.c` utilizing OS-level monotonic clocks (`CLOCK_MONOTONIC` on Linux, `GetTickCount64()` on Windows, Mach `SYSTEM_CLOCK` on macOS).
- Added declaration of `w_get_monotonic_time()` to `src/headers/time_op.h`.
- Wall-clock time (`time(0)`) is intentionally preserved for reconnect logic, manager-side timestamps, and logging.
- Added `-lkernel32` to Windows agent link flags in `src/Makefile` to resolve `GetTickCount64` symbol at link time.

### Results and Evidence

**Without fix (reproduced on v4.14.5, Windows 11 agent):**
```bash
12:02 UTC → Last keep alive: 1779364830  ← frozen immediately after rollback
12:07 UTC → Last keep alive: 1779364830  ← frozen
12:15 UTC → Status: Disconnected         ← false disconnect
```

**With fix - Ubuntu 20.04 (Tier 2), 9-hour rollback:**
```bash
# 08:33:56 UTC → Status: Active, Last keep alive: 1779957229  (pre-rollback)
sudo date -s "$(date -d '-9 hours')"  # rollback executed
# 08:34:41 UTC → Last keep alive: 1779957269  ✓ advancing
# 08:41:23 UTC → Last keep alive: 1779957670  ✓ advancing
# 08:56:19 UTC → Last keep alive: 1779958571  ✓ advancing (22 min post-rollback)
# Status: Active - never Disconnected
```

**With fix - Amazon Linux 2023 (Tier 1), 9-hour rollback:**
```bash
# 10:55:03 UTC → Status: Active, Last keep alive: 1779965687  (pre-rollback)
sudo date -s "$(date -d '-9 hours')"  # rollback executed
# 10:55:54 UTC → Last keep alive: 1779965747  ✓ advancing
# 11:11:14 UTC → Last keep alive: 1779966666  ✓ advancing (16 min post-rollback)
# Status: Active - never Disconnected
```

**With fix - Ubuntu 26.04 (Tier 1), 9-hour rollback:**
```bash
# 11:48:49 UTC → Status: Active, Last keep alive: 1779968922  (pre-rollback)
sudo date -s "$(date -d '-9 hours')"  # rollback executed
# 11:49:19 UTC → Last keep alive: 1779968942  ✓ advancing
# 11:50:50 UTC → Last keep alive: 1779969043  ✓ advancing
# 12:06:36 UTC → Last keep alive: 1779969993  ✓ advancing (18 min post-rollback)
# Status: Active - never Disconnected
```

**With fix - macOS Sequoia 15.0 (Tier 1), 9-hour rollback:**
```bash
# 11:13:46 UTC → Status: Active, Last keep alive: 1780053217  (pre-rollback)
sudo date -v-9H  # rollback executed
# 11:14:01 UTC → Last keep alive: 1780053237  ✓ advancing
# 11:14:21 UTC → Last keep alive: 1780053257  ✓ advancing
# 11:30:08 UTC → Last keep alive: 1780054197  ✓ advancing (16 min post-rollback)
# Status: Active - never Disconnected
```

**With fix - Windows 11 (Tier 1), 9-hour rollback:**
```powershell
# 08:15:35 UTC → Status: Active, Last keep alive: 1780474530  (pre-rollback)
$newTime = (Get-Date).AddHours(-9); Set-Date -Date $newTime  # rollback executed
# 08:15:55 UTC → Last keep alive: 1780474550  ✓ advancing
# 08:33:52 UTC → Last keep alive: 1780475629  ✓ advancing (18 min post-rollback)
# Status: Active - never Disconnected
```

**With fix - Solaris 11 (Tier 3), 9-hour rollback:**
```bash
# 10:42:07 UTC → Status: Active, Last keep alive: 1780483309  (pre-rollback)
sudo date 060301422026.00  # rollback executed
# 10:42:12 UTC → Last keep alive: 1780483328  ✓ advancing
# 10:43:03 UTC → Last keep alive: 1780483366  ✓ advancing
# 11:10:54 UTC → Last keep alive: 1780485047  ✓ advancing (28 min post-rollback)
# Status: Active - never Disconnected
```

**With fix - CentOS 5 (Tier 3, RPM legacy), 9-hour rollback:**
```bash
# 08:39:13 UTC → Status: Active, Last keep alive: 1780648744  (pre-rollback)
sudo date -s "$(date -d '-9 hours')"  # rollback executed
# 08:39:28 UTC → Last keep alive: 1780648763  ✓ advancing
# 08:39:54 UTC → Last keep alive: 1780648783  ✓ advancing
# 08:58:17 UTC → Last keep alive: 1780649883  ✓ advancing (19 min post-rollback)
# Status: Active - never Disconnected
```

**Summary:**
| Platform | Tier | Rollback | Status | Timeout exceeded |
|---|---|---|---|---|
| Ubuntu 20.04 | 2 | 9h | Active ✅ | 22 min |
| Amazon Linux 2023 | 1 | 9h | Active ✅ | 16 min |
| Ubuntu 26.04 | 1 | 9h | Active ✅ | 18 min |
| macOS Sequoia 15.0 | 1 | 9h | Active ✅ | 16 min |
| Windows 11 | 1 | 9h | Active ✅ | 18 min |
| Solaris 11 | 3 | 9h | Active ✅ | 28 min |
| CentOS 5 | 3 | 9h | Active ✅ | 19 min |

All tested agents remained `Active` past the 15-minute disconnection timeout with keepalives continuously advancing after the rollback.

### Artifacts Affected
- `src/client-agent/notify.c`
- `src/shared/time_op.c`
- `src/headers/time_op.h`
- `src/Makefile`

### Configuration Changes
N/A

### Documentation Updates
N/A

### Tests Introduced
- **Scope:** Manual Validation
- **Details:** Reproduced the clock rollback scenario (9-hour rollback) with the patched binary on Ubuntu 20.04, Amazon Linux 2023, Ubuntu 26.04, macOS Sequoia 15.0, Windows 11, Solaris 11 and CentOS 5 agents. Verified keepalive timestamps continue advancing post-rollback and agents never transition to `Disconnected` past the 15-minute timeout.


## Review Checklist
**Manual tests with their corresponding evidence:**
- Compilation without warnings on every supported platform
    - [x] Linux - Ubuntu 20.04, Ubuntu 26.04, Amazon Linux 2023
    - [x] Windows
    - [x] macOS - Sequoia 15.0 (x86_64)

- [ ] Log syntax and correct language review

- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues