### PR TITLE
Fix race condition preventing inventory synchronization after agent reload

### DIFF
--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -654,22 +654,21 @@ static int wm_sca_start(wm_sca_t *sca) {
 #ifndef WIN32
         // Launch SCA synchronization thread as joinable so we can wait for it
         // before releasing resources on shutdown
+        sca_sync_module_running = 1;
         sca_sync_worker_thread_initialized = (CreateThreadJoinable(&sca_sync_worker_thread, wm_sca_sync_module, NULL) == 0);
-        if (sca_sync_worker_thread_initialized)
-        {
-            sca_sync_module_running = 1;
-        }
-        else
+        if (!sca_sync_worker_thread_initialized)
         {
             merror(THREAD_ERROR);
+            sca_sync_module_running = 0;
         }
 #else
+        sca_sync_module_running = 1;
         sca_sync_worker_thread = CreateThread(NULL, 0, wm_sca_sync_module, NULL, 0, NULL);
         if (sca_sync_worker_thread == NULL) {
             merror(THREAD_ERROR);
+            sca_sync_module_running = 0;
         } else {
             sca_sync_worker_thread_initialized = true;
-            sca_sync_module_running = 1;
         }
 #endif
     } else {

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -715,25 +715,24 @@ void* wm_sys_main(wm_sys_t* sys)
 #ifndef WIN32
             // Launch inventory synchronization thread as joinable so we can wait for it
             // before releasing resources on shutdown
+            sync_module_running = 1;
             sync_worker_thread_initialized = (CreateThreadJoinable(&sync_worker_thread, wm_sync_module, NULL) == 0);
-            if (sync_worker_thread_initialized)
+            if (!sync_worker_thread_initialized)
             {
-                sync_module_running = 1;
-            }
-            else
-            {
-                merror(THREAD_ERROR);
+                mterror(WM_SYS_LOGTAG, THREAD_ERROR);
+                sync_module_running = 0;
             }
 #else
+            sync_module_running = 1;
             sync_worker_thread = CreateThread(NULL, 0, wm_sync_module, NULL, 0, NULL);
             if (sync_worker_thread == NULL)
             {
                 mterror(WM_SYS_LOGTAG, THREAD_ERROR);
+                sync_module_running = 0;
             }
             else
             {
                 sync_worker_thread_initialized = true;
-                sync_module_running = 1;
             }
 
 #endif


### PR DESCRIPTION
## Description

Closes #36662 

After updating `ossec.conf` and running `wazuh-control reload`, approximately 50% of agents fail to synchronize their inventory with the manager (blank inventory in the interface). A full restart via `wazuh-control restart` resolves the issue.

The root cause is a race condition in `wm_syscollector.c`: the sync worker thread's running flag (`sync_module_running`) was set to `1` **after** the thread was created, leaving a window where the thread could start, read the flag as `0`, and immediately exit without ever synchronizing. The same behavior may occur with SCA.

### Root Cause Analysis

Both modules follow the same pattern for their sync worker threads:

```c
// BEFORE (bug)
sync_worker_thread_initialized = (CreateThreadJoinable(&sync_worker_thread, wm_sync_module, NULL) == 0);
if (sync_worker_thread_initialized)
{
    sync_module_running = 1;  // ← too late: thread may have already read this as 0
}
```

The sync thread immediately calls `wm_sys_get_startup_action()` (or `wm_sca_get_startup_action()`), which contains a while-loop gate:

```c
while (sync_module_running && !is_shutdown_process_started())
{
    // ... poll for first scan completion
}
return SYSCOLLECTOR_STARTUP_ACTION_STOP;  // ← reached if sync_module_running == 0
```

If `sync_module_running` is still `0` when the thread evaluates this condition (because the flag hasn't been set yet by the main thread), the function returns `STOP` on the first iteration, causing the sync thread to exit silently. No synchronization ever occurs and no error is logged.

## Proposed Changes

Set `sync_module_running = 1` / `sca_sync_module_running = 1` **before** calling `CreateThreadJoinable` / `CreateThread`, and reset it to `0` only if thread creation fails.

```c
// AFTER (fixed)
sync_module_running = 1;  // ← set before thread starts
sync_worker_thread_initialized = (CreateThreadJoinable(&sync_worker_thread, wm_sync_module, NULL) == 0);
if (!sync_worker_thread_initialized)
{
    merror(THREAD_ERROR);
    sync_module_running = 0;  // ← reset only on failure
}
```

### Results and Evidence

Reproduction steps (with the intentional `sleep(1)` to widen the race window):
1. Start agent.
2. When the agent connects to the manager, it is reloaded to apply the shared configuration.
3. **Before fix:** `ossec.log` shows `wazuh-modulesd:syscollector` starts evaluation and finishes, but "Starting inventory synchronization." never appears. SCA and FIM sync correctly.
4. **After fix:** "Starting inventory synchronization." appears immediately after "Evaluation finished.", inventory is populated in the manager interface.

<details><summary>Before fix</summary>

```console
2026/05/29 20:47:10 wazuh-agentd: INFO: Started (pid: 197268).
2026/05/29 20:47:10 wazuh-agentd: INFO: Requesting a key from server: 192.168.56.30
2026/05/29 20:47:10 wazuh-agentd: INFO: No authentication password provided
2026/05/29 20:47:10 wazuh-agentd: INFO: Using agent name as: dd4c300576e9
2026/05/29 20:47:10 wazuh-agentd: INFO: Waiting for server reply
2026/05/29 20:47:10 wazuh-agentd: INFO: Valid key received
2026/05/29 20:47:11 wazuh-modulesd: INFO: Started (pid: 197300).
2026/05/29 20:47:11 wazuh-modulesd:control: INFO: Starting control thread.
2026/05/29 20:47:30 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/05/29 20:47:30 wazuh-agentd: INFO: Trying to connect to server ([192.168.56.30]:1514/tcp).
2026/05/29 20:47:30 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
2026/05/29 20:47:30 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/05/29 20:47:30 wazuh-modulesd:control: INFO: Executing 'reload' on wazuh-agent using wazuh-control
2026/05/29 20:47:30 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/05/29 20:47:30 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/05/29 20:47:30 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/05/29 20:47:30 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/05/29 20:47:30 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/05/29 20:47:33 wazuh-modulesd: INFO: Started (pid: 197564).
2026/05/29 20:47:33 wazuh-modulesd:control: INFO: Starting control thread.
2026/05/29 20:47:50 wazuh-execd: INFO: Started (pid: 197538).
2026/05/29 20:47:50 wazuh-rootcheck: INFO: Started (pid: 197549).
2026/05/29 20:47:50 wazuh-syscheckd: INFO: Started (pid: 197549).
2026/05/29 20:47:51 wazuh-logcollector: INFO: Started (pid: 197557).
2026/05/29 20:47:51 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/05/29 20:47:51 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 197564).
2026/05/29 20:47:51 wazuh-modulesd:agent-info: INFO: Started (pid: 197564).
2026/05/29 20:47:51 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/05/29 20:47:51 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/05/29 20:47:51 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/05/29 20:47:51 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/05/29 20:47:51 wazuh-modulesd:sca: INFO: Started (pid: 197564).
2026/05/29 20:47:51 wazuh-modulesd:sca: INFO: Scan started.
2026/05/29 20:47:52 wazuh-modulesd:syscollector: INFO: Started (pid: 197564).
2026/05/29 20:47:52 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/29 20:47:52 wazuh-modulesd:sca: INFO: Scan ended.
2026/05/29 20:47:52 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/29 20:47:53 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/29 20:47:53 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/29 20:47:53 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/05/29 20:48:03 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/05/29 20:48:03 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/05/29 20:48:13 wazuh-rootcheck: INFO: Rootcheck scan ended.
2026/05/29 20:53:03 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/05/29 20:53:03 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/05/29 20:53:03 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/05/29 20:53:03 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
```

</details> 

<details><summary>After fix</summary>

```console
2026/06/01 14:42:47 wazuh-agentd: INFO: Started (pid: 41564).
2026/06/01 14:42:47 wazuh-agentd: INFO: Requesting a key from server: 192.168.56.30
2026/06/01 14:42:47 wazuh-agentd: INFO: No authentication password provided
2026/06/01 14:42:47 wazuh-agentd: INFO: Using agent name as: dd4c300576e9
2026/06/01 14:42:47 wazuh-agentd: INFO: Waiting for server reply
2026/06/01 14:42:47 wazuh-agentd: INFO: Valid key received
2026/06/01 14:42:49 wazuh-modulesd: INFO: Started (pid: 41633).
2026/06/01 14:42:49 wazuh-modulesd:control: INFO: Starting control thread.
2026/06/01 14:43:07 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/06/01 14:43:07 wazuh-agentd: INFO: Trying to connect to server ([192.168.56.30]:1514/tcp).
2026/06/01 14:43:07 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
2026/06/01 14:43:07 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/06/01 14:43:07 wazuh-modulesd:control: INFO: Executing 'reload' on wazuh-agent using wazuh-control
2026/06/01 14:43:07 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/06/01 14:43:07 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/06/01 14:43:07 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/06/01 14:43:07 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/06/01 14:43:07 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/06/01 14:43:09 wazuh-modulesd: INFO: Started (pid: 41896).
2026/06/01 14:43:09 wazuh-modulesd:control: INFO: Starting control thread.
2026/06/01 14:43:27 wazuh-execd: INFO: Started (pid: 41870).
2026/06/01 14:43:27 wazuh-rootcheck: INFO: Started (pid: 41881).
2026/06/01 14:43:27 wazuh-syscheckd: INFO: Started (pid: 41881).
2026/06/01 14:43:27 wazuh-logcollector: INFO: Started (pid: 41889).
2026/06/01 14:43:27 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/06/01 14:43:27 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/06/01 14:43:27 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/06/01 14:43:27 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/06/01 14:43:27 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/06/01 14:43:27 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 41896).
2026/06/01 14:43:27 wazuh-modulesd:agent-info: INFO: Started (pid: 41896).
2026/06/01 14:43:27 wazuh-modulesd:sca: INFO: Started (pid: 41896).
2026/06/01 14:43:27 wazuh-modulesd:syscollector: INFO: Started (pid: 41896).
2026/06/01 14:43:27 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/06/01 14:43:27 wazuh-modulesd:sca: INFO: Scan started.
2026/06/01 14:43:27 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/06/01 14:43:28 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/06/01 14:43:28 wazuh-modulesd:sca: INFO: Scan ended.
2026/06/01 14:43:29 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/06/01 14:43:29 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/06/01 14:43:29 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/06/01 14:43:33 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/06/01 14:43:33 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/06/01 14:43:51 wazuh-rootcheck: INFO: Rootcheck scan ended.
2026/06/01 14:43:53 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/06/01 14:43:53 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

</details> 

### Artifacts Affected

| File | Change |
|---|---|
| `src/wazuh_modules/src/wm_syscollector.c` | Set `sync_module_running = 1` before `CreateThreadJoinable` (Linux) and `CreateThread` (Windows) |
| `src/wazuh_modules/src/wm_sca.c` | Set `sca_sync_module_running = 1` before `CreateThreadJoinable` (Linux) and `CreateThread` (Windows) |

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

No automated tests added. The race is timing-dependent and was verified manually by reproducing the condition with a deliberate `sleep(1)` between thread creation and flag assignment.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues