### PR TITLE
wazuh-agent remains active after uninstall on Fedora 44 / DNF5

### DIFF
--- a/src/init/templates/wazuh-agent.service
+++ b/src/init/templates/wazuh-agent.service
@@ -12,7 +12,6 @@ ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop
 ExecReload=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control reload
 
 KillMode=process
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Closes #36608

On Fedora 40+ with DNF5 (≥ 5.x), `systemctl stop wazuh-agent.service` fails
silently inside the RPM `%preun` scriptlet due to D-Bus instability in the
DNF5 transaction context. `wazuh-control stop` then kills the daemons directly,
but because systemd's `ExecStop` was never invoked, systemd has no knowledge of
the shutdown. With `RemainAfterExit=yes` in a `Type=forking` unit, systemd keeps
the service marked `active (exited)` indefinitely — even after the package is
fully removed.

Root cause chain:
1. `systemctl stop` fails silently in DNF5 scriptlet (D-Bus env not set)
2. `wazuh-control stop` kills daemons directly → processes gone, systemd not notified
3. `RemainAfterExit=yes` keeps the unit `active (exited)` in systemd memory
4. Result: `rpm -q wazuh-agent` → not installed, `systemctl is-active` → `active`

## Proposed Changes

Remove `RemainAfterExit=yes` from the wazuh-agent systemd unit template.

With `Type=forking` and no `RemainAfterExit=yes`, systemd tracks process
membership in the service cgroup. When the cgroup becomes empty (daemons killed
by any means), systemd auto-transitions to `inactive (dead)` without needing
`ExecStop` to be invoked through systemd. The start/stop/reload lifecycle is
unchanged.

```diff
 KillMode=process
-RemainAfterExit=yes
 
 [Install]
```

### Results and Evidence

**Test environment:** Fedora 44, kernel 6.19.14-300.fc44.x86_64, systemd 259, DNF5 5.4.2.0  
**Package under test:** wazuh-agent 4.14.5-1 (official repo, real binaries)

<details><summary>Phase 1 — BUG reproduced (<code>RemainAfterExit=yes</code>, original config)</summary>

```bash
[fedora@ip-172-31-30-124 ~]$ rpm -q wazuh-agent
wazuh-agent-4.14.5-1.x86_64

[fedora@ip-172-31-30-124 ~]$ grep RemainAfterExit /usr/lib/systemd/system/wazuh-agent.service
RemainAfterExit=yes

[fedora@ip-172-31-30-124 ~]$ sudo systemctl start wazuh-agent

[fedora@ip-172-31-30-124 ~]$ systemctl is-active wazuh-agent
active

[fedora@ip-172-31-30-124 ~]$ pgrep -a wazuh
31476 /var/ossec/bin/wazuh-execd
31485 /var/ossec/bin/wazuh-agentd
31499 /var/ossec/bin/wazuh-syscheckd
31510 /var/ossec/bin/wazuh-logcollector
31528 /var/ossec/bin/wazuh-modulesd

[fedora@ip-172-31-30-124 ~]$ sudo kill 31476 31485 31499 31510 31528
[fedora@ip-172-31-30-124 ~]$ sudo kill $(pgrep wazuh)

[fedora@ip-172-31-30-124 ~]$ pgrep -a wazuh
(no wazuh processes running)

[fedora@ip-172-31-30-124 ~]$ systemctl is-active wazuh-agent
active

[fedora@ip-172-31-30-124 ~]$ systemctl status wazuh-agent --no-pager
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/usr/lib/systemd/system/wazuh-agent.service; enabled; preset: disabled)
     Active: active (exited) since Tue 2026-06-02 06:08:40 UTC; 1min 23s ago
   Mem peak: 30.3M
        CPU: 4.692s
```

**BUG REPRODUCED:** `active (exited)` with zero live wazuh processes.

</details>

<details><summary>Phase 2 — FIX validated (<code>RemainAfterExit=yes</code> removed)</summary>

```bash
[fedora@ip-172-31-30-124 ~]$ sudo sed -i '/RemainAfterExit/d' /usr/lib/systemd/system/wazuh-agent.service

[fedora@ip-172-31-30-124 ~]$ grep RemainAfterExit /usr/lib/systemd/system/wazuh-agent.service || echo "(line removed)"
(line removed)

[fedora@ip-172-31-30-124 ~]$ sudo systemctl daemon-reload
[fedora@ip-172-31-30-124 ~]$ sudo systemctl stop wazuh-agent
[fedora@ip-172-31-30-124 ~]$ sudo systemctl start wazuh-agent

[fedora@ip-172-31-30-124 ~]$ systemctl is-active wazuh-agent
active

[fedora@ip-172-31-30-124 ~]$ pgrep -a wazuh
32695 /var/ossec/bin/wazuh-execd
32707 /var/ossec/bin/wazuh-agentd
32721 /var/ossec/bin/wazuh-syscheckd
32732 /var/ossec/bin/wazuh-logcollector
32747 /var/ossec/bin/wazuh-modulesd

[fedora@ip-172-31-30-124 ~]$ systemctl status wazuh-agent --no-pager
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/usr/lib/systemd/system/wazuh-agent.service; enabled; preset: disabled)
     Active: active (running) since Tue 2026-06-02 06:10:41 UTC; 42ms ago
     CGroup: /system.slice/wazuh-agent.service
             ├─32695 /var/ossec/bin/wazuh-execd
             ├─32707 /var/ossec/bin/wazuh-agentd
             ├─32721 /var/ossec/bin/wazuh-syscheckd
             ├─32732 /var/ossec/bin/wazuh-logcollector
             └─32747 /var/ossec/bin/wazuh-modulesd

[fedora@ip-172-31-30-124 ~]$ sudo kill 32695 32707 32721 32732 32747
[fedora@ip-172-31-30-124 ~]$ sudo kill $(pgrep wazuh)

[fedora@ip-172-31-30-124 ~]$ pgrep -a wazuh
(no wazuh processes running)

[fedora@ip-172-31-30-124 ~]$ systemctl is-active wazuh-agent
inactive

[fedora@ip-172-31-30-124 ~]$ systemctl status wazuh-agent --no-pager
     Active: inactive (dead) since Tue 2026-06-02 06:11:02 UTC; 33s ago
```

**FIX VALIDATED:** systemd detects the empty cgroup and auto-transitions to `inactive (dead)`.

</details>

<details><summary>Phase 3 — Full <code>dnf remove</code> while agent running (target bug scenario)</summary>

```bash
[fedora@ip-172-31-30-124 ~]$ sudo systemctl start wazuh-agent

[fedora@ip-172-31-30-124 ~]$ systemctl is-active wazuh-agent
active

[fedora@ip-172-31-30-124 ~]$ pgrep -a wazuh
33744 /var/ossec/bin/wazuh-execd
33753 /var/ossec/bin/wazuh-agentd
33767 /var/ossec/bin/wazuh-syscheckd
33778 /var/ossec/bin/wazuh-logcollector
33796 /var/ossec/bin/wazuh-modulesd

[fedora@ip-172-31-30-124 ~]$ sudo dnf remove -y wazuh-agent
Package      Arch   Version    Repository      Size
Removing:
 wazuh-agent x86_64 0:4.14.5-1 wazuh       32.7 MiB

Transaction Summary:
 Removing:           1 package

After this operation, 33 MiB will be freed (install 0 B, remove 33 MiB).
Running transaction
[1/2] Prepare transaction               100% |   0.0   B/s |   1.0   B |  00m17s
[2/2] Removing wazuh-agent-0:4.14.5-1.x 100% | 637.0   B/s | 422.0   B |  00m01s
Complete!

[fedora@ip-172-31-30-124 ~]$ rpm -q wazuh-agent
package wazuh-agent is not installed

[fedora@ip-172-31-30-124 ~]$ systemctl is-active wazuh-agent
inactive

[fedora@ip-172-31-30-124 ~]$ pgrep -a wazuh
(no wazuh processes running)
```
</details>
<details><summary>Phase 4 — Full <code>apt remove</code> while agent running (target scenario)</summary>

```bash
ubuntu-wazuh-test:~$ sudo systemctl start wazuh-agent

ubuntu-wazuh-test:~$ systemctl is-active wazuh-agent
active

ubuntu-wazuh-test:~$ pgrep -a wazuh
5299 /var/ossec/bin/wazuh-execd
5310 /var/ossec/bin/wazuh-agentd
5323 /var/ossec/bin/wazuh-syscheckd
5336 /var/ossec/bin/wazuh-logcollector
5353 /var/ossec/bin/wazuh-modulesd

ubuntu-wazuh-test:~$ sudo apt remove -y wazuh-agent
The following packages will be REMOVED:
  wazuh-agent
0 upgraded, 0 newly installed, 1 to remove and 127 not upgraded.
After this operation, 48.9 MB disk space will be freed.
Removing wazuh-agent (4.14.5-1) ...
...

ubuntu-wazuh-test:~$ dpkg -l wazuh-agent | tail -1
rc  wazuh-agent    4.14.5-1     amd64        Wazuh agent

ubuntu-wazuh-test:~$ systemctl is-active wazuh-agent
inactive

ubuntu-wazuh-test:~$ pgrep -a wazuh
(no wazuh processes running)

ubuntu-wazuh-test:~$ systemctl status wazuh-agent --no-pager | grep Active
Unit wazuh-agent.service could not be found.
```

**BUG RESOLVED:** Full `dnf remove` on a running agent leaves the system clean.

</details>

| Phase | `RemainAfterExit` | Action | `is-active` | Result |
|---|---|---|---|---|
| 1 | `yes` (original) | kill daemons directly | `active` | **BUG** |
| 2 | removed (fix) | kill daemons directly | `inactive` | **FIX VALIDATED** |
| 3 | removed (fix) | `dnf remove` while running | `inactive` | **BUG RESOLVED** |
| 4 | removed (fix) | `apt remove` while running | `inactive` | **Safe change** |

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues