### PR TITLE
Fix AlmaLinux 9/10 bootloader permissions SCA check regex and optional file handling

### DIFF
--- a/ruleset/sca/almalinux/cis_alma_linux_10.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_10.yml
@@ -927,9 +927,9 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0700/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
 
   # 1.5.1 Ensure core dump storage is disabled. (Automated)
 

--- a/ruleset/sca/almalinux/cis_alma_linux_9.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_9.yml
@@ -927,9 +927,9 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0700/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)|cannot stat'
 
   # 1.5.1 Ensure core dump storage is disabled. (Automated)
 


### PR DESCRIPTION
## Description

This PR fixes two issues in the AlmaLinux 9 and 10 CIS SCA policies related to bootloader configuration file permissions validation (check ID 32534):

1. **Incorrect permissions regex pattern**: The regex patterns were checking for `-r--------` (0400) instead of `-rw-------` (0600) for grub.cfg, grubenv, and user.cfg files
2. **Missing optional file handling**: The check for `/boot/grub2/user.cfg` was failing when the file didn't exist, even though this file is optional

These issues caused false positive SCA alerts on systems where bootloader files had correct 0600 permissions or where user.cfg didn't exist.

**Credits**: Bug reported by @JustinBrownDev

## Proposed Changes

### Results and Evidence

**Before the fix:**
- Systems with correct 0600 permissions on bootloader files would fail the SCA check due to regex mismatch
- Systems without `/boot/grub2/user.cfg` would fail the check even when the file is optional per CIS guidelines

<details><summary>Alert</summary>

```json
{
    "timestamp": "2026-05-25T09:32:49.550+0200",
    "rule": {
        "level": 7,
        "description": "CIS Benchmark for Alma Linux 9: Ensure permissions on bootloader config are configured.",
        "id": "19007",
        "firedtimes": 30,
        "mail": false,
        "groups": [
            "sca"
        ],
        "gdpr": [
            "IV_35.7.d"
        ],
        "pci_dss": [
            "2.2"
        ],
        "nist_800_53": [
            "CM.1"
        ],
        "tsc": [
            "CC7.1",
            "CC7.2"
        ],
        "cis": [
            "1.4.2"
        ],
        "cis_csc_v8": [
            "3.3"
        ],
        "cis_csc_v7": [
            "14.6"
        ],
        "hipaa": [
            "164.308(a)(3)(i)",
            "164.308(a)(3)(ii)(A)",
            "164.312(a)(1)"
        ],
        "iso_27001-2013": [
            "A.9.1.1"
        ],
        "mitre_mitigations": [
            "M1022"
        ],
        "mitre_tactics": [
            "TA0005",
            "TA0007"
        ],
        "mitre_techniques": [
            "T1542"
        ],
        "nist_sp_800-53": [
            "AC-5",
            "AC-6"
        ],
        "soc_2": [
            "CC5.2",
            "CC6.1"
        ]
    },
    "agent": {
        "id": "001",
        "name": "alma9"
    },
    "manager": {
        "name": "ubuntu"
    },
    "id": "1779694369.149015",
    "cluster": {
        "name": "wazuh",
        "node": "node01"
    },
    "decoder": {
        "name": "sca"
    },
    "data": {
        "sca": {
            "type": "check",
            "scan_id": "594481718",
            "policy": "CIS Benchmark for Alma Linux 9",
            "check": {
                "id": "32534",
                "title": "Ensure permissions on bootloader config are configured.",
                "description": "The grub files contain information on boot settings and passwords for unlocking boot options.",
                "rationale": "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them.",
                "remediation": "Run the following commands to set ownership and permissions on your grub configuration files: Run the following command to set ownership and permissions on grub.cfg: # chown root:root /boot/grub2/grub.cfg # chmod og-rwx /boot/grub2/grub.cfg Run the following command to set ownership and permissions on grubenv: # chown root:root /boot/grub2/grubenv # chmod u-x,og-rwx /boot/grub2/grubenv Run the following command to set ownership and permissions on user.cfg: # chown root:root /boot/grub2/user.cfg # chmod u-x,og-rwx /boot/grub2/user.cfg Note: This may require a re-boot to enable the change.",
                "compliance": {
                    "cis": "1.4.2",
                    "cis_csc_v8": "3.3",
                    "cis_csc_v7": "14.6",
                    "cmmc_v2": {
                        "0": "AC.L1-3.1.1,AC.L1-3.1.2,AC.L2-3.1.3,AC.L2-3.1.5,MP.L2-3.8.2"
                    },
                    "hipaa": "164.308(a)(3)(i),164.308(a)(3)(ii)(A),164.312(a)(1)",
                    "iso_27001-2013": "A.9.1.1",
                    "mitre_mitigations": "M1022",
                    "mitre_tactics": "TA0005,TA0007",
                    "mitre_techniques": "T1542",
                    "nist_sp_800-53": "AC-5,AC-6",
                    "pci_dss_v3": {
                        "2": {
                            "1": "7.1,7.1.1,7.1.2,7.1.3"
                        }
                    },
                    "pci_dss_v4": {
                        "0": "1.3.1,7.1"
                    },
                    "soc_2": "CC5.2,CC6.1"
                },
                "command": [
                    "stat -L /boot/grub2/grub.cfg"
                ],
                "result": "failed"
            }
        }
    },
    "location": "sca"
}
```

</details>

**After the fix:**
- Regex correctly matches 0600 permissions (`-rw-------`) for all three bootloader files
- The `user.cfg` check passes when the file doesn't exist (using `|cannot stat` pattern)

<details><summary>Alert</summary>

```json
{
    "timestamp": "2026-05-25T09:51:51.178+0200",
    "rule": {
        "level": 3,
        "description": "CIS Benchmark for Alma Linux 9: Ensure permissions on bootloader config are configured.",
        "id": "19008",
        "firedtimes": 412,
        "mail": false,
        "groups": [
            "sca"
        ],
        "gdpr": [
            "IV_35.7.d"
        ],
        "pci_dss": [
            "2.2"
        ],
        "nist_800_53": [
            "CM.1"
        ],
        "tsc": [
            "CC7.1",
            "CC7.2"
        ],
        "cis": [
            "1.4.2"
        ],
        "cis_csc_v8": [
            "3.3"
        ],
        "cis_csc_v7": [
            "14.6"
        ],
        "hipaa": [
            "164.308(a)(3)(i)",
            "164.308(a)(3)(ii)(A)",
            "164.312(a)(1)"
        ],
        "iso_27001-2013": [
            "A.9.1.1"
        ],
        "mitre_mitigations": [
            "M1022"
        ],
        "mitre_tactics": [
            "TA0005",
            "TA0007"
        ],
        "mitre_techniques": [
            "T1542"
        ],
        "nist_sp_800-53": [
            "AC-5",
            "AC-6"
        ],
        "soc_2": [
            "CC5.2",
            "CC6.1"
        ]
    },
    "agent": {
        "id": "001",
        "name": "alma9",
        "ip": "10.0.2.15"
    },
    "manager": {
        "name": "ubuntu"
    },
    "id": "1779695511.3729747",
    "cluster": {
        "name": "wazuh",
        "node": "node01"
    },
    "decoder": {
        "name": "sca"
    },
    "data": {
        "sca": {
            "type": "check",
            "scan_id": "1300248525",
            "policy": "CIS Benchmark for Alma Linux 9",
            "check": {
                "id": "32534",
                "title": "Ensure permissions on bootloader config are configured.",
                "description": "The grub files contain information on boot settings and passwords for unlocking boot options.",
                "rationale": "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them.",
                "remediation": "Run the following commands to set ownership and permissions on your grub configuration files: Run the following command to set ownership and permissions on grub.cfg: # chown root:root /boot/grub2/grub.cfg # chmod og-rwx /boot/grub2/grub.cfg Run the following command to set ownership and permissions on grubenv: # chown root:root /boot/grub2/grubenv # chmod u-x,og-rwx /boot/grub2/grubenv Run the following command to set ownership and permissions on user.cfg: # chown root:root /boot/grub2/user.cfg # chmod u-x,og-rwx /boot/grub2/user.cfg Note: This may require a re-boot to enable the change.",
                "compliance": {
                    "cis": "1.4.2",
                    "cis_csc_v8": "3.3",
                    "cis_csc_v7": "14.6",
                    "cmmc_v2": {
                        "0": "AC.L1-3.1.1,AC.L1-3.1.2,AC.L2-3.1.3,AC.L2-3.1.5,MP.L2-3.8.2"
                    },
                    "hipaa": "164.308(a)(3)(i),164.308(a)(3)(ii)(A),164.312(a)(1)",
                    "iso_27001-2013": "A.9.1.1",
                    "mitre_mitigations": "M1022",
                    "mitre_tactics": "TA0005,TA0007",
                    "mitre_techniques": "T1542",
                    "nist_sp_800-53": "AC-5,AC-6",
                    "pci_dss_v3": {
                        "2": {
                            "1": "7.1,7.1.1,7.1.2,7.1.3"
                        }
                    },
                    "pci_dss_v4": {
                        "0": "1.3.1,7.1"
                    },
                    "soc_2": "CC5.2,CC6.1"
                },
                "command": [
                    "stat -L /boot/grub2/grub.cfg",
                    "stat -L /boot/grub2/grubenv",
                    "stat -L /boot/grub2/user.cfg"
                ],
                "result": "passed"
            }
        }
    },
    "location": "sca"
}
```

</details>

### Artifacts Affected

- `ruleset/sca/almalinux/cis_alma_linux_9.yml` - Check ID 32534, lines 930-932
- `ruleset/sca/almalinux/cis_alma_linux_10.yml` - Check ID 32534, lines 930-932

### Configuration Changes

No configuration changes required.

### Documentation Updates

No documentation updates required. The remediation text in the SCA policy already correctly specifies 0600 permissions (chmod og-rwx) and treats user.cfg as optional.

### Tests Introduced

No unit tests introduced. SCA policy content is validated through runtime evaluation against target systems.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (N/A - SCA content validation)
- [ ] Configuration changes documented (N/A - no config changes)
- [ ] Developer documentation reflects the changes (N/A - no doc changes needed)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
