### PR TITLE
Safeguards to inventory sync

### DIFF
--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -183,7 +183,7 @@ jobs:
           if systemctl is-active --quiet wazuh-manager 2>/dev/null; then
             sudo systemctl stop wazuh-manager
           fi
-          if [ -f "$INSTALLATION_DIR/logs/wazuh-manager.log" ]; then
+          if sudo test -f "$INSTALLATION_DIR/logs/wazuh-manager.log"; then
             sudo tail -50 "$INSTALLATION_DIR/logs/wazuh-manager.log"
             sudo cp "$INSTALLATION_DIR/logs/wazuh-manager.log" ./wazuh-manager.log
             sudo chown "$(id -un):$(id -gn)" ./wazuh-manager.log
@@ -206,4 +206,3 @@ jobs:
             src/wazuh_modules/inventory_sync/qa/wazuh_agents.json
           retention-days: 7
           if-no-files-found: warn
-

--- a/docs/ref/modules/inventory-sync/configuration.md
+++ b/docs/ref/modules/inventory-sync/configuration.md
@@ -10,6 +10,8 @@ The runtime configuration passed to Inventory Sync contains:
 - **`clusterName`**: the manager cluster name.
 - **`clusterNodeName`**: the local manager node name.
 - **`maxSessions`**: the session cap derived from internal options.
+- **`queueSize`**: the input worker queue cap derived from internal options.
+- **`dataValueQuota`**: the global `DataValue` quota derived from internal options.
 
 The module refuses to start if `clusterName` is missing.
 
@@ -33,7 +35,9 @@ Example configuration payload passed to the module:
   },
   "clusterName": "wazuh",
   "clusterNodeName": "node01",
-  "maxSessions": 1000
+  "maxSessions": 1000,
+  "queueSize": 10000,
+  "dataValueQuota": 500000
 }
 ```
 
@@ -48,6 +52,32 @@ Current manager-side behavior:
 - Allowed range: `1` to `100000`.
 - Default on manager builds: `1000`.
 - New Start messages are rejected when the active session count reaches that limit.
+
+### Input worker queue size
+
+Inventory Sync reads the input worker queue cap from the internal option `wazuh_modules.inventory_sync_queue_size`.
+
+The cap is applied to the queue that buffers incoming router messages before they reach the worker threads.
+
+Current manager-side behavior:
+
+- Allowed range: `100` to `1000000`.
+- Default on manager builds: `10000`.
+- When the queue is full, the incoming message is dropped.
+- A warning is logged for the first drop and is then suppressed for the next `90` seconds to avoid log flooding.
+
+### Global DataValue quota
+
+Inventory Sync reads the global `DataValue` quota from the internal option `wazuh_modules.inventory_sync_data_value_quota`.
+
+The quota bounds the total number of `DataValue` items that all active sessions can collectively handle. When a Start message arrives, the value declared in its `size` field is reserved from the quota; when the session ends (success, error, stale cleanup, or timeout), the reservation is returned.
+
+Current manager-side behavior:
+
+- Allowed range: `1` to `1000000000`.
+- Default on manager builds: `500000`.
+- If the requested `size` exceeds the remaining quota, the Start message is rejected with `Status_Offline` (the agent will retry later, mirroring the `max_sessions` rejection shape).
+- Quota-rejection events are always logged (no rate limiting).
 
 ## Operational constants
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -735,7 +735,10 @@ public:
             logWarn(m_logTag.c_str(),
                     "Update by query skipped: no valid indices after filtering (input had %zu entries)",
                     indices.size());
-            m_notify.clear();
+            // No HTTP request needed, but pending notify callbacks (e.g. unlockAgent +
+            // sendEndAck) must still fire so the session terminates cleanly. Treat the
+            // missing/filtered indices as a no-op success.
+            m_shouldNotifyAfterBulk = true;
             return;
         }
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -60,6 +60,38 @@ constexpr auto DELETE_FORMATTED_LENGTH {DELETE_OPERATION_PREFIX + DELETE_ID_FIEL
                                         NEWLINE_CHAR};
 
 /**
+ * @brief Validates that an index name is safe to embed in a URL path component or
+ *        in a JSON string sent to wazuh-indexer.
+ *
+ * Rejects empty strings and any character outside the conservative allowlist
+ * `[a-zA-Z0-9._*-]`. Blocks `/`, `?`, `#`, `,`, whitespace and quote characters,
+ * which would otherwise enable path traversal, query-string injection in URLs,
+ * or JSON-body escape attacks. `*` is allowed because wazuh-indexer interprets it
+ * as a wildcard and the connector has legitimate callers that use patterns such
+ * as `wazuh-states-*`.
+ *
+ * @param idx Candidate index name.
+ * @return true if the name is non-empty and contains only safe characters.
+ */
+inline bool isSafeIndexName(std::string_view idx) noexcept
+{
+    if (idx.empty())
+    {
+        return false;
+    }
+    for (const char c : idx)
+    {
+        const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' ||
+                        c == '_' || c == '.' || c == '*';
+        if (!ok)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * @brief Appends an ID to bulkData, escaping special characters if necessary
  * @param bulkData The string to append the ID to
  * @param id The ID to append (will be escaped if needed)
@@ -704,21 +736,29 @@ public:
 
     void deleteByQuery(const std::string& index, const std::string& agentId)
     {
+        if (!isSafeIndexName(index))
+        {
+            logWarn(m_logTag.c_str(),
+                    "Refusing deleteByQuery for unsafe index name '%s' (empty or contains characters outside "
+                    "[a-zA-Z0-9._*-]).",
+                    index.c_str());
+            return;
+        }
         auto [it, success] = m_deleteByQuery.try_emplace(index, nlohmann::json::object());
         it->second["query"]["bool"]["filter"]["terms"]["wazuh.agent.id"].push_back(agentId);
     }
 
     void executeUpdateByQuery(const std::vector<std::string>& indices, const nlohmann::json& updateQuery)
     {
-        // Filter and join valid indices with comma separator for the URL.
-        // Only indices starting with "wazuh-states-" are included.
+        // Reject any entry that fails the connector's safe-name check
         std::string indexList;
         for (const auto& idx : indices)
         {
-            if (!idx.starts_with("wazuh-states-"))
+            if (!isSafeIndexName(idx))
             {
                 logWarn(m_logTag.c_str(),
-                        "Skipping index '%s' for update by query: does not match expected prefix 'wazuh-states-'",
+                        "Skipping index '%s' for update by query: empty or contains characters outside "
+                        "[a-zA-Z0-9._*-].",
                         idx.c_str());
                 continue;
             }
@@ -858,6 +898,12 @@ public:
 
     nlohmann::json executeSearchQuery(const std::string& index, const nlohmann::json& searchQuery)
     {
+        if (!isSafeIndexName(index))
+        {
+            throw IndexerConnectorException("executeSearchQuery: unsafe index name '" + index +
+                                            "' (empty or contains characters outside [a-zA-Z0-9._*-])");
+        }
+
         nlohmann::json resultJson;
 
         const auto onSuccess = [this, &resultJson](const std::string& response)
@@ -894,6 +940,12 @@ public:
                                           const nlohmann::json& query,
                                           std::function<void(const nlohmann::json&)> onResponse)
     {
+        if (!isSafeIndexName(index))
+        {
+            throw IndexerConnectorException("executeSearchQueryWithPagination: unsafe index name '" + index +
+                                            "' (empty or contains characters outside [a-zA-Z0-9._*-])");
+        }
+
         nlohmann::json currentQuery = query;
         while (true)
         {
@@ -957,6 +1009,15 @@ public:
         if (keepAlive.empty())
         {
             throw IndexerConnectorException("keepAlive parameter cannot be empty for PIT creation");
+        }
+
+        for (const auto& idx : indices)
+        {
+            if (!isSafeIndexName(idx))
+            {
+                throw IndexerConnectorException("createPointInTime: unsafe index name '" + idx +
+                                                "' (empty or contains characters outside [a-zA-Z0-9._*-])");
+            }
         }
 
         std::string indicesStr;
@@ -1155,6 +1216,18 @@ public:
 
     void bulkDelete(std::string_view id, std::string_view index)
     {
+        if (!isSafeIndexName(index))
+        {
+            logError(m_logTag.c_str(),
+                     "Refusing bulkDelete for unsafe index name '%.*s' (empty or contains characters outside "
+                     "[a-zA-Z0-9._*-]) on document '%.*s'",
+                     static_cast<int>(index.size()),
+                     index.data(),
+                     static_cast<int>(id.size()),
+                     id.data());
+            throw IndexerConnectorException("Unsafe index name");
+        }
+
         if (constexpr auto FORMATTED_SIZE {DELETE_FORMATTED_LENGTH};
             m_bulkData.length() + FORMATTED_SIZE + index.size() + id.size() > MaxBulkSize)
         {
@@ -1180,13 +1253,16 @@ public:
         constexpr auto VERSION_SIZE {32};
 
         // Validate input parameters
-        if (index.empty())
+        if (!isSafeIndexName(index))
         {
             logError(m_logTag.c_str(),
-                     "Index name cannot be empty for document: %.*s",
+                     "Refusing bulkIndex for unsafe index name '%.*s' (empty or contains characters outside "
+                     "[a-zA-Z0-9._*-]) on document '%.*s'",
+                     static_cast<int>(index.size()),
+                     index.data(),
                      static_cast<int>(id.size()),
                      id.data());
-            throw IndexerConnectorException("Index name cannot be empty");
+            throw IndexerConnectorException("Unsafe index name");
         }
 
         if (data.empty())
@@ -1310,6 +1386,12 @@ public:
 
     void refresh(std::string_view indexPattern)
     {
+        if (!isSafeIndexName(indexPattern))
+        {
+            throw IndexerConnectorException("refresh: unsafe index pattern '" + std::string(indexPattern) +
+                                            "' (empty or contains characters outside [a-zA-Z0-9._*-])");
+        }
+
         std::string url;
         url += m_selector->getNext();
         url += "/";

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -710,15 +710,33 @@ public:
 
     void executeUpdateByQuery(const std::vector<std::string>& indices, const nlohmann::json& updateQuery)
     {
-        // Join indices with comma
+        // Filter and join valid indices with comma separator for the URL.
+        // Only indices starting with "wazuh-states-" are included.
         std::string indexList;
-        for (size_t i = 0; i < indices.size(); ++i)
+        for (const auto& idx : indices)
         {
-            if (i > 0)
+            if (!idx.starts_with("wazuh-states-"))
+            {
+                logWarn(m_logTag.c_str(),
+                        "Skipping index '%s' for update by query: does not match expected prefix 'wazuh-states-'",
+                        idx.c_str());
+                continue;
+            }
+
+            if (!indexList.empty())
             {
                 indexList.append(",");
             }
-            indexList.append(indices[i]);
+            indexList.append(idx);
+        }
+
+        if (indexList.empty())
+        {
+            logWarn(m_logTag.c_str(),
+                    "Update by query skipped: no valid indices after filtering (input had %zu entries)",
+                    indices.size());
+            m_notify.clear();
+            return;
         }
 
         bool needToRetry = false;

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -742,7 +742,7 @@ public:
                     "Refusing deleteByQuery for unsafe index name '%s' (empty or contains characters outside "
                     "[a-zA-Z0-9._*-]).",
                     index.c_str());
-            return;
+            throw IndexerConnectorException("Unsafe index name");
         }
         auto [it, success] = m_deleteByQuery.try_emplace(index, nlohmann::json::object());
         it->second["query"]["bool"]["filter"]["terms"]["wazuh.agent.id"].push_back(agentId);

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -4049,17 +4049,18 @@ TEST_F(IndexerConnectorSyncTest, BulkDelete_RejectsIndexWithSlash)
     EXPECT_THROW(connector.bulkDelete("id1", "wazuh-states-/secret"), IndexerConnectorException);
 }
 
-TEST_F(IndexerConnectorSyncTest, DeleteByQuery_SkipsUnsafeIndex_NoEnqueue)
+TEST_F(IndexerConnectorSyncTest, DeleteByQuery_RejectsUnsafeIndex_Throws)
 {
-    // An unsafe index is silently dropped (logged + return). The follow-up
-    // flush() must not POST anything because nothing was enqueued.
+    // An unsafe index must throw so the caller can't assume the delete was
+    // enqueued. The follow-up flush() must not POST anything because nothing
+    // was enqueued.
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
     EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
     IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
 
     EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
 
-    connector.deleteByQuery("wazuh-states-/evil", "001");
+    EXPECT_THROW(connector.deleteByQuery("wazuh-states-/evil", "001"), IndexerConnectorException);
     connector.flush();
 }
 

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -3984,3 +3984,322 @@ TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryWithPaginationSortArray)
 
     EXPECT_EQ(pageCount, 2);
 }
+
+// =============================================================================
+// PTests for the connector-layer `isSafeIndexName` allowlist.
+// The connector refuses any index name that is empty or contains characters
+// outside [a-zA-Z0-9._*-]. Domain rules (e.g. "starts with wazuh-states-")
+// are enforced by callers, not here.
+// =============================================================================
+
+TEST_F(IndexerConnectorSyncTest, BulkIndex_RejectsIndexWithSlash)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_THROW(connector.bulkIndex("id1", "wazuh-states-/secret", R"({"a":1})"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkIndex_RejectsIndexWithQuestionMark)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_THROW(connector.bulkIndex("id1", "wazuh-states-?q=1", R"({"a":1})"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkIndex_RejectsIndexWithComma)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_THROW(connector.bulkIndex("id1", "wazuh-states-a,wazuh-states-b", R"({"a":1})"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkIndex_RejectsIndexWithNewline)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_THROW(connector.bulkIndex("id1", "wazuh-states-\nfoo", R"({"a":1})"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkIndex_AcceptsSystemIndexWithDotPrefix)
+{
+    // Indexes like `.wazuh-cti-consumers` are valid OpenSearch system indices
+    // used by other modules (content_manager). They must pass the safety check
+    // because they contain only [a-zA-Z0-9._-].
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkIndex("id1", ".wazuh-cti-consumers", R"({"a":1})"));
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkDelete_RejectsIndexWithSlash)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_THROW(connector.bulkDelete("id1", "wazuh-states-/secret"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, DeleteByQuery_SkipsUnsafeIndex_NoEnqueue)
+{
+    // An unsafe index is silently dropped (logged + return). The follow-up
+    // flush() must not POST anything because nothing was enqueued.
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
+
+    connector.deleteByQuery("wazuh-states-/evil", "001");
+    connector.flush();
+}
+
+TEST_F(IndexerConnectorSyncTest, DeleteByQuery_AcceptsSafeIndex_Enqueues)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    std::string capturedUrl;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&capturedUrl](auto requestParams, auto postParams, auto /*configParams*/)
+            {
+                std::visit([&capturedUrl](const auto& p) { capturedUrl = p.url.url(); }, requestParams);
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                }
+            }));
+
+    connector.deleteByQuery("wazuh-states-vulnerabilities", "001");
+    connector.flush();
+    EXPECT_THAT(capturedUrl, HasSubstr("/wazuh-states-vulnerabilities/_delete_by_query"));
+}
+
+TEST_F(IndexerConnectorSyncTest, ExecuteSearchQuery_RejectsUnsafeIndex_Throws)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
+    EXPECT_THROW(connector.executeSearchQuery("wazuh-states-/x", nlohmann::json::object()), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryWithPagination_RejectsUnsafeIndex_Throws)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
+    EXPECT_THROW(connector.executeSearchQueryWithPagination(
+                     "wazuh-states-/x", nlohmann::json::object(), [](const nlohmann::json&) {}),
+                 IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, ExecuteUpdateByQuery_FiltersUnsafeEntries)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    std::string capturedUrl;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&capturedUrl](auto requestParams, auto postParams, auto /*configParams*/)
+            {
+                std::visit([&capturedUrl](const auto& p) { capturedUrl = p.url.url(); }, requestParams);
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onSuccess(R"({"updated":0,"total":0,"failures":[]})");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"updated":0,"total":0,"failures":[]})");
+                }
+            }));
+
+    nlohmann::json q;
+    q["query"]["match_all"] = nlohmann::json::object();
+
+    std::vector<std::string> indices = {"wazuh-states-fim-files", "wazuh-states-/evil", "bad name with space"};
+    connector.executeUpdateByQuery(indices, q);
+
+    // Only the safe entry should appear in the URL path.
+    EXPECT_THAT(capturedUrl, HasSubstr("/wazuh-states-fim-files/_update_by_query"));
+    EXPECT_THAT(capturedUrl, ::testing::Not(HasSubstr("/evil")));
+    EXPECT_THAT(capturedUrl, ::testing::Not(HasSubstr("bad name")));
+}
+
+TEST_F(IndexerConnectorSyncTest, ExecuteUpdateByQuery_AllUnsafe_FiresPendingNotify)
+{
+    // When all entries are filtered out, the function must still mark
+    // m_shouldNotifyAfterBulk=true so that the caller's invokePendingCallbacks
+    // can fire the registered notify (this is what kept the agent unlocked
+    // after the GroupCheck flow).
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
+
+    std::atomic<bool> called {false};
+    connector.registerNotify([&called]() { called = true; });
+
+    nlohmann::json q;
+    q["query"]["match_all"] = nlohmann::json::object();
+    connector.executeUpdateByQuery({"wazuh-states-/x", ""}, q);
+    connector.invokePendingCallbacks();
+
+    EXPECT_TRUE(called);
+}
+
+TEST_F(IndexerConnectorSyncTest, ExecuteUpdateByQuery_AcceptsAnyValidNameRegardlessOfPrefix)
+{
+    // The connector no longer enforces the "wazuh-states-" prefix — that domain
+    // rule belongs to the inventory_sync caller. The connector only refuses
+    // injection-unsafe characters. Therefore an arbitrary safe name like
+    // "wazuh-other-foo" must be forwarded to the indexer.
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    std::string capturedUrl;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&capturedUrl](auto requestParams, auto postParams, auto /*configParams*/)
+            {
+                std::visit([&capturedUrl](const auto& p) { capturedUrl = p.url.url(); }, requestParams);
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onSuccess(R"({"updated":0,"total":0,"failures":[]})");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams)
+                        .onSuccess(R"({"updated":0,"total":0,"failures":[]})");
+                }
+            }));
+
+    nlohmann::json q;
+    q["query"]["match_all"] = nlohmann::json::object();
+    connector.executeUpdateByQuery({"wazuh-other-foo"}, q);
+
+    EXPECT_THAT(capturedUrl, HasSubstr("/wazuh-other-foo/_update_by_query"));
+}
+
+TEST_F(IndexerConnectorSyncTest, CreatePointInTime_RejectsAnyUnsafeEntry_Throws)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
+    EXPECT_THROW(connector.createPointInTime({"wazuh-states-x", "wazuh-states-/x"}, "5m"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, CreatePointInTime_AcceptsWildcardIndices)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [](auto /*requestParams*/, auto postParams, auto /*configParams*/)
+            {
+                const std::string ok = R"({"pit_id":"abc","creation_time":1})";
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(ok);
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(std::string(ok));
+                }
+            }));
+
+    EXPECT_NO_THROW(connector.createPointInTime({"wazuh-states-*"}, "5m"));
+}
+
+TEST_F(IndexerConnectorSyncTest, Refresh_RejectsUnsafePattern)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _)).Times(0);
+    EXPECT_THROW(connector.refresh("wazuh-states-/oh"), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, Refresh_AcceptsWildcard)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    std::string capturedUrl;
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(1)
+        .WillOnce(Invoke(
+            [&capturedUrl](auto requestParams, auto postParams, auto /*configParams*/)
+            {
+                std::visit([&capturedUrl](const auto& p) { capturedUrl = p.url.url(); }, requestParams);
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess("{}");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess("{}");
+                }
+            }));
+
+    EXPECT_NO_THROW(connector.refresh("wazuh-states-*"));
+    EXPECT_THAT(capturedUrl, HasSubstr("/wazuh-states-*/_refresh"));
+}
+
+TEST_F(IndexerConnectorSyncTest, IsSafeIndexName_Allowlist)
+{
+    // Spot-check the helper directly with a representative set of vectors so
+    // the documented allowlist is locked in by a regression test rather than
+    // only by indirect API exercising.
+    EXPECT_FALSE(isSafeIndexName(""));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-/x"));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-?q=1"));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-#x"));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-a,b"));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states- "));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-\nfoo"));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-\"foo\""));
+    EXPECT_FALSE(isSafeIndexName("wazuh-states-foo\\bar"));
+
+    EXPECT_TRUE(isSafeIndexName("wazuh-states-vulnerabilities"));
+    EXPECT_TRUE(isSafeIndexName("wazuh-states-inventory-system"));
+    EXPECT_TRUE(isSafeIndexName("wazuh-states-fim-files"));
+    EXPECT_TRUE(isSafeIndexName(".wazuh-cti-consumers"));
+    EXPECT_TRUE(isSafeIndexName("wazuh-states-*"));
+    EXPECT_TRUE(isSafeIndexName("Idx_With.MixedCase-1.2.3"));
+}

--- a/src/shared_modules/utils/asyncValueDispatcher.hpp
+++ b/src/shared_modules/utils/asyncValueDispatcher.hpp
@@ -49,19 +49,23 @@ namespace Utils
             cancel();
         }
 
-        void push(Type&& value)
+        bool push(Type&& value)
         {
             if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue.size() < m_maxQueueSize))
             {
                 m_queue.push(std::move(value));
+                return true;
             }
+            return false;
         }
-        void push(Type& value)
+        bool push(Type& value)
         {
             if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue.size() < m_maxQueueSize))
             {
                 m_queue.push(value);
+                return true;
             }
+            return false;
         }
 
         void cancel()

--- a/src/shared_modules/utils/tests/asyncValueDispatcher_test.cpp
+++ b/src/shared_modules/utils/tests/asyncValueDispatcher_test.cpp
@@ -311,3 +311,64 @@ TEST_F(AsyncValueDispatcherTest, CaptureWarningMsg)
     dispatcher.cancel();
     Log::deassignLogFunction();
 }
+
+TEST_F(AsyncValueDispatcherTest, Push_ReturnsTrueWhenAccepted)
+{
+    Utils::AsyncValueDispatcher<int, std::function<void(int)>> dispatcher([](int) {}, 1, /*maxQueueSize*/ 10);
+    EXPECT_TRUE(dispatcher.push(42));
+}
+
+TEST_F(AsyncValueDispatcherTest, Push_ReturnsFalseWhenQueueFull)
+{
+    constexpr auto QUEUE_SIZE = 2;
+    std::promise<void> blockWorker;
+    std::shared_future<void> blockFuture = blockWorker.get_future().share();
+
+    // Single worker blocks on the first message so subsequent pushes pile up on
+    // the queue until it hits maxQueueSize. Any push beyond that must return
+    // false, signalling the drop to the caller.
+    Utils::AsyncValueDispatcher<int, std::function<void(int)>> dispatcher([blockFuture](int) { blockFuture.wait(); },
+                                                                          /*numberOfThreads*/ 1,
+                                                                          QUEUE_SIZE);
+
+    // First push is consumed by the worker (which then blocks).
+    EXPECT_TRUE(dispatcher.push(1));
+    // Give the worker a moment to pick up the first message.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // The next QUEUE_SIZE pushes fill the bounded queue.
+    EXPECT_TRUE(dispatcher.push(2));
+    EXPECT_TRUE(dispatcher.push(3));
+
+    // Anything past QUEUE_SIZE is dropped.
+    EXPECT_FALSE(dispatcher.push(4));
+    EXPECT_FALSE(dispatcher.push(5));
+
+    // Release the worker so the dispatcher can shut down cleanly.
+    blockWorker.set_value();
+}
+
+TEST_F(AsyncValueDispatcherTest, Push_ReturnsFalseAfterCancel)
+{
+    Utils::AsyncValueDispatcher<int, std::function<void(int)>> dispatcher([](int) {}, 1, /*maxQueueSize*/ 10);
+    dispatcher.cancel();
+    EXPECT_FALSE(dispatcher.push(7));
+}
+
+TEST_F(AsyncValueDispatcherTest, Push_ReturnsTrueOnUnlimitedQueue)
+{
+    // Default constructor uses UNLIMITED_QUEUE_SIZE.
+    std::promise<void> blockWorker;
+    std::shared_future<void> blockFuture = blockWorker.get_future().share();
+    Utils::AsyncValueDispatcher<int, std::function<void(int)>> dispatcher([blockFuture](int) { blockFuture.wait(); },
+                                                                          1);
+
+    // Push more items than any reasonable bounded queue would accept; with the
+    // unlimited size, every push must succeed.
+    for (int i = 0; i < 1000; ++i)
+    {
+        EXPECT_TRUE(dispatcher.push(i));
+    }
+
+    blockWorker.set_value();
+}

--- a/src/wazuh_modules/inventory_sync/qa/expected_data/data_value_quota_exhausted_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/expected_data/data_value_quota_exhausted_flow.json
@@ -1,0 +1,26 @@
+{
+    "description": "Expected results for DataValue quota exhausted test",
+    "expected_message_count": 1,
+    "validate_session_consistency": true,
+    "expected_messages": [
+      {
+        "type": "start",
+        "expected_status": "sent",
+        "description": "Start with size above the quota - manager must respond Status_Offline with session=-1",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "start_ack",
+            "status": 2
+          },
+          "validate_session": false,
+          "timeout": 5.0
+        }
+      }
+    ],
+    "validation_rules": {
+      "session_consistency": "Not applicable - session is never created when the quota check rejects the Start",
+      "message_order": "Single Start message followed by its rejection",
+      "response_format": "Status 2 = Status_Offline; session is UINT64_MAX (-1) because no session was created"
+    }
+  }

--- a/src/wazuh_modules/inventory_sync/qa/expected_data/forbidden_index_in_checksum_module_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/expected_data/forbidden_index_in_checksum_module_flow.json
@@ -1,0 +1,46 @@
+{
+    "description": "Expected results for forbidden index in ChecksumModule test",
+    "expected_message_count": 3,
+    "validate_session_consistency": true,
+    "expected_messages": [
+      {
+        "type": "start",
+        "expected_status": "sent",
+        "description": "ModuleCheck Start accepted (size=0 is valid for ModuleCheck mode)",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "start_ack",
+            "status": 0
+          },
+          "validate_session": true,
+          "timeout": 5.0
+        }
+      },
+      {
+        "type": "checksum_module",
+        "expected_status": "sent",
+        "description": "ChecksumModule with bad index dropped silently (no response expected)",
+        "expected_response": null
+      },
+      {
+        "type": "end",
+        "expected_status": "sent",
+        "description": "Final end_ack must be Status_Error because checksumIndex stayed empty after the filter rejected the bad index",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "end_ack",
+            "status": 1
+          },
+          "validate_session": true,
+          "timeout": 30.0
+        }
+      }
+    ],
+    "validation_rules": {
+      "session_consistency": "All messages share the same session ID",
+      "message_order": "start -> checksum_module -> end",
+      "response_format": "End_ack status=1 (Status_Error) confirms the ChecksumModule filter is applied AND that the ModuleCheck downstream branch reacts correctly to an empty checksumIndex"
+    }
+  }

--- a/src/wazuh_modules/inventory_sync/qa/expected_data/forbidden_index_in_dataclean_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/expected_data/forbidden_index_in_dataclean_flow.json
@@ -1,0 +1,52 @@
+{
+    "description": "Expected results for forbidden index in DataClean test",
+    "expected_message_count": 4,
+    "validate_session_consistency": true,
+    "expected_messages": [
+      {
+        "type": "start",
+        "expected_status": "sent",
+        "description": "Start message accepted normally",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "start_ack",
+            "status": 0
+          },
+          "validate_session": true,
+          "timeout": 5.0
+        }
+      },
+      {
+        "type": "dataclean",
+        "expected_status": "sent",
+        "description": "DataClean with non-states index dropped silently (no response expected)",
+        "expected_response": null
+      },
+      {
+        "type": "data",
+        "expected_status": "sent",
+        "description": "Valid DataValue queued for bulk indexing (no response expected)",
+        "expected_response": null
+      },
+      {
+        "type": "end",
+        "expected_status": "sent",
+        "description": "End must yield end_ack(Status_Ok) - the valid DataValue is indexed and the bad DataClean was filtered out",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "end_ack",
+            "status": 0
+          },
+          "validate_session": true,
+          "timeout": 30.0
+        }
+      }
+    ],
+    "validation_rules": {
+      "session_consistency": "All messages share the same session ID",
+      "message_order": "start -> dataclean -> data -> end",
+      "response_format": "Final end_ack must be Status_Ok; the filter must NOT abort the session"
+    }
+  }

--- a/src/wazuh_modules/inventory_sync/qa/expected_data/forbidden_index_in_datavalue_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/expected_data/forbidden_index_in_datavalue_flow.json
@@ -1,0 +1,46 @@
+{
+    "description": "Expected results for forbidden index in DataValue test",
+    "expected_message_count": 3,
+    "validate_session_consistency": true,
+    "expected_messages": [
+      {
+        "type": "start",
+        "expected_status": "sent",
+        "description": "Start message accepted normally - session must be created",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "start_ack",
+            "status": 0
+          },
+          "validate_session": true,
+          "timeout": 5.0
+        }
+      },
+      {
+        "type": "data",
+        "expected_status": "sent",
+        "description": "DataValue with non-states index sent successfully (no response expected at this stage)",
+        "expected_response": null
+      },
+      {
+        "type": "end",
+        "expected_status": "sent",
+        "description": "End must yield end_ack(Status_Ok) via the no-op session path because no bulk/delete operations were enqueued",
+        "expected_response": {
+          "type": "flatbuffer",
+          "data": {
+            "type": "end_ack",
+            "status": 0
+          },
+          "validate_session": true,
+          "timeout": 30.0
+        }
+      }
+    ],
+    "validation_rules": {
+      "session_consistency": "All messages share the same session ID",
+      "message_order": "start -> data -> end",
+      "response_format": "Final end_ack must be Status_Ok despite no bulk write happening; without the no-op session fix the notify callback would be stranded and this test would time out"
+    }
+  }

--- a/src/wazuh_modules/inventory_sync/qa/expected_data/out_of_range_seq_rejection_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/expected_data/out_of_range_seq_rejection_flow.json
@@ -1,0 +1,72 @@
+{
+  "description": "Expected results for out-of-range seq rejection test",
+  "expected_message_count": 6,
+  "validate_session_consistency": true,
+  "expected_messages": [
+    {
+      "type": "start",
+      "expected_status": "sent",
+      "description": "Start accepted, declares 2 expected DataValues (valid seqs 0..1)",
+      "expected_response": {
+        "type": "flatbuffer",
+        "data": {
+          "type": "start_ack",
+          "status": 0
+        },
+        "validate_session": true,
+        "timeout": 5.0
+      }
+    },
+    {
+      "type": "data",
+      "expected_status": "sent",
+      "description": "DataValue seq=0 observed correctly (no response expected)",
+      "expected_response": null
+    },
+    {
+      "type": "data",
+      "expected_status": "sent",
+      "description": "DataValue seq=5 dropped by handleData (out of range) - no side effects on GapSet (no response expected)",
+      "expected_response": null
+    },
+    {
+      "type": "end",
+      "expected_status": "sent",
+      "description": "End must yield ReqRet for the still-missing seq=1 (proves seq=5 did not contaminate the GapSet)",
+      "expected_response": {
+        "type": "flatbuffer",
+        "data": {
+          "type": "reqret"
+        },
+        "validate_session": true,
+        "timeout": 5.0
+      }
+    },
+    {
+      "type": "data",
+      "expected_status": "sent",
+      "description": "Retransmitted seq=1 observed correctly (no response expected)",
+      "expected_response": null
+    },
+    {
+      "type": "end",
+      "expected_status": "sent",
+      "description": "Final end_ack(Status_Ok) after the GapSet is complete. Timeout is generous (60s) because the bulk thread has a FlushInterval of 20s and the End must wait for the bulk POST to OpenSearch to complete before the notify callback fires the final ack.",
+      "expected_response": {
+        "type": "flatbuffer",
+        "data": {
+          "type": "end_ack",
+          "status": 0
+        },
+        "validate_session": true,
+        "timeout": 60.0
+      }
+    }
+  ],
+  "validation_rules": {
+    "session_consistency": "All messages share the same session ID",
+    "message_order": "start -> data(0) -> data(5, OOR) -> end -> data(1) -> end",
+    "response_format": "First End triggers ReqRet; second End triggers end_ack(Status_Ok)",
+    "out_of_range_handling": "seq=5 must NOT mark anything in the GapSet, so the End correctly identifies seq=1 as the only missing sequence"
+  }
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/basic_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/basic_flow.json
@@ -21,7 +21,7 @@
         "seq": 0,
         "operation": 0,
         "id": "doc123",
-        "index": "test",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Hello", "timestamp": "2025-08-20T10:00:00Z"}
       },
       "description": "Send data message using session from start response",

--- a/src/wazuh_modules/inventory_sync/qa/test_data/data_value_quota_exhausted_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/data_value_quota_exhausted_flow.json
@@ -1,0 +1,19 @@
+{
+  "description": "DataValue quota exhausted test: Start with size larger than the global quota (default 500000) must be rejected with Status_Offline before the session is created.",
+  "messages": [
+    {
+      "type": "start",
+      "data": {
+        "module": "inventory_sync",
+        "mode": 1,
+        "size": 500001,
+        "agentid": "001",
+        "agentname": "quota-test-agent",
+        "agentversion": "5.0.0"
+      },
+      "description": "Start request declaring size=500001, one above the default DataValue quota - manager must refuse with Status_Offline",
+      "delay": 0.5,
+      "expect_session_response": true
+    }
+  ]
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_checksum_module_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_checksum_module_flow.json
@@ -1,0 +1,45 @@
+{
+  "description": "Forbidden index in ChecksumModule test: a ChecksumModule message whose 'index' does not match wazuh-states-* must be silently dropped by handleChecksumModule, leaving m_context->checksumIndex empty. Mode_ModuleCheck (mode=2 per the FlatBuffer schema) downstream detects the missing checksum index and responds with Status_Error.",
+  "messages": [
+    {
+      "type": "start",
+      "data": {
+        "module": "inventory_sync",
+        "mode": 2,
+        "size": 0,
+        "option": 0,
+        "agentid": "001",
+        "agentname": "checksum-filter-agent",
+        "agentversion": "5.0.0",
+        "architecture": "x86_64",
+        "hostname": "test-host",
+        "osname": "Linux",
+        "osplatform": "linux",
+        "ostype": "linux",
+        "osversion": "5.0"
+      },
+      "description": "Start a ModuleCheck (mode=2) session - no indices field so res.context->indices stays empty",
+      "delay": 0.5,
+      "expect_session_response": true
+    },
+    {
+      "type": "checksum_module",
+      "data": {
+        "index": "bogus-index",
+        "checksum": "should-not-matter"
+      },
+      "description": "ChecksumModule with non wazuh-states-* index - handleChecksumModule must NOT set m_context->checksumIndex",
+      "delay": 0.3,
+      "use_session_from_start": true
+    },
+    {
+      "type": "end",
+      "data": {},
+      "description": "End the session - Mode_ModuleCheck branch sees empty checksumIndex and must send end_ack(Status_Error)",
+      "delay": 0.5,
+      "use_session_from_start": true,
+      "expect_end_response": true,
+      "expected_status": "Status_Error"
+    }
+  ]
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_dataclean_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_dataclean_flow.json
@@ -1,0 +1,51 @@
+{
+  "description": "Forbidden index in DataClean test: a DataClean message with a non wazuh-states-* index must be silently dropped by handleDataClean. A valid DataValue in the same session must still be indexed and the session must close with end_ack(Status_Ok).",
+  "messages": [
+    {
+      "type": "start",
+      "data": {
+        "module": "inventory_sync",
+        "mode": 1,
+        "size": 2,
+        "agentid": "001",
+        "agentname": "dataclean-filter-agent",
+        "agentversion": "5.0.0"
+      },
+      "description": "Start a ModuleDelta session declaring 2 sequenced messages (one DataClean + one DataValue)",
+      "delay": 0.5,
+      "expect_session_response": true
+    },
+    {
+      "type": "dataclean",
+      "data": {
+        "seq": 0,
+        "index": "not-wazuh-states"
+      },
+      "description": "DataClean with a non-states index - handleDataClean must drop it without inserting into dataCleanIndices",
+      "delay": 0.3,
+      "use_session_from_start": true
+    },
+    {
+      "type": "data",
+      "data": {
+        "seq": 1,
+        "operation": 0,
+        "id": "doc-valid",
+        "index": "wazuh-states-inventory-system",
+        "data": {"value": 1}
+      },
+      "description": "Legitimate DataValue with a wazuh-states-* index - must be indexed normally",
+      "delay": 0.3,
+      "use_session_from_start": true
+    },
+    {
+      "type": "end",
+      "data": {},
+      "description": "End the session - bulk completes with the valid DataValue only",
+      "delay": 0.5,
+      "use_session_from_start": true,
+      "expect_end_response": true,
+      "expected_status": "Status_Ok"
+    }
+  ]
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_datavalue_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_datavalue_flow.json
@@ -1,0 +1,41 @@
+{
+  "description": "Forbidden index in DataValue test: a DataValue whose 'index' does not match 'wazuh-states-*' must be silently filtered by the bulk loop. With no other DataValue accepted, the session must still close cleanly via the no-op path and emit a final end_ack(Status_Ok) instead of stranding the notify callback.",
+  "messages": [
+    {
+      "type": "start",
+      "data": {
+        "module": "inventory_sync",
+        "mode": 0,
+        "size": 1,
+        "agentid": "001",
+        "agentname": "forbidden-index-agent",
+        "agentversion": "5.0.0"
+      },
+      "description": "Start a ModuleFull session declaring 1 DataValue",
+      "delay": 0.5,
+      "expect_session_response": true
+    },
+    {
+      "type": "data",
+      "data": {
+        "seq": 0,
+        "operation": 0,
+        "id": "doc-forbidden",
+        "index": "forbidden-index",
+        "data": {"x": 42}
+      },
+      "description": "DataValue with a non wazuh-states-* index - must be skipped by the bulk loop",
+      "delay": 0.3,
+      "use_session_from_start": true
+    },
+    {
+      "type": "end",
+      "data": {},
+      "description": "End the session - bulk loop has nothing valid to send, but the Fix B path must still emit a final end_ack(Status_Ok)",
+      "delay": 0.5,
+      "use_session_from_start": true,
+      "expect_end_response": true,
+      "expected_status": "Status_Ok"
+    }
+  ]
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/out_of_range_seq_rejection_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/out_of_range_seq_rejection_flow.json
@@ -1,0 +1,75 @@
+{
+  "description": "Out-of-range seq rejection test: a DataValue with seq >= declared size must be ignored by handleData (GapSet::observe throws std::out_of_range absorbed by the WorkersQueue wrapper). The GapSet must NOT mark that seq as observed, so the End triggers a ReqRet for the still-missing valid seq, and after retransmission the session completes normally.",
+  "messages": [
+    {
+      "type": "start",
+      "data": {
+        "module": "inventory_sync",
+        "mode": 1,
+        "size": 2,
+        "agentid": "001",
+        "agentname": "out-of-range-agent",
+        "agentversion": "5.0.0"
+      },
+      "description": "Start a ModuleDelta session declaring exactly 2 DataValues (valid seqs are 0 and 1)",
+      "delay": 0.5,
+      "expect_session_response": true,
+      "session_id": "oor_test"
+    },
+    {
+      "type": "data",
+      "data": {
+        "seq": 0,
+        "operation": 0,
+        "id": "doc-valid-0",
+        "index": "wazuh-states-inventory-system",
+        "data": {"description": "first valid datavalue"}
+      },
+      "description": "Legitimate DataValue with seq=0 (in range)",
+      "delay": 0.3,
+      "use_session_from_start": "oor_test"
+    },
+    {
+      "type": "data",
+      "data": {
+        "seq": 5,
+        "operation": 0,
+        "id": "doc-out-of-range",
+        "index": "wazuh-states-inventory-system",
+        "data": {"description": "should be rejected"}
+      },
+      "description": "DataValue with seq=5 (declaredSize is 2) - GapSet::observe throws and the message is dropped; the GapSet must NOT be flipped to allObserved",
+      "delay": 0.3,
+      "use_session_from_start": "oor_test"
+    },
+    {
+      "type": "end",
+      "data": {},
+      "description": "End - GapSet still has seq=1 missing (seq=5 did not register), so the manager must answer with a ReqRet asking for seq=1",
+      "delay": 0.5,
+      "use_session_from_start": "oor_test"
+    },
+    {
+      "type": "data",
+      "data": {
+        "seq": 1,
+        "operation": 0,
+        "id": "doc-valid-1",
+        "index": "wazuh-states-inventory-system",
+        "data": {"description": "second valid datavalue retransmitted"}
+      },
+      "description": "Retransmit the still-missing seq=1",
+      "delay": 0.3,
+      "use_session_from_start": "oor_test"
+    },
+    {
+      "type": "end",
+      "data": {},
+      "description": "End again - all seqs in [0,1] are observed, the session must complete with end_ack(Status_Ok)",
+      "delay": 0.5,
+      "use_session_from_start": "oor_test",
+      "expect_end_response": true,
+      "expected_status": "Status_Ok"
+    }
+  ]
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/reqret_end_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/reqret_end_flow.json
@@ -22,7 +22,7 @@
         "seq": 0,
         "operation": 0,
         "id": "doc001",
-        "index": "test_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "First message", "timestamp": "2025-01-20T10:00:00Z"}
       },
       "description": "Send first data message (seq=0)",
@@ -35,7 +35,7 @@
         "seq": 2,
         "operation": 0,
         "id": "doc003",
-        "index": "test_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Third message", "timestamp": "2025-01-20T10:02:00Z"}
       },
       "description": "Send third data message (seq=2) - skip seq=1 to create gap",
@@ -48,7 +48,7 @@
         "seq": 4,
         "operation": 0,
         "id": "doc005",
-        "index": "test_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Fifth message", "timestamp": "2025-01-20T10:04:00Z"}
       },
       "description": "Send fifth data message (seq=4) - skip seq=3 to create another gap",
@@ -68,7 +68,7 @@
         "seq": 1,
         "operation": 0,
         "id": "doc002",
-        "index": "test_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Second message (after reqret)", "timestamp": "2025-01-20T10:01:00Z"}
       },
       "description": "Retransmit missing seq=1 after receiving ReqRet",
@@ -81,7 +81,7 @@
         "seq": 3,
         "operation": 0,
         "id": "doc004",
-        "index": "test_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Fourth message (after reqret)", "timestamp": "2025-01-20T10:03:00Z"}
       },
       "description": "Retransmit missing seq=3 after receiving ReqRet",

--- a/src/wazuh_modules/inventory_sync/qa/test_data/simple_reqret_test.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/simple_reqret_test.json
@@ -22,7 +22,7 @@
         "seq": 0,
         "operation": 0,
         "id": "doc001",
-        "index": "test_simple_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Message 0", "seq": 0}
       },
       "description": "Send message seq=0",
@@ -35,7 +35,7 @@
         "seq": 2,
         "operation": 0,
         "id": "doc003",
-        "index": "test_simple_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Message 2", "seq": 2}
       },
       "description": "Send message seq=2 (skip seq=1 intentionally)",
@@ -55,7 +55,7 @@
         "seq": 1,
         "operation": 0,
         "id": "doc002",
-        "index": "test_simple_reqret",
+        "index": "wazuh-states-inventory-system",
         "data": {"message": "Message 1 (retransmitted)", "seq": 1}
       },
       "description": "Send missing seq=1 after receiving ReqRet",

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -274,14 +274,15 @@ public:
                     m_context->sessionId,
                     m_context->agentId.c_str(),
                     m_context->moduleName.c_str());
+            throw std::out_of_range("Sequence number out of declared size bounds");
         }
-        m_gapSet->observe(data->seq());
 
-        // Store in RocksDB with session and sequence as key. If fails and throws, we will mark the sequence as observed
-        // anyway, to avoid blocking the session with infinit loop of retries. (The error should log and be
-        // investigated, but the session should continue)
         m_store.put(std::format("{}_{}", session, seq),
                     rocksdb::Slice(reinterpret_cast<const char*>(dataRaw), dataSize));
+
+        // The validation of the sequence number against declared size is performed above, so if we reach this line
+        // the observation should not throw, though if it does the data chunk is already stored.
+        m_gapSet->observe(data->seq());
 
         logDebug2(LOGGER_DEFAULT_TAG,
                   "Data received: %s %llu %llu %s",
@@ -394,16 +395,16 @@ public:
                     m_context->sessionId,
                     m_context->agentId.c_str(),
                     m_context->moduleName.c_str());
+            throw std::out_of_range("Sequence number out of declared size bounds");
         }
 
-        // if fails validation, it won't added to the bulk of data messages
-        m_gapSet->observe(seq);
-
         // Store in RocksDB with "_context" suffix to distinguish from DataValue
-        // If fails and throws, we will mark the sequence as observed anyway, to avoid blocking the session with
-        // infinit loop of retries. (The error should log and be investigated, but the session should continue)
         m_store.put(std::format("{}_{}_context", session, seq),
                     rocksdb::Slice(reinterpret_cast<const char*>(dataRaw), dataSize));
+
+        // The validation of the sequence number against declared size is performed above, so if we reach this line
+        // the observation should not throw, though if it does the data chunk is already stored.
+        m_gapSet->observe(seq);
 
         logDebug2(LOGGER_DEFAULT_TAG,
                   "DataContext received: %s %llu %llu %s",

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -233,17 +233,19 @@ public:
 
         logDebug2(LOGGER_DEFAULT_TAG, "Handling sequence number '%llu' for session '%llu'", seq, session);
 
-        // Avoid storing data if the sequence number is out of declared size bounds,
+        // Avoid storing data if the sequence number is out of declared size bounds;
+        // GapSet::observe will throw std::out_of_range below and the WorkersQueue
+        // wrapper will absorb it, so m_store.put never runs and no orphan key is left.
         if (seq >= m_declaredSize)
         {
             logWarn(LOGGER_DEFAULT_TAG,
-                    "Data sequence number '%llu' exceeds declared size '%llu' for session '%llu'.",
-                     seq,
-                     m_declaredSize,
-                     m_context->sessionId,
-                     m_context->agentId,
-                     m_context->moduleName.c_str()
-                    );
+                    "Data sequence number '%llu' exceeds declared size '%llu' for session %llu "
+                    "(agent '%s', module '%s'); rejecting message.",
+                    seq,
+                    m_declaredSize,
+                    m_context->sessionId,
+                    m_context->agentId.c_str(),
+                    m_context->moduleName.c_str());
         }
         m_gapSet->observe(data->seq());
 
@@ -259,7 +261,7 @@ public:
                   m_context->agentId,
                   m_context->moduleName.c_str());
 
-        if (m_endReceived)
+        if (m_endReceived && !m_endEnqueued)
         {
             if (m_gapSet->empty())
             {
@@ -284,6 +286,17 @@ public:
         }
 
         std::lock_guard lock(m_mutex);
+
+        // Once the session has been enqueued for indexing, mutating m_context->checksum/
+        // checksumIndex would race against the bulk thread that reads them. Drop late
+        // ChecksumModule messages — they can no longer influence the in-flight bulk.
+        if (m_endEnqueued)
+        {
+            logDebug2(LOGGER_DEFAULT_TAG,
+                      "ChecksumModule arrived after End was enqueued for session %llu; ignoring",
+                      m_context->sessionId);
+            return;
+        }
 
         if (data->checksum())
         {
@@ -327,17 +340,19 @@ public:
 
         logDebug2(LOGGER_DEFAULT_TAG, "Handling DataContext sequence number '%llu' for session '%llu'", seq, session);
 
-        // Avoid storing context if the sequence number is out of declared size bounds,
+        // Avoid storing context if the sequence number is out of declared size bounds;
+        // GapSet::observe will throw std::out_of_range below and the WorkersQueue
+        // wrapper will absorb it, so m_store.put never runs and no orphan key is left.
         if (seq >= m_declaredSize)
         {
             logWarn(LOGGER_DEFAULT_TAG,
-                    "DataContext sequence number '%llu' exceeds declared size '%llu' for session '%llu'.",
-                     seq,
-                     m_declaredSize,
-                     m_context->sessionId,
-                     m_context->agentId,
-                     m_context->moduleName.c_str()
-                    );
+                    "DataContext sequence number '%llu' exceeds declared size '%llu' for session %llu "
+                    "(agent '%s', module '%s'); rejecting message.",
+                    seq,
+                    m_declaredSize,
+                    m_context->sessionId,
+                    m_context->agentId.c_str(),
+                    m_context->moduleName.c_str());
         }
 
         // if fails validation, it won't added to the bulk of data messages
@@ -357,7 +372,7 @@ public:
                   m_context->agentId,
                   m_context->moduleName.c_str());
 
-        if (m_endReceived)
+        if (m_endReceived && !m_endEnqueued)
         {
             if (m_gapSet->empty())
             {
@@ -390,17 +405,18 @@ public:
 
         logDebug2(LOGGER_DEFAULT_TAG, "Handling DataClean sequence number '%llu' for session '%llu'", seq, session);
 
-        // Check if the sequence number is within declared size bounds before extracting index
+        // Check if the sequence number is within declared size bounds; GapSet::observe will
+        // throw std::out_of_range below and the WorkersQueue wrapper will absorb it.
         if (seq >= m_declaredSize)
         {
             logWarn(LOGGER_DEFAULT_TAG,
-                    "DataClean sequence number '%llu' exceeds declared size '%llu' for session '%llu'. Ignoring index but marking as observed.",
-                     seq,
-                     m_declaredSize,
-                     m_context->sessionId,
-                     m_context->agentId,
-                     m_context->moduleName.c_str()
-                    );
+                    "DataClean sequence number '%llu' exceeds declared size '%llu' for session %llu "
+                    "(agent '%s', module '%s'); rejecting message.",
+                    seq,
+                    m_declaredSize,
+                    m_context->sessionId,
+                    m_context->agentId.c_str(),
+                    m_context->moduleName.c_str());
         }
         m_gapSet->observe(seq);
 
@@ -423,7 +439,8 @@ public:
                      seq);
         }
 
-        if (m_endReceived)
+
+        if (m_endReceived && !m_endEnqueued)
         {
             if (m_gapSet->empty())
             {

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -79,6 +79,7 @@ class AgentSessionImpl final
     bool m_endReceived = false;         ///< Whether the END message has been received
     std::mutex m_mutex;                 ///< Mutex to guard shared state
     bool m_endEnqueued = false;         ///< Whether the END message has been enqueued
+    uint64_t m_declaredSize {0};        ///< DataValue count declared in the Start message (for quota accounting)
 
 public:
     explicit AgentSessionImpl(const uint64_t sessionId,
@@ -159,6 +160,7 @@ public:
             throw AgentSessionException("Invalid size");
         }
 
+        m_declaredSize = data->size();
         m_gapSet = std::make_unique<GapSet>(data->size());
 
         m_context =
@@ -440,6 +442,16 @@ public:
     std::shared_ptr<Context> getContext() const
     {
         return m_context;
+    }
+
+    /**
+     * @brief Get the number of DataValue items declared in the Start message.
+     *
+     * Used by the facade to reclaim the global DataValue quota when the session ends.
+     */
+    uint64_t declaredSize() const noexcept
+    {
+        return m_declaredSize;
     }
 };
 

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -233,10 +233,24 @@ public:
 
         logDebug2(LOGGER_DEFAULT_TAG, "Handling sequence number '%llu' for session '%llu'", seq, session);
 
+        // Avoid storing data if the sequence number is out of declared size bounds,
+        if (seq >= m_declaredSize)
+        {
+            logWarn(LOGGER_DEFAULT_TAG,
+                    "Data sequence number '%llu' exceeds declared size '%llu' for session '%llu'.",
+                     seq,
+                     m_declaredSize,
+                     m_context->sessionId,
+                     m_context->agentId,
+                     m_context->moduleName.c_str()
+                    );
+        }
+        m_gapSet->observe(data->seq());
+
+        // Store in RocksDB with session and sequence as key. If fails and throws, we will mark the sequence as observed
+        // anyway, to avoid blocking the session with infinit loop of retries. (The error should log and be investigated, but the session should continue)
         m_store.put(std::format("{}_{}", session, seq),
                     rocksdb::Slice(reinterpret_cast<const char*>(dataRaw), dataSize));
-
-        m_gapSet->observe(data->seq());
 
         logDebug2(LOGGER_DEFAULT_TAG,
                   "Data received: %s %llu %llu %s",
@@ -313,11 +327,28 @@ public:
 
         logDebug2(LOGGER_DEFAULT_TAG, "Handling DataContext sequence number '%llu' for session '%llu'", seq, session);
 
+        // Avoid storing context if the sequence number is out of declared size bounds,
+        if (seq >= m_declaredSize)
+        {
+            logWarn(LOGGER_DEFAULT_TAG,
+                    "DataContext sequence number '%llu' exceeds declared size '%llu' for session '%llu'.",
+                     seq,
+                     m_declaredSize,
+                     m_context->sessionId,
+                     m_context->agentId,
+                     m_context->moduleName.c_str()
+                    );
+        }
+
+        // if fails validation, it won't added to the bulk of data messages
+        m_gapSet->observe(seq);
+
         // Store in RocksDB with "_context" suffix to distinguish from DataValue
+        // If fails and throws, we will mark the sequence as observed anyway, to avoid blocking the session with
+        // infinit loop of retries. (The error should log and be investigated, but the session should continue)
         m_store.put(std::format("{}_{}_context", session, seq),
                     rocksdb::Slice(reinterpret_cast<const char*>(dataRaw), dataSize));
 
-        m_gapSet->observe(seq);
 
         logDebug2(LOGGER_DEFAULT_TAG,
                   "DataContext received: %s %llu %llu %s",
@@ -359,6 +390,20 @@ public:
 
         logDebug2(LOGGER_DEFAULT_TAG, "Handling DataClean sequence number '%llu' for session '%llu'", seq, session);
 
+        // Check if the sequence number is within declared size bounds before extracting index
+        if (seq >= m_declaredSize)
+        {
+            logWarn(LOGGER_DEFAULT_TAG,
+                    "DataClean sequence number '%llu' exceeds declared size '%llu' for session '%llu'. Ignoring index but marking as observed.",
+                     seq,
+                     m_declaredSize,
+                     m_context->sessionId,
+                     m_context->agentId,
+                     m_context->moduleName.c_str()
+                    );
+        }
+        m_gapSet->observe(seq);
+
         if (data->index())
         {
             std::string index = data->index()->str();
@@ -377,8 +422,6 @@ public:
                      m_context->sessionId,
                      seq);
         }
-
-        m_gapSet->observe(seq);
 
         if (m_endReceived)
         {

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -40,6 +40,20 @@ struct Response
 using WorkersQueue = Utils::AsyncValueDispatcher<std::vector<char>, std::function<void(const std::vector<char>&)>>;
 using IndexerQueue = Utils::AsyncValueDispatcher<Response, std::function<void(const Response&)>>;
 
+/**
+ * @brief Inventory-sync business rule: an index name must belong to the
+ *        wazuh-states-* family and have a non-empty suffix.
+ *
+ * The connector layer applies an independent safety check (non-empty, only
+ * [a-zA-Z0-9._*-]) that prevents URL/JSON injection regardless of caller. This
+ * helper only encodes the inventory_sync-specific domain rule.
+ */
+inline bool isInventoryStateIndex(std::string_view idx) noexcept
+{
+    constexpr std::string_view kPrefix = "wazuh-states-";
+    return idx.starts_with(kPrefix) && idx.size() > kPrefix.size();
+}
+
 class AgentSessionException : public std::exception
 {
 public:
@@ -134,7 +148,9 @@ public:
             }
         }
 
-        // Extract indices
+        // Extract indices. Only keep entries that belong to the wazuh-states-* family
+        // (inventory_sync's domain rule). The connector layer applies an additional
+        // safety check that rejects characters outside [a-zA-Z0-9._*-].
         std::vector<std::string> indices;
 
         if (data->index())
@@ -143,7 +159,19 @@ public:
             {
                 if (index)
                 {
-                    indices.emplace_back(index->str());
+                    auto entry = index->str();
+                    if (!isInventoryStateIndex(entry))
+                    {
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "Start: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                                "agent '%.*s' (session %llu).",
+                                entry.c_str(),
+                                static_cast<int>(agentId.size()),
+                                agentId.data(),
+                                sessionId);
+                        continue;
+                    }
+                    indices.emplace_back(std::move(entry));
                 }
             }
         }
@@ -250,7 +278,8 @@ public:
         m_gapSet->observe(data->seq());
 
         // Store in RocksDB with session and sequence as key. If fails and throws, we will mark the sequence as observed
-        // anyway, to avoid blocking the session with infinit loop of retries. (The error should log and be investigated, but the session should continue)
+        // anyway, to avoid blocking the session with infinit loop of retries. (The error should log and be
+        // investigated, but the session should continue)
         m_store.put(std::format("{}_{}", session, seq),
                     rocksdb::Slice(reinterpret_cast<const char*>(dataRaw), dataSize));
 
@@ -305,7 +334,19 @@ public:
 
         if (data->index())
         {
-            m_context->checksumIndex = data->index()->str();
+            auto candidate = data->index()->str();
+            if (!isInventoryStateIndex(candidate))
+            {
+                logWarn(LOGGER_DEFAULT_TAG,
+                        "ChecksumModule: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                        "session %llu.",
+                        candidate.c_str(),
+                        m_context->sessionId);
+            }
+            else
+            {
+                m_context->checksumIndex = std::move(candidate);
+            }
         }
 
         logDebug2(LOGGER_DEFAULT_TAG,
@@ -363,7 +404,6 @@ public:
         // infinit loop of retries. (The error should log and be investigated, but the session should continue)
         m_store.put(std::format("{}_{}_context", session, seq),
                     rocksdb::Slice(reinterpret_cast<const char*>(dataRaw), dataSize));
-
 
         logDebug2(LOGGER_DEFAULT_TAG,
                   "DataContext received: %s %llu %llu %s",
@@ -423,13 +463,25 @@ public:
         if (data->index())
         {
             std::string index = data->index()->str();
-            m_context->dataCleanIndices.insert(index);
+            if (!isInventoryStateIndex(index))
+            {
+                logWarn(LOGGER_DEFAULT_TAG,
+                        "DataClean: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                        "session %llu, seq %llu.",
+                        index.c_str(),
+                        m_context->sessionId,
+                        seq);
+            }
+            else
+            {
+                m_context->dataCleanIndices.insert(index);
 
-            logDebug2(LOGGER_DEFAULT_TAG,
-                      "DataClean received for session %llu, seq %llu, index: %s",
-                      m_context->sessionId,
-                      seq,
-                      index.c_str());
+                logDebug2(LOGGER_DEFAULT_TAG,
+                          "DataClean received for session %llu, seq %llu, index: %s",
+                          m_context->sessionId,
+                          seq,
+                          index.c_str());
+            }
         }
         else
         {
@@ -438,7 +490,6 @@ public:
                      m_context->sessionId,
                      seq);
         }
-
 
         if (m_endReceived && !m_endEnqueued)
         {

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -344,8 +344,7 @@ class InventorySyncFacadeImpl final
                                 static_cast<long long>(requestedSize),
                                 static_cast<long long>(remaining),
                                 std::string(agentId).c_str());
-                        m_responseDispatcher->sendStartAck(
-                            Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
+                        m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
                     }
                     else
                     {
@@ -706,8 +705,8 @@ public:
                     if (m_agentSessions.find(res.context->sessionId) == m_agentSessions.end())
                     {
                         logWarn(LOGGER_DEFAULT_TAG,
-                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                 res.context->sessionId);
+                                "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                res.context->sessionId);
                         return;
                     }
                 }
@@ -1030,6 +1029,15 @@ public:
                     }
                     else
                     {
+                        // Track whether anything was actually enqueued to the indexer connector.
+                        // The Mode_ModuleFull branch and the dataCleanIndices loop both rely on
+                        // res.context->indices / dataCleanIndices being non-empty AFTER the layer-2
+                        // filter; if every entry got dropped (e.g. an agent sent only non-states
+                        // indices) we must NOT register a notify callback that would never fire —
+                        // it would strand the session's final end_ack and leak through to a future
+                        // session's response stream.
+                        bool hasDeleteByQueryEnqueued = false;
+
                         // Execute DataClean deletions if any were received during the session
                         if (!res.context->dataCleanIndices.empty())
                         {
@@ -1044,6 +1052,7 @@ public:
                                           index.c_str(),
                                           res.context->agentId.c_str());
                                 m_indexerConnector->deleteByQuery(index, res.context->agentId);
+                                hasDeleteByQueryEnqueued = true;
                             }
                         }
 
@@ -1057,6 +1066,7 @@ public:
                             for (const auto& index : res.context->indices)
                             {
                                 m_indexerConnector->deleteByQuery(index, res.context->agentId);
+                                hasDeleteByQueryEnqueued = true;
                             }
                         }
 
@@ -1077,7 +1087,6 @@ public:
                                 continue;
                             }
 
-                            hasBulkData = true;
                             logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Processing data...");
                             flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()),
                                                            value.size());
@@ -1090,6 +1099,60 @@ public:
                                     throw InventorySyncException("Invalid data message");
                                 }
 
+                                // Validate the per-document index against the inventory_sync domain rule
+                                const auto rawIndex = data->index() ? data->index()->string_view() : std::string_view();
+                                if (!isInventoryStateIndex(rawIndex))
+                                {
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "InventorySyncFacade::start: skipping bulk entry for session %llu - "
+                                            "index '%.*s' does not belong to wazuh-states-* family.",
+                                            res.context->sessionId,
+                                            static_cast<int>(rawIndex.size()),
+                                            rawIndex.data());
+                                    continue;
+                                }
+
+                                // For Upsert: parse the agent-supplied document body up-front. nlohmann::json
+                                // rejects unescaped control characters (literal '\n' / '\r' that would otherwise
+                                // enable bulk request smuggling against the NDJSON stream), trailing garbage,
+                                // and we additionally require an object at the root. Doing this BEFORE
+                                // hasBulkData = true keeps the bookkeeping consistent if every entry is invalid.
+                                nlohmann::json document;
+                                const bool isUpsert = data->operation() == Wazuh::SyncSchema::Operation_Upsert;
+                                if (isUpsert)
+                                {
+                                    try
+                                    {
+                                        document = nlohmann::json::parse(std::string_view(
+                                            reinterpret_cast<const char*>(data->data()->data()), data->data()->size()));
+                                    }
+                                    catch (const nlohmann::json::parse_error& e)
+                                    {
+                                        logWarn(LOGGER_DEFAULT_TAG,
+                                                "InventorySyncFacade::start: skipping bulk entry for session "
+                                                "%llu (seq %llu) - DataValue body is not valid JSON: %s",
+                                                res.context->sessionId,
+                                                data->seq(),
+                                                e.what());
+                                        continue;
+                                    }
+                                    if (!document.is_object())
+                                    {
+                                        logWarn(LOGGER_DEFAULT_TAG,
+                                                "InventorySyncFacade::start: skipping bulk entry for session "
+                                                "%llu (seq %llu) - DataValue body is not a JSON object",
+                                                res.context->sessionId,
+                                                data->seq());
+                                        continue;
+                                    }
+                                }
+                                else if (data->operation() != Wazuh::SyncSchema::Operation_Delete)
+                                {
+                                    throw InventorySyncException("Invalid operation");
+                                }
+
+                                hasBulkData = true;
+
                                 thread_local std::string elementId;
                                 elementId.clear();
 
@@ -1100,34 +1163,29 @@ public:
                                 elementId.append("_");
                                 elementId.append(data->id()->string_view());
 
-                                if (data->operation() == Wazuh::SyncSchema::Operation_Upsert)
+                                if (isUpsert)
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Upserting data...");
 
-                                    // Build metadata using nlohmann::json for automatic escaping
-                                    nlohmann::json metadata;
-                                    metadata["wazuh"]["agent"]["id"] = res.context->agentId;
-                                    metadata["wazuh"]["agent"]["name"] = res.context->agentName;
-                                    metadata["wazuh"]["agent"]["version"] = res.context->agentVersion;
-                                    metadata["wazuh"]["agent"]["groups"] = res.context->groups;
-                                    metadata["wazuh"]["agent"]["host"]["architecture"] = res.context->architecture;
-                                    metadata["wazuh"]["agent"]["host"]["hostname"] = res.context->hostname;
-                                    metadata["wazuh"]["agent"]["host"]["os"]["name"] = res.context->osname;
-                                    metadata["wazuh"]["agent"]["host"]["os"]["platform"] = res.context->osplatform;
-                                    metadata["wazuh"]["agent"]["host"]["os"]["type"] = res.context->ostype;
-                                    metadata["wazuh"]["agent"]["host"]["os"]["version"] = res.context->osversion;
-                                    metadata["wazuh"]["cluster"]["name"] =
+                                    // Overlay manager-controlled metadata on top of the agent payload.
+                                    // Any field the agent tries to set under wazuh.* gets clobbered here,
+                                    // so the agent cannot impersonate another agent or another cluster.
+                                    document["wazuh"]["agent"]["id"] = res.context->agentId;
+                                    document["wazuh"]["agent"]["name"] = res.context->agentName;
+                                    document["wazuh"]["agent"]["version"] = res.context->agentVersion;
+                                    document["wazuh"]["agent"]["groups"] = res.context->groups;
+                                    document["wazuh"]["agent"]["host"]["architecture"] = res.context->architecture;
+                                    document["wazuh"]["agent"]["host"]["hostname"] = res.context->hostname;
+                                    document["wazuh"]["agent"]["host"]["os"]["name"] = res.context->osname;
+                                    document["wazuh"]["agent"]["host"]["os"]["platform"] = res.context->osplatform;
+                                    document["wazuh"]["agent"]["host"]["os"]["type"] = res.context->ostype;
+                                    document["wazuh"]["agent"]["host"]["os"]["version"] = res.context->osversion;
+                                    document["wazuh"]["cluster"]["name"] =
                                         !res.context->clusterName.empty() ? res.context->clusterName : m_clusterName;
 
-                                    // Serialize metadata to string and append FlatBuffer inventory data
                                     thread_local std::string dataString;
-                                    dataString = metadata.dump();
-                                    // Remove closing brace to append inventory data
-                                    dataString.pop_back();
-                                    dataString.append(",");
-                                    // Append inventory data (skip opening brace from FlatBuffer data)
-                                    dataString.append(std::string_view((const char*)data->data()->data() + 1,
-                                                                       data->data()->size() - 1));
+                                    dataString = document.dump();
+
                                     const auto version = data->version();
                                     const auto indexName = data->index()->string_view();
                                     if (version && version > 0)
@@ -1140,14 +1198,10 @@ public:
                                         m_indexerConnector->bulkIndex(elementId, indexName, dataString);
                                     }
                                 }
-                                else if (data->operation() == Wazuh::SyncSchema::Operation_Delete)
+                                else
                                 {
                                     logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Deleting data...");
                                     m_indexerConnector->bulkDelete(elementId, data->index()->string_view());
-                                }
-                                else
-                                {
-                                    throw InventorySyncException("Invalid operation");
                                 }
                             }
                             else
@@ -1270,9 +1324,14 @@ public:
                             }
                         }
 
-                        // Only register notify callback if there's bulk data or deleteByQuery operations
-                        if (hasBulkData || !res.context->dataCleanIndices.empty() ||
-                            res.context->mode == Wazuh::SyncSchema::Mode_ModuleFull)
+                        // Only register notify callback if there's bulk data or deleteByQuery
+                        // operations actually enqueued. Checking hasDeleteByQueryEnqueued (instead
+                        // of mode == Mode_ModuleFull or dataCleanIndices.empty()) is critical: if
+                        // every potential delete target was filtered out by the inventory_sync
+                        // index allowlist, no HTTP request will be made and no future flush will
+                        // fire the notify — the callback would be stranded and leak its end_ack
+                        // into the next session's response stream.
+                        if (hasBulkData || hasDeleteByQueryEnqueued)
                         {
                             // Register notify callback for bulk operations (after accumulating all data)
                             m_indexerConnector->registerNotify(
@@ -2016,10 +2075,11 @@ private:
     }
 
     std::string m_clusterName;
-    int m_maxSessions {1000};                                  // Maximum concurrent sessions (configured from internal_options)
-    size_t m_workersQueueSize {10000};                         // Input queue cap (configured from internal_options)
-    std::atomic<int64_t> m_dataValueQuotaRemaining {500000};   // Global DataValue quota (configured from internal_options)
-    std::atomic<int64_t> m_lastQueueDropLogNs {0};             // steady_clock ns of last queue-drop warning
+    int m_maxSessions {1000};          // Maximum concurrent sessions (configured from internal_options)
+    size_t m_workersQueueSize {10000}; // Input queue cap (configured from internal_options)
+    std::atomic<int64_t> m_dataValueQuotaRemaining {
+        500000};                                   // Global DataValue quota (configured from internal_options)
+    std::atomic<int64_t> m_lastQueueDropLogNs {0}; // steady_clock ns of last queue-drop warning
     static constexpr int64_t WARN_THROTTLE_NS = 90LL * 1000LL * 1000LL * 1000LL; // 90 s
     mutable std::shared_mutex m_agentSessionsMutex;
     mutable std::condition_variable_any m_sessionCompletedCV;

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -323,9 +323,9 @@ class InventorySyncFacadeImpl final
                 }
                 else
                 {
-                    // Reserve DataValue quota for this session. Reject if reservation would go negative.
-                    const int64_t requestedSize = static_cast<int64_t>(startMsg->size());
-                    int64_t remaining = m_dataValueQuotaRemaining.load(std::memory_order_relaxed);
+                    // Reserve DataValue quota for this session. Reject if reservation would underflow.
+                    const uint64_t requestedSize = startMsg->size();
+                    uint64_t remaining = m_dataValueQuotaRemaining.load(std::memory_order_relaxed);
                     bool admitted = false;
                     while (remaining >= requestedSize)
                     {
@@ -340,9 +340,9 @@ class InventorySyncFacadeImpl final
                     {
                         logWarn(LOGGER_DEFAULT_TAG,
                                 "InventorySyncFacade::start: DataValue quota exhausted "
-                                "(requested=%lld, remaining=%lld); rejecting session for agent %s",
-                                static_cast<long long>(requestedSize),
-                                static_cast<long long>(remaining),
+                                "(requested=%llu, remaining=%llu); rejecting session for agent %s",
+                                static_cast<unsigned long long>(requestedSize),
+                                static_cast<unsigned long long>(remaining),
                                 std::string(agentId).c_str());
                         m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
                     }
@@ -631,13 +631,13 @@ public:
         }
         if (configuration.contains("dataValueQuota"))
         {
-            m_dataValueQuotaRemaining.store(configuration.at("dataValueQuota").get<int64_t>(),
+            m_dataValueQuotaRemaining.store(configuration.at("dataValueQuota").get<uint64_t>(),
                                             std::memory_order_relaxed);
         }
         logDebug1(LOGGER_DEFAULT_TAG,
-                  "InventorySync queue size: %zu, DataValue quota: %lld",
+                  "InventorySync queue size: %zu, DataValue quota: %llu",
                   m_workersQueueSize,
-                  static_cast<long long>(m_dataValueQuotaRemaining.load()));
+                  static_cast<unsigned long long>(m_dataValueQuotaRemaining.load()));
 
         logDebug2(LOGGER_DEFAULT_TAG, "Cluster name to be used in indexer: %s", m_clusterName.c_str());
 
@@ -1051,8 +1051,20 @@ public:
                                           "InventorySyncFacade::start: Deleting data from index '%s' for agent %s",
                                           index.c_str(),
                                           res.context->agentId.c_str());
-                                m_indexerConnector->deleteByQuery(index, res.context->agentId);
-                                hasDeleteByQueryEnqueued = true;
+                                try
+                                {
+                                    m_indexerConnector->deleteByQuery(index, res.context->agentId);
+                                    hasDeleteByQueryEnqueued = true;
+                                }
+                                catch (const std::exception& e)
+                                {
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
+                                            "(session %llu): %s",
+                                            index.c_str(),
+                                            res.context->sessionId,
+                                            e.what());
+                                }
                             }
                         }
 
@@ -1065,8 +1077,20 @@ public:
                             // Delete from all indices specified in the Start message
                             for (const auto& index : res.context->indices)
                             {
-                                m_indexerConnector->deleteByQuery(index, res.context->agentId);
-                                hasDeleteByQueryEnqueued = true;
+                                try
+                                {
+                                    m_indexerConnector->deleteByQuery(index, res.context->agentId);
+                                    hasDeleteByQueryEnqueued = true;
+                                }
+                                catch (const std::exception& e)
+                                {
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
+                                            "(session %llu): %s",
+                                            index.c_str(),
+                                            res.context->sessionId,
+                                            e.what());
+                                }
                             }
                         }
 
@@ -1782,7 +1806,7 @@ public:
     {
         if (size > 0)
         {
-            m_dataValueQuotaRemaining.fetch_add(static_cast<int64_t>(size), std::memory_order_acq_rel);
+            m_dataValueQuotaRemaining.fetch_add(size, std::memory_order_acq_rel);
         }
     }
 
@@ -2077,7 +2101,7 @@ private:
     std::string m_clusterName;
     int m_maxSessions {1000};          // Maximum concurrent sessions (configured from internal_options)
     size_t m_workersQueueSize {10000}; // Input queue cap (configured from internal_options)
-    std::atomic<int64_t> m_dataValueQuotaRemaining {
+    std::atomic<uint64_t> m_dataValueQuotaRemaining {
         500000};                                   // Global DataValue quota (configured from internal_options)
     std::atomic<int64_t> m_lastQueueDropLogNs {0}; // steady_clock ns of last queue-drop warning
     static constexpr int64_t WARN_THROTTLE_NS = 90LL * 1000LL * 1000LL * 1000LL; // 90 s

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -705,7 +705,7 @@ public:
                     std::shared_lock sessionLock(m_agentSessionsMutex);
                     if (m_agentSessions.find(res.context->sessionId) == m_agentSessions.end())
                     {
-                        logError(LOGGER_DEFAULT_TAG,
+                        logWarn(LOGGER_DEFAULT_TAG,
                                  "InventorySyncFacade::start: Session not found, sessionId: %llu",
                                  res.context->sessionId);
                         return;

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -24,6 +24,8 @@
 #include "stringHelper.h"
 #include "vulnerabilityScannerFacade.hpp"
 #include <asyncValueDispatcher.hpp>
+#include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <format>
 #include <functional>
@@ -321,22 +323,59 @@ class InventorySyncFacadeImpl final
                 }
                 else
                 {
-                    // Generate random number for session ID.
-                    std::random_device rd;
-                    std::mt19937 gen(rd());
-                    std::uniform_int_distribution<uint64_t> dis(0, UINT64_MAX);
-                    const auto sessionId = dis(gen);
-
-                    // Check if session already exists.
-                    if (m_agentSessions.contains(sessionId))
+                    // Reserve DataValue quota for this session. Reject if reservation would go negative.
+                    const int64_t requestedSize = static_cast<int64_t>(startMsg->size());
+                    int64_t remaining = m_dataValueQuotaRemaining.load(std::memory_order_relaxed);
+                    bool admitted = false;
+                    while (remaining >= requestedSize)
                     {
-                        throw InventorySyncException("Session already exists");
+                        if (m_dataValueQuotaRemaining.compare_exchange_weak(
+                                remaining, remaining - requestedSize, std::memory_order_acq_rel))
+                        {
+                            admitted = true;
+                            break;
+                        }
                     }
+                    if (!admitted)
+                    {
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "InventorySyncFacade::start: DataValue quota exhausted "
+                                "(requested=%lld, remaining=%lld); rejecting session for agent %s",
+                                static_cast<long long>(requestedSize),
+                                static_cast<long long>(remaining),
+                                std::string(agentId).c_str());
+                        m_responseDispatcher->sendStartAck(
+                            Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
+                    }
+                    else
+                    {
+                        // Generate random number for session ID.
+                        std::random_device rd;
+                        std::mt19937 gen(rd());
+                        std::uniform_int_distribution<uint64_t> dis(0, UINT64_MAX);
+                        const auto sessionId = dis(gen);
 
-                    // AgentSession will extract all info (including module) from Start message
-                    m_agentSessions.try_emplace(
-                        sessionId, sessionId, startMsg, *m_dataStore, *m_indexerQueue, *m_responseDispatcher);
-                    logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Session created %llu", sessionId);
+                        // Check if session already exists.
+                        if (m_agentSessions.contains(sessionId))
+                        {
+                            restoreQuota(requestedSize);
+                            throw InventorySyncException("Session already exists");
+                        }
+
+                        try
+                        {
+                            // AgentSession will extract all info (including module) from Start message
+                            m_agentSessions.try_emplace(
+                                sessionId, sessionId, startMsg, *m_dataStore, *m_indexerQueue, *m_responseDispatcher);
+                        }
+                        catch (...)
+                        {
+                            // AgentSession ctor can throw (e.g. "Invalid size") — restore reservation.
+                            restoreQuota(requestedSize);
+                            throw;
+                        }
+                        logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Session created %llu", sessionId);
+                    }
                 }
             }
         }
@@ -586,6 +625,21 @@ public:
         }
         logDebug1(LOGGER_DEFAULT_TAG, "InventorySync session limit: %d", m_maxSessions);
 
+        // Get input queue size and DataValue quota from configuration
+        if (configuration.contains("queueSize"))
+        {
+            m_workersQueueSize = configuration.at("queueSize").get<size_t>();
+        }
+        if (configuration.contains("dataValueQuota"))
+        {
+            m_dataValueQuotaRemaining.store(configuration.at("dataValueQuota").get<int64_t>(),
+                                            std::memory_order_relaxed);
+        }
+        logDebug1(LOGGER_DEFAULT_TAG,
+                  "InventorySync queue size: %zu, DataValue quota: %lld",
+                  m_workersQueueSize,
+                  static_cast<long long>(m_dataValueQuotaRemaining.load()));
+
         logDebug2(LOGGER_DEFAULT_TAG, "Cluster name to be used in indexer: %s", m_clusterName.c_str());
 
         m_workersQueue = std::make_unique<WorkersQueue>(
@@ -622,17 +676,25 @@ public:
                 }
             },
             std::thread::hardware_concurrency(),
-            UNLIMITED_QUEUE_SIZE);
+            m_workersQueueSize);
 
         m_inventorySubscription =
             std::make_unique<TRouterSubscriber>(INVENTORY_SYNC_TOPIC, INVENTORY_SYNC_SUBSCRIBER_ID, false);
         m_inventorySubscription->subscribe(
             // coverity[copy_constructor_call]
-            [queue = m_workersQueue.get()](const std::vector<char>& message)
+            [this, queue = m_workersQueue.get()](const std::vector<char>& message)
             {
                 logDebug2(LOGGER_DEFAULT_TAG, "InventorySyncFacade::start: Received message from router");
                 // TODO: Temporal allocation, we need to use move semantics in router module.
-                queue->push(std::move(const_cast<std::vector<char>&>(message)));
+                if (!queue->push(std::move(const_cast<std::vector<char>&>(message))))
+                {
+                    if (shouldLogThrottled(m_lastQueueDropLogNs))
+                    {
+                        logWarn(LOGGER_DEFAULT_TAG,
+                                "InventorySyncFacade: workers queue full (max=%zu); dropping inbound message",
+                                m_workersQueueSize);
+                    }
+                }
             });
 
         m_indexerQueue = std::make_unique<IndexerQueue>(
@@ -1341,30 +1403,32 @@ public:
                     lock.unlock();
 
                     std::unique_lock agentSessionsLock(m_agentSessionsMutex);
-                    std::erase_if(m_agentSessions,
-                                  [this](const auto& pair)
-                                  {
-                                      if (!pair.second.isAlive(std::chrono::seconds(DEFAULT_TIME * 2)))
-                                      {
-                                          logDebug2(LOGGER_DEFAULT_TAG, "Session %llu has timed out", pair.first);
+                    for (auto it = m_agentSessions.begin(); it != m_agentSessions.end();)
+                    {
+                        if (!it->second.isAlive(std::chrono::seconds(DEFAULT_TIME * 2)))
+                        {
+                            logDebug2(LOGGER_DEFAULT_TAG, "Session %llu has timed out", it->first);
 
-                                          // Unlock agent if this session owns the lock
-                                          const auto& context = pair.second.getContext();
-                                          if (context->ownsAgentLock)
-                                          {
-                                              unlockAgent(context->agentId);
-                                              logDebug1(LOGGER_DEFAULT_TAG,
-                                                        "Session %llu for agent %s timed out - agent unlocked",
-                                                        pair.first,
-                                                        context->agentId.c_str());
-                                          }
+                            // Unlock agent if this session owns the lock
+                            const auto& context = it->second.getContext();
+                            if (context->ownsAgentLock)
+                            {
+                                unlockAgent(context->agentId);
+                                logDebug1(LOGGER_DEFAULT_TAG,
+                                          "Session %llu for agent %s timed out - agent unlocked",
+                                          it->first,
+                                          context->agentId.c_str());
+                            }
 
-                                          // Delete data from database.
-                                          m_dataStore->deleteByPrefix(std::to_string(pair.first));
-                                          return true;
-                                      }
-                                      return false;
-                                  });
+                            // Delete data from database.
+                            m_dataStore->deleteByPrefix(std::to_string(it->first));
+                            it = eraseSessionLocked(it);
+                        }
+                        else
+                        {
+                            ++it;
+                        }
+                    }
                     m_sessionCompletedCV.notify_all();
                 }
             });
@@ -1641,11 +1705,50 @@ public:
         return false; // no matching session found
     }
 
+    // Returns true if the caller should emit the warning now (rate-limited to WARN_THROTTLE_NS).
+    static bool shouldLogThrottled(std::atomic<int64_t>& lastLog)
+    {
+        const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+        int64_t prev = lastLog.load(std::memory_order_relaxed);
+        if (now - prev < WARN_THROTTLE_NS)
+        {
+            return false;
+        }
+        return lastLog.compare_exchange_strong(prev, now, std::memory_order_relaxed);
+    }
+
+    // Restore the DataValue quota that was reserved when the session was created.
+    // Safe to call even after a constructor failure — declaredSize() defaults to 0.
+    void restoreQuota(uint64_t size)
+    {
+        if (size > 0)
+        {
+            m_dataValueQuotaRemaining.fetch_add(static_cast<int64_t>(size), std::memory_order_acq_rel);
+        }
+    }
+
+    // Erase a session whose iterator is held by the caller. Caller MUST hold m_agentSessionsMutex
+    // exclusively. Restores the DataValue quota the session had reserved.
+    template<typename Iterator>
+    Iterator eraseSessionLocked(Iterator it)
+    {
+        const uint64_t reclaim = it->second.declaredSize();
+        auto next = m_agentSessions.erase(it);
+        restoreQuota(reclaim);
+        return next;
+    }
+
     // Always use this instead of erasing m_agentSessions directly — it holds the exclusive lock.
     size_t eraseSession(uint64_t sessionId)
     {
         std::unique_lock lock(m_agentSessionsMutex);
-        return m_agentSessions.erase(sessionId);
+        auto it = m_agentSessions.find(sessionId);
+        if (it == m_agentSessions.end())
+        {
+            return 0;
+        }
+        eraseSessionLocked(it);
+        return 1;
     }
 
     /**
@@ -1693,8 +1796,8 @@ public:
                 // Delete data from database
                 m_dataStore->deleteByPrefix(std::to_string(sessionId));
 
-                // Remove session
-                m_agentSessions.erase(it);
+                // Remove session (restores DataValue quota)
+                eraseSessionLocked(it);
                 cleanedCount++;
             }
         }
@@ -1905,15 +2008,19 @@ private:
                 // Delete data from database
                 m_dataStore->deleteByPrefix(std::to_string(staleSessionId));
 
-                // Remove session from map
-                m_agentSessions.erase(it);
+                // Remove session from map (restores DataValue quota)
+                eraseSessionLocked(it);
                 m_sessionCompletedCV.notify_all();
             }
         }
     }
 
     std::string m_clusterName;
-    int m_maxSessions {1000}; // Maximum concurrent sessions (configured from internal_options)
+    int m_maxSessions {1000};                                  // Maximum concurrent sessions (configured from internal_options)
+    size_t m_workersQueueSize {10000};                         // Input queue cap (configured from internal_options)
+    std::atomic<int64_t> m_dataValueQuotaRemaining {500000};   // Global DataValue quota (configured from internal_options)
+    std::atomic<int64_t> m_lastQueueDropLogNs {0};             // steady_clock ns of last queue-drop warning
+    static constexpr int64_t WARN_THROTTLE_NS = 90LL * 1000LL * 1000LL * 1000LL; // 90 s
     mutable std::shared_mutex m_agentSessionsMutex;
     mutable std::condition_variable_any m_sessionCompletedCV;
     std::mutex m_sessionTimeoutMutex;

--- a/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
@@ -689,3 +689,398 @@ TEST_F(AgentSessionTest, HandleData_ReserializedFromDataBatch)
         ASSERT_NO_THROW({ session.handleData(reserialized, dvBuilder.GetBufferPointer(), dvBuilder.GetSize()); });
     }
 }
+
+// =============================================================================
+// Tests cover the safeguards/security hardening  (`wazuh-states-*` filtering,
+// out-of-range seq, dedup guards, and the declaredSize() accessor).
+// =============================================================================
+
+namespace
+{
+    flatbuffers::Offset<Wazuh::SyncSchema::Start>
+    createStartWithIndices(flatbuffers::FlatBufferBuilder& builder,
+                           uint64_t size,
+                           const std::vector<std::string>& indices,
+                           Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleFull,
+                           const std::string& moduleName = "syscollector")
+    {
+        auto agentIdOffset = builder.CreateString("001");
+        auto agentNameOffset = builder.CreateString("test-agent");
+        auto agentVersionOffset = builder.CreateString("4.0.0");
+        auto moduleOffset = builder.CreateString(moduleName);
+
+        std::vector<flatbuffers::Offset<flatbuffers::String>> indexOffsets;
+        indexOffsets.reserve(indices.size());
+        for (const auto& idx : indices)
+        {
+            indexOffsets.push_back(builder.CreateString(idx));
+        }
+        auto indexVector = builder.CreateVector(indexOffsets);
+
+        Wazuh::SyncSchema::StartBuilder startBuilder(builder);
+        startBuilder.add_module_(moduleOffset);
+        startBuilder.add_size(size);
+        startBuilder.add_mode(mode);
+        startBuilder.add_option(Wazuh::SyncSchema::Option_Sync);
+        startBuilder.add_agentid(agentIdOffset);
+        startBuilder.add_agentname(agentNameOffset);
+        startBuilder.add_agentversion(agentVersionOffset);
+        startBuilder.add_index(indexVector);
+        return startBuilder.Finish();
+    }
+} // namespace
+
+TEST_F(AgentSessionTest, Constructor_StartIndices_FiltersOutNonStatePrefix)
+{
+    auto startMsg = createStartWithIndices(builder, 1, {"wazuh-states-fim-files", "wazuh-other-foo", "random"});
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    const auto& storedIndices = session.getContext()->indices;
+    ASSERT_EQ(storedIndices.size(), 1u);
+    EXPECT_EQ(storedIndices[0], "wazuh-states-fim-files");
+}
+
+TEST_F(AgentSessionTest, Constructor_StartIndices_EmptyPrefixOnlyRejected)
+{
+    // "wazuh-states-" exactly (empty suffix) must be rejected, even though it
+    // starts with the prefix — isInventoryStateIndex requires a non-empty
+    // suffix because an empty suffix would collapse to an unusable index name.
+    auto startMsg = createStartWithIndices(builder, 1, {"wazuh-states-"});
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    EXPECT_TRUE(session.getContext()->indices.empty());
+}
+
+TEST_F(AgentSessionTest, Constructor_StartIndices_AllValidPassedThrough)
+{
+    auto startMsg = createStartWithIndices(
+        builder, 1, {"wazuh-states-vulnerabilities", "wazuh-states-inventory-system", "wazuh-states-fim-files"});
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    EXPECT_EQ(session.getContext()->indices.size(), 3u);
+}
+
+TEST_F(AgentSessionTest, HandleChecksumModule_NonStateIndex_Ignored)
+{
+    auto startMsg =
+        createStartMessage(0, "001", "test-agent", "4.0.0", "syscollector", Wazuh::SyncSchema::Mode_ModuleCheck);
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder checksumBuilder;
+    auto checksumStr = checksumBuilder.CreateString("abc123");
+    auto indexStr = checksumBuilder.CreateString("wazuh-other-foo");
+
+    Wazuh::SyncSchema::ChecksumModuleBuilder cmBuilder(checksumBuilder);
+    cmBuilder.add_session(sessionId);
+    cmBuilder.add_checksum(checksumStr);
+    cmBuilder.add_index(indexStr);
+    auto cmMsg = cmBuilder.Finish();
+    checksumBuilder.Finish(cmMsg);
+
+    auto checksumModule = flatbuffers::GetRoot<Wazuh::SyncSchema::ChecksumModule>(checksumBuilder.GetBufferPointer());
+    ASSERT_NO_THROW({ session.handleChecksumModule(checksumModule); });
+
+    // The non-states index must NOT be persisted on the context. The checksum
+    // value itself is still allowed in (it is used for comparison only and never
+    // reaches the indexer URL), but checksumIndex must stay empty.
+    EXPECT_TRUE(session.getContext()->checksumIndex.empty());
+}
+
+TEST_F(AgentSessionTest, HandleChecksumModule_StateIndex_Stored)
+{
+    auto startMsg =
+        createStartMessage(0, "001", "test-agent", "4.0.0", "syscollector", Wazuh::SyncSchema::Mode_ModuleCheck);
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder checksumBuilder;
+    auto checksumStr = checksumBuilder.CreateString("abc123");
+    auto indexStr = checksumBuilder.CreateString("wazuh-states-vulnerabilities");
+
+    Wazuh::SyncSchema::ChecksumModuleBuilder cmBuilder(checksumBuilder);
+    cmBuilder.add_session(sessionId);
+    cmBuilder.add_checksum(checksumStr);
+    cmBuilder.add_index(indexStr);
+    auto cmMsg = cmBuilder.Finish();
+    checksumBuilder.Finish(cmMsg);
+
+    auto checksumModule = flatbuffers::GetRoot<Wazuh::SyncSchema::ChecksumModule>(checksumBuilder.GetBufferPointer());
+    ASSERT_NO_THROW({ session.handleChecksumModule(checksumModule); });
+
+    EXPECT_EQ(session.getContext()->checksumIndex, "wazuh-states-vulnerabilities");
+}
+
+TEST_F(AgentSessionTest, HandleDataClean_NonStateIndex_Ignored)
+{
+    auto startMsg = createStartMessage(1, "001", "test-agent", "4.0.0", "fim", Wazuh::SyncSchema::Mode_ModuleDelta);
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dcBuilder;
+    auto indexStr = dcBuilder.CreateString("wazuh-not-states");
+
+    Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
+    b.add_session(sessionId);
+    b.add_seq(0);
+    b.add_index(indexStr);
+    auto msg = b.Finish();
+    dcBuilder.Finish(msg);
+
+    auto dc = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder.GetBufferPointer());
+    ASSERT_NO_THROW({ session.handleDataClean(dc); });
+
+    EXPECT_TRUE(session.getContext()->dataCleanIndices.empty());
+}
+
+TEST_F(AgentSessionTest, HandleData_SeqOutOfRange_DoesNotStore)
+{
+    // declaredSize=1 means only seq=0 is valid. seq=1 is out of range and must
+    // be rejected. m_gapSet->observe throws std::out_of_range and the handler
+    // surfaces it; m_store.put is NEVER reached, so the bulk path stays clean
+    // of orphan keys.
+    auto startMsg = createStartMessage(1, "001");
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dataBuilder;
+    std::vector<int8_t> testData = {0x01};
+    auto dataVector = dataBuilder.CreateVector(testData);
+    Wazuh::SyncSchema::DataValueBuilder dvb(dataBuilder);
+    dvb.add_seq(1); // OUT OF RANGE
+    dvb.add_session(sessionId);
+    dvb.add_data(dataVector);
+    auto dvOff = dvb.Finish();
+    dataBuilder.Finish(dvOff);
+
+    auto data = flatbuffers::GetRoot<Wazuh::SyncSchema::DataValue>(dataBuilder.GetBufferPointer());
+
+    EXPECT_CALL(mockStore, put(_, _)).Times(0);
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
+
+    EXPECT_THROW(
+        { session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size()); },
+        std::out_of_range);
+}
+
+TEST_F(AgentSessionTest, HandleDataContext_SeqOutOfRange_DoesNotStore)
+{
+    auto startMsg = createStartMessage(1, "001");
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dcBuilder;
+    std::vector<int8_t> raw = {0x01};
+    auto dataVec = dcBuilder.CreateVector(raw);
+    Wazuh::SyncSchema::DataContextBuilder b(dcBuilder);
+    b.add_seq(1); // OUT OF RANGE
+    b.add_session(sessionId);
+    b.add_data(dataVec);
+    auto off = b.Finish();
+    dcBuilder.Finish(off);
+
+    auto ctx = flatbuffers::GetRoot<Wazuh::SyncSchema::DataContext>(dcBuilder.GetBufferPointer());
+
+    EXPECT_CALL(mockStore, put(_, _)).Times(0);
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
+
+    EXPECT_THROW(
+        { session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size()); },
+        std::out_of_range);
+}
+
+TEST_F(AgentSessionTest, HandleDataClean_SeqOutOfRange_DoesNotInsertIndex)
+{
+    auto startMsg = createStartMessage(1, "001", "test-agent", "4.0.0", "fim", Wazuh::SyncSchema::Mode_ModuleDelta);
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dcBuilder;
+    auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
+    Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
+    b.add_session(sessionId);
+    b.add_seq(1); // OUT OF RANGE (declared size is 1)
+    b.add_index(indexStr);
+    auto msg = b.Finish();
+    dcBuilder.Finish(msg);
+
+    auto dc = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder.GetBufferPointer());
+
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
+
+    EXPECT_THROW({ session.handleDataClean(dc); }, std::out_of_range);
+    EXPECT_TRUE(session.getContext()->dataCleanIndices.empty());
+}
+
+TEST_F(AgentSessionTest, HandleData_DuplicateAfterEnd_DoesNotRePush)
+{
+    auto startMsg = createStartMessage(1, "001");
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dataBuilder;
+    std::vector<int8_t> testData = {0x01};
+    auto dataVector = dataBuilder.CreateVector(testData);
+    Wazuh::SyncSchema::DataValueBuilder dvb(dataBuilder);
+    dvb.add_seq(0);
+    dvb.add_session(sessionId);
+    dvb.add_data(dataVector);
+    auto dvOff = dvb.Finish();
+    dataBuilder.Finish(dvOff);
+
+    auto data = flatbuffers::GetRoot<Wazuh::SyncSchema::DataValue>(dataBuilder.GetBufferPointer());
+
+    // Two store puts (one per delivery — idempotent overwrite), one indexer
+    // push only — the duplicate must NOT re-enqueue after the End has been
+    // forwarded to the indexer.
+    EXPECT_CALL(mockStore, put(_, _)).Times(2);
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
+    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
+
+    session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
+    session.handleEnd(mockResponseDispatcher);
+    // Retransmission arrives AFTER the End has been pushed.
+    session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
+}
+
+TEST_F(AgentSessionTest, HandleDataContext_DuplicateAfterEnd_DoesNotRePush)
+{
+    auto startMsg = createStartMessage(1, "001");
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dcBuilder;
+    std::vector<int8_t> raw = {0x01};
+    auto dataVec = dcBuilder.CreateVector(raw);
+    Wazuh::SyncSchema::DataContextBuilder b(dcBuilder);
+    b.add_seq(0);
+    b.add_session(sessionId);
+    b.add_data(dataVec);
+    auto off = b.Finish();
+    dcBuilder.Finish(off);
+
+    auto ctx = flatbuffers::GetRoot<Wazuh::SyncSchema::DataContext>(dcBuilder.GetBufferPointer());
+
+    EXPECT_CALL(mockStore, put(_, _)).Times(2);
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
+    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
+
+    session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size());
+    session.handleEnd(mockResponseDispatcher);
+    session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size());
+}
+
+TEST_F(AgentSessionTest, HandleDataClean_DuplicateAfterEnd_DoesNotRePush)
+{
+    auto startMsg = createStartMessage(1, "001", "test-agent", "4.0.0", "fim", Wazuh::SyncSchema::Mode_ModuleDelta);
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    flatbuffers::FlatBufferBuilder dcBuilder;
+    auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
+    Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
+    b.add_session(sessionId);
+    b.add_seq(0);
+    b.add_index(indexStr);
+    auto msg = b.Finish();
+    dcBuilder.Finish(msg);
+
+    auto dc = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder.GetBufferPointer());
+
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
+    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
+
+    session.handleDataClean(dc);
+    session.handleEnd(mockResponseDispatcher);
+    session.handleDataClean(dc); // duplicate after the End was pushed
+}
+
+TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
+{
+    // size=0 + Mode_ModuleCheck so the End handler pushes the Response right
+    // away (no missing seqs). A late ChecksumModule must not modify the
+    // context — the bulk thread could already be reading checksumIndex/checksum
+    // and the agent must not race against it.
+    auto startMsg =
+        createStartMessage(0, "001", "test-agent", "4.0.0", "syscollector", Wazuh::SyncSchema::Mode_ModuleCheck);
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
+    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
+
+    // End first.
+    session.handleEnd(mockResponseDispatcher);
+
+    // Late ChecksumModule must NOT mutate the context.
+    flatbuffers::FlatBufferBuilder checksumBuilder;
+    auto checksumStr = checksumBuilder.CreateString("late-checksum");
+    auto indexStr = checksumBuilder.CreateString("wazuh-states-vulnerabilities");
+    Wazuh::SyncSchema::ChecksumModuleBuilder cmBuilder(checksumBuilder);
+    cmBuilder.add_session(sessionId);
+    cmBuilder.add_checksum(checksumStr);
+    cmBuilder.add_index(indexStr);
+    auto cmMsg = cmBuilder.Finish();
+    checksumBuilder.Finish(cmMsg);
+
+    auto checksumModule = flatbuffers::GetRoot<Wazuh::SyncSchema::ChecksumModule>(checksumBuilder.GetBufferPointer());
+    ASSERT_NO_THROW({ session.handleChecksumModule(checksumModule); });
+
+    EXPECT_TRUE(session.getContext()->checksum.empty());
+    EXPECT_TRUE(session.getContext()->checksumIndex.empty());
+}
+
+TEST_F(AgentSessionTest, DeclaredSize_ReturnsValueFromStart)
+{
+    constexpr uint64_t kSize = 5;
+    auto startMsg = createStartMessage(kSize, "001");
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    EXPECT_EQ(session.declaredSize(), kSize);
+}

--- a/src/wazuh_modules/src/wm_inventory_sync.c
+++ b/src/wazuh_modules/src/wm_inventory_sync.c
@@ -82,12 +82,16 @@
              os_free(manager_node_name);
 
              // Add max sessions from internal_options (inventory_sync specific)
-#ifdef CLIENT
-             int max_sessions = getDefine_Int("wazuh_modules", "max_sessions", 1, 100000);
-#else
              int max_sessions = getDefine_Int_default("wazuh_modules", "max_sessions", 1, 100000, 1000);
-#endif
              cJSON_AddNumberToObject(config_json, "maxSessions", max_sessions);
+
+             // Add input worker queue size from internal_options
+             int queue_size = getDefine_Int_default("wazuh_modules", "inventory_sync_queue_size", 100, 1000000, 10000);
+             cJSON_AddNumberToObject(config_json, "queueSize", queue_size);
+
+             // Add global DataValue quota from internal_options
+             int data_value_quota = getDefine_Int_default("wazuh_modules", "inventory_sync_data_value_quota", 1, 1000000000, 500000);
+             cJSON_AddNumberToObject(config_json, "dataValueQuota", data_value_quota);
 
              wm_inventory_sync_log_config(config_json);
              inventory_sync_start_ptr(mtLoggingFunctionsWrapper, config_json);

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/008/input_002.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/008/input_002.json
@@ -18,7 +18,7 @@
         "indices": [
             "wazuh-states-inventory-system"
         ],
-        "size": 1
+        "size": 2
     },
     "data_values": [
         {

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/input_001.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/input_001.json
@@ -18,7 +18,7 @@
         "indices": [
             "wazuh-states-inventory-packages"
         ],
-        "size": 2
+        "size": 3
     },
     "data_values": [
         {


### PR DESCRIPTION
## Description

Inventory Sync previously had only one configurable safeguard (`max_sessions`). The worker queue was created with `UNLIMITED_QUEUE_SIZE` and there was no global cap on the number of `DataValue` items that active sessions could collectively hold, so under high load — or when downstream components (RocksDB / Indexer) were slow — both the worker queue and per-session storage could grow without bound, threatening manager stability.

This PR therefore (1) adds the two configurable safeguards, (2) hardens the per-session handlers to tolerate out-of-order delivery and retransmissions

Closes #36339

## Proposed Changes

### Safeguards (the original scope of the issue)

- **Configurable input queue cap** (`inventory_sync_queue_size`, default `10000`, range `[100, 1000000]`): applied to the `WorkersQueue` that buffers router messages before they reach worker threads. When the queue is full the incoming message is dropped, and a rate-limited warning (one entry per 90 s) is emitted.
- **Configurable global DataValue quota** (`inventory_sync_data_value_quota`, default `500000`, range `[1, 1000000000]`): a single atomic counter that is decremented by `startMsg->size()` when a session is admitted and restored when the session ends (success, error, timeout, zombie cleanup or stale cleanup). If a Start would push the counter below zero, the session is rejected with `Status_Offline` (mirroring the existing `max_sessions` rejection shape). Quota-rejection events are always logged.
- **`AsyncValueDispatcher::push` now returns `bool`** indicating whether the value was enqueued (or dropped because the queue is full). Existing callers ignore the return value and compile unchanged.
- **`eraseSessionLocked` helper in the facade** consolidates the four session-erase paths (canonical `eraseSession`, timeout sweeper, zombie cleanup, stale cleanup) so all of them restore the DataValue quota atomically.

### Retransmission / reordering hardening in `AgentSessionImpl`

- `handleData`, `handleDataContext`, `handleDataClean` gate the `Response` enqueue with `if (m_endReceived && !m_endEnqueued)` so a late or duplicate DataValue cannot push a second `Response` once the session has already been submitted to the indexer bulk.
- `handleChecksumModule` short-circuits when `m_endEnqueued` is true, to avoid a data race on `m_context->checksum` / `checksumIndex` against the bulk thread that reads them.
- Out-of-range sequence numbers (`seq >= declaredSize`) are now logged with a corrected format string (placeholders and arguments match) and the `m_store.put` no longer runs before `m_gapSet->observe`, so no orphan key is written when `observe` throws `std::out_of_range`.
- New `declaredSize()` accessor on `AgentSession` so the facade can reclaim the DataValue quota on erase.

### Facade bulk loop bookkeeping

- The bulk loop now tracks `hasDeleteByQueryEnqueued` and uses it (instead of the older `mode == Mode_ModuleFull` check) to decide whether to register the notify callback. If every DataValue was filtered and `dataCleanIndices` / `Mode_ModuleFull indices` were also empty, the session falls through to the immediate `sendEndAck(Status_Ok)` + `eraseSession` path instead of registering a notify that would never fire and stranding the session.

### Workflow fix

- `.github/workflows/5_testintegration_inventory-sync.yml` — `[ -f /var/wazuh-manager/logs/wazuh-manager.log ]` replaced with `sudo test -f ...` so the log artifact upload actually succeeds (the file is owned by `wazuh-manager`, the check failed under the unprivileged runner user).

### Documentation

- `docs/ref/modules/inventory-sync/configuration.md` — documents `queueSize`, `dataValueQuota`, the two new internal options keys, their ranges, defaults, and rejection behavior.

## Results and Evidence

<details><summary>Limited queue and + limited quota</summary>

***/var/wazuh-manager/etc/wazuh-manager-internal-options.conf**
```
wazuh_modules.inventory_sync_queue_size=100
wazuh_modules.inventory_sync_data_value_quota=500
```

***Manager logs***
```
2026/05/29 00:32:12 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/05/29 00:32:22 wazuh-manager-remoted: INFO: (1410): Reading authentication keys file.
2026/05/29 00:32:32 wazuh-manager-remoted: INFO: (1410): Reading authentication keys file.
2026/05/29 00:33:02 logger-helper: WARNING: InventorySyncFacade::start: DataValue quota exhausted (requested=847, remaining=500); rejecting session for agent 001
2026/05/29 00:33:03 logger-helper: WARNING: InventorySyncFacade::start: DataValue quota exhausted (requested=763, remaining=213); rejecting session for agent 002
2026/05/29 00:33:05 logger-helper: WARNING: InventorySyncFacade::start: DataValue quota exhausted (requested=187, remaining=137); rejecting session for agent 002
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='002' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Packages scan completed in 19 ms: 178 packages scanned, 0 skipped, 4 vulnerable packages
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - Vulnerability scan completed: 6 new, 0 solved
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '002' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='002' type=full reason=first_scan option=VDFirst
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 17 ms: 115 packages scanned, 0 skipped, 27 vulnerable packages
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 43 new, 0 solved
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/05/29 00:33:23 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=first_scan option=VDFirst
```

***Agents logs***
```
26/05/29 00:33:03 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/29 00:33:03 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/05/29 00:33:03 wazuh-syscheckd: ERROR: Received StartAck with error status. Aborting synchronization.
2026/05/29 00:33:03 wazuh-syscheckd: ERROR: Synchronization failed due to manager error.
2026/05/29 00:33:03 wazuh-syscheckd: WARNING: FIM synchronization failed.
2026/05/29 00:33:04 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/05/29 00:33:04 wazuh-modulesd:sca: INFO: Scan ended.
2026/05/29 00:33:05 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/29 00:33:05 wazuh-modulesd:sca: ERROR: Received StartAck with error status. Aborting synchronization.
2026/05/29 00:33:05 wazuh-modulesd:sca: ERROR: Synchronization failed due to manager error.
2026/05/29 00:33:05 wazuh-modulesd:sca: ERROR: SCA initial synchronization failed
2026/05/29 00:33:05 wazuh-modulesd:sca: WARNING: SCA synchronization failed.
2026/05/29 00:33:11 wazuh-rootcheck: INFO: Rootcheck scan ended.
2026/05/29 00:33:42 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/05/29 00:33:42 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

```
2026/05/29 00:33:02 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/29 00:33:02 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/29 00:33:02 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/05/29 00:33:02 wazuh-syscheckd: ERROR: Received StartAck with error status. Aborting synchronization.
2026/05/29 00:33:02 wazuh-syscheckd: ERROR: Synchronization failed due to manager error.
2026/05/29 00:33:02 wazuh-syscheckd: WARNING: FIM synchronization failed.
2026/05/29 00:33:03 wazuh-modulesd:sca: INFO: Scan ended.
2026/05/29 00:33:03 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/29 00:33:03 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/05/29 00:33:09 wazuh-rootcheck: INFO: Rootcheck scan ended.
2026/05/29 00:33:22 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/05/29 00:33:42 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/05/29 00:33:42 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

</details>


<details><summary>Default value + Restart the server</summary>

```
2026/05/29 00:43:04 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/05/29 00:43:16 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/05/29 00:43:22 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/29 00:43:22 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/05/29 00:43:42 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/05/29 00:43:42 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

```
2026/05/29 00:43:02 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/05/29 00:43:16 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/05/29 00:43:22 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/29 00:43:22 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/05/29 00:43:42 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/05/29 00:43:42 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

</details>


<img width="4201" height="909" alt="image" src="https://github.com/user-attachments/assets/28e63d97-ab1e-4d53-b6ef-d336a5031e00" />

<img width="4038" height="1478" alt="image" src="https://github.com/user-attachments/assets/05eadafb-5d08-40f6-9bd0-c3f3e25a76fb" />

<img width="4038" height="1478" alt="image" src="https://github.com/user-attachments/assets/d0679533-67fd-4a11-ba38-abf89796aeb8" />

<img width="4038" height="1478" alt="image" src="https://github.com/user-attachments/assets/912f2e2c-01e4-42c1-b353-72eae6d08770" />

<img width="4038" height="1576" alt="image" src="https://github.com/user-attachments/assets/83e0fdf6-0f8b-4f7e-983d-76459d008f8f" />

## Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-manager-modulesd` /  `libinventory_sync.so` / Indexer connector
- CI workflow `.github/workflows/5_testintegration_inventory-sync.yml`: log artifact upload fix 
- Documentation: `docs/ref/modules/inventory-sync/configuration.md`.

### Configuration Changes

Two new `internal_options.conf` keys under the `wazuh_modules` section, read at manager start by `wm_inventory_sync.c`:

| Key                                       | Range                  | Default  | Effect                                                                                                                            |
| ----------------------------------------- | ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
| `wazuh_modules.inventory_sync_queue_size` | `100` – `1000000`      | `10000`  | Maximum size of the worker input queue. When full, incoming messages are dropped; a warning is logged at most once every 90 s.    |
| `wazuh_modules.inventory_sync_data_value_quota` | `1` – `1000000000` | `500000` | Maximum cumulative `DataValue` items reservable by concurrent sessions. New Start messages are rejected with `Status_Offline` when the requested `size` would exceed the remaining quota. |

### Tests Introduced

**Unit tests (36 new)**

- `src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp` — 14
- `src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp` — 18
- `src/shared_modules/utils/tests/asyncValueDispatcher_test.cpp` — 4 

**Integration tests (5 new fixtures, paired test_data + expected_data)**

Added under `src/wazuh_modules/inventory_sync/qa/test_data/` and `qa/expected_data/`:

| Fixture | Covers | Observable assertion |
| --- | --- | --- |
| `data_value_quota_exhausted_flow` | Global DataValue quota rejection | `start_ack Status_Offline (2)` with `session = UINT64_MAX` |
| `forbidden_index_in_datavalue_flow` | `isInventoryStateIndex` filter on `DataValue.index` + facade no-op session path when every entry is filtered | `end_ack Status_Ok` final |
| `forbidden_index_in_dataclean_flow` | `isInventoryStateIndex` filter on `DataClean.index` combined with a valid DataValue | `end_ack Status_Ok` final |
| `forbidden_index_in_checksum_module_flow` | `isInventoryStateIndex` filter on `ChecksumModule.index` (mode=2 / `Mode_ModuleCheck`) + downstream `if checksumIndex.empty() → Status_Error` | `end_ack Status_Error (1)` |
| `out_of_range_seq_rejection_flow` | `seq >= declaredSize` rejection in `handleData` does not contaminate the GapSet; subsequent retransmission of the genuinely missing seq completes the session | `reqret` for the still-missing seq, then `end_ack Status_Ok` after retransmission |

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
