### PR TITLE
fix(sca): correct nosuid remediation text in cis_ubuntu14-04 check 19508

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu14-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu14-04.yml
@@ -226,7 +226,7 @@ checks:
     name: "Ensure nosuid option set on /tmp partition"
     description: "The nosuid mount option specifies that the filesystem cannot contain set userid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create set userid files in /tmp."
-    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp: # mount -o remount,nodev /tmp"
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp: # mount -o remount,nosuid /tmp"
     compliance:
       cmmc: ["CM.L2-3.4.1", "CA.L2-3.12.4"]
       fedramp: ["CM-8"]


### PR DESCRIPTION
## Description

Check ID 19508 in `ruleset/sca/ubuntu/cis_ubuntu14-04.yml` had a 
copy-paste error in the remediation field. The check is named "Ensure 
nosuid option set on /tmp partition" but the remediation incorrectly 
instructed administrators to add `nodev` instead of `nosuid` in two 
places. An administrator following the original remediation would apply 
the wrong mount option and the check would continue to fail.

## Changes

- Corrected `nodev` to `nosuid` in the remediation field of check 19508

## Related issue

Fixes #36140