### PR TITLE
Restore event counter and classify received messages

### DIFF
--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -1037,6 +1037,9 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         if (rc < 0) {
             dispose_evt_item(e);
             mwarn("Dropping event for agent '%s' (rc=%d)", agentid_str, rc);
+            rem_inc_recv_events_failed();
+        } else {
+            rem_inc_recv_events(agentid_str);
         }
     }
 
@@ -1117,6 +1120,7 @@ bool router_message_forward(char* msg, size_t msg_length, const char* agent_id) 
             return false;
         }
 
+        rem_inc_recv_states(agent_id);
         return true;
     }
     else if (message_type == MT_UPGRADE_ACK) {
@@ -1148,6 +1152,7 @@ bool router_message_forward(char* msg, size_t msg_length, const char* agent_id) 
             // Free the printed message and JSON object
             cJSON_free(upgrade_message);
             cJSON_Delete(upgrade_ack_json);
+            rem_inc_recv_upgrade_ack(agent_id);
             return true;
         }
         else {
@@ -1369,6 +1374,7 @@ static uint64_t mono_ms(void) {
 static void drop_consumer(void *data, void *user) {
     (void)user;
     mwarn("Dropped event: unable to connect with analysisd");
+    rem_inc_recv_events_failed();
     dispose_evt_item((evt_item_t *)data);
 }
 

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -43,13 +43,25 @@ STATIC void w_remoted_clean_agents_state(int *sock);
  * @brief Increment received event messages counter for agents
  * @param agent_id Id of the agent that corresponds to the message
  */
-static void rem_inc_agents_recv_evt(const char *agent_id);
+static void rem_inc_agents_recv_events(const char *agent_id);
 
 /**
  * @brief Increment received control messages counter for agents
  * @param agent_id Id of the agent that corresponds to the message
  */
 static void rem_inc_agents_recv_ctrl(const char *agent_id);
+
+/**
+ * @brief Increment received state messages counter for agents
+ * @param agent_id Id of the agent that corresponds to the message
+ */
+static void rem_inc_agents_recv_states(const char *agent_id);
+
+/**
+ * @brief Increment received upgrade-ack messages counter for agents
+ * @param agent_id Id of the agent that corresponds to the message
+ */
+static void rem_inc_agents_recv_upgrade_ack(const char *agent_id);
 
 /**
  * @brief Increment received keepalive control messages counter for agents
@@ -180,10 +192,10 @@ STATIC void w_remoted_clean_agents_state(int *sock) {
     return;
 }
 
-static void rem_inc_agents_recv_evt(const char *agent_id) {
+static void rem_inc_agents_recv_events(const char *agent_id) {
     w_mutex_lock(&agents_state_mutex);
     remoted_agent_state_t *agent_node = get_node(agent_id);
-    agent_node->recv_evt_count++;
+    agent_node->recv_events_count++;
     w_mutex_unlock(&agents_state_mutex);
 }
 
@@ -191,6 +203,20 @@ static void rem_inc_agents_recv_ctrl(const char *agent_id) {
     w_mutex_lock(&agents_state_mutex);
     remoted_agent_state_t *agent_node = get_node(agent_id);
     agent_node->recv_ctrl_count++;
+    w_mutex_unlock(&agents_state_mutex);
+}
+
+static void rem_inc_agents_recv_states(const char *agent_id) {
+    w_mutex_lock(&agents_state_mutex);
+    remoted_agent_state_t *agent_node = get_node(agent_id);
+    agent_node->recv_states_count++;
+    w_mutex_unlock(&agents_state_mutex);
+}
+
+static void rem_inc_agents_recv_upgrade_ack(const char *agent_id) {
+    w_mutex_lock(&agents_state_mutex);
+    remoted_agent_state_t *agent_node = get_node(agent_id);
+    agent_node->recv_upgrade_ack_count++;
     w_mutex_unlock(&agents_state_mutex);
 }
 
@@ -275,13 +301,13 @@ void rem_add_recv(unsigned long bytes) {
     w_mutex_unlock(&state_mutex);
 }
 
-void rem_inc_recv_evt(const char *agent_id) {
+void rem_inc_recv_events(const char *agent_id) {
     w_mutex_lock(&state_mutex);
-    remoted_state.recv_breakdown.evt_count++;
+    remoted_state.recv_breakdown.events_count++;
     w_mutex_unlock(&state_mutex);
 
     if (agent_id != NULL) {
-        rem_inc_agents_recv_evt(agent_id);
+        rem_inc_agents_recv_events(agent_id);
     }
 }
 
@@ -293,6 +319,32 @@ void rem_inc_recv_ctrl(const char *agent_id) {
     if (agent_id != NULL) {
         rem_inc_agents_recv_ctrl(agent_id);
     }
+}
+
+void rem_inc_recv_states(const char *agent_id) {
+    w_mutex_lock(&state_mutex);
+    remoted_state.recv_breakdown.states_count++;
+    w_mutex_unlock(&state_mutex);
+
+    if (agent_id != NULL) {
+        rem_inc_agents_recv_states(agent_id);
+    }
+}
+
+void rem_inc_recv_upgrade_ack(const char *agent_id) {
+    w_mutex_lock(&state_mutex);
+    remoted_state.recv_breakdown.upgrade_ack_count++;
+    w_mutex_unlock(&state_mutex);
+
+    if (agent_id != NULL) {
+        rem_inc_agents_recv_upgrade_ack(agent_id);
+    }
+}
+
+void rem_inc_recv_events_failed() {
+    w_mutex_lock(&state_mutex);
+    remoted_state.recv_breakdown.events_failed_count++;
+    w_mutex_unlock(&state_mutex);
 }
 
 void rem_inc_recv_ping() {
@@ -481,11 +533,14 @@ cJSON* rem_create_state_json() {
     cJSON_AddNumberToObject(_control_breakdown, "shutdown", state_cpy.recv_breakdown.ctrl_breakdown.shutdown_count);
     cJSON_AddNumberToObject(_control_breakdown, "startup", state_cpy.recv_breakdown.ctrl_breakdown.startup_count);
 
+    cJSON_AddNumberToObject(_received_breakdown, "events_failed", state_cpy.recv_breakdown.events_failed_count);
     cJSON_AddNumberToObject(_received_breakdown, "dequeued_after", state_cpy.recv_breakdown.dequeued_count);
     cJSON_AddNumberToObject(_received_breakdown, "discarded", state_cpy.recv_breakdown.discarded_count);
-    cJSON_AddNumberToObject(_received_breakdown, "event", state_cpy.recv_breakdown.evt_count);
+    cJSON_AddNumberToObject(_received_breakdown, "events", state_cpy.recv_breakdown.events_count);
+    cJSON_AddNumberToObject(_received_breakdown, "states", state_cpy.recv_breakdown.states_count);
     cJSON_AddNumberToObject(_received_breakdown, "ping", state_cpy.recv_breakdown.ping_count);
     cJSON_AddNumberToObject(_received_breakdown, "unknown", state_cpy.recv_breakdown.unknown_count);
+    cJSON_AddNumberToObject(_received_breakdown, "upgrade_ack", state_cpy.recv_breakdown.upgrade_ack_count);
 
     cJSON *_sent_breakdown = cJSON_CreateObject();
     cJSON_AddItemToObject(_messages, "sent_breakdown", _sent_breakdown);
@@ -561,7 +616,9 @@ cJSON* rem_create_agents_state_json(int* agents_ids) {
                 cJSON_AddNumberToObject(_control_breakdown, "shutdown", agent_state->ctrl_breakdown.shutdown_count);
                 cJSON_AddNumberToObject(_control_breakdown, "startup", agent_state->ctrl_breakdown.startup_count);
 
-                cJSON_AddNumberToObject(_received_breakdown, "event", agent_state->recv_evt_count);
+                cJSON_AddNumberToObject(_received_breakdown, "events", agent_state->recv_events_count);
+                cJSON_AddNumberToObject(_received_breakdown, "states", agent_state->recv_states_count);
+                cJSON_AddNumberToObject(_received_breakdown, "upgrade_ack", agent_state->recv_upgrade_ack_count);
 
                 cJSON *_sent_breakdown = cJSON_CreateObject();
                 cJSON_AddItemToObject(_messages, "sent_breakdown", _sent_breakdown);

--- a/src/remoted/src/state.h
+++ b/src/remoted/src/state.h
@@ -28,12 +28,15 @@ typedef struct _ctrl_msgs_t
 
 typedef struct _recv_msgs_t
 {
-    uint64_t evt_count;
+    uint64_t events_count;
     uint64_t ctrl_count;
+    uint64_t states_count;
+    uint32_t upgrade_ack_count;
     uint32_t ping_count;
     uint32_t unknown_count;
     uint32_t dequeued_count;
     uint32_t discarded_count;
+    uint32_t events_failed_count;
     ctrl_msgs_t ctrl_breakdown;
 } recv_msgs_t;
 
@@ -68,8 +71,10 @@ typedef struct _remoted_state_t
 typedef struct _remoted_agent_state_t
 {
     uint64_t uptime;
-    uint64_t recv_evt_count;
+    uint64_t recv_events_count;
     uint64_t recv_ctrl_count;
+    uint64_t recv_states_count;
+    uint32_t recv_upgrade_ack_count;
     ctrl_msgs_t ctrl_breakdown;
     sent_msgs_t sent_breakdown;
 } remoted_agent_state_t;
@@ -106,13 +111,35 @@ void rem_add_recv(unsigned long bytes);
  * @brief Increment received event messages counter
  * @param agent_id Id of the agent that corresponds to the message
  */
-void rem_inc_recv_evt(const char* agent_id);
+void rem_inc_recv_events(const char* agent_id);
 
 /**
  * @brief Increment received control messages counter
  * @param agent_id Id of the agent that corresponds to the message
  */
 void rem_inc_recv_ctrl(const char* agent_id);
+
+/**
+ * @brief Increment received state messages counter
+ * @param agent_id Id of the agent that corresponds to the message
+ */
+void rem_inc_recv_states(const char* agent_id);
+
+/**
+ * @brief Increment received upgrade-ack messages counter
+ * @param agent_id Id of the agent that corresponds to the message
+ */
+void rem_inc_recv_upgrade_ack(const char* agent_id);
+
+/**
+ * @brief Increment failed-event messages counter
+ *
+ * Counts events that were accepted from the agent but could not be
+ * delivered to analysisd, either because the batch queue refused the
+ * enqueue or because the analysisd dispatcher dropped the item (POST
+ * failed or connection unavailable).
+ */
+void rem_inc_recv_events_failed();
 
 /**
  * @brief Increment received ping messages counter

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -57,7 +57,9 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,agent_meta_from_agent_info -Wl,--wrap,agent_meta_upsert_locked \
                             -Wl,--wrap,batch_queue_enqueue_ex \
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock -Wl,--wrap,getDefine_Int -Wl,--wrap,getDefine_Int_default \
-                            -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_evt \
+                            -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_events \
+                            -Wl,--wrap,rem_inc_recv_states -Wl,--wrap,rem_inc_recv_upgrade_ack \
+                            -Wl,--wrap,rem_inc_recv_discarded -Wl,--wrap,rem_inc_recv_events_failed \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap,router_provider_send -Wl,--wrap,router_provider_send_sync \
                             -Wl,--wrap,w_query_agentd ${HASH_OP_WRAPPERS}")

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -45,12 +45,15 @@ static int test_setup(void ** state) {
     remoted_state.recv_bytes = 123456;
     remoted_state.sent_bytes = 234567;
     remoted_state.keys_reload_count = 15;
-    remoted_state.recv_breakdown.evt_count = 1234;
+    remoted_state.recv_breakdown.events_count = 1234;
     remoted_state.recv_breakdown.ctrl_count = 2345;
+    remoted_state.recv_breakdown.states_count = 333;
+    remoted_state.recv_breakdown.upgrade_ack_count = 11;
     remoted_state.recv_breakdown.ping_count = 18;
     remoted_state.recv_breakdown.unknown_count = 8;
     remoted_state.recv_breakdown.dequeued_count = 4;
     remoted_state.recv_breakdown.discarded_count = 95;
+    remoted_state.recv_breakdown.events_failed_count = 7;
     remoted_state.recv_breakdown.ctrl_breakdown.keepalive_count = 1115;
     remoted_state.recv_breakdown.ctrl_breakdown.startup_count = 48;
     remoted_state.recv_breakdown.ctrl_breakdown.shutdown_count = 12;
@@ -75,8 +78,10 @@ static int test_setup_agent(void ** state) {
     remoted_agents_state = __wrap_OSHash_Create();
 
     test_data->agent_state->uptime = 123456789;
-    test_data->agent_state->recv_evt_count = 12568;
+    test_data->agent_state->recv_events_count = 12568;
     test_data->agent_state->recv_ctrl_count = 2568;
+    test_data->agent_state->recv_states_count = 442;
+    test_data->agent_state->recv_upgrade_ack_count = 5;
     test_data->agent_state->ctrl_breakdown.keepalive_count = 1234;
     test_data->agent_state->ctrl_breakdown.startup_count = 2345;
     test_data->agent_state->ctrl_breakdown.shutdown_count = 234;
@@ -175,10 +180,14 @@ void test_rem_create_state_json(void ** state) {
     assert_non_null(cJSON_GetObjectItem(messages, "received_breakdown"));
     cJSON* recv = cJSON_GetObjectItem(messages, "received_breakdown");
 
-    assert_non_null(cJSON_GetObjectItem(recv, "event"));
-    assert_int_equal(cJSON_GetObjectItem(recv, "event")->valueint, 1234);
+    assert_non_null(cJSON_GetObjectItem(recv, "events"));
+    assert_int_equal(cJSON_GetObjectItem(recv, "events")->valueint, 1234);
     assert_non_null(cJSON_GetObjectItem(recv, "control"));
     assert_int_equal(cJSON_GetObjectItem(recv, "control")->valueint, 2345);
+    assert_non_null(cJSON_GetObjectItem(recv, "states"));
+    assert_int_equal(cJSON_GetObjectItem(recv, "states")->valueint, 333);
+    assert_non_null(cJSON_GetObjectItem(recv, "upgrade_ack"));
+    assert_int_equal(cJSON_GetObjectItem(recv, "upgrade_ack")->valueint, 11);
     assert_non_null(cJSON_GetObjectItem(recv, "ping"));
     assert_int_equal(cJSON_GetObjectItem(recv, "ping")->valueint, 18);
     assert_non_null(cJSON_GetObjectItem(recv, "unknown"));
@@ -187,6 +196,8 @@ void test_rem_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(recv, "dequeued_after")->valueint, 4);
     assert_non_null(cJSON_GetObjectItem(recv, "discarded"));
     assert_int_equal(cJSON_GetObjectItem(recv, "discarded")->valueint, 95);
+    assert_non_null(cJSON_GetObjectItem(recv, "events_failed"));
+    assert_int_equal(cJSON_GetObjectItem(recv, "events_failed")->valueint, 7);
 
     assert_non_null(cJSON_GetObjectItem(recv, "control_breakdown"));
     cJSON* ctrl = cJSON_GetObjectItem(recv, "control_breakdown");
@@ -266,8 +277,10 @@ void test_rem_create_agents_state_json(void ** state) {
     assert_non_null(cJSON_GetObjectItem(messages, "received_breakdown"));
     cJSON* messages_received_breakdown = cJSON_GetObjectItem(messages, "received_breakdown");
 
-    assert_int_equal(cJSON_GetObjectItem(messages_received_breakdown, "event")->valueint, 12568);
+    assert_int_equal(cJSON_GetObjectItem(messages_received_breakdown, "events")->valueint, 12568);
     assert_int_equal(cJSON_GetObjectItem(messages_received_breakdown, "control")->valueint, 2568);
+    assert_int_equal(cJSON_GetObjectItem(messages_received_breakdown, "states")->valueint, 442);
+    assert_int_equal(cJSON_GetObjectItem(messages_received_breakdown, "upgrade_ack")->valueint, 5);
 
     assert_non_null(cJSON_GetObjectItem(messages_received_breakdown, "control_breakdown"));
     cJSON* control_breakdown = cJSON_GetObjectItem(messages_received_breakdown, "control_breakdown");

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -1292,6 +1292,7 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -1387,6 +1388,7 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -1977,6 +1979,7 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2051,6 +2054,7 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2122,6 +2126,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_success(void** state
     expect_string(__wrap_router_provider_send, message, "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\",\"agents\":[1]}}");
     expect_value(__wrap_router_provider_send, message_size, strlen("{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,\"message\":\"Upgrade successful\",\"status\":\"Done\",\"agents\":[1]}}") + 1);
     will_return(__wrap_router_provider_send, 0);
+    expect_string(__wrap_rem_inc_recv_upgrade_ack, agent_id, "001");
 
     // Since message was successfully forwarded to router, it should NOT be enqueued to analysisd
 
@@ -2201,6 +2206,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_no_handle(void** sta
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2277,6 +2283,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json(void** 
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2354,6 +2361,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_json_without_paramet
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2437,6 +2445,7 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed(void** s
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '042' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2516,6 +2525,7 @@ void test_HandleSecureMessage_router_forwarding_disabled(void** state)
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2607,6 +2617,20 @@ static int check_evt_item_sentinel(const LargestIntegralType value,
     return 1;
 }
 
+/* When batch_queue_enqueue_ex is mocked as successful the production code
+ * relinquishes ownership of the evt_item; capture it here so the test can
+ * dispose it after HandleSecureMessage returns. */
+static evt_item_t *g_captured_evt_item;
+
+static int check_evt_item_capture(const LargestIntegralType value,
+                                  const LargestIntegralType check_value_data) {
+    (void)check_value_data;
+    g_captured_evt_item = (evt_item_t *)(uintptr_t)value;
+    assert_non_null(g_captured_evt_item);
+    assert_non_null(g_captured_evt_item->raw);
+    return 1;
+}
+
 void test_HandleSecureMessage_event_without_trailing_null(void** state)
 {
     const char *payload = "Apr 23 12:34:56 host dpkg[1]: status installed foo:amd64 1.0.0";
@@ -2667,10 +2691,92 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
     expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_sentinel, NULL);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
     router_forwarding_disabled = 0;
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key->ip);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+    batch_queue_free(events_queue);
+}
+
+void test_HandleSecureMessage_event_enqueue_success(void** state)
+{
+    const char *payload = "Apr 23 12:34:56 host dpkg[1]: status installed foo:amd64 1.0.0";
+    size_t payload_len = strlen(payload);
+
+    char buffer[OS_MAXSTR + 1];
+    memset(buffer, 0xAA, sizeof(buffer));
+    memcpy(buffer, payload, payload_len);
+
+    message_t message = {.buffer = buffer, .size = payload_len, .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+    w_rr_queue_t * events_queue = batch_queue_init(10);
+    batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
+
+    keyentry** keyentries;
+    os_calloc(2, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+    os_calloc(1, sizeof(os_ip), key->ip);
+
+    key->id = strdup("001");
+    key->sock = 1;
+    key->keyid = 1;
+    key->rcvd = 0;
+    key->ip->ip = "127.0.0.1";
+    key->name = strdup("name");
+
+    keys.keyentries[1] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 1);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_any(__wrap_ReadSecMSG, buffer);
+    expect_value(__wrap_ReadSecMSG, id, 1);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, payload_len);
+    will_return(__wrap_ReadSecMSG, buffer);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_function_call(__wrap_key_unlock);
+
+    router_forwarding_disabled = 1;
+
+    g_captured_evt_item = NULL;
+    expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
+    expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
+    expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_capture, NULL);
+    will_return(__wrap_batch_queue_enqueue_ex, 0);
+    expect_string(__wrap_rem_inc_recv_events, agent_id, "001");
+
+    HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    router_forwarding_disabled = 0;
+
+    /* The mocked queue did not actually take ownership; release the item. */
+    if (g_captured_evt_item) {
+        dispose_evt_item(g_captured_evt_item);
+        g_captured_evt_item = NULL;
+    }
 
     os_free(key->id);
     os_free(key->name);
@@ -2758,6 +2864,7 @@ void test_HandleSecureMessage_event_with_trailing_null(void** state)
     expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_trimmed, NULL);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
     expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -2857,6 +2964,7 @@ void test_HandleSecureMessage_inventory_sync_preserves_trailing_null(void** stat
                  g_expected_flatbuf_len);
     expect_string(__wrap_router_provider_send_sync, authenticated_agent_id, "001");
     will_return(__wrap_router_provider_send_sync, 0);
+    expect_string(__wrap_rem_inc_recv_states, agent_id, "001");
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
 
@@ -3240,6 +3348,7 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_router_forwarding_disabled),
         cmocka_unit_test(test_HandleSecureMessage_discard_dbsync_message),
         cmocka_unit_test(test_HandleSecureMessage_event_without_trailing_null),
+        cmocka_unit_test(test_HandleSecureMessage_event_enqueue_success),
         cmocka_unit_test(test_HandleSecureMessage_event_with_trailing_null),
         cmocka_unit_test(test_HandleSecureMessage_inventory_sync_preserves_trailing_null),
         // Tests handle_new_tcp_connection

--- a/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.c
@@ -24,9 +24,8 @@ void __wrap_rem_dec_tcp() {
     return;
 }
 
-void __wrap_rem_inc_recv_evt() {
-    function_called();
-    return;
+void __wrap_rem_inc_recv_events(const char *agent_id) {
+    check_expected(agent_id);
 }
 
 void __wrap_rem_add_recv(unsigned long bytes) {
@@ -35,6 +34,22 @@ void __wrap_rem_add_recv(unsigned long bytes) {
 
 void __wrap_rem_inc_recv_ctrl(const char *agent_id) {
     check_expected(agent_id);
+}
+
+void __wrap_rem_inc_recv_states(const char *agent_id) {
+    check_expected(agent_id);
+}
+
+void __wrap_rem_inc_recv_upgrade_ack(const char *agent_id) {
+    check_expected(agent_id);
+}
+
+void __wrap_rem_inc_recv_discarded() {
+    function_called();
+}
+
+void __wrap_rem_inc_recv_events_failed() {
+    function_called();
 }
 
 void __wrap_rem_inc_recv_ctrl_request(const char *agent_id) {

--- a/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.h
@@ -20,9 +20,17 @@ void __wrap_rem_inc_tcp();
 
 void __wrap_rem_dec_tcp();
 
-void __wrap_rem_inc_recv_evt();
+void __wrap_rem_inc_recv_events(const char *agent_id);
 
 void __wrap_rem_inc_recv_ctrl(const char *agent_id);
+
+void __wrap_rem_inc_recv_states(const char *agent_id);
+
+void __wrap_rem_inc_recv_upgrade_ack(const char *agent_id);
+
+void __wrap_rem_inc_recv_discarded();
+
+void __wrap_rem_inc_recv_events_failed();
 
 void __wrap_rem_inc_recv_ctrl_request(const char *agent_id);
 


### PR DESCRIPTION
Closes #36336

# PR description — counter inventory

## Counters introduced / fixed by this PR

### Global

| Field | Change | What it now reflects |
|---|---|---|
| `messages.received_breakdown.events` | **Restored** | Events accepted into the analysisd batch queue (was always `0` on `main` because the increment was lost during the enrichment refactor) |
| `messages.received_breakdown.states` | **New** | `s:{module}:...` payloads successfully forwarded to the inventory-sync router |
| `messages.received_breakdown.upgrade_ack` | **New** | `u:upgrade_module:...` payloads successfully forwarded to the upgrade router |
| `messages.received_breakdown.events_failed` | **New** | Events that were accepted from the agent but could not be delivered to analysisd — either because `batch_queue_enqueue_ex` refused the enqueue or because the analysisd dispatcher dropped the item (POST failed / connection unavailable) |



# Evidence

```
          {
            "uptime": "2026-05-28T19:40:27+00:00",
            "timestamp": "2026-05-28T20:10:28+00:00",
            "name": "wazuh-manager-remoted",
            "metrics": {
               "bytes": {
                  "received": 1454162,
                  "sent": 4004
               },
               "keys_reload_count": 1,
               "messages": {
                  "received_breakdown": {
                     "control": 21,
                     "control_breakdown": {
                        "keepalive": 20,
                        "request": 0,
                        "shutdown": 0,
                        "startup": 1
                     },
                     "events_failed": 0,
                     "dequeued_after": 0,
                     "discarded": 0,
                     "events": 39,
                     "states": 115,
                     "ping": 0,
                     "unknown": 0,
                     "upgrade_ack": 0
                  },
                  "sent_breakdown": {
                     "ack": 21,
                     "ar": 12,
                     "discarded": 0,
                     "request": 0,
                     "shared": 3
                  }
               },
               "queues": {
                  "received": {
                     "size": 131072,
                     "usage": 0
                  }
               },
               "tcp_sessions": 1,
               "control_messages_queue_usage": 0,
               "control_messages_queue_breakdown": {
                  "inserted": 21,
                  "replaced": 0,
                  "processed": 21
               }
            }
         }
```