### PR TITLE
Bump CB_SCAN_STARTED timeout and trigger ITs on wm_syscollector.c

### DIFF
--- a/.github/test-modules-windows.json
+++ b/.github/test-modules-windows.json
@@ -141,6 +141,7 @@
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
         ".github/test-modules-windows.json",
         "src/config/src/wmodules-syscollector.c",
+        "src/wazuh_modules/src/wm_syscollector.c",
         "src/wazuh_modules/syscollector/**",
         "src/win32/**",
         "src/Makefile",

--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -304,6 +304,7 @@
         ".github/workflows/5_testintegration_linux-integration-tests.yml",
         ".github/test_modules_linux.json",
         "src/config/src/wmodules-syscollector.c",
+        "src/wazuh_modules/src/wm_syscollector.c",
         "src/wazuh_modules/syscollector/**",
         "src/Makefile",
         "tests/integration/conftest.py",

--- a/tests/integration/test_syscollector/test_configuration/test_syscollector_configuration.py
+++ b/tests/integration/test_syscollector/test_configuration/test_syscollector_configuration.py
@@ -567,8 +567,12 @@ def test_syscollector_collectors_disabled(test_configuration, test_metadata, set
     log_monitor.start(callback=callbacks.generate_callback(patterns.CB_MODULE_STARTED), timeout=180)
     assert log_monitor.callback_result, "Module should continue running after DataClean"
 
-    # Check general scan has started (enabled collectors should scan)
-    log_monitor.start(callback=callbacks.generate_callback(patterns.CB_SCAN_STARTED), timeout=10)
+    # Check general scan has started (enabled collectors should scan).
+    # CB_MODULE_STARTED now fires in wm_sys_main *before* Syscollector::start()
+    # runs, so the gap until the first "Starting evaluation." can include the
+    # full handleNotifyDataClean retry budget (m_dataCleanRetries * 60s) when
+    # the test env's remoted_simulator does not ack DataClean.
+    log_monitor.start(callback=callbacks.generate_callback(patterns.CB_SCAN_STARTED), timeout=240)
     assert log_monitor.callback_result, "Scan should start for enabled collectors"
 
     # Map collector names to their scan callbacks


### PR DESCRIPTION
Fixes #36447.

## Summary

Restores green status for the three `test_syscollector_collectors_disabled` parametrized cases (`packages_disabled`, `packages_processes_disabled`, `network_disabled`) on both Linux and Windows ITs, and prevents the same class of regression from slipping past path triggers again.

## Root cause

#36234 (wazuh/wazuh#36234, *Review agent info logs*, merged 2026-05-25) moved syscollector's startup INFO log from `Syscollector::syncLoop()` (post-DataClean) to `wm_sys_main()` (pre-DataClean). The qa-integration-framework pattern `CB_MODULE_STARTED = r'INFO: Started \(pid: \d+\).'` was updated to match the new log, but the test's `CB_SCAN_STARTED` follow-on `timeout=10` was not.

Before #36234:
```
[INFO] Module started.        <-- emitted in syncLoop, AFTER handleNotifyDataClean
[INFO] Starting evaluation.   <-- emitted by Syscollector::scan(), ~immediately after
```
After #36234:
```
[INFO] Started (pid: N).      <-- emitted in wm_sys_main, BEFORE syscollector_start_ptr()
...
   handleNotifyDataClean retries (m_dataCleanRetries × 60s, default 3 → 120s wait)
...
[INFO] Starting evaluation.
```

In the IT environment the `remoted_simulator` does not ack DataClean, so `notifyDisableCollectorsDataClean()` always fails and `handleNotifyDataClean()` consumes its full retry budget before falling through to `syncLoop()` → `scan()` → `"Starting evaluation."`. The test only allowed 10 s for that gap, so all three partial-disabled cases time out on `assert log_monitor.callback_result, "Scan should start for enabled collectors"` (test_syscollector_configuration.py:572).

## Why it landed undetected

The syscollector IT trigger paths in `.github/test_modules_linux.json` and `.github/test-modules-windows.json` listed `src/config/src/wmodules-syscollector.c` and `src/wazuh_modules/syscollector/**` but **not** `src/wazuh_modules/src/wm_syscollector.c`. #36234's change lives in `wm_syscollector.c`, so the matrix builder didn't select the syscollector shard and no IT ran on that PR.

(There is also a separate latent issue: the trigger evaluator uses `PurePosixPath.match()`, which does not implement recursive `**` semantics — `src/wazuh_modules/syscollector/**` only matches files exactly one segment deep. That's out of scope here; this PR keeps the same matcher and just adds the missing entry.)

## Proposed changes

- **`tests/integration/test_syscollector/test_configuration/test_syscollector_configuration.py`** — bump the `CB_SCAN_STARTED` timeout from `10` to `240` seconds, with an inline comment explaining the new log placement and retry budget. 240 s leaves a comfortable margin over the worst-case retry budget (default 3 × 60 s) plus DB delete / `fetchDocumentLimitsFromAgentd` / `syncLoop` preamble.
- **`.github/test_modules_linux.json`** and **`.github/test-modules-windows.json`** — add `src/wazuh_modules/src/wm_syscollector.c` to the `syscollector` module's `paths`, so future changes to the wm-side entry point trigger the syscollector IT.

## Verification

- `IT Linux - syscollector (tier-0-1)` ✅ pass on this PR — https://github.com/wazuh/wazuh/actions/runs/26478074983/job/77969351068
- `IT Windows - syscollector (tier-0-1)` ✅ pass on this PR — https://github.com/wazuh/wazuh/actions/runs/26478074962/job/77970188711

(Editing the JSON trigger files makes this PR run the full IT matrix on both platforms; the syscollector shard is the only one this PR semantically touches. The `IT Windows - logcollector` failure on this run is unrelated and pre-existing on `main` — it isn't normally exercised on PRs because no recent PR has touched both that module's trigger paths and a JSON config file.)

## Test plan

- [x] Linux syscollector IT (`IT Linux - syscollector (tier-0-1)`) green on this PR — verifies the three previously failing cases pass with the new timeout.
- [x] Windows syscollector IT (`IT Windows - syscollector (tier-0-1)`) green on this PR.
- [x] No regression on the other 36 syscollector cases (still pass within their existing timeouts).