### PR TITLE
Fix non-atomic write for `file_status.json` in logcollector

### DIFF
--- a/src/logcollector/src/logcollector.c
+++ b/src/logcollector/src/logcollector.c
@@ -2616,15 +2616,32 @@ STATIC void w_save_file_status() {
 
     FILE * fd = NULL;
     size_t size_str = strlen(str);
+    const char * const tmp_path = LOCALFILE_STATUS ".tmp";
 
-    if (fd = wfopen(LOCALFILE_STATUS, "w"), fd != NULL) {
-        if (fwrite(str, 1, size_str, fd) == 0) {
-            merror(FWRITE_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
+    if (fd = wfopen(tmp_path, "w"), fd != NULL) {
+        if (fwrite(str, 1, size_str, fd) != size_str) {
+            merror(FWRITE_ERROR, tmp_path, errno, strerror(errno));
             clearerr(fd);
+            fclose(fd);
+            unlink(tmp_path);
+        } else if (fclose(fd) != 0) {
+            merror("Could not close file '%s': %s", tmp_path, strerror(errno));
+            unlink(tmp_path);
+        } else {
+#ifdef WIN32
+            if (!MoveFileExA(tmp_path, LOCALFILE_STATUS, MOVEFILE_REPLACE_EXISTING)) {
+                merror("Could not rename '%s' to '%s' (error %lu)", tmp_path, LOCALFILE_STATUS, GetLastError());
+                unlink(tmp_path);
+            }
+#else
+            if (rename(tmp_path, LOCALFILE_STATUS) != 0) {
+                merror("Could not rename '%s' to '%s': %s", tmp_path, LOCALFILE_STATUS, strerror(errno));
+                unlink(tmp_path);
+            }
+#endif
         }
-        fclose(fd);
     } else {
-        merror_exit(FOPEN_ERROR, LOCALFILE_STATUS, errno, strerror(errno));
+        merror_exit(FOPEN_ERROR, tmp_path, errno, strerror(errno));
     }
 
     os_free(str);

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -49,7 +49,8 @@ else()
                                     -Wl,--wrap,stat -Wl,--wrap=fgetc -Wl,--wrap=w_fseek -Wl,--wrap,w_ftell \
                                     -Wl,--wrap,OS_SHA1_File_Nbytes_with_fp_check -Wl,--wrap,cJSON_CreateString \
                                     -Wl,--wrap,cJSON_AddItemToObject -Wl,--wrap,wpclose -Wl,--wrap,kill \
-                                    -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle -Wl,--wrap,popen ${DEBUG_OP_WRAPPERS} \
+                                    -Wl,--wrap,so_get_function_sym -Wl,--wrap,so_get_module_handle -Wl,--wrap,popen \
+                                    -Wl,--wrap,rename -Wl,--wrap,unlink -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS} \
                                     ${HASH_OP_WRAPPERS}")
 
     list(APPEND logcollector_names "test_read_multiline_regex")

--- a/src/unit_tests/logcollector/test_logcollector.c
+++ b/src/unit_tests/logcollector/test_logcollector.c
@@ -28,6 +28,7 @@
 #include "../wrappers/wazuh/os_crypto/sha1_op_wrappers.h"
 #include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/posix/signal_wrappers.h"
+#include "../wrappers/posix/unistd_wrappers.h"
 
 
 extern OSHash *files_status;
@@ -828,11 +829,11 @@ void test_w_save_file_status_wfopen_error(void ** state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json");
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json.tmp");
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, 0);
 
-    expect_string(__wrap__merror_exit, formatted_msg, "(1103): Could not open file 'queue/logcollector/file_status.json' due to [(0)-(Success)].");
+    expect_string(__wrap__merror_exit, formatted_msg, "(1103): Could not open file 'queue/logcollector/file_status.json.tmp' due to [(0)-(Success)].");
     expect_assert_failure(w_save_file_status());
 }
 
@@ -895,19 +896,22 @@ void test_w_save_file_status_fwrite_error(void ** state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json");
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json.tmp");
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, "test");
 
     will_return(__wrap_fwrite, 0);
 
-    expect_string(__wrap__merror, formatted_msg, "(1110): Could not write file 'queue/logcollector/file_status.json' due to [(0)-(Success)].");
+    expect_string(__wrap__merror, formatted_msg, "(1110): Could not write file 'queue/logcollector/file_status.json.tmp' due to [(0)-(Success)].");
 
     expect_function_call(__wrap_clearerr);
     expect_string(__wrap_clearerr, __stream, "test");
 
     expect_value(__wrap_fclose, _File, "test");
     will_return(__wrap_fclose, 1);
+
+    expect_string(__wrap_unlink, file, "queue/logcollector/file_status.json.tmp");
+    will_return(__wrap_unlink, 0);
 
     w_save_file_status();
 }
@@ -970,14 +974,94 @@ void test_w_save_file_status_OK(void ** state) {
 
     expect_function_call(__wrap_cJSON_Delete);
 
-    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json");
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json.tmp");
     expect_string(__wrap_wfopen, mode, "w");
     will_return(__wrap_wfopen, "test");
 
-    will_return(__wrap_fwrite, 1);
+    will_return(__wrap_fwrite, 9);
 
     expect_value(__wrap_fclose, _File, "test");
-    will_return(__wrap_fclose, 1);
+    will_return(__wrap_fclose, 0);
+
+    expect_string(__wrap_rename, __old, "queue/logcollector/file_status.json.tmp");
+    expect_string(__wrap_rename, __new, "queue/logcollector/file_status.json");
+    will_return(__wrap_rename, 0);
+
+    w_save_file_status();
+}
+
+void test_w_save_file_status_fclose_error(void ** state) {
+    test_logcollector_t *test_data = *state;
+
+    os_file_status_t * data = test_data->status;
+    OSHashNode *hash_node = test_data->node;
+
+    strcpy(data->hash,"test1234");
+    data->offset = 5;
+
+    hash_node->key = "test";
+    hash_node->data = data;
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    strcpy(macos_log_vault.timestamp,"hi 123");
+    macos_log_vault.settings = "my settings";
+
+    expect_value(__wrap_OSHash_Begin, self, files_status);
+    will_return(__wrap_OSHash_Begin, hash_node);
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+
+    expect_string(__wrap_cJSON_AddArrayToObject, name, "files");
+    will_return(__wrap_cJSON_AddArrayToObject, (cJSON *) 1);
+
+    will_return(__wrap_cJSON_CreateObject, (cJSON *) 1);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "path");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "test");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "hash");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "test1234");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_string(__wrap_cJSON_AddStringToObject, name, "offset");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "5");
+    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+
+    expect_function_call(__wrap_cJSON_AddItemToArray);
+    will_return(__wrap_cJSON_AddItemToArray, true);
+
+    expect_value(__wrap_OSHash_Next, self, files_status);
+    will_return(__wrap_OSHash_Next, NULL);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
+
+    expect_function_call(__wrap_pthread_rwlock_rdlock);
+    expect_function_call(__wrap_pthread_rwlock_unlock);
+
+    will_return(__wrap_cJSON_PrintUnformatted, strdup("test_1234"));
+
+    expect_function_call(__wrap_cJSON_Delete);
+
+    expect_string(__wrap_wfopen, path, "queue/logcollector/file_status.json.tmp");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, "test");
+
+    will_return(__wrap_fwrite, 9);
+
+    expect_value(__wrap_fclose, _File, "test");
+    will_return(__wrap_fclose, EOF);
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "Could not close file 'queue/logcollector/file_status.json.tmp': Success");
+
+    expect_string(__wrap_unlink, file, "queue/logcollector/file_status.json.tmp");
+    will_return(__wrap_unlink, 0);
 
     w_save_file_status();
 }
@@ -2858,6 +2942,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_w_save_file_status_str_NULL, setup_local_hashmap, teardown_local_hashmap),
         cmocka_unit_test_setup_teardown(test_w_save_file_status_wfopen_error, setup_log_context, teardown_log_context),
         cmocka_unit_test_setup_teardown(test_w_save_file_status_fwrite_error, setup_log_context, teardown_log_context),
+        cmocka_unit_test_setup_teardown(test_w_save_file_status_fclose_error, setup_log_context, teardown_log_context),
         cmocka_unit_test_setup_teardown(test_w_save_file_status_OK, setup_log_context, teardown_log_context),
 
         // Test w_load_files_status


### PR DESCRIPTION
## Description

Logcollector `w_save_file_status()` function used a non-atomic two-step write: first it truncated `file_status.json` to 0 bytes via `wfopen(..., "w")`, then wrote the JSON content with `fwrite`. If the agent was killed (e.g., by `SIGKILL` from the WPK upgrade `preinstall.sh` script) between those two steps, the file was left empty. On the next startup `fread` returned 0 bytes, triggering error `(1115)`, and all previously saved log read offsets were lost — causing logcollector to re-read monitored files from the beginning and potentially producing duplicate log ingestion.

Closes #36615.

## Proposed Changes

Replace the direct overwrite with an atomic write-then-rename pattern in `w_save_file_status()`:

1. Write the new JSON content to `file_status.json.tmp`.
2. If `fwrite` succeeds **and `fclose()` succeeds**, atomically replace `file_status.json` with the `.tmp` file via `rename()` (POSIX) or `MoveFileExA(MOVEFILE_REPLACE_EXISTING)` (Windows).
3. If `fwrite` or `fclose()` fails, delete the `.tmp` file and leave the original intact.

The `fwrite` success check is also tightened from `== 0` to `!= size_str` to catch partial writes. `fclose()` is now checked explicitly because a failed flush (e.g., `ENOSPC`) would otherwise silently replace the valid destination file with a corrupt `.tmp`.

### Results and Evidence

**Before the fix** — reproduction steps:
1. Start the agent (ensures `file_status.json` has content).
2. Wait for a periodic `w_save_file_status()` call.
3. Send `SIGKILL` to `wazuh-logcollector` during the write window.
4. Result: `file_status.json` has 0 bytes.
5. Restart agent → `ERROR: (1115): Could not read from file 'queue/logcollector/file_status.json'`.

<details><summary>ossec.log</summary>

```console
2026/05/28 19:39:51 wazuh-agentd: INFO: Started (pid: 67555).
2026/05/28 19:39:51 wazuh-agentd: INFO: Trying to connect to server ([192.168.56.30]:1514/tcp).
2026/05/28 19:39:51 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
2026/05/28 19:39:52 wazuh-execd: INFO: Started (pid: 67543).
2026/05/28 19:39:52 wazuh-rootcheck: INFO: Started (pid: 67580).
2026/05/28 19:39:52 wazuh-syscheckd: INFO: Started (pid: 67580).
2026/05/28 19:39:52 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/05/28 19:39:52 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/05/28 19:39:52 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/05/28 19:39:52 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/05/28 19:39:52 wazuh-logcollector: ERROR: (1115): Could not read from file 'queue/logcollector/file_status.json' due to [(0)-(Success)].
2026/05/28 19:39:52 wazuh-logcollector: INFO: Started (pid: 67589).
2026/05/28 19:39:52 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/05/28 19:39:52 wazuh-modulesd: INFO: Started (pid: 67603).
2026/05/28 19:39:52 wazuh-modulesd:control: INFO: Starting control thread.
2026/05/28 19:39:52 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 67603).
2026/05/28 19:39:52 wazuh-modulesd:agent-info: INFO: Started (pid: 67603).
2026/05/28 19:39:52 wazuh-modulesd:sca: INFO: Started (pid: 67603).
2026/05/28 19:39:52 wazuh-modulesd:syscollector: INFO: Started (pid: 67603).
2026/05/28 19:39:52 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/05/28 19:39:52 wazuh-modulesd:sca: INFO: Scan started.
2026/05/28 19:39:52 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/05/28 19:39:53 wazuh-modulesd:sca: INFO: Scan ended.
2026/05/28 19:39:54 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/05/28 19:40:14 wazuh-rootcheck: INFO: Rootcheck scan ended.
```

</details> 

**After the fix** — `file_status.json` is never left in a 0-byte or partial state. Killing the process mid-write leaves the previous complete file intact because the destination is only replaced after the `.tmp` file is fully written, flushed, and closed successfully.

### Artifacts Affected

| File | Change |
|------|--------|
| `src/logcollector/src/logcollector.c` | `w_save_file_status()` rewritten to use atomic write-then-rename |
| `src/unit_tests/logcollector/test_logcollector.c` | Updated 3 existing tests to match new `.tmp` path, error messages, and new `rename`/`unlink` expectations. Added `unistd_wrappers.h` include. Added 1 new test for `fclose()` failure path. |
| `src/unit_tests/logcollector/CMakeLists.txt` | Added `--wrap,rename`, `--wrap,unlink`, and `--wrap,getpid` linker flags to `test_logcollector` target |

### Configuration Changes

None.

### Documentation Updates

None. The change is transparent to the user; `file_status.json` path and format are unchanged.

### Tests Introduced

Three existing unit tests were updated and one new test was added:

| Test | Change |
|------|--------|
| `test_w_save_file_status_wfopen_error` | `wfopen` path and `merror_exit` message updated to `.json.tmp` |
| `test_w_save_file_status_fwrite_error` | `wfopen` path and `merror` message updated to `.json.tmp`; added `expect unlink(".json.tmp")` after the failed write |
| `test_w_save_file_status_fclose_error` | **New** — `fwrite` succeeds, `fclose` returns `EOF`; expects `merror` + `unlink(".json.tmp")`; no `rename` |
| `test_w_save_file_status_OK` | `wfopen` path updated to `.json.tmp`; `fwrite` return value set to match `size_str`; `fclose` returns `0`; added `expect rename(".json.tmp", ".json")` |

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues