### PR TITLE
SCA typo bug in SELinux SCA rule for CentOS 8/9/10

### DIFF
--- a/ruleset/sca/centos/10/cis_centos10_linux.yml
+++ b/ruleset/sca/centos/10/cis_centos10_linux.yml
@@ -998,7 +998,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
   - id: 37546

--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -998,7 +998,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
   - id: 6546

--- a/ruleset/sca/centos/9/cis_centos9_linux.yml
+++ b/ruleset/sca/centos/9/cis_centos9_linux.yml
@@ -998,7 +998,7 @@ checks:
     condition: all
     rules:
       - "c:getenforce -> r:^Enforcing$|^Permissive$"
-      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
+      - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permissive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
   - id: 39046


### PR DESCRIPTION
## Description

Closes #36053

Fixes a typo in the SELinux SCA policy rules for CentOS 8, 9, and 10. The word `permisive` (single 's') was misspelled in the regex pattern matching `SELINUX=permissive`, causing systems correctly configured with `SELINUX=permissive` to unexpectedly fail the SCA check for rule 1.6.1.4 (Ensure the SELinux mode is not disabled, Rule ID 37545).

**Files affected:**
- `ruleset/sca/centos/8/cis_centos8_linux.yml`
- `ruleset/sca/centos/9/cis_centos9_linux.yml`
- `ruleset/sca/centos/10/cis_centos10_linux.yml`

## Proposed Changes

- Corrected `permisive` → `permissive` in the SELinux regex check across CentOS 8, 9, and 10 SCA policy files.
- Minor formatting cleanup.

### Manual tests with their corresponding evidence

- [x] Verified the corrected regex matches `SELINUX=permissive` as expected on a CentOS 9 environment.

### Artifacts Affected

- SCA policy YAML files for CentOS 8, 9, and 10.

### Configuration Changes

None.

### Tests Introduced

None. The fix is a one-character typo correction in YAML ruleset files.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
