### PR TITLE
Make agent-info shutdown waits interruptible

### DIFF
--- a/src/shared/include/error_messages/debug_messages.h
+++ b/src/shared/include/error_messages/debug_messages.h
@@ -32,7 +32,6 @@
 #define FIM_MAX_RECURSION_LEVEL             "(6217): Maximum level of recursion reached. Depth:%d recursion_level:%d '%s'"
 #define FIM_SYMBOLIC_LINK_DISCARDED         "(6218): Discarding symbolic link '%s' is already added in the configuration."
 #define FIM_SYMBOLIC_LINK_ADD               "(6219): Directory added to FIM configuration by link '%s'"
-#define FIM_SHUTDOWN_DETECTED               "(6220): Reconnection attempts terminated due to the shutdown of FIM."
 #define FIM_FREQUENCY_DIRECTORY             "(6221): Directory loaded from syscheck db: '%s'"
 #define FIM_STAT_FAILED                     "(6222): Stat() function failed on: '%s' due to [(%d)-(%s)]"
 #define FIM_SKIP_NFS                        "(6223): FIM skip_nfs=%d, '%s'::is_nfs=%d"
@@ -225,6 +224,7 @@
 
 /* Generic messages */
 #define SUCCESSFULLY_RECONNECTED_SOCKET     "(8300): Successfully reconnected to '%s'"
+#define MQ_SHUTDOWN_DETECTED                "(8301): Reconnection attempts terminated due to shutdown."
 
 /* Logcollector */
 

--- a/src/shared/src/mq_op.c
+++ b/src/shared/src/mq_op.c
@@ -69,7 +69,7 @@ int StartMQPredicated(const char *path, short int type, short int n_attempts, bo
         // If n_attempts is 0, trying to reconnect infinitely
         while ((rc = OS_ConnectUnixDomain(path, SOCK_DGRAM, OS_MAXSTR + 256)), rc < 0) {
             if ((*fn_ptr)()) {
-                mdebug2(FIM_SHUTDOWN_DETECTED);
+                mdebug2(MQ_SHUTDOWN_DETECTED);
                 return OS_INVALID;
             }
             attempt++;
@@ -82,7 +82,7 @@ int StartMQPredicated(const char *path, short int type, short int n_attempts, bo
             sleep_time += 5;
             for (int slept = 0; slept < sleep_time; slept++) {
                 if ((*fn_ptr)()) {
-                    mdebug2(FIM_SHUTDOWN_DETECTED);
+                    mdebug2(MQ_SHUTDOWN_DETECTED);
                     return OS_INVALID;
                 }
                 sleep(1);

--- a/src/shared/src/mq_op.c
+++ b/src/shared/src/mq_op.c
@@ -77,7 +77,16 @@ int StartMQPredicated(const char *path, short int type, short int n_attempts, bo
             if (n_attempts != INFINITE_OPENQ_ATTEMPTS && attempt == n_attempts) {
                 break;
             }
-            sleep(sleep_time += 5);
+            // Interruptible backoff: keep the escalating delay, but re-check the
+            // shutdown predicate every second so shutdown is honored within ~1 s.
+            sleep_time += 5;
+            for (int slept = 0; slept < sleep_time; slept++) {
+                if ((*fn_ptr)()) {
+                    mdebug2(FIM_SHUTDOWN_DETECTED);
+                    return OS_INVALID;
+                }
+                sleep(1);
+            }
         }
 
         if (rc < 0) {

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -307,6 +307,40 @@ void test_start_mq_predicated_write_fail(void ** state){
     assert_int_equal(ret, -1);
 }
 
+void test_start_mq_predicated_write_shutdown_during_backoff(void ** state){
+    (void)state; // Unused
+
+    /* Function parameters */
+    short int n_attempts = 0; // INFINITE_OPENQ_ATTEMPTS
+    short int type = WRITE;
+    char * path = "/test";
+
+    int ret = 0;
+    char message[OS_SIZE_128];
+
+    errno = ERRNO;
+
+    /* ptr_function toggles its return value on each call. Seeding it to true
+     * makes the first (top-of-loop) check return false, so the connection
+     * failure proceeds into the escalating backoff; the second call (now inside
+     * the backoff) returns true, so shutdown must be honored without waiting out
+     * the sleep. */
+    ptr_function_value = true;
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, path);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
+    will_return(__wrap_OS_ConnectUnixDomain, -1);
+
+    snprintf(message, OS_SIZE_128, "Can't connect to '%s': %s (%d). Attempt: %d", path, strerror(errno), errno, 1);
+    expect_string(__wrap__mdebug1, formatted_msg, message);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "(6220): Reconnection attempts terminated due to the shutdown of FIM.");
+
+    ret = StartMQPredicated(path, type, n_attempts, ptr_function);
+    assert_int_equal(ret, -1);
+}
+
 void test_reconnect_mq_simple_success(void ** state){
     (void)state; // Unused
 
@@ -579,6 +613,7 @@ int main(void){
        cmocka_unit_test(test_reconnect_mq_simple_success),
        cmocka_unit_test(test_start_mq_predicated_write_success),
        cmocka_unit_test(test_start_mq_predicated_write_fail),
+       cmocka_unit_test(test_start_mq_predicated_write_shutdown_during_backoff),
        // Test test_SendMSGAction
        cmocka_unit_test(test_SendMSGAction_format_error),
        cmocka_unit_test(test_SendMSGAction_secure_msg),

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -301,7 +301,7 @@ void test_start_mq_predicated_write_fail(void ** state){
     expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_DGRAM);
     expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR + 256);
     will_return(__wrap_OS_ConnectUnixDomain, -1);
-    expect_string(__wrap__mdebug2, formatted_msg, "(6220): Reconnection attempts terminated due to the shutdown of FIM.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(8301): Reconnection attempts terminated due to shutdown.");
 
     ret = StartMQPredicated(path, type, n_attempts, ptr_function);
     assert_int_equal(ret, -1);
@@ -335,7 +335,7 @@ void test_start_mq_predicated_write_shutdown_during_backoff(void ** state){
     snprintf(message, OS_SIZE_128, "Can't connect to '%s': %s (%d). Attempt: %d", path, strerror(errno), errno, 1);
     expect_string(__wrap__mdebug1, formatted_msg, message);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "(6220): Reconnection attempts terminated due to the shutdown of FIM.");
+    expect_string(__wrap__mdebug2, formatted_msg, "(8301): Reconnection attempts terminated due to shutdown.");
 
     ret = StartMQPredicated(path, type, n_attempts, ptr_function);
     assert_int_equal(ret, -1);

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -143,10 +143,13 @@ int main(int argc, char **argv)
     // Start com request thread
     w_create_thread(wmcom_main, NULL);
 
-    // Wait for threads
-
-    for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
-        pthread_join(cur_module->thread, NULL);
+    // Modules run until a shutdown signal arrives. The SIGTERM/SIGINT handler
+    // performs the orderly stop + timed-join + exit, so the main thread must NOT
+    // also join the module threads: two concurrent joins of the same thread
+    // return EINVAL/ESRCH, which were misreported as shutdown timeouts. Idle here
+    // until the handler exits the process.
+    for (;;) {
+        pause();
     }
 
     return EXIT_SUCCESS;
@@ -292,8 +295,10 @@ void wm_handler(int signum)
                 if (cur_module->thread == (pthread_t)0) continue;
                 if (cur_module->thread == pthread_self()) continue;
 #ifdef __linux__
-                if (pthread_timedjoin_np(cur_module->thread, NULL, &deadline) != 0) {
-                    mwarn("Module '%s' did not stop within the shutdown timeout.", cur_module->context->name);
+                int join_rc = pthread_timedjoin_np(cur_module->thread, NULL, &deadline);
+                if (join_rc != 0) {
+                    mwarn("Module '%s' did not stop within the shutdown timeout. (rc=%d: %s)",
+                          cur_module->context->name, join_rc, strerror(join_rc));
                 }
 #else
                 pthread_join(cur_module->thread, NULL);

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -203,26 +203,12 @@ static bool wm_agent_info_is_shutting_down()
     return g_shutting_down || wm_shutdown_requested;
 }
 
-// Open the queue. For infinite attempts, retry with a 1 s interruptible delay
-// so shutdown is honored within ~1 s. Finite attempts are delegated as-is.
+// Open the queue. StartMQPredicated re-checks the shutdown predicate during its
+// (now interruptible) backoff, so both finite and infinite attempts honor
+// shutdown within ~1 s; delegate directly.
 static int wm_agent_info_startmq(const char* key, short type, short attempts)
 {
-    if (attempts != INFINITE_OPENQ_ATTEMPTS)
-    {
-        return StartMQPredicated(key, type, attempts, wm_agent_info_is_shutting_down);
-    }
-
-    while (!wm_agent_info_is_shutting_down())
-    {
-        int queue = StartMQPredicated(key, type, 1, wm_agent_info_is_shutting_down);
-        if (queue >= 0)
-        {
-            return queue;
-        }
-        wm_sleep_interruptible(1);
-    }
-
-    return OS_INVALID;
+    return StartMQPredicated(key, type, attempts, wm_agent_info_is_shutting_down);
 }
 
 static int

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -415,7 +415,7 @@ static bool wm_agent_info_query_agentd_handshake(char* cluster_name,
 // Callback to send stateless messages
 static int wm_agent_info_send_stateless(const char* message)
 {
-    if (g_shutting_down)
+    if (wm_agent_info_is_shutting_down())
     {
         return -1;
     }
@@ -687,7 +687,7 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
     char agent_groups[OS_SIZE_65536] = {0};
     bool handshake_success = false;
 
-    while (!handshake_success && !g_shutting_down)
+    while (!handshake_success && !wm_agent_info_is_shutting_down())
     {
         if (wm_agent_info_query_agentd_handshake(cluster_name,
                                                  sizeof(cluster_name),
@@ -716,11 +716,11 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
         else
         {
             mdebug1("Handshake data not available yet, retrying in 1 second...");
-            sleep(1);
+            wm_sleep_interruptible(1);
         }
     }
 
-    if (g_shutting_down)
+    if (wm_agent_info_is_shutting_down())
     {
         mdebug1("Shutdown requested during handshake wait, exiting.");
         return NULL;

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -196,16 +196,33 @@ agent_info_log_callback(const modules_log_level_t level, const char* log, __attr
     }
 }
 
-// Check if module is shutting down
+// True once a shutdown is requested. Checks both flags: wm_shutdown_requested
+// is set first, g_shutting_down later.
 static bool wm_agent_info_is_shutting_down()
 {
-    return g_shutting_down;
+    return g_shutting_down || wm_shutdown_requested;
 }
 
-// Agent-info message queue functions
+// Open the queue. For infinite attempts, retry with a 1 s interruptible delay
+// so shutdown is honored within ~1 s. Finite attempts are delegated as-is.
 static int wm_agent_info_startmq(const char* key, short type, short attempts)
 {
-    return StartMQ(key, type, attempts);
+    if (attempts != INFINITE_OPENQ_ATTEMPTS)
+    {
+        return StartMQPredicated(key, type, attempts, wm_agent_info_is_shutting_down);
+    }
+
+    while (!wm_agent_info_is_shutting_down())
+    {
+        int queue = StartMQPredicated(key, type, 1, wm_agent_info_is_shutting_down);
+        if (queue >= 0)
+        {
+            return queue;
+        }
+        wm_sleep_interruptible(1);
+    }
+
+    return OS_INVALID;
 }
 
 static int
@@ -413,11 +430,17 @@ static int wm_agent_info_send_stateless(const char* message)
     if (SendMSGPredicated(
             g_agent_info_queue, message, WM_AGENT_INFO_LOGTAG, LOCALFILE_MQ, wm_agent_info_is_shutting_down) < 0)
     {
+        // Aborted by shutdown: exit quietly.
+        if (wm_agent_info_is_shutting_down())
+        {
+            return -1;
+        }
+
         merror("Error sending message to queue");
 
-        if ((g_agent_info_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0)
+        // A negative result here means shutdown, so exit quietly.
+        if ((g_agent_info_queue = wm_agent_info_startmq(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0)
         {
-            merror("Cannot restart agent-info message queue");
             return -1;
         }
 
@@ -425,7 +448,10 @@ static int wm_agent_info_send_stateless(const char* message)
         if (SendMSGPredicated(
                 g_agent_info_queue, message, WM_AGENT_INFO_LOGTAG, LOCALFILE_MQ, wm_agent_info_is_shutting_down) < 0)
         {
-            merror("Error sending message to queue after reconnection");
+            if (!wm_agent_info_is_shutting_down())
+            {
+                merror("Error sending message to queue after reconnection");
+            }
             return -1;
         }
     }
@@ -589,11 +615,15 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
     }
 
     // Initialize message queue
-    g_agent_info_queue = StartMQ(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
+    g_agent_info_queue = wm_agent_info_startmq(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS);
 
     if (g_agent_info_queue < 0)
     {
-        merror("Cannot initialize agent-info message queue.");
+        // A negative result here means shutdown, so don't log an error.
+        if (!wm_agent_info_is_shutting_down())
+        {
+            merror("Cannot initialize agent-info message queue.");
+        }
         return NULL;
     }
 


### PR DESCRIPTION
# Description

On agent stop (and during upgrades) `wazuh-modulesd` logs `WARNING: Module 'agent-info' did not stop within the shutdown timeout`. There are **two** independent root causes:

1. **agent-info blocking waits.** The module connected to the local queue with the non-interruptible `StartMQ(..., INFINITE_OPENQ_ATTEMPTS)`, and `StartMQPredicated`'s reconnect backoff slept without re-checking the shutdown flag, so the worker could not observe a graceful-stop request and its thread stayed blocked. The handshake wait had the same problem (`sleep(1)` loop).

2. **A double-join race in the shutdown harness.** Module threads were joined in two places at once: the main thread's `pthread_join` loop (`src/wazuh_modules/src/main.c:148-150`) and the SIGTERM handler's `pthread_timedjoin_np` loop (`main.c:291-302`). POSIX allows a thread to be joined only once, so the handler's join returned `EINVAL`/`ESRCH` immediately, and `main.c` reported **any** non-zero return as a shutdown timeout. This produced the warning even when the module stopped promptly (the warning fires ~1 s after `SIGTERM`, not at the 30 s deadline).

This PR makes the agent-info queue-connect and handshake waits cooperative with shutdown, makes the shared `StartMQPredicated` backoff itself interruptible, and makes the SIGTERM handler the single owner of the module-thread join so the warning is only emitted on a genuine timeout. Addresses #36408.

## Proposed Changes

- `src/shared/src/mq_op.c` — `StartMQPredicated`: make the escalating reconnect backoff interruptible. The delay still escalates, but the shutdown predicate is re-checked once per second during the sleep and the call returns `OS_INVALID` on shutdown, instead of a single `sleep(sleep_time += 5)` that could block for the full (growing, eventually >30 s) interval. This benefits every `StartMQPredicated` caller (e.g. FIM), not just agent-info.
- `src/wazuh_modules/src/wm_agent_info.c`:
  - `wm_agent_info_is_shutting_down()` now observes **both** `g_shutting_down` and `wm_shutdown_requested` (the latter is raised first, in `wm_handler()`), so connect/retry loops react to the earliest shutdown signal.
  - All queue opens — `wm_agent_info_startmq()` (the sync-protocol MQ callback), the reconnect path in `wm_agent_info_send_stateless()`, and the initial open in `wm_agent_info_main()` — now go through `StartMQPredicated` with that predicate instead of the non-interruptible `StartMQ`.
  - The handshake-wait loop uses the predicate and `wm_sleep_interruptible(1)` instead of `sleep(1)`.
  - Suppress misleading error logs (`Error sending message to queue`, `Cannot restart/initialize agent-info message queue`) when the failure is a shutdown-aborted send/reconnect/init — these are expected on stop/upgrade, not errors.
- `src/wazuh_modules/src/main.c`:
  - Remove the main thread's `pthread_join` loop (`main.c:148-150`) so the SIGTERM/SIGINT handler is the **single** joiner of module threads. The main thread now idles in `pause()` until the handler's `exit()` ends the process. This eliminates the concurrent-join `EINVAL`/`ESRCH` that was misreported as a timeout.
  - The join warning now logs the actual return code (`mwarn(... (rc=%d: %s))`), so a real timeout (`ETIMEDOUT`, rc=110) is distinguishable from other errors.
- `src/unit_tests/shared/test_mq_op.c` — new test `test_start_mq_predicated_write_shutdown_during_backoff` verifying that a shutdown signalled during the backoff returns `OS_INVALID` without waiting out the sleep.

### Scope

This PR covers the C-layer agent-info blocking sites (queue connect + handshake), the shared `StartMQPredicated` backoff, and the shutdown-harness double-join in `main.c` (which affects all modules and explains why the warning also appeared for `agent-upgrade`). The C++ sync/pause sites described in #36408 — `pollFimPauseCompletion`, `synchronizeMetadataOrGroups`/`performIntegritySync`, and `queryModuleWithRetry` in `agent_info_impl.cpp` — are not modified here and remain as follow-up. With the double-join fixed, any remaining shutdown-timeout warning will report `rc=110` (`ETIMEDOUT`) and indicate a genuinely blocked module.

### Results and Evidence

Two Amazon Linux 2 agents enrolled against the same nightly 5.x AIO manager, both with `wazuh_modules.debug=2`. Reproduction on each agent: remove `queue/agent_info/db/agent_info.db`, kill `wazuh-agentd` (closing the local queue socket) so agent-info enters the queue reconnect loop, then send `SIGTERM` to `wazuh-modulesd`. Both traces below are taken from `ossec.log` and anchored on the same `Signal received: 15`.

Script to reproduce the issue: 
[on_agent_repro.sh](https://github.com/user-attachments/files/28513314/on_agent_repro.sh)

<details><summary>Before fix — wazuh-agent 5.0.0-latest: agent-info and agent-upgrade warn ~10 s after SIGTERM</summary>

```bash
2026/06/02 13:17:11 wazuh-modulesd[1706] main.c:258 at wm_handler(): DEBUG: Signal received: 15, handling.
2026/06/02 13:17:12 wazuh-modulesd[1706] main.c:270 at wm_handler(): DEBUG: Shutting down Wazuh modules.
2026/06/02 13:17:12 wazuh-modulesd:agent-info[1706] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo module loop ended.
2026/06/02 13:17:12 wazuh-modulesd:agent-info[1706] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo module stopped.
2026/06/02 13:17:22 wazuh-modulesd[1706] main.c:296 at wm_handler(): WARNING: Module 'agent-upgrade' did not stop within the shutdown timeout.
2026/06/02 13:17:22 wazuh-modulesd[1706] main.c:296 at wm_handler(): WARNING: Module 'agent-info' did not stop within the shutdown timeout.
2026/06/02 13:17:35 wazuh-modulesd:agent-info[1706] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo destroyed.
```

</details>

The warning fires ~10 s after `SIGTERM`, not at the 30 s deadline, and agent-info has already logged `module stopped`. Annotating the join return code (`mwarn(... (rc=%d: %s))`) showed why: it is a misreported join error, not a timeout. `agent-info` returns `EINVAL` (the main thread was already joining it) and `agent-upgrade` returns `ESRCH` (already reaped by the main thread's join) — neither is `ETIMEDOUT` (rc=110).


<details><summary>Diagnosis — join return codes prove the double-join (rc=22 EINVAL / rc=3 ESRCH, not rc=110 ETIMEDOUT)</summary>

```bash
2026/06/02 12:21:16 wazuh-modulesd[1307] main.c:258 at wm_handler(): DEBUG: Signal received: 15, handling.
2026/06/02 12:21:17 wazuh-modulesd[1307] main.c:270 at wm_handler(): DEBUG: Shutting down Wazuh modules.
2026/06/02 12:27:25 wazuh-modulesd[1725] main.c:258 at wm_handler(): DEBUG: Signal received: 15, handling.
2026/06/02 12:27:26 wazuh-modulesd[1725] main.c:270 at wm_handler(): DEBUG: Shutting down Wazuh modules.
2026/06/02 12:27:26 wazuh-modulesd:agent-info[1725] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo module loop ended.
2026/06/02 12:27:26 wazuh-modulesd:agent-info[1725] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo module stopped.
2026/06/02 12:27:26 wazuh-modulesd[1725] main.c:297 at wm_handler(): WARNING: Module 'agent-upgrade' did not stop within the shutdown timeout. (rc=3: No such process)
2026/06/02 12:27:26 wazuh-modulesd[1725] main.c:297 at wm_handler(): WARNING: Module 'agent-info' did not stop within the shutdown timeout. (rc=22: Invalid argument)
2026/06/02 12:27:27 wazuh-modulesd:agent-info[1725] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo destroyed.
```

</details>

<details><summary>After fix — wazuh-agent 5.0.0-0: agent-info destroyed in the same second as SIGTERM, no warning (for any module)</summary>

```bash
2026/06/02 13:17:11 wazuh-modulesd[1709] main.c:261 at wm_handler(): DEBUG: Signal received: 15, handling.
2026/06/02 13:17:12 wazuh-modulesd[1709] main.c:273 at wm_handler(): DEBUG: Shutting down Wazuh modules.
2026/06/02 13:17:12 wazuh-modulesd:agent-info[1709] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo module loop ended.
2026/06/02 13:17:12 wazuh-modulesd:agent-info[1709] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo module stopped.
2026/06/02 13:17:12 wazuh-modulesd:agent-info[1709] wm_agent_info.c:192 at agent_info_log_callback(): INFO: AgentInfo destroyed.
```

</details>

With the fix, agent-info is fully destroyed in the same second as `SIGTERM` and **no** shutdown-timeout warning is emitted — neither for agent-info nor agent-upgrade, confirming the double-join was the source of both.

### Artifacts Affected

- `wazuh-modulesd` — the agent-info module and the module shutdown path in `main.c` (the join fix affects how **all** modules are stopped). Shipped in the `wazuh-agent` package.
- Shared `mq_op` (`StartMQPredicated`) — affects every caller, including FIM (`wazuh-syscheckd`).

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

- `src/unit_tests/shared/test_mq_op.c` — `test_start_mq_predicated_write_shutdown_during_backoff`: shutdown signalled during the reconnect backoff returns `OS_INVALID` without waiting out the sleep.

Also validated manually via the two-agent (latest vs fix) container reproduction above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
