### PR TITLE
Improve the method of detecting duplicates

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -1612,9 +1612,9 @@ field: index_unclassified_events()
 
 ## Target Field
 
-| Type | Possible values |
-| ---- | --------------- |
-| array | [number, string, boolean, object, array] |
+| Path | Type | Possible values |
+| ---- | ---- | --------------- |
+| wazuh.integration.decoders | array | [number, string, boolean, object, array] |
 
 
 ## Description
@@ -1622,14 +1622,15 @@ field: index_unclassified_events()
 Determines whether unclassified events should be indexed based on policy configuration.
 This filter returns true if and only if:
 1. The policy flag 'indexUnclassifiedEvents' is enabled (configured at build time)
-2. The target field is an array containing exactly 1 element
+2. The target field is exactly 'wazuh.integration.decoders'
+3. 'wazuh.integration.decoders' is an array containing exactly 1 element
 
 This helper is used in output routing to decide whether to index events that have only
 one decoder (unclassified events) when the policy allows it. If the policy flag is
 disabled or the array has a different size, the validation fails.
 
-Note: This helper does not accept any arguments and depends on the policy context
-configured at build time.
+Note: This helper does not accept any arguments, rejects any target field other than
+'wazuh.integration.decoders', and depends on the policy context configured at build time.
 
 
 ## Keywords
@@ -1648,14 +1649,14 @@ Array with exactly one element (unclassified event)
 
 ```yaml
 check:
-  - target_field: index_unclassified_events()
+  - wazuh.integration.decoders: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "target_field": [
+  "wazuh.integration.decoders": [
     "single_decoder"
   ]
 }
@@ -1671,7 +1672,7 @@ Empty array - not an unclassified event
 
 ```yaml
 check:
-  - target_field: index_unclassified_events()
+  - wazuh.integration.decoders: index_unclassified_events()
 ```
 
 #### Input Event
@@ -1690,14 +1691,14 @@ Array with two elements - classified event
 
 ```yaml
 check:
-  - target_field: index_unclassified_events()
+  - wazuh.integration.decoders: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "target_field": [
+  "wazuh.integration.decoders": [
     "decoder1",
     "decoder2"
   ]
@@ -1714,14 +1715,14 @@ Array with three elements - classified event
 
 ```yaml
 check:
-  - target_field: index_unclassified_events()
+  - wazuh.integration.decoders: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "target_field": [
+  "wazuh.integration.decoders": [
     "d1",
     "d2",
     "d3"
@@ -1739,14 +1740,14 @@ Target field is not an array
 
 ```yaml
 check:
-  - target_field: index_unclassified_events()
+  - wazuh.integration.decoders: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "target_field": "not_an_array"
+  "wazuh.integration.decoders": "not_an_array"
 }
 ```
 
@@ -1760,14 +1761,14 @@ Target field is a number, not an array
 
 ```yaml
 check:
-  - target_field: index_unclassified_events()
+  - wazuh.integration.decoders: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "target_field": 42
+  "wazuh.integration.decoders": 42
 }
 ```
 
@@ -16150,6 +16151,8 @@ field: merge_key_in(any_object, key)
 Merge in target field value with the content of some key in the specified object, where the key is specified with a reference to another field.
 The object parameter must be a definition object or a reference to a field containing the object.
 This helper function is typically used in the map stage.
+When a key exists in both the source and the target, the source value overwrites the target value entirely (no recursion into nested structures).
+If the source contains duplicate keys, all occurrences are iterated and the last duplicate value is the one that remains in the target.
 
 
 ## Keywords
@@ -16372,9 +16375,11 @@ field: merge_recursive_key_in(any_object, key)
 
 Recursively merge the target field value with the content of a specified key in the given object.
 The key is identified through a reference to another field.
-If the key's value contains nested objects, the merge operation is applied recursively, combining all levels of the structure.
+If the key's value contains nested objects or arrays, the merge operation is applied recursively, combining all levels of the structure.
+For primitive values (strings, numbers, booleans), when a key exists in both source and target, the source value overwrites the target value.
 The object parameter must be a definition object or a reference to a field containing the object.
 This helper function is typically used in the map stage to ensure deep merging of complex objects.
+If the source contains duplicate keys, all occurrences are iterated and the last duplicate value is the one that remains in the target.
 
 
 ## Keywords

--- a/src/engine/ruleset/schemas/engine-schema.json
+++ b/src/engine/ruleset/schemas/engine-schema.json
@@ -771,51 +771,6 @@
     "email.x_mailer": {
       "type": "keyword"
     },
-    "enrichments.indicator.confidence": {
-      "type": "short"
-    },
-    "enrichments.indicator.feed.name": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.first_seen": {
-      "type": "date"
-    },
-    "enrichments.indicator.id": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.last_seen": {
-      "type": "date"
-    },
-    "enrichments.indicator.name": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.provider": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.reference": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.software": {
-      "type": "object"
-    },
-    "enrichments.indicator.software.alias": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.software.name": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.software.type": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.tags": {
-      "type": "keyword"
-    },
-    "enrichments.indicator.type": {
-      "type": "keyword"
-    },
-    "enrichments.source": {
-      "type": "keyword"
-    },
     "error.code": {
       "type": "keyword"
     },
@@ -3685,7 +3640,7 @@
       "type": "keyword"
     },
     "threat.enrichments": {
-      "type": "nested"
+      "type": "object"
     },
     "threat.enrichments.indicator": {
       "type": "object"
@@ -5797,7 +5752,7 @@
       "type": "keyword"
     },
     "wazuh.threat.enrichments": {
-      "type": "nested"
+      "type": "object"
     },
     "wazuh.threat.enrichments.indicator": {
       "type": "object"

--- a/src/engine/ruleset/schemas/wazuh-decoders.json
+++ b/src/engine/ruleset/schemas/wazuh-decoders.json
@@ -1721,103 +1721,6 @@
             "string"
           ]
         },
-        "enrichments.indicator.confidence": {
-          "description": "Module: ecs\nIndexerType: short\n\nIndicator confidence rating.",
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-          "type": [
-            "number",
-            "string"
-          ]
-        },
-        "enrichments.indicator.feed.name": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nName of the feed that supplied the indicator.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.first_seen": {
-          "description": "Module: ecs\nIndexerType: date\n\nDate/time indicator was first reported.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.id": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nUnique identifier for the enrichment data, such as a hash of the indicator data or a unique ID from the provider.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.last_seen": {
-          "description": "Module: ecs\nIndexerType: date\n\nDate/time indicator was last reported.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.name": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nIndicator display name.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.provider": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nIndicator provider.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.reference": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nIndicator reference URL.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.software": {
-          "additionalProperties": false,
-          "description": "Module: ecs\nIndexerType: object\n\nName of the software associated with the indicator, such as malware or attack framework.",
-          "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
-          "properties": {
-            "alias": {
-              "description": "Module: ecs\nIndexerType: keyword\n\nAlias or alternative names for the software associated with the indicator.",
-              "type": [
-                "string"
-              ]
-            },
-            "name": {
-              "description": "Module: ecs\nIndexerType: keyword\n\nName of the software associated with the indicator.",
-              "type": [
-                "string"
-              ]
-            },
-            "type": {
-              "description": "Module: ecs\nIndexerType: keyword\n\nType of software associated with the indicator, such as malware, attack framework, or tool.",
-              "type": [
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "object",
-            "string"
-          ]
-        },
-        "enrichments.indicator.tags": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nList of tags associated with the indicator.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.indicator.type": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nType of indicator.",
-          "type": [
-            "string"
-          ]
-        },
-        "enrichments.source": {
-          "description": "Module: ecs\nIndexerType: keyword\n\nSource of the enrichment data identifying the external provider that supplied the indicator.",
-          "type": [
-            "string"
-          ]
-        },
         "error.code": {
           "description": "Module: ecs\nIndexerType: keyword\n\nError code describing the error.",
           "type": [
@@ -8182,7 +8085,7 @@
         },
         "threat.enrichments": {
           "additionalProperties": false,
-          "description": "Module: ecs\nIndexerType: nested\n\nA list of associated indicators objects enriching the event, and the context of that association/enrichment.",
+          "description": "Module: ecs\nIndexerType: object\n\nA list of associated indicators objects enriching the event, and the context of that association/enrichment.",
           "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "properties": {
             "indicator": {
@@ -12710,7 +12613,7 @@
         },
         "wazuh.threat.enrichments": {
           "additionalProperties": false,
-          "description": "Module: ecs\nIndexerType: nested\n\nA list of associated indicators objects enriching the event, and the context of that association/enrichment.",
+          "description": "Module: ecs\nIndexerType: object\n\nA list of associated indicators objects enriching the event, and the context of that association/enrichment.",
           "pattern": "^\\$[\\w\\.]+$|^[\\w]+\\(.*\\)$",
           "properties": {
             "indicator": {

--- a/src/engine/source/base/CMakeLists.txt
+++ b/src/engine/source/base/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(base::bench ALIAS base_bench)
 
 add_executable(base_benchmark
     ${BENCH_SRC_DIR}/eventParser_bench.cpp
+    ${BENCH_SRC_DIR}/json_bench.cpp
 )
 target_include_directories(base_benchmark
     PRIVATE

--- a/src/engine/source/base/benchmark/src/json_bench.cpp
+++ b/src/engine/source/base/benchmark/src/json_bench.cpp
@@ -1,0 +1,626 @@
+#include <benchmark/benchmark.h>
+
+#include <string>
+
+#include <base/json.hpp>
+#include <rapidjson/document.h>
+
+using namespace json;
+
+// =============================================================================
+// Test data: JSON strings of varying sizes and structures
+// =============================================================================
+
+static const std::string SMALL_FLAT_JSON = R"({
+    "name": "wazuh-agent",
+    "id": "001",
+    "version": "5.0.0",
+    "status": "active",
+    "ip": "192.168.1.100"
+})";
+
+// --- Documents WITH duplicate keys (for removeDuplicateKeys benchmarks) ---
+
+static const std::string SMALL_WITH_DUPS = R"({
+    "name": "wazuh-agent",
+    "id": "001",
+    "name": "duplicate-name",
+    "status": "active",
+    "id": "002"
+})";
+
+static const std::string MEDIUM_WITH_DUPS = R"({
+    "agent": {
+        "id": "001",
+        "name": "wazuh-agent",
+        "id": "002",
+        "host": {
+            "hostname": "server01",
+            "hostname": "server02",
+            "os": {
+                "name": "Ubuntu",
+                "name": "Debian",
+                "version": "24.04"
+            }
+        }
+    },
+    "event": {
+        "kind": "event",
+        "kind": "alert",
+        "category": ["process"]
+    },
+    "agent": {"id": "003"}
+})";
+
+static const std::string MEDIUM_NESTED_JSON = R"({
+    "agent": {
+        "id": "001",
+        "name": "wazuh-agent",
+        "version": "5.0.0",
+        "host": {
+            "hostname": "server01",
+            "os": {
+                "name": "Ubuntu",
+                "version": "24.04",
+                "platform": "linux",
+                "arch": "x86_64"
+            },
+            "ip": ["192.168.1.100", "10.0.0.5"],
+            "mac": ["00:11:22:33:44:55"]
+        }
+    },
+    "event": {
+        "kind": "event",
+        "category": ["process"],
+        "type": ["start"],
+        "module": "syscheck",
+        "dataset": "file"
+    },
+    "message": "File integrity monitoring event detected",
+    "rule": {
+        "id": "550",
+        "level": 7,
+        "description": "Integrity checksum changed"
+    }
+})";
+
+static const std::string LARGE_DEEPLY_NESTED_JSON = R"({
+    "event": {
+        "kind": "alert",
+        "category": ["intrusion_detection"],
+        "type": ["info"],
+        "severity": 3,
+        "created": "2026-01-15T10:30:00.000Z",
+        "provider": "wazuh",
+        "module": "syscheck"
+    },
+    "agent": {
+        "id": "003",
+        "name": "prod-server-03",
+        "type": "endpoint",
+        "version": "5.0.0",
+        "host": {
+            "hostname": "prod-server-03",
+            "architecture": "x86_64",
+            "os": {
+                "family": "debian",
+                "name": "Ubuntu",
+                "version": "24.04.1 LTS",
+                "kernel": "6.8.0-45-generic",
+                "platform": "linux",
+                "type": "linux",
+                "codename": "noble"
+            },
+            "ip": ["10.0.1.50", "172.16.0.50", "fd00::50"],
+            "mac": ["00:11:22:33:44:55", "00:11:22:33:44:56"],
+            "geo": {
+                "city_name": "San Francisco",
+                "country_name": "United States",
+                "location": {
+                    "lat": 37.7749,
+                    "lon": -122.4194
+                },
+                "region_name": "California"
+            }
+        }
+    },
+    "source": {
+        "ip": "203.0.113.50",
+        "port": 44312,
+        "geo": {
+            "city_name": "Moscow",
+            "country_name": "Russia",
+            "continent_name": "Europe",
+            "location": {
+                "lat": 55.7558,
+                "lon": 37.6173
+            }
+        }
+    },
+    "destination": {
+        "ip": "10.0.1.50",
+        "port": 22,
+        "service": "ssh"
+    },
+    "rule": {
+        "id": "5712",
+        "level": 10,
+        "description": "SSHD brute force trying to get access to the system",
+        "groups": ["syslog", "sshd", "authentication_failures"],
+        "mitre": {
+            "id": ["T1110"],
+            "tactic": ["Credential Access"],
+            "technique": ["Brute Force"]
+        },
+        "pci_dss": ["10.2.4", "10.2.5", "11.4"],
+        "gdpr": ["IV_35.7.d", "IV_32.2"],
+        "hipaa": ["164.312.b"]
+    },
+    "vulnerability": {
+        "id": "CVE-2024-1234",
+        "severity": "high",
+        "score": {
+            "base": 8.1,
+            "version": "3.1"
+        },
+        "category": ["remote_code_execution"],
+        "reference": "https://nvd.nist.gov/vuln/detail/CVE-2024-1234"
+    },
+    "file": {
+        "path": "/etc/shadow",
+        "hash": {
+            "sha256": "abc123def456789012345678901234567890123456789012345678901234abcd",
+            "md5": "d41d8cd98f00b204e9800998ecf8427e"
+        },
+        "owner": "root",
+        "group": "shadow",
+        "mode": "0640",
+        "size": 1542,
+        "inode": 262147
+    }
+})";
+
+// Generate a flat JSON with N unique keys
+static std::string generateFlatJson(size_t numKeys)
+{
+    std::string json = "{";
+    for (size_t i = 0; i < numKeys; ++i)
+    {
+        if (i > 0)
+            json += ",";
+        json += "\"key_" + std::to_string(i) + "\":\"value_" + std::to_string(i) + "\"";
+    }
+    json += "}";
+    return json;
+}
+
+// Generate a flat JSON where a fraction of keys are duplicates
+static std::string generateFlatJsonWithDups(size_t numKeys, size_t numDups)
+{
+    std::string json = "{";
+    for (size_t i = 0; i < numKeys; ++i)
+    {
+        if (i > 0)
+            json += ",";
+        json += "\"key_" + std::to_string(i) + "\":\"value_" + std::to_string(i) + "\"";
+    }
+    // Append duplicate keys at the end
+    for (size_t i = 0; i < numDups; ++i)
+    {
+        json += ",\"key_" + std::to_string(i) + "\":\"dup_value_" + std::to_string(i) + "\"";
+    }
+    json += "}";
+    return json;
+}
+
+// Generate a JSON with arrays of objects
+static std::string generateArrayJson(size_t numElements)
+{
+    std::string json = R"({"data":[)";
+    for (size_t i = 0; i < numElements; ++i)
+    {
+        if (i > 0)
+            json += ",";
+        json += R"({"id":)" + std::to_string(i) + R"(,"name":"item_)" + std::to_string(i)
+                + R"(","active":true,"score":)" + std::to_string(i * 1.5) + "}";
+    }
+    json += "]}";
+    return json;
+}
+
+static const std::string LARGE_FLAT_JSON = generateFlatJson(100);
+static const std::string ARRAY_JSON = generateArrayJson(50);
+static const std::string LARGE_FLAT_WITH_DUPS = generateFlatJsonWithDups(100, 20);
+
+// =============================================================================
+// Group A: JSON construction (parse only — constructors no longer check dups)
+// =============================================================================
+
+static void BM_JsonConstruction_SmallFlat(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(SMALL_FLAT_JSON);
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(SMALL_FLAT_JSON.size()));
+}
+BENCHMARK(BM_JsonConstruction_SmallFlat);
+
+static void BM_JsonConstruction_MediumNested(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(MEDIUM_NESTED_JSON);
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(MEDIUM_NESTED_JSON.size()));
+}
+BENCHMARK(BM_JsonConstruction_MediumNested);
+
+static void BM_JsonConstruction_LargeFlat(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_FLAT_JSON);
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(LARGE_FLAT_JSON.size()));
+}
+BENCHMARK(BM_JsonConstruction_LargeFlat);
+
+static void BM_JsonConstruction_LargeDeeplyNested(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_DEEPLY_NESTED_JSON);
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(LARGE_DEEPLY_NESTED_JSON.size()));
+}
+BENCHMARK(BM_JsonConstruction_LargeDeeplyNested);
+
+static void BM_JsonConstruction_WithArrays(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(ARRAY_JSON);
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(ARRAY_JSON.size()));
+}
+BENCHMARK(BM_JsonConstruction_WithArrays);
+
+// =============================================================================
+// Group B: checkDuplicateKeys in isolation (detection only, no removal)
+// Measures the traversal cost of detecting duplicate keys.
+// =============================================================================
+
+static void BM_CheckDuplicateKeys_SmallFlat(benchmark::State& state)
+{
+    Json json(SMALL_FLAT_JSON);
+    for (auto _ : state)
+    {
+        auto result = json.checkDuplicateKeys();
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_CheckDuplicateKeys_SmallFlat);
+
+static void BM_CheckDuplicateKeys_MediumNested(benchmark::State& state)
+{
+    Json json(MEDIUM_NESTED_JSON);
+    for (auto _ : state)
+    {
+        auto result = json.checkDuplicateKeys();
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_CheckDuplicateKeys_MediumNested);
+
+static void BM_CheckDuplicateKeys_LargeFlat(benchmark::State& state)
+{
+    Json json(LARGE_FLAT_JSON);
+    for (auto _ : state)
+    {
+        auto result = json.checkDuplicateKeys();
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_CheckDuplicateKeys_LargeFlat);
+
+static void BM_CheckDuplicateKeys_LargeDeeplyNested(benchmark::State& state)
+{
+    Json json(LARGE_DEEPLY_NESTED_JSON);
+    for (auto _ : state)
+    {
+        auto result = json.checkDuplicateKeys();
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_CheckDuplicateKeys_LargeDeeplyNested);
+
+static void BM_CheckDuplicateKeys_WithArrays(benchmark::State& state)
+{
+    Json json(ARRAY_JSON);
+    for (auto _ : state)
+    {
+        auto result = json.checkDuplicateKeys();
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_CheckDuplicateKeys_WithArrays);
+
+// =============================================================================
+// Group C: removeDuplicateKeys in isolation
+// Measures the cost of finding AND removing duplicate keys.
+// Each iteration re-parses to restore the duplicates before removing them.
+// =============================================================================
+
+static void BM_RemoveDuplicateKeys_SmallNoDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(SMALL_FLAT_JSON);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_RemoveDuplicateKeys_SmallNoDups);
+
+static void BM_RemoveDuplicateKeys_SmallWithDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(SMALL_WITH_DUPS);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_RemoveDuplicateKeys_SmallWithDups);
+
+static void BM_RemoveDuplicateKeys_MediumWithDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(MEDIUM_WITH_DUPS);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_RemoveDuplicateKeys_MediumWithDups);
+
+static void BM_RemoveDuplicateKeys_LargeFlatNoDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_FLAT_JSON);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_RemoveDuplicateKeys_LargeFlatNoDups);
+
+static void BM_RemoveDuplicateKeys_LargeFlatWithDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_FLAT_WITH_DUPS);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_RemoveDuplicateKeys_LargeFlatWithDups);
+
+static void BM_RemoveDuplicateKeys_LargeDeeplyNested(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_DEEPLY_NESTED_JSON);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+BENCHMARK(BM_RemoveDuplicateKeys_LargeDeeplyNested);
+
+// =============================================================================
+// Group D: Full pipeline — construct + checkDuplicateKeys + removeDuplicateKeys
+// Simulates the pattern used by fileDriver (validate before writing to disk).
+// =============================================================================
+
+static void BM_FullPipeline_SmallFlat(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(SMALL_FLAT_JSON);
+        auto error = json.checkDuplicateKeys();
+        if (error)
+        {
+            json.removeDuplicateKeys();
+        }
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(SMALL_FLAT_JSON.size()));
+}
+BENCHMARK(BM_FullPipeline_SmallFlat);
+
+static void BM_FullPipeline_SmallWithDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(SMALL_WITH_DUPS);
+        auto error = json.checkDuplicateKeys();
+        if (error)
+        {
+            json.removeDuplicateKeys();
+        }
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(SMALL_WITH_DUPS.size()));
+}
+BENCHMARK(BM_FullPipeline_SmallWithDups);
+
+static void BM_FullPipeline_LargeFlatNoDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_FLAT_JSON);
+        auto error = json.checkDuplicateKeys();
+        if (error)
+        {
+            json.removeDuplicateKeys();
+        }
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(LARGE_FLAT_JSON.size()));
+}
+BENCHMARK(BM_FullPipeline_LargeFlatNoDups);
+
+static void BM_FullPipeline_LargeFlatWithDups(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_FLAT_WITH_DUPS);
+        auto error = json.checkDuplicateKeys();
+        if (error)
+        {
+            json.removeDuplicateKeys();
+        }
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(LARGE_FLAT_WITH_DUPS.size()));
+}
+BENCHMARK(BM_FullPipeline_LargeFlatWithDups);
+
+static void BM_FullPipeline_LargeDeeplyNested(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        Json json(LARGE_DEEPLY_NESTED_JSON);
+        auto error = json.checkDuplicateKeys();
+        if (error)
+        {
+            json.removeDuplicateKeys();
+        }
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(LARGE_DEEPLY_NESTED_JSON.size()));
+}
+BENCHMARK(BM_FullPipeline_LargeDeeplyNested);
+
+// =============================================================================
+// Group E: Scaling — compare operations with increasing number of flat keys
+// =============================================================================
+
+// E1: Construction only (parse) — scales with document size
+static void BM_Construction_Scaling(benchmark::State& state)
+{
+    const auto numKeys = static_cast<size_t>(state.range(0));
+    const std::string jsonStr = generateFlatJson(numKeys);
+
+    for (auto _ : state)
+    {
+        Json json(jsonStr);
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(jsonStr.size()));
+    state.SetLabel(std::to_string(numKeys) + " keys");
+}
+BENCHMARK(BM_Construction_Scaling)->RangeMultiplier(2)->Range(8, 1024);
+
+// E2: checkDuplicateKeys — detection cost scales with key count (no dups)
+static void BM_CheckDuplicateKeys_Scaling(benchmark::State& state)
+{
+    const auto numKeys = static_cast<size_t>(state.range(0));
+    const std::string jsonStr = generateFlatJson(numKeys);
+    Json json(jsonStr);
+
+    for (auto _ : state)
+    {
+        auto result = json.checkDuplicateKeys();
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetLabel(std::to_string(numKeys) + " keys");
+}
+BENCHMARK(BM_CheckDuplicateKeys_Scaling)->RangeMultiplier(2)->Range(8, 1024);
+
+// E3: removeDuplicateKeys on clean docs (no dups to remove)
+static void BM_RemoveDuplicateKeys_ScalingNoDups(benchmark::State& state)
+{
+    const auto numKeys = static_cast<size_t>(state.range(0));
+    const std::string jsonStr = generateFlatJson(numKeys);
+
+    for (auto _ : state)
+    {
+        Json json(jsonStr);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetLabel(std::to_string(numKeys) + " keys");
+}
+BENCHMARK(BM_RemoveDuplicateKeys_ScalingNoDups)->RangeMultiplier(2)->Range(8, 1024);
+
+// E4: removeDuplicateKeys with 20% duplicate keys
+static void BM_RemoveDuplicateKeys_ScalingWithDups(benchmark::State& state)
+{
+    const auto numKeys = static_cast<size_t>(state.range(0));
+    const size_t numDups = numKeys / 5; // 20% duplicates
+    const std::string jsonStr = generateFlatJsonWithDups(numKeys, numDups);
+
+    for (auto _ : state)
+    {
+        Json json(jsonStr);
+        auto removed = json.removeDuplicateKeys();
+        benchmark::DoNotOptimize(removed);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetLabel(std::to_string(numKeys) + " keys + " + std::to_string(numDups) + " dups");
+}
+BENCHMARK(BM_RemoveDuplicateKeys_ScalingWithDups)->RangeMultiplier(2)->Range(8, 1024);
+
+// E5: Full pipeline scaling (construct + check + conditional remove)
+static void BM_FullPipeline_ScalingWithDups(benchmark::State& state)
+{
+    const auto numKeys = static_cast<size_t>(state.range(0));
+    const size_t numDups = numKeys / 5;
+    const std::string jsonStr = generateFlatJsonWithDups(numKeys, numDups);
+
+    for (auto _ : state)
+    {
+        Json json(jsonStr);
+        auto error = json.checkDuplicateKeys();
+        if (error)
+        {
+            json.removeDuplicateKeys();
+        }
+        benchmark::DoNotOptimize(json);
+    }
+    state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(jsonStr.size()));
+    state.SetLabel(std::to_string(numKeys) + " keys + " + std::to_string(numDups) + " dups");
+}
+BENCHMARK(BM_FullPipeline_ScalingWithDups)->RangeMultiplier(2)->Range(8, 1024);

--- a/src/engine/source/base/include/base/json.hpp
+++ b/src/engine/source/base/include/base/json.hpp
@@ -824,6 +824,14 @@ public:
      */
     std::optional<base::Error> checkDuplicateKeys() const;
 
+    /**
+     * @brief Remove duplicate keys from the Json document, keeping the first occurrence.
+     * Operates recursively on nested objects and arrays.
+     *
+     * @return size_t The number of duplicate keys that were removed.
+     */
+    size_t removeDuplicateKeys();
+
     /************************************************************************************/
     // Setters
     /************************************************************************************/

--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -1248,32 +1248,26 @@ std::optional<base::Error> Json::validate(const Json& schema) const
 
 std::optional<base::Error> Json::checkDuplicateKeys() const
 {
-    // TODO: This should be checked by the library, or make a better validator.
-    // As stated in rapidjson docs, if an object contains duplicated memebers,
-    // equality comparator always returns false, for said member or for the whole
-    // object if it contains duplicated members.
-
-    // If equality between a member and itself is false, then it is a duplicate or
-    // contains duplicated members.
-
-    // Exception is not throw when repeated keys have the same value. Check this operator == in
-    // https://miloyip.github.io/rapidjson/classrapidjson_1_1_generic_value.html#afbdbc9cbc3b59feb5a28d5bfee97dbb3
-
     auto validateDuplicatedKeys = [](const rapidjson::Value& value, auto& recurRef) -> void
     {
         if (value.IsObject())
         {
+            std::unordered_set<std::string> seen;
             for (auto it = value.MemberBegin(); it != value.MemberEnd(); ++it)
             {
-                if (value[it->name.GetString()] != value[it->name.GetString()])
+                std::string key {it->name.GetString(), it->name.GetStringLength()};
+                if (!seen.insert(key).second)
                 {
-                    throw std::runtime_error(fmt::format("Unable to build json document because there is a duplicated "
-                                                         "key '{}', or a duplicated key inside object '{}'.",
-                                                         it->name.GetString(),
-                                                         it->name.GetString()));
+                    throw std::runtime_error(fmt::format("Duplicate key '{}' found in JSON object.", key));
                 }
-
                 recurRef(it->value, recurRef);
+            }
+        }
+        else if (value.IsArray())
+        {
+            for (auto it = value.Begin(); it != value.End(); ++it)
+            {
+                recurRef(*it, recurRef);
             }
         }
     };
@@ -1282,13 +1276,7 @@ std::optional<base::Error> Json::checkDuplicateKeys() const
     {
         if (m_document.IsObject())
         {
-            const rapidjson::Value& value = m_document;
-
-            if (value != value)
-            {
-                return base::Error {"Unable to build json document because there is a duplicated key"};
-            }
-            validateDuplicatedKeys(value, validateDuplicatedKeys);
+            validateDuplicatedKeys(m_document, validateDuplicatedKeys);
         }
     }
     catch (const std::exception& e)

--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -51,12 +51,6 @@ Json::Json(const char* json)
         throw std::runtime_error(
             fmt::format("JSON document could not be parsed: {}", rapidjson::GetParseError_En(result.Code())));
     }
-
-    auto error = checkDuplicateKeys();
-    if (error)
-    {
-        throw std::runtime_error(fmt::format("JSON document has duplicated keys: {}", error->message));
-    }
 }
 
 Json::Json(std::string_view json)
@@ -67,12 +61,6 @@ Json::Json(std::string_view json)
     {
         throw std::runtime_error(
             fmt::format("JSON document could not be parsed: {}", rapidjson::GetParseError_En(result.Code())));
-    }
-
-    auto error = checkDuplicateKeys();
-    if (error)
-    {
-        throw std::runtime_error(fmt::format("JSON document has duplicated keys: {}", error->message));
     }
 }
 
@@ -1285,6 +1273,44 @@ std::optional<base::Error> Json::checkDuplicateKeys() const
     }
 
     return std::nullopt;
+}
+
+size_t Json::removeDuplicateKeys()
+{
+    size_t removedCount = 0;
+
+    auto deduplicate = [&removedCount](rapidjson::Value& value, auto& recurRef) -> void
+    {
+        if (value.IsObject())
+        {
+            std::unordered_set<std::string> seen;
+            for (auto it = value.MemberBegin(); it != value.MemberEnd();)
+            {
+                std::string key {it->name.GetString(), it->name.GetStringLength()};
+                if (!seen.insert(key).second)
+                {
+                    it = value.EraseMember(it);
+                    ++removedCount;
+                }
+                else
+                {
+                    recurRef(it->value, recurRef);
+                    ++it;
+                }
+            }
+        }
+        else if (value.IsArray())
+        {
+            for (auto it = value.Begin(); it != value.End(); ++it)
+            {
+                recurRef(*it, recurRef);
+            }
+        }
+    };
+
+    deduplicate(m_document, deduplicate);
+
+    return removedCount;
 }
 
 bool Json::eraseIfKey(const std::function<bool(const std::string&)>& func, bool recursive, const std::string& path)

--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -2939,77 +2939,72 @@ INSTANTIATE_TEST_SUITE_P(Json,
                                            isEmptyT(false, R"({"a":false})", "/a/0"),
                                            isEmptyT(false, R"({"a":null})", "/a/0")));
 
-class JsonValidParamTest : public ::testing::TestWithParam<std::pair<bool, std::string>>
+class JsonDuplicateKeyTest : public ::testing::TestWithParam<std::tuple<std::string, size_t, std::string>>
 {
 };
 
-TEST_P(JsonValidParamTest, CheckDuplicateKey)
+TEST_P(JsonDuplicateKeyTest, CheckAndRemoveDuplicateKeys)
 {
-    const auto& param = GetParam();
-    const auto& verify = param.first;
-    const auto& jsonInput = param.second;
+    const auto& [jsonInput, expectedDups, expectedJson] = GetParam();
 
-    if (verify)
+    // Construction should NOT throw even with duplicates
+    json::Json doc {jsonInput.c_str()};
+
+    // checkDuplicateKeys detects them
+    auto error = doc.checkDuplicateKeys();
+    if (expectedDups > 0)
     {
-        ASSERT_NO_THROW(auto result = json::Json {jsonInput.c_str()});
+        ASSERT_TRUE(error.has_value());
     }
     else
     {
-        ASSERT_ANY_THROW(auto result = json::Json {jsonInput.c_str()});
+        ASSERT_FALSE(error.has_value());
+    }
+
+    // removeDuplicateKeys removes them and returns count
+    size_t removed = doc.removeDuplicateKeys();
+    ASSERT_EQ(removed, expectedDups);
+
+    // After removal, no more duplicates
+    ASSERT_FALSE(doc.checkDuplicateKeys().has_value());
+
+    // Verify resulting JSON matches expected
+    if (expectedDups > 0)
+    {
+        json::Json expected {expectedJson.c_str()};
+        ASSERT_EQ(doc, expected);
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(CheckDuplicateKey,
-                         JsonValidParamTest,
-                         ::testing::Values(std::make_pair(true, R"({
-        "check": "$event.id == 2"
-        })"),
-                                           std::make_pair(false, R"({
-        "a": 1,
-        "b": 2,
-        "c": {
-            "c": 3,
-            "c": 4
-        }
-        })"),
-                                           std::make_pair(false, R"({
-        "a": 1,
-        "b": 3,
-        "a": 2
-        })"),
-                                           std::make_pair(false, R"({
-        "b": 1,
-        "a": 3,
-        "a": 2
-        })"),
-                                           std::make_pair(false, R"({
-        "a": 3,
-        "a": 2
-        })"),
-                                           std::make_pair(false, R"({
-        "check": "$event == 2",
-        "check": "$event.id == 2"
-        })"),
-                                           std::make_pair(false, R"({
-        "level": "5",
-        "level": "5"
-        })"),
-                                           std::make_pair(false, R"({
-        "a": {"x": 1},
-        "a": {"x": 1}
-        })"),
-                                           std::make_pair(false, R"({
-        "items": [
-            {"id": 1, "id": 2},
-            {"name": "foo"}
-        ]
-        })"),
-                                           std::make_pair(false, R"({
-        "items": [
-            {"name": "foo"},
-            {"id": 1, "id": 1}
-        ]
-        })")));
+INSTANTIATE_TEST_SUITE_P(
+    CheckDuplicateKey,
+    JsonDuplicateKeyTest,
+    ::testing::Values(
+        // No duplicates
+        std::make_tuple(R"({"check": "$event.id == 2"})", size_t(0), R"({"check": "$event.id == 2"})"),
+        // Nested duplicate
+        std::make_tuple(R"({"a": 1, "b": 2, "c": {"c": 3, "c": 4}})", size_t(1), R"({"a":1,"b":2,"c":{"c":3}})"),
+        // Root duplicate (a appears twice)
+        std::make_tuple(R"({"a": 1, "b": 3, "a": 2})", size_t(1), R"({"a":1,"b":3})"),
+        // Root duplicate (different order)
+        std::make_tuple(R"({"b": 1, "a": 3, "a": 2})", size_t(1), R"({"b":1,"a":3})"),
+        // Only duplicates
+        std::make_tuple(R"({"a": 3, "a": 2})", size_t(1), R"({"a":3})"),
+        // Duplicate with complex values
+        std::make_tuple(
+            R"({"check": "$event == 2", "check": "$event.id == 2"})", size_t(1), R"({"check":"$event == 2"})"),
+        // Duplicate with same values
+        std::make_tuple(R"({"level": "5", "level": "5"})", size_t(1), R"({"level":"5"})"),
+        // Duplicate with object values
+        std::make_tuple(R"({"a": {"x": 1}, "a": {"x": 1}})", size_t(1), R"({"a":{"x":1}})"),
+        // Duplicate inside array element
+        std::make_tuple(R"({"items": [{"id": 1, "id": 2}, {"name": "foo"}]})",
+                        size_t(1),
+                        R"({"items":[{"id":1},{"name":"foo"}]})"),
+        // Duplicate inside second array element
+        std::make_tuple(R"({"items": [{"name": "foo"}, {"id": 1, "id": 1}]})",
+                        size_t(1),
+                        R"({"items":[{"name":"foo"},{"id":1}]})")));
 
 // ---------- Functors (templated-friendly) ----------
 struct Identity

--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -2989,6 +2989,26 @@ INSTANTIATE_TEST_SUITE_P(CheckDuplicateKey,
                                            std::make_pair(false, R"({
         "check": "$event == 2",
         "check": "$event.id == 2"
+        })"),
+                                           std::make_pair(false, R"({
+        "level": "5",
+        "level": "5"
+        })"),
+                                           std::make_pair(false, R"({
+        "a": {"x": 1},
+        "a": {"x": 1}
+        })"),
+                                           std::make_pair(false, R"({
+        "items": [
+            {"id": 1, "id": 2},
+            {"name": "foo"}
+        ]
+        })"),
+                                           std::make_pair(false, R"({
+        "items": [
+            {"name": "foo"},
+            {"id": 1, "id": 1}
+        ]
         })")));
 
 // ---------- Functors (templated-friendly) ----------

--- a/src/engine/test/helper_tests/helpers_description/transformation/merge_key_in.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/merge_key_in.yml
@@ -6,6 +6,8 @@ metadata:
     Merge in target field value with the content of some key in the specified object, where the key is specified with a reference to another field.
     The object parameter must be a definition object or a reference to a field containing the object.
     This helper function is typically used in the map stage.
+    When a key exists in both the source and the target, the source value overwrites the target value entirely (no recursion into nested structures).
+    If the source contains duplicate keys, all occurrences are iterated and the last duplicate value is the one that remains in the target.
 
   keywords:
     - undefined

--- a/src/engine/test/helper_tests/helpers_description/transformation/merge_recursive_key_in.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/merge_recursive_key_in.yml
@@ -5,9 +5,11 @@ metadata:
   description: |
     Recursively merge the target field value with the content of a specified key in the given object.
     The key is identified through a reference to another field.
-    If the key's value contains nested objects, the merge operation is applied recursively, combining all levels of the structure.
+    If the key's value contains nested objects or arrays, the merge operation is applied recursively, combining all levels of the structure.
+    For primitive values (strings, numbers, booleans), when a key exists in both source and target, the source value overwrites the target value.
     The object parameter must be a definition object or a reference to a field containing the object.
     This helper function is typically used in the map stage to ensure deep merging of complex objects.
+    If the source contains duplicate keys, all occurrences are iterated and the last duplicate value is the one that remains in the target.
 
   keywords:
     - undefined


### PR DESCRIPTION
## Description

Improve duplicate key handling in the `Json` class by decoupling detection from construction and adding a new removal method.

Previously, `Json::checkDuplicateKeys()` was called inside both constructors (`const char*` and `std::string_view`), throwing an exception if duplicates were found. This made construction expensive (full DOM traversal on every parse) and prevented callers from choosing how to handle duplicates. Additionally, the old detection logic relied on a RapidJSON `operator==` quirk that failed to detect duplicates with identical values (e.g., `{"level": "5", "level": "5"}`).

### Implications

- **API**: Queries that submit JSON with duplicate keys will continue failing as before 
- **Event processing**: Since constructors no longer reject duplicates, it is now possible to generate an event containing duplicate keys during pipeline processing. If this happens, indexation will fail and an error log will be printed in the manager.
- **Merge behavior change**: When merging into a destination that already contains a key, the second (source) value is kept. This can be observed in the evidence logs.
- **Future work**: A helper function (`remove_duplicated_keys`) will be implemented to allow decoders to explicitly strip duplicate keys from events before indexation.

Closes #36151

## Proposed Changes

- **Remove `checkDuplicateKeys()` from constructors**: `Json(const char*)` and `Json(std::string_view)` no longer validate for duplicate keys at construction time. This eliminates the O(n) traversal overhead on every parse. Call sites that need validation (e.g., `fileDriver`) continue calling `checkDuplicateKeys()` explicitly.

- **Rewrite `checkDuplicateKeys()` detection logic**: Replace the old RapidJSON `operator==` self-comparison trick with explicit tracking using `std::unordered_set<std::string>`. This correctly detects all duplicates, including those with identical values. Also adds recursion into arrays (previously missing).

- **Add `removeDuplicateKeys()` method**: New mutating method that recursively removes duplicate keys from the document, keeping the first occurrence. Returns `size_t` count of removed keys. Uses `value.EraseMember(it)` for in-place removal.

- **Add comprehensive benchmarks** (`json_bench.cpp`): 5 benchmark groups measuring construction, detection, removal, full pipeline, and scaling behavior from 8 to 1024 keys with and without duplicates.

- **Update unit tests**: Replace the old `JsonValidParamTest` (which asserted constructor throws) with `JsonDuplicateKeyTest` that verifies: construction succeeds with duplicates, `checkDuplicateKeys()` detects them, `removeDuplicateKeys()` returns correct count and produces expected output. Expanded from 6 to 10 test cases covering nested objects, arrays, and edge cases.

- **Update helper function descriptions**: `merge_key_in` and `merge_recursive_key_in` descriptions now document behavior with duplicate keys (last value wins) and overwrite semantics.

- **Schema changes**: Remove unused `enrichments.indicator.*` fields from `engine-schema.json` and `wazuh-decoders.json`. Change `threat.enrichments` and `wazuh.threat.enrichments` type from `nested` to `object`.

- **Documentation update**: `ref-helper-functions.md` updated to reflect `index_unclassified_events()` target field restriction to `wazuh.integration.decoders`.

## Results and Evidence

Benchmark results (debug build, 32-core machine):
```
BM_CheckDuplicateKeys_SmallFlat            1166 ns
BM_RemoveDuplicateKeys_SmallNoDups         3933 ns
BM_RemoveDuplicateKeys_SmallWithDups       3673 ns
BM_FullPipeline_SmallFlat                  3925 ns
BM_FullPipeline_SmallWithDups              6707 ns
```

All 10 unit tests pass:
```
[  PASSED  ] 10 tests.
```



### Merge duplicate keys

**Custom ruleset**

```yml
---
name: "decoder/core-wazuh-message/0"
metadata:
  author: "Wazuh, Inc."
  date: "2026-05-29T19:37:22Z"
  description: "Base decoder to process Wazuh message format, parses location part\
    \ and enriches the events that comes from a Wazuh agent with the host information."
  documentation: ""
  modified: "2026-05-29T19:37:22Z"
  references:
  - "https://documentation.wazuh.com/"
  supports: []
  title: "Wazuh message decoder"
normalize:
- map:
  - _tmp_json: "parse_json($event.original)"
enabled: true
id: "9bdccbb2-2203-4d93-81e2-117a2529cb90"
---
name: "decoder/child/0"
enabled: true
metadata:
  title: "Placeholder Decoder"
  description: "This is a placeholder decoder. Please update the fields accordingly."
  author: "User"
  references: []
  documentation: ""
  supports: []
  date: "2026-05-29T19:39:01Z"
  modified: "2026-05-29T19:49:42Z"
parents:
- "decoder/core-wazuh-message/0"
normalize:
- map:
  - event.category: "category A"
  - event: "merge($_tmp_json)"
id: "16de2a01-c546-4d54-aac2-795976d7c031"

```

**Agent side**
```bash
echo '{"kind": "K A", "kind": "K B"}' >> /var/ossec/logs/active-responses.log 
```

**Indexed event**

<img width="4244" height="1341" alt="Pasted image" src="https://github.com/user-attachments/assets/9f2c7e39-e230-4c94-ab75-9ce39d2b53b3" />


```json
{
  "_index": ".ds-wazuh-events-v5-other-000001",
  "_id": "cN9VdZ4BEarxTl8AgiRH",
  "_version": 1,
  "_score": null,
  "_source": {
    "wazuh": {
      "protocol": {
        "queue": 49,
        "location": "/var/ossec/logs/active-responses.log"
      },
      "agent": {
        "host": {
          "os": {
            "name": "Ubuntu",
            "version": "22.04.5 LTS (Jammy Jellyfish)",
            "platform": "ubuntu",
            "type": "linux"
          },
          "architecture": "x86_64",
          "hostname": "wazuh-agent-5x-ubuntu"
        },
        "id": "001",
        "name": "wazuh-agent-5x-ubuntu",
        "version": "v5.0.0",
        "groups": [
          "default"
        ]
      },
      "cluster": {
        "name": "wazuh",
        "node": "node01"
      },
      "event": {
        "id": "33b270f1-537f-45aa-afa9-1128eee694e1"
      },
      "integration": {
        "category": "other",
        "name": "test",
        "decoders": [
          "decoder/core-wazuh-message/0",
          "decoder/child/0"
        ]
      },
      "space": {
        "name": "custom"
      }
    },
    "event": {
      "original": "{\"kind\": \"K A\", \"kind\": \"K B\"}",
      "category": "test category 2",
      "kind": "K B"
    },
    "@timestamp": "2026-05-29T20:03:07.836Z"
  },
  "fields": {
    "@timestamp": [
      "2026-05-29T20:03:07.836Z"
    ]
  },
  "sort": [
    1780084987836
  ]
}
```


### Fail duplicate index

**Custom ruleset**

```yml
---
name: "decoder/child/0"
enabled: true
metadata:
  title: "Placeholder Decoder"
  description: "This is a placeholder decoder. Please update the fields accordingly."
  author: "User"
  references: []
  documentation: ""
  supports: []
  date: "2026-05-29T19:39:01Z"
  modified: "2026-05-29T23:20:31Z"
parents:
- "decoder/core-wazuh-message/0"
normalize:
- map:
  - user: "$_tmp_json"
id: "16de2a01-c546-4d54-aac2-795976d7c031"
```

**Agent side**
```bash
echo '{"name":"test", "name":"test2"}' >> /var/ossec/logs/active-responses.log 
```

**Manager log**
```
2026/05/29 23:25:19 wazuh-manager-analysisd (indexer-connector): WARNING: Error indexing document (type mapper_parsing_exception - reason: 'failed to parse' - caused by: json_parse_exception - 'Duplicate field 'name'
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 711]') - Associated event: {"create":{"_index":"wazuh-events-v5-other"}}
{"wazuh":{"protocol":{"queue":49,"location":"/var/ossec/logs/active-responses.log"},"agent":{"host":{"os":{"name":"Ubuntu","version":"22.04.5 LTS (Jammy Jellyfish)","platform":"ubuntu","type":"linux"},"architecture":"x86_64","hostname":"wazuh-agent-5x-ubuntu"},"id":"001","name":"wazuh-agent-5x-ubuntu","version":"v5.0.0","groups":["default"]},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"1076f861-75c0-49a1-b282-d947f52e310d"},"integration":{"category":"other","name":"test","decoders":["decoder/core-wazuh-message/0","decoder/child/0"]},"space":{"name":"custom"}},"event":{"original":"{\"name\":\"test\", \"name\":\"test2\"}"},"@timestamp":"2026-05-29T23:25:14.788Z","user":{"name":"test","name":"test2"}}
```



### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-engine` binary (Linux)
- Engine ruleset schemas (`engine-schema.json`, `wazuh-decoders.json`)

### Configuration Changes

N/A

### Tests Introduced

- `JsonDuplicateKeyTest.CheckAndRemoveDuplicateKeys` -- 10 parameterized GoogleTest cases covering:
  - No duplicates (baseline)
  - Nested object duplicates
  - Root-level duplicates (various orders)
  - Duplicates with identical values
  - Duplicates with complex object values
  - Duplicates inside array elements

- `json_bench.cpp` -- Google Benchmark suite with 5 groups:
  - Group A: Construction (parse only)
  - Group B: `checkDuplicateKeys` in isolation
  - Group C: `removeDuplicateKeys` (with/without duplicates)
  - Group D: Full pipeline (construct + check + remove)
  - Group E: Scaling (8-1024 keys)

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
