### PR TITLE
Update unclassified event criteria

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -1614,7 +1614,7 @@ field: index_unclassified_events()
 
 | Path | Type | Possible values |
 | ---- | ---- | --------------- |
-| wazuh.integration.decoders | array | [number, string, boolean, object, array] |
+| wazuh.integration.category | string | unclassified, access-management, applications, cloud-services, network-activity, other, security, system-activity |
 
 
 ## Description
@@ -1622,20 +1622,21 @@ field: index_unclassified_events()
 Determines whether unclassified events should be indexed based on policy configuration.
 This filter returns true if and only if:
 1. The policy flag 'indexUnclassifiedEvents' is enabled (configured at build time)
-2. The target field is exactly 'wazuh.integration.decoders'
-3. 'wazuh.integration.decoders' is an array containing exactly 1 element
+2. The target field is exactly 'wazuh.integration.category'
+3. 'wazuh.integration.category' equals the string "unclassified"
 
-This helper is used in output routing to decide whether to index events that have only
-one decoder (unclassified events) when the policy allows it. If the policy flag is
-disabled or the array has a different size, the validation fails.
+This helper is used in output routing to decide whether to index events that the
+root decoder tagged as unclassified (no integration decoder matched) when the policy
+allows it. If the policy flag is disabled, the category differs from "unclassified",
+or the field is missing / not a string, the validation fails.
 
 Note: This helper does not accept any arguments, rejects any target field other than
-'wazuh.integration.decoders', and depends on the policy context configured at build time.
+'wazuh.integration.category', and depends on the policy context configured at build time.
 
 
 ## Keywords
 
-- `array` 
+- `string` 
 
 - `policy` 
 
@@ -1643,22 +1644,20 @@ Note: This helper does not accept any arguments, rejects any target field other 
 
 ### Example 1
 
-Array with exactly one element (unclassified event)
+Category equals "unclassified" (event tagged by the root decoder)
 
 #### Asset
 
 ```yaml
 check:
-  - wazuh.integration.decoders: index_unclassified_events()
+  - wazuh.integration.category: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "wazuh.integration.decoders": [
-    "single_decoder"
-  ]
+  "wazuh.integration.category": "unclassified"
 }
 ```
 
@@ -1666,42 +1665,41 @@ check:
 
 ### Example 2
 
-Empty array - not an unclassified event
+Category is a known one different from "unclassified"
 
 #### Asset
 
 ```yaml
 check:
-  - wazuh.integration.decoders: index_unclassified_events()
-```
-
-#### Input Event
-
-```json
-{}
-```
-
-*The check was performed with errors*
-
-### Example 3
-
-Array with two elements - classified event
-
-#### Asset
-
-```yaml
-check:
-  - wazuh.integration.decoders: index_unclassified_events()
+  - wazuh.integration.category: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "wazuh.integration.decoders": [
-    "decoder1",
-    "decoder2"
-  ]
+  "wazuh.integration.category": "security"
+}
+```
+
+*The check was performed with errors*
+
+### Example 3
+
+Category is a known one different from "unclassified"
+
+#### Asset
+
+```yaml
+check:
+  - wazuh.integration.category: index_unclassified_events()
+```
+
+#### Input Event
+
+```json
+{
+  "wazuh.integration.category": "system-activity"
 }
 ```
 
@@ -1709,24 +1707,20 @@ check:
 
 ### Example 4
 
-Array with three elements - classified event
+Category is an empty string
 
 #### Asset
 
 ```yaml
 check:
-  - wazuh.integration.decoders: index_unclassified_events()
+  - wazuh.integration.category: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "wazuh.integration.decoders": [
-    "d1",
-    "d2",
-    "d3"
-  ]
+  "wazuh.integration.category": ""
 }
 ```
 
@@ -1734,20 +1728,20 @@ check:
 
 ### Example 5
 
-Target field is not an array
+Target field is a number, not a string
 
 #### Asset
 
 ```yaml
 check:
-  - wazuh.integration.decoders: index_unclassified_events()
+  - wazuh.integration.category: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "wazuh.integration.decoders": "not_an_array"
+  "wazuh.integration.category": 42
 }
 ```
 
@@ -1755,20 +1749,22 @@ check:
 
 ### Example 6
 
-Target field is a number, not an array
+Target field is an array, not a string
 
 #### Asset
 
 ```yaml
 check:
-  - wazuh.integration.decoders: index_unclassified_events()
+  - wazuh.integration.category: index_unclassified_events()
 ```
 
 #### Input Event
 
 ```json
 {
-  "wazuh.integration.decoders": 42
+  "wazuh.integration.category": [
+    "unclassified"
+  ]
 }
 ```
 

--- a/src/engine/ruleset/outputs/indexer.yml
+++ b/src/engine/ruleset/outputs/indexer.yml
@@ -13,7 +13,7 @@ outputs:
         - wazuh-indexer:
             index: "wazuh-events-v5-unclassified"
 
-    - check: string_not_equal($wazuh.integration.category, "unclassified")
+    - check: string_not_equal($wazuh.integration.decoders, "unclassified")
       then:
         - wazuh-indexer:
             index: "wazuh-events-v5-${wazuh.integration.category}"

--- a/src/engine/ruleset/outputs/indexer.yml
+++ b/src/engine/ruleset/outputs/indexer.yml
@@ -8,12 +8,12 @@ metadata:
 
 outputs:
   - first_of:
-    - check: index_unclassified_events($wazuh.integration.decoders)
+    - check: index_unclassified_events($wazuh.integration.category)
       then:
         - wazuh-indexer:
             index: "wazuh-events-v5-unclassified"
 
-    - check: NOT array_length_eq($wazuh.integration.decoders, 1)
+    - check: string_not_equal($wazuh.integration.category, "unclassified")
       then:
         - wazuh-indexer:
             index: "wazuh-events-v5-${wazuh.integration.category}"

--- a/src/engine/ruleset/outputs/indexer.yml
+++ b/src/engine/ruleset/outputs/indexer.yml
@@ -13,7 +13,7 @@ outputs:
         - wazuh-indexer:
             index: "wazuh-events-v5-unclassified"
 
-    - check: string_not_equal($wazuh.integration.decoders, "unclassified")
+    - check: string_not_equal($wazuh.integration.category, "unclassified")
       then:
         - wazuh-indexer:
             index: "wazuh-events-v5-${wazuh.integration.category}"

--- a/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
+++ b/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
@@ -3,6 +3,7 @@
 #include <exception>
 #include <fmt/format.h>
 
+#include <cmstore/categories.hpp>
 #include <fastmetrics/registry.hpp>
 
 #include "syntax.hpp"
@@ -97,16 +98,12 @@ base::Expression postOutputUnclassifiedCounter(const std::string& spaceName,
         "postOutputUnclassified",
         [unclassifiedCounter](base::Event event) -> base::result::Result<base::Event>
         {
-            try
+            std::string_view category;
+            const json::PointerPath ppIntegrationCategory {syntax::asset::CATEGORY_PATH};
+            if (event->getString(category, ppIntegrationCategory) == json::RetGet::Success
+                && category == cm::store::categories::UNCLASSIFIED_CATEGORY)
             {
-                if (event->size(syntax::asset::DECODERS_PATH) == 1)
-                {
-                    unclassifiedCounter->add(1);
-                }
-            }
-            catch (...)
-            {
-                // Ignore size() errors
+                unclassifiedCounter->add(1);
             }
             return base::result::makeSuccess<decltype(event)>(event);
         });

--- a/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
+++ b/src/engine/source/builder/src/builders/enrichment/enrichment.cpp
@@ -56,7 +56,8 @@ getDiscardedEventsFilter(const cm::store::dataType::Policy& policy,
 
     auto op = base::Term<base::EngineOp>::create(
         DISCARDED_EVENTS_FILTER_TRACEABLE_NAME,
-        [shouldIndex, discardFieldPath, isTestMode, discardedCounter](base::Event event) -> base::result::Result<base::Event>
+        [shouldIndex, discardFieldPath, isTestMode, discardedCounter](
+            base::Event event) -> base::result::Result<base::Event>
         {
             // Policy enables indexing of discarded events
             if (shouldIndex)

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
@@ -10,6 +10,7 @@
 #include "syntax.hpp"
 #include <base/baseTypes.hpp>
 #include <base/utils/ipUtils.hpp>
+#include <cmstore/categories.hpp>
 #include <fastmetrics/registry.hpp>
 
 namespace builder::builders::opfilter
@@ -1900,10 +1901,11 @@ FilterOp opBuilderHelperIndexUnclassifiedEvents(const Reference& targetField,
                                                 const std::vector<OpArg>& opArgs,
                                                 const std::shared_ptr<const IBuildCtx>& buildCtx)
 {
-    if (targetField.jsonPath() != syntax::asset::DECODERS_PATH)
+    if (targetField.jsonPath() != syntax::asset::CATEGORY_PATH)
     {
-        throw std::runtime_error(fmt::format("index_unclassified_events: target field must be 'wazuh.integration.decoders', got '{}'",
-                                             targetField.dotPath()));
+        throw std::runtime_error(
+            fmt::format("index_unclassified_events: target field must be 'wazuh.integration.category', got '{}'",
+                        targetField.dotPath()));
     }
 
     // Assert expected number of parameters
@@ -1914,16 +1916,17 @@ FilterOp opBuilderHelperIndexUnclassifiedEvents(const Reference& targetField,
 
     // Tracing
     const std::string successTrace {
-        fmt::format("[{}] -> Success: Policy index_unclassified_events=true and array has 1 element", name)};
+        fmt::format("[{}] -> Success: Policy index_unclassified_events=true and category is 'unclassified'", name)};
     const std::string failureTrace1 {
         fmt::format("[{}] -> Failure: Target field '{}' not found", name, targetField.dotPath())};
     const std::string failureTrace2 {
-        fmt::format("[{}] -> Failure: Target field '{}' is not an array", name, targetField.dotPath())};
+        fmt::format("[{}] -> Failure: Target field '{}' is not a string", name, targetField.dotPath())};
     const std::string failureTrace3 {fmt::format(
-        "[{}] -> Failure: Policy index_unclassified_events=false or array does not have exactly 1 element", name)};
+        "[{}] -> Failure: Policy index_unclassified_events=false or category is not 'unclassified'", name)};
 
-    return [=, isTestMode = buildCtx->isTestMode(), targetField = targetField.jsonPath()](
-               base::ConstEvent event) -> FilterResult
+    return [=,
+            isTestMode = buildCtx->isTestMode(),
+            targetFieldPP = json::PointerPath(targetField.jsonPath())](base::ConstEvent event) -> FilterResult
     {
         // Check if policy flag is enabled
         if (!policyIndexUnclassified)
@@ -1931,24 +1934,20 @@ FilterOp opBuilderHelperIndexUnclassifiedEvents(const Reference& targetField,
             RETURN_FAILURE(isTestMode, false, failureTrace3);
         }
 
-        // Check if field exists
-        if (!event->exists(targetField))
+        std::string_view category;
+        const auto ret = event->getString(category, targetFieldPP);
+        if (ret == json::RetGet::NotFound)
         {
             RETURN_FAILURE(isTestMode, false, failureTrace1);
         }
-
-        // Check if array has exactly 1 element
-        try
+        if (ret == json::RetGet::WrongType)
         {
-            if (event->size(targetField) == 1)
-            {
-                RETURN_SUCCESS(isTestMode, true, successTrace);
-            }
-        }
-        catch (const std::exception&)
-        {
-            // size() throws if field is not an array, object, or string
             RETURN_FAILURE(isTestMode, false, failureTrace2);
+        }
+
+        if (category == cm::store::categories::UNCLASSIFIED_CATEGORY)
+        {
+            RETURN_SUCCESS(isTestMode, true, successTrace);
         }
 
         RETURN_FAILURE(isTestMode, false, failureTrace3);

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
@@ -1921,12 +1921,11 @@ FilterOp opBuilderHelperIndexUnclassifiedEvents(const Reference& targetField,
         fmt::format("[{}] -> Failure: Target field '{}' not found", name, targetField.dotPath())};
     const std::string failureTrace2 {
         fmt::format("[{}] -> Failure: Target field '{}' is not a string", name, targetField.dotPath())};
-    const std::string failureTrace3 {fmt::format(
-        "[{}] -> Failure: Policy index_unclassified_events=false or category is not 'unclassified'", name)};
+    const std::string failureTrace3 {
+        fmt::format("[{}] -> Failure: Policy index_unclassified_events=false or category is not 'unclassified'", name)};
 
-    return [=,
-            isTestMode = buildCtx->isTestMode(),
-            targetFieldPP = json::PointerPath(targetField.jsonPath())](base::ConstEvent event) -> FilterResult
+    return [=, isTestMode = buildCtx->isTestMode(), targetFieldPP = json::PointerPath(targetField.jsonPath())](
+               base::ConstEvent event) -> FilterResult
     {
         // Check if policy flag is enabled
         if (!policyIndexUnclassified)

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -755,15 +755,15 @@ FilterOp opBuilderHelperArrayLength(const Reference& targetField,
                                     const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
- * @brief Create `index_unclassified_events` helper function that checks policy settings and array size.
+ * @brief Create `index_unclassified_events` helper function that checks policy settings and integration category.
  *
  * This helper returns true if:
  * - The policy has indexUnclassifiedEvents flag set to true AND
- * - $wazuh.integration.decoders has exactly 1 element
+ * - $wazuh.integration.category equals "unclassified"
  *
  * Otherwise, it returns false.
  *
- * @param targetField Reference to $wazuh.integration.decoders. Any other field is rejected at build-time.
+ * @param targetField Reference to $wazuh.integration.category. Any other field is rejected at build-time.
  * @param opArgs Vector of operation arguments (empty for this helper)
  * @param buildCtx Build context containing policy configuration
  * @return FilterOp The filter operation

--- a/src/engine/source/builder/test/src/unit/builders/enrichment/enrichment_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/enrichment/enrichment_test.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <memory>
 #include <string>
@@ -25,19 +25,18 @@ cm::store::dataType::Policy makePolicy(const std::string& originSpace = "testspa
                                        bool indexDiscardedEvents = false,
                                        bool cleanupDecoderVariables = true)
 {
-    return cm::store::dataType::Policy(
-        "Test Policy",                                                       // title
-        true,                                                                // enabled
-        "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",                            // rootDecoder
-        {"b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"},                           // integrations
-        {},                                                                  // filters
-        {},                                                                  // enrichments
-        {},                                                                  // outputs
-        originSpace,                                                         // originSpace
-        "",                                                                  // hash
-        false,                                                               // indexUnclassifiedEvents
-        indexDiscardedEvents,                                                // indexDiscardedEvents
-        cleanupDecoderVariables                                              // cleanupDecoderVariables
+    return cm::store::dataType::Policy("Test Policy",                            // title
+                                       true,                                     // enabled
+                                       "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",   // rootDecoder
+                                       {"b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"}, // integrations
+                                       {},                                       // filters
+                                       {},                                       // enrichments
+                                       {},                                       // outputs
+                                       originSpace,                              // originSpace
+                                       "",                                       // hash
+                                       false,                                    // indexUnclassifiedEvents
+                                       indexDiscardedEvents,                     // indexDiscardedEvents
+                                       cleanupDecoderVariables                   // cleanupDecoderVariables
     );
 }
 
@@ -371,10 +370,9 @@ protected:
 // Inner expression succeeds => counter not incremented
 TEST_F(FilterDiscardCounterTest, InnerSuccessNoIncrement)
 {
-    auto innerTerm = base::Term<base::EngineOp>::create(
-        "inner",
-        [](base::Event event) -> base::result::Result<base::Event>
-        { return base::result::makeSuccess<base::Event>(event); });
+    auto innerTerm = base::Term<base::EngineOp>::create("inner",
+                                                        [](base::Event event) -> base::result::Result<base::Event>
+                                                        { return base::result::makeSuccess<base::Event>(event); });
 
     auto expr = makeFilterDiscardCounter(innerTerm, mockCounter, "testWrapper");
 
@@ -387,10 +385,9 @@ TEST_F(FilterDiscardCounterTest, InnerSuccessNoIncrement)
 // Inner expression fails => counter incremented, result is failure
 TEST_F(FilterDiscardCounterTest, InnerFailureIncrementsCounter)
 {
-    auto innerTerm = base::Term<base::EngineOp>::create(
-        "inner",
-        [](base::Event event) -> base::result::Result<base::Event>
-        { return base::result::makeFailure<base::Event>(event); });
+    auto innerTerm = base::Term<base::EngineOp>::create("inner",
+                                                        [](base::Event event) -> base::result::Result<base::Event>
+                                                        { return base::result::makeFailure<base::Event>(event); });
 
     auto expr = makeFilterDiscardCounter(innerTerm, mockCounter, "testWrapper");
 

--- a/src/engine/source/builder/test/src/unit/builders/enrichment/enrichment_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/enrichment/enrichment_test.cpp
@@ -248,7 +248,7 @@ protected:
 };
 
 // Category != "unclassified" => no increment
-TEST_F(UnclassifiedCounterTest, MultipleDecodersNoIncrement)
+TEST_F(UnclassifiedCounterTest, ClassifiedCategoryNoIncrement)
 {
     auto expr = postOutputUnclassifiedCounter("space1", mockCounter);
 
@@ -259,7 +259,7 @@ TEST_F(UnclassifiedCounterTest, MultipleDecodersNoIncrement)
 }
 
 // Category == "unclassified" => increment
-TEST_F(UnclassifiedCounterTest, SingleDecoderIncrements)
+TEST_F(UnclassifiedCounterTest, UnclassifiedCategoryIncrements)
 {
     auto expr = postOutputUnclassifiedCounter("space1", mockCounter);
 
@@ -270,7 +270,7 @@ TEST_F(UnclassifiedCounterTest, SingleDecoderIncrements)
 }
 
 // No category field => no crash, no increment
-TEST_F(UnclassifiedCounterTest, NoDecodersFieldNoCrash)
+TEST_F(UnclassifiedCounterTest, NoCategoryFieldNoCrash)
 {
     auto expr = postOutputUnclassifiedCounter("space1", mockCounter);
 

--- a/src/engine/source/builder/test/src/unit/builders/enrichment/enrichment_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/enrichment/enrichment_test.cpp
@@ -248,29 +248,29 @@ protected:
     void TearDown() override { SingletonLocator::unregisterManager<fastmetrics::IManager>(); }
 };
 
-// More than 1 decoder => no increment
+// Category != "unclassified" => no increment
 TEST_F(UnclassifiedCounterTest, MultipleDecodersNoIncrement)
 {
     auto expr = postOutputUnclassifiedCounter("space1", mockCounter);
 
-    auto event = makeEvent(R"({"wazuh":{"integration":{"decoders":["dec1","dec2"]}}})");
+    auto event = makeEvent(R"({"wazuh":{"integration":{"category":"security"}}})");
     EXPECT_CALL(*mockCounter, add(_)).Times(0);
     auto result = evalTerm(expr, event);
     EXPECT_TRUE(result.success());
 }
 
-// Exactly 1 decoder => increment
+// Category == "unclassified" => increment
 TEST_F(UnclassifiedCounterTest, SingleDecoderIncrements)
 {
     auto expr = postOutputUnclassifiedCounter("space1", mockCounter);
 
-    auto event = makeEvent(R"({"wazuh":{"integration":{"decoders":["dec1"]}}})");
+    auto event = makeEvent(R"({"wazuh":{"integration":{"category":"unclassified"}}})");
     EXPECT_CALL(*mockCounter, add(1)).Times(1);
     auto result = evalTerm(expr, event);
     EXPECT_TRUE(result.success());
 }
 
-// No decoders field => no crash, no increment
+// No category field => no crash, no increment
 TEST_F(UnclassifiedCounterTest, NoDecodersFieldNoCrash)
 {
     auto expr = postOutputUnclassifiedCounter("space1", mockCounter);

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/indexUnclassifiedEvents_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/indexUnclassifiedEvents_test.cpp
@@ -69,72 +69,71 @@ TEST_F(IndexUnclassifiedEventsBuildTest, RejectsReferenceArgument)
 
 namespace filteroperatestest
 {
-INSTANTIATE_TEST_SUITE_P(
-    Builders,
-    FilterOperationTest,
-    testing::Values(
-        /*** Index Unclassified Events - Tests with policy disabled (default) ***/
-        // Policy disabled, category unclassified - should fail
-        FilterT(R"({"wazuh": {"integration": {"category": "unclassified"}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(false))),
-        // Policy disabled, category security - should fail
-        FilterT(R"({"wazuh": {"integration": {"category": "security"}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(false))),
-        // Policy disabled, category missing - should fail
-        FilterT(R"({"wazuh": {"integration": {}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(false))),
-        /*** Index Unclassified Events - Tests with policy enabled ***/
-        // Policy enabled, category unclassified - should succeed
-        FilterT(R"({"wazuh": {"integration": {"category": "unclassified"}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                SUCCESS(contextExpected(true))),
-        // Policy enabled, category security - should fail
-        FilterT(R"({"wazuh": {"integration": {"category": "security"}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(true))),
-        // Policy enabled, category system-activity - should fail
-        FilterT(R"({"wazuh": {"integration": {"category": "system-activity"}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(true))),
-        /*** Index Unclassified Events - Error cases ***/
-        // Policy enabled, category field missing - should fail (not found)
-        FilterT(R"({"wazuh": {"integration": {}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(true))),
-        // Policy enabled, completely unrelated event - should fail (not found)
-        FilterT(R"({"other": "x"})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(true))),
-        // Policy enabled, category is not a string (number) - should fail (wrong type)
-        FilterT(R"({"wazuh": {"integration": {"category": 123}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(true))),
-        // Policy enabled, category is not a string (array) - should fail (wrong type)
-        FilterT(R"({"wazuh": {"integration": {"category": ["unclassified"]}}})",
-                opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                "wazuh.integration.category",
-                {},
-                FAILURE(contextExpected(true)))),
-    testNameFormatter<FilterOperationTest>("IndexUnclassifiedEvents"));
+INSTANTIATE_TEST_SUITE_P(Builders,
+                         FilterOperationTest,
+                         testing::Values(
+                             /*** Index Unclassified Events - Tests with policy disabled (default) ***/
+                             // Policy disabled, category unclassified - should fail
+                             FilterT(R"({"wazuh": {"integration": {"category": "unclassified"}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(false))),
+                             // Policy disabled, category security - should fail
+                             FilterT(R"({"wazuh": {"integration": {"category": "security"}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(false))),
+                             // Policy disabled, category missing - should fail
+                             FilterT(R"({"wazuh": {"integration": {}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(false))),
+                             /*** Index Unclassified Events - Tests with policy enabled ***/
+                             // Policy enabled, category unclassified - should succeed
+                             FilterT(R"({"wazuh": {"integration": {"category": "unclassified"}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     SUCCESS(contextExpected(true))),
+                             // Policy enabled, category security - should fail
+                             FilterT(R"({"wazuh": {"integration": {"category": "security"}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(true))),
+                             // Policy enabled, category system-activity - should fail
+                             FilterT(R"({"wazuh": {"integration": {"category": "system-activity"}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(true))),
+                             /*** Index Unclassified Events - Error cases ***/
+                             // Policy enabled, category field missing - should fail (not found)
+                             FilterT(R"({"wazuh": {"integration": {}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(true))),
+                             // Policy enabled, completely unrelated event - should fail (not found)
+                             FilterT(R"({"other": "x"})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(true))),
+                             // Policy enabled, category is not a string (number) - should fail (wrong type)
+                             FilterT(R"({"wazuh": {"integration": {"category": 123}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(true))),
+                             // Policy enabled, category is not a string (array) - should fail (wrong type)
+                             FilterT(R"({"wazuh": {"integration": {"category": ["unclassified"]}}})",
+                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                                     "wazuh.integration.category",
+                                     {},
+                                     FAILURE(contextExpected(true)))),
+                         testNameFormatter<FilterOperationTest>("IndexUnclassifiedEvents"));
 } // namespace filteroperatestest

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/indexUnclassifiedEvents_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/indexUnclassifiedEvents_test.cpp
@@ -29,9 +29,9 @@ class IndexUnclassifiedEventsBuildTest : public BaseBuilderTest
 {
 };
 
-TEST_F(IndexUnclassifiedEventsBuildTest, BuildsWithDecodersField)
+TEST_F(IndexUnclassifiedEventsBuildTest, BuildsWithCategoryField)
 {
-    Reference targetField {"wazuh.integration.decoders"};
+    Reference targetField {"wazuh.integration.category"};
 
     contextExpected(true)(*mocks);
     expectBuildSuccess();
@@ -41,14 +41,18 @@ TEST_F(IndexUnclassifiedEventsBuildTest, BuildsWithDecodersField)
 
 TEST_F(IndexUnclassifiedEventsBuildTest, RejectsUnexpectedTargetField)
 {
-    Reference targetField {"targetField"};
-
-    ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {}, mocks->ctx), std::exception);
+    // Any field other than wazuh.integration.category must be rejected at build-time.
+    for (const auto& path : {"targetField", "wazuh.integration.decoders", "wazuh.integration.name"})
+    {
+        Reference targetField {path};
+        ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {}, mocks->ctx), std::exception)
+            << "Expected throw for target field: " << path;
+    }
 }
 
 TEST_F(IndexUnclassifiedEventsBuildTest, RejectsValueArgument)
 {
-    Reference targetField {"wazuh.integration.decoders"};
+    Reference targetField {"wazuh.integration.category"};
 
     ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {makeValue(R"(1)")}, mocks->ctx),
                  std::exception);
@@ -56,7 +60,7 @@ TEST_F(IndexUnclassifiedEventsBuildTest, RejectsValueArgument)
 
 TEST_F(IndexUnclassifiedEventsBuildTest, RejectsReferenceArgument)
 {
-    Reference targetField {"wazuh.integration.decoders"};
+    Reference targetField {"wazuh.integration.category"};
 
     ASSERT_THROW(opfilter::opBuilderHelperIndexUnclassifiedEvents(targetField, {makeRef("ref")}, mocks->ctx),
                  std::exception);
@@ -65,65 +69,72 @@ TEST_F(IndexUnclassifiedEventsBuildTest, RejectsReferenceArgument)
 
 namespace filteroperatestest
 {
-INSTANTIATE_TEST_SUITE_P(Builders,
-                         FilterOperationTest,
-                         testing::Values(
-                             /*** Index Unclassified Events - Tests with policy disabled (default) ***/
-                             // Policy disabled, array size 1 - should fail
-                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1"]}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(false))),
-                             // Policy disabled, array size 2 - should fail
-                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1", "decoder2"]}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(false))),
-                             // Policy disabled, empty array - should fail
-                             FilterT(R"({"wazuh": {"integration": {"decoders": []}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(false))),
-                             /*** Index Unclassified Events - Tests with policy enabled ***/
-                             // Policy enabled, array size 1 - should succeed
-                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1"]}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     SUCCESS(contextExpected(true))),
-                             // Policy enabled, array size 2 - should fail
-                             FilterT(R"({"wazuh": {"integration": {"decoders": ["decoder1", "decoder2"]}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(true))),
-                             // Policy enabled, empty array - should fail
-                             FilterT(R"({"wazuh": {"integration": {"decoders": []}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(true))),
-                             // Policy enabled, array size 3 - should fail
-                             FilterT(R"({"wazuh": {"integration": {"decoders": ["d1", "d2", "d3"]}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(true))),
-                             /*** Index Unclassified Events - Error cases ***/
-                             // Test with non-existent field (policy enabled)
-                             FilterT(R"({"other": ["decoder"]})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(true))),
-                             // Test with non-array field (policy enabled)
-                             FilterT(R"({"wazuh": {"integration": {"decoders": "decoder"}}})",
-                                     opfilter::opBuilderHelperIndexUnclassifiedEvents,
-                                     "wazuh.integration.decoders",
-                                     {},
-                                     FAILURE(contextExpected(true)))),
-                         testNameFormatter<FilterOperationTest>("IndexUnclassifiedEvents"));
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    FilterOperationTest,
+    testing::Values(
+        /*** Index Unclassified Events - Tests with policy disabled (default) ***/
+        // Policy disabled, category unclassified - should fail
+        FilterT(R"({"wazuh": {"integration": {"category": "unclassified"}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(false))),
+        // Policy disabled, category security - should fail
+        FilterT(R"({"wazuh": {"integration": {"category": "security"}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(false))),
+        // Policy disabled, category missing - should fail
+        FilterT(R"({"wazuh": {"integration": {}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(false))),
+        /*** Index Unclassified Events - Tests with policy enabled ***/
+        // Policy enabled, category unclassified - should succeed
+        FilterT(R"({"wazuh": {"integration": {"category": "unclassified"}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                SUCCESS(contextExpected(true))),
+        // Policy enabled, category security - should fail
+        FilterT(R"({"wazuh": {"integration": {"category": "security"}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(true))),
+        // Policy enabled, category system-activity - should fail
+        FilterT(R"({"wazuh": {"integration": {"category": "system-activity"}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(true))),
+        /*** Index Unclassified Events - Error cases ***/
+        // Policy enabled, category field missing - should fail (not found)
+        FilterT(R"({"wazuh": {"integration": {}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(true))),
+        // Policy enabled, completely unrelated event - should fail (not found)
+        FilterT(R"({"other": "x"})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(true))),
+        // Policy enabled, category is not a string (number) - should fail (wrong type)
+        FilterT(R"({"wazuh": {"integration": {"category": 123}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(true))),
+        // Policy enabled, category is not a string (array) - should fail (wrong type)
+        FilterT(R"({"wazuh": {"integration": {"category": ["unclassified"]}}})",
+                opfilter::opBuilderHelperIndexUnclassifiedEvents,
+                "wazuh.integration.category",
+                {},
+                FAILURE(contextExpected(true)))),
+    testNameFormatter<FilterOperationTest>("IndexUnclassifiedEvents"));
 } // namespace filteroperatestest

--- a/src/engine/source/cmstore/interface/cmstore/categories.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/categories.hpp
@@ -23,13 +23,13 @@ inline constexpr std::string_view UNCLASSIFIED_CATEGORY = "unclassified";
  * in the CMStore system. Any integration or asset should belong to one of these categories.
  */
 inline constexpr std::array<std::string_view, 8> AVAILABLE_CATEGORIES = {"access-management",
-                                                                        "applications",
-                                                                        "cloud-services",
-                                                                        "network-activity",
-                                                                        "other",
-                                                                        "security",
-                                                                        "system-activity",
-                                                                        UNCLASSIFIED_CATEGORY};
+                                                                         "applications",
+                                                                         "cloud-services",
+                                                                         "network-activity",
+                                                                         "other",
+                                                                         "security",
+                                                                         "system-activity",
+                                                                         UNCLASSIFIED_CATEGORY};
 
 /**
  * @brief Get all available categories and their indexes in the namespace

--- a/src/engine/source/cmstore/interface/cmstore/categories.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/categories.hpp
@@ -8,13 +8,28 @@ namespace cm::store::categories
 {
 
 /**
+ * @brief Special category for unclassified events.
+ *
+ * Events are tagged with this category by the root decoder when no integration
+ * decoder matches. Output routing and metrics behavior for these events depend
+ * on the policy flag `index_unclassified_events`.
+ */
+inline constexpr std::string_view UNCLASSIFIED_CATEGORY = "unclassified";
+
+/**
  * @brief Available Categories and their Indexes
  *
  * This map defines the available categories
  * in the CMStore system. Any integration or asset should belong to one of these categories.
  */
-inline constexpr std::array<std::string_view, 7> AVAILABLE_CATEGORIES = {
-    "access-management", "applications", "cloud-services", "network-activity", "other", "security", "system-activity"};
+inline constexpr std::array<std::string_view, 8> AVAILABLE_CATEGORIES = {"access-management",
+                                                                        "applications",
+                                                                        "cloud-services",
+                                                                        "network-activity",
+                                                                        "other",
+                                                                        "security",
+                                                                        "system-activity",
+                                                                        UNCLASSIFIED_CATEGORY};
 
 /**
  * @brief Get all available categories and their indexes in the namespace

--- a/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
+++ b/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
@@ -81,7 +81,8 @@ TEST_F(CMStoreNSJsonTest, JsonResourcesOnDiskAreLoadedDuringStoreInitialization)
     const auto jsonPath = m_root / "decoders" / "decoder_syslog_0.json";
     std::ofstream jsonFile(jsonPath);
     ASSERT_TRUE(jsonFile.is_open());
-    jsonFile << R"({"name":"decoder/syslog/0","id":"3f086ce2-32a4-42b0-be7e-40dcfb9c6160","metadata":{"module":"syslog"}})";
+    jsonFile
+        << R"({"name":"decoder/syslog/0","id":"3f086ce2-32a4-42b0-be7e-40dcfb9c6160","metadata":{"module":"syslog"}})";
     jsonFile.close();
 
     cm::store::CMStoreNS store {cm::store::NamespaceId("test"), m_root, m_outputs};
@@ -337,16 +338,15 @@ TEST(IntegrationTest, ConstructorEmptyCategoryThrows)
 
 TEST(IntegrationTest, ConstructorInvalidCategoryThrows)
 {
-    EXPECT_THROW(
-        cm::store::dataType::Integration(validUUID(), "name", true, "invalid_category", std::nullopt, {}, {}),
-        std::runtime_error);
+    EXPECT_THROW(cm::store::dataType::Integration(validUUID(), "name", true, "invalid_category", std::nullopt, {}, {}),
+                 std::runtime_error);
 }
 
 TEST(IntegrationTest, ConstructorInvalidDefaultParentThrows)
 {
-    EXPECT_THROW(cm::store::dataType::Integration(
-                     validUUID(), "name", true, "security", std::string("not-a-uuid"), {}, {}),
-                 std::runtime_error);
+    EXPECT_THROW(
+        cm::store::dataType::Integration(validUUID(), "name", true, "security", std::string("not-a-uuid"), {}, {}),
+        std::runtime_error);
 }
 
 TEST(IntegrationTest, ConstructorDuplicateDecoderUUIDsThrows)
@@ -650,16 +650,17 @@ TEST_F(CMStoreNSTest, CreateDuplicateNameThrows)
     auto store = makeStore();
 
     store->createResource("decoder/test/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/test/0"));
-    EXPECT_THROW(store->createResource("decoder/test/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/test/0")),
-                 std::runtime_error);
+    EXPECT_THROW(
+        store->createResource("decoder/test/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/test/0")),
+        std::runtime_error);
 }
 
 TEST_F(CMStoreNSTest, ResolveUUIDFromName)
 {
     auto store = makeStore();
 
-    auto uuid =
-        store->createResource("filter/myfilter/0", cm::store::ResourceType::FILTER, makeFilterJson("filter/myfilter/0"));
+    auto uuid = store->createResource(
+        "filter/myfilter/0", cm::store::ResourceType::FILTER, makeFilterJson("filter/myfilter/0"));
     auto resolved = store->resolveUUIDFromName("filter/myfilter/0", cm::store::ResourceType::FILTER);
     EXPECT_EQ(uuid, resolved);
 }
@@ -842,8 +843,7 @@ TEST_F(CMStoreNSTest, CreateAndGetIntegration)
 
     auto uuid = store->createResource("test_integration",
                                       cm::store::ResourceType::INTEGRATION,
-                                      makeIntegrationJson("test_integration",
-                                                          "f47ac10b-58cc-4372-a567-0e02b2c3d479"));
+                                      makeIntegrationJson("test_integration", "f47ac10b-58cc-4372-a567-0e02b2c3d479"));
     EXPECT_FALSE(uuid.empty());
 
     auto integration = store->getIntegrationByName("test_integration");
@@ -873,9 +873,8 @@ TEST_F(CMStoreNSTest, CreateAndGetKVDB)
 {
     auto store = makeStore();
 
-    auto uuid = store->createResource("test_kvdb",
-                                      cm::store::ResourceType::KVDB,
-                                      makeKVDBJson("test_kvdb", "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"));
+    auto uuid = store->createResource(
+        "test_kvdb", cm::store::ResourceType::KVDB, makeKVDBJson("test_kvdb", "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"));
     EXPECT_FALSE(uuid.empty());
 
     auto kvdb = store->getKVDBByName("test_kvdb");
@@ -1146,8 +1145,7 @@ TEST(KVDBTest, ConstructorInvalidUUIDThrows)
 {
     json::Json content;
     content.setString("v", "/k");
-    EXPECT_THROW(cm::store::dataType::KVDB("not-a-uuid", "name", std::move(content), true, true),
-                 std::runtime_error);
+    EXPECT_THROW(cm::store::dataType::KVDB("not-a-uuid", "name", std::move(content), true, true), std::runtime_error);
 }
 
 TEST(KVDBTest, ConstructorEmptyNameThrows)
@@ -1294,72 +1292,32 @@ TEST(PolicyTest, ConstructorValidData)
 
 TEST(PolicyTest, ConstructorInvalidOriginSpaceThrows)
 {
-    EXPECT_THROW(cm::store::dataType::Policy("title",
-                                             true,
-                                             validUUID(),
-                                             {},
-                                             {},
-                                             {},
-                                             {},
-                                             "invalid space!",
-                                             "",
-                                             false,
-                                             false,
-                                             true),
+    EXPECT_THROW(cm::store::dataType::Policy(
+                     "title", true, validUUID(), {}, {}, {}, {}, "invalid space!", "", false, false, true),
                  std::runtime_error);
 }
 
 TEST(PolicyTest, ConstructorDuplicateIntegrationsThrows)
 {
     const std::string uuid = validUUID();
-    EXPECT_THROW(cm::store::dataType::Policy("title",
-                                             true,
-                                             validUUID(),
-                                             {uuid, uuid},
-                                             {},
-                                             {},
-                                             {},
-                                             "UNDEFINED",
-                                             "",
-                                             false,
-                                             false,
-                                             true),
+    EXPECT_THROW(cm::store::dataType::Policy(
+                     "title", true, validUUID(), {uuid, uuid}, {}, {}, {}, "UNDEFINED", "", false, false, true),
                  std::runtime_error);
 }
 
 TEST(PolicyTest, ConstructorDuplicateFiltersThrows)
 {
     const std::string uuid = validUUID();
-    EXPECT_THROW(cm::store::dataType::Policy("title",
-                                             true,
-                                             validUUID(),
-                                             {},
-                                             {uuid, uuid},
-                                             {},
-                                             {},
-                                             "UNDEFINED",
-                                             "",
-                                             false,
-                                             false,
-                                             true),
+    EXPECT_THROW(cm::store::dataType::Policy(
+                     "title", true, validUUID(), {}, {uuid, uuid}, {}, {}, "UNDEFINED", "", false, false, true),
                  std::runtime_error);
 }
 
 TEST(PolicyTest, ConstructorDuplicateOutputsThrows)
 {
     const std::string uuid = validUUID();
-    EXPECT_THROW(cm::store::dataType::Policy("title",
-                                             true,
-                                             validUUID(),
-                                             {},
-                                             {},
-                                             {},
-                                             {uuid, uuid},
-                                             "UNDEFINED",
-                                             "",
-                                             false,
-                                             false,
-                                             true),
+    EXPECT_THROW(cm::store::dataType::Policy(
+                     "title", true, validUUID(), {}, {}, {}, {uuid, uuid}, "UNDEFINED", "", false, false, true),
                  std::runtime_error);
 }
 
@@ -1825,16 +1783,14 @@ TEST_F(CMStoreNSTest, CreateResourceWithNonObjectContentThrows)
 {
     auto store = makeStore();
     json::Json arrayJson("[]");
-    EXPECT_THROW(store->createResource("decoder/x/0", cm::store::ResourceType::DECODER, arrayJson),
-                 std::runtime_error);
+    EXPECT_THROW(store->createResource("decoder/x/0", cm::store::ResourceType::DECODER, arrayJson), std::runtime_error);
 }
 
 TEST_F(CMStoreNSTest, CreateResourceWithInvalidNameThrows)
 {
     auto store = makeStore();
     auto j = makeDecoderJson("decoder/with*star/0");
-    EXPECT_THROW(store->createResource("decoder/with*star/0", cm::store::ResourceType::DECODER, j),
-                 std::runtime_error);
+    EXPECT_THROW(store->createResource("decoder/with*star/0", cm::store::ResourceType::DECODER, j), std::runtime_error);
 }
 
 TEST_F(CMStoreNSTest, CreateResourceWithUndefinedTypeThrows)
@@ -1872,23 +1828,22 @@ TEST_F(CMStoreNSTest, CreateResourceFailsWhenFilePathBlockedByDirectory)
 TEST_F(CMStoreNSTest, UpdateResourceByNameFailsWhenWriteFails)
 {
     auto store = makeStore();
-    const auto uuid = store->createResource(
-        "decoder/upd/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/upd/0"));
+    const auto uuid =
+        store->createResource("decoder/upd/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/upd/0"));
 
     const auto path = storagePath() / "decoders" / "decoder_upd_0.json";
     std::filesystem::remove(path);
     std::filesystem::create_directories(path);
 
     auto j = makeDecoderJson("decoder/upd/0", uuid);
-    EXPECT_THROW(store->updateResourceByName("decoder/upd/0", cm::store::ResourceType::DECODER, j),
-                 std::runtime_error);
+    EXPECT_THROW(store->updateResourceByName("decoder/upd/0", cm::store::ResourceType::DECODER, j), std::runtime_error);
 }
 
 TEST_F(CMStoreNSTest, UpdateResourceByUUIDFailsWhenWriteFails)
 {
     auto store = makeStore();
-    const auto uuid = store->createResource(
-        "decoder/upd2/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/upd2/0"));
+    const auto uuid =
+        store->createResource("decoder/upd2/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/upd2/0"));
 
     const auto path = storagePath() / "decoders" / "decoder_upd2_0.json";
     std::filesystem::remove(path);
@@ -1907,8 +1862,7 @@ TEST_F(CMStoreNSTest, DeleteResourceByNameFailsWhenPathIsNonEmptyDir)
     std::filesystem::remove(path);
     std::filesystem::create_directories(path / "blocker");
 
-    EXPECT_THROW(store->deleteResourceByName("decoder/del/0", cm::store::ResourceType::DECODER),
-                 std::runtime_error);
+    EXPECT_THROW(store->deleteResourceByName("decoder/del/0", cm::store::ResourceType::DECODER), std::runtime_error);
 }
 
 TEST_F(CMStoreNSTest, DeleteResourceByUUIDFailsWhenPathIsNonEmptyDir)
@@ -1949,10 +1903,9 @@ TEST_F(CMStoreNSTest, UpsertPolicyFailsWhenFilePathBlockedByDirectory)
     auto store = makeStore();
     std::filesystem::create_directories(storagePath() / "policy.json");
 
-    EXPECT_THROW(
-        store->upsertPolicy(
-            cm::store::dataType::Policy {"title", true, validUUID(), {}, {}, {}, {}, "UNDEFINED", "", false, false, true}),
-        std::runtime_error);
+    EXPECT_THROW(store->upsertPolicy(cm::store::dataType::Policy {
+                     "title", true, validUUID(), {}, {}, {}, {}, "UNDEFINED", "", false, false, true}),
+                 std::runtime_error);
 }
 
 TEST_F(CMStoreNSTest, DeletePolicyFailsWhenPathIsNonEmptyDir)
@@ -2030,9 +1983,8 @@ TEST_F(CMStoreNSTest, TemplateGetResourceByNameWorksForSupportedTypes)
 {
     auto store = makeStore();
 
-    store->createResource("decoder/template/0",
-                          cm::store::ResourceType::DECODER,
-                          makeDecoderJson("decoder/template/0"));
+    store->createResource(
+        "decoder/template/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/template/0"));
     store->createResource("templ_integration",
                           cm::store::ResourceType::INTEGRATION,
                           makeIntegrationJson("templ_integration", validUUID()));
@@ -2055,14 +2007,13 @@ TEST_F(CMStoreNSTest, TemplateGetResourceByUUIDWorksForSupportedTypes)
 {
     auto store = makeStore();
 
-    const auto assetUUID = store->createResource("decoder/templateuuid/0",
-                                                 cm::store::ResourceType::DECODER,
-                                                 makeDecoderJson("decoder/templateuuid/0"));
+    const auto assetUUID = store->createResource(
+        "decoder/templateuuid/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/templateuuid/0"));
     const auto integrationUUID = store->createResource("templ_uuid_integration",
                                                        cm::store::ResourceType::INTEGRATION,
                                                        makeIntegrationJson("templ_uuid_integration", validUUID()));
-    const auto kvdbUUID =
-        store->createResource("templ_uuid_kvdb", cm::store::ResourceType::KVDB, makeKVDBJson("templ_uuid_kvdb", validUUID()));
+    const auto kvdbUUID = store->createResource(
+        "templ_uuid_kvdb", cm::store::ResourceType::KVDB, makeKVDBJson("templ_uuid_kvdb", validUUID()));
 
     const auto& reader = static_cast<const cm::store::ICMStoreNSReader&>(*store);
 

--- a/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
+++ b/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
@@ -558,6 +558,7 @@ TEST(CategoriesTest, ExistingCategoriesFound)
 {
     EXPECT_TRUE(cm::store::categories::exists("security"));
     EXPECT_TRUE(cm::store::categories::exists("network-activity"));
+    EXPECT_TRUE(cm::store::categories::exists("unclassified"));
 }
 
 TEST(CategoriesTest, UnknownCategoryNotFound)
@@ -569,7 +570,7 @@ TEST(CategoriesTest, UnknownCategoryNotFound)
 TEST(CategoriesTest, GetAvailableCategoriesNonEmpty)
 {
     const auto& cats = cm::store::categories::getAvailableCategories();
-    EXPECT_EQ(cats.size(), 7U);
+    EXPECT_EQ(cats.size(), 8U);
 }
 
 // ======================================================================

--- a/src/engine/test/helper_tests/helpers_description/filter/index_unclassified_events.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/index_unclassified_events.yml
@@ -6,17 +6,18 @@ metadata:
     Determines whether unclassified events should be indexed based on policy configuration.
     This filter returns true if and only if:
     1. The policy flag 'indexUnclassifiedEvents' is enabled (configured at build time)
-    2. The target field is exactly 'wazuh.integration.decoders'
-    3. 'wazuh.integration.decoders' is an array containing exactly 1 element
+    2. The target field is exactly 'wazuh.integration.category'
+    3. 'wazuh.integration.category' equals the string "unclassified"
 
-    This helper is used in output routing to decide whether to index events that have only
-    one decoder (unclassified events) when the policy allows it. If the policy flag is
-    disabled or the array has a different size, the validation fails.
+    This helper is used in output routing to decide whether to index events that the
+    root decoder tagged as unclassified (no integration decoder matched) when the
+    policy allows it. If the policy flag is disabled, the category differs from
+    "unclassified", or the field is missing / not a string, the validation fails.
 
     Note: This helper does not accept any arguments, rejects any target field other than
-    'wazuh.integration.decoders', and depends on the policy context configured at build time.
+    'wazuh.integration.category', and depends on the policy context configured at build time.
   keywords:
-    - array
+    - string
     - policy
 
 helper_type: filter
@@ -24,32 +25,32 @@ helper_type: filter
 # Indicates whether the helper function supports a variable number of arguments
 is_variadic: false
 
-# No arguments - this helper only checks the array size and policy flag
+# No arguments - this helper only checks the category value and policy flag
 arguments: {}
 
 target_field:
-  type: array
-  generate: all
-  path: wazuh.integration.decoders
+  type: string
+  generate: string
+  path: wazuh.integration.category
 
 # Note: These tests assume the policy flag 'indexUnclassifiedEvents' is enabled in the test environment.
 # In production, this flag is configured per policy and evaluated at build time.
 test:
-  - target_field: ["single_decoder"]
+  - target_field: "unclassified"
     should_pass: true
-    description: Array with exactly one element (unclassified event)
-  - target_field: []
+    description: Category equals "unclassified" (event tagged by the root decoder)
+  - target_field: "security"
     should_pass: false
-    description: Empty array - not an unclassified event
-  - target_field: ["decoder1", "decoder2"]
+    description: Category is a known one different from "unclassified"
+  - target_field: "system-activity"
     should_pass: false
-    description: Array with two elements - classified event
-  - target_field: ["d1", "d2", "d3"]
+    description: Category is a known one different from "unclassified"
+  - target_field: ""
     should_pass: false
-    description: Array with three elements - classified event
-  - target_field: "not_an_array"
-    should_pass: false
-    description: Target field is not an array
+    description: Category is an empty string
   - target_field: 42
     should_pass: false
-    description: Target field is a number, not an array
+    description: Target field is a number, not a string
+  - target_field: ["unclassified"]
+    should_pass: false
+    description: Target field is an array, not a string

--- a/src/engine/test/integration_tests/engine-it/src/integration_test/initial_state.py
+++ b/src/engine/test/integration_tests/engine-it/src/integration_test/initial_state.py
@@ -310,7 +310,7 @@ def init_cm_resources(api_client: APIClient):
         integ_uuid=INTEG_WAZUH_CORE_UUID,
         integ_title="wazuh-core-test",
         default_parent=DECODER_TEST_UUID,
-        category="other",
+        category="unclassified",
         decoder_uuid=DECODER_TEST_UUID,
     )
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Closes #36472

Related: #34519, #35120, #35542, #36339

Re-introduces the `"unclassified"` integration category (partially reverting
PR #35542) and changes the `index_unclassified_events` helper + the
`postOutputUnclassifiedCounter` metric so they decide based on
`wazuh.integration.category == "unclassified"` instead of on the size of the
`wazuh.integration.decoders` array.

The pre-enrichment pipeline filter `getUnclassifiedFilter` removed by
PR #35542 is **intentionally NOT re-introduced**: the only gate for
unclassified routing remains at the output stage, via the helper.


## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- The decoder-count heuristic (`decoders.size() == 1`) introduced in #35120 /
  #35542 is fragile: any integration that legitimately produces a single
  decoder hit was being mis-routed as "unclassified".
- The category field is the source of truth that integrations already declare
  and that the root decoder tags when no integration matches.
- Routing by `${wazuh.integration.category}` (the second branch of
  `indexer.yml`) is consistent with how every other category is indexed.


### Engine — core
- `cmstore/interface/cmstore/categories.hpp`
  - New named constant `cm::store::categories::UNCLASSIFIED_CATEGORY = "unclassified"`.
  - `AVAILABLE_CATEGORIES` grown from `array<…,7>` to `array<…,8>` and
    `UNCLASSIFIED_CATEGORY` appended; `categories::exists("unclassified")`
    now returns `true`, so integrations declaring `category: unclassified`
    validate again.
- `builder/.../opfilter/opBuilderHelperFilter.{cpp,hpp}` —
  `opBuilderHelperIndexUnclassifiedEvents`
  - Target field is now `wazuh.integration.category` (rejects any other
    path at build time, including the previous `wazuh.integration.decoders`).
  - Runtime returns `SUCCESS` iff
    `policy.index_unclassified_events == true` **and**
    `wazuh.integration.category == "unclassified"`.
  - Distinct failure traces for: policy disabled / wrong category, target
    field not found, target field wrong type.
  - Doxygen / header description updated accordingly.
- `builder/.../enrichment/enrichment.cpp` —
  `postOutputUnclassifiedCounter`
  - Counter now increments when `wazuh.integration.category == "unclassified"`.
  - Reads via `event->getString(...)` + `PointerPath` of
    `syntax::asset::CATEGORY_PATH`; no `try/catch` needed.

### Ruleset
- `ruleset/outputs/indexer.yml`
  - First branch: `check: index_unclassified_events($wazuh.integration.category)`
    → routes to `wazuh-events-v5-unclassified`.
  - Unconditional fallback: routes to `wazuh-events-v5-${wazuh.integration.category}`.
  - Inline `TODO` left to re-evaluate whether the fallback should refuse to
    route events when category is missing or when the policy flag is `false`.

### Tests
- `cmstore_test.cpp`
  - `CategoriesTest.ExistingCategoriesFound`: asserts
    `exists("unclassified")` again.
  - `CategoriesTest.GetAvailableCategoriesNonEmpty`: expects `cats.size() == 8U`.
- `indexUnclassifiedEvents_test.cpp` — rewritten:
  - Build tests target `wazuh.integration.category`, reject every other
    path (including the legacy `wazuh.integration.decoders`).

- `enrichment_test.cpp`
  - Coverage added for: category != `"unclassified"` (no increment),
    category == `"unclassified"` (increment by 1), and missing category
    field (no crash, no increment).
- `policy/factory_test.cpp` — intentionally unchanged: confirms that the
  pre-enrichment layout `{originSpace, discarded, cleanupVars}` (size 3)
  introduced by #35542 is preserved — the `unclassified` filter is **not**
  re-added.


### Results and Evidence

<img width="1903" height="944" alt="Screenshot From 2026-06-02 13-36-11" src="https://github.com/user-attachments/assets/a6d1ef1c-e233-4d5b-b487-f7cb7caab180" />
<img width="1903" height="944" alt="Screenshot From 2026-06-02 13-27-04" src="https://github.com/user-attachments/assets/8e72dbe1-60f0-4d85-9875-e072b16d4980" />


  * stats
 
  ```console
 (venv) ╭─root@ab0fc00f16c6 /workspaces/devContainer 
╰─# engine-metrics get space.standard.events.unclassified       
space.standard.events.unclassified: 0.0  (type=counter, enabled)
(venv) ╭─root@ab0fc00f16c6 /workspaces/devContainer 
╰─# engine-metrics get space.custom.events.unclassified  
space.custom.events.unclassified: 6.0  (type=counter, enabled)
  ```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<details><summary>Details</summary>
<p>

* without policy flag

`"index_unclassified_events":false`

```console
╰─# engine-test run unclasified -n cmsync_custom_bf0c -dd -t "output/indexer/0"


Enter any events [ENTER to send event, CTRL+C to finish]:

{"filename": "malware.exe"}


---
traces:
[🟢] output/indexer/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.category)] -> Failure
  ↳ [check: string_not_equal($wazuh.integration.category, "unclassified")] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-${wazuh.integration.category}) -> Success

output:
  '@timestamp': '2026-06-02T16:34:35.952Z'
  event:
    category:
    - file
    kind: event
    original: '{"filename": "malware.exe"}'
  file:
    name: malware.exe
  message: matched security integration
  wazuh:
    event:
      id: ce7b4623-bef9-4442-9e53-2dedcd8ee655
    integration:
      category: security
      decoders:
      - decoder/category-root/0
      - security-branch
      - decoder/security-branch/0
      name: integrationout
    protocol:
      location: location
      queue: 49
    space:
      name: custom



Enter any events [ENTER to send event, CTRL+C to finish]:

{"filename": ""}           


---
traces:
[🟢] output/indexer/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.category)] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-unclassified) -> Success

output:
  '@timestamp': '2026-06-02T16:34:53.751Z'
  event:
    kind: event
    original: '{"filename": ""}'
  message: matched unclassified integration
  wazuh:
    event:
      id: 4d97d029-5b3a-450d-a7a0-e0d3adba0980
    integration:
      category: unclassified
      decoders:
      - decoder/category-root/0
      - unclassified-branch
      - decoder/unclassified-branch/0
      name: unclassified
    protocol:
      location: location
      queue: 49
    space:
      name: custom
```


* with policy flag

`"index_unclassified_events":true`


```console
╰─# engine-test run unclasified -n cmsync_custom_bf0c -dd -t "output/indexer/0"


Enter any events [ENTER to send event, CTRL+C to finish]:

{"filename": "somename"}


---
traces:
[🟢] output/indexer/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.category)] -> Failure
  ↳ [check: string_not_equal($wazuh.integration.category, "unclassified")] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-${wazuh.integration.category}) -> Success

output:
  '@timestamp': '2026-06-02T16:36:49.943Z'
  event:
    category:
    - file
    kind: event
    original: '{"filename": "somename"}'
  file:
    name: somename
  message: matched security integration
  wazuh:
    event:
      id: b1ec8e23-5145-426b-a1c8-2b7b4b611c7e
    integration:
      category: security
      decoders:
      - decoder/category-root/0
      - security-branch
      - decoder/security-branch/0
      name: integrationout
    protocol:
      location: location
      queue: 49
    space:
      name: custom



Enter any events [ENTER to send event, CTRL+C to finish]:

{"filename": ""}


---
traces:
[🟢] output/indexer/0 -> success
  ↳ [check: index_unclassified_events($wazuh.integration.category)] -> Success
  ↳ write.output(wazuh-indexer/wazuh-events-v5-unclassified) -> Success

output:
  '@timestamp': '2026-06-02T16:36:59.324Z'
  event:
    kind: event
    original: '{"filename": ""}'
  message: matched unclassified integration
  wazuh:
    event:
      id: 52a1ad94-530d-4d28-aa6c-6330397b0f4c
    integration:
      category: unclassified
      decoders:
      - decoder/category-root/0
      - unclassified-branch
      - decoder/unclassified-branch/0
      name: unclassified
    protocol:
      location: location
      queue: 49
    space:
      name: custom

```

</p>
</details> 

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
