### PR TITLE
Prevent Syscollector and SCA use-after-free on modulesd shutdown

### DIFF
--- a/src/wazuh_modules/sca/include/sca.h
+++ b/src/wazuh_modules/sca/include/sca.h
@@ -52,6 +52,7 @@ EXPORTED void sca_start(const struct wm_sca_t* sca_config);
 EXPORTED void sca_init();
 
 EXPORTED void sca_stop();
+EXPORTED void sca_release_resources();
 
 EXPORTED void sca_set_wm_exec(wm_exec_callback_t wm_exec_callback);
 
@@ -85,6 +86,7 @@ typedef void (*sca_init_func)();
 typedef void (*sca_start_func)(const struct wm_sca_t* sca_config);
 
 typedef void (*sca_stop_func)();
+typedef void (*sca_release_resources_func)();
 
 typedef void (*sca_set_wm_exec_func)(
     int (*wm_exec_callback)(char* command, char** output, int* exitcode, int secs, const char* add_path));

--- a/src/wazuh_modules/sca/include/sca.hpp
+++ b/src/wazuh_modules/sca/include/sca.hpp
@@ -72,6 +72,14 @@ class EXPORTED SCA final
         /// internal SecurityConfigurationAssessment instance.
         void destroy();
 
+        /// @brief Signals the SCA implementation to stop without releasing resources.
+        /// Safe to call while the sync worker thread is still running.
+        void quiesce();
+
+        /// @brief Releases SCA resources (e.g. DBSync).
+        /// Must be called only after the sync worker thread has been joined.
+        void releaseResources();
+
         /// @brief Synchronizes the SCA module with the centralized database.
         ///
         /// Performs database synchronization using the specified mode, handling

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -59,6 +59,16 @@ class SecurityConfigurationAssessment
         /// @copydoc IModule::Stop
         void Stop() ;
 
+        /// @brief Signals the module to stop and waits for in-flight operations
+        /// to finish, but does not release owned resources (e.g. m_dBSync).
+        /// Safe to call while the sync worker thread is still running.
+        void quiesce();
+
+        /// @brief Releases owned resources after the sync worker thread has exited.
+        /// Must be called only after all threads that may use those resources
+        /// (in particular the sync worker thread) have been joined.
+        void releaseResources();
+
         /// @copydoc IModule::Name
         const std::string& Name() const ;
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -323,9 +323,9 @@ void SecurityConfigurationAssessment::Setup(bool enabled,
     m_yamlToJsonFunc = yamlToJsonFunc;
 }
 
-void SecurityConfigurationAssessment::Stop()
+void SecurityConfigurationAssessment::quiesce()
 {
-    LoggingHelper::getInstance().log(LOG_DEBUG, "SecurityConfigurationAssessment::Stop() called");
+    LoggingHelper::getInstance().log(LOG_DEBUG, "SecurityConfigurationAssessment::quiesce() called");
     {
         std::lock_guard<std::mutex> lock(m_pauseMutex);
         m_keepRunning = false;
@@ -336,7 +336,7 @@ void SecurityConfigurationAssessment::Stop()
     // Wake up the Run() loop if it's sleeping
     m_cv.notify_all();
 
-    // Signal sync protocol to stop any ongoing operations
+    // Signal sync protocol to stop any ongoing synchronizeModule() calls
     if (m_spSyncProtocol)
     {
         m_spSyncProtocol->stop();
@@ -354,11 +354,22 @@ void SecurityConfigurationAssessment::Stop()
         policy->Stop();
     }
 
-    // Explicitly release DBSync before static destruction to avoid use-after-free
-    // during shutdown when DBSyncImplementation singleton may be destroyed first
-    m_dBSync.reset();
-
     LoggingHelper::getInstance().log(LOG_INFO, "SCA module stopped.");
+}
+
+void SecurityConfigurationAssessment::releaseResources()
+{
+    // Explicitly release DBSync before static destruction to avoid use-after-free
+    // during shutdown when DBSyncImplementation singleton may be destroyed first.
+    // Must be called only after the sync worker thread has been joined, because
+    // synchronizeDatabaseSnapshot() uses m_dBSync without holding any mutex.
+    m_dBSync.reset();
+}
+
+void SecurityConfigurationAssessment::Stop()
+{
+    quiesce();
+    releaseResources();
 }
 
 const std::string& SecurityConfigurationAssessment::Name() const

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -109,10 +109,11 @@ void sca_init()
     }
 }
 
-/// @brief Stops the SCA module execution.
+/// @brief Quiesces the SCA module execution.
 ///
-/// Cleanly shuts down the SCA module, stopping all assessments and
-/// releasing allocated resources.
+/// Signals the SCA module and sync protocol to stop all assessments.
+/// Resource teardown is deferred to sca_release_resources(), which must
+/// be called only after all threads using SCA resources have fully exited.
 void sca_stop()
 {
     SCA::instance().quiesce();

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -115,7 +115,12 @@ void sca_init()
 /// releasing allocated resources.
 void sca_stop()
 {
-    SCA::instance().destroy();
+    SCA::instance().quiesce();
+}
+
+void sca_release_resources()
+{
+    SCA::instance().releaseResources();
 }
 
 /// @brief Sets the logging callback function for the SCA module.
@@ -348,6 +353,22 @@ void SCA::destroy()
     }
 
     m_sca->Stop();
+}
+
+void SCA::quiesce()
+{
+    if (m_sca)
+    {
+        m_sca->quiesce();
+    }
+}
+
+void SCA::releaseResources()
+{
+    if (m_sca)
+    {
+        m_sca->releaseResources();
+    }
 }
 
 // LCOV_EXCL_START

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -651,12 +651,15 @@ static int wm_sca_start(wm_sca_t *sca) {
 
     // Initialize sync protocol if enabled
     if (sca_enable_synchronization && sca_sync_module_ptr) {
-        sca_sync_module_running = 1;
 #ifndef WIN32
         // Launch SCA synchronization thread as joinable so we can wait for it
         // before releasing resources on shutdown
         sca_sync_worker_thread_initialized = (CreateThreadJoinable(&sca_sync_worker_thread, wm_sca_sync_module, NULL) == 0);
-        if (!sca_sync_worker_thread_initialized)
+        if (sca_sync_worker_thread_initialized)
+        {
+            sca_sync_module_running = 1;
+        }
+        else
         {
             merror(THREAD_ERROR);
         }
@@ -666,6 +669,7 @@ static int wm_sca_start(wm_sca_t *sca) {
             merror(THREAD_ERROR);
         } else {
             sca_sync_worker_thread_initialized = true;
+            sca_sync_module_running = 1;
         }
 #endif
     } else {
@@ -673,33 +677,16 @@ static int wm_sca_start(wm_sca_t *sca) {
     }
 
     sca_start_ptr(sca);
-    return 0;
-}
 
-// Destroy data
-void wm_sca_destroy(wm_sca_t * data) {
-    if (data) {
-        os_free(data);
-    }
-}
-
-// Stop
-void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
-{
-    g_shutting_down = 1;
+    // Ensure the sync worker exits even if sca_start_ptr returned early
+    // (e.g., all collectors disabled) without wm_sca_stop() being called first.
     sca_sync_module_running = 0;
 
-    // Signal the sync protocol to stop any ongoing synchronizeModule() calls.
-    // This does NOT destroy m_dBSync yet.
-    if (sca_stop_ptr) {
-        sca_stop_ptr();
-    }
-
-    // Now wait for the sync worker to fully exit.  synchronizeModule() was
-    // aborted above, so the thread will check sca_sync_module_running and
-    // return promptly.  Joining here guarantees the thread is no longer
-    // executing synchronizeDatabaseSnapshot() (which uses m_dBSync) before
-    // we destroy it below.
+    // Join the sync worker before releasing m_dBSync.  This guarantees the worker
+    // is no longer inside synchronizeDatabaseSnapshot() (which uses m_dBSync).
+    // wm_sca_stop() only signals the thread to exit; the join must happen here,
+    // after the main SCA run loop has also returned, so no code path can still
+    // be holding a reference to m_dBSync.
 #ifndef WIN32
     if (sca_sync_worker_thread_initialized)
     {
@@ -716,11 +703,36 @@ void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
     }
 #endif
 
-    // Safe to release resources now that the sync worker has exited.
+    // Safe to release resources now that both the sync worker and the main SCA
+    // run loop have exited.  m_dBSync is no longer referenced by any thread.
     if (sca_release_resources_ptr)
     {
         sca_release_resources_ptr();
         sca_release_resources_ptr = NULL;
+    }
+
+    return 0;
+}
+
+// Destroy data
+void wm_sca_destroy(wm_sca_t * data) {
+    if (data) {
+        os_free(data);
+    }
+}
+
+// Stop
+void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
+{
+    g_shutting_down = 1;
+    sca_sync_module_running = 0;
+
+    // Quiesce the sync protocol and the main SCA loop.  Resource teardown
+    // (join + releaseResources) is deferred to wm_sca_start() after
+    // sca_start_ptr() returns, so that we do not free m_dBSync while the
+    // SCA run loop is still using it.
+    if (sca_stop_ptr) {
+        sca_stop_ptr();
     }
 }
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -37,6 +37,8 @@
 
 // Global flag to stop sync module
 static volatile int sca_sync_module_running = 0;
+static pthread_t sca_sync_worker_thread;
+static bool sca_sync_worker_thread_initialized = false;
 
 // SCA message queue variables
 static int g_shutting_down = 0;
@@ -106,6 +108,7 @@ void *sca_module = NULL;
 sca_init_func sca_init_ptr = NULL;
 sca_start_func sca_start_ptr = NULL;
 sca_stop_func sca_stop_ptr = NULL;
+sca_release_resources_func sca_release_resources_ptr = NULL;
 sca_set_wm_exec_func sca_set_wm_exec_ptr = NULL;
 sca_set_log_function_func sca_set_log_function_ptr = NULL;
 sca_set_push_functions_func sca_set_push_functions_ptr = NULL;
@@ -521,6 +524,7 @@ void * wm_sca_main(wm_sca_t * data) {
         sca_init_ptr = so_get_function_sym(sca_module, "sca_init");
         sca_start_ptr = so_get_function_sym(sca_module, "sca_start");
         sca_stop_ptr = so_get_function_sym(sca_module, "sca_stop");
+        sca_release_resources_ptr = so_get_function_sym(sca_module, "sca_release_resources");
         sca_set_wm_exec_ptr = so_get_function_sym(sca_module, "sca_set_wm_exec");
         sca_set_log_function_ptr = so_get_function_sym(sca_module, "sca_set_log_function");
         sca_set_push_functions_ptr = so_get_function_sym(sca_module, "sca_set_push_functions");
@@ -645,8 +649,13 @@ static int wm_sca_start(wm_sca_t *sca) {
     if (sca_enable_synchronization && sca_sync_module_ptr) {
         sca_sync_module_running = 1;
 #ifndef WIN32
-        // Launch SCA synchronization thread
-        w_create_thread(wm_sca_sync_module, NULL);
+        // Launch SCA synchronization thread as joinable so we can wait for it
+        // before releasing resources on shutdown
+        sca_sync_worker_thread_initialized = (CreateThreadJoinable(&sca_sync_worker_thread, wm_sca_sync_module, NULL) == 0);
+        if (!sca_sync_worker_thread_initialized)
+        {
+            merror(THREAD_ERROR);
+        }
 #else
         if (CreateThread(NULL, 0, wm_sca_sync_module, NULL, 0, NULL) == NULL) {
             merror(THREAD_ERROR);
@@ -673,8 +682,30 @@ void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
     g_shutting_down = 1;
     sca_sync_module_running = 0;
 
+    // Signal the sync protocol to stop any ongoing synchronizeModule() calls.
+    // This does NOT destroy m_dBSync yet.
     if (sca_stop_ptr) {
         sca_stop_ptr();
+    }
+
+    // Now wait for the sync worker to fully exit.  synchronizeModule() was
+    // aborted above, so the thread will check sca_sync_module_running and
+    // return promptly.  Joining here guarantees the thread is no longer
+    // executing synchronizeDatabaseSnapshot() (which uses m_dBSync) before
+    // we destroy it below.
+#ifndef WIN32
+    if (sca_sync_worker_thread_initialized)
+    {
+        sca_sync_worker_thread_initialized = false;
+        pthread_join(sca_sync_worker_thread, NULL);
+    }
+#endif
+
+    // Safe to release resources now that the sync worker has exited.
+    if (sca_release_resources_ptr)
+    {
+        sca_release_resources_ptr();
+        sca_release_resources_ptr = NULL;
     }
 }
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -37,7 +37,11 @@
 
 // Global flag to stop sync module
 static volatile int sca_sync_module_running = 0;
+#ifndef WIN32
 static pthread_t sca_sync_worker_thread;
+#else
+static HANDLE sca_sync_worker_thread = NULL;
+#endif
 static bool sca_sync_worker_thread_initialized = false;
 
 // SCA message queue variables
@@ -657,8 +661,11 @@ static int wm_sca_start(wm_sca_t *sca) {
             merror(THREAD_ERROR);
         }
 #else
-        if (CreateThread(NULL, 0, wm_sca_sync_module, NULL, 0, NULL) == NULL) {
+        sca_sync_worker_thread = CreateThread(NULL, 0, wm_sca_sync_module, NULL, 0, NULL);
+        if (sca_sync_worker_thread == NULL) {
             merror(THREAD_ERROR);
+        } else {
+            sca_sync_worker_thread_initialized = true;
         }
 #endif
     } else {
@@ -698,6 +705,14 @@ void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
     {
         sca_sync_worker_thread_initialized = false;
         pthread_join(sca_sync_worker_thread, NULL);
+    }
+#else
+    if (sca_sync_worker_thread_initialized && sca_sync_worker_thread != NULL)
+    {
+        sca_sync_worker_thread_initialized = false;
+        WaitForSingleObject(sca_sync_worker_thread, INFINITE);
+        CloseHandle(sca_sync_worker_thread);
+        sca_sync_worker_thread = NULL;
     }
 #endif
 

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -53,6 +53,8 @@ pthread_mutex_t sys_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool need_shutdown_wait = false;
 static pthread_t sys_main_thread;
 static bool sys_main_thread_initialized = false;
+static pthread_t sync_worker_thread;
+static bool sync_worker_thread_initialized = false;
 pthread_mutex_t sys_reconnect_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool shutdown_process_started = false;
 
@@ -74,6 +76,7 @@ void* syscollector_module = NULL;
 syscollector_init_func syscollector_init_ptr = NULL;
 syscollector_start_func syscollector_start_ptr = NULL;
 syscollector_stop_func syscollector_stop_ptr = NULL;
+syscollector_release_resources_func syscollector_release_resources_ptr = NULL;
 
 // Sync protocol function pointers
 syscollector_init_sync_func syscollector_init_sync_ptr = NULL;
@@ -607,6 +610,7 @@ void* wm_sys_main(wm_sys_t* sys)
         syscollector_init_ptr = so_get_function_sym(syscollector_module, "syscollector_init");
         syscollector_start_ptr = so_get_function_sym(syscollector_module, "syscollector_start");
         syscollector_stop_ptr = so_get_function_sym(syscollector_module, "syscollector_stop");
+        syscollector_release_resources_ptr = so_get_function_sym(syscollector_module, "syscollector_release_resources");
 
         // Get sync protocol function pointers
         syscollector_init_sync_ptr = so_get_function_sym(syscollector_module, "syscollector_init_sync");
@@ -705,9 +709,14 @@ void* wm_sys_main(wm_sys_t* sys)
             syscollector_init_sync_ptr(WM_SYS_LOCATION, SYS_SYNC_PROTOCOL_DB_PATH, SYS_SYNC_PROTOCOL_VD_DB_PATH, &mq_funcs, sync_end_delay, sync_response_timeout, SYS_SYNC_RETRIES, sync_max_eps,
                                        integrity_interval);
 #ifndef WIN32
-            // Launch inventory synchronization thread
+            // Launch inventory synchronization thread as joinable so we can wait for it
+            // before releasing resources on shutdown
             sync_module_running = 1;
-            w_create_thread(wm_sync_module, NULL);
+            sync_worker_thread_initialized = (CreateThreadJoinable(&sync_worker_thread, wm_sync_module, NULL) == 0);
+            if (!sync_worker_thread_initialized)
+            {
+                merror(THREAD_ERROR);
+            }
 #else
             sync_module_running = 1;
 
@@ -741,6 +750,16 @@ void* wm_sys_main(wm_sys_t* sys)
         close(queue_fd);
         queue_fd = 0;
     }
+
+    // Wait for the inventory sync worker thread to finish before signaling that
+    // resources can be released.
+#ifndef WIN32
+    if (sync_worker_thread_initialized)
+    {
+        sync_worker_thread_initialized = false;
+        pthread_join(sync_worker_thread, NULL);
+    }
+#endif
 
     mtinfo(WM_SYS_LOGTAG, "Module finished.");
     w_mutex_lock(&sys_stop_mutex);
@@ -802,6 +821,12 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
     }
 
     w_mutex_unlock(&sys_stop_mutex);
+
+    if (syscollector_release_resources_ptr)
+    {
+        syscollector_release_resources_ptr();
+        syscollector_release_resources_ptr = NULL;
+    }
 }
 
 cJSON* wm_sys_dump(const wm_sys_t* sys)

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -715,14 +715,16 @@ void* wm_sys_main(wm_sys_t* sys)
 #ifndef WIN32
             // Launch inventory synchronization thread as joinable so we can wait for it
             // before releasing resources on shutdown
-            sync_module_running = 1;
             sync_worker_thread_initialized = (CreateThreadJoinable(&sync_worker_thread, wm_sync_module, NULL) == 0);
-            if (!sync_worker_thread_initialized)
+            if (sync_worker_thread_initialized)
+            {
+                sync_module_running = 1;
+            }
+            else
             {
                 merror(THREAD_ERROR);
             }
 #else
-            sync_module_running = 1;
             sync_worker_thread = CreateThread(NULL, 0, wm_sync_module, NULL, 0, NULL);
             if (sync_worker_thread == NULL)
             {
@@ -731,6 +733,7 @@ void* wm_sys_main(wm_sys_t* sys)
             else
             {
                 sync_worker_thread_initialized = true;
+                sync_module_running = 1;
             }
 
 #endif
@@ -758,6 +761,10 @@ void* wm_sys_main(wm_sys_t* sys)
         close(queue_fd);
         queue_fd = 0;
     }
+
+    // Ensure the sync worker exits even if syscollector_start_ptr returned early
+    // (e.g., all collectors disabled) without wm_sys_stop() being called first.
+    sync_module_running = 0;
 
     // Wait for the inventory sync worker thread to finish before signaling that
     // resources can be released.

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -53,7 +53,11 @@ pthread_mutex_t sys_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool need_shutdown_wait = false;
 static pthread_t sys_main_thread;
 static bool sys_main_thread_initialized = false;
+#ifndef WIN32
 static pthread_t sync_worker_thread;
+#else
+static HANDLE sync_worker_thread = NULL;
+#endif
 static bool sync_worker_thread_initialized = false;
 pthread_mutex_t sys_reconnect_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool shutdown_process_started = false;
@@ -719,10 +723,14 @@ void* wm_sys_main(wm_sys_t* sys)
             }
 #else
             sync_module_running = 1;
-
-            if (CreateThread(NULL, 0, wm_sync_module, NULL, 0, NULL) == NULL)
+            sync_worker_thread = CreateThread(NULL, 0, wm_sync_module, NULL, 0, NULL);
+            if (sync_worker_thread == NULL)
             {
                 mterror(WM_SYS_LOGTAG, THREAD_ERROR);
+            }
+            else
+            {
+                sync_worker_thread_initialized = true;
             }
 
 #endif
@@ -759,6 +767,14 @@ void* wm_sys_main(wm_sys_t* sys)
         sync_worker_thread_initialized = false;
         pthread_join(sync_worker_thread, NULL);
     }
+#else
+    if (sync_worker_thread_initialized && sync_worker_thread != NULL)
+    {
+        sync_worker_thread_initialized = false;
+        WaitForSingleObject(sync_worker_thread, INFINITE);
+        CloseHandle(sync_worker_thread);
+        sync_worker_thread = NULL;
+    }
 #endif
 
     mtinfo(WM_SYS_LOGTAG, "Module finished.");
@@ -767,6 +783,14 @@ void* wm_sys_main(wm_sys_t* sys)
     sys_main_thread_initialized = false;
     w_cond_signal(&sys_stop_condition);
     w_mutex_unlock(&sys_stop_mutex);
+
+    // Safe to release resources now that the sync worker has exited.
+    if (syscollector_release_resources_ptr)
+    {
+        syscollector_release_resources_ptr();
+        syscollector_release_resources_ptr = NULL;
+    }
+
     return 0;
 }
 
@@ -821,12 +845,6 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
     }
 
     w_mutex_unlock(&sys_stop_mutex);
-
-    if (syscollector_release_resources_ptr)
-    {
-        syscollector_release_resources_ptr();
-        syscollector_release_resources_ptr = NULL;
-    }
 }
 
 cJSON* wm_sys_dump(const wm_sys_t* sys)

--- a/src/wazuh_modules/syscollector/include/syscollector.h
+++ b/src/wazuh_modules/syscollector/include/syscollector.h
@@ -79,6 +79,7 @@ EXPORTED void syscollector_init(const unsigned int inverval,
                                 const bool notifyOnFirstScan);
 
 EXPORTED void syscollector_stop();
+EXPORTED void syscollector_release_resources();
 EXPORTED void syscollector_start();
 
 // Sync protocol C wrapper functions
@@ -139,6 +140,7 @@ typedef void(*syscollector_init_func)(const unsigned int inverval,
 
 typedef void(*syscollector_start_func)();
 typedef void(*syscollector_stop_func)();
+typedef void(*syscollector_release_resources_func)();
 
 // Sync protocol C wrapper functions
 typedef void(*syscollector_init_sync_func)(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD, const MQ_Functions* mqFuncs, unsigned int syncEndDelay, unsigned int timeout,

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -85,6 +85,8 @@ class EXPORTED Syscollector final
         void setAgentdQueryFunction(AgentdQueryFunc queryFunc);
 
         void start();
+        void quiesce();
+        void releaseResources();
         void destroy();
 
         // Sync protocol methods

--- a/src/wazuh_modules/syscollector/src/syscollector.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollector.cpp
@@ -136,7 +136,12 @@ void syscollector_start()
 
 void syscollector_stop()
 {
-    Syscollector::instance().destroy();
+    Syscollector::instance().quiesce();
+}
+
+void syscollector_release_resources()
+{
+    Syscollector::instance().releaseResources();
 }
 
 void syscollector_init_sync(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD, const MQ_Functions* mqFuncs, unsigned int syncEndDelay, unsigned int timeout,

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -689,20 +689,11 @@ bool Syscollector::handleNotifyDataClean()
     return ret;
 }
 
-void Syscollector::destroy()
+void Syscollector::quiesce()
 {
     m_stopping = true;
     m_cv.notify_all();
 
-    std::unique_lock<std::mutex> lock{m_scan_mutex, std::try_to_lock};
-    const bool scanMutexAvailable = lock.owns_lock();
-
-    if (scanMutexAvailable)
-    {
-        lock.unlock();
-    }
-
-    // Signal sync protocols to stop any ongoing operations
     if (m_spSyncProtocol)
     {
         m_spSyncProtocol->stop();
@@ -717,6 +708,31 @@ void Syscollector::destroy()
     {
         m_asyncFlushController->waitForFlushToFinish();
     }
+}
+
+void Syscollector::releaseResources()
+{
+    // Explicitly release all resources to ensure clean state between tests
+    // and prevent use-after-free when Syscollector singleton destructs
+    // after static dependencies have already been destroyed
+    m_spDBSync.reset();
+    m_spNormalizer.reset();
+    m_spSyncProtocol.reset();
+    m_spSyncProtocolVD.reset();
+    m_spInfo.reset();
+}
+
+void Syscollector::destroy()
+{
+    quiesce();
+
+    std::unique_lock<std::mutex> lock{m_scan_mutex, std::try_to_lock};
+    const bool scanMutexAvailable = lock.owns_lock();
+
+    if (scanMutexAvailable)
+    {
+        lock.unlock();
+    }
 
     if (!scanMutexAvailable)
     {
@@ -728,14 +744,7 @@ void Syscollector::destroy()
         return;
     }
 
-    // Explicitly release all resources to ensure clean state between tests
-    // and prevent use-after-free when Syscollector singleton destructs
-    // after static dependencies have already been destroyed
-    m_spDBSync.reset();
-    m_spNormalizer.reset();
-    m_spSyncProtocol.reset();
-    m_spSyncProtocolVD.reset();
-    m_spInfo.reset();
+    releaseResources();
 }
 
 std::pair<nlohmann::json, uint64_t> Syscollector::ecsData(const nlohmann::json& data, const std::string& table, bool createFields)

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -4900,11 +4900,12 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
     // Expect NO persist callback for invalid hardware data (will be rejected by mock validator)
     EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(0);
 
-    // Capture log messages to verify validation errors
-    std::vector<std::string> loggedMessages;
-    auto customLogFunction = [&loggedMessages](modules_log_level_t, const std::string & message)
+    // Capture log messages to verify validation errors.
+    // Keep data on heap because Syscollector may still invoke the logger during fixture TearDown.
+    auto loggedMessages = std::make_shared<std::vector<std::string>>();
+    auto customLogFunction = [loggedMessages](modules_log_level_t, const std::string & message)
     {
-        loggedMessages.push_back(message);
+        loggedMessages->push_back(message);
     };
 
     // Create mock validator that will reject all validations
@@ -4974,13 +4975,13 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
     SchemaValidator::SchemaValidatorFactory::getInstance().reset();
 
     // Verify that validation errors were logged
-    EXPECT_FALSE(loggedMessages.empty());
+    ASSERT_FALSE(loggedMessages->empty());
 
     bool foundValidationError = false;
     bool foundDiscardMessage = false;
     bool foundDeferredDeletion = false;
 
-    for (const auto& msg : loggedMessages)
+    for (const auto& msg : *loggedMessages)
     {
         if (msg.find("Schema validation failed") != std::string::npos)
         {


### PR DESCRIPTION
## Description

Closes #36250 

On `wazuh-modulesd` shutdown, the inventory synchronization thread in both **Syscollector** and **SCA** was created as a **detached** thread via `w_create_thread`. This allowed resources to be freed while the sync worker thread was still executing inside `synchronizeModule()` or `synchronizeDatabaseSnapshot()`, holding raw references to objects already destroyed — a use-after-free that manifests as an abort/SIGABRT at runtime.

### Syscollector

The shutdown sequence in `wm_sys_stop()` called `Syscollector::quiesce()` and then waited only for the **scan loop** to finish. However, `wm_sys_main()` could return — triggering `syscollector_release_resources()`, which destroys the `PersistentQueue`/SQLite objects — while the detached sync worker was still executing inside `synchronizeModule()`.

### SCA

`SCA::Stop()` called `m_dBSync.reset()` after signaling the sync protocol to stop. The problem is that `m_spSyncProtocol->stop()` only interrupts `synchronizeModule()`, which is called **at the end** of `synchronizeDatabaseSnapshot()`. The earlier `m_dBSync->selectRows()` queries have no stop signal and no mutex protecting them — so `m_dBSync.reset()` could race with an ongoing `selectRows()` call in the sync worker thread, corrupting heap state.

The correct fix requires joining the sync worker **between** the signal-stop step and the resource-release step, so that `m_dBSync.reset()` only runs after the thread has fully exited.

## Proposed Changes

### Syscollector

1. **Split `Syscollector::destroy()` into two stages:**
   - `quiesce()`: sets `m_stopping = true`, signals the condition variable, stops the sync protocol, and waits for any in-flight flush to finish. Does **not** free resources.
   - `releaseResources()`: resets all smart pointers (`m_spDBSync`, `m_spSyncProtocol`, `m_spSyncProtocolVD`, etc.).
   - `destroy()` (existing callers and unit tests) is kept and now delegates to `quiesce()` + `releaseResources()`.

2. **Export `syscollector_release_resources()` as a new C API symbol** from `libsyscollector.so` (with its corresponding function pointer typedef), so the C wrapper `wm_syscollector.c` can call it at the right point in the shutdown sequence.

3. **Create `wm_sync_module` as a joinable thread** using `CreateThreadJoinable` instead of `w_create_thread`.

4. **Add `pthread_join(sync_worker_thread)`** in `wm_sys_main()`, called **before** signaling `need_shutdown_wait = false`. This guarantees the sync worker has fully exited before the main thread returns.

5. **Call `syscollector_release_resources_ptr()`** from `wm_sys_stop()`, **after** `pthread_cond_timedwait` returns (i.e., after the scan loop is confirmed done). At that point both the scan loop and the sync worker have terminated, so releasing resources is safe.

### SCA

1. **Split `SecurityConfigurationAssessment::Stop()` into two stages:**
   - `quiesce()`: sets `m_keepRunning = false`, signals all condition variables, stops the sync protocol, waits for the flush controller, and stops all policies. Does **not** reset `m_dBSync`.
   - `releaseResources()`: calls `m_dBSync.reset()`.
   - `Stop()` (existing callers and unit tests) is kept and now delegates to `quiesce()` + `releaseResources()`.

2. **Expose `quiesce()` and `releaseResources()` through the `SCA` wrapper class** and export `sca_release_resources()` as a new C API symbol from `libsca.so` (with its function pointer typedef).

3. **Change `sca_stop()` to call `SCA::instance().quiesce()`** instead of `destroy()`, so the C wrapper can control when `m_dBSync` is freed.

4. **Create `wm_sca_sync_module` as a joinable thread** using `CreateThreadJoinable` instead of `w_create_thread`.

5. **In `wm_sca_stop()`**, call `sca_stop_ptr()` (quiesce) first to interrupt any in-flight `synchronizeModule()` call, then **`pthread_join(sca_sync_worker_thread)`** to wait for the thread to fully exit `synchronizeDatabaseSnapshot()`, then **`sca_release_resources_ptr()`** to safely call `m_dBSync.reset()`.

### Results and Evidence

A 400 ms artificial delay was injected into `AgentSyncProtocol::synchronizeModule()` to widen the race window and make both bugs deterministic. With the original code, repeated `wazuh-control stop` calls consistently triggered an abort due to SQLite use-after-free. 

```
2026/05/21 14:53:02 wazuh-agentd: INFO: Started (pid: 44278).
2026/05/21 14:53:02 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
2026/05/21 14:53:03 wazuh-rootcheck: INFO: Ending rootcheck scan.
2026/05/21 14:53:04 wazuh-modulesd: INFO: Started (pid: 44302).
2026/05/21 14:53:04 wazuh-modulesd:control: INFO: Starting control thread.
2026/05/21 14:53:04 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/21 14:53:04 wazuh-modulesd:agent-info: INFO: AgentInfo initialized.
2026/05/21 14:53:04 wazuh-modulesd:sca: INFO: SCA initialized.
2026/05/21 14:53:04 wazuh-modulesd:sca: INFO: Started (pid: 44302).
2026/05/21 14:53:04 wazuh-modulesd:sca: INFO: SCA module running.
2026/05/21 14:53:04 wazuh-modulesd:sca: INFO: SCA module scan on start.
2026/05/21 14:53:04 wazuh-modulesd:syscollector: INFO: Module started.
2026/05/21 14:53:04 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/21 14:53:04 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/21 14:53:04 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/21 14:53:05 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/05/21 14:53:05 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/05/21 14:53:07 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/05/21 14:53:07 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/05/21 14:53:07 wazuh-modulesd:syscollector: INFO: Sync End message retries exhausted because module is stopping.
2026/05/21 14:53:07 wazuh-modulesd:syscollector: INFO: Module finished.
2026/05/21 14:53:07 wazuh-modulesd:agent-info: WARNING: DBSync not available for table agent_metadata
2026/05/21 14:53:07 wazuh-modulesd:agent-info: WARNING: DBSync not available for table agent_groups
2026/05/21 14:53:07 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/05/21 14:53:07 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/05/21 14:53:07 wazuh-modulesd:syscollector: ERROR: PersistentQueue: Error resetting items: bad parameter or other API misuse
2026/05/21 14:53:07 wazuh-modulesd:syscollector: ERROR: Failed to finalize sync state: bad parameter or other API misuse
2026/05/21 14:53:08 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/05/21 14:53:08 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/05/21 14:57:44 wazuh-syscheckd: INFO: Starting FIM synchronization.
```

After applying both fixes, repeated shutdown cycles produced clean exits with no crashes.

```
2026/05/26 15:16:52 wazuh-agentd: INFO: Started (pid: 48979).
2026/05/26 15:16:52 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
2026/05/26 15:16:54 wazuh-modulesd: INFO: Started (pid: 48991).
2026/05/26 15:16:54 wazuh-modulesd:control: INFO: Starting control thread.
2026/05/26 15:16:54 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/05/26 15:16:54 wazuh-modulesd:agent-info: INFO: AgentInfo initialized.
2026/05/26 15:16:54 wazuh-modulesd:sca: INFO: SCA initialized.
2026/05/26 15:16:54 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/05/26 15:16:54 wazuh-modulesd:syscollector: INFO: Module started.
2026/05/26 15:16:54 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/26 15:16:54 wazuh-modulesd:sca: INFO: Started (pid: 48991).
2026/05/26 15:16:54 wazuh-modulesd:sca: INFO: SCA module running.
2026/05/26 15:16:54 wazuh-modulesd:sca: INFO: SCA module scan on start.
2026/05/26 15:16:54 wazuh-modulesd:sca: INFO: SCA scan started.
2026/05/26 15:16:54 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/26 15:16:55 wazuh-modulesd:sca: INFO: SCA scan ended.
2026/05/26 15:16:56 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/26 15:16:58 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/05/26 15:16:58 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/05/26 15:16:58 wazuh-modulesd:syscollector: INFO: Sync End message retries exhausted because module is stopping.
2026/05/26 15:16:58 wazuh-modulesd:agent-info: WARNING: DBSync not available for table agent_metadata
2026/05/26 15:16:58 wazuh-modulesd:agent-info: WARNING: DBSync not available for table agent_groups
2026/05/26 15:16:58 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/05/26 15:16:58 wazuh-modulesd:syscollector: INFO: Module finished.
2026/05/26 15:16:58 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/05/26 15:16:58 wazuh-modulesd:sca: INFO: Sync End message retries exhausted because module is stopping.
2026/05/26 15:16:58 wazuh-modulesd:sca: ERROR: SCA initial synchronization failed
2026/05/26 15:16:58 wazuh-modulesd:sca: WARNING: SCA synchronization failed.
2026/05/26 15:16:59 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/05/26 15:17:00 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
```

No SQLite errors, no SIGABRT. The SCA "synchronization failed" messages are **expected**: they appear because `synchronizeModule()` returns `false` when it detects `m_stopping = true` during shutdown — the sync worker was interrupted cleanly, not crashed.

### Artifacts Affected

**Syscollector**

| File | Change |
|---|---|
| `src/wazuh_modules/src/wm_syscollector.c` | Joinable thread creation, `pthread_join`, `syscollector_release_resources_ptr` call |
| `src/wazuh_modules/syscollector/include/syscollector.h` | New `syscollector_release_resources()` export and function pointer typedef |
| `src/wazuh_modules/syscollector/include/syscollector.hpp` | New `quiesce()` and `releaseResources()` declarations |
| `src/wazuh_modules/syscollector/src/syscollector.cpp` | `syscollector_stop()` calls `quiesce()`; new `syscollector_release_resources()` implementation |
| `src/wazuh_modules/syscollector/src/syscollectorImp.cpp` | `destroy()` split into `quiesce()` + `releaseResources()` |

**SCA**

| File | Change |
|---|---|
| `src/wazuh_modules/src/wm_sca.c` | Joinable thread creation, `pthread_join` in `wm_sca_stop()`, `sca_release_resources_ptr` call |
| `src/wazuh_modules/sca/include/sca.h` | New `sca_release_resources()` export and function pointer typedef |
| `src/wazuh_modules/sca/include/sca.hpp` | New `quiesce()` and `releaseResources()` declarations in `SCA` wrapper |
| `src/wazuh_modules/sca/src/sca.cpp` | `sca_stop()` calls `quiesce()`; new `sca_release_resources()` implementation; `SCA::quiesce()` and `SCA::releaseResources()` |
| `src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp` | New `quiesce()` and `releaseResources()` declarations in `SecurityConfigurationAssessment` |
| `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp` | `Stop()` split into `quiesce()` + `releaseResources()`; `m_dBSync.reset()` moved to `releaseResources()` |

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. Both race conditions are exercised manually via reproduction scripts that inject an artificial delay in `synchronizeModule()` and trigger `wazuh-control stop` while the sync worker is active.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues