### PR TITLE
Fix `detect-changes` glob to honour `**` recursively and extract logic into a reusable action

### DIFF
--- a/.github/actions/5_testintegration_detect-changes/action.yml
+++ b/.github/actions/5_testintegration_detect-changes/action.yml
@@ -1,0 +1,58 @@
+name: Detect changed integration test modules
+description: |
+  Inspect the diff between two commits and build a GitHub Actions matrix of
+  integration test modules whose declared `paths` match any changed file.
+  Glob patterns honour `**` recursive matching independently of the host
+  Python version, fixing a long-standing portability gap with
+  `pathlib.PurePath.match` on Python < 3.13.
+
+inputs:
+  modules-config:
+    description: Path to the JSON file describing the test modules.
+    required: true
+  base-sha:
+    description: |
+      Base commit SHA to diff against. Defaults to the PR base SHA. When
+      empty (e.g. outside a pull_request context) the action emits
+      `none-matrix` without running git.
+    required: false
+    default: ${{ github.event.pull_request.base.sha }}
+  head-sha:
+    description: Head commit SHA to diff. Defaults to the PR head SHA.
+    required: false
+    default: ${{ github.event.pull_request.head.sha }}
+  none-matrix:
+    description: |
+      JSON value emitted as the matrix when no module matches. The keys of
+      its entries must match those produced for matched modules so that the
+      consuming workflow's `with:` block can reference them uniformly.
+    required: true
+  field-defaults:
+    description: |
+      Optional JSON object with default values applied to every matched
+      entry for fields the module did not declare. Use this to keep the
+      shape of matrix entries uniform across modules.
+    required: false
+    default: '{}'
+
+outputs:
+  matrix:
+    description: GitHub Actions matrix include with the matched modules.
+    value: ${{ steps.detect.outputs.matrix }}
+  any_matched:
+    description: '"true" if at least one module matched, "false" otherwise.'
+    value: ${{ steps.detect.outputs.any_matched }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build matrix from changed files
+      id: detect
+      shell: bash
+      env:
+        MODULES_CONFIG: ${{ inputs.modules-config }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        NONE_MATRIX: ${{ inputs.none-matrix }}
+        FIELD_DEFAULTS: ${{ inputs.field-defaults }}
+      run: python3 "${GITHUB_ACTION_PATH}/detect_modules.py"

--- a/.github/actions/5_testintegration_detect-changes/detect_modules.py
+++ b/.github/actions/5_testintegration_detect-changes/detect_modules.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Build a GitHub Actions matrix of integration test modules whose declared
+paths match the files changed in a pull request.
+
+Glob patterns honour gitignore-style semantics:
+  - ``**``  matches any number of path segments (including zero).
+  - ``*``   matches any characters except ``/``.
+  - ``?``   matches a single character except ``/``.
+  - ``[abc]`` / ``[!abc]`` character classes.
+
+This is portable across Python versions, unlike ``pathlib.PurePath.match``,
+which only learnt to honour ``**`` recursively in Python 3.13.
+
+Inputs are taken from environment variables:
+  - MODULES_CONFIG: path to the JSON file describing the modules.
+  - BASE_SHA / HEAD_SHA: commits to diff. If either is empty, the script
+    emits ``none_matrix`` and exits without consulting git.
+  - NONE_MATRIX: JSON value to emit when no module matches. The shape must
+    be compatible with the consumer workflow's matrix (same keys as the
+    matched entries).
+  - FIELD_DEFAULTS: optional JSON object with default values applied to
+    each matched entry for fields the module did not declare. Used to
+    keep every matrix entry uniform.
+  - GITHUB_OUTPUT: file to append outputs to.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    i, n = 0, len(pattern)
+    out: list[str] = ["^"]
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                j = i + 2
+                if j < n and pattern[j] == "/":
+                    # `prefix/**/suffix` also matches `prefix/suffix`.
+                    out.append("(?:.*/)?")
+                    i = j + 1
+                else:
+                    out.append(".*")
+                    i = j
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c == "[":
+            j = i + 1
+            if j < n and pattern[j] == "!":
+                j += 1
+            if j < n and pattern[j] == "]":
+                j += 1
+            while j < n and pattern[j] != "]":
+                j += 1
+            if j >= n:
+                out.append(re.escape(c))
+                i += 1
+            else:
+                cls = pattern[i + 1 : j]
+                if cls.startswith("!"):
+                    cls = "^" + cls[1:]
+                out.append(f"[{cls}]")
+                i = j + 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def _matches(pattern: str, files: Iterable[str]) -> bool:
+    rx = _glob_to_regex(pattern)
+    return any(rx.match(fp) for fp in files)
+
+
+def _emit(output_path: str, matrix: dict, any_matched: bool) -> None:
+    with open(output_path, "a", encoding="utf-8") as fp:
+        fp.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
+        fp.write(f"any_matched={'true' if any_matched else 'false'}\n")
+
+
+def main() -> int:
+    base_sha = os.environ.get("BASE_SHA", "").strip()
+    head_sha = os.environ.get("HEAD_SHA", "").strip()
+    modules_config = os.environ["MODULES_CONFIG"]
+    none_matrix = json.loads(os.environ["NONE_MATRIX"])
+    field_defaults = json.loads(os.environ.get("FIELD_DEFAULTS", "{}"))
+    github_output = os.environ["GITHUB_OUTPUT"]
+
+    if not base_sha or not head_sha:
+        print("BASE_SHA or HEAD_SHA not provided; emitting none-matrix.", file=sys.stderr)
+        _emit(github_output, none_matrix, False)
+        return 0
+
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", base_sha, head_sha],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    changed = [line for line in diff.stdout.splitlines() if line]
+    print(f"Changed files ({len(changed)}):", file=sys.stderr)
+    for fp in changed:
+        print(f"  {fp}", file=sys.stderr)
+
+    with open(modules_config, encoding="utf-8") as fp:
+        config = json.load(fp)
+
+    matched: list[dict] = []
+    for module in config["modules"]:
+        name = module["name"]
+        matched_pattern: str | None = None
+        for pattern in module.get("paths", []):
+            if _matches(pattern, changed):
+                matched_pattern = pattern
+                break
+        if matched_pattern is None:
+            continue
+        print(f"Module '{name}' matched via pattern '{matched_pattern}'", file=sys.stderr)
+
+        base_entry = {k: v for k, v in module.items() if k not in ("paths", "tiers")}
+        for k, v in field_defaults.items():
+            base_entry.setdefault(k, v)
+
+        for tier in module.get("tiers", ["0 1"]):
+            entry = dict(base_entry)
+            entry["shard_name"] = f"tier-{tier.replace(' ', '-')}"
+            entry["pytest_tier_args"] = " ".join(f"--tier {t}" for t in tier.split())
+            matched.append(entry)
+
+    if matched:
+        _emit(github_output, {"include": matched}, True)
+    else:
+        print("No module matched the changed files; emitting none-matrix.", file=sys.stderr)
+        _emit(github_output, none_matrix, False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/test-modules-windows.json
+++ b/.github/test-modules-windows.json
@@ -56,7 +56,7 @@
       "name": "fim",
       "pytest_target": "test_fim\\",
       "tiers": ["0", "1"],
-      "exclude": ["test_fim\\test_files\\test_basic_usage\\test_rename.py"],
+      "pytest_ignore_args": "--ignore=test_fim\\test_files\\test_basic_usage\\test_rename.py",
       "start_service": true,
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -632,80 +632,21 @@ jobs:
     permissions:
       contents: read
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      any_matched: ${{ steps.set-matrix.outputs.any_matched }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+      any_matched: ${{ steps.detect.outputs.any_matched }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Build matrix from changed files
-        id: set-matrix
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        shell: python
-        run: |
-          import json, os, subprocess
-          from pathlib import PurePosixPath
-
-          base_sha = os.environ.get("BASE_SHA", "").strip()
-          head_sha = os.environ.get("HEAD_SHA", "").strip()
-
-          none_matrix = {
-              "include": [{
-                  "name": "none",
-                  "shard_name": "none",
-                  "pytest_target": "",
-                  "pytest_extra_args": "",
-                  "pytest_tier_args": "",
-                  "pre_install": "",
-                  "setup_aws_credentials": False,
-                  "timeout_minutes": 1
-              }]
-          }
-
-          if not base_sha or not head_sha:
-              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                  f.write(f"matrix={json.dumps(none_matrix)}\n")
-                  f.write("any_matched=false\n")
-              raise SystemExit(0)
-
-          result = subprocess.run(
-              ["git", "diff", "--name-only", base_sha, head_sha],
-              capture_output=True, text=True
-          )
-          changed = set(result.stdout.splitlines())
-
-          with open(".github/test_modules_linux.json") as f:
-              config = json.load(f)
-
-          matched = []
-          for mod in config["modules"]:
-              for pattern in mod["paths"]:
-                  if any(PurePosixPath(fp).match(pattern) for fp in changed):
-                      tiers = mod.get("tiers", ["0 1"])
-                      for tier in tiers:
-                          tier_args = " ".join(f"--tier {t}" for t in tier.split())
-                          shard_name = f"tier-{tier.replace(' ', '-')}"
-                          matched.append({
-                              "name": mod["name"],
-                              "shard_name": shard_name,
-                              "pytest_target": mod["pytest_target"],
-                              "pytest_extra_args": mod.get("pytest_extra_args", ""),
-                              "pytest_tier_args": tier_args,
-                              "pre_install": mod.get("pre_install", ""),
-                              "setup_aws_credentials": mod.get("setup_aws_credentials", False),
-                              "timeout_minutes": mod.get("timeout_minutes", 120)
-                          })
-                      break
-
-          matrix = {"include": matched} if matched else none_matrix
-          any_matched = "true" if matched else "false"
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"matrix={json.dumps(matrix)}\n")
-              f.write(f"any_matched={any_matched}\n")
+      - name: Detect changed modules
+        id: detect
+        uses: ./.github/actions/5_testintegration_detect-changes
+        with:
+          modules-config: .github/test_modules_linux.json
+          none-matrix: '{"include":[{"name":"none","shard_name":"none","pytest_target":"","pytest_extra_args":"","pytest_tier_args":"","pre_install":"","setup_aws_credentials":false,"timeout_minutes":1}]}'
+          field-defaults: '{"pytest_extra_args":"","pre_install":"","setup_aws_credentials":false,"timeout_minutes":120}'
 
   run-integration-tests:
     needs: [upload-deb-to-s3, detect-changes]

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -527,78 +527,21 @@ jobs:
     permissions:
       contents: read
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      any_matched: ${{ steps.set-matrix.outputs.any_matched }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+      any_matched: ${{ steps.detect.outputs.any_matched }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Build matrix from changed files
-        id: set-matrix
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        shell: python
-        run: |
-          import json, os, subprocess
-          from pathlib import PurePosixPath
-
-          base_sha = os.environ.get("BASE_SHA", "").strip()
-          head_sha = os.environ.get("HEAD_SHA", "").strip()
-
-          none_matrix = {
-              "include": [{
-                  "name": "none",
-                  "shard_name": "none",
-                  "pytest_target": "",
-                  "pytest_extra_args": "",
-                  "pytest_tier_args": "",
-                  "pre_install": "",
-                  "timeout_minutes": 1
-              }]
-          }
-
-          if not base_sha or not head_sha:
-              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                  f.write(f"matrix={json.dumps(none_matrix)}\n")
-                  f.write("any_matched=false\n")
-              raise SystemExit(0)
-
-          result = subprocess.run(
-              ["git", "diff", "--name-only", base_sha, head_sha],
-              capture_output=True, text=True
-          )
-          changed = set(result.stdout.splitlines())
-
-          with open(".github/test_modules_macos.json") as f:
-              config = json.load(f)
-
-          matched = []
-          for mod in config["modules"]:
-              for pattern in mod["paths"]:
-                  if any(PurePosixPath(fp).match(pattern) for fp in changed):
-                      tiers = mod.get("tiers", ["0 1"])
-                      for tier in tiers:
-                          tier_args = " ".join(f"--tier {t}" for t in tier.split())
-                          shard_name = f"tier-{tier.replace(' ', '-')}"
-                          matched.append({
-                              "name": mod["name"],
-                              "shard_name": shard_name,
-                              "pytest_target": mod["pytest_target"],
-                              "pytest_extra_args": mod.get("pytest_extra_args", ""),
-                              "pytest_tier_args": tier_args,
-                              "pre_install": mod.get("pre_install", ""),
-                              "timeout_minutes": mod.get("timeout_minutes", 120)
-                          })
-                      break
-
-          matrix = {"include": matched} if matched else none_matrix
-          any_matched = "true" if matched else "false"
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"matrix={json.dumps(matrix)}\n")
-              f.write(f"any_matched={any_matched}\n")
+      - name: Detect changed modules
+        id: detect
+        uses: ./.github/actions/5_testintegration_detect-changes
+        with:
+          modules-config: .github/test_modules_macos.json
+          none-matrix: '{"include":[{"name":"none","shard_name":"none","pytest_target":"","pytest_extra_args":"","pytest_tier_args":"","pre_install":"","timeout_minutes":1}]}'
+          field-defaults: '{"pytest_extra_args":"","pre_install":"","timeout_minutes":120}'
 
   run-integration-tests:
     needs: [upload-macos-arm64-to-s3, detect-changes]

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -45,8 +45,8 @@ jobs:
     runs-on: ubuntu-24.04
     name: Detect changed Windows test modules
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      any_matched: ${{ steps.set-matrix.outputs.any_matched }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+      any_matched: ${{ steps.detect.outputs.any_matched }}
 
     steps:
       - name: Checkout repository
@@ -54,86 +54,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build matrix from JSON (windows)
-        id: set-matrix
-        shell: bash
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          python3.12 - <<'PY'
-          import json
-          import os
-          import pathlib
-          import subprocess
-
-          event_name = os.environ['EVENT_NAME']
-          output_path = os.environ['GITHUB_OUTPUT']
-
-          if event_name != 'pull_request':
-              matched = []
-          else:
-              base_ref = os.environ['BASE_REF']
-              diff_range = f'origin/{base_ref}...HEAD'
-              changed_files = subprocess.check_output(
-                  ['git', 'diff', '--name-only', diff_range],
-                  text=True,
-              ).splitlines()
-
-              with open('.github/test-modules-windows.json', encoding='utf-8') as stream:
-                  modules = json.load(stream).get('modules', [])
-
-              matched = []
-              for module in modules:
-                  module_name = module['name']
-                  matched_pattern = None
-
-                  for pattern in module.get('paths', []):
-                      if any(pathlib.PurePosixPath(changed).match(pattern) for changed in changed_files):
-                          matched_pattern = pattern
-                          break
-
-                  if matched_pattern is not None:
-                      print(f"Matched {module_name} with pattern {matched_pattern}")
-                      tiers = module.get('tiers', ['0 1'])
-                      for tier in tiers:
-                          tier_args = ' '.join(f'--tier {t}' for t in tier.split())
-                          shard_name = f"tier-{tier.replace(' ', '-')}"
-                          excludes = module.get('exclude', [])
-                          ignore_args = ' '.join(f'--ignore={e}' for e in excludes)
-                          matched.append({
-                              'name': module_name,
-                              'shard_name': shard_name,
-                              'pytest_target': module['pytest_target'],
-                              'pytest_extra_args': module.get('pytest_extra_args', ''),
-                              'pytest_tier_args': tier_args,
-                              'pytest_ignore_args': ignore_args,
-                              'start_service': module.get('start_service', False),
-                              'skip_tests': False,
-                          })
-
-              print(f'Final matrix: {json.dumps(matched)}')
-
-          if matched:
-              matrix = {'include': matched}
-          else:
-              matrix = {
-                  'include': [{
-                      'name': 'none',
-                      'shard_name': 'none',
-                      'pytest_target': 'test_none\\',
-                      'pytest_extra_args': '',
-                      'pytest_tier_args': '',
-                      'pytest_ignore_args': '',
-                      'start_service': False,
-                      'skip_tests': True,
-                  }]
-              }
-          any_matched = 'true' if matched else 'false'
-          with open(output_path, 'a', encoding='utf-8') as stream:
-              stream.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
-              stream.write(f"any_matched={any_matched}\n")
-          PY
+      - name: Detect changed modules
+        id: detect
+        uses: ./.github/actions/5_testintegration_detect-changes
+        with:
+          modules-config: .github/test-modules-windows.json
+          none-matrix: '{"include":[{"name":"none","shard_name":"none","pytest_target":"test_none\\","pytest_extra_args":"","pytest_tier_args":"","pytest_ignore_args":"","start_service":false,"skip_tests":true}]}'
+          field-defaults: '{"pytest_extra_args":"","pytest_ignore_args":"","start_service":false,"skip_tests":false}'
 
   build-windows-i686:
     needs: detect-changes


### PR DESCRIPTION
## Description

The `detect-changes` job that gates integration test execution in the three agent build workflows fails to trigger any module whose changed files live in a subdirectory of a `dir/**` pattern. As a result, pull requests that legitimately modify a component can land without their integration tests ever running.

This was observed in [PR #36302](https://github.com/wazuh/wazuh/pull/36302), which modified files under `src/client-agent/include/`, `src/client-agent/src/` and `src/syscheckd/src/` but did not run the `agentd` / `fim` integration tests.

Root cause: `pathlib.PurePosixPath.match()` only learnt to honour `**` as a recursive wildcard in Python 3.13. On every earlier interpreter (Ubuntu 24.04 default of 3.12, and the explicit `python3.12` invocation in the Windows workflow), `**` is treated as a single-segment wildcard and the match is right-anchored on a per-component basis.

```python
PurePosixPath('src/client-agent/agentd.c').match('src/client-agent/**')          # True
PurePosixPath('src/client-agent/include/agentd.h').match('src/client-agent/**')  # False  <- bug
PurePosixPath('src/syscheckd/src/main.c').match('src/syscheckd/**')              # False  <- bug
```

The bug was masked for most PRs because each module declares anchor paths that do not depend on `**` (e.g. `src/Makefile`, `tests/integration/conftest.py`, the workflow file itself). PR #36302 happened to touch only subdirectory files, exposing the gap.

Closes #36616

## Proposed Changes

- Replace the version-dependent `pathlib.PurePosixPath.match()` call with a portable glob-to-regex matcher that honours gitignore-style semantics (`**` recursive, `*` single-segment, `?`, character classes), independent of the host Python version.
- Extract the matching logic, previously duplicated across three workflows, into a single reusable composite action.
- Simplify `test-modules-windows.json` by replacing the `exclude` array on `fim` with a `pytest_ignore_args` precomputed string, eliminating the only piece of transformation the matcher used to perform. The string passed to pytest is identical to before.
- Unify the Windows diff strategy with Linux/macOS (`git diff <base.sha> <head.sha>` two-dot, instead of `origin/<base_ref>...HEAD` three-dot).

Net diff: ~189 lines of duplicated Python removed, ~28 lines added in the workflows, plus the new composite action.

### Results and Evidence

**Matcher unit tests** — 15/15 representative cases pass, including:

```
match('src/client-agent/**', 'src/client-agent/agentd.c')             → True
match('src/client-agent/**', 'src/client-agent/include/agentd.h')     → True   (regression case)
match('src/client-agent/**', 'src/client-agent/src/sub/deep.c')       → True
match('src/client-agent/**', 'src/client-agent-extra/foo.c')          → False  (sibling prefix)
match('src/syscheckd/**',    'src/syscheckd')                         → False  (not under)
match('wodles/aws/*.py',     'wodles/aws/sub/aws_s3.py')              → False  (single-star non-recursive)
```

**End-to-end against PR #36302 file list** — simulated the action with the 11 changed files of that PR:

| Platform | Modules triggered (after fix) | Before |
|---|---|---|
| Linux | `agentd` (tier-0-1), `enrollment` (tier-0-1), `fim` (tier-0, tier-1) | none |
| macOS | `fim` (tier-0, tier-1) | none |
| Windows | `agentd` (tier-0-1), `enrollment` (tier-0-1), `fim` (tier-0, tier-1) | none |

**Lint** — YAML on the four touched workflow / action files and JSON on the three `test_modules_*.json` files validated.

### Artifacts Affected

CI only — no packaged artifacts or runtime binaries change.

- `.github/workflows/5_builderpackage_agent-linux.yml`
- `.github/workflows/5_builderpackage_agent-macos.yml`
- `.github/workflows/5_builderpackage_agent-windows.yml`
- `.github/actions/5_testintegration_detect-changes/` (new composite action with `action.yml` and `detect_modules.py`)
- `.github/test-modules-windows.json` (`exclude` → `pytest_ignore_args` on the `fim` module)

### Configuration Changes

None 

### Documentation Updates

None.

### Tests Introduced

No automated tests added — the new matcher is exercised locally with a representative set of cases and against the PR #36302 file list, as documented in the *Results and Evidence* section. The first PRs landed after this change will validate the new logic in the live CI.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues