### PR TITLE
Treat the absence of the hash document as expected, not an error

### DIFF
--- a/src/engine/source/iocsync/src/iocsync.cpp
+++ b/src/engine/source/iocsync/src/iocsync.cpp
@@ -500,7 +500,7 @@ void IocSync::synchronize()
         const auto remoteTypeHashesOpt = getRemoteHashesFromRemote();
         if (!remoteTypeHashesOpt.has_value())
         {
-            LOG_INFO("[IOC::Sync] IOC syncronization skipped because the IOC consumer is not idle (data is being "
+            LOG_INFO("[IOC::Sync] IOC syncronization skipped because the IOC consumer is not idle (data/hash is being "
                      "updated in the indexer)");
             return;
         }

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -906,10 +906,11 @@ WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consu
         return std::nullopt;
     }
 
+    // Hashes document not found, is expected on fresh installs without any IOC indexed yet — return empty map
     if (!hashesDoc.has_value())
     {
-        throw IndexerConnectorException(
-            fmt::format("Hash document '{}' not found in index '{}'", IOC_HASHES_DOC_ID, IOC_INDEX));
+        LOG_DEBUG("[indexer-connector] Hash document '{}' not found in index '{}'", IOC_HASHES_DOC_ID, IOC_INDEX);
+        return std::nullopt;
     }
 
     return parseIocHashesDocument(*hashesDoc);

--- a/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
+++ b/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
@@ -810,7 +810,7 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesNoDocumentThrows)
     EXPECT_CALL(*mock, search(_, _, _, _, _, _)).WillOnce(Return(hits));
 
     auto connector = makeConnector();
-    EXPECT_THROW(connector->getIocTypeHashes(), IndexerConnectorException);
+    EXPECT_EQ(connector->getIocTypeHashes(), std::nullopt);
 }
 
 TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesFlatFormat)


### PR DESCRIPTION
Closes #36251

## Description

On fresh installations of the manager — when no IOC has been  (generated) yet — the `__ioc_type_hashes__` document does not exist in the `wazuh-threatintel-enrichments` index. The previous implementation in `WIndexerConnector::getIocTypeHashes` treated this case as an error and threw an `IndexerConnectorException`. The retry logic in `IocSync` then surfaced this expected condition as three `WARNING` log lines plus a final `WARNING` reporting that the synchronization cycle failed after 3 attempts.

These warnings were observed during deployability tests (DTT3) across all supported Manager-linux platforms (amazon-2023-amd64, amazon-2023-arm64, ubuntu-24-amd64, ubuntu-24-arm64) on freshly installed 5.0.0-beta1 AIO deployments, despite the absence of the hash document being an expected state for a fresh install.

## Proposed Changes

- `WIndexerConnector::getIocTypeHashes`: when the hash document is missing, no longer throw an exception. Log the event at `DEBUG` level and return `std::nullopt`, which is the same return value already used to signal "consumer not idle" and is already handled by the caller as a skip-cycle condition.
- `IocSync::synchronize`: refine the `LOG_INFO` message so it reflects both possible reasons the remote hashes are unavailable (data **or** hash is being updated in the indexer).

The caller (`IocSync::synchronize` at `src/engine/source/iocsync/src/iocsync.cpp:500`) already checks `remoteTypeHashesOpt.has_value()` and skips the cycle without surfacing a warning, so the new return path integrates cleanly with existing logic.

### Results and Evidence

N/A

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-engine` (manager target, Linux)

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
