### PR TITLE
Validate IP address in ip-customblock active response

### DIFF
--- a/src/active-response/ip-customblock.c
+++ b/src/active-response/ip-customblock.c
@@ -30,6 +30,14 @@ int main (int argc, char **argv) {
         return OS_INVALID;
     }
 
+    if (get_ip_version(srcip) == OS_INVALID) {
+        memset(log_msg, '\0', OS_MAXSTR);
+        snprintf(log_msg, OS_MAXSTR - 1, "Unable to run active response (invalid IP: '%s')", srcip);
+        write_debug_file(argv[0], log_msg);
+        cJSON_Delete(input_json);
+        return OS_INVALID;
+    }
+
     if (action == ADD_COMMAND) {
         char **keys = NULL;
         int action2 = OS_INVALID;

--- a/src/unit_tests/active-response/CMakeLists.txt
+++ b/src/unit_tests/active-response/CMakeLists.txt
@@ -23,6 +23,8 @@ target_link_libraries(ACTIVE-RESPONSE_O ${WAZUHLIB} ${WAZUHEXT} -lpthread)
 if(NOT ${TARGET} STREQUAL "winagent")
     list(APPEND active-response_names "test_active-response")
     list(APPEND active-response_flags "-Wl,--wrap,getaddrinfo -Wl,--wrap,fcntl")
+    list(APPEND active-response_names "test_ip-customblock")
+    list(APPEND active-response_flags "-Wl,--wrap,getaddrinfo -Wl,--wrap,fcntl")
 endif()
 
 list(LENGTH active-response_names count)

--- a/src/unit_tests/active-response/test_ip-customblock.c
+++ b/src/unit_tests/active-response/test_ip-customblock.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <setjmp.h>
+#include <stdio.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../headers/shared.h"
+#include "../../active-response/active_responses.h"
+
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+// Structs
+typedef struct test_struct {
+    struct addrinfo *addr;
+} test_struct_t;
+
+// Setup / Teardown
+
+static int test_setup(void **state) {
+    test_struct_t *init_data = NULL;
+
+    os_calloc(1, sizeof(test_struct_t), init_data);
+    os_calloc(1, sizeof(struct addrinfo), init_data->addr);
+    os_calloc(1, sizeof(struct sockaddr), init_data->addr->ai_addr);
+
+    *state = init_data;
+
+    test_mode = 1;
+
+    return OS_SUCCESS;
+}
+
+static int test_teardown(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+
+    os_free(data->addr->ai_addr);
+    os_free(data->addr);
+    os_free(data);
+
+    test_mode = 0;
+
+    return OS_SUCCESS;
+}
+
+// Tests
+
+void test_ip_customblock_valid_ipv4(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    char *valid_ipv4 = "192.168.1.100";
+
+    data->addr->ai_family = AF_INET;
+
+    expect_string(__wrap_getaddrinfo, node, valid_ipv4);
+    will_return(__wrap_getaddrinfo, data->addr);
+    will_return(__wrap_getaddrinfo, 0);
+
+    int ret = get_ip_version(valid_ipv4);
+
+    assert_int_equal(ret, 4);
+}
+
+void test_ip_customblock_valid_ipv6(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    char *valid_ipv6 = "2001:0db8::1";
+
+    data->addr->ai_family = AF_INET6;
+
+    expect_string(__wrap_getaddrinfo, node, valid_ipv6);
+    will_return(__wrap_getaddrinfo, data->addr);
+    will_return(__wrap_getaddrinfo, 0);
+
+    int ret = get_ip_version(valid_ipv6);
+
+    assert_int_equal(ret, 6);
+}
+
+void test_ip_customblock_invalid_ip_with_path_traversal(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    char *malicious_ip = "../../tmp/malicious";
+
+    expect_string(__wrap_getaddrinfo, node, malicious_ip);
+    will_return(__wrap_getaddrinfo, data->addr);
+    will_return(__wrap_getaddrinfo, 1);
+
+    int ret = get_ip_version(malicious_ip);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_ip_customblock_invalid_ip_with_special_chars(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    char *malicious_ip = "192.168.1.1; rm -rf /";
+
+    expect_string(__wrap_getaddrinfo, node, malicious_ip);
+    will_return(__wrap_getaddrinfo, data->addr);
+    will_return(__wrap_getaddrinfo, 1);
+
+    int ret = get_ip_version(malicious_ip);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_ip_customblock_invalid_ip_empty_string(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    char *empty_ip = "";
+
+    expect_string(__wrap_getaddrinfo, node, empty_ip);
+    will_return(__wrap_getaddrinfo, data->addr);
+    will_return(__wrap_getaddrinfo, 1);
+
+    int ret = get_ip_version(empty_ip);
+
+    assert_int_equal(ret, OS_INVALID);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_ip_customblock_valid_ipv4, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ip_customblock_valid_ipv6, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ip_customblock_invalid_ip_with_path_traversal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ip_customblock_invalid_ip_with_special_chars, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_ip_customblock_invalid_ip_empty_string, test_setup, test_teardown),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Description

This PR adds IP address validation to the `ip-customblock` active response script to ensure that only valid IP addresses are processed. The validation prevents malformed input from being used in file path operations.

## Proposed Changes

- Added IP validation check after extracting `srcip` from JSON input
- Returns `OS_INVALID` and logs an error message if the IP address format is invalid
- Uses the existing `get_ip_version()` utility function which validates IPs using `getaddrinfo()` with `AI_NUMERICHOST`

### Results and Evidence

The `ip-customblock.c` script now validates the `srcip` parameter using the `get_ip_version()` function before constructing file paths. This brings it in line with other active response scripts (`host-deny.c`, `firewalld-drop.c`, `default-firewall-drop.c`) which already implement this validation pattern.

Unit tests passing:

```
100% tests passed, 0 tests failed out of 82
```

### Artifacts Affected

- `ip-customblock` binary (active response script)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

New unit test file `test_ip-customblock.c` with the following test cases:
- `test_ip_customblock_valid_ipv4`: Validates acceptance of valid IPv4 addresses
- `test_ip_customblock_valid_ipv6`: Validates acceptance of valid IPv6 addresses
- `test_ip_customblock_invalid_ip_with_dots_and_slashes`: Validates rejection of malformed strings with dots and slashes
- `test_ip_customblock_invalid_ip_with_special_chars`: Validates rejection of strings with special characters
- `test_ip_customblock_invalid_ip_empty_string`: Validates rejection of empty strings

Updated `CMakeLists.txt` to include the new test in the build configuration.

## Credits

Thanks to @TristanInSec for raising this issue to our attention.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues