### PR TITLE
builder: enforce policy stage allow-lists per asset type

### DIFF
--- a/src/engine/source/builder/src/policy/assetBuilder.cpp
+++ b/src/engine/source/builder/src/policy/assetBuilder.cpp
@@ -4,6 +4,7 @@
 #include <fmt/format.h>
 
 #include "syntax.hpp"
+#include "stageValidator.hpp"
 
 namespace builder::policy
 {
@@ -294,6 +295,7 @@ Asset AssetBuilder::operator()(const json::Json& document) const
 
     // Get parents (optional)
     std::vector<base::Name> parents;
+    if (!objDoc.empty())
     {
         const auto& [key, value] = *objDoc.begin();
         if (key == syntax::asset::PARENTS_KEY)
@@ -303,6 +305,8 @@ Asset AssetBuilder::operator()(const json::Json& document) const
         }
     }
 
+    // Validate stages before building the expression.
+    validateStages(name, objDoc);
     // Build the expression (rest of keys if any)
     auto expression = buildExpression(name, objDoc);
 

--- a/src/engine/source/builder/src/policy/stageValidator.hpp
+++ b/src/engine/source/builder/src/policy/stageValidator.hpp
@@ -1,0 +1,278 @@
+#ifndef BUILDER_POLICY_STAGEVALIDATOR_HPP
+#define BUILDER_POLICY_STAGEVALIDATOR_HPP
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+#include <base/json.hpp>
+#include <base/name.hpp>
+#include <base/dotPath.hpp>
+#include <fmt/format.h>
+
+#include "syntax.hpp"
+
+namespace builder::policy
+{
+
+namespace detail
+{
+
+inline bool startsWith(const std::string& value, std::string_view prefix)
+{
+    return std::string_view(value).substr(0, prefix.size()) == prefix;
+}
+
+struct StageRule
+{
+    const char* name;
+    bool isPrefix;
+};
+
+struct AssetStageRules
+{
+    const char* description;
+    std::vector<StageRule> rules;
+};
+
+static constexpr char PARSE_STAGE_PREFIX[] = "parse|";
+static constexpr std::size_t PARSE_STAGE_PREFIX_SIZE = sizeof(PARSE_STAGE_PREFIX) - 1;
+
+inline const AssetStageRules& allowedStageRules(const std::string& assetType)
+{
+    static const AssetStageRules decoderRules {
+        "check, parse|<field>, normalize",
+        {{syntax::asset::CHECK_KEY, false},
+         {PARSE_STAGE_PREFIX, true},
+         {syntax::asset::NORMALIZE_KEY, false}}};
+
+    static const AssetStageRules filterRules {
+        "check",
+        {{syntax::asset::CHECK_KEY, false}}};
+
+    static const AssetStageRules outputRules {
+        "check, outputs",
+        {{syntax::asset::CHECK_KEY, false},
+         {syntax::asset::OUTPUTS_KEY, false}}};
+
+    if (assetType == "decoder")
+    {
+        return decoderRules;
+    }
+
+    if (assetType == "filter")
+    {
+        return filterRules;
+    }
+
+    if (assetType == "output")
+    {
+        return outputRules;
+    }
+
+    throw std::runtime_error(fmt::format("Unknown asset type '{}'", assetType));
+}
+
+inline bool isAllowedStage(const std::string& stage, const AssetStageRules& rules)
+{
+    return std::any_of(rules.rules.begin(),
+                       rules.rules.end(),
+                       [&stage](const auto& rule)
+                       {
+                           if (rule.isPrefix)
+                           {
+                               return startsWith(stage, rule.name);
+                           }
+
+                           return stage == rule.name;
+                       });
+}
+
+inline std::string assetTypeName(const base::Name& name)
+{
+    if (syntax::name::isDecoder(name))
+    {
+        return "decoder";
+    }
+
+    if (syntax::name::isFilter(name))
+    {
+        return "filter";
+    }
+
+    if (syntax::name::isOutput(name))
+    {
+        return "output";
+    }
+
+    throw std::runtime_error(fmt::format("Unknown asset type for asset '{}'", name.toStr()));
+}
+
+inline const char* allowedStages(const std::string& assetType)
+{
+    return allowedStageRules(assetType).description;
+}
+
+inline void throwInvalidStage(const std::string& stage, const base::Name& assetName, const std::string& assetType)
+{
+    throw std::runtime_error(fmt::format("Invalid stage '{}' for {} asset '{}'. Allowed stages: {}",
+                                         stage,
+                                         assetType,
+                                         assetName.toStr(),
+                                         allowedStages(assetType)));
+}
+
+inline bool isSupportedOutputOperation(const std::string& operation)
+{
+    return operation == syntax::asset::FIRST_OF_KEY || operation == syntax::asset::FILE_OUTPUT_KEY
+           || operation == syntax::asset::INDEXER_OUTPUT_KEY;
+}
+
+inline void validateOutputsStage(const json::Json& outputs, const base::Name& assetName)
+{
+    const auto arr = outputs.getArray();
+
+    if (!arr)
+    {
+        throw std::runtime_error(
+            fmt::format("Invalid outputs stage for output asset '{}'. Expected a non-empty array of objects",
+                        assetName.toStr()));
+    }
+
+    if (arr.value().empty())
+    {
+        throw std::runtime_error(
+            fmt::format("Invalid outputs stage for output asset '{}'. Expected a non-empty array of objects",
+                        assetName.toStr()));
+    }
+
+    for (const auto& item : arr.value())
+    {
+        const auto obj = item.getObject();
+
+        if (!obj)
+        {
+            throw std::runtime_error(
+                fmt::format("Invalid outputs stage for output asset '{}'. Expected every item to be an object",
+                            assetName.toStr()));
+        }
+
+        if (obj.value().size() != 1)
+        {
+            throw std::runtime_error(
+                fmt::format("Invalid outputs stage for output asset '{}'. Each item must contain exactly one operation",
+                            assetName.toStr()));
+        }
+
+        for (const auto& operationEntry : obj.value())
+        {
+            const auto& operation = std::get<0>(operationEntry);
+
+            if (!isSupportedOutputOperation(operation))
+            {
+                throw std::runtime_error(
+                    fmt::format("Invalid output operation '{}' for output asset '{}'.\nAllowed operations: {}, {}, {}",
+                                operation,
+                                assetName.toStr(),
+                                syntax::asset::FIRST_OF_KEY,
+                                syntax::asset::FILE_OUTPUT_KEY,
+                                syntax::asset::INDEXER_OUTPUT_KEY));
+            }
+        }
+    }
+}
+
+inline void validateDecoderStage(const std::string& stage, const base::Name& assetName)
+{
+    const auto& rules = allowedStageRules("decoder");
+    if (!isAllowedStage(stage, rules))
+    {
+        throwInvalidStage(stage, assetName, "decoder");
+    }
+
+    if (!startsWith(stage, PARSE_STAGE_PREFIX))
+    {
+        return;
+    }
+
+    const auto field = stage.substr(PARSE_STAGE_PREFIX_SIZE);
+
+    if (field.empty())
+    {
+        throw std::runtime_error(fmt::format(
+            "Invalid parse stage '{}' for decoder asset '{}': missing field. Expected format: parse|<field>",
+            stage,
+            assetName.toStr()));
+    }
+
+    try
+    {
+        DotPath {field};
+    }
+    catch (const std::exception& e)
+    {
+        throw std::runtime_error(
+            fmt::format("Invalid parse stage '{}' for decoder asset '{}': {}", stage, assetName.toStr(), e.what()));
+    }
+}
+
+inline void validateFilterStage(const std::string& stage, const base::Name& assetName)
+{
+    const auto& rules = allowedStageRules("filter");
+    if (!isAllowedStage(stage, rules))
+    {
+        throwInvalidStage(stage, assetName, "filter");
+    }
+
+}
+
+inline void validateOutputStage(const std::string& stage, const json::Json& value, const base::Name& assetName)
+{
+    const auto& rules = allowedStageRules("output");
+    if (!isAllowedStage(stage, rules))
+    {
+        throwInvalidStage(stage, assetName, "output");
+    }
+
+    if (stage == syntax::asset::OUTPUTS_KEY)
+    {
+        validateOutputsStage(value, assetName);
+    }
+
+}
+
+} // namespace detail
+
+inline void validateStages(const base::Name& assetName, const std::vector<std::tuple<std::string, json::Json>>& stages)
+{
+    const auto assetType = detail::assetTypeName(assetName);
+
+    for (const auto& [stage, value] : stages)
+    {
+        if (stage == syntax::asset::DEFINITIONS_KEY)
+        {
+            continue;
+        }
+
+        if (assetType == "decoder")
+        {
+            detail::validateDecoderStage(stage, assetName);
+        }
+        else if (assetType == "filter")
+        {
+            detail::validateFilterStage(stage, assetName);
+        }
+        else if (assetType == "output")
+        {
+            detail::validateOutputStage(stage, value, assetName);
+        }
+    }
+}
+
+} // namespace builder::policy
+
+#endif // BUILDER_POLICY_STAGEVALIDATOR_HPP
+

--- a/src/engine/source/builder/test/src/unit/policy/assetBuilder_test.cpp
+++ b/src/engine/source/builder/test/src/unit/policy/assetBuilder_test.cpp
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <base/behaviour.hpp>
@@ -530,13 +531,13 @@ using Expc = Expected<SuccessExpected, FailureExpected>;
 auto SUCCESS = Expc::success();
 auto FAILURE = Expc::failure();
 
-using BuildT = std::tuple<std::string, Expc>;
+using BuildT = std::tuple<std::string, std::string, Expc>;
 
 using BuildAsset = AssetBuilderTest<BuildT>;
 
 TEST_P(BuildAsset, Build)
 {
-    auto [assetStr, expected] = GetParam();
+    auto [assetStr, expectedMsg, expected] = GetParam();
     auto asset = json::Json(assetStr.c_str());
 
     if (expected)
@@ -551,42 +552,80 @@ TEST_P(BuildAsset, Build)
     else
     {
         expected.failCase()(m_mocks);
-        EXPECT_THROW(m_assetBuilder->operator()(asset), std::runtime_error);
+        if (!expectedMsg.empty())
+        {
+            EXPECT_THROW(
+                {
+                    try
+                    {
+                        m_assetBuilder->operator()(asset);
+                    }
+                    catch (const std::runtime_error& e)
+                    {
+                        EXPECT_THAT(e.what(), ::testing::HasSubstr(expectedMsg));
+                        throw;
+                    }
+                },
+                std::runtime_error);
+        }
+        else
+        {
+            EXPECT_THROW(m_assetBuilder->operator()(asset), std::runtime_error);
+        }
     }
 }
 
 INSTANTIATE_TEST_SUITE_P(
     AssetBuilder,
     BuildAsset,
-    ::testing::Values(BuildT(R"({})", FAILURE()),
-                      BuildT(R"({"noName": "name"})", FAILURE()),
-                      BuildT(R"({"name": 1})", FAILURE()),
-                      BuildT(R"({"name": "name"})",
+    ::testing::Values(BuildT(R"({})", "", FAILURE()),
+                      BuildT(R"({"noName": "name"})", "", FAILURE()),
+                      BuildT(R"({"name": 1})", "", FAILURE()),
+                      BuildT(R"({"name": "output/wazuh/0"})",
+                             "",
                              SUCCESS(
                                  [](Mocks mocks)
                                  {
                                      EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
                                          .WillOnce(testing::Return(mocks.m_mockDefs));
-                                     return Asset(base::Name("name"), assetExpr, {});
+                                     auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                     auto consequence = base::And::create(base::Name("stages"), {});
+                                     return Asset(base::Name("output/wazuh/0"),
+                                                  base::Implication::create(
+                                                      base::Name("output/wazuh/0"), condition, consequence),
+                                                  {});
                                  })),
-                      BuildT(R"({"name": "name", "metadata": {}})",
+                      BuildT(R"({"name": "output/wazuh/0", "metadata": {}})",
+                             "",
                              SUCCESS(
                                  [](Mocks mocks)
                                  {
                                      EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
                                          .WillOnce(testing::Return(mocks.m_mockDefs));
-                                     return Asset(base::Name("name"), assetExpr, {});
+                                     auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                     auto consequence = base::And::create(base::Name("stages"), {});
+                                     return Asset(base::Name("output/wazuh/0"),
+                                                  base::Implication::create(
+                                                      base::Name("output/wazuh/0"), condition, consequence),
+                                                  {});
                                  })),
-                      BuildT(R"({"name": "name", "parents": ["parent"]})",
+                      BuildT(R"({"name": "output/wazuh/0", "parents": ["parent"]})",
+                             "",
                              SUCCESS(
                                  [](Mocks mocks)
                                  {
                                      EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
                                          .WillOnce(testing::Return(mocks.m_mockDefs));
-                                     return Asset(base::Name("name"), assetExpr, {base::Name("parent")});
+                                     auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                     auto consequence = base::And::create(base::Name("stages"), {});
+                                     return Asset(base::Name("output/wazuh/0"),
+                                                  base::Implication::create(
+                                                      base::Name("output/wazuh/0"), condition, consequence),
+                                                  {base::Name("parent")});
                                  })),
-                      BuildT(R"({"name": "name", "parents": {}})", FAILURE()),
-                      BuildT(R"({"name": "name", "check": {}})",
+                      BuildT(R"({"name": "output/wazuh/0", "parents": {}})", "", FAILURE()),
+                      BuildT(R"({"name": "output/wazuh/0", "check": {}})",
+                             "",
                              SUCCESS(
                                  [](Mocks mocks)
                                  {
@@ -604,17 +643,247 @@ INSTANTIATE_TEST_SUITE_P(
                                      auto condition =
                                          base::And::create(base::Name("condition"), {checkExpr, traceExpr});
                                      auto consequence = base::And::create(base::Name("stages"), {});
-                                     return Asset(base::Name("name"),
-                                                  base::Implication::create(base::Name("name"), condition, consequence),
+                                     return Asset(base::Name("output/wazuh/0"),
+                                                  base::Implication::create(
+                                                      base::Name("output/wazuh/0"), condition, consequence),
                                                   {});
                                  })),
-                      BuildT(R"({"name": "name", "check": {}})",
+                      BuildT(R"({"name": "output/wazuh/0", "check": {}})",
+                             "",
                              FAILURE(
                                  [](Mocks mocks)
                                  {
                                      EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
                                          .WillOnce(testing::Throw(std::runtime_error("")));
                                      return None {};
-                                 }))));
+                                 })),
+                    // Stage validation: invalid cases (should fail)
+                    // filter + normalize
+                    BuildT(R"({"name": "filter/wazuh/0", "type": "pre-filter", "normalize": []})",
+                        "Invalid stage 'normalize' for filter asset",
+                        FAILURE()),
+                    // filter + parse|message
+                    BuildT(R"({"name": "filter/wazuh/0", "type": "pre-filter", "parse|message": []})",
+                        "Invalid stage 'parse|message' for filter asset",
+                        FAILURE()),
+                    // filter + outputs
+                    BuildT(R"({"name": "filter/wazuh/0", "type": "pre-filter", "outputs": []})",
+                        "Invalid stage 'outputs' for filter asset",
+                        FAILURE()),
+                    // decoder + outputs
+                    BuildT(R"({"name": "decoder/wazuh/0", "outputs": []})",
+                        "Invalid stage 'outputs' for decoder asset",
+                        FAILURE()),
+                    // output + normalize
+                    BuildT(R"({"name": "output/wazuh/0", "normalize": []})",
+                        "Invalid stage 'normalize' for output asset",
+                        FAILURE()),
+                    // output + parse|message
+                    BuildT(R"({"name": "output/wazuh/0", "parse|message": []})",
+                        "Invalid stage 'parse|message' for output asset",
+                        FAILURE()),
+                    // outputs + invalid operation
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": [{"invalid_op": {}}]})",
+                        "Invalid output operation 'invalid_op' for output asset",
+                        FAILURE()),
+
+                    // Stage validation: valid cases (should pass)
+                    // filter + check
+                    BuildT(R"({"name": "filter/wazuh/0", "type": "pre-filter", "check": []})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto checkExpr = base::Term<base::EngineOp>::create(
+                                    "check", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("check"))
+                                    .WillOnce(testing::Return(
+                                        [checkExpr](const json::Json& value,
+                                                    const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return checkExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {checkExpr, traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {});
+                                return Asset(base::Name("filter/wazuh/0"),
+                                            base::Implication::create(base::Name("filter/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // decoder + normalize
+                    BuildT(R"({"name": "decoder/wazuh/0", "normalize": []})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto normalizeExpr = base::Term<base::EngineOp>::create(
+                                    "normalize", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("normalize"))
+                                    .WillOnce(testing::Return(
+                                        [normalizeExpr](const json::Json& value,
+                                                        const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return normalizeExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {normalizeExpr, automappingExpr});
+                                return Asset(base::Name("decoder/wazuh/0"),
+                                            base::Implication::create(base::Name("decoder/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // decoder + parse|message
+                    BuildT(R"({"name": "decoder/wazuh/0", "parse|message": []})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto parseExpr = base::Term<base::EngineOp>::create(
+                                    "parse", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("parse"))
+                                    .WillOnce(testing::Return(
+                                        [parseExpr](const json::Json& value,
+                                                    const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return parseExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {parseExpr, traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {automappingExpr});
+                                return Asset(base::Name("decoder/wazuh/0"),
+                                            base::Implication::create(base::Name("decoder/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // output + check
+                    BuildT(R"({"name": "output/wazuh/0", "check": []})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto checkExpr = base::Term<base::EngineOp>::create(
+                                    "check", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("check"))
+                                    .WillOnce(testing::Return(
+                                        [checkExpr](const json::Json& value,
+                                                    const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return checkExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {checkExpr, traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {});
+                                return Asset(base::Name("output/wazuh/0"),
+                                            base::Implication::create(base::Name("output/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // output + outputs with first_of
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": [{"first_of": {}}]})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto outputsExpr = base::Term<base::EngineOp>::create(
+                                    "outputs", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("outputs"))
+                                    .WillOnce(testing::Return(
+                                        [outputsExpr](const json::Json& value,
+                                                    const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return outputsExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {outputsExpr});
+                                return Asset(base::Name("output/wazuh/0"),
+                                            base::Implication::create(base::Name("output/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // decoder + parse| (empty field after pipe)
+                    BuildT(R"({"name": "decoder/wazuh/0", "parse|": []})",
+                        "Invalid parse stage 'parse|' for decoder asset 'decoder/wazuh/0': missing field",
+                        FAILURE()),
+                    // decoder + parse|field..invalid (invalid DotPath)
+                    BuildT(R"({"name": "decoder/wazuh/0", "parse|field..invalid": []})",
+                        "Invalid parse stage 'parse|field..invalid' for decoder asset",
+                        FAILURE()),
+                    // output + outputs: null (not an array)
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": null})",
+                        "Invalid outputs stage for output asset 'output/wazuh/0'. Expected a non-empty array of objects",
+                        FAILURE()),
+                    // output + outputs: [] (empty array)
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": []})",
+                        "Invalid outputs stage for output asset 'output/wazuh/0'. Expected a non-empty array of objects",
+                        FAILURE()),
+                    // output + outputs: ["string"] (item is not an object)
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": ["string"]})",
+                        "Invalid outputs stage for output asset 'output/wazuh/0'. Expected every item to be an object",
+                        FAILURE()),
+                    // output + outputs: [{}] (empty object — no operation)
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": [{}]})",
+                        "Invalid outputs stage for output asset 'output/wazuh/0'. Each item must contain exactly one operation",
+                        FAILURE()),
+                    // output + outputs: [{"first_of": {}, "file": {}}] (multiple operations in one item)
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": [{"first_of": {}, "file": {}}]})",
+                        "Invalid outputs stage for output asset 'output/wazuh/0'. Each item must contain exactly one operation",
+                        FAILURE()),
+                    // output + outputs: [{"file": {}}]
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": [{"file": {}}]})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto outputsExpr = base::Term<base::EngineOp>::create(
+                                    "outputs", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("outputs"))
+                                    .WillOnce(testing::Return(
+                                        [outputsExpr](const json::Json& value,
+                                                    const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return outputsExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {outputsExpr});
+                                return Asset(base::Name("output/wazuh/0"),
+                                            base::Implication::create(base::Name("output/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // output + outputs: [{"wazuh-indexer": {}}]
+                    BuildT(R"({"name": "output/wazuh/0", "outputs": [{"wazuh-indexer": {}}]})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto outputsExpr = base::Term<base::EngineOp>::create(
+                                    "outputs", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("outputs"))
+                                    .WillOnce(testing::Return(
+                                        [outputsExpr](const json::Json& value,
+                                                    const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return outputsExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {outputsExpr});
+                                return Asset(base::Name("output/wazuh/0"),
+                                            base::Implication::create(base::Name("output/wazuh/0"), condition, consequence),
+                                            {});
+                            })),
+                    // decoder + definitions + normalize (definitions should be skipped)
+                    BuildT(R"({"name": "decoder/wazuh/0", "definitions": {"foo": "bar"}, "normalize": []})",
+                        "",
+                        SUCCESS(
+                            [](Mocks mocks)
+                            {
+                                EXPECT_CALL(*mocks.m_mockDefBuilder, build(testing::_))
+                                    .WillOnce(testing::Return(mocks.m_mockDefs));
+                                auto normalizeExpr = base::Term<base::EngineOp>::create(
+                                    "normalize", [](auto e) { return base::result::makeSuccess(e, "SUCCESS"); });
+                                EXPECT_CALL(mocks.m_mockRegistry->getRegistry<StageBuilder>(), get("normalize"))
+                                    .WillOnce(testing::Return(
+                                        [normalizeExpr](const json::Json& value,
+                                                        const std::shared_ptr<const IBuildCtx>& ctx) -> base::Expression
+                                        { return normalizeExpr; }));
+                                auto condition = base::And::create(base::Name("condition"), {traceExpr});
+                                auto consequence = base::And::create(base::Name("stages"), {normalizeExpr, automappingExpr});
+                                return Asset(base::Name("decoder/wazuh/0"),
+                                            base::Implication::create(base::Name("decoder/wazuh/0"), condition, consequence),
+                                            {});
+                            }))
+                        ));
 
 } // namespace assetbuildtest


### PR DESCRIPTION
## Description

This PR closes #33950 by adding centralized validation for policy asset stages before expression construction.

The policy builder now enforces stage allow-lists per asset type:

* Decoders accept `check`, `parse|<field>`, and `normalize`.
* Filters accept only `check`.
* Outputs accept `check` and `outputs`.

The validation rejects invalid stage combinations earlier in the policy building process, before executable expressions are generated. It also validates parse sub-stages and supported output operations, while keeping structural keys out of stage validation.

This change does not modify the runtime behavior of valid policies. It only makes invalid policy assets fail earlier with clearer validation errors.

## Testing

* Built the builder target successfully.
* Added unit coverage for invalid stage combinations across decoder, filter, and output assets.
* Added coverage for invalid parse sub-stages.
* Added coverage for output stage shape edge cases.

Closes #33950