### PR TITLE
Use per-target rpath and remove redundant LD_LIBRARY_PATH/WAZUH_ENGINE_GROUP exports

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,10 @@ set(WAZUH_MAIN_PROJECT
     ON
     CACHE BOOL "Main Wazuh CMake project" FORCE)
 
+# Shared CMake helpers
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(WazuhRpath)
+
 # Define CLIENT for agent builds
 if("${TARGET}" STREQUAL "winagent" OR "${TARGET}" STREQUAL "agent")
   add_definitions(-DCLIENT)

--- a/src/addagent/CMakeLists.txt
+++ b/src/addagent/CMakeLists.txt
@@ -4,6 +4,8 @@ project(manage_agents C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -115,13 +117,5 @@ elseif(NOT UNIT_TEST)
                                                ${SRC_FOLDER}/build/bin)
   target_link_libraries(manage_agents PRIVATE addagent_lib)
 
-  if(APPLE)
-    set_target_properties(
-      manage_agents PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                               INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      manage_agents PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                               INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(manage_agents)
 endif()

--- a/src/addagent/CMakeLists.txt
+++ b/src/addagent/CMakeLists.txt
@@ -120,6 +120,8 @@ elseif(NOT UNIT_TEST)
       manage_agents PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      manage_agents PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                               INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/client-agent/CMakeLists.txt
+++ b/src/client-agent/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-agentd C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -105,13 +107,5 @@ elseif(NOT UNIT_TEST)
                                               ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-agentd PRIVATE agentd_lib)
 
-  if(APPLE)
-    set_target_properties(
-      wazuh-agentd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                              INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      wazuh-agentd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                              INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-agentd)
 endif()

--- a/src/client-agent/CMakeLists.txt
+++ b/src/client-agent/CMakeLists.txt
@@ -110,6 +110,8 @@ elseif(NOT UNIT_TEST)
       wazuh-agentd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                               INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-agentd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                              INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/client-agent/src/rotate_log.c
+++ b/src/client-agent/src/rotate_log.c
@@ -52,7 +52,7 @@ void * w_rotate_log_thread(__attribute__((unused)) void * arg) {
     // /var/ossec/logs/ossec.json
     snprintf(path_json, PATH_MAX, "%s", LOGJSONFILE);
 #else
-    // WAZUH_HOME/logs/<wazuh log file>
+    // <wazuh-home>/logs/<wazuh log file>
     snprintf(path, PATH_MAX, "%s", LOGFILE);
     // /var/ossec/logs/ossec.json
     snprintf(path_json, PATH_MAX, "%s", LOGJSONFILE);

--- a/src/cmake/WazuhRpath.cmake
+++ b/src/cmake/WazuhRpath.cmake
@@ -1,0 +1,30 @@
+# Sets the RPATH for a Wazuh daemon or CLI tool.
+#
+# Release:        $ORIGIN/../lib            (clean, portable)
+# Debug/sanitize: build-tree libs first     (run from src/build/bin/ as-is)
+# Windows:        no-op (PE has no RPATH)
+#
+# Usage: wazuh_set_runtime_rpath(<target>)
+
+function(wazuh_set_runtime_rpath target)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    return()
+  endif()
+
+  if(APPLE)
+    set(install_rpath "@executable_path/../lib")
+  else()
+    set(install_rpath "$ORIGIN/../lib")
+  endif()
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR FSANITIZE)
+    list(PREPEND install_rpath
+      "${CMAKE_SOURCE_DIR}/build/lib"
+      "${CMAKE_SOURCE_DIR}/external/rocksdb/build"
+      "${CMAKE_SOURCE_DIR}/external/jemalloc/lib")
+  endif()
+
+  set_target_properties(${target} PROPERTIES
+    INSTALL_RPATH "${install_rpath}"
+    BUILD_WITH_INSTALL_RPATH TRUE)
+endfunction()

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -208,13 +208,22 @@ if(NOT _orig_rpath)
   set(_orig_rpath "")
 endif()
 
+# $ORIGIN/../lib -> manager install (bin/ -> ../lib/)
+# $ORIGIN/lib    -> standalone package and wazuh-indexer (bin/ -> bin/lib/)
 set(_new_paths
-  ${CMAKE_SOURCE_DIR}/build/lib     # For shared libwazuhext.so
-  ${ROCKSDB_LIB_BUILD_DIR}          # External precompiled rocksdb lib
-  ${INDEXERCONNECTOR_LIB_BUILD_DIR} # Internal precompiled indexer connector lib
   "$ORIGIN/../lib"
   "$ORIGIN/lib"
 )
+
+# Debug/sanitizer: also resolve libs from the build tree so the binary runs
+# straight from src/build/engine/ without LD_LIBRARY_PATH. Never in Release.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR FSANITIZE)
+  list(PREPEND _new_paths
+    ${CMAKE_SOURCE_DIR}/build/lib
+    ${ROCKSDB_LIB_BUILD_DIR}
+    ${INDEXERCONNECTOR_LIB_BUILD_DIR}
+  )
+endif()
 
 # Append the new paths to the original RPATH
 list(APPEND _orig_rpath ${_new_paths})

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
 
         if (chdir(base::process::getWazuhHome().string().c_str()) == -1)
         {
-            fprintf(stderr, "chdir to WAZUH_HOME failed: %s\n", strerror(errno));
+            fprintf(stderr, "chdir to Wazuh home failed: %s\n", strerror(errno));
             return EXIT_FAILURE;
         }
 

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -10,9 +10,6 @@ cd ${LOCAL}
 PWD=`pwd`
 DIR=`dirname $PWD`;
 
-# Ensure the correct lib dir is used when agent/manager are co-hosted.
-export LD_LIBRARY_PATH="${DIR}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
 # Installation info
 VERSION="v5.0.0"
 REVISION="beta2"

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -13,15 +13,10 @@ DIR=`dirname $PWD`;
 PLIST=${DIR}/bin/.process_list;
 WAZUH_CONF="${WAZUH_CONF:-wazuh-manager.conf}"
 
-# Ensure the correct lib dir is used when agent/manager are co-hosted.
-export LD_LIBRARY_PATH="${DIR}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-
 # Installation info
 VERSION="v5.0.0"
 REVISION="beta2"
 TYPE="manager"
-WAZUH_ENGINE_GROUP="${WAZUH_ENGINE_GROUP:-wazuh-manager}"
-export WAZUH_ENGINE_GROUP
 
 ###  Do not modify below here ###
 

--- a/src/logcollector/CMakeLists.txt
+++ b/src/logcollector/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-logcollector C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -101,13 +103,5 @@ elseif(NOT UNIT_TEST)
                                                     ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-logcollector PRIVATE logcollector_lib)
 
-  if(APPLE)
-    set_target_properties(
-      wazuh-logcollector PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                    INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      wazuh-logcollector PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                    INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-logcollector)
 endif()

--- a/src/logcollector/CMakeLists.txt
+++ b/src/logcollector/CMakeLists.txt
@@ -106,6 +106,8 @@ elseif(NOT UNIT_TEST)
       wazuh-logcollector PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                     INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-logcollector PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                    INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/monitord/CMakeLists.txt
+++ b/src/monitord/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-monitord C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -87,13 +89,5 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
                                                         ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-monitord PRIVATE monitord_lib)
 
-  if(APPLE)
-    set_target_properties(
-      wazuh-manager-monitord PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                        INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      wazuh-manager-monitord PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                        INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-manager-monitord)
 endif()

--- a/src/monitord/CMakeLists.txt
+++ b/src/monitord/CMakeLists.txt
@@ -92,6 +92,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
       wazuh-manager-monitord PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                         INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-manager-monitord PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                        INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/os_auth/CMakeLists.txt
+++ b/src/os_auth/CMakeLists.txt
@@ -89,6 +89,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
       wazuh-manager-authd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                      INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-manager-authd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                     INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/os_auth/CMakeLists.txt
+++ b/src/os_auth/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-authd C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -84,13 +86,5 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
                                                      ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-authd PRIVATE authd_lib)
 
-  if(APPLE)
-    set_target_properties(
-      wazuh-manager-authd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                     INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      wazuh-manager-authd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                     INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-manager-authd)
 endif()

--- a/src/os_execd/CMakeLists.txt
+++ b/src/os_execd/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-execd C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -98,15 +100,5 @@ elseif(NOT UNIT_TEST)
                                  ${SRC_FOLDER}/build/bin)
   target_link_libraries(${WAZUH_EXECD_DAEMON_NAME} PRIVATE execd_lib)
 
-  if(APPLE)
-    set_target_properties(
-      ${WAZUH_EXECD_DAEMON_NAME}
-      PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
-                                               "@executable_path/../lib")
-  else()
-    set_target_properties(
-      ${WAZUH_EXECD_DAEMON_NAME}
-      PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
-                                               "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(${WAZUH_EXECD_DAEMON_NAME})
 endif()

--- a/src/os_execd/CMakeLists.txt
+++ b/src/os_execd/CMakeLists.txt
@@ -104,6 +104,9 @@ elseif(NOT UNIT_TEST)
       PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
                                                "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      ${WAZUH_EXECD_DAEMON_NAME}
+      PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
+                                               "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/remoted/CMakeLists.txt
+++ b/src/remoted/CMakeLists.txt
@@ -95,6 +95,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
       wazuh-manager-remoted PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                        INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-manager-remoted PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                       INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/remoted/CMakeLists.txt
+++ b/src/remoted/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-remoted C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -90,13 +92,5 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
                                                        ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-remoted PRIVATE remoted_lib)
 
-  if(APPLE)
-    set_target_properties(
-      wazuh-manager-remoted PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                       INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      wazuh-manager-remoted PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                       INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-manager-remoted)
 endif()

--- a/src/shared/include/defs.h
+++ b/src/shared/include/defs.h
@@ -109,8 +109,13 @@ https://www.gnu.org/licenses/gpl.html\n"
 
 #define ROOT_GID (0)
 
-// Wazuh home environment variable
-#define WAZUH_HOME_ENV "WAZUH_HOME"
+// Wazuh home environment variable (target-specific to avoid clashes on
+// co-hosted manager + agent installs).
+#ifdef CLIENT
+#define WAZUH_HOME_ENV "WAZUH_AGENT_HOME"
+#else
+#define WAZUH_HOME_ENV "WAZUH_MANAGER_HOME"
+#endif
 
 /* Default queue */
 #define DEFAULTQUEUE "queue/sockets/queue"

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -21,7 +21,11 @@
 #define NULL_ERROR    "(1105): Attempted to use null string."
 #define FORMAT_ERROR  "(1106): String not correctly formatted."
 #define MKDIR_ERROR   "(1107): Could not create directory '%s' due to [(%d)-(%s)]."
-#define HOME_ERROR    "(1108): Unable to find Wazuh install directory. Export it to WAZUH_HOME environment variable."
+#ifdef CLIENT
+#define HOME_ERROR    "(1108): Unable to find Wazuh install directory. Export it to WAZUH_AGENT_HOME environment variable."
+#else
+#define HOME_ERROR    "(1108): Unable to find Wazuh install directory. Export it to WAZUH_MANAGER_HOME environment variable."
+#endif
 #define THREAD_ERROR  "(1109): Unable to create new pthread."
 #define FWRITE_ERROR  "(1110): Could not write file '%s' due to [(%d)-(%s)]."
 #define WAITPID_ERROR "(1111): Error during waitpid()-call due to [(%d)-(%s)]."

--- a/src/shared/include/file_op.h
+++ b/src/shared/include/file_op.h
@@ -746,7 +746,8 @@ int w_uncompress_bz2_gz_file(const char * path, const char * dest);
 /**
  * @brief Get the Wazuh installation directory
  *
- * It is obtained from the /proc directory, argv[0], or the env variable WAZUH_HOME
+ * The target-specific env var (`WAZUH_MANAGER_HOME` or `WAZUH_AGENT_HOME`) wins
+ * if set; otherwise it is auto-detected from /proc, then argv[0].
  *
  * @param arg ARGV0 - Program name
  * @return Pointer to the Wazuh installation path on success

--- a/src/shared/src/file_op.c
+++ b/src/shared/src/file_op.c
@@ -3173,7 +3173,9 @@ int w_uncompress_bz2_gz_file(const char * path, const char * dest) {
 /**
  * @brief Get the Wazuh installation directory
  *
- * It is obtained from the /proc directory, argv[0], or the env variable WAZUH_HOME
+ * The target-specific env var (`WAZUH_MANAGER_HOME` or `WAZUH_AGENT_HOME`,
+ * picked at build time via `WAZUH_HOME_ENV`) wins if set. Otherwise the path
+ * is auto-detected from /proc, then argv[0].
  *
  * @param arg ARGV0 - Program name
  * @return Pointer to the Wazuh installation path on success
@@ -3183,34 +3185,35 @@ char *w_homedir(char *arg) {
     struct stat buff_stat;
     char * delim = "/bin";
     os_calloc(PATH_MAX, sizeof(char), buff);
-#ifdef __MACH__
-    pid_t pid = getpid();
-    if (proc_pidpath(pid, buff, PATH_MAX) > 0) {
-        buff = w_strtok_r_str_delim(delim, &buff);
-    }
-#else
-    if (realpath("/proc/self/exe", buff) != NULL) {
-        dirname(buff);
-        buff = w_strtok_r_str_delim(delim, &buff);
-    }
-    else if (realpath("/proc/curproc/file", buff) != NULL) {
-        dirname(buff);
-        buff = w_strtok_r_str_delim(delim, &buff);
-    }
-    else if (realpath("/proc/self/path/a.out", buff) != NULL) {
-        dirname(buff);
-        buff = w_strtok_r_str_delim(delim, &buff);
-    }
-#endif
-    else if (realpath(arg, buff) != NULL) {
-        dirname(buff);
-        buff = w_strtok_r_str_delim(delim, &buff);
+
+    // Target-specific home env var wins if set.
+    char * home_env = getenv(WAZUH_HOME_ENV);
+    if (home_env && *home_env) {
+        snprintf(buff, PATH_MAX, "%s", home_env);
     } else {
-        // The path was not found so read WAZUH_HOME env var
-        char * home_env = NULL;
-        if (home_env = getenv(WAZUH_HOME_ENV), home_env) {
-            snprintf(buff, PATH_MAX, "%s", home_env);
+#ifdef __MACH__
+        pid_t pid = getpid();
+        if (proc_pidpath(pid, buff, PATH_MAX) > 0) {
+            buff = w_strtok_r_str_delim(delim, &buff);
         }
+#else
+        if (realpath("/proc/self/exe", buff) != NULL) {
+            dirname(buff);
+            buff = w_strtok_r_str_delim(delim, &buff);
+        }
+        else if (realpath("/proc/curproc/file", buff) != NULL) {
+            dirname(buff);
+            buff = w_strtok_r_str_delim(delim, &buff);
+        }
+        else if (realpath("/proc/self/path/a.out", buff) != NULL) {
+            dirname(buff);
+            buff = w_strtok_r_str_delim(delim, &buff);
+        }
+        else if (realpath(arg, buff) != NULL) {
+            dirname(buff);
+            buff = w_strtok_r_str_delim(delim, &buff);
+        }
+#endif
     }
 
     if ((w_stat(buff, &buff_stat) < 0) || !S_ISDIR(buff_stat.st_mode)) {

--- a/src/shared_modules/utils/homedirHelper.hpp
+++ b/src/shared_modules/utils/homedirHelper.hpp
@@ -21,21 +21,27 @@ namespace Utils
         std::filesystem::path homeDir;
         std::error_code ec;
 
-        homeDir = std::filesystem::read_symlink("/proc/self/exe", ec).parent_path();
-        if (homeDir.filename() == "bin")
+        // Target-specific env var wins if set (manager/agent separation
+        // for co-hosted installs).
+#ifdef CLIENT
+        const char* envHome = std::getenv("WAZUH_AGENT_HOME");
+#else
+        const char* envHome = std::getenv("WAZUH_MANAGER_HOME");
+#endif
+        if (envHome != nullptr && *envHome != '\0')
         {
-            homeDir.remove_filename();
+            homeDir = envHome;
         }
-        if (ec)
+        else
         {
-            const char* envHome = std::getenv("WAZUH_HOME");
-            if (envHome != nullptr)
-            {
-                homeDir = envHome;
-            }
-            else
+            homeDir = std::filesystem::read_symlink("/proc/self/exe", ec).parent_path();
+            if (ec)
             {
                 throw std::runtime_error(ec.message());
+            }
+            if (homeDir.filename() == "bin")
+            {
+                homeDir.remove_filename();
             }
         }
 

--- a/src/syscheckd/CMakeLists.txt
+++ b/src/syscheckd/CMakeLists.txt
@@ -176,6 +176,8 @@ elseif(NOT UNIT_TEST)
                                  INSTALL_RPATH "@executable_path/../lib")
   else()
     # Linux/Unix
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-syscheckd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                 INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/syscheckd/CMakeLists.txt
+++ b/src/syscheckd/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-syscheckd C CXX)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 include_directories(${SRC_FOLDER}/shared/include/)
@@ -169,15 +171,5 @@ elseif(NOT UNIT_TEST)
                                                    ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-syscheckd PRIVATE syscheckd_lib)
 
-  if(APPLE)
-    # macOS
-    set_target_properties(
-      wazuh-syscheckd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                 INSTALL_RPATH "@executable_path/../lib")
-  else()
-    # Linux/Unix
-    set_target_properties(
-      wazuh-syscheckd PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                 INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-syscheckd)
 endif()

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -798,12 +798,40 @@ void test_w_uncompress_gzfile_success(void **state) {
 }
 
 // w_homedir
+//
+// Note: WAZUH_HOME_ENV resolves to "WAZUH_MANAGER_HOME" or "WAZUH_AGENT_HOME"
+// at compile time depending on -DCLIENT. The test binary and the linked
+// libwazuh_test.a may be built under different CLIENT settings, so the env
+// var name passed to __wrap_getenv() is not asserted here — expect_any() is
+// used instead of expect_string().
+
+void test_w_homedir_env_var(void **state)
+{
+    char *val = NULL;
+    char *argv0 = "bin/test";
+    struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
+
+    // env var set -> realpath() not called.
+    expect_any(__wrap_getenv, name);
+    will_return(__wrap_getenv, "/home/wazuh");
+
+    expect_string(__wrap_stat, __file, "/home/wazuh");
+    will_return(__wrap_stat, &stat_buf);
+    will_return(__wrap_stat, 0);
+
+    val = w_homedir(argv0);
+    assert_string_equal(val, "/home/wazuh");
+    free(val);
+}
 
 void test_w_homedir_first_attempt(void **state)
 {
     char *argv0 = "/usr/share/wazuh/bin/test";
     struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
     char *val = NULL;
+
+    expect_any(__wrap_getenv, name);
+    will_return(__wrap_getenv, NULL);
 
     expect_string(__wrap_realpath, path, "/proc/self/exe");
     will_return(__wrap_realpath, argv0);
@@ -822,6 +850,9 @@ void test_w_homedir_second_attempt(void **state)
     char *argv0 = "/usr/share/wazuh/bin/test";
     struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
     char *val = NULL;
+
+    expect_any(__wrap_getenv, name);
+    will_return(__wrap_getenv, NULL);
 
     expect_string(__wrap_realpath, path, "/proc/self/exe");
     will_return(__wrap_realpath, NULL);
@@ -843,6 +874,9 @@ void test_w_homedir_third_attempt(void **state)
     char *argv0 = "/usr/share/wazuh/bin/test";
     struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
     char *val = NULL;
+
+    expect_any(__wrap_getenv, name);
+    will_return(__wrap_getenv, NULL);
 
     expect_string(__wrap_realpath, path, "/proc/self/exe");
     will_return(__wrap_realpath, NULL);
@@ -868,6 +902,9 @@ void test_w_homedir_check_argv0(void **state)
     struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
     char *val = NULL;
 
+    expect_any(__wrap_getenv, name);
+    will_return(__wrap_getenv, NULL);
+
     expect_string(__wrap_realpath, path, "/proc/self/exe");
     will_return(__wrap_realpath, NULL);
     expect_string(__wrap_realpath, path, "/proc/curproc/file");
@@ -888,37 +925,13 @@ void test_w_homedir_check_argv0(void **state)
     free(val);
 }
 
-void test_w_homedir_env_var(void **state)
-{
-    char *val = NULL;
-    char *argv0 = "bin/test";
-    struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
-
-    expect_string(__wrap_realpath, path, "/proc/self/exe");
-    will_return(__wrap_realpath, NULL);
-    expect_string(__wrap_realpath, path, "/proc/curproc/file");
-    will_return(__wrap_realpath, NULL);
-    expect_string(__wrap_realpath, path, "/proc/self/path/a.out");
-    will_return(__wrap_realpath, NULL);
-    expect_string(__wrap_realpath, path, argv0);
-    will_return(__wrap_realpath, NULL);
-
-    expect_string(__wrap_getenv, name, WAZUH_HOME_ENV);
-    will_return(__wrap_getenv, "/home/wazuh");
-
-    expect_string(__wrap_stat, __file, "/home/wazuh");
-    will_return(__wrap_stat, &stat_buf);
-    will_return(__wrap_stat, 0);
-
-    val = w_homedir(argv0);
-    assert_string_equal(val, "/home/wazuh");
-    free(val);
-}
-
 void test_w_homedir_stat_fail(void **state)
 {
     char *argv0 = "/fake/dir/bin";
     struct stat stat_buf = { .st_mode = 0040000 }; // S_IFDIR
+
+    expect_any(__wrap_getenv, name);
+    will_return(__wrap_getenv, NULL);
 
     expect_string(__wrap_realpath, path, "/proc/self/exe");
     will_return(__wrap_realpath, argv0);
@@ -927,7 +940,11 @@ void test_w_homedir_stat_fail(void **state)
     will_return(__wrap_stat, &stat_buf);
     will_return(__wrap_stat, -1);
 
-    expect_string(__wrap__merror_exit, formatted_msg, "(1108): Unable to find Wazuh install directory. Export it to WAZUH_HOME environment variable.");
+    // HOME_ERROR resolves to a target-specific string at compile time (see
+    // note above on WAZUH_HOME_ENV); the lib and the test may have been
+    // built under different CLIENT settings, so the exact message is not
+    // asserted — only that merror_exit() is reached.
+    expect_any(__wrap__merror_exit, formatted_msg);
 
     expect_assert_failure(w_homedir(argv0));
 }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -67,6 +67,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
       verify-agent-conf PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                    INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      verify-agent-conf PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                   INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-util C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Skip building utilities during unit tests
@@ -62,13 +64,5 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif(NOT APPLE)
   endif(UNIX)
 
-  if(APPLE)
-    set_target_properties(
-      verify-agent-conf PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                   INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      verify-agent-conf PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                   INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(verify-agent-conf)
 endif()

--- a/src/wazuh_db/CMakeLists.txt
+++ b/src/wazuh_db/CMakeLists.txt
@@ -108,6 +108,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
       wazuh-manager-db PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
                                   INSTALL_RPATH "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      wazuh-manager-db PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                  INSTALL_RPATH "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/wazuh_db/CMakeLists.txt
+++ b/src/wazuh_db/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-db C)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Include directories
@@ -103,13 +105,5 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
                                                   ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-db PRIVATE wdb_lib)
 
-  if(APPLE)
-    set_target_properties(
-      wazuh-manager-db PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                  INSTALL_RPATH "@executable_path/../lib")
-  else()
-    set_target_properties(
-      wazuh-manager-db PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                  INSTALL_RPATH "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(wazuh-manager-db)
 endif()

--- a/src/wazuh_modules/CMakeLists.txt
+++ b/src/wazuh_modules/CMakeLists.txt
@@ -4,6 +4,8 @@ project(wazuh-modulesd C CXX)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)
   get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
+  list(APPEND CMAKE_MODULE_PATH "${SRC_FOLDER}/cmake")
+  include(WazuhRpath)
 endif()
 
 # Core include directories
@@ -204,15 +206,5 @@ elseif(NOT UNIT_TEST)
   target_link_libraries(${WAZUH_MODULESD_DAEMON_NAME}
                         PRIVATE wazuh_modulesd_lib)
 
-  if(APPLE)
-    set_target_properties(
-      ${WAZUH_MODULESD_DAEMON_NAME}
-      PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
-                                               "@executable_path/../lib")
-  else()
-    set_target_properties(
-      ${WAZUH_MODULESD_DAEMON_NAME}
-      PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
-                                               "$ORIGIN/../lib")
-  endif()
+  wazuh_set_runtime_rpath(${WAZUH_MODULESD_DAEMON_NAME})
 endif()

--- a/src/wazuh_modules/CMakeLists.txt
+++ b/src/wazuh_modules/CMakeLists.txt
@@ -210,6 +210,9 @@ elseif(NOT UNIT_TEST)
       PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
                                                "@executable_path/../lib")
   else()
-    string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib")
+    set_target_properties(
+      ${WAZUH_MODULESD_DAEMON_NAME}
+      PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
+                                               "$ORIGIN/../lib")
   endif()
 endif()

--- a/src/wazuh_modules/src/wm_inventory_sync.c
+++ b/src/wazuh_modules/src/wm_inventory_sync.c
@@ -82,11 +82,7 @@
              os_free(manager_node_name);
 
              // Add max sessions from internal_options (inventory_sync specific)
-#ifdef CLIENT
-             int max_sessions = getDefine_Int("wazuh_modules", "max_sessions", 1, 100000);
-#else
              int max_sessions = getDefine_Int_default("wazuh_modules", "max_sessions", 1, 100000, 1000);
-#endif
              cJSON_AddNumberToObject(config_json, "maxSessions", max_sessions);
 
              wm_inventory_sync_log_config(config_json);


### PR DESCRIPTION
# Description

This PR replaces the directory-scoped string(`APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-rpath,$ORIGIN/../lib"`) pattern with proper per target `set_target_properties(INSTALL_RPATH "$ORIGIN/../lib" BUILD_WITH_INSTALL_RPATH TRUE)` across all native daemons and CLI tools on Linux. With each binary now carrying the correct rpath as a target property, the `LD_LIBRARY_PATH` export in `wazuh-server.sh` and `wazuh-client.sh` is no longer needed and is removed. The redundant `WAZUH_ENGINE_GROUP` export in `wazuh-server.sh` is also dropped, since the engine already defaults to wazuh-manager in `conf.cpp`.

Closes #36458

## Additional changes

- **Centralized rpath helper**: new `src/cmake/WazuhRpath.cmake` exposes a single `wazuh_set_runtime_rpath(<target>)` function used by every daemon CMakeLists. Removes ~150 lines of duplicated `if(APPLE) ... else() ... endif()` blocks and keeps the rpath policy in one place.
- **Debug/sanitizer-friendly rpath**: in `DEBUG=YES` or `FSANITIZE=YES` builds the helper prepends the build-tree library directories (`${CMAKE_SOURCE_DIR}/build/lib`, `${CMAKE_SOURCE_DIR}/external/rocksdb/build`, `${CMAKE_SOURCE_DIR}/external/jemalloc/lib`) to the binary RPATH, so a daemon can be executed directly from `src/build/bin/` without `LD_LIBRARY_PATH`. In Release the RPATH stays clean (`$ORIGIN/../lib`).
- **Engine RPATH cleanup**: the same gating is applied to `wazuh-engine`. Its previously unconditional build-tree paths (`${CMAKE_SOURCE_DIR}/build/lib`, `${ROCKSDB_LIB_BUILD_DIR}`, `${INDEXERCONNECTOR_LIB_BUILD_DIR}`) now only appear in Debug/sanitizer builds. Release packages (manager install and standalone/indexer) ship with only `$ORIGIN/../lib:$ORIGIN/lib`.
- **Target-specific home env var override**: `w_homedir()` (C) and `Utils::findHomeDirectory()` (C++) now read a target-specific env var as the first-checked source, so co-hosted manager + agent installs are unambiguous:
  - Manager binaries read `WAZUH_MANAGER_HOME`.
  - Agent binaries read `WAZUH_AGENT_HOME`.

  The name is picked at build time via the `WAZUH_HOME_ENV` macro (gated by the existing `CLIENT` definition), so a developer can keep both exports in the shell and each binary picks the right one:
    ```
    export WAZUH_MANAGER_HOME=/var/wazuh-manager
    export WAZUH_AGENT_HOME=/var/ossec
    ./src/build/bin/wazuh-manager-monitord -f  # uses /var/wazuh-manager
    ./src/build/bin/wazuh-agentd -f            # uses /var/ossec
    ```
    When unset, `/proc/self/exe` and `argv[0]` resolution remain unchanged. The previous generic `WAZUH_HOME` is no longer read by the binaries. Unit tests for `w_homedir` were updated to expect the new getenv-first order and to consume `HOME_ERROR` from the header instead of asserting the literal.
- **Removed redundant rootcheck log**: `rootcheck_init()` (loaded inside `wazuh-syscheckd`) was emitting an `INFO: Started (pid: …)` entry that duplicated syscheckd's own startup log and leaked into `wazuh-control` output. Dropped.




## Evidence
- Before the patch

```
$ readelf -d /var/wazuh-manager/bin/wazuh-manager-monitord | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib:/home/vagrant/git/wazuh/src:/home/vagrant/git/wazuh/src/build/lib:/home/vagrant/git/wazuh/src/external/rocksdb/build:/home/vagrant/git/wazuh/src/external/jemalloc/lib]
```

Same pattern on `modulesd`, `remoted`, `db`, `authd`. On a build/QA host these paths exist and the loader resolves libs from the build tree, not from `$ORIGIN/../lib`.

- After the patch — RUNPATH clean

```
$ readelf -d /var/wazuh-manager/bin/wazuh-manager-monitord | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]

$ readelf -d /var/wazuh-manager/bin/wazuh-manager-modulesd | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]

$ readelf -d /var/wazuh-manager/bin/wazuh-manager-remoted | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]

$ readelf -d /var/wazuh-manager/bin/wazuh-manager-db | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]

$ readelf -d /var/wazuh-manager/bin/wazuh-manager-authd | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]
```

`wazuh-manager-analysisd` retains its `$ORIGIN/../lib:$ORIGIN/lib` plus engine-specific entries (intentional, supports the standalone mode used by `wazuh-indexer`).

## Functional check — manager starts without `LD_LIBRARY_PATH`

Reproduced with the build tree renamed (`/home/vagrant/git/wazuh/src` → `src.HIDDEN`) and `LD_LIBRARY_PATH` unset, to make sure resolution falls only on the rpath of the installed binaries:

```
$ unset LD_LIBRARY_PATH && systemctl start wazuh-manager && wazuh-manager-control status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...

$ pgrep -af 'wazuh_manager_(apid|clusterd)'
29726 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/api/scripts/wazuh_manager_apid.py
30258 /var/wazuh-manager/framework/python/bin/python3 /var/wazuh-manager/framework/scripts/wazuh_manager_clusterd.py
```


## Engine group default 

```
$ ps -o pid,user,group,comm -C wazuh-manager-analysisd
    PID USER     GROUP    COMMAND
  30885 root     wazuh-m+ wazuh-manager-a
  30911 root     wazuh-m+ wazuh-manager-a
```


# Test DEBUG flag in compilation
## Debug / sanitizer build — run binaries from the build tree

- RUNPATH of the debug binaries

```
$ readelf -d src/build/bin/wazuh-manager-monitord | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [/home/vagrant/git/wazuh/src/build/lib:/home/vagrant/git/wazuh/src/external/rocksdb/build:/home/vagrant/git/wazuh/src/external/jemalloc/lib:$ORIGIN/../lib]

$ readelf -d src/build/engine/wazuh-engine | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [/home/vagrant/git/wazuh/src/build/lib:/home/vagrant/git/wazuh/src/external/rocksdb/build:/home/vagrant/git/wazuh/src/build/lib:$ORIGIN/../lib:$ORIGIN/lib]
```

- Libraries resolved straight from the build tree, no `LD_LIBRARY_PATH` set

```
$ unset LD_LIBRARY_PATH
$ ldd src/build/bin/wazuh-manager-monitord | grep -E 'wazuhext|rocksdb|jemalloc|not found'
	libjemalloc.so.2 => /home/vagrant/git/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x0000e59082a90000)
	libwazuhext.so   => /home/vagrant/git/wazuh/src/build/lib/libwazuhext.so (0x0000e59082060000)

$ ldd src/build/engine/wazuh-engine | grep -E 'wazuhext|rocksdb|jemalloc|not found'
	librocksdb.so.8  => /home/vagrant/git/wazuh/src/external/rocksdb/build/librocksdb.so.8 (0x0000ed26135a0000)
	libwazuhext.so   => /home/vagrant/git/wazuh/src/build/lib/libwazuhext.so (0x0000ed2612b70000)
```

## `WAZUH_MANAGER_HOME` / `WAZUH_AGENT_HOME` override

Without the target-specific env var, the debug binary auto-detects its home as
`src/build/`, where `etc/wazuh-manager.conf` does not exist:

```
$ unset WAZUH_MANAGER_HOME
$ ./src/build/bin/wazuh-manager-monitord -t 2>&1 | head -5
2026/06/01 08:07:07 wazuh-manager-monitord: ERROR: (1226): Error reading XML file 'etc/wazuh-manager.conf':  (line 0).
```

With `WAZUH_MANAGER_HOME` pointing at the real install, the override wins and
the test config succeeds silently:

```
$ WAZUH_MANAGER_HOME=/var/wazuh-manager ./src/build/bin/wazuh-manager-monitord -t
$ echo $?
0
```

The generic `WAZUH_HOME` is no longer consulted; agent binaries read
`WAZUH_AGENT_HOME` instead, so both can be exported safely on a co-hosted
machine and each binary picks the right one.

## Functional check — debug binary running against the real install

Stop the service, kill `wazuh-manager-monitord`, replace it with the debug
build pointing at `/var/wazuh-manager` via `WAZUH_MANAGER_HOME`:

```
$ systemctl stop wazuh-manager && systemctl start wazuh-manager && sleep 5
$ pkill -f wazuh-manager-monitord
$ rm -f /var/wazuh-manager/var/run/wazuh-manager-monitord-*.pid
$ unset LD_LIBRARY_PATH
$ WAZUH_MANAGER_HOME=/var/wazuh-manager ./src/build/bin/wazuh-manager-monitord -f &
[1] 558221
2026/06/01 08:08:29 wazuh-manager-monitord: INFO: Started (pid: 558221).

$ ps -p 558221 -o pid,user,group,comm
    PID USER     GROUP    COMMAND
 558221 wazuh-m+ wazuh-m+ wazuh-manager-m

$ ls -l /proc/558221/cwd
lrwxrwxrwx 1 root root 0 Jun  1 08:08 /proc/558221/cwd -> /var/wazuh-manager

$ cat /proc/558221/maps | grep -oE '/[^ ]+\.so[^ ]*' | sort -u
/home/vagrant/git/wazuh/src/build/lib/libwazuhext.so
/home/vagrant/git/wazuh/src/external/jemalloc/lib/libjemalloc.so.2
/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
/usr/lib/aarch64-linux-gnu/libc.so.6
/usr/lib/aarch64-linux-gnu/libdl.so.2
/usr/lib/aarch64-linux-gnu/libm.so.6
/usr/lib/aarch64-linux-gnu/libpthread.so.0

$ /var/wazuh-manager/bin/wazuh-manager-control status | grep monitord
wazuh-manager-monitord is running...
```

The debug daemon picks up the install layout (config, sockets, logs, group,
PID file) from `/var/wazuh-manager`, while resolving its dynamic libraries
from the build tree (`src/build/lib/`, `src/external/jemalloc/lib/`).

## Release rebuild — RPATH restored to clean state

```
$ readelf -d src/build/bin/wazuh-manager-monitord | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]
$ readelf -d src/build/engine/wazuh-engine | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib:$ORIGIN/lib]
```


# Testing E2E functionality

<img width="1503" height="701" alt="image" src="https://github.com/user-attachments/assets/b2927241-e039-4907-bb6f-4b5d5511514f" />


- Finding VD:
```
{
  "_index": ".ds-wazuh-findings-v5-security-000001",
  "_id": "ia9lf54BFZSIakC0uEDp",
  "_score": null,
  "_source": {
    "observer": {
      "vendor": "Wazuh"
    },
    "@timestamp": "2026-05-31T18:56:24.576Z",
    "package": {
      "name": "Django",
      "description": "A high-level Python Web framework that encourages rapid development and clean, pragmatic design.",
      "type": "pypi",
      "version": "3.2.13"
    },
    "data_stream": {
      "type": "logs",
      "dataset": "wazuh.vd"
    },
    "wazuh": {
      "cluster": {
        "node": "node01",
        "name": "wazuh"
      },
      "protocol": {
        "location": "vulnerability-scanner",
        "queue": 118
      },
      "agent": {
        "host": {
          "hostname": "ubuntu24",
          "os": {
            "name": "Ubuntu",
            "type": "linux",
            "version": "24.04.3 LTS (Noble Numbat)",
            "platform": "ubuntu"
          },
          "architecture": "aarch64"
        },
        "name": "ubuntu24",
        "groups": [
          "default"
        ],
        "id": "001",
        "version": "v5.0.0"
      },
      "integration": {
        "name": "wazuh-vd",
        "decoders": [
          "decoder/core-wazuh-message/0",
          "decoder/wazuh-vd/0"
        ],
        "category": "security"
      },
      "rule": {
        "sigma_id": "4651a422-4392-4408-8973-63719f6f77f4",
        "level": "informational",
        "compliance": {
          "iso_27001": [
            "A.12.6.1",
            "A.14.2.3"
          ],
          "hipaa": [
            "164.308.a.1.ii.D",
            "164.308.a.8"
          ],
          "pci_dss": [
            "6.3.3",
            "11.3"
          ],
          "tsc": [
            "A1.2",
            "CC7.1"
          ],
          "nis2": [
            "21.2.a",
            "21.2.e"
          ],
          "nist_800_171": [
            "3.11.3",
            "3.14.4"
          ],
          "fedramp": [
            "CA-7",
            "RA-5",
            "SI-2",
            "SI-4"
          ],
          "nist_800_53": [
            "CA-7",
            "RA-5",
            "SI-2"
          ],
          "cmmc": [
            "AU.L2-3.3.1",
            "CA.L2-3.12.1",
            "RA.L2-3.11.1",
            "RA.L2-3.11.3",
            "SI.L2-3.14.1"
          ],
          "gdpr": [
            "IV_32.1.a"
          ]
        },
        "mitre": {
          "technique": [
            "T1068",
            "T1190"
          ],
          "tactic": [
            "TA0001",
            "TA0004"
          ]
        },
        "id": "4651a422-4392-4408-8973-63719f6f77f4",
        "title": "Wazuh VD - Vulnerability CVE-2023-36053 remediated",
        "tags": [
          "informational",
          "wazuh-vd",
          "attack.initial-access",
          "attack.privilege-escalation",
          "attack.t1190",
          "attack.t1068"
        ],
        "status": "stable"
      },
      "event": {
        "id": "a0adc3f8-af91-45d5-82a0-eb61e895998c"
      },
      "space": {
        "name": "standard"
      }
    },
    "vulnerability": {
      "severity": "High",
      "score": {
        "version": "3.1",
        "base": 7.5
      },
      "scanner": {
        "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2023-36053",
        "condition": "Unknown"
      },
      "id": "CVE-2023-36053",
      "category": [
        "Packages"
      ],
      "published_at": "2023-07-03T13:15:09Z",
      "under_evaluation": false
    },
    "event": {
      "original": "{\"collector\":\"packages\",\"data\":{\"event\":{\"created\":\"2026-05-31T18:56:24.574Z\",\"type\":\"delete\"},\"host\":{\"os\":{\"full\":\"Ubuntu 24.04.3 LTS (Noble Numbat)\",\"name\":\"Ubuntu\",\"platform\":\"ubuntu\",\"type\":\"linux\"}},\"package\":{\"description\":\"A high-level Python Web framework that encourages rapid development and clean, pragmatic design.\",\"name\":\"Django\",\"path\":\"/usr/local/lib/python3.12/dist-packages/Django-3.2.13.dist-info/METADATA\",\"type\":\"pypi\",\"version\":\"3.2.13\"},\"vulnerability\":{\"category\":\"Packages\",\"detected_at\":\"2026-05-31T18:56:24.573Z\",\"id\":\"CVE-2023-36053\",\"published_at\":\"2023-07-03T13:15:09Z\",\"scanner\":{\"condition\":\"Unknown\",\"reference\":\"https://cti.wazuh.com/vulnerabilities/cves/CVE-2023-36053\",\"vendor\":\"Wazuh\"},\"score\":{\"base\":7.5,\"version\":\"3.1\"},\"severity\":\"High\",\"under_evaluation\":false}},\"module\":\"vulnerability-scanner\"}",
      "provider": "packages",
      "kind": "event",
      "start": "2026-05-31T18:56:24.573Z",
      "action": "vulnerability-resolved",
      "index": ".ds-wazuh-events-v5-security-000001",
      "category": [
        "vulnerability"
      ],
      "type": [
        "indicator"
      ],
      "dataset": "wazuh.vd",
      "doc_id": "3K9lf54BFZSIakC0Qz_W",
      "outcome": "success"
    }
  },
  "fields": {
    "vulnerability.published_at": [
      "2023-07-03T13:15:09.000Z"
    ],
    "event.start": [
      "2026-05-31T18:56:24.576Z"
    ],
    "@timestamp": [
      "2026-05-31T18:56:24.576Z"
    ]
  },
  "sort": [
    1780253784576
  ]
}
```