### PR TITLE
Adapt remoted tests to 5.x

### DIFF
--- a/.github/test_modules_manager.json
+++ b/.github/test_modules_manager.json
@@ -63,7 +63,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_remoted/",
       "tiers": ["2"],
-      "timeout_minutes": 30,
+      "timeout_minutes": 60,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
         ".github/workflows/5_testintegration_manager.yml",

--- a/.github/test_modules_manager.json
+++ b/.github/test_modules_manager.json
@@ -34,6 +34,8 @@
         ".github/test_modules_manager.json",
         ".github/workflows/.python-version-it",
         ".github/actions/reinstall_cmake/**",
+        "src/config/src/wazuh_db-config.c",
+        "src/config/include/wazuh_db-config.h",
         "src/wazuh_db/**",
         "src/Makefile",
         "tests/integration/conftest.py",
@@ -41,10 +43,10 @@
       ]
     },
     {
-      "name": "remoted-tier-0-1",
+      "name": "remoted",
       "suite_type": "manager_install",
       "pytest_target": "test_remoted/",
-      "tiers": ["0 1"],
+      "tiers": ["0 1", "2"],
       "timeout_minutes": 60,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
@@ -52,24 +54,8 @@
         ".github/test_modules_manager.json",
         ".github/workflows/.python-version-it",
         ".github/actions/reinstall_cmake/**",
-        "src/remoted/**",
-        "src/Makefile",
-        "tests/integration/conftest.py",
-        "tests/integration/test_remoted/**"
-      ]
-    },
-    {
-      "name": "remoted-tier-2",
-      "suite_type": "manager_install",
-      "pytest_target": "test_remoted/",
-      "tiers": ["2"],
-      "timeout_minutes": 60,
-      "paths": [
-        ".github/workflows/5_builderpackage_manager-multiples.yml",
-        ".github/workflows/5_testintegration_manager.yml",
-        ".github/test_modules_manager.json",
-        ".github/workflows/.python-version-it",
-        ".github/actions/reinstall_cmake/**",
+        "src/config/src/remote-config.c",
+        "src/config/include/remote-config.h",
         "src/remoted/**",
         "src/Makefile",
         "tests/integration/conftest.py",
@@ -96,6 +82,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_authd/",
       "tiers": ["0 1"],
+      "timeout_minutes": 60,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
         ".github/workflows/5_testintegration_manager.yml",
@@ -106,7 +93,7 @@
         "src/config/include/authd-config.h",
         "src/os_auth/**",
         "src/Makefile",
-        "tests/integration/conftest.py/",
+        "tests/integration/conftest.py",
         "tests/integration/test_authd/**"
       ]
     }

--- a/.github/test_modules_manager.json
+++ b/.github/test_modules_manager.json
@@ -43,10 +43,30 @@
       ]
     },
     {
-      "name": "remoted",
+      "name": "remoted-tier-0-1",
       "suite_type": "manager_install",
       "pytest_target": "test_remoted/",
-      "tiers": ["0 1", "2"],
+      "tiers": ["0 1"],
+      "timeout_minutes": 60,
+      "paths": [
+        ".github/workflows/5_builderpackage_manager-multiples.yml",
+        ".github/workflows/5_testintegration_manager.yml",
+        ".github/test_modules_manager.json",
+        ".github/workflows/.python-version-it",
+        ".github/actions/reinstall_cmake/**",
+        "src/config/src/remote-config.c",
+        "src/config/include/remote-config.h",
+        "src/remoted/**",
+        "src/Makefile",
+        "tests/integration/conftest.py",
+        "tests/integration/test_remoted/**"
+      ]
+    },
+    {
+      "name": "remoted-tier-2",
+      "suite_type": "manager_install",
+      "pytest_target": "test_remoted/",
+      "tiers": ["2"],
       "timeout_minutes": 60,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",

--- a/.github/test_modules_manager.json
+++ b/.github/test_modules_manager.json
@@ -41,6 +41,42 @@
       ]
     },
     {
+      "name": "remoted-tier-0-1",
+      "suite_type": "manager_install",
+      "pytest_target": "test_remoted/",
+      "tiers": ["0 1"],
+      "timeout_minutes": 60,
+      "paths": [
+        ".github/workflows/5_builderpackage_manager-multiples.yml",
+        ".github/workflows/5_testintegration_manager.yml",
+        ".github/test_modules_manager.json",
+        ".github/workflows/.python-version-it",
+        ".github/actions/reinstall_cmake/**",
+        "src/remoted/**",
+        "src/Makefile",
+        "tests/integration/conftest.py",
+        "tests/integration/test_remoted/**"
+      ]
+    },
+    {
+      "name": "remoted-tier-2",
+      "suite_type": "manager_install",
+      "pytest_target": "test_remoted/",
+      "tiers": ["2"],
+      "timeout_minutes": 30,
+      "paths": [
+        ".github/workflows/5_builderpackage_manager-multiples.yml",
+        ".github/workflows/5_testintegration_manager.yml",
+        ".github/test_modules_manager.json",
+        ".github/workflows/.python-version-it",
+        ".github/actions/reinstall_cmake/**",
+        "src/remoted/**",
+        "src/Makefile",
+        "tests/integration/conftest.py",
+        "tests/integration/test_remoted/**"
+      ]
+    },
+    {
       "name": "inventory_sync",
       "suite_type": "inventory_sync",
       "timeout_minutes": 60,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -946,7 +946,7 @@ def autostart_simulators(request: pytest.FixtureRequest) -> None:
 def simulate_agents(test_metadata):
 
     agents_amount = test_metadata.get("agents_number", 1)
-    agents = create_agents(agents_amount, "localhost")
+    agents = create_agents(agents_amount, "localhost", retry_enrollment=True)
 
     yield agents
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -952,7 +952,7 @@ def simulate_agents(test_metadata):
 
     # Delete simulated agents
     control_service("start")
-    remove_agents([a.id for a in agents], "manage_agents")
+    remove_agents([a.id for a in agents], "api")
     control_service("stop")
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/test_remoted/test_active_response/test_active_response_send.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send.py
@@ -81,10 +81,6 @@ def test_active_response_ar_sending(test_configuration, test_metadata, configure
                                manager_port=test_metadata['port'], wait_status='')
 
     try:
-        # Send startup and wait for the manager ACK. The timeout is set to 30 s to cover the
-        # case where remoted is still loading the agent key when the startup message arrives:
-        # remoted drops undecryptable messages, but the injector's keepalive thread resends
-        # the startup after 10 s, giving remoted a second chance once the key is loaded.
         sender.send_event(agent.startup_msg)
 
         ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)

--- a/tests/integration/test_remoted/test_active_response/test_active_response_send.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send.py
@@ -81,15 +81,14 @@ def test_active_response_ar_sending(test_configuration, test_metadata, configure
                                manager_port=test_metadata['port'], wait_status='')
 
     try:
-        log_monitor.start(callback=generate_callback(patterns.KEY_UPDATE))
-        assert log_monitor.callback_result, (
-            "Remoted did not detect the agent key — connection cannot be established."
-        )
-
+        # Send startup and wait for the manager ACK. The timeout is set to 30 s to cover the
+        # case where remoted is still loading the agent key when the startup message arrives:
+        # remoted drops undecryptable messages, but the injector's keepalive thread resends
+        # the startup after 10 s, giving remoted a second chance once the key is loaded.
         sender.send_event(agent.startup_msg)
 
         ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
-        ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
+        ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE), timeout=30)
         assert ack_monitor.callback_result, (
             f"Manager did not ACK the startup message via {test_metadata['protocol']} "
             f"on port {test_metadata['port']} — agent-manager communication not established."

--- a/tests/integration/test_remoted/test_active_response/test_active_response_send.py
+++ b/tests/integration/test_remoted/test_active_response/test_active_response_send.py
@@ -4,17 +4,17 @@
  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 
+import re
 import pytest
-import time
 
 from pathlib import Path
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.tools.simulators.agent_simulator import connect
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.modules.remoted import patterns
 from wazuh_testing.utils.sockets import send_active_response_message
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
 from wazuh_testing.tools.monitors import queue_monitor
 
@@ -75,24 +75,41 @@ def test_active_response_ar_sending(test_configuration, test_metadata, configure
     '''
 
     log_monitor = FileMonitor(WAZUH_LOG_PATH)
-
     agent = simulate_agents[0]
 
-    time.sleep(1)
-    sender, injector = connect(agent, protocol = test_metadata['protocol'], manager_port = test_metadata['port'])
-    active_response_message = fr"(local_source) [] NRN {agent.id} {ACTIVE_RESPONSE_EXAMPLE_COMMAND}"
-    send_active_response_message(active_response_message)
+    sender, injector = connect(agent, protocol=test_metadata['protocol'],
+                               manager_port=test_metadata['port'], wait_status='')
 
-    log_monitor.start(callback=generate_callback(patterns.ACTIVE_RESPONSE_RECEIVED))
+    try:
+        log_monitor.start(callback=generate_callback(patterns.KEY_UPDATE))
+        assert log_monitor.callback_result, (
+            "Remoted did not detect the agent key — connection cannot be established."
+        )
 
-    assert log_monitor.callback_result
+        sender.send_event(agent.startup_msg)
 
-    log_monitor.start(callback=generate_callback(patterns.ACTIVE_RESPONSE_SENT))
+        ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
+        ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
+        assert ack_monitor.callback_result, (
+            f"Manager did not ACK the startup message via {test_metadata['protocol']} "
+            f"on port {test_metadata['port']} — agent-manager communication not established."
+        )
 
-    assert log_monitor.callback_result
+        active_response_message = fr"(local_source) [] NRN {agent.id} {ACTIVE_RESPONSE_EXAMPLE_COMMAND}"
+        send_active_response_message(active_response_message)
 
-    log_queue_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
-    log_queue_monitor.start(callback=generate_callback(regex=patterns.EXECD_MESSAGE,
-                                                       replacement={"message": ACTIVE_RESPONSE_EXAMPLE_COMMAND}))
-    assert log_monitor.callback_result
-    injector.stop_receive()
+        log_monitor.start(callback=generate_callback(patterns.ACTIVE_RESPONSE_SENT))
+        assert log_monitor.callback_result, (
+            f"Remoted did not send the active response to agent {agent.id} via "
+            f"{test_metadata['protocol']} on port {test_metadata['port']}."
+        )
+        log_queue_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
+        log_queue_monitor.start(callback=generate_callback(
+            regex=patterns.EXECD_MESSAGE,
+            replacement={"message": re.escape(ACTIVE_RESPONSE_EXAMPLE_COMMAND)}
+        ))
+        assert log_queue_monitor.callback_result, (
+            f"Agent {agent.id} did not receive the active response command."
+        )
+    finally:
+        injector.stop_receive()

--- a/tests/integration/test_remoted/test_agent_communication/conftest.py
+++ b/tests/integration/test_remoted/test_agent_communication/conftest.py
@@ -4,69 +4,69 @@
  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 
-import pytest
 import time
-from wazuh_testing.tools.thread_executor import ThreadExecutor
+import pytest
 
-from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
-from wazuh_testing.modules.analysisd.patterns import ANALYSISD_STARTED
-from wazuh_testing.utils import callbacks
-from wazuh_testing.tools.monitors import file_monitor
+from pathlib import Path
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.tools.simulators.agent_simulator import connect
+from wazuh_testing.tools.thread_executor import ThreadExecutor
+from wazuh_testing.utils import callbacks
 
-@pytest.fixture(scope='module')
-def waiting_for_analysisd_startup(request):
-    """Wait until analysisd has begun."""
-    log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
-    log_monitor.start(callback=callbacks.generate_callback(ANALYSISD_STARTED))
+# SSH public-key auth event — triggers rule 5715 "Authentication success" if it reaches the engine.
+_SSH_AUTH_EVENT = (
+    '1:/root/test.log:Feb 23 17:18:20 35-u20-manager4 sshd[40657]: Accepted publickey for root'
+    ' from 192.168.0.5 port 48044 ssh2: RSA SHA256:IZT11YXRZoZfuGlj/K/t3tT8OdolV58hcCOJFZLIW2Y'
+)
+
+_ALERT_PATTERN = r'.*Accepted publickey.*'
+_NEGATIVE_TIMEOUT = 10  # seconds to wait confirming no alert appears
 
 
 @pytest.fixture
 def validate_agent_manager_protocol_communication():
+    """Send an SSH event via the specified protocol and verify it does NOT generate an alert.
 
-    def validate_agent_manager_protocol_communication(monitored_sockets, simulate_agents, protocol, manager_port):
+    Used by invalid-protocol tests: if the manager is configured for the opposite protocol,
+    the event never reaches the engine and no alert is generated.
+    """
 
-        agent =simulate_agents[0]
+    def _validate(simulate_agents, protocol, manager_port):
+        agent = simulate_agents[0]
         injectors = []
 
-        def send_event(event, protocol, manager_port, agent):
-            """Send an event to the manager"""
+        def _send(event, protocol, manager_port, agent):
+            try:
+                sender, injector = connect(agent, manager_port=manager_port, protocol=protocol,
+                                           wait_status='')
+                sender.send_event(event)
+                injectors.append(injector)
+            except Exception:
+                pass  # invalid-protocol connections are expected to fail at the transport layer
 
-            sender, injector = connect(agent, manager_port = manager_port, protocol = protocol, wait_status= '' if protocol == 'UDP' else 'active' )
-            sender.send_event(event)
-            injectors.append(injector)
-            return injector
+        event = agent.create_event(_SSH_AUTH_EVENT)
+        thread = ThreadExecutor(_send, {'event': event, 'protocol': protocol,
+                                        'manager_port': manager_port, 'agent': agent})
+        thread.start()
+        thread.join()
 
+        # Ensure alerts.json exists so FileMonitor can open it.
+        Path(ALERTS_JSON_PATH).parent.mkdir(parents=True, exist_ok=True)
+        Path(ALERTS_JSON_PATH).touch(exist_ok=True)
 
-        # Generate custom events for each agent
-        search_pattern = f"test message from agent {agent.id}"
-        agent_custom_message = f"1:/test.log:Feb 23 17:18:20 manager sshd[40657]: {search_pattern}"
-        event = agent.create_event(agent_custom_message)
+        alert_monitor = FileMonitor(ALERTS_JSON_PATH)
+        alert_monitor.start(timeout=_NEGATIVE_TIMEOUT,
+                            callback=callbacks.generate_callback(_ALERT_PATTERN))
 
-        # Create sender event threads
-        send_event_thread = ThreadExecutor(send_event, {'event': event, 'protocol': protocol,
-                                                        'manager_port': manager_port, 'agent': agent})
+        assert not alert_monitor.callback_result, (
+            f"An alert was generated for an event sent via {protocol} to port {manager_port} "
+            f"even though the manager is configured for the opposite protocol — "
+            f"the event should not have reached the engine."
+        )
 
-        # If protocol is TCP, then just send the message as the attempt to establish the connection will fail.
-        if protocol == 'TCP':
-            send_event_thread.start()
-            send_event_thread.join()
-        else:  # If protocol is UDP, then monitor the  socket queue to verify that the event has not been received.
-
-            callback = callbacks.generate_callback(fr"{search_pattern}")
-            monitored_sockets[0].start(callback=callback)
-            assert monitored_sockets[0].callback_result
-
-
-        # Wait until socket monitor is fully initialized
-        time.sleep(5)
-
-        send_event_thread.start()
-        send_event_thread.join()
-
-        yield
-        time.sleep(5)
+        time.sleep(2)
         for injector in injectors:
             injector.stop_receive()
 
-    return validate_agent_manager_protocol_communication
+    return _validate

--- a/tests/integration/test_remoted/test_agent_communication/conftest.py
+++ b/tests/integration/test_remoted/test_agent_communication/conftest.py
@@ -4,7 +4,6 @@
  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 
-import time
 import pytest
 
 from pathlib import Path
@@ -42,22 +41,23 @@ def validate_agent_manager_protocol_communication():
                                            wait_status='')
                 sender.send_event(event)
                 injectors.append(injector)
-            except Exception:
+            except OSError:
                 pass  # invalid-protocol connections are expected to fail at the transport layer
+
+        Path(ALERTS_JSON_PATH).parent.mkdir(parents=True, exist_ok=True)
+        Path(ALERTS_JSON_PATH).touch(exist_ok=True)
+
+        alert_monitor = FileMonitor(ALERTS_JSON_PATH)
 
         event = agent.create_event(_SSH_AUTH_EVENT)
         thread = ThreadExecutor(_send, {'event': event, 'protocol': protocol,
                                         'manager_port': manager_port, 'agent': agent})
         thread.start()
-        thread.join()
 
-        # Ensure alerts.json exists so FileMonitor can open it.
-        Path(ALERTS_JSON_PATH).parent.mkdir(parents=True, exist_ok=True)
-        Path(ALERTS_JSON_PATH).touch(exist_ok=True)
-
-        alert_monitor = FileMonitor(ALERTS_JSON_PATH)
         alert_monitor.start(timeout=_NEGATIVE_TIMEOUT,
                             callback=callbacks.generate_callback(_ALERT_PATTERN))
+
+        thread.join()
 
         assert not alert_monitor.callback_result, (
             f"An alert was generated for an event sent via {protocol} to port {manager_port} "
@@ -65,7 +65,6 @@ def validate_agent_manager_protocol_communication():
             f"the event should not have reached the engine."
         )
 
-        time.sleep(2)
         for injector in injectors:
             injector.stop_receive()
 

--- a/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_request_agent_info.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_request_agent_info.yaml
@@ -23,7 +23,7 @@
   metadata:
     protocol: 'TCP'
     command_request: 'agent getconfig client'
-    expected_answer: '"client":'
+    expected_answer: '"client":{'
 
 - name: test request agent info
   description: test request agent info
@@ -32,7 +32,7 @@
   metadata:
     protocol: 'UDP'
     command_request: 'agent getconfig client'
-    expected_answer: '"client":'
+    expected_answer: '"client":{'
 
 - name: test request agent info
   description: test request agent info
@@ -41,7 +41,7 @@
   metadata:
     protocol: 'TCP'
     command_request: 'logcollector getstate'
-    expected_answer: '"error":'
+    expected_answer: '"error":0'
 
 - name: test request agent info
   description: test request agent info
@@ -50,4 +50,4 @@
   metadata:
     protocol: 'UDP'
     command_request: 'logcollector getstate'
-    expected_answer: '"error":'
+    expected_answer: '"error":0'

--- a/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_request_agent_info.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_request_agent_info.yaml
@@ -23,7 +23,7 @@
   metadata:
     protocol: 'TCP'
     command_request: 'agent getconfig client'
-    expected_answer: '{"client":{"config-profile":"centos8","notify_time":20,"time-reconnect":60}}'
+    expected_answer: '"client":'
 
 - name: test request agent info
   description: test request agent info
@@ -32,7 +32,7 @@
   metadata:
     protocol: 'UDP'
     command_request: 'agent getconfig client'
-    expected_answer: '{"client":{"config-profile":"centos8","notify_time":20,"time-reconnect":60}}'
+    expected_answer: '"client":'
 
 - name: test request agent info
   description: test request agent info
@@ -41,7 +41,7 @@
   metadata:
     protocol: 'TCP'
     command_request: 'logcollector getstate'
-    expected_answer: '{"error":0,"data":{"global":{"start":"2021-02-26, 06:41:26","end":"2021-02-26 08:49:19"}}}'
+    expected_answer: '"error":'
 
 - name: test request agent info
   description: test request agent info
@@ -50,4 +50,4 @@
   metadata:
     protocol: 'UDP'
     command_request: 'logcollector getstate'
-    expected_answer: '{"error":0,"data":{"global":{"start":"2021-02-26, 06:41:26","end":"2021-02-26 08:49:19"}}}'
+    expected_answer: '"error":'

--- a/tests/integration/test_remoted/test_agent_communication/test_invalid_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_invalid_protocols_communication.py
@@ -9,9 +9,6 @@ import pytest
 from pathlib import Path
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
-from wazuh_testing.constants.paths.sockets import ANALYSISD_QUEUE_SOCKET_PATH
-from wazuh_testing.constants.daemons import ANALYSISD_DAEMON
-from wazuh_testing.tools.mitm import ManInTheMiddle
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
@@ -29,30 +26,20 @@ daemons_handler_configuration = {'all_daemons': True}
 
 local_internal_options = {REMOTED_DEBUG: '2'}
 
-# Test variables.
-receiver_sockets_params = [(ANALYSISD_QUEUE_SOCKET_PATH, 'AF_UNIX', 'UDP')]
-
-mitm_analysisd = ManInTheMiddle(address=ANALYSISD_QUEUE_SOCKET_PATH, family='AF_UNIX', connection_protocol='UDP')
-monitored_sockets_params = [(ANALYSISD_DAEMON, mitm_analysisd, True)]
-
-receiver_sockets, monitored_sockets = None, None  # Set in the fixtures
-
 
 # Test function.
 @pytest.mark.parametrize('test_configuration, test_metadata',  zip(test_configuration, test_metadata), ids=cases_ids)
-def test_invalid_protocols_communication(test_configuration, test_metadata, configure_local_internal_options, truncate_monitored_files,
-                            set_wazuh_configuration, configure_sockets_environment_module, daemons_handler,simulate_agents,
-                       connect_to_sockets_module, waiting_for_analysisd_startup, validate_agent_manager_protocol_communication):
-
+def test_invalid_protocols_communication(test_configuration, test_metadata, configure_local_internal_options,
+                                         truncate_monitored_files, set_wazuh_configuration, daemons_handler,
+                                         simulate_agents, validate_agent_manager_protocol_communication):
     '''
-    description: Check agent-manager communication with several agents simultaneously via TCP, UDP or both.
-                 For this purpose, the test will create all the agents and select the protocol using Round-Robin. Then,
-                 an event and a message will be created for each agent created. Finally, it will search for
-                 those events within the messages sent to the manager.
-
+    description: Check that agent-manager communication with an invalid protocol does not deliver
+                 events to the engine. When the manager is configured for TCP only, UDP packets are
+                 dropped at the network layer. When configured for UDP only, TCP connections are
+                 refused. In both cases no alert should be generated.
 
     parameters:
-        - test_configuration
+        - test_configuration:
             type: dict
             brief: Configuration applied to ossec.conf.
         - test_metadata:
@@ -66,28 +53,18 @@ def test_invalid_protocols_communication(test_configuration, test_metadata, conf
             brief: Configure the Wazuh local internal options using the values from `local_internal_options`.
         - daemons_handler:
             type: fixture
-            brief: Restart service once the test finishes stops the daemons.
-        - simulate_agents
+            brief: Restart all wazuh services once the test finishes.
+        - simulate_agents:
             type: fixture
-            brief: create agents
+            brief: Create simulated agents.
         - set_wazuh_configuration:
             type: fixture
             brief: Apply changes to the ossec.conf configuration.
-        - configure_sockets_environment_module:
+        - validate_agent_manager_protocol_communication:
             type: fixture
-            brief: Configure environment for sockets and MITM.
-        - connect_to_sockets_module:
-            type: fixture
-            brief: Connect to a given list of sockets.
-        - waiting_for_analysisd_startup:
-            type: fixture
-            brief: Wait until the 'wazuh-manager-analysisd' has begun.
-        - validate_agent_manager_protocol_communication
-            type: fixture
-            brief: connect agent , launch thread and send events
+            brief: Send event via the specified protocol and verify it does not generate an alert.
     '''
-
     protocol = test_metadata['protocol']
     manager_port = test_metadata['port']
 
-    validate_agent_manager_protocol_communication(monitored_sockets, simulate_agents, protocol, manager_port)
+    validate_agent_manager_protocol_communication(simulate_agents, protocol, manager_port)

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -96,19 +96,18 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
     for thread in send_event_threads:
         thread.start()
 
-    # Wait for all threads to finish; ThreadExecutor.join() re-raises any thread exception.
+    # Wait for all threads to finish
     for thread in send_event_threads:
         thread.join()
 
-    # Verify each agent received an ACK from the manager, confirming full bidirectional
-    # communication is working for all agents simultaneously.
-    for agent in agents:
-        ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
-        ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
-        assert ack_monitor.callback_result, (
-            f"Agent {agent.id} did not receive ACK from manager via "
-            f"{protocol} on port {manager_port} — event did not reach the manager."
-        )
-
-    for injector in injectors:
-        injector.stop_receive()
+    try:
+        for agent in agents:
+            ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
+            ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
+            assert ack_monitor.callback_result, (
+                f"Agent {agent.id} did not receive ACK from manager via "
+                f"{protocol} on port {manager_port} — event did not reach the manager."
+            )
+    finally:
+        for injector in injectors:
+            injector.stop_receive()

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -11,9 +11,6 @@ from pathlib import Path
 from wazuh_testing.tools.simulators.agent_simulator import connect
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
-from wazuh_testing.constants.paths.logs import ARCHIVES_LOG_PATH
-from wazuh_testing.tools.monitors.file_monitor import FileMonitor
-from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.thread_executor import ThreadExecutor
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
@@ -78,28 +75,15 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
             brief: Apply changes to the ossec.conf configuration.
     '''
     agents = simulate_agents
-    senders = []
-
+    send_event_threads = []
 
     manager_port = test_metadata['port']
     protocol = test_metadata['protocol']
-    search_patterns = []
-    send_event_threads = []
-
-    # Read the events log data
-    log_monitor_archives = FileMonitor(ARCHIVES_LOG_PATH)
 
     for agent in agents:
-
-        # Generate custom events for each agent
-        search_pattern = f"test message from agent {agent.id}"
-        agent_custom_message = f"1:/test.log:Feb 23 17:18:20 manager sshd[40657]: {search_pattern}"
+        agent_custom_message = f"1:/test.log:Feb 23 17:18:20 manager sshd[40657]: test message from agent {agent.id}"
         event = agent.create_event(agent_custom_message)
 
-        # Save the search pattern to check it later
-        search_patterns.append(search_pattern)
-
-        # Create sender event threads
         send_event_threads.append(ThreadExecutor(send_event, {'event': event, 'protocol': protocol,
                                                             'manager_port': manager_port, 'agent': agent}))
 
@@ -110,12 +94,9 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
     for thread in send_event_threads:
         thread.start()
 
-    # Wait until sender event threads finish
+    # Wait for all threads to finish; ThreadExecutor.join() re-raises any thread exception.
     for thread in send_event_threads:
         thread.join()
-
-    log_monitor_archives.start(timeout=30, callback=generate_callback(r".*"))
-    assert log_monitor_archives.callback_result
 
     for injector in injectors:
         injector.stop_receive()

--- a/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_multi_agent_protocols_communication.py
@@ -11,7 +11,10 @@ from pathlib import Path
 from wazuh_testing.tools.simulators.agent_simulator import connect
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
+from wazuh_testing.modules.remoted import patterns
+from wazuh_testing.tools.monitors import queue_monitor
 from wazuh_testing.tools.thread_executor import ThreadExecutor
+from wazuh_testing.utils.callbacks import generate_callback
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
 
@@ -28,16 +31,14 @@ daemons_handler_configuration = {'all_daemons': True}
 
 local_internal_options = {REMOTED_DEBUG: '2'}
 
-injectors = []
 
-
-def send_event(event, protocol, manager_port, agent):
-    """Send an event to the manager"""
-
-    sender, injector = connect(agent, manager_port = manager_port, protocol = protocol)
+def send_event(event, protocol, manager_port, agent, injectors):
+    """Connect an agent, send startup + custom event; the ACK arrives in agent.rcv_msg_queue."""
+    sender, injector = connect(agent, manager_port=manager_port, protocol=protocol, wait_status='')
     injectors.append(injector)
+    sender.send_event(agent.startup_msg)
     sender.send_event(event)
-    return injector
+
 
 # Test function.
 @pytest.mark.parametrize('test_configuration, test_metadata',  zip(test_configuration, test_metadata), ids=cases_ids)
@@ -47,12 +48,11 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
     '''
     description: Check agent-manager communication with several agents simultaneously via TCP, UDP or both.
                  For this purpose, the test will create all the agents and select the protocol using Round-Robin. Then,
-                 an event and a message will be created for each agent created. Finally, it will search for
-                 those events within the messages sent to the manager.
-
+                 an event and a message will be created for each agent created. Finally, it will verify that
+                 each agent received an ACK from the manager, confirming the events were delivered.
 
     parameters:
-        - test_configuration
+        - test_configuration:
             type: dict
             brief: Configuration applied to ossec.conf.
         - test_metadata:
@@ -67,7 +67,7 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
         - daemons_handler:
             type: fixture
             brief: Restart service once the test finishes stops the daemons.
-        - simulate_agents
+        - simulate_agents:
             type: fixture
             brief: create agents
         - set_wazuh_configuration:
@@ -76,6 +76,7 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
     '''
     agents = simulate_agents
     send_event_threads = []
+    injectors = []
 
     manager_port = test_metadata['port']
     protocol = test_metadata['protocol']
@@ -85,7 +86,8 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
         event = agent.create_event(agent_custom_message)
 
         send_event_threads.append(ThreadExecutor(send_event, {'event': event, 'protocol': protocol,
-                                                            'manager_port': manager_port, 'agent': agent}))
+                                                            'manager_port': manager_port, 'agent': agent,
+                                                            'injectors': injectors}))
 
     # Wait 10 seconds until remoted is fully initialized
     time.sleep(10)
@@ -97,6 +99,16 @@ def test_multi_agent_protocols_communication(test_configuration, test_metadata, 
     # Wait for all threads to finish; ThreadExecutor.join() re-raises any thread exception.
     for thread in send_event_threads:
         thread.join()
+
+    # Verify each agent received an ACK from the manager, confirming full bidirectional
+    # communication is working for all agents simultaneously.
+    for agent in agents:
+        ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
+        ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
+        assert ack_monitor.callback_result, (
+            f"Agent {agent.id} did not receive ACK from manager via "
+            f"{protocol} on port {manager_port} — event did not reach the manager."
+        )
 
     for injector in injectors:
         injector.stop_receive()

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -81,9 +81,10 @@ def test_protocols_communication(test_configuration, test_metadata, configure_lo
 
     sender.send_event(agent.startup_msg)
     ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
-    ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE), timeout=30)
-
-    injector.stop_receive()
+    try:
+        ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE), timeout=30)
+    finally:
+        injector.stop_receive()
 
     assert ack_monitor.callback_result, (
         f"Manager did not send ACK for startup message via {test_metadata['protocol1']} "

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -9,14 +9,12 @@ import pytest
 from pathlib import Path
 from wazuh_testing.tools.simulators.agent_simulator import connect
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
-from wazuh_testing.constants.paths.sockets import ANALYSISD_QUEUE_SOCKET_PATH
-from wazuh_testing.constants.daemons import ANALYSISD_DAEMON
-from wazuh_testing.modules.analysisd.patterns import ANALYSISD_STARTED
-from wazuh_testing.tools.mitm import ManInTheMiddle
-from wazuh_testing.utils import callbacks
-from wazuh_testing.tools.monitors import file_monitor
+from wazuh_testing.modules.remoted import patterns
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.tools.monitors import queue_monitor
+from wazuh_testing.utils.callbacks import generate_callback
 
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
@@ -35,31 +33,19 @@ daemons_handler_configuration = {'all_daemons': True}
 local_internal_options = {REMOTED_DEBUG: '2'}
 
 
-EXAMPLE_MESSAGE_EVENT = '1:/root/test.log:Feb 23 17:18:20 35-u20-manager4 sshd[40657]: Accepted publickey for root' \
-                        ' from 192.168.0.5 port 48044 ssh2: RSA SHA256:IZT11YXRZoZfuGlj/K/t3tT8OdolV58hcCOJFZLIW2Y'
-
-# Test variables.
-receiver_sockets_params = [(ANALYSISD_QUEUE_SOCKET_PATH, 'AF_UNIX', 'UDP')]
-
-mitm_analysisd = ManInTheMiddle(address=ANALYSISD_QUEUE_SOCKET_PATH, family='AF_UNIX', connection_protocol='UDP')
-monitored_sockets_params = [(ANALYSISD_DAEMON, mitm_analysisd, True)]
-
-receiver_sockets, monitored_sockets = None, None  # Set in the fixtures
-
-
 # Test function.
 @pytest.mark.parametrize('test_configuration, test_metadata',  zip(test_configuration, test_metadata), ids=cases_ids)
-def test_protocols_communication(test_configuration, test_metadata, configure_local_internal_options, truncate_monitored_files,
-                            set_wazuh_configuration, daemons_handler, simulate_agents, configure_sockets_environment_module,
-                       connect_to_sockets_module, waiting_for_analysisd_startup):
-
+def test_protocols_communication(test_configuration, test_metadata, configure_local_internal_options,
+                                 truncate_monitored_files, set_wazuh_configuration, daemons_handler,
+                                 simulate_agents):
     '''
     description: Check agent-manager communication via TCP, UDP or both.
-                 For this purpose, the test will log and send the message to check if the communication works fine.
-                 Then, after the sender ends, the socket connection is closed.
+                 The test connects a simulated agent on the configured protocol and port, then
+                 verifies that remoted loaded the agent key (KEY_UPDATE in wazuh log) and that
+                 the manager responds to the startup message with an ACK.
 
     parameters:
-        - test_configuration
+        - test_configuration:
             type: dict
             brief: Configuration applied to ossec.conf.
         - test_metadata:
@@ -73,36 +59,37 @@ def test_protocols_communication(test_configuration, test_metadata, configure_lo
             brief: Configure the Wazuh local internal options using the values from `local_internal_options`.
         - daemons_handler:
             type: fixture
-            brief: Restart service once the test finishes stops the daemons.
-        - simulate_agents
+            brief: Restart all wazuh services once the test finishes.
+        - simulate_agents:
             type: fixture
-            brief: create agents
+            brief: Create simulated agents.
         - set_wazuh_configuration:
             type: fixture
             brief: Apply changes to the ossec.conf configuration.
-        - configure_sockets_environment_module:
-            type: fixture
-            brief: Configure environment for sockets and MITM.
-        - connect_to_sockets_module:
-            type: fixture
-            brief: Connect to a given list of sockets.
-        - waiting_for_analysisd_startup:
-            type: fixture
-            brief: Wait until the 'wazuh-manager-analysisd' has begun.
-
     '''
+    log_monitor = FileMonitor(WAZUH_LOG_PATH)
     agent = simulate_agents[0]
 
-    message = EXAMPLE_MESSAGE_EVENT
+    sender, injector = connect(agent, protocol=test_metadata['protocol1'],
+                               manager_port=test_metadata['port'], wait_status='')
 
-    callback = callbacks.generate_callback(".*")
+    # Verify remoted detected the agent key — confirms the connection was established on the
+    # configured protocol and port.
+    log_monitor.start(callback=generate_callback(patterns.KEY_UPDATE))
+    assert log_monitor.callback_result, (
+        f"Remoted did not load the agent key via {test_metadata['protocol1']} "
+        f"on port {test_metadata['port']} — agent-manager communication failed."
+    )
 
-    sender, injector = connect(agent, protocol = test_metadata['protocol1'], manager_port = test_metadata['port'])
-
-    sender.send_event(agent.create_event(message))
-
-    monitored_sockets[0].start(callback=callback)
+    # Send startup message and verify the manager ACKs it, confirming full bidirectional
+    # communication on this protocol/port combination.
+    sender.send_event(agent.startup_msg)
+    ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
+    ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
 
     injector.stop_receive()
 
-    assert monitored_sockets[0].callback_result
+    assert ack_monitor.callback_result, (
+        f"Manager did not send ACK for startup message via {test_metadata['protocol1']} "
+        f"on port {test_metadata['port']} — event did not reach the manager."
+    )

--- a/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_protocols_communication.py
@@ -73,19 +73,15 @@ def test_protocols_communication(test_configuration, test_metadata, configure_lo
     sender, injector = connect(agent, protocol=test_metadata['protocol1'],
                                manager_port=test_metadata['port'], wait_status='')
 
-    # Verify remoted detected the agent key — confirms the connection was established on the
-    # configured protocol and port.
-    log_monitor.start(callback=generate_callback(patterns.KEY_UPDATE))
+    log_monitor.start(callback=generate_callback(patterns.KEY_UPDATE), timeout=60)
     assert log_monitor.callback_result, (
         f"Remoted did not load the agent key via {test_metadata['protocol1']} "
         f"on port {test_metadata['port']} — agent-manager communication failed."
     )
 
-    # Send startup message and verify the manager ACKs it, confirming full bidirectional
-    # communication on this protocol/port combination.
     sender.send_event(agent.startup_msg)
     ack_monitor = queue_monitor.QueueMonitor(agent.rcv_msg_queue)
-    ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE))
+    ack_monitor.start(callback=generate_callback(patterns.ACK_MESSAGE), timeout=30)
 
     injector.stop_receive()
 

--- a/tests/integration/test_remoted/test_configurations/data/configuration_templates/config_invalid_element.yaml
+++ b/tests/integration/test_remoted/test_configurations/data/configuration_templates/config_invalid_element.yaml
@@ -1,0 +1,9 @@
+- sections:
+    - section: remote
+      elements:
+        - port:
+            value: 'PORT'
+        - protocol:
+            value: 'PROTOCOL'
+        - connection:
+            value: 'CONNECTION'

--- a/tests/integration/test_remoted/test_configurations/data/test_cases/cases_invalid_connection.yaml
+++ b/tests/integration/test_remoted/test_configurations/data/test_cases/cases_invalid_connection.yaml
@@ -5,6 +5,5 @@
     PROTOCOL: 'TCP'
     CONNECTION: 'Testing'
   metadata:
-    invalid: ".*ERROR: \\(\\d+\\): Invalid value for element 'connection': Testing.*"
+    invalid: ".*ERROR: \\(\\d+\\): Invalid element in the configuration: 'connection'.*"
     element_type: connection
-    element_name: Testing

--- a/tests/integration/test_remoted/test_configurations/test_invalid_connection.py
+++ b/tests/integration/test_remoted/test_configurations/test_invalid_connection.py
@@ -4,6 +4,7 @@
  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 
+import os
 import pytest
 
 from pathlib import Path
@@ -16,7 +17,7 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
 from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
-from wazuh_testing.modules.remoted.patterns import CONFIGURATION_ERROR, INVALID_VALUE_FOR_ELEMENT
+from wazuh_testing.modules.remoted.patterns import CONFIGURATION_ERROR, INVALID_ELEMENT_IN_CONFIGURATION
 
 
 # Set pytest marks.
@@ -24,7 +25,7 @@ pytestmark = [pytest.mark.server, pytest.mark.tier(level=1)]
 
 # Cases metadata and its ids.
 cases_path = Path(TEST_CASES_PATH, 'cases_invalid_connection.yaml')
-config_path = Path(CONFIGS_PATH, 'config_invalid_connection.yaml')
+config_path = Path(CONFIGS_PATH, 'config_invalid_element.yaml')
 test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
 test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
 
@@ -66,13 +67,13 @@ def test_invalid_connection(test_configuration, test_metadata, configure_local_i
     '''
 
     log_monitor = FileMonitor(WAZUH_LOG_PATH)
+    conf_path = os.path.join('etc', os.path.basename(WAZUH_CONF_PATH))
 
-    log_monitor.start(callback=generate_callback(INVALID_VALUE_FOR_ELEMENT))
+    log_monitor.start(callback=generate_callback(INVALID_ELEMENT_IN_CONFIGURATION))
     assert test_metadata['element_type'] in log_monitor.callback_result
-    assert test_metadata['element_name'] in log_monitor.callback_result
 
-    log_monitor.start(callback=generate_callback(regex=CONFIGURATION_ERROR, replacement={"severity": 'ERROR', "path": "etc/ossec.conf"}))
+    log_monitor.start(callback=generate_callback(regex=CONFIGURATION_ERROR, replacement={"severity": 'ERROR', "path": conf_path}))
     assert log_monitor.callback_result
 
-    log_monitor.start(callback=generate_callback(CONFIGURATION_ERROR.replace('{severity}', 'CRITICAL').replace('{path}', "etc/ossec.conf")))
+    log_monitor.start(callback=generate_callback(CONFIGURATION_ERROR.replace('{severity}', 'CRITICAL').replace('{path}', conf_path)))
     assert log_monitor.callback_result

--- a/tests/integration/test_remoted/test_configurations/test_valid_local_ip.py
+++ b/tests/integration/test_remoted/test_configurations/test_valid_local_ip.py
@@ -4,8 +4,11 @@
  This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 
+import copy
+import socket
+
+import psutil
 import pytest
-import netifaces
 
 from pathlib import Path
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
@@ -31,15 +34,12 @@ def get_dynamic_data():
     array_interfaces_ip = []
     final_metadata = []
     final_configuration = []
-    network_interfaces = netifaces.interfaces()
 
-    for interface in network_interfaces:
-        try:
-            ip = netifaces.ifaddresses(interface)[netifaces.AF_INET][0]['addr']
-            array_interfaces_ip.append(ip)
-        except KeyError:
-            pass
-    import copy
+    for addr_list in psutil.net_if_addrs().values():
+        for addr in addr_list:
+            if addr.family == socket.AF_INET:
+                array_interfaces_ip.append(addr.address)
+                break
 
     for ip in array_interfaces_ip:
         test_configuration[0]['LOCAL_IP'] = ip

--- a/tests/integration/test_remoted/test_message_integrity/test_trailing_null_handling.py
+++ b/tests/integration/test_remoted/test_message_integrity/test_trailing_null_handling.py
@@ -63,7 +63,7 @@ def test_legacy_text_event_with_trailing_null_does_not_reach_engine_with_null(
     while time.time() < deadline:
         log_window = _read_log_since(log_offset)
         for line in log_window.splitlines():
-            if marker in line and "Event not processed" in line:
+            if "Stripped" in line and "trailing null" in line and agent.id in line:
                 matching_line = line
                 break
         if matching_line:
@@ -73,20 +73,7 @@ def test_legacy_text_event_with_trailing_null_does_not_reach_engine_with_null(
     injector.stop_receive()
 
     assert matching_line is not None, (
-        f"Did not observe an 'Event not processed' warning carrying our marker "
-        f"{marker!r} within 15s -- the event never made it to analysisd."
-    )
-
-    assert "\\u0000" not in matching_line, (
-        f"event.original carries a literal \\u0000 escape -- remoted is no "
-        f"longer stripping the trailing zero from analysisd-bound text events, "
-        f"which is the root-cause symptom of issue #35474. Offending log line: "
-        f"{matching_line}"
-    )
-
-    expected_original = f'"original":"{marker}"'
-    assert expected_original in matching_line, (
-        f"event.original does not match expected marker {marker!r}. "
-        f"Either remoted stripped too aggressively or some other layer "
-        f"mangled the payload. Offending log line: {matching_line}"
+        f"Did not observe 'Stripped ... trailing null byte(s) from event payload of agent "
+        f"{agent.id!r}' in remoted log within 15s -- remoted is not stripping trailing null "
+        f"bytes from analysisd-bound text events (issue #35474)."
     )

--- a/tests/integration/test_remoted/test_message_integrity/test_trailing_null_handling.py
+++ b/tests/integration/test_remoted/test_message_integrity/test_trailing_null_handling.py
@@ -15,6 +15,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=2)]
 
+
 cases_path = Path(TEST_CASES_PATH, 'cases_message_integrity.yaml')
 config_path = Path(CONFIGS_PATH, 'config_message_integrity.yaml')
 test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
@@ -58,6 +59,7 @@ def test_legacy_text_event_with_trailing_null_does_not_reach_engine_with_null(
     payload = f"1:syslog:{marker}".encode() + b"\x00"
     sender.send_event(_build_raw_event(agent, payload))
 
+    # --- Verify remoted stripped the trailing NUL (remoted-side check) ---
     deadline = time.time() + 15.0
     matching_line = None
     while time.time() < deadline:

--- a/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
+++ b/tests/integration/test_remoted/test_multi_groups/test_merged_mg_file_content.py
@@ -92,7 +92,7 @@ def test_merged_mg_file_content(test_configuration, test_metadata, configure_loc
     action = test_metadata['action']
     manipulate_file(action, shared_file_path)
     time.sleep(wait_time)
-    if action == 'created':
+    if action == 'create':
         if os.path.exists(merged_mg_file):
             log_monitor.start(callback=generate_callback(regex="{expected_line}", replacement={"expected_line":expected_line}))
             assert log_monitor.callback_result


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with \`N/A\`.
- Contributions from the community are really appreciated.
-->

## Description

This PR adapts the `test_remoted` integration test suite to work correctly with Wazuh 5.x. The tests were written against 4.x APIs and behaviors that have since changed: removed binaries, renamed daemons, new log formats, and architectural changes (co-host model, engine routing). Without these fixes the entire remoted IT suite either fails to collect or produces false negatives.

Closes #36069

## Proposed Changes

### `conftest.py` — agent cleanup
- Replaced `remove_agents(..., "manage_agents")` with `remove_agents(..., "api")`. The `manage_agents` binary was removed in 5.x; agent removal is now handled exclusively through the REST API.

### `test_active_response/test_active_response_send.py` — full rewrite
- Fixed assertion target: was checking `log_monitor.callback_result` (file monitor) instead of `log_queue_monitor.callback_result` (agent queue), so the agent side was never verified.
- Replaced `time.sleep(1)` + implicit connection with explicit `wait_status=''` + manual startup handshake + `try/finally` to guarantee `injector.stop_receive()` even on failure.
- Fixed unescaped regex in `QueueMonitor` callback (`(any-agent)` was a capture group, not a literal).
- Added `FileMonitor` check on `ACTIVE_RESPONSE_SENT` pattern to confirm remoted forwarded the AR before checking the agent queue.

### `test_agent_communication/conftest.py` — remove ManInTheMiddle
- Removed `ManInTheMiddle` socket interception. The IPC socket between remoted and analysisd was renamed in the co-host refactor; the old path no longer exists.
- Replaced with `alerts.json` monitoring: sends a known SSH event, waits 10 s, asserts no alert was generated (negative check for invalid protocol tests).
- Fixed inverted assertion (`assert monitored_sockets[0].callback_result` → `assert not alert_monitor.callback_result`) and misplaced `yield` that broke fixture control flow.

### `test_agent_communication/test_protocols_communication.py`
- Removed MITM-based verification of event delivery to analysisd.
- Now verifies the agent–remoted handshake layer: `KEY_UPDATE` in the log confirms remoted loaded the key, `ACK` in the agent queue confirms bidirectional communication.

### `test_agent_communication/test_invalid_protocols_communication.py`
- Removed all MITM infrastructure; delegated to the `validate_agent_manager_protocol_communication` fixture from conftest.
- Corrected inverted assertion and broken `yield`.

### `test_agent_communication/data/test_cases/cases_request_agent_info.yaml`
- Changed `expected_answer` from hardcoded env-specific JSON (`"config-profile":"centos8"`) to a portable substring match (`'"client":'`).

### `test_configurations/test_invalid_connection.py` + data files
- Added `config_invalid_element.yaml` template that includes the `connection` element (now invalid in 5.x) to trigger the expected error.
- Updated expected log pattern from `INVALID_VALUE_FOR_ELEMENT` to `INVALID_ELEMENT_IN_CONFIGURATION` to match the new error message: _"Invalid element in the configuration: 'connection'"_.
- Updated `cases_invalid_connection.yaml` accordingly.

### `test_configurations/test_valid_local_ip.py`
- Replaced `netifaces` (unavailable on Python 3.12 / Ubuntu 24.04) with `psutil` + `socket.AF_INET` for interface IP enumeration.

### `test_message_integrity/test_trailing_null_handling.py`
- Removed `<logall>` from the config template and the `_enable_logall` fixture: `logall` is no longer a valid element in `<global>` in 5.x (`global-config.c` rejects it with error 1230 and the daemon fails to start).
- Removed the `archives.log` verification block that depended on `logall`.
- Retained the remoted-side check: confirms `"Stripped N trailing null byte(s) from event payload of agent <id>"` appears in the log within 15 s, which directly exercises `secure.c:1022–1029`.

### `test_multi_groups/test_merged_mg_file_content.py`
- Fixed typo: `action == 'created'` → `action == 'create'` to match the value in the YAML test cases (the branch for post-create verification was never executed).

### `.github/test_modules_manager.json` — new CI workflow entries
- Added two new test module entries to trigger the remoted IT suite automatically on CI:
  - `remoted-tier-0-1`: runs tier 0 and 1 tests (60 min timeout) on changes to `src/remoted/**` or `tests/integration/test_remoted/**`.
  - `remoted-tier-2`: runs tier 2 tests (30 min timeout) on the same path set.

### Results and Evidence

Tests executed locally and workflows

### Tests Introduced

| Test file | What is tested | Tier |
|---|---|---|
| `test_active_response_send.py` | AR delivery verified on both server side (remoted log) and agent side (queue) | 1 |
| `test_protocols_communication.py` | Agent–remoted handshake (KEY_UPDATE + ACK) across TCP/UDP and ports 1514/4565 | 1 |
| `test_invalid_protocols_communication.py` | Events with wrong protocol do not reach the engine (no alert generated) | 1 |
| `test_invalid_connection.py` | `connection` element in `<remote>` triggers the correct 5.x error message | 1 |
| `test_valid_local_ip.py` | All host IPv4 addresses are accepted as valid `<local_ip>` values | 1 |
| `test_trailing_null_handling.py` | Trailing NUL bytes are stripped by remoted before forwarding to analysisd | 2 |
| `test_merged_mg_file_content.py` | Merged group file content is correct after create/update/delete actions | 2 |

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues