### PR TITLE
Engine support null values in schema validation

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -3623,7 +3623,7 @@ check:
 {}
 ```
 
-*The check was performed with errors*
+*The check was successful*
 
 ### Example 2
 

--- a/src/engine/source/api/tester/src/handlers.cpp
+++ b/src/engine/source/api/tester/src/handlers.cpp
@@ -268,6 +268,12 @@ void collectOutputErrors(const json::Json& node,
         }
     }
 
+    // Null accepted and treated as a missing value for every type.
+    if (node.isNull())
+    {
+        return;
+    }
+
     if (node.isObject())
     {
         if (!schemaPath.empty())

--- a/src/engine/source/api/tester/test/src/unit/handlers_test.cpp
+++ b/src/engine/source/api/tester/test/src/unit/handlers_test.cpp
@@ -944,6 +944,20 @@ INSTANTIATE_TEST_SUITE_P(
                 ASSERT_TRUE(v.valid());
                 EXPECT_EQ(v.errors_size(), 0);
             },
+        },
+        // 15 ─ null leaf on known schema fields is accepted
+        OutputValidationCase {
+            "NullLeafKnownField",
+            R"({"agent.id":null,"source.port":null})",
+            []() -> std::shared_ptr<schemf::IValidator>
+            {
+                return makeSchemaMock({{"agent.id", schemf::Type::KEYWORD}, {"source.port", schemf::Type::INTEGER}});
+            },
+            [](const eEngine::tester::Result_Validation& v)
+            {
+                EXPECT_TRUE(v.valid());
+                EXPECT_EQ(v.errors_size(), 0);
+            },
         }),
     [](const testing::TestParamInfo<OutputValidationCase>& info) { return info.param.name; });
 

--- a/src/engine/source/builder/src/builders/baseHelper.cpp
+++ b/src/engine/source/builder/src/builders/baseHelper.cpp
@@ -95,7 +95,8 @@ runType(const OpBuilder& builder, const Reference& targetField, const schemf::Va
 
         // Wrapper MapOp
         const auto& invalidTrace = fmt::format("{} -> schema validation failed: ", buildCtx->context().opName);
-        return [invalidTrace, mapOp, runValidator, isTestMode = buildCtx->isTestMode()](base::ConstEvent event) -> MapResult
+        return [invalidTrace, mapOp, runValidator, isTestMode = buildCtx->isTestMode()](
+                   base::ConstEvent event) -> MapResult
         {
             auto mapRes = mapOp(event);
             if (mapRes.failure())
@@ -105,12 +106,15 @@ runType(const OpBuilder& builder, const Reference& targetField, const schemf::Va
 
             const auto& value = mapRes.payload();
 
-            auto error = runValidator(value);
-            if (error)
+            // Allow null values
+            if (!value.isNull())
             {
-                RETURN_FAILURE(isTestMode, json::Json(), invalidTrace + error.value().message);
+                auto error = runValidator(value);
+                if (error)
+                {
+                    RETURN_FAILURE(isTestMode, json::Json(), invalidTrace + error.value().message);
+                }
             }
-
             return std::move(mapRes);
         };
     };
@@ -421,7 +425,18 @@ baseHelperBuilder(const json::Json& definition, const std::shared_ptr<const IBui
             default: return base::Chain::create(opName, subExpressions);
         };
     }
-    else // Null
+    else if (jValue.isNull())
+    {
+        // Null values accepted
+        switch (helperType)
+        {
+            case HelperType::MAP: helperName = "map"; break;
+            case HelperType::FILTER: helperName = "filter"; break;
+            default: throw std::runtime_error("Invalid helper type");
+        }
+        opArgs.emplace_back(std::make_shared<Value>(json::Json(jValue)));
+    }
+    else
     {
         throw std::runtime_error(
             fmt::format("Invalid type for operation definition, got '{}'", json::Json::typeToStr(jValue.type())));

--- a/src/engine/source/builder/test/src/unit/builders/baseHelper_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/baseHelper_test.cpp
@@ -533,10 +533,32 @@ TEST_F(BaseHelperTest, JsonDefinitionMultipleKeys)
     ASSERT_THROW(baseHelperBuilder(def, ctx, HelperType::MAP), std::runtime_error);
 }
 
-TEST_F(BaseHelperTest, JsonDefinitionNullValue)
+TEST_F(BaseHelperTest, JsonDefinitionNullValueMap)
 {
+    // null literal is now accepted as a map operation
     json::Json def(R"({"target.field": null})");
-    ASSERT_THROW(baseHelperBuilder(def, ctx, HelperType::MAP), std::runtime_error);
+
+    setupRegistry("map", OpBuilder{makeSimpleMapBuilder()});
+    setupValidationOk();
+    auto cloneCtx = setupClone();
+    EXPECT_CALL(*ctx, definitions()).WillRepeatedly(ReturnRef(*definitions));
+
+    auto expr = baseHelperBuilder(def, ctx, HelperType::MAP);
+    ASSERT_NE(expr, nullptr);
+}
+
+TEST_F(BaseHelperTest, JsonDefinitionNullValueFilter)
+{
+    // null literal is also accepted in filter/check stages
+    json::Json def(R"({"target.field": null})");
+
+    setupRegistry("filter", OpBuilder{makeSimpleFilterBuilder()});
+    setupValidationOk();
+    auto cloneCtx = setupClone();
+    EXPECT_CALL(*ctx, definitions()).WillRepeatedly(ReturnRef(*definitions));
+
+    auto expr = baseHelperBuilder(def, ctx, HelperType::FILTER);
+    ASSERT_NE(expr, nullptr);
 }
 
 TEST_F(BaseHelperTest, JsonDefinitionBoolValueMap)

--- a/src/engine/source/schemf/src/validator.cpp
+++ b/src/engine/source/schemf/src/validator.cpp
@@ -24,6 +24,7 @@ bool isTemporaryField(const DotPath& name)
 
 void Schema::Validator::registerCompatibles()
 {
+    // All types are compatible with null jsons type.
     m_compatibles.emplace(Type::BOOLEAN,
                           ValidationInfo {{json::Json::Type::Boolean}, validators::getBoolValidator(), {}});
     m_compatibles.emplace(Type::BYTE,
@@ -291,6 +292,12 @@ base::RespOrError<ValidationResult> Schema::Validator::validate(const DotPath& n
 
 base::RespOrError<ValidationResult> Schema::Validator::validate(const DotPath& name, const ValueToken& token) const
 {
+    // null is always accepted
+    if (token.value().isNull())
+    {
+        return ValidationResult();
+    }
+
     const auto& entry = m_compatibles.at(m_schema.getType(name));
 
     // When validating json values, if the schema type has a validator, validate the value

--- a/src/engine/source/schemf/test/src/unit/validator_test.cpp
+++ b/src/engine/source/schemf/test/src/unit/validator_test.cpp
@@ -235,6 +235,19 @@ TEST_F(ValidatorTest, Validate_NullToken_RuntimeOnly)
     EXPECT_TRUE(base::getResponse(res).needsRuntimeValidation());
 }
 
+TEST_F(ValidatorTest, Validate_NullValue_AlwaysAccepted)
+{
+    // A ValueToken carrying JSON null must be accepted for every schema type.
+    auto token = ValueToken::create(json::Json {"null"});
+    for (const char* field : {"source.ip", "source.port", "event.kind", "event.duration", "host.name", "@timestamp"})
+    {
+        SCOPED_TRACE(field);
+        auto res = m_validator->validate(DotPath {field}, token);
+        EXPECT_OK(res);
+        EXPECT_FALSE(base::getResponse(res).needsRuntimeValidation());
+    }
+}
+
 TEST_F(ValidatorTest, Validate_BaseTokenDispatchReturnsRuntimeValidator)
 {
     // BaseToken is not JType/SType/Value — falls through to the last branch

--- a/src/engine/test/helper_tests/helpers_description/filter/is_null.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/is_null.yml
@@ -26,7 +26,7 @@ target_field:
 
 test:
   - target_field: null
-    should_pass: false
+    should_pass: true
     description: Is null
   - target_field: "hello"
     should_pass: false

--- a/src/engine/tools/devContainer/.devcontainer/devcontainer.json
+++ b/src/engine/tools/devContainer/.devcontainer/devcontainer.json
@@ -50,7 +50,9 @@
 				"eamodio.gitlens",
 				"pbkit.vscode-pbkit",
 				"eriklynd.json-tools",
-				"mads-hartmann.bash-ide-vscode"
+				"mads-hartmann.bash-ide-vscode",
+				"GitHub.copilot",
+				"anthropic.claude-vscode"
 			]
 		}
 	},

--- a/src/engine/tools/devContainer/.vscode/tasks.json
+++ b/src/engine/tools/devContainer/.vscode/tasks.json
@@ -331,6 +331,19 @@
             ],
             "group": "build",
             "problemMatcher": []
+        },
+        {
+            "label": "Clean unused containers (interactive)",
+            "type": "shell",
+            "command": "bash ${env:WAZUH_DEV_SCRIPTS}/clean-unused-containers.sh",
+            "problemMatcher": [],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared"
+            },
+            "detail": "Lists stopped containers with last used date and size, then interactively asks which to delete."
         }
     ]
 }

--- a/src/engine/tools/devContainer/scripts/clean-unused-containers.sh
+++ b/src/engine/tools/devContainer/scripts/clean-unused-containers.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# clean-unused-containers.sh
+#
+# Lists all containers (stopped by default, or all with --all) showing:
+#   - Container ID
+#   - Name
+#   - Image
+#   - Status
+#   - Last used date (FinishedAt, or CreatedAt if never finished)
+#   - Size on disk
+#
+# Then prompts the user to choose which containers to delete and
+# asks for an explicit confirmation before removing them.
+#
+# Usage:
+#   clean-unused-containers.sh           # only stopped/exited containers
+#   clean-unused-containers.sh --all     # list every container (including running)
+#   clean-unused-containers.sh -h        # show help
+
+set -euo pipefail
+
+SHOW_ALL=0
+for arg in "$@"; do
+    case "$arg" in
+        -a|--all)
+            SHOW_ALL=1
+            ;;
+        -h|--help)
+            sed -n '2,18p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: docker CLI not found in PATH." >&2
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "Error: cannot talk to the Docker daemon (is it running?)." >&2
+    exit 1
+fi
+
+# Build the list of candidate container IDs.
+if [[ "$SHOW_ALL" -eq 1 ]]; then
+    mapfile -t CONTAINER_IDS < <(docker ps -a --format '{{.ID}}')
+else
+    mapfile -t CONTAINER_IDS < <(docker ps -a --filter "status=exited" --filter "status=created" --filter "status=dead" --format '{{.ID}}')
+fi
+
+if [[ "${#CONTAINER_IDS[@]}" -eq 0 ]]; then
+    if [[ "$SHOW_ALL" -eq 1 ]]; then
+        echo "No containers found."
+    else
+        echo "No stopped containers to clean."
+    fi
+    exit 0
+fi
+
+# Pretty-print the table with sizes (docker ps -s is required to expose Size).
+echo
+printf "  %-4s %-14s %-28s %-30s %-12s %-22s %-14s\n" \
+    "IDX" "CONTAINER ID" "NAME" "IMAGE" "STATUS" "LAST USED (UTC)" "SIZE"
+printf "  %-4s %-14s %-28s %-30s %-12s %-22s %-14s\n" \
+    "----" "------------" "----" "-----" "------" "----------------" "----"
+
+declare -a INDEX_TO_ID=()
+idx=1
+for cid in "${CONTAINER_IDS[@]}"; do
+    # Use docker inspect for accurate fields.
+    read -r name image status finished_at created_at <<<"$(docker inspect \
+        --format '{{.Name}} {{.Config.Image}} {{.State.Status}} {{.State.FinishedAt}} {{.Created}}' \
+        "$cid")"
+
+    name="${name#/}"
+
+    # Pick the most meaningful "last used" timestamp.
+    last_used="$finished_at"
+    if [[ -z "$last_used" || "$last_used" == "0001-01-01T00:00:00Z" ]]; then
+        last_used="$created_at"
+    fi
+    last_used="${last_used%.*}"        # drop nanoseconds
+    last_used="${last_used//T/ }"      # nicer formatting
+    last_used="${last_used%Z}"
+
+    # Size comes from `docker ps -s` only.
+    size="$(docker ps -a -s --filter "id=$cid" --format '{{.Size}}' | head -n1)"
+    [[ -z "$size" ]] && size="n/a"
+
+    printf "  %-4s %-14s %-28s %-30s %-12s %-22s %-14s\n" \
+        "$idx" "${cid:0:12}" "${name:0:28}" "${image:0:30}" "${status:0:12}" "${last_used:0:22}" "${size:0:14}"
+
+    INDEX_TO_ID[$idx]="$cid"
+    idx=$((idx + 1))
+done
+echo
+
+cat <<'EOF'
+Select what to delete:
+  - A list of indexes or container IDs separated by spaces (e.g. "1 3 5")
+  - "all" to delete every listed container
+  - empty / "q" / "n" to cancel
+EOF
+read -r -p "Your choice: " selection
+
+if [[ -z "${selection// /}" || "$selection" =~ ^([qQ]|[nN]|cancel|exit)$ ]]; then
+    echo "Cancelled. No containers were removed."
+    exit 0
+fi
+
+declare -a TO_DELETE=()
+if [[ "$selection" =~ ^([aA][lL][lL])$ ]]; then
+    TO_DELETE=("${CONTAINER_IDS[@]}")
+else
+    for token in $selection; do
+        if [[ "$token" =~ ^[0-9]+$ ]] && [[ -n "${INDEX_TO_ID[$token]:-}" ]]; then
+            TO_DELETE+=("${INDEX_TO_ID[$token]}")
+        elif docker inspect "$token" >/dev/null 2>&1; then
+            TO_DELETE+=("$token")
+        else
+            echo "  ! Ignoring invalid selection: '$token'"
+        fi
+    done
+fi
+
+if [[ "${#TO_DELETE[@]}" -eq 0 ]]; then
+    echo "Nothing valid selected. Aborting."
+    exit 0
+fi
+
+echo
+echo "The following containers will be REMOVED:"
+for cid in "${TO_DELETE[@]}"; do
+    name="$(docker inspect --format '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')"
+    echo "  - ${cid:0:12}  ${name}"
+done
+echo
+
+read -r -p "Are you sure? Type 'yes' to confirm: " confirm
+if [[ "$confirm" != "yes" ]]; then
+    echo "Aborted. No containers were removed."
+    exit 0
+fi
+
+# Stop running ones first (only relevant with --all).
+for cid in "${TO_DELETE[@]}"; do
+    state="$(docker inspect --format '{{.State.Running}}' "$cid" 2>/dev/null || echo false)"
+    if [[ "$state" == "true" ]]; then
+        echo "Stopping running container ${cid:0:12}..."
+        docker stop "$cid" >/dev/null
+    fi
+done
+
+echo "Removing containers..."
+docker rm -v "${TO_DELETE[@]}"
+
+echo "Done. Removed ${#TO_DELETE[@]} container(s)."


### PR DESCRIPTION
## Description

The engine currently rejects `null` JSON values at two points: the **build-time** helper builder throws an exception for any null literal in a normalize/check definition, and the **runtime** schema validator rejects null because every `schemf::validators` entry only accepts a specific JSON type.

This means that a rule author cannot express "clear this field" or "accept absence" via a null literal, and any helper that produces a null on failure causes a spurious `schema validation failed` trace.

Closes #36098

## Proposed Changes

Null is now treated as "absent / no value" at every validation layer.

- **`schemf` validator** (`src/engine/source/schemf/src/validator.cpp`): `Validator::validate(DotPath, ValueToken)` returns an empty (success) `ValidationResult` immediately when the token carries a JSON null, bypassing all type-specific validators.

- **Builder – build-time** (`src/engine/source/builder/src/builders/baseHelper.cpp`, `baseHelperBuilder`): The branch that previously `throw`-ed for null literals now routes them to the `map` or `filter` helper (via a new `Value` argument wrapping `json::Json(null)`), so null-literal assignments compile cleanly.

- **Builder – runtime wrapper** (`baseHelper.cpp`, `runType`): The `MapOp` wrapper that called `runValidator` now skips validation entirely when the produced value is null, preventing false `schema validation failed` failures at runtime.

- **API tester output validator** (`src/engine/source/api/tester/src/handlers.cpp`, `collectOutputErrors`): Null leaf nodes in the output JSON are skipped (treated as absent) instead of flagged as type mismatches.

- **DevContainer tooling** (unrelated to the core fix):
  - Added GitHub Copilot and Claude VSCode extensions to `.devcontainer/devcontainer.json`.
  - Added a `Clean unused containers (interactive)` VS Code task backed by a new script `scripts/clean-unused-containers.sh`.

### Results and Evidence

Unit tests for all three engine layers pass.

| Module | Test | Expected |
|---|---|---|
| `schemf` | `Validate_NullValue_AlwaysAccepted` | OK for every schema type |
| `builder` | `JsonDefinitionNullValueMap` | expression built, not null |
| `builder` | `JsonDefinitionNullValueFilter` | expression built, not null |
| `api/tester` | `NullLeafKnownField` | `valid=true`, `errors_size=0` |

The `decoder_null_types.yaml` decoder (in `backupContainers/testingPRs/`) documents all three failure modes that existed before this fix and can be used to manually exercise the engine before/after.

### Manual tests with their corresponding evidence

<details><summary> Decoder </summary>
<p>

```yaml
name: decoder/null-types-test/0
enabled: true

metadata:
  module: null-types-test
  description: |
    Decoder used to exercise every WCS schema type with null values.

check: exists($event.original)

normalize:
  - map:
      # ----- Helper bag holding a null produced via a temp path ------
      - _temp.null_ref: null
      - _temp.empty_string: ""

      # ----- 1) Literal null on every schema type -------
      - dll.code_signature.timestamp: null  # date
      - agent.id: null                      # keyword
      - dll.code_signature.exists: null     # boolean
      - wazuh.protocol.queue: null          # byte
      - threat.indicator.confidence: null   # short
      - gen_ai.request.max_tokens: null     # integer
      - client.bytes: null                  # long
      - event.risk_score: null              # float
      - gen_ai.request.temperature: null    # double
      - container.cpu.usage: null           # scaled_float
      - client.ip: null                     # ip
      - container.labels: null              # object
      - dll.pe.sections: null               # nested
      - dll.pe.go_imports: null             # flat_object
      - client.geo.location: null           # geo_point

      # ----- 2) Reference to a null value -------------
      - agent.id: $_temp.null_ref
      - client.ip: $_temp.null_ref
      - dll.code_signature.timestamp: $_temp.null_ref

      # ----- 3) Helper output that may yield null --------------------
      - dll.code_signature.timestamp: parse_date($_temp.empty_string, "%Y-%m-%dT%H:%M:%SZ")

      # ----- 4) Happy path (control) ---------------------------------
      - agent.id: "agent-001"
      - dll.code_signature.exists: true
      - wazuh.protocol.queue: 49
      - threat.indicator.confidence: 5
      - gen_ai.request.max_tokens: 1024
      - client.bytes: 4096
      - event.risk_score: 1.5
      - gen_ai.request.temperature: 0.7
      - container.cpu.usage: 0.42
      - client.ip: "10.0.0.1"
      - dll.code_signature.timestamp: "2026-05-26T12:00:00Z"
```

</p>
</details> 

<details><summary> CLI log test </summary>
<p>

```console
╰─# engine-test run test -n logtest_8f612d  -dd          


Enter any events [ENTER to send event, CTRL+C to finish]:

asdasd


---
traces:
[🟢] decoder/null-types-test/0 -> success
  ↳ [check: exists($event.original)] -> Success
  ↳ _temp.null_ref: map(null) -> Success
  ↳ _temp.empty_string: map("") -> Success
  ↳ dll.code_signature.timestamp: map(null) -> Success
  ↳ agent.id: map(null) -> Success
  ↳ dll.code_signature.exists: map(null) -> Success
  ↳ wazuh.protocol.queue: map(null) -> Success
  ↳ threat.indicator.confidence: map(null) -> Success
  ↳ gen_ai.request.max_tokens: map(null) -> Success
  ↳ client.bytes: map(null) -> Success
  ↳ event.risk_score: map(null) -> Success
  ↳ gen_ai.request.temperature: map(null) -> Success
  ↳ container.cpu.usage: map(null) -> Success
  ↳ client.ip: map(null) -> Success
  ↳ container.labels: map(null) -> Success
  ↳ dll.pe.sections: map(null) -> Success
  ↳ dll.pe.go_imports: map(null) -> Success
  ↳ client.geo.location: map(null) -> Success
  ↳ agent.id: map($_temp.null_ref) -> Success
  ↳ client.ip: map($_temp.null_ref) -> Success
  ↳ dll.code_signature.timestamp: map($_temp.null_ref) -> Success
  ↳ dll.code_signature.timestamp: parse_date($_temp.empty_string, "%Y-%m-%dT%H:%M:%SZ") -> Parser parser failed at: 
  ↳ agent.id: map("agent-001") -> Success
  ↳ dll.code_signature.exists: map(true) -> Success
  ↳ wazuh.protocol.queue: map(49) -> Success
  ↳ threat.indicator.confidence: map(5) -> Success
  ↳ gen_ai.request.max_tokens: map(1024) -> Success
  ↳ client.bytes: map(4096) -> Success
  ↳ event.risk_score: map(1.5) -> Success
  ↳ gen_ai.request.temperature: map(0.7) -> Success
  ↳ container.cpu.usage: map(0.42) -> Success
  ↳ client.ip: map("10.0.0.1") -> Success
  ↳ dll.code_signature.timestamp: map("2026-05-26T12:00:00Z") -> Success
[🟢] filter/DiscardedEvents -> success
  ↳ Discard_event() -> Success: Event will be indexed (wazuh.space.event_discarded=false)
[🟢] cleanup/DecoderTemporaryVariables -> success
  ↳ cleanupDecoderTemporaryVariables() -> Success: Removed root keys prefixed with '_'

output:
  '@timestamp': '2026-05-28T13:19:35.743Z'
  agent:
    id: agent-001
  client:
    bytes: 4096
    geo:
      location: null
    ip: 10.0.0.1
  container:
    cpu:
      usage: 0.42
    labels: null
  dll:
    code_signature:
      exists: true
      timestamp: '2026-05-26T12:00:00Z'
    pe:
      go_imports: null
      sections: null
  event:
    original: asdasd
    risk_score: 1.5
  gen_ai:
    request:
      max_tokens: 1024
      temperature: 0.7
  threat:
    indicator:
      confidence: 5
  wazuh:
    event:
      id: 83a0297b-8f8c-4a5b-b8de-79b2e0de7957
    integration:
      category: security
      decoders:
      - decoder/null-types-test/0
      name: nulltestInt
    protocol:
      location: location
      queue: 49
    space:
      name: nulltest

```

</p>
</details> 

<details><summary> Dashboard check</summary>
<p>

<img width="1898" height="945" alt="Screenshot From 2026-05-28 12-18-05" src="https://github.com/user-attachments/assets/563a52f1-350d-4f88-a338-54e233297390" />
<img width="1902" height="939" alt="Screenshot From 2026-05-28 12-17-39" src="https://github.com/user-attachments/assets/0c888b02-d2dd-4dc0-aa53-42844b5feb6f" />


</p>
</details> 


* Job with Indexer artifact for testing:

https://github.com/wazuh/wazuh-indexer/actions/runs/26597071381

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine

- Wazuh server API/Framework
  - N/A

### Artifacts Affected

- `wazuh-engine` binary (Linux) — runtime null-handling behavior changed in builder and schemf layers.

### Configuration Changes

N/A

### Tests Introduced

Four new unit tests across three modules:

| File | Test name | What it checks |
|---|---|---|
| `schemf/test/…/validator_test.cpp` | `Validate_NullValue_AlwaysAccepted` | `validate(DotPath, ValueToken{null})` returns OK for ip, port, keyword, long, and timestamp schema types |
| `builder/test/…/baseHelper_test.cpp` | `JsonDefinitionNullValueMap` | Null literal in a `normalize.map` definition builds without throwing |
| `builder/test/…/baseHelper_test.cpp` | `JsonDefinitionNullValueFilter` | Null literal in a `check/filter` definition builds without throwing |
| `api/tester/test/…/handlers_test.cpp` | `NullLeafKnownField` | Output JSON with null fields on known schema paths produces no validation errors |

The existing `JsonDefinitionNullValue` test was split into the two tests above; the expected behavior changed from `ASSERT_THROW` to `ASSERT_NE(expr, nullptr)`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
