### PR TITLE
Add missing 4.8.2 entry to packages changelogs

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -52,6 +52,12 @@ wazuh-agent (4.9.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 05 Sep 2024 00:00:00 +0000
 
+wazuh-agent (4.8.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 22 Aug 2024 00:00:00 +0000
+
 wazuh-agent (4.8.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -52,6 +52,12 @@ wazuh-manager (4.9.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 05 Sep 2024 00:00:00 +0000
 
+wazuh-manager (4.8.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 22 Aug 2024 00:00:00 +0000
+
 wazuh-manager (4.8.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -782,6 +782,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html
 * Thu Sep 05 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Thu Aug 22 2024 support <info@wazuh.com> - 4.8.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 * Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -921,6 +921,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html
 * Thu Sep 05 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Thu Aug 22 2024 support <info@wazuh.com> - 4.8.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 * Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0


### PR DESCRIPTION
## Related issue

https://github.com/wazuh/wazuh/issues/36333

## Description

Adds the missing `4.8.2` entry to the RPM `.spec` and Debian `changelog` files for both `wazuh-manager` and `wazuh-agent`, so the package changelogs are aligned with `CHANGELOG.md`.
