### PR TITLE
SCA policies migration guide from 4.x to 5.x

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,6 +11,12 @@
 - [Build external dependencies](dev/build-external-dependencies.md)
 - [Test execution](dev/test-execution.md)
 
+# User Guides
+
+- [Overview](guide/README.md)
+- [Migration](guide/migration/README.md)
+  - [SCA policies from 4.x to 5.x](guide/migration/sca-policies-4x-to-5x.md)
+
 # Reference Manual
 
 - [Introduction](ref/README.md)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,0 +1,3 @@
+# User guides
+
+This section contains operational guides for common maintenance and migration tasks.

--- a/docs/guide/migration/README.md
+++ b/docs/guide/migration/README.md
@@ -1,0 +1,3 @@
+# Migration
+
+This section contains migration guides for changes that require manual review when moving between major Wazuh versions.

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -63,21 +63,24 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 
 4. Convert SCA rules to PCRE2.
 
-   The `regex_type` field is ignored in 5.x (the engine is always PCRE2), so it can be removed. Because every pattern is now evaluated as PCRE2, review every rule that uses `r:` or `n:`. Common conversions are:
+   The `regex_type` field is ignored in 5.x (the engine is always PCRE2), so it can be removed. Because every pattern is now evaluated as PCRE2, review every rule that uses `r:` or `n:`. The following changes are required, because the original pattern either fails to compile under PCRE2 or no longer evaluates correctly:
 
-   | 4.x OSRegex-style pattern | 5.x PCRE2 pattern | Reason |
+   | 4.x pattern | 5.x pattern | Reason |
    |---|---|---|
-   | `r:\.+` | `r:.+` | `\.` is a literal dot in PCRE2; use `.` for any character. |
-   | `r:\.*.conf` | `r:.*\.conf` | Use `.*` for any prefix and escape the literal dot before `conf`. |
-   | `r:pam_unix.so` | `r:pam_unix\.so` | Escape literal dots when they must match dots only. |
-   | `r:127.0.0.1` | `r:127\.0\.0\.1` | Escape literal IP-address dots. |
-   | `r:*` | `r:\*` | `*` is a quantifier in PCRE2 and must be escaped when literal. |
-   | `r:\w+` | `r:[\w@-]+` | Expand word matches when target values can contain characters such as `@` or `-`. |
-   | `n:audit_backlog_limit=(d+) compare >= 8192` | `n:audit_backlog_limit=(\d+) compare >= 8192` | Use PCRE2 digit classes and capture the numeric value. |
-   | `n:remember=(\d+) compare => 5` | `n:remember=(\d+) compare >= 5` | Use standard comparison operators. |
+   | `r:*` | `r:\*` | A bare `*` is a quantifier with nothing to repeat and fails PCRE2 compilation; escape it to match a literal `*`. |
+   | `n:audit_backlog_limit=(d+) compare >= 8192` | `n:audit_backlog_limit=(\d+) compare >= 8192` | Use the `\d` digit class so the capture group matches the numeric value. |
+   | `n:remember=(\d+) compare => 5` | `n:remember=(\d+) compare >= 5` | `=`, `=>`, and `=<` are not valid operators; use `==`, `>=`, and `<=`. |
    | `n:gpgcheck=(\d+) compare \!= 1` | `n:gpgcheck=(\d+) compare != 1` | Do not escape comparison operators. |
 
-   Replace OSRegex-specific wildcards such as `\p` with an explicit PCRE2 character class that matches the intended data. For example, if the policy needs one of `*`, `!`, `+`, or `-`, use `[*!+-]`.
+   Also replace OSRegex-specific wildcards such as `\p` with an explicit PCRE2 character class that matches the intended data. For example, if the policy needs one of `*`, `!`, `+`, or `-`, use `[*!+-]`.
+
+   The following patterns still compile under PCRE2 but change meaning, so rewrite them only when the original intent requires it:
+
+   | 4.x pattern | PCRE2 rewrite | When to apply |
+   |---|---|---|
+   | `r:pam_unix.so`, `r:127.0.0.1` | `r:pam_unix\.so`, `r:127\.0\.0\.1` | `.` matches any character in PCRE2. Escape the dots if they must match literal dots only. |
+   | `r:\.+`, `r:\.*.conf` | `r:.+`, `r:.*\.conf` | `\.` is a literal dot in PCRE2. If the intent was "any character", use `.`. |
+   | `r:\w+` | `r:[\w@-]+` | `\w+` is valid as-is; widen the class only if matched values can contain characters such as `@` or `-`. |
 
 5. Convert compliance and MITRE metadata.
 

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -24,6 +24,8 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 
    Include policies referenced from `<sca><policies>` and any policy copied into a shared agent group. Check both local agent policies and manager-distributed policies.
 
+   Watch for legacy 4.x stock policies that used the old `*_rcl.yml` naming, such as `cis_rhel7_linux_rcl.yml`, `system_audit_rcl.yml`, or `win_audit_rcl.yml`. If these remain referenced in `<sca><policies>` after the upgrade, SCA skips them silently without logging a warning, so remove or replace those references.
+
 2. Back up policies and move custom files out of package-managed paths.
 
    Do not edit or store custom policies in `$WAZUH_HOME/ruleset/sca`. Package upgrades replace stock policy files in that directory. Use an administrator-managed path, such as a policy directory under `$WAZUH_HOME/etc/shared`, and point `<policy>` entries to that path.

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -11,7 +11,7 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 | Area | 4.x behavior | 5.x behavior | Migration action |
 |---|---|---|---|
 | Regular expression engine | `osregex` was the default SCA regex engine. Policies and checks could set `regex_type: pcre2`. | SCA rules are evaluated with PCRE2. `osregex` must not be used for migrated custom policies. | Rewrite every `r:` and `n:` expression that depends on OSRegex syntax. Remove `regex_type: osregex`; use PCRE2-compatible patterns. |
-| Policy and check names | Requirements and checks used `title`. | Stock policies use `name`. Runtime state and generated events expose `name`. | Rename `requirements.title` and each `checks[*].title` to `name`. |
+| Policy and check names | Requirements and checks used `title`. | `name` is the canonical field; stock policies, runtime state, and generated events use `name`. A `title` field is still accepted and automatically mapped to `name`, but is deprecated. | Rename `requirements.title` and each `checks[*].title` to `name`. The rename is recommended rather than mandatory, since legacy `title` is still mapped to `name`. |
 | Compliance metadata | Many stock policies used an array of single-key objects, often with versioned keys such as `pci_dss_v4.0`. | `compliance` is an object. Only normalized keys are accepted: `cmmc`, `fedramp`, `gdpr`, `hipaa`, `iso_27001`, `nis2`, `nist_800_171`, `nist_800_53`, `pci_dss`, and `tsc`. | Convert the array format to an object and use only supported keys. Unsupported keys are ignored with a warning. |
 | MITRE metadata | MITRE values were commonly stored under compliance keys such as `mitre_tactics`, `mitre_techniques`, and `mitre_mitigations`. | MITRE data is stored in a separate `mitre` object. Only the `tactic`, `technique`, and `subtechnique` keys are recognized. | Move MITRE values out of `compliance` and into `mitre`, using only `tactic`, `technique`, and `subtechnique`. |
 | Numeric comparisons | Some stock 4.x rules used forms such as `compare =`, `compare =>`, `compare =<`, missing spaces, or an escaped `\!=`. | Numeric expressions require `compare <`, `compare <=`, `compare ==`, `compare !=`, `compare >=`, or `compare >` followed by a value. Spaces are required around `compare` and the operator. | Normalize every `n:` expression and make sure the regex captures the numeric value in a group. |
@@ -48,7 +48,7 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 
 3. Rename `title` fields to `name`.
 
-   Apply this change to `requirements` and to every check:
+   `name` is the canonical field. For backward compatibility, a `title` field is still accepted and automatically mapped to `name`, so existing 4.x policies keep working; however, `title` is deprecated. Rename it in `requirements` and in every check:
 
    ```yaml
    requirements:
@@ -171,7 +171,7 @@ checks:
 
 - Custom policies are stored outside `$WAZUH_HOME/ruleset/sca`.
 - SCA configuration references the migrated custom policy paths.
-- `requirements` and checks use `name`.
+- `requirements` and checks use `name` (the deprecated `title` still works but should be replaced).
 - No policy or check uses `regex_type: osregex`.
 - All regex and numeric expressions compile as PCRE2.
 - `compliance` is an object with supported keys only.

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -10,7 +10,7 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 
 | Area | 4.x behavior | 5.x behavior | Migration action |
 |---|---|---|---|
-| Regular expression engine | `osregex` was the default SCA regex engine. Policies and checks could set `regex_type: pcre2`. | SCA rules are evaluated with PCRE2. `osregex` must not be used for migrated custom policies. | Rewrite every `r:` and `n:` expression that depends on OSRegex syntax. Remove `regex_type: osregex`; use PCRE2-compatible patterns. |
+| Regular expression engine | `osregex` was the default SCA regex engine. Policies and checks could set `regex_type`. | All SCA rules are evaluated with PCRE2. The `regex_type` field is ignored: the engine is always PCRE2 and OSRegex is no longer available. | Rewrite every `r:` and `n:` expression that depends on OSRegex syntax so it is valid PCRE2. The now-ignored `regex_type` field can be removed. |
 | Policy and check names | Requirements and checks used `title`. | `name` is the canonical field; stock policies, runtime state, and generated events use `name`. A `title` field is still accepted and automatically mapped to `name`, but is deprecated. | Rename `requirements.title` and each `checks[*].title` to `name`. The rename is recommended rather than mandatory, since legacy `title` is still mapped to `name`. |
 | Compliance metadata | Many stock policies used an array of single-key objects, often with versioned keys such as `pci_dss_v4.0`. | `compliance` is an object. Only normalized keys are accepted: `cmmc`, `fedramp`, `gdpr`, `hipaa`, `iso_27001`, `nis2`, `nist_800_171`, `nist_800_53`, `pci_dss`, and `tsc`. | Convert the array format to an object and use only supported keys. Unsupported keys are ignored with a warning. |
 | MITRE metadata | MITRE values were commonly stored under compliance keys such as `mitre_tactics`, `mitre_techniques`, and `mitre_mitigations`. | MITRE data is stored in a separate `mitre` object. Only the `tactic`, `technique`, and `subtechnique` keys are recognized. | Move MITRE values out of `compliance` and into `mitre`, using only `tactic`, `technique`, and `subtechnique`. |
@@ -61,7 +61,7 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 
 4. Convert SCA rules to PCRE2.
 
-   Remove `regex_type: osregex` and review every rule that uses `r:` or `n:`. Common conversions are:
+   The `regex_type` field is ignored in 5.x (the engine is always PCRE2), so it can be removed. Because every pattern is now evaluated as PCRE2, review every rule that uses `r:` or `n:`. Common conversions are:
 
    | 4.x OSRegex-style pattern | 5.x PCRE2 pattern | Reason |
    |---|---|---|
@@ -136,7 +136,7 @@ checks:
       - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:\d+:(\d+): compare > 365'
 ```
 
-The 5.x version uses `name`, removes the OSRegex selection, converts compliance and MITRE metadata, and rewrites the expressions for PCRE2:
+The 5.x version uses `name`, drops the now-ignored `regex_type` field, converts compliance and MITRE metadata, and rewrites the expressions for PCRE2:
 
 ```yaml
 policy:
@@ -172,7 +172,7 @@ checks:
 - Custom policies are stored outside `$WAZUH_HOME/ruleset/sca`.
 - SCA configuration references the migrated custom policy paths.
 - `requirements` and checks use `name` (the deprecated `title` still works but should be replaced).
-- No policy or check uses `regex_type: osregex`.
+- The `regex_type` field is removed (it is ignored in 5.x; all patterns are PCRE2).
 - All regex and numeric expressions compile as PCRE2.
 - `compliance` is an object with supported keys only.
 - MITRE metadata is under `mitre`.

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -1,0 +1,181 @@
+# SCA policies from 4.x to 5.x
+
+This guide describes the manual changes required to run custom Security Configuration Assessment (SCA) policies created for Wazuh 4.x on Wazuh 5.x.
+
+There is no automatic migration tool for custom SCA policies. Review each custom policy, migrate it to the 5.x policy format, and validate it on a non-production 5.x agent before rolling it out.
+
+For the current custom policy schema, see [Creating custom SCA policies](../../ref/modules/sca/custom-policies.md).
+
+## Summary of changes
+
+| Area | 4.x behavior | 5.x behavior | Migration action |
+|---|---|---|---|
+| Regular expression engine | `osregex` was the default SCA regex engine. Policies and checks could set `regex_type: pcre2`. | SCA rules are evaluated with PCRE2. `osregex` must not be used for migrated custom policies. | Rewrite every `r:` and `n:` expression that depends on OSRegex syntax. Remove `regex_type: osregex`; use PCRE2-compatible patterns. |
+| Policy and check names | Requirements and checks used `title`. | Stock policies use `name`. Runtime state and generated events expose `name`. | Rename `requirements.title` and each `checks[*].title` to `name`. |
+| Compliance metadata | Many stock policies used an array of single-key objects, often with versioned keys such as `pci_dss_v4.0`. | `compliance` is an object. Only normalized keys are accepted: `cmmc`, `fedramp`, `gdpr`, `hipaa`, `iso_27001`, `nis2`, `nist_800_171`, `nist_800_53`, `pci_dss`, and `tsc`. | Convert the array format to an object and use only supported keys. Unsupported keys are ignored with a warning. |
+| MITRE metadata | MITRE values were commonly stored under compliance keys such as `mitre_tactics`, `mitre_techniques`, and `mitre_mitigations`. | MITRE data is stored in a separate `mitre` object with `tactic`, `technique`, `subtechnique`, and `mitigation` keys. | Move MITRE values out of `compliance` and into `mitre`. |
+| Numeric comparisons | Some stock 4.x rules used forms such as `compare =`, `compare =>`, `compare =<`, missing spaces, or an escaped `\!=`. | Numeric expressions require `compare <`, `compare <=`, `compare ==`, `compare !=`, `compare >=`, or `compare >` followed by a value. Spaces are required around `compare` and the operator. | Normalize every `n:` expression and make sure the regex captures the numeric value in a group. |
+| SCA configuration | Some 4.x configurations included `<skip_nfs>`. | `<skip_nfs>` is deprecated for SCA and produces a warning. SCA synchronization settings are available under `<synchronization>`. | Remove `<skip_nfs>` from SCA configuration. Keep or tune synchronization settings as needed. |
+| Stock policies | Stock policy files under `ruleset/sca` were package-managed. | Upgrades replace stock policies. Some legacy stock policies were removed, including HP-UX, RHEL 5, SLES/SUSE 11, and Solaris/SunOS policies. | Do not customize files under `ruleset/sca`. Keep custom policies in a separate managed path and reference them explicitly. |
+
+## Step-by-step migration
+
+1. Inventory all custom SCA policies currently in use.
+
+   Include policies referenced from `<sca><policies>` and any policy copied into a shared agent group. Check both local agent policies and manager-distributed policies.
+
+2. Back up policies and move custom files out of package-managed paths.
+
+   Do not edit or store custom policies in `$WAZUH_HOME/ruleset/sca`. Package upgrades replace stock policy files in that directory. Use an administrator-managed path, such as a policy directory under `$WAZUH_HOME/etc/shared`, and point `<policy>` entries to that path.
+
+   ```xml
+   <sca>
+     <enabled>yes</enabled>
+     <scan_on_start>yes</scan_on_start>
+     <interval>12h</interval>
+     <policies>
+       <policy>etc/shared/default/sca/custom_linux.yml</policy>
+       <policy enabled="no">ruleset/sca/cis_debian12.yml</policy>
+     </policies>
+     <synchronization>
+       <enabled>yes</enabled>
+       <interval>5m</interval>
+       <integrity_interval>24h</integrity_interval>
+       <max_eps>75</max_eps>
+     </synchronization>
+   </sca>
+   ```
+
+3. Rename `title` fields to `name`.
+
+   Apply this change to `requirements` and to every check:
+
+   ```yaml
+   requirements:
+     name: "Run only on Linux hosts"
+
+   checks:
+     - id: 90001
+       name: "Ensure SSH root login is disabled"
+   ```
+
+4. Convert SCA rules to PCRE2.
+
+   Remove `regex_type: osregex` and review every rule that uses `r:` or `n:`. Common conversions are:
+
+   | 4.x OSRegex-style pattern | 5.x PCRE2 pattern | Reason |
+   |---|---|---|
+   | `r:\.+` | `r:.+` | `\.` is a literal dot in PCRE2; use `.` for any character. |
+   | `r:\.*.conf` | `r:.*\.conf` | Use `.*` for any prefix and escape the literal dot before `conf`. |
+   | `r:pam_unix.so` | `r:pam_unix\.so` | Escape literal dots when they must match dots only. |
+   | `r:127.0.0.1` | `r:127\.0\.0\.1` | Escape literal IP-address dots. |
+   | `r:*` | `r:\*` | `*` is a quantifier in PCRE2 and must be escaped when literal. |
+   | `r:\w+` | `r:[\w@-]+` | Expand word matches when target values can contain characters such as `@` or `-`. |
+   | `n:audit_backlog_limit=(d+) compare >= 8192` | `n:audit_backlog_limit=(\d+) compare >= 8192` | Use PCRE2 digit classes and capture the numeric value. |
+   | `n:remember=(\d+) compare => 5` | `n:remember=(\d+) compare >= 5` | Use standard comparison operators. |
+   | `n:gpgcheck=(\d+) compare \!= 1` | `n:gpgcheck=(\d+) compare != 1` | Do not escape comparison operators. |
+
+   Replace OSRegex-specific wildcards such as `\p` with an explicit PCRE2 character class that matches the intended data. For example, if the policy needs one of `*`, `!`, `+`, or `-`, use `[*!+-]`.
+
+5. Convert compliance and MITRE metadata.
+
+   Use only supported compliance keys and move MITRE values to the `mitre` object:
+
+   ```yaml
+   compliance:
+     pci_dss: ["2.2"]
+     nist_800_53: ["CM-6"]
+     tsc: ["CC6.6"]
+   mitre:
+     tactic: ["TA0005"]
+     technique: ["T1036"]
+     mitigation: ["M1022"]
+   ```
+
+6. Remove deprecated SCA configuration.
+
+   Delete `<skip_nfs>` from the SCA module configuration. If you explicitly configure synchronization, keep it under `<synchronization>` as shown in step 2.
+
+7. Validate the migrated policy on Wazuh 5.x.
+
+   Install the policy on a non-production 5.x agent or manager, restart the service, and run a scan. Check the Wazuh logs for policy parsing, invalid compliance keys, and PCRE2 errors. Search for messages such as `Failed to parse policy`, `Invalid compliance key`, `Unexpected compliance format`, and `PCRE2 compilation failed`.
+
+8. Roll out incrementally.
+
+   Start with one agent group or one endpoint type. Compare SCA results with the expected 4.x behavior, then expand deployment once the migrated policies parse cleanly and produce the expected pass, fail, and not applicable results.
+
+## Migration example
+
+The following 4.x check uses `title`, OSRegex syntax, array-style compliance metadata, MITRE values inside `compliance`, and a reversed numeric comparison operator:
+
+```yaml
+policy:
+  id: "custom_linux"
+  file: "custom_linux.yml"
+  name: "Custom Linux hardening"
+  description: "Custom checks for Linux endpoints."
+  regex_type: "osregex"
+
+requirements:
+  title: "Run only on Linux hosts"
+  description: "Linux host requirement."
+  condition: all
+  rules:
+    - "f:/proc/sys/kernel/ostype -> Linux"
+
+checks:
+  - id: 90001
+    title: "Check SSH and password aging"
+    compliance:
+      - pci_dss_v4.0: ["2.2.6"]
+      - nist_sp_800-53: ["CM-6"]
+      - mitre_tactics: ["TA0005"]
+      - mitre_techniques: ["T1036"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/system-auth -> r:pam_unix.so && n:remember=(\d+) compare => 5'
+      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:\d+:(\d+): compare > 365'
+```
+
+The 5.x version uses `name`, removes the OSRegex selection, converts compliance and MITRE metadata, and rewrites the expressions for PCRE2:
+
+```yaml
+policy:
+  id: "custom_linux"
+  file: "custom_linux.yml"
+  name: "Custom Linux hardening"
+  description: "Custom checks for Linux endpoints."
+
+requirements:
+  name: "Run only on Linux hosts"
+  description: "Linux host requirement."
+  condition: all
+  rules:
+    - "f:/proc/sys/kernel/ostype -> Linux"
+
+checks:
+  - id: 90001
+    name: "Check SSH and password aging"
+    compliance:
+      pci_dss: ["2.2"]
+      nist_800_53: ["CM-6"]
+    mitre:
+      tactic: ["TA0005"]
+      technique: ["T1036"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/system-auth -> r:pam_unix\.so && n:remember=(\d+) compare >= 5'
+      - 'not f:/etc/shadow -> n:^[\w@-]+:\$.*:\d+:\d+:(\d+) compare > 365'
+```
+
+## Final checklist
+
+- Custom policies are stored outside `$WAZUH_HOME/ruleset/sca`.
+- SCA configuration references the migrated custom policy paths.
+- `requirements` and checks use `name`.
+- No policy or check uses `regex_type: osregex`.
+- All regex and numeric expressions compile as PCRE2.
+- `compliance` is an object with supported keys only.
+- MITRE metadata is under `mitre`.
+- `<skip_nfs>` is removed from SCA configuration.
+- A non-production 5.x validation scan completes without SCA parsing or PCRE2 errors.

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -24,11 +24,13 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 
    Include policies referenced from `<sca><policies>` and any policy copied into a shared agent group. Check both local agent policies and manager-distributed policies.
 
-   Watch for legacy 4.x stock policies that used the old `*_rcl.yml` naming, such as `cis_rhel7_linux_rcl.yml`, `system_audit_rcl.yml`, or `win_audit_rcl.yml`. If these remain referenced in `<sca><policies>` after the upgrade, SCA skips them silently without logging a warning, so remove or replace those references.
+   Watch for `<policy>` entries that reference legacy filenames ending in `_rcl.yml`, such as `cis_rhel7_linux_rcl.yml`, `system_audit_rcl.yml`, or `win_audit_rcl.yml`. These are old policy names carried over from earlier Wazuh versions, not 5.x SCA policy files. The SCA configuration reader keeps a built-in list of these filenames and silently skips them, without logging a warning, if they are still referenced in `<sca><policies>`, so remove or replace those references. Note that only the exact filenames in that built-in list are skipped silently; any other missing or unresolved policy path instead logs a `File '...' not found` or `Policy file '...' not found` warning.
 
 2. Back up policies and move custom files out of package-managed paths.
 
-   Do not edit or store custom policies in `$WAZUH_HOME/ruleset/sca`. Package upgrades replace stock policy files in that directory. Use an administrator-managed path, such as a policy directory under `$WAZUH_HOME/etc/shared`, and point `<policy>` entries to that path.
+   Do not edit or store custom policies in `$WAZUH_HOME/ruleset/sca`. Package upgrades replace stock policy files in that directory. Use an administrator-managed path and point `<policy>` entries to that path.
+
+   Policies under `$WAZUH_HOME/etc/shared` are shared policies. The agent treats paths that contain `etc/shared/` as remote policies, so command rules (`c:`) in those policies run only when the `sca.remote_commands` internal option is enabled. External local paths outside `etc/shared`, such as `/opt/wazuh-sca/custom_linux.yml`, are not treated as remote by this check, but the file must exist locally on each agent.
 
    ```xml
    <sca>
@@ -36,7 +38,10 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
      <scan_on_start>yes</scan_on_start>
      <interval>12h</interval>
      <policies>
+       <!-- Shared policy: distributed through etc/shared; command rules require sca.remote_commands=1. -->
        <policy>etc/shared/default/sca/custom_linux.yml</policy>
+       <!-- External local policy: must exist on each agent. -->
+       <policy>/opt/wazuh-sca/custom_linux_local.yml</policy>
        <policy enabled="no">ruleset/sca/cis_debian12.yml</policy>
      </policies>
      <synchronization>

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -158,7 +158,7 @@ checks:
   - id: 90001
     name: "Check SSH and password aging"
     compliance:
-      pci_dss: ["2.2"]
+      pci_dss: ["2.2.6"]
       nist_800_53: ["CM-6"]
     mitre:
       tactic: ["TA0005"]

--- a/docs/guide/migration/sca-policies-4x-to-5x.md
+++ b/docs/guide/migration/sca-policies-4x-to-5x.md
@@ -13,7 +13,7 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
 | Regular expression engine | `osregex` was the default SCA regex engine. Policies and checks could set `regex_type: pcre2`. | SCA rules are evaluated with PCRE2. `osregex` must not be used for migrated custom policies. | Rewrite every `r:` and `n:` expression that depends on OSRegex syntax. Remove `regex_type: osregex`; use PCRE2-compatible patterns. |
 | Policy and check names | Requirements and checks used `title`. | Stock policies use `name`. Runtime state and generated events expose `name`. | Rename `requirements.title` and each `checks[*].title` to `name`. |
 | Compliance metadata | Many stock policies used an array of single-key objects, often with versioned keys such as `pci_dss_v4.0`. | `compliance` is an object. Only normalized keys are accepted: `cmmc`, `fedramp`, `gdpr`, `hipaa`, `iso_27001`, `nis2`, `nist_800_171`, `nist_800_53`, `pci_dss`, and `tsc`. | Convert the array format to an object and use only supported keys. Unsupported keys are ignored with a warning. |
-| MITRE metadata | MITRE values were commonly stored under compliance keys such as `mitre_tactics`, `mitre_techniques`, and `mitre_mitigations`. | MITRE data is stored in a separate `mitre` object with `tactic`, `technique`, `subtechnique`, and `mitigation` keys. | Move MITRE values out of `compliance` and into `mitre`. |
+| MITRE metadata | MITRE values were commonly stored under compliance keys such as `mitre_tactics`, `mitre_techniques`, and `mitre_mitigations`. | MITRE data is stored in a separate `mitre` object. Only the `tactic`, `technique`, and `subtechnique` keys are recognized. | Move MITRE values out of `compliance` and into `mitre`, using only `tactic`, `technique`, and `subtechnique`. |
 | Numeric comparisons | Some stock 4.x rules used forms such as `compare =`, `compare =>`, `compare =<`, missing spaces, or an escaped `\!=`. | Numeric expressions require `compare <`, `compare <=`, `compare ==`, `compare !=`, `compare >=`, or `compare >` followed by a value. Spaces are required around `compare` and the operator. | Normalize every `n:` expression and make sure the regex captures the numeric value in a group. |
 | SCA configuration | Some 4.x configurations included `<skip_nfs>`. | `<skip_nfs>` is deprecated for SCA and produces a warning. SCA synchronization settings are available under `<synchronization>`. | Remove `<skip_nfs>` from SCA configuration. Keep or tune synchronization settings as needed. |
 | Stock policies | Stock policy files under `ruleset/sca` were package-managed. | Upgrades replace stock policies. Some legacy stock policies were removed, including HP-UX, RHEL 5, SLES/SUSE 11, and Solaris/SunOS policies. | Do not customize files under `ruleset/sca`. Keep custom policies in a separate managed path and reference them explicitly. |
@@ -89,7 +89,6 @@ For the current custom policy schema, see [Creating custom SCA policies](../../r
    mitre:
      tactic: ["TA0005"]
      technique: ["T1036"]
-     mitigation: ["M1022"]
    ```
 
 6. Remove deprecated SCA configuration.

--- a/docs/ref/modules/sca/custom-policies.md
+++ b/docs/ref/modules/sca/custom-policies.md
@@ -159,7 +159,7 @@ Unknown keys are rejected with a warning and excluded from the check.
 
 The `mitre` field is an object that maps MITRE ATT&CK categories to arrays of identifier strings. The following keys are supported:
 
-`tactic`, `technique`, `subtechnique`, `mitigation`
+`tactic`, `technique`, `subtechnique`
 
 ---
 

--- a/docs/ref/modules/sca/custom-policies.md
+++ b/docs/ref/modules/sca/custom-policies.md
@@ -34,7 +34,7 @@ policy:
     - https://www.ssh.com/ssh/
 
 requirements:
-  title: "Check that the SSH service and password-related files are present on the system"
+  name: "Check that the SSH service and password-related files are present on the system"
   description: "Requirements for running the SCA scan against the Unix based systems policy."
   condition: any
   rules:
@@ -48,7 +48,7 @@ variables:
 
 checks:
   - id: 3000
-    title: "SSH Hardening: Port should not be 22"
+    name: "SSH Hardening: Port should not be 22"
     description: "The ssh daemon should not be listening on port 22 (the default value) for incoming connections."
     rationale: "Changing the default port you may reduce the number of successful attacks from zombie bots."
     remediation: "Change the Port option value in the sshd_config file."
@@ -63,7 +63,7 @@ checks:
       - 'f:$sshd_file -> !r:^# && r:Port && !r:\s*\t*22$'
 
   - id: 3001
-    title: "SSH Hardening: Protocol should be set to 2"
+    name: "SSH Hardening: Protocol should be set to 2"
 ```
 
 > **Note**  
@@ -77,10 +77,9 @@ checks:
 |-------------|-----------|------------------|------------------------------|---------------------|
 | id          | Yes       | String           | Any string                   | Policy ID           |
 | file        | Yes       | String           | Any string                   | Policy filename     |
-| name        | Yes       | String           | Any string                   | Policy title        |
+| name        | Yes       | String           | Any string                   | Policy name         |
 | description | Yes       | String           | Any string                   | Brief description   |
 | references  | No        | Array of strings | Any string                   | Reference links     |
-| regex_type  | No        | String           | osregex, pcre2               | Regex engine        |
 
 ---
 
@@ -88,7 +87,7 @@ checks:
 
 | Field       | Mandatory | Type             | Allowed values |
 |------------|-----------|------------------|----------------|
-| title      | Yes       | String           | Any string     |
+| name       | Yes       | String           | Any string     |
 | description| Yes       | String           | Any string     |
 | condition  | Yes       | String           | Any string     |
 | rules      | Yes       | Array of strings | Any string     |
@@ -136,7 +135,7 @@ Checks define what actions the agent performs and how results are evaluated.
 | Field        | Mandatory | Type                      | Allowed values        |
 |-------------|-----------|---------------------------|-----------------------|
 | id          | Yes       | Numeric                   | Any integer           |
-| title       | Yes       | String                    | Any string            |
+| name        | Yes       | String                    | Any string            |
 | description | No        | String                    | Any string            |
 | rationale   | No        | String                    | Any string            |
 | remediation | No        | String                    | Any string            |
@@ -145,10 +144,8 @@ Checks define what actions the agent performs and how results are evaluated.
 | references  | No        | Array of strings          | Any string            |
 | condition   | Yes       | String                    | all, any, none        |
 | rules       | Yes       | Array of strings          | Any string            |
-| regex_type  | No        | String                    | pcre2, osregex        |
 
-> **Note**
-> A `regex_type` defined at the check level overrides the policy-level regex engine.
+SCA rules are evaluated with PCRE2. Custom policies migrated from 4.x must not rely on OSRegex syntax. See [SCA policies from 4.x to 5.x](../../../guide/migration/sca-policies-4x-to-5x.md) for migration guidance.
 
 #### Compliance keys
 
@@ -275,8 +272,8 @@ c:systemctl is-enabled cups -> r:^enabled
 
 ## Composite rules
 
-- `f:/etc/ssh/sshd_config -> !r:^# && r:Port\.+22`
-- `not f:/etc/ssh/sshd_config -> !r:^# && r:Port\.+22`
+- `f:/etc/ssh/sshd_config -> !r:^# && r:Port\s+22`
+- `not f:/etc/ssh/sshd_config -> !r:^# && r:Port\s+22`
 
 ---
 
@@ -286,4 +283,4 @@ c:systemctl is-enabled cups -> r:^enabled
 - `p:avahi-daemon`
 - `d:/etc/mysql`
 - `c:sshd -T -> !r:^\s*maxauthtries\s+4\s*$`
-- `f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:`
+- `f:/etc/passwd -> !r:^# && !r:^root: && r:^[\w@-]+:[\w@-]+:0:`

--- a/docs/ref/modules/sca/database-schema.md
+++ b/docs/ref/modules/sca/database-schema.md
@@ -123,7 +123,7 @@ Unknown keys are rejected with a warning during policy parsing and excluded from
 
 The `mitre` column stores a JSON-serialized object that maps MITRE ATT&CK categories to arrays of identifier strings. The following keys are supported:
 
-`tactic`, `technique`, `subtechnique`, `mitigation`
+`tactic`, `technique`, `subtechnique`
 
 **Example Data:**
 ```sql


### PR DESCRIPTION
## Description

Wazuh 5.x introduces several breaking changes to Security Configuration Assessment (SCA) that affect custom policies migrated from 4.x: the regex engine is now always PCRE2 (OSRegex is gone and `regex_type` is ignored), `name` replaces `title`, `compliance` is an object with a fixed set of normalized keys, MITRE metadata moves to a dedicated `mitre` object, deprecated `<skip_nfs>` is removed, and package upgrades overwrite stock policies under `ruleset/sca`. There was no documentation describing these changes or how to migrate existing custom policies.

This PR adds a dedicated migration guide and updates the custom-policies reference to match the 5.x format.

Closes #36569

## Proposed Changes

- Add `docs/guide/migration/sca-policies-4x-to-5x.md`: a migration guide covering the 4.x → 5.x SCA changes (regex engine, `title` → `name`, compliance/MITRE metadata, `<skip_nfs>`, stock-policy overwrite), a step-by-step migration procedure, a before/after example, and a final checklist.
- Update `docs/ref/modules/sca/custom-policies.md` to reflect the 5.x schema: rename `title` to `name`, drop the now-ignored `regex_type` field, note that all rules are evaluated with PCRE2, fix composite/example expressions to valid PCRE2, and link to the new migration guide.
- Add a new **User Guides** section to the docs navigation (`docs/SUMMARY.md`) with `docs/guide/README.md` and `docs/guide/migration/README.md` landing pages.

### Results and Evidence

Although this is a documentation-only change, the migration **procedure was validated end-to-end at runtime** to satisfy the issue's "Procedure validated" Definition of Done. A custom SCA policy written with legacy 4.x idioms was run on a real **Wazuh 4.14.5** agent and a real **Wazuh 5.0.0** agent; the guide's migration steps were then applied and the migrated policy re-run on 5.x.

| Run | Agent | Policy | Outcome |
|---|---|---|---|
| Baseline | 4.14.5 | legacy `custom_linux_4x.yml` | scans, `passed:0 failed:2 invalid:0` — legacy syntax tolerated, no warnings/errors |
| Unfixed | 5.0.0 | same file | scans, but emits every predicted WARNING/ERROR; broken checks become `Invalid` |
| Migrated | 5.0.0 | `custom_linux_5x.yml` (guide applied) | scans, both checks **Passed**, zero SCA WARN/ERROR |

Most illustrative: on 4.x the deprecated `compare => 1` is **silently misinterpreted** — the agent logs `Operation is '5 == 1'` (it reads `=>` as `==`, so `5 == 1` → false: a wrong result with no error). 5.x turns that latent bug into an explicit error, and the migrated `compare >= 1` evaluates correctly. Likewise `r:*` is tolerated by 4.x OSRegex but is a `PCRE2 compilation failed` error on 5.x.

Per-claim mapping (guide → observed at runtime):

| Guide claim | 4.x | 5.x unfixed | 5.x migrated |
|---|---|---|---|
| Numeric operator `=>` → `>=` | `Operation is '5 == 1'` (silently wrong) | `ERROR: Invalid operator in numeric comparison` (pattern `compare => 1`) | check 90001 **Passed** |
| OSRegex `r:*` → escaped | `Testing minterm (r:*)(hello) -> 0` (no error) | `ERROR: PCRE2 compilation failed at offset 0: quantifier does not follow a repeatable item` (pattern `r:*`) | check 90002 **Passed** |
| Compliance array → object | array accepted, no warning | `WARNING: Unexpected compliance format in check 90001/90002, ignoring` | no warning |
| `<skip_nfs>` deprecated | accepted, no warning | `WARNING: Detected a deprecated configuration for SCA: 'skip_nfs' is no longer available.` | removed |
| Scan completes (errors cascade) | `invalid:0`, scan summary | `Scan started.` … errors … `Scan ended.` | `Scan started.` … both Passed … `Scan ended.` |

<details><summary><b>4.x baseline</b> — legacy syntax tolerated, <code>invalid:0</code></summary>

```
# 4.x agent (Wazuh 4.14.5) — legacy policy custom_linux_4x.yml BASELINE
# Source: /var/ossec/logs/ossec.log  | wazuh_modules.debug=2
# The 4.x <sca> config ships with <skip_nfs> by default and accepts it with NO warning.
# Note: on 4.x the policy was loaded via ruleset/sca auto-load (the <policies> external-path
#       entry hit a 4.x multi-policy enable quirk unrelated to the migration claims).

2026/06/01 15:45:16 sca[6388] wm_sca.c:191 at wm_sca_main(): INFO: Loaded policy '/var/ossec/ruleset/sca/custom_linux_4x.yml'
2026/06/01 15:45:16 sca[6388] wm_sca.c:497 at wm_sca_read_files(): INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/custom_linux_4x.yml'
2026/06/01 15:45:16 sca[6388] wm_sca.c:1027 at wm_sca_do_scan(): DEBUG: Beginning evaluation of check id: 90001 'Numeric compare with legacy operator'
2026/06/01 15:45:16 sca[6388] wm_sca.c:1911 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '(\d+)'. Partial comparison: '=> 1'
2026/06/01 15:45:16 sca[6388] wm_sca.c:1779 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Partial comparison '=> 1'
2026/06/01 15:45:16 sca[6388] wm_sca.c:1830 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Value given for comparison: '1'
2026/06/01 15:45:16 sca[6388] wm_sca.c:1863 at wm_sca_apply_numeric_partial_comparison(): DEBUG: Operation is '5 == 1'
2026/06/01 15:45:16 sca[6388] wm_sca.c:2040 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:(\d+) compare => 1)(5) -> 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:1911 at wm_sca_regex_numeric_comparison(): DEBUG: REGEX: '(\d+)'. Partial comparison: '=> 1'
2026/06/01 15:45:16 sca[6388] wm_sca.c:2040 at wm_sca_pattern_matches(): DEBUG: Testing minterm (n:(\d+) compare => 1)(EMPTY_LINE) -> 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:1279 at wm_sca_do_scan(): DEBUG: Result for rule 'c:echo 5 -> n:(\d+) compare => 1': 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:1302 at wm_sca_do_scan(): DEBUG: Result for check id: 90001 'Numeric compare with legacy operator' -> 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:1027 at wm_sca_do_scan(): DEBUG: Beginning evaluation of check id: 90002 'Regex with bare quantifier'
2026/06/01 15:45:16 sca[6388] wm_sca.c:2040 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:*)(hello) -> 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:2040 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:*)(EMPTY_LINE) -> 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:1279 at wm_sca_do_scan(): DEBUG: Result for rule 'c:echo hello -> r:*': 0
2026/06/01 15:45:16 sca[6388] wm_sca.c:1302 at wm_sca_do_scan(): DEBUG: Result for check id: 90002 'Regex with bare quantifier' -> 0
2026/06/01 15:45:19 sca[6388] wm_sca.c:271 at wm_sca_send_alert(): DEBUG: Sending event: {"type":"summary","scan_id":2043272844,"name":"Custom Linux hardening (4.x legacy)","policy_id":"custom_linux_4x","file":"custom_linux_4x.yml","description":"Legacy 4.x custom SCA policy for migration validation.","passed":0,"failed":2,"invalid":0,"total_checks":2,"score":0,"start_time":1780328716,"end_time":1780328716,"hash":"567cbc74f20e5da57d738ca37b892af6bfa3bfeebd877864e526384128bba8e9","hash_file":"163a74942c9d8f2d4ac0ae4104c8df8daef75b7bb673aa69cd1f4fcb87775bb2","first_scan":1}
```
</details>

<details><summary><b>5.x unfixed</b> — same file, every predicted warning/error</summary>

```
# 5.x agent (Wazuh 5.0.0-beta2) — legacy policy custom_linux_4x.yml (UNFIXED)
# Source: /var/ossec/logs/ossec.log  | wazuh_modules.debug=2  | stateful-event JSON dumps removed

2026/06/01 15:28:42 wazuh-modulesd:sca[177043] wmodules-sca.c:431 at wm_sca_read(): WARNING: Detected a deprecated configuration for SCA: 'skip_nfs' is no longer available.
2026/06/01 15:28:46 wazuh-modulesd:sca[177140] wmodules-sca.c:431 at wm_sca_read(): WARNING: Detected a deprecated configuration for SCA: 'skip_nfs' is no longer available.
2026/06/01 15:28:46 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Loading policy from /opt/wazuh-sca-test/custom_linux_4x.yml
2026/06/01 15:28:46 wazuh-modulesd:sca[177140] wm_sca.c:302 at sca_log_callback(): WARNING: Unexpected compliance format in check 90001, ignoring
2026/06/01 15:28:46 wazuh-modulesd:sca[177140] wm_sca.c:302 at sca_log_callback(): WARNING: Unexpected compliance format in check 90002, ignoring
2026/06/01 15:28:46 wazuh-modulesd:sca[177140] wm_sca.c:299 at sca_log_callback(): INFO: Scan started.
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Starting Policy requirements evaluation for policy "custom_linux_4x".
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy requirements evaluation completed for policy "custom_linux_4x", result: Passed
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Starting Policy checks evaluation for policy "custom_linux_4x".
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:305 at sca_log_callback(): ERROR: Exception 'Invalid operator in numeric comparison' was caught while evaluating pattern 'n:(\d+) compare => 1'.
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy check "90001" evaluation completed for policy "custom_linux_4x", result: Failed
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:305 at sca_log_callback(): ERROR: Exception 'PCRE2 compilation failed at offset 0: quantifier does not follow a repeatable item' was caught while evaluating pattern 'r:*'.
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy check "90002" evaluation completed for policy "custom_linux_4x", result: Failed
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy checks evaluation completed for policy "custom_linux_4x"
2026/06/01 15:28:47 wazuh-modulesd:sca[177140] wm_sca.c:299 at sca_log_callback(): INFO: Scan ended.
```
</details>

<details><summary><b>5.x migrated</b> — guide applied, clean scan, checks pass</summary>

```
# 5.x agent (Wazuh 5.0.0-beta2) — migrated policy custom_linux_5x.yml (FIXED)
# Source: /var/ossec/logs/ossec.log  | wazuh_modules.debug=2  | stateful-event JSON dumps removed

2026/06/01 15:31:18 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Loading policy from /opt/wazuh-sca-test/custom_linux_5x.yml
2026/06/01 15:31:18 wazuh-modulesd:sca[177906] wm_sca.c:299 at sca_log_callback(): INFO: Scan started.
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Starting Policy requirements evaluation for policy "custom_linux_5x".
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy requirements evaluation completed for policy "custom_linux_5x", result: Passed
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Starting Policy checks evaluation for policy "custom_linux_5x".
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy check "90001" evaluation completed for policy "custom_linux_5x", result: Passed
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy check "90002" evaluation completed for policy "custom_linux_5x", result: Passed
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:293 at sca_log_callback(): DEBUG: Policy checks evaluation completed for policy "custom_linux_5x"
2026/06/01 15:31:19 wazuh-modulesd:sca[177906] wm_sca.c:299 at sca_log_callback(): INFO: Scan ended.
```
</details>

Environment notes: 5.x SCA blocks until the manager sends `limits.sca` (`src/wazuh_modules/src/wm_sca.c:602-609`), so the 5.x runs used an enrolled `wazuh-testenv` agent (5.0.0-beta2 source build of this branch) + a 5.0.0 manager; 4.x scans locally with no such gate. Both agents ran with `wazuh_modules.debug=2` to surface per-check evaluation.

### Manual tests with their corresponding evidence

N/A — documentation-only change; no source code or binaries are modified.

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A
  - [ ] Windows — N/A
  - [ ] MAC OS X — N/A
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity — N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) — N/A
  - [ ] AddressSanitizer — N/A
- Memory tests for Windows
  - [ ] Coverity — N/A
  - [ ] UMDH — N/A
- Memory tests for macOS
  - [ ] Leaks — N/A
  - [ ] AddressSanitizer — N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel — N/A
  - [ ] ASAN for test (utest/ctest) — N/A
  - [ ] TSAN for test and wazuh-engine. — N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A

### Artifacts Affected

Developer documentation only (`docs/`). No executables, default configuration files, or packages are affected.

### Configuration Changes

N/A — this PR introduces no configuration changes to the codebase. The migration guide documents user-facing SCA configuration changes already present in 5.x (the deprecation of `<skip_nfs>` and the `<synchronization>` settings).

### Tests Introduced

N/A — documentation-only change.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — N/A (documentation-only)
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
