### PR TITLE
Validate cluster node name format

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -649,7 +649,8 @@ def clean_up(node_name=""):
                 continue
 
     try:
-        rm_path = path.join(common.WAZUH_PATH, 'queue', 'cluster', node_name)
+        cluster_base = path.join(common.WAZUH_PATH, 'queue', 'cluster')
+        rm_path = safe_join(cluster_base, node_name)
         logger.debug(f"Removing '{rm_path}'.")
         remove_directory_contents(rm_path)
         logger.debug(f"Removed '{rm_path}'.")

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -8,6 +8,7 @@ import functools
 import inspect
 import itertools
 import logging
+import re
 import traceback
 from time import perf_counter
 from typing import Tuple, Dict
@@ -137,13 +138,15 @@ class AbstractServerHandler(c_common.Handler):
         bytes
             Response message.
         """
-        self.name = data.decode()
-        if self.name in self.server.clients:
-            self.name = ''
-            raise exception.WazuhClusterError(3028, extra_message=data.decode())
-        elif self.name == self.server.configuration['node_name']:
+        node_name = data.decode()
+        if not re.fullmatch(r'[A-Za-z0-9_-]+', node_name):
+            raise exception.WazuhClusterError(3060, extra_message=node_name)
+        elif node_name in self.server.clients:
+            raise exception.WazuhClusterError(3028, extra_message=node_name)
+        elif node_name == self.server.configuration['node_name']:
             raise exception.WazuhClusterError(3029)
         else:
+            self.name = node_name
             self.server.clients[self.name] = self
             self.tag = f'{self.tag} {self.name}'
             context_tag.set(self.tag)

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -498,13 +498,13 @@ def test_compare_files_ko(logger_mock, mock_get_cluster_items):
 def test_clean_up_ok():
     """Check if the cleaning function is working properly."""
 
-    with patch('os.path.join', return_value="some/path/"):
+    with patch('wazuh.core.cluster.cluster.safe_join', return_value="some/path"):
         with patch.object(wazuh.core.cluster.cluster.logger, "debug") as mock_logger:
             with patch('os.path.exists', return_value=False) as path_exists_mock:
                 cluster.clean_up("worker1")
-                mock_logger.assert_any_call("Removing 'some/path/'.")
-                mock_logger.assert_any_call("Nothing to remove in 'some/path/'.")
-                mock_logger.assert_called_with("Removed 'some/path/'.")
+                mock_logger.assert_any_call("Removing 'some/path'.")
+                mock_logger.assert_any_call("Nothing to remove in 'some/path'.")
+                mock_logger.assert_called_with("Removed 'some/path'.")
 
                 path_exists_mock.return_value = True
                 with patch('wazuh.core.cluster.cluster.listdir',
@@ -512,38 +512,43 @@ def test_clean_up_ok():
                     with patch('os.path.isdir', return_value=True) as is_dir_mock:
                         with patch('shutil.rmtree'):
                             cluster.clean_up("worker1")
-                            mock_logger.assert_any_call("Removing 'some/path/'.")
-                            mock_logger.assert_called_with("Removed 'some/path/'.")
+                            mock_logger.assert_any_call("Removing 'some/path'.")
+                            mock_logger.assert_called_with("Removed 'some/path'.")
 
                         is_dir_mock.return_value = False
                         with patch('wazuh.core.cluster.cluster.remove'):
                             cluster.clean_up("worker1")
-                            mock_logger.assert_any_call("Removing 'some/path/'.")
-                            mock_logger.assert_called_with("Removed 'some/path/'.")
+                            mock_logger.assert_any_call("Removing 'some/path'.")
+                            mock_logger.assert_called_with("Removed 'some/path'.")
 
 
 def test_clean_up_ko():
     """Check if the cleaning function raising the exceptions properly."""
-    error_cleaning = "Error cleaning up: stat: path should be string, bytes, os.PathLike or integer, not type."
-    error_removing = f"Error removing '{Exception}': " \
-                     f"'stat: path should be string, bytes, os.PathLike or integer, not type'."
+    error_removing = "Error removing 'some/path/other_file.txt': 'test error'."
 
-    with patch('os.path.join') as path_join_mock:
+    with patch('wazuh.core.cluster.cluster.safe_join', return_value="some/path"):
         with patch.object(wazuh.core.cluster.cluster.logger, "error") as mock_error_logger:
             with patch.object(wazuh.core.cluster.cluster.logger, "debug") as mock_debug_logger:
-                path_join_mock.return_value = Exception
-                cluster.clean_up("worker1")
-                mock_debug_logger.assert_any_call(f"Removing '{Exception}'.")
-                mock_error_logger.assert_called_once_with(error_cleaning)
-
                 with patch('os.path.exists', return_value=True):
                     with patch('wazuh.core.cluster.cluster.listdir',
                                return_value=["c-internal.sock", "other_file.txt"]):
-                        with patch('shutil.rmtree', side_effect=Exception):
-                            cluster.clean_up("worker1")
-                            mock_debug_logger.assert_any_call(f"Removing '{Exception}'.")
-                            mock_error_logger.assert_any_call(error_removing)
-                            mock_debug_logger.assert_called_with(f"Removed '{Exception}'.")
+                        with patch('os.path.isdir', return_value=True):
+                            with patch('shutil.rmtree', side_effect=Exception("test error")):
+                                cluster.clean_up("worker1")
+                                mock_debug_logger.assert_any_call("Removing 'some/path'.")
+                                mock_error_logger.assert_any_call(error_removing)
+                                mock_debug_logger.assert_called_with("Removed 'some/path'.")
+
+
+def test_clean_up_node_name_validation():
+    """Check that clean_up rejects invalid node names."""
+    with patch('wazuh.core.cluster.cluster.safe_join') as safe_join_mock:
+        safe_join_mock.side_effect = WazuhInternalError(3003, extra_message="unsafe path")
+
+        with patch.object(wazuh.core.cluster.cluster.logger, "error") as mock_error_logger:
+            cluster.clean_up("../../etc")
+            mock_error_logger.assert_called_once()
+            assert "Error cleaning up" in str(mock_error_logger.call_args)
 
 
 @patch('wazuh.core.cluster.cluster.listdir', return_value=['005', '006'])

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -143,7 +143,21 @@ def test_AbstractServerHandler_hello(event_loop):
     abstract_server_handler.server.clients["if_test"] = "testing"
     with pytest.raises(WazuhClusterError, match=f".* 3028 .* if_test"):
         abstract_server_handler.hello(b"if_test")
-    assert abstract_server_handler.name == ""
+
+    with pytest.raises(WazuhClusterError, match=".* 3060 .*"):
+        abstract_server_handler.hello(b"../../etc")
+
+    with pytest.raises(WazuhClusterError, match=".* 3060 .*"):
+        abstract_server_handler.hello(b"test/node")
+
+    with pytest.raises(WazuhClusterError, match=".* 3060 .*"):
+        abstract_server_handler.hello(b"test\\node")
+
+    with pytest.raises(WazuhClusterError, match=".* 3060 .*"):
+        abstract_server_handler.hello(b".")
+
+    with pytest.raises(WazuhClusterError, match=".* 3060 .*"):
+        abstract_server_handler.hello(b"..")
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -528,6 +528,10 @@ class WazuhException(Exception):
         3050: "Payload size exceeds maximum allowed limit",
         3051: "Too many concurrent divided messages",
         3052: "Invalid cluster file parameter",
+        3060: {'message': "Invalid node name format",
+               'remediation': f"Check and fix [worker names](https://documentation.wazuh.com/{DOCU_VERSION}/"
+                              f"user-manual/reference/ossec-conf/cluster.html#node-name)"
+                              " and restart the `wazuh-manager` service."},
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.


### PR DESCRIPTION
## Description

Add validation for cluster node names to prevent unsafe characters in node identifiers. This ensures node names conform to expected formats and are properly sanitized before being used in filesystem operations.

**Credits:** Issue reported by @moltenbit.

## Proposed Changes

- Add strict node name format validation using regex pattern `[A-Za-z0-9_-]+`
- Validate node name before assignment to prevent rejected values from being used
- Use `safe_join` for path construction in cleanup operations
- Introduce error code 3060 for invalid node name format
- Update existing tests to reflect new path handling

### Results and Evidence

All tests passing:

```
wazuh/core/cluster/tests/test_cluster.py::test_clean_up_ok PASSED
wazuh/core/cluster/tests/test_cluster.py::test_clean_up_ko PASSED
wazuh/core/cluster/tests/test_cluster.py::test_clean_up_node_name_validation PASSED
wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_hello PASSED
```

### Artifacts Affected

- wazuh-clusterd

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `test_clean_up_node_name_validation` - Validates that `clean_up` properly rejects invalid node names
- Extended `test_AbstractServerHandler_hello` with additional validation cases for node names containing:
  - Path separators (`/`, `\`)
  - Traversal sequences (`..`, `../../etc`)
  - Directory references (`.`, `..`)
  - Invalid characters outside `[A-Za-z0-9_-]`

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
