### PR TITLE
fix(framework): replace bare except with except OSError in WazuhQueue send path

### DIFF
--- a/framework/wazuh/core/tests/test_wazuh_queue.py
+++ b/framework/wazuh/core/tests/test_wazuh_queue.py
@@ -154,9 +154,13 @@ def test_WazuhQueue_send_msg_to_agent(mock_send, mock_conn, msg, agent_id, msg_t
     ('force_reconnect', None, None, 1014),
 ])
 @patch('wazuh.core.wazuh_queue.socket.socket.connect')
-@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=Exception)
+@patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=OSError)
 def test_WazuhQueue_send_msg_to_agent_ko(mock_send, mock_conn, msg, agent_id, msg_type, expected_exception):
     """Test WazuhQueue.send_msg_to_agent function exceptions.
+
+    The send path narrows its handler to ``OSError`` (covering ``socket.error``,
+    which is an alias for ``OSError`` in Python 3), so the side effect used here
+    must be an ``OSError`` for the wrap into ``WazuhError(1014)`` to apply.
 
     Parameters
     ----------
@@ -174,5 +178,25 @@ def test_WazuhQueue_send_msg_to_agent_ko(mock_send, mock_conn, msg, agent_id, ms
 
     with pytest.raises(WazuhException, match=f'.* {expected_exception} .*'):
         queue.send_msg_to_agent(msg, agent_id, msg_type)
+
+    mock_conn.assert_called_once_with('test_path')
+
+
+@pytest.mark.parametrize('propagated_exception', [KeyboardInterrupt, SystemExit, MemoryError])
+@patch('wazuh.core.wazuh_queue.socket.socket.connect')
+def test_WazuhQueue_send_msg_to_agent_propagates_non_oserror(mock_conn, propagated_exception):
+    """Regression test for #36149.
+
+    The previous bare ``except`` in ``WazuhQueue.send_msg_to_agent`` swallowed
+    ``KeyboardInterrupt``, ``SystemExit`` and ``MemoryError`` and re-raised them
+    as ``WazuhError(1014)``. After narrowing the handler to ``except OSError``,
+    these exceptions must propagate unchanged so controlled shutdowns and OOM
+    signals reach the calling code.
+    """
+    queue = WazuhQueue('test_path')
+
+    with patch('wazuh.core.wazuh_queue.WazuhQueue._send', side_effect=propagated_exception):
+        with pytest.raises(propagated_exception):
+            queue.send_msg_to_agent(WazuhQueue.HC_FORCE_RECONNECT, None, None)
 
     mock_conn.assert_called_once_with('test_path')

--- a/framework/wazuh/core/wazuh_queue.py
+++ b/framework/wazuh/core/wazuh_queue.py
@@ -169,7 +169,7 @@ class WazuhQueue(BaseQueue):
         try:
             # Send message
             self._send(socket_msg.encode())
-        except:
+        except OSError:
             raise WazuhError(1014, extra_message=f": WazuhQueue socket with path {self.path}")
 
         return ret_msg


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes #36149.

`WazuhQueue.send_msg_to_agent` wrapped `self._send(...)` in a bare `except:`, which catches `KeyboardInterrupt`, `SystemExit`, and `MemoryError` and re-raises them as `WazuhError(1014)`. This silently suppresses controlled shutdowns and OOM signals.

The fix narrows the handler to `except OSError:`, matching the issue description and aligning with the scoping used elsewhere in `wazuh_queue.py` (`socket.error` on line 77, `Exception` reserved for `_connect` on line 53, which has broader failure modes including `setsockopt`).

### Side effect of narrowing the handler (please review)

`_send()` already catches `socket.error` (an alias for `OSError` in Python 3) and converts it to `WazuhInternalError(1011)` on line 78. Under the previous bare-`except:`, that `WazuhInternalError(1011)` was caught here and re-wrapped as `WazuhError(1014)`. After narrowing to `except OSError:`, `WazuhInternalError(1011)` propagates to the caller unchanged.

That looked intentional to me (1011 is more specific than the 1014 wrapper, and it preserves the queue path), but flagging it explicitly so reviewers can confirm. If the wrapping should be preserved, the handler can be widened to `except (OSError, WazuhInternalError):` - happy to update.

## Proposed Changes

- `framework/wazuh/core/wazuh_queue.py`: replace bare `except:` with `except OSError:` in `WazuhQueue.send_msg_to_agent`.
- `framework/wazuh/core/tests/test_wazuh_queue.py`:
  - Update `test_WazuhQueue_send_msg_to_agent_ko` to use `side_effect=OSError` (after the fix, `Exception` is no longer caught - the prior test was passing only because of the bare-except bug it was meant to validate).
  - Add `test_WazuhQueue_send_msg_to_agent_propagates_non_oserror`, a parametrized regression test asserting `KeyboardInterrupt`, `SystemExit`, and `MemoryError` propagate unchanged.

### Results and Evidence

Local pytest collection of `test_wazuh_queue.py` requires POSIX-only modules (`grp`, `pwd`, `socket.AF_UNIX`), so local validation on Windows is blocked for both the modified and the unmodified tree. Relying on CI for canonical test execution.

Visual verification of the diff is straightforward - see the two files in this PR. The new regression test (`test_WazuhQueue_send_msg_to_agent_propagates_non_oserror`) follows the same parametrize/decorator pattern already used by `test_WazuhQueue_send_msg_to_agent_ko` immediately above it.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux - N/A (Python-only change)
  - [ ] Windows - N/A
  - [ ] MAC OS X - N/A
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity - N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) - N/A
  - [ ] AddressSanitizer - N/A
- Memory tests for Windows
  - [ ] Coverity - N/A
  - [ ] UMDH - N/A
- Memory tests for macOS
  - [ ] Leaks - N/A
  - [ ] AddressSanitizer - N/A