### PR TITLE
Fix policy evaluation errors

### DIFF
--- a/ruleset/sca/amazon/cis_amazon_linux_2.yml
+++ b/ruleset/sca/amazon/cis_amazon_linux_2.yml
@@ -1858,13 +1858,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.log_martians -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
       - 'c:sysctl net.ipv4.conf.default.log_martians -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
 
   # 3.3.5 Ensure broadcast ICMP requests are ignored. (Automated)
   - id: 20571
@@ -1890,9 +1890,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
   # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated)
   - id: 20572
@@ -1918,9 +1918,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
   # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated)
   - id: 20573
@@ -1946,9 +1946,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
 
   # 3.3.8 Ensure TCP SYN Cookies is enabled. (Automated)
   - id: 20574
@@ -1974,9 +1974,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
 
   # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated) - Not Implemented
 

--- a/ruleset/sca/centos/7/cis_centos7_linux.yml
+++ b/ruleset/sca/centos/7/cis_centos7_linux.yml
@@ -2038,13 +2038,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.send_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.send_redirects\s*=\s*0$'
 
   ##################################################
   # 3.3 Network Parameters (Host and Router)
@@ -2075,13 +2075,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.accept_source_route -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.accept_source_route -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.accept_source_route\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.accept_source_route\s*=\s*0$'
 
   # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
 
@@ -2110,13 +2110,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.secure_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.secure_redirects\s*=\s*0$'
 
   # 3.3.4 Ensure suspicious packets are logged. (Automated)
   - id: 6081
@@ -2144,13 +2144,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.log_martians -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
       - 'c:sysctl net.ipv4.conf.default.log_martians -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.log_martians\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.default\.log_martians\s*=\s*1$'
 
   # 3.3.5 Ensure broadcast ICMP requests are ignored. (Automated)
   - id: 6082
@@ -2176,9 +2176,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
   # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated)
   - id: 6083
@@ -2204,9 +2204,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
   # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated)
   - id: 6084
@@ -2232,9 +2232,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.conf\.all\.rp_filter\s*=\s*1$'
 
   # 3.3.8 Ensure TCP SYN Cookies is enabled. (Automated)
   - id: 6085
@@ -2260,9 +2260,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
 
   # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated)
   - id: 6086
@@ -2289,13 +2289,13 @@ checks:
       - 'c:sysctl net.ipv6.conf.all.accept_raa -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
       - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.all\.accept_raa\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv6\.conf\.default\.accept_ra\s*=\s*1$'
 
   ###############################################
   # 3.4 Uncommon Network Protocols

--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -3452,7 +3452,7 @@ checks:
     condition: any
     rules:
       - "f:/etc/security/faillock.conf -> r:even_deny_root"
-      - "f:/etc/security/faillock.conf -> n:root_unlock_time >= 60"
+      - 'f:/etc/security/faillock.conf -> n:root_unlock_time\s*\t*=\s*\t*(\d+) compare >= 60'
 
   # 5.3.3.2.1 Ensure password number of changed characters is configured. (Automated)
   - id: 33193

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -3041,9 +3041,9 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
-      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
-      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:.*ACCEPT.*all.*lo.*\*.*0\.0\.0\.0/0.*0\.0\.0\.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:.*DROP.*all.*\*.*\*.*127\.0\.0\.0/8.*0\.0\.0\.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:.*ACCEPT.*all.*\*.*lo.*0\.0\.0\.0/0.*0\.0\.0\.0/0'
 
   # 3.5.3.2.2 Ensure iptables outbound and established connections are configured. (Manual) - Not Implemented
   # 3.5.3.2.3 Ensure iptables rules exist for all open ports. (Automated) - Not Implemented
@@ -3130,9 +3130,9 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - 'c:ip6tables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*::/0\.*::/0'
-      - 'c:ip6tables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'
-      - 'c:ip6tables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'
+      - 'c:ip6tables -L INPUT -v -n -> r:.*ACCEPT.*all.*lo.*\*.*::/0.*::/0'
+      - 'c:ip6tables -L INPUT -v -n -> r:.*DROP.*all.*\*.*\*.*::1.*::/0'
+      - 'c:ip6tables -L OUTPUT -v -n -> r:.*ACCEPT.*all.*\*.*lo.*::/0.*::/0'
 
   # 3.5.3.3.2 Ensure ip6tables outbound and established connections are configured. (Manual) - Not Implemented
   # 3.5.3.3.3 Ensure ip6tables firewall rules exist for all open ports. (Automated) - Not Implemented
@@ -3868,10 +3868,10 @@ checks:
       subtechnique: ["T1562.002", "T1070.001"]
     condition: all
     rules:
-      - 'f:/etc/rsyslog.conf -> !r:# && r:^*.* @@\.+'
-      - 'f:/etc/rsyslog.conf -> !r:# && r:^*.* action && r:target="'
-      - 'd:/etc/rsyslog.d/ -> r:*.conf -> !r:# && r:^*.* @@\.+'
-      - 'd:/etc/rsyslog.d/ -> r:*.conf -> !r:# && r:^*.* action && r:target="'
+      - 'f:/etc/rsyslog.conf -> !r:# && r:^\*\.\* @@.+'
+      - 'f:/etc/rsyslog.conf -> !r:# && r:^\*\.\* action && r:target="'
+      - 'd:/etc/rsyslog.d/ -> r:.*\.conf -> !r:# && r:^\*\.\* @@.+'
+      - 'd:/etc/rsyslog.d/ -> r:.*\.conf -> !r:# && r:^\*\.\* action && r:target="'
 
   # 4.2.1.6 Ensure remote rsyslog messages are only accepted on designated log hosts. (Manual)
   - id: 4640

--- a/ruleset/sca/rhel/7/cis_rhel7_linux.yml
+++ b/ruleset/sca/rhel/7/cis_rhel7_linux.yml
@@ -2187,14 +2187,14 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.ip_forward -> r:^net.ipv4.ip_forward\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
       - 'c:sysctl net.ipv6.conf.all.forwarding -> r:^net.ipv6.conf.all.forwarding\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.ip_forward\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.forwarding\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.forwarding\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.forwarding\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.forwarding\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.forwarding\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.forwarding\s*=\s*1$'
 
   # 3.2.2 Ensure packet redirect sending is disabled. (Automated)
   - id: 4582
@@ -2221,13 +2221,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
 
   ###############################################
   # 3.3 Network Parameters (Host and Router)
@@ -2258,13 +2258,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.accept_source_route -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.accept_source_route -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_source_route\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_source_route\s*=\s*0$'
 
   # 3.3.2 Ensure ICMP redirects are not accepted. (Automated)
   - id: 4584
@@ -2291,23 +2291,23 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.accept_redirects -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.accept_redirects -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.accept_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.accept_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv6.conf.all.accept_redirects -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv6.conf.default.accept_redirects -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_redirects\s*=\s*0$'
 
   # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated)
   - id: 4585
@@ -2334,13 +2334,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
 
   # 3.3.4 Ensure suspicious packets are logged. (Automated)
   - id: 4586
@@ -2368,13 +2368,13 @@ checks:
       - 'c:sysctl net.ipv4.conf.all.log_martians -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
       - 'c:sysctl net.ipv4.conf.default.log_martians -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
 
   # 3.3.5 Ensure broadcast ICMP requests are ignored. (Automated)
   - id: 4587
@@ -2400,9 +2400,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
   # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated)
   - id: 4588
@@ -2428,9 +2428,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
   # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated)
   - id: 4589
@@ -2456,9 +2456,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
 
   # 3.3.8 Ensure TCP SYN Cookies is enabled. (Automated)
   - id: 4590
@@ -2484,9 +2484,9 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
   # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated)
   - id: 4591
@@ -2513,13 +2513,13 @@ checks:
       - 'c:sysctl net.ipv6.conf.all.accept_raa -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
       - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.all.accept_raa\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
-      - 'd:->/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
-      - 'd:->/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
+      - 'd:/usr/lib/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
+      - 'd:/run/sysctl.d/ -> r:\.*.conf -> r:^net.ipv6.conf.default.accept_ra\s*=\s*1$'
 
   ###############################################
   # 3.4 Uncommon Network Protocols

--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -1866,7 +1866,7 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
   # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated)
   - id: 21071
@@ -1892,7 +1892,7 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
   # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
 
@@ -1920,7 +1920,7 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:.*\.conf -> r:^net\.ipv4\.tcp_syncookies\s*=\s*1$'
 
   # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated) - Not Implemented
 

--- a/ruleset/sca/sles/16/cis_sles16_linux.yml
+++ b/ruleset/sca/sles/16/cis_sles16_linux.yml
@@ -1866,7 +1866,7 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
   # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated)
   - id: 40571
@@ -1892,7 +1892,7 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
   # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
 
@@ -1920,7 +1920,7 @@ checks:
     rules:
       - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
       - 'f:/etc/sysctl.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
-      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'd:/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
   # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated) - Not Implemented
 

--- a/ruleset/sca/sles/16/cis_sles16_linux.yml
+++ b/ruleset/sca/sles/16/cis_sles16_linux.yml
@@ -2377,9 +2377,9 @@ checks:
       subtechnique: ["T1090.001", "T1090.002", "T1557.001"]
     condition: all
     rules:
-      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
-      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
-      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:.*ACCEPT.*all.*lo.*\*.*0\.0\.0\.0/0.*0\.0\.0\.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:.*DROP.*all.*\*.*\*.*127\.0\.0\.0/8.*0\.0\.0\.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:.*ACCEPT.*all.*\*.*lo.*0\.0\.0\.0/0.*0\.0\.0\.0/0'
 
   # 3.5.3.2.3 Ensure outbound and established connections are configured. (Manual) - Not Implemented
 


### PR DESCRIPTION
## Description

Fixes three SCA policy errors identified in the log analysis from issue #36253, causing checks to be silently skipped or evaluated incorrectly, and generating error logs, on several Linux distributions.

Closes #36340

## Proposed Changes

### Bug 1 — `Rule cannot be empty` (Amazon Linux 2, CentOS 7, RHEL 7, SLES 15/16)

Rules using the `d:->` directory notation (e.g. `d:->/etc/sysctl.d/ -> r:.*\.conf`) caused the parser to find the embedded `->` at position 2 instead of the ` -> ` delimiter, leaving `d:` with an empty value and throwing `Rule cannot be empty`, skipping the entire check.

**Fix:** Removed the invalid `->` prefix from all `d:->` paths across affected policies.

| File | Affected checks | Rules fixed |
|---|---|---|
| `cis_amazon_linux_2.yml` | 20570–20574 | 18 |
| `cis_centos7_linux.yml` | 6077–6086 | 42 |
| `cis_rhel7_linux.yml` | 4581–4591 | 60 |
| `cis_sles15_linux.yml` | 21070–21072 | 3 |
| `cis_sles16_linux.yml` | 40570–40572 | 3 |

### Bug 2 — Invalid PCRE2 patterns (RHEL 7, SLES 16)

Patterns such as `\.**`, `*.conf`, and `^*.*` were written for the legacy regex engine but are invalid under PCRE2. The second `*` in `\.**` attempts to quantify a quantifier, and `*.conf` / `^*.*` have a quantifier with no preceding repeatable item.

**Fixes:**

| File | Check | Fix |
|---|---|---|
| `cis_rhel7_linux.yml` | 4610 | `\.*ACCEPT\.*lo\.**\.*` → `.*ACCEPT.*lo.*\*.*` |
| `cis_rhel7_linux.yml` | 4613 | same pattern, ip6tables loopback |
| `cis_rhel7_linux.yml` | 4639 | `*.conf` → `.*\.conf`; `^*.*` → `^\*\.\*` |
| `cis_sles16_linux.yml` | 40589 | same iptables loopback pattern as RHEL 7 4610 |

### Bug 3 — `compare` keyword missing (Debian 12)

Check 33192 used `n:root_unlock_time >= 60`, which lacks the capture group and `compare` keyword.

**Fix:** `n:root_unlock_time >= 60` → `n:root_unlock_time\s*\t*=\s*\t*(\d+) compare >= 60`

### Results and Evidence

#### Bug 1 — Amazon Linux 2 (amd64)

**Before**

```
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20569 parsed.
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:56:04 wazuh-modulesd:sca[2719] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20575 parsed.
```

**After**

```
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20569 parsed.
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20570 parsed.
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20571 parsed.
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20572 parsed.
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20573 parsed.
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20574 parsed.
2026/05/26 23:04:17 wazuh-modulesd:sca[175] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 20575 parsed.
```

#### Bug 1 — CentOS 7 (amd64)

**Before**

```
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6074 parsed.
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:298 at sca_log_callback(): ERROR: Failed to parse a check. Skipping it. Error: Rule cannot be empty
2026/05/25 19:55:12 wazuh-modulesd:sca[2644] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6087 parsed.
```

**After**

```
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6074 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6077 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6078 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6080 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6081 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6082 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6083 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6084 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6085 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6086 parsed.
2026/05/26 23:04:25 wazuh-modulesd:sca[176] wm_sca.c:286 at sca_log_callback(): DEBUG: Check 6087 parsed.
```

#### Bug 2 — RHEL 7 (amd64)

**Before**

```
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'iptables -L INPUT -v -n'
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Received query: {"command":"get_scan_completed"}
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Executing command: get_scan_completed
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 23: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'.
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: iptables -L INPUT -v -n' pattern 'r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0' was not found
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'iptables -L INPUT -v -n'
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Received query: {"command":"get_scan_completed"}
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Executing command: get_scan_completed
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 16: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'.
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: iptables -L INPUT -v -n' pattern 'r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0' was not found
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'iptables -L OUTPUT -v -n'
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Received query: {"command":"get_scan_completed"}
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Executing command: get_scan_completed
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 18: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'.
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: iptables -L OUTPUT -v -n' pattern 'r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0' was not found
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "4610" evaluation completed for policy "cis_rhel7_linux", result: Failed
...
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'ip6tables -L INPUT -v -n'
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Received query: {"command":"get_scan_completed"}
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Executing command: get_scan_completed
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 23: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:\.*ACCEPT\.*all\.*lo\.**\.*::/0\.*::/0'.
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: ip6tables -L INPUT -v -n' pattern 'r:\.*ACCEPT\.*all\.*lo\.**\.*::/0\.*::/0' was not found
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'ip6tables -L INPUT -v -n'
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Receive
d query: {"command":"get_scan_completed"}
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Executing command: get_scan_completed
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 16: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:\.*DROP\.*all\.**\.**\.*::1\.*::/0'.
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: ip6tables -L INPUT -v -n' pattern 'r:\.*DROP\.*all\.**\.**\.*::1\.*::/0' was not found
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'ip6tables -L OUTPUT -v -n'
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Received query: {"command":"get_scan_completed"}
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Executing command: get_scan_completed
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 18: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0'.
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: ip6tables -L OUTPUT -v -n' pattern 'r:\.*ACCEPT\.*all\.**\.*lo\.*::/0\.*::/0' was not found
2026/05/25 20:07:40 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "4613" evaluation completed for policy "cis_rhel7_linux", result: Failed
...
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/rsyslog.conf' against pattern:  !r:# && r:^*.*
@@\.+
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 1: quantifier does not follow a repeatable item' was caught while evaluating pattern '!r:# && r:^*.* @@\.+'.
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Invalid pattern '!r:# && r:^*.* @@\.+' for file '/etc/rsyslog.conf'
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/rsyslog.conf' against pattern:  !r:# && r:^*.* action && r:target="
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 1: quantifier does not follow a repeatable item' was caught while evaluating pattern '!r:# && r:^*.* action && r:target="'.
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Invalid pattern '!r:# && r:^*.* action && r:target="' for file '/etc/rsyslog.conf'
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing directory rule:  '/etc/rsyslog.d/'
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 0: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:*.conf'.
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 0: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:*.conf'.
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Invalid pattern 'r:*.conf -> !r:# && r:^*.* @@\.+' for directory '/etc/rsyslog.d'
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing directory rule:  '/etc/rsyslog.d/'
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 0: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:*.conf'.
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 0: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:*.conf'.
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Invalid pattern 'r:*.conf -> !r:# && r:^*.* action && r:target="' for directory '/etc/rsyslog.d'
2026/05/25 20:07:41 wazuh-modulesd:sca[1218] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "4639" evaluation completed for policy "cis_rhel7_linux", result: Not applicable
```

**After**

```
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'iptables -L INPUT -v -n'
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: iptables -L INPUT -v -n' pattern 'r:.*ACCEPT.*all.*lo.*\*.*0\.0\.0\.0/0.*0\.0\.0\.0/0' was not found
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'iptables -L INPUT -v -n'
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: iptables -L INPUT -v -n' pattern 'r:.*DROP.*all.*\*.*\*.*127\.0\.0\.0/8.*0\.0\.0\.0/0' was not found
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'iptables -L OUTPUT -v -n'
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: iptables -L OUTPUT -v -n' pattern 'r:.*ACCEPT.*all.*\*.*lo.*0\.0\.0\.0/0.*0\.0\.0\.0/0' was not found
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "4610" evaluation completed for policy "cis_rhel7_linux", result: Failed
...
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'ip6tables -L INPUT -v -n'
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: ip6tables -L INPUT -v -n' pattern 'r:.*ACCEPT.*all.*lo.*\*.*::/0.*::/0' was not found
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'ip6tables -L INPUT -v -n'
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: ip6tables -L INPUT -v -n' pattern 'r:.*DROP.*all.*\*.*\*.*::1.*::/0' was not found
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing command rule: 'ip6tables -L OUTPUT -v -n'
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Command rule evaluation result: ip6tables -L OUTPUT -v -n' pattern 'r:.*ACCEPT.*all.*\*.*lo.*::/0.*::/0' was not found
2026/05/26 23:04:45 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "4613" evaluation completed for policy "cis_rhel7_linux", result: Failed
...
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/rsyslog.conf' against pattern:  !r:# && r:^\*\.\* @@.+
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern '!r:# && r:^\*\.\* @@.+' was found in file '/etc/rsyslog.conf'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/rsyslog.conf' against pattern:  !r:# && r:^\*\.\* action && r:target="
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern '!r:# && r:^\*\.\* action && r:target="' was found in file '/etc/rsyslog.conf'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing directory rule:  '/etc/rsyslog.d/'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern '!r:# && r:^\*\.\* @@.+' was not found in file '/etc/rsyslog.d/listen.conf'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern '!r:# && r:^\*\.\* @@.+' was found in file '/etc/rsyslog.d/remote.conf'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern 'r:.*\.conf -> !r:# && r:^\*\.\* @@.+' was found in directory '/etc/rsyslog.d'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing directory rule:  '/etc/rsyslog.d/'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern '!r:# && r:^\*\.\* action && r:target="' was not found in file '/etc/rsyslog.d/listen.conf'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern '!r:# && r:^\*\.\* action && r:target="' was found in file '/etc/rsyslog.d/remote.conf'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern 'r:.*\.conf -> !r:# && r:^\*\.\* action && r:target="' was found in directory '/etc/rsyslog.d'
2026/05/26 23:04:46 wazuh-modulesd:sca[152] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "4639" evaluation completed for policy "cis_rhel7_linux", result: Passed
```

#### Bug 3 — Debian 12 (amd64)

**Before**

```
2026/05/25 19:56:46 wazuh-modulesd:sca[6509] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/security/faillock.conf' against pattern:  r:even_deny_root
2026/05/25 19:56:46 wazuh-modulesd:sca[6509] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern 'r:even_deny_root' was found in file '/etc/security/faillock.conf'
2026/05/25 19:56:46 wazuh-modulesd:sca[6509] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/security/faillock.conf' against pattern:  n:root_unlock_time >= 60
2026/05/25 19:56:46 wazuh-modulesd:sca[6509] wm_sca.c:298 at sca_log_callback(): ERROR: Exception 'Invalid expression format, 'compare' keyword missing' was caught while evaluating pattern 'n:root_unlock_time >= 60'.
2026/05/25 19:56:46 wazuh-modulesd:sca[6509] wm_sca.c:286 at sca_log_callback(): DEBUG: Invalid pattern 'n:root_unlock_time >= 60' for file '/etc/security/faillock.conf'
2026/05/25 19:56:46 wazuh-modulesd:sca[6509] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "33192" evaluation completed for policy "cis_debian12", result: Passed
```

**After**

```
2026/05/26 23:04:33 wazuh-modulesd:sca[122] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/security/faillock.conf' against pattern:  r:even_deny_root
2026/05/26 23:04:33 wazuh-modulesd:sca[122] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern 'r:even_deny_root' was found in file '/etc/security/faillock.conf'
2026/05/26 23:04:33 wazuh-modulesd:sca[122] wm_sca.c:286 at sca_log_callback(): DEBUG: Processing file rule. Checking contents of file: '/etc/security/faillock.conf' against pattern:  n:root_unlock_time\s*\t*=\s*\t*(\d+) compare >= 60
2026/05/26 23:04:33 wazuh-modulesd:sca[122] wm_sca.c:286 at sca_log_callback(): DEBUG: Pattern 'n:root_unlock_time\s*\t*=\s*\t*(\d+) compare >= 60' was found in file '/etc/security/faillock.conf'
2026/05/26 23:04:33 wazuh-modulesd:sca[122] wm_sca.c:286 at sca_log_callback(): DEBUG: Policy check "33192" evaluation completed for policy "cis_debian12", result: Passed
```

### Artifacts Affected

- `ruleset/sca/amazon/cis_amazon_linux_2.yml`
- `ruleset/sca/centos/7/cis_centos7_linux.yml`
- `ruleset/sca/rhel/7/cis_rhel7_linux.yml`
- `ruleset/sca/sles/15/cis_sles15_linux.yml`
- `ruleset/sca/sles/16/cis_sles16_linux.yml`
- `ruleset/sca/debian/cis_debian12.yml`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
