### PR TITLE
Reduce log noise when engine has no synchronized ruleset

### DIFF
--- a/docs/ref/modules/engine/README.md
+++ b/docs/ref/modules/engine/README.md
@@ -2486,7 +2486,7 @@ Most Engine messages use the `wazuh-manager-analysisd` component tag, but some s
 2026/04/14 20:07:44 wazuh-manager-analysisd: INFO: Indexer Connector initialized.
 2026/04/14 20:09:16 wazuh-manager-analysisd: INFO: Archiver initialized.
 2026/04/14 20:09:16 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
-2026/04/14 20:09:16 wazuh-manager-analysisd: INFO: Engine started and ready to process events.
+2026/04/14 20:09:16 wazuh-manager-analysisd: INFO: Engine started.
 ```
 
 Warning and error lines include a context tag in brackets that identifies the internal

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -879,8 +879,6 @@ int main(int argc, char* argv[])
                 }
             };
 
-            // Log initial state synchronously before the scheduler starts.
-            reportRouteStatus();
 
             // Async Synchronize on startup
             scheduler->scheduleTask(

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -1,4 +1,4 @@
-#include <atomic>
+#include <algorithm>
 #include <csignal>
 #include <exception>
 #include <filesystem>
@@ -841,11 +841,47 @@ int main(int argc, char* argv[])
         }
         else
         {
-            LOG_INFO("Engine started and ready to process events.");
+            LOG_INFO("Engine started.");
         }
 
         if (enableProcessing)
         {
+            // Helper to check if the orchestrator has any enabled route.
+            const auto hasEnabledRoutes = [&orchestrator]()
+            {
+                const auto entries = orchestrator->getEntries();
+                return std::any_of(entries.begin(),
+                                   entries.end(),
+                                   [](const auto& e) { return e.status() == router::env::State::ENABLED; });
+            };
+
+            // Tracks the last reported state. nullopt = no prior report, so the
+            // first observation always logs.
+            auto lastWarned = std::make_shared<std::optional<bool>>();
+
+            // Logs only on state transitions (no routes <-> at least one enabled route).
+            const auto reportRouteStatus = [hasEnabledRoutes, lastWarned]()
+            {
+                const bool shouldWarn = !hasEnabledRoutes();
+                if (*lastWarned == shouldWarn)
+                {
+                    return;
+                }
+                *lastWarned = shouldWarn;
+                if (shouldWarn)
+                {
+                    LOG_WARNING("[CMSync] No active routes available. Incoming events will be discarded "
+                                "until content synchronization completes.");
+                }
+                else
+                {
+                    LOG_INFO("[CMSync] Event processing is now active.");
+                }
+            };
+
+            // Log initial state synchronously before the scheduler starts.
+            reportRouteStatus();
+
             // Async Synchronize on startup
             scheduler->scheduleTask(
                 "cm-sync-task",
@@ -854,12 +890,19 @@ int main(int argc, char* argv[])
                                        .CPUPriority = 0,
                                        .taskFunction = [=]()
                                        {
+                                           // Detect external loss of routes between sync runs
+                                           // (e.g., manual route deletion).
+                                           reportRouteStatus();
+
                                            // Expand the router worker pool before the initial
                                            // content synchronization. This ensures the initial sync
                                            // mutates the complete worker pool instead of only the
                                            // primary worker.
                                            orchestrator->expandWorkerPool();
                                            cmSyncService->synchronize();
+
+                                           // Detect recovery (or re-loss) after sync.
+                                           reportRouteStatus();
                                        }});
             scheduler->scheduleTaskFirst("cm-sync-task");
 

--- a/src/engine/source/router/src/router.cpp
+++ b/src/engine/source/router/src/router.cpp
@@ -229,7 +229,7 @@ void Router::ingest(base::Event&& event)
 
     if (!processed && event)
     {
-        LOG_WARNING("Event not processed: {}", event->str());
+        LOG_TRACE("Event not processed: {}", event->str());
     }
 }
 

--- a/src/engine/test/acceptance_test/acceptance_test.sh
+++ b/src/engine/test/acceptance_test/acceptance_test.sh
@@ -161,7 +161,7 @@ wait_for_ready() {
 
     # 1. Wait for the "ready" log line
     while [[ $SECONDS -lt $deadline ]]; do
-        if grep -q "Engine started and ready to process events" "${ANALYSISD_LOG}" 2>/dev/null; then
+        if grep -q "Engine started." "${ANALYSISD_LOG}" 2>/dev/null; then
             log "Engine ready (log detected)."
             break
         fi


### PR DESCRIPTION
## Description

When wazuh-manager is installed for the first time and the initial content synchronization has not completed yet, the engine receives events before any ruleset/policy is available. Previously, every incoming event produced a WARNING-level log:

```
WARNING: Event not processed: { ... }
```


This created excessive log noise (potentially thousands of lines per second) during the window between engine startup and the first successful cm-sync-task.

## Proposed Changes

- Downgraded the per-event "not processed" message from LOG_WARNING to LOG_TRACE. This ensures individual discarded events are only visible when explicitly tracing, eliminating log spam in production.
- Added startup route check: Before scheduling the cm-sync-task, the engine inspects whether the orchestrator already has enabled routes (restored from a previous session). The warning is only emitted if no routes are active.

- Single state-transition WARNING ([CMSync] No active routes available...): Logged once when the engine detects there are no active routes — either at startup or after a sync that results in route loss.

- Single recovery INFO ([CMSync] Event processing is now active.): Logged once when the cm-sync-task successfully synchronizes content and routes become enabled.

- Atomic flag (eventDiscardWarned): Uses std::atomic<bool>::exchange() to guarantee each state-transition message is emitted exactly once, regardless of how many sync iterations run concurrently.

### Results and Evidence

#### After delete rm -rf /var/wazuh-manager/data/store/router/router/0 and restart
```
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Store initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: IOC initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: GEO initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Schema initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: HLP initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Indexer Connector initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Stream logger initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Builder initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized (index: wazuh-events-raw-v5).
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: 2000.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Dumper Events initialized.
2026/05/22 20:12:27 wazuh-manager-analysisd: INFO: Metrics stream logging enabled (interval: 1 seconds, on-demand channel creation).
2026/05/22 20:12:28 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/05/22 20:12:28 wazuh-manager-analysisd: INFO: Engine started.
2026/05/22 20:12:28 wazuh-manager-analysisd: WARNING: [CMSync] No active routes available. Incoming events will be discarded until content synchronization completes.
2026/05/22 20:12:28 wazuh-manager-analysisd: INFO: Scheduler started.
2026/05/22 20:12:28 wazuh-manager-analysisd: INFO: [CMSync] Changes detected for space 'standard', updating...
2026/05/22 20:12:31 wazuh-manager-analysisd: INFO: [CMSync] Successfully synchronized space 'standard'
2026/05/22 20:12:31 wazuh-manager-analysisd: INFO: [CMSync] Changes detected for space 'custom', updating...
2026/05/22 20:12:31 wazuh-manager-analysisd: INFO: [CMSync] Successfully synchronized space 'custom'
2026/05/22 20:12:31 wazuh-manager-analysisd: INFO: [CMSync] Event processing is now active.
```

#### Normal start without logs
```
2026/05/22 20:24:08 wazuh-manager-analysisd: INFO: Store initialized.
2026/05/22 20:24:08 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/05/22 20:24:08 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/05/22 20:24:08 wazuh-manager-analysisd: INFO: IOC initialized.
2026/05/22 20:24:08 wazuh-manager-analysisd: INFO: GEO initialized.
2026/05/22 20:24:08 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Schema initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: HLP initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Indexer Connector initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Stream logger initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Builder initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized.
2026/05/22 20:24:09 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized (index: wazuh-events-raw-v5).
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: 2000.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Dumper Events initialized.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Metrics stream logging enabled (interval: 1 seconds, on-demand channel creation).
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Engine started.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: [CMSync] Event processing is now active.
2026/05/22 20:24:10 wazuh-manager-analysisd: INFO: Scheduler started.
```


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
