### PR TITLE
Add Cisco IOS EMWEB-3-LOGIN_FAILED decoder to extract srcuser

### DIFF
--- a/ruleset/decoders/0065-cisco-ios_decoders.xml
+++ b/ruleset/decoders/0065-cisco-ios_decoders.xml
@@ -261,6 +261,18 @@ Details: https://www.cisco.com/c/en/us/td/docs/routers/access/wireless/software/
   <order>cisco.facility, cisco.severity, cisco.mnemonic, srcuser, srcip</order>
 </decoder>
 
+<!-- Cisco IOS EMWEB login failure
+  - Extracts srcuser from failed EWS authentication attempts.
+  - Sample:
+  - %EMWEB-3-LOGIN_FAILED: ews_auth.c:1234 Login failed for the user:jsmith. Service-Type is not present.
+  -->
+<decoder name="cisco-ios-emweb-login">
+  <parent>cisco-ios</parent>
+  <prematch>%EMWEB-3-LOGIN_FAILED</prematch>
+  <regex type="pcre2">%(\w+)-(\d)-(\w+): \S+ Login failed for the user:(\S+)\.</regex>
+  <order>cisco.facility, cisco.severity, cisco.mnemonic, srcuser</order>
+</decoder>
+
 <!-- Cisco IOS
   - Extracts the ID of cisco ios messages IF NOT IDS/ACL log.
   -->


### PR DESCRIPTION
## Summary

Closes #14739

Adds a child decoder `cisco-ios-emweb-login` to `ruleset/decoders/0065-cisco-ios_decoders.xml` that extracts `srcuser` from `EMWEB-3-LOGIN_FAILED` events generated by Cisco IOS EWS (Embedded Web Server) authentication failures.

**Sample log:**
```
%EMWEB-3-LOGIN_FAILED: ews_auth.c:1234 Login failed for the user:jsmith. Service-Type is not present or it doesn't allow READ/WRITE permission..
```

**Extracted fields:**
| Field | Value |
|---|---|
| `cisco.facility` | `EMWEB` |
| `cisco.severity` | `3` |
| `cisco.mnemonic` | `LOGIN_FAILED` |
| `srcuser` | `jsmith` |

The decoder is placed immediately before `cisco-ios-default` (the catch-all) to ensure correct load-order precedence. Uses `type="pcre2"` on the regex to ensure `\S+` backtracks correctly before the trailing period in the username field.

## Test plan

- [x] Regex tested in Python against 3 sample log variants — all pass
- [x] XML well-formed (validated via `xml.etree`)
- [x] Validated with `wazuh-logtest` in a `wazuh/wazuh-manager:4.7.5` container — `srcuser` extracted correctly across all variants