### PR TITLE
Add missing 4.10.2-4.10.5 and 4.8.2 entries to changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -707,6 +707,95 @@ All notable changes to this project will be documented in this file.
 - Added the `security:revoke` action to the `PUT /security/user/revoke` endpoint. ([#26255](https://github.com/wazuh/wazuh/pull/26255))
 
 
+## [v4.10.5]
+
+
+## [v4.10.4]
+
+### Manager
+
+#### Changed
+
+- Masked `authd.pass` in configuration API responses for users without update permissions. ([#34128](https://github.com/wazuh/wazuh/pull/34128))
+
+#### Fixed
+
+- Fixed analysisd plugin decoder argument alignment. ([#35222](https://github.com/wazuh/wazuh/pull/35222))
+- Fixed path traversal in authd via agent group name validation. ([#35258](https://github.com/wazuh/wazuh/pull/35258))
+- Hardened cluster deserialization by restricting callable decoding to Wazuh modules and improving error handling. ([#35256](https://github.com/wazuh/wazuh/pull/35256))
+- Fixed DAPI callable resolution to restrict invocations to exposed resources only. ([#35256](https://github.com/wazuh/wazuh/pull/35256))
+- Fixed admin protection in update user endpoint. ([#35469](https://github.com/wazuh/wazuh/pull/35469))
+- Fixed protected settings checks when multiple `<ossec_config>` blocks are present. ([#34690](https://github.com/wazuh/wazuh/pull/34690))
+- Restricted cluster file transfer write paths. ([#34659](https://github.com/wazuh/wazuh/pull/34659))
+- Improved cluster file synchronization path handling by adding safe path joins. ([#35008](https://github.com/wazuh/wazuh/pull/35008))
+- Fixed Vulnerability Detector offset DB update to occur only after processing (backport from 4.12.0). ([#31901](https://github.com/wazuh/wazuh/pull/31901))
+
+### Agent
+
+#### Added
+
+- Added detection of the `-a never,task` Audit rule in FIM whodata for Linux. ([#34661](https://github.com/wazuh/wazuh/pull/34661))
+
+#### Changed
+
+- Changed sync primitive disposal to stop and soften teardown failures. ([#34680](https://github.com/wazuh/wazuh/pull/34680))
+
+#### Fixed
+
+- Fixed Windows FIM Registry scan crash on non-null-terminated values. ([#34679](https://github.com/wazuh/wazuh/pull/34679))
+
+### Other
+
+#### Changed
+
+- Updated curl dependency to 8.12.1. ([#34687](https://github.com/wazuh/wazuh/pull/34687))
+- Updated `starlette` dependency to 0.49.1. ([#33383](https://github.com/wazuh/wazuh/pull/33383))
+- Upgraded Python embedded interpreter to 3.10.19. ([#32790](https://github.com/wazuh/wazuh/pull/32790))
+
+
+## [v4.10.3]
+
+### Other
+
+#### Changed
+
+- Updated `requests` to version 2.32.4 (backport from 4.14.0). ([#30829](https://github.com/wazuh/wazuh/pull/30829))
+- Updated `urllib3` to version 2.5.0 and `protobuf` to version 5.29.5 (backport from 4.14.0). ([#30829](https://github.com/wazuh/wazuh/pull/30829))
+- Updated dependencies: setuptools, Jinja2, and PyJWT (backport from 4.14.0). ([#29933](https://github.com/wazuh/wazuh/pull/29933))
+
+
+## [v4.10.2]
+
+### Manager
+
+#### Fixed
+
+- Enabled inventory synchronization in Vulnerability Detector when the Indexer module is disabled (backport from 4.11.0). ([#29612](https://github.com/wazuh/wazuh/pull/29612))
+- Fixed the OS CPE build for package scans with data from Wazuh-DB (backport from 4.11.1). ([#29613](https://github.com/wazuh/wazuh/pull/29613))
+- Fixed heap buffer overflow in Analysisd rule parser (backport from 4.11.1). ([#29599](https://github.com/wazuh/wazuh/pull/29599))
+- Improved the signal handling during processes stop (backport from 4.12.0). ([#29615](https://github.com/wazuh/wazuh/pull/29615))
+- Fixed crash when reading email alerts missing the `email_to` attribute (backport from 4.12.0). ([#29616](https://github.com/wazuh/wazuh/pull/29616))
+
+#### Changed
+
+- Improved SCA and Syscheck decoders (backport from 4.11.0). ([#29633](https://github.com/wazuh/wazuh/pull/29633))
+
+### Agent
+
+#### Fixed
+
+- Fixed a bug that could cause `wazuh-modulesd` to crash at startup (backport from 4.12.0). ([#29598](https://github.com/wazuh/wazuh/pull/29598))
+- Fixed WPK package upgrades for DEB when upgrading from version 4.3.11 or earlier (backport from 4.12.0). ([#29600](https://github.com/wazuh/wazuh/pull/29600))
+- Fixed error in event processing on AWS Custom Logs Buckets module (backport from 4.11.0). ([#29635](https://github.com/wazuh/wazuh/pull/29635))
+- Improved URL validation in the Maltiverse integration (backport from 4.12.0). ([#29604](https://github.com/wazuh/wazuh/pull/29604))
+
+### Other
+
+#### Changed
+
+- Upgraded python-multipart to 0.0.20, starlette to 0.42.0 and Werkzeug to 3.1.3 (backport from 4.12.0), h11 to 0.16.0 and httpcore to 1.0.9. ([#29669](https://github.com/wazuh/wazuh/pull/29669))
+
+
 ## [v4.10.1] - 2025-01-17
 
 ### Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -707,9 +707,6 @@ All notable changes to this project will be documented in this file.
 - Added the `security:revoke` action to the `PUT /security/user/revoke` endpoint. ([#26255](https://github.com/wazuh/wazuh/pull/26255))
 
 
-## [v4.10.5]
-
-
 ## [v4.10.4]
 
 ### Manager

--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -76,6 +76,30 @@ wazuh-agent (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
+wazuh-agent (4.10.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-agent (4.10.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-agent (4.10.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 19 Aug 2025 00:00:00 +0000
+
+wazuh-agent (4.10.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 21 May 2025 00:00:00 +0000
+
 wazuh-agent (4.10.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
@@ -105,6 +129,12 @@ wazuh-agent (4.9.0-RELEASE) stable; urgency=low
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 05 Sep 2024 00:00:00 +0000
+
+wazuh-agent (4.8.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 22 Aug 2024 00:00:00 +0000
 
 wazuh-agent (4.8.1-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -76,12 +76,6 @@ wazuh-agent (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
-wazuh-agent (4.10.5-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
-
- -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
-
 wazuh-agent (4.10.4-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -76,12 +76,6 @@ wazuh-manager (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
-wazuh-manager (4.10.5-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
-
- -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
-
 wazuh-manager (4.10.4-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -76,6 +76,30 @@ wazuh-manager (4.11.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 19 Feb 2025 00:00:00 +0000
 
+wazuh-manager (4.10.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-manager (4.10.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 21 May 2026 00:00:00 +0000
+
+wazuh-manager (4.10.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 19 Aug 2025 00:00:00 +0000
+
+wazuh-manager (4.10.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 21 May 2025 00:00:00 +0000
+
 wazuh-manager (4.10.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
@@ -105,6 +129,12 @@ wazuh-manager (4.9.0-RELEASE) stable; urgency=low
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 
  -- Wazuh, Inc <info@wazuh.com>  Thu, 05 Sep 2024 00:00:00 +0000
+
+wazuh-manager (4.8.2-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 22 Aug 2024 00:00:00 +0000
 
 wazuh-manager (4.8.1-RELEASE) stable; urgency=low
 

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -833,8 +833,6 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
-* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
 * Thu May 21 2026 support <info@wazuh.com> - 4.10.4
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
 * Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -833,6 +833,14 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.4
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+* Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+* Wed May 21 2025 support <info@wazuh.com> - 4.10.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
 * Thu Jan 16 2025 support <info@wazuh.com> - 4.10.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
 * Thu Jan 09 2025 support <info@wazuh.com> - 4.10.0
@@ -843,6 +851,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html
 * Thu Sep 05 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Thu Aug 22 2024 support <info@wazuh.com> - 4.8.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 * Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -999,6 +999,14 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
+* Thu May 21 2026 support <info@wazuh.com> - 4.10.4
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
+* Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-3.html
+* Wed May 21 2025 support <info@wazuh.com> - 4.10.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-2.html
 * Thu Jan 16 2025 support <info@wazuh.com> - 4.10.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-1.html
 * Thu Jan 09 2025 support <info@wazuh.com> - 4.10.0
@@ -1009,6 +1017,8 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-1.html
 * Thu Sep 05 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Thu Aug 22 2024 support <info@wazuh.com> - 4.8.2
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 * Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -999,8 +999,6 @@ rm -fr %{buildroot}
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-1.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
-* Thu May 21 2026 support <info@wazuh.com> - 4.10.5
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-5.html
 * Thu May 21 2026 support <info@wazuh.com> - 4.10.4
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-10-4.html
 * Tue Aug 19 2025 support <info@wazuh.com> - 4.10.3


### PR DESCRIPTION
## Related issue

https://github.com/wazuh/wazuh/issues/36333

## Description

Adds the missing version entries to align `CHANGELOG.md` with the RPM `.spec` and Debian `changelog` files on the `4.14.6` branch:

- `4.10.2`, `4.10.3`, `4.10.4`, `4.10.5` (LTS backports that never reached this branch via upward merges).
- `4.8.2` (missing from the package changelogs even though `CHANGELOG.md` already had it).

All entries are inserted following descending version order, consistent with the existing convention in this branch.
