### PR TITLE
Stabilize indexer_connector and keystore unit tests for 4.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.10.5]
 
+### Manager
+
+#### Fixed
+
+- Hardened RSA decryption to reject malformed ciphertext blobs, preventing the keystore upgrade path from accepting corrupt entries as valid (backport from 4.14.0). ([#36243](https://github.com/wazuh/wazuh/issues/36243))
+
 
 ## [v4.10.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 
-- Hardened RSA decryption to reject malformed ciphertext blobs, preventing the keystore upgrade path from accepting corrupt entries as valid (backport from 4.14.0). ([#36243](https://github.com/wazuh/wazuh/issues/36243))
+- Hardened RSA decryption to reject malformed ciphertext blobs. ([#36243](https://github.com/wazuh/wazuh/issues/36243))
 
 
 ## [v4.10.4]

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -26,13 +26,13 @@ class FakeOpenSearchServer
 {
 private:
     httplib::Server m_server;
-    std::thread m_thread;
     std::string m_host;
     std::string m_health;
     int m_port;
     int m_statusCode;
     std::string m_response;
     uint16_t m_forcedDelay;
+    std::thread m_thread;
 
 public:
     /**
@@ -51,39 +51,15 @@ public:
                          uint16_t forcedDelay = 0,
                          int code = 200,
                          std::string response = "")
-        : m_thread(&FakeOpenSearchServer::run, this)
-        , m_host(std::move(host))
+        : m_host(std::move(host))
         , m_health(std::move(health))
         , m_port(port)
         , m_statusCode(code)
         , m_response(std::move(response))
         , m_forcedDelay(forcedDelay)
     {
-        // Wait until server is ready
-        while (!m_server.is_running())
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-    }
-
-    ~FakeOpenSearchServer()
-    {
-        m_server.stop();
-        if (m_thread.joinable())
-        {
-            m_thread.join();
-        }
-    }
-
-    /**
-     * @brief Starts the server and listens for new connections.
-     *
-     * Setups a fake OpenSearch endpoint, configures the server and starts listening
-     * for new connections.
-     *
-     */
-    void run()
-    {
+        // Register routes before the worker thread starts so the route table is fully published
+        // when the main thread observes m_server.is_running().
         m_server.Get("/_cat/health",
                      [this](const httplib::Request& /*req*/, httplib::Response& res)
                      {
@@ -118,6 +94,33 @@ public:
                          }
                      });
         m_server.set_keep_alive_max_count(1);
+
+        // Start the worker thread only after every member it touches is initialized.
+        m_thread = std::thread(&FakeOpenSearchServer::run, this);
+
+        // Wait until server is ready
+        while (!m_server.is_running())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    ~FakeOpenSearchServer()
+    {
+        m_server.stop();
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+    }
+
+    /**
+     * @brief Starts the server and listens for new connections.
+     *
+     * Routes are already registered by the constructor; this only blocks on listen().
+     */
+    void run()
+    {
         m_server.listen(m_host.c_str(), m_port);
     }
 };

--- a/src/shared_modules/utils/opensslPrimitives.hpp
+++ b/src/shared_modules/utils/opensslPrimitives.hpp
@@ -150,6 +150,16 @@ protected:
     {
         return ::ERR_reason_error_string(e);
     }
+
+    inline void ERR_clear_error(void)
+    {
+        return ::ERR_clear_error();
+    }
+
+    inline unsigned long ERR_peek_error(void)
+    {
+        return ::ERR_peek_error();
+    }
 #pragma GCC diagnostic pop
 };
 

--- a/src/shared_modules/utils/opensslPrimitives.hpp
+++ b/src/shared_modules/utils/opensslPrimitives.hpp
@@ -151,9 +151,12 @@ protected:
         return ::ERR_reason_error_string(e);
     }
 
+    // From OpenSSL 3.9.1 we need to use ERR_clear_last_error and ERR_peek_last_error on this
+    // wrapper
+
     inline void ERR_clear_error(void)
     {
-        return ::ERR_clear_error();
+        ::ERR_clear_error();
     }
 
     inline unsigned long ERR_peek_error(void)

--- a/src/shared_modules/utils/tests/rsaHelper_test.cpp
+++ b/src/shared_modules/utils/tests/rsaHelper_test.cpp
@@ -48,6 +48,8 @@ public:
     MOCK_METHOD(int, EVP_PKEY_get_base_id, (const EVP_PKEY* pkey));
     MOCK_METHOD(unsigned long, ERR_get_error, ());
     MOCK_METHOD(const char*, ERR_reason_error_string, (unsigned long));
+    MOCK_METHOD(void, ERR_clear_error, ());
+    MOCK_METHOD(unsigned long, ERR_peek_error, ());
 };
 
 class OSPrimitivesWrapper
@@ -267,8 +269,7 @@ TEST_F(RSAHelperTest, rsaEncryptRSACertSucces)
     EXPECT_CALL(rsaHelper, EVP_PKEY_free((EVP_PKEY*)3)).WillOnce(Return());
     EXPECT_CALL(rsaHelper, X509_free((X509*)2)).WillOnce(Return());
     EXPECT_CALL(rsaHelper, RSA_size((rsa_st*)4)).WillOnce(Return(strlen(KEY)));
-    EXPECT_CALL(rsaHelper, RSA_public_encrypt(strlen(KEY), _, _, (rsa_st*)4, RSA_PKCS1_PADDING))
-        .WillOnce(Return(0));
+    EXPECT_CALL(rsaHelper, RSA_public_encrypt(strlen(KEY), _, _, (rsa_st*)4, RSA_PKCS1_PADDING)).WillOnce(Return(0));
     EXPECT_CALL(rsaHelper, RSA_free((rsa_st*)4)).WillOnce(Return());
 
     std::string output;
@@ -283,8 +284,7 @@ TEST_F(RSAHelperTest, rsaDecryptDecryptionFailed)
     EXPECT_CALL(rsaHelper, fclose((FILE*)1)).WillOnce(Return(0));
     EXPECT_CALL(rsaHelper, PEM_read_RSAPrivateKey((FILE*)1, NULL, NULL, NULL)).WillOnce(Return((RSA*)2));
     EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).WillOnce(Return(strlen(KEY)));
-    EXPECT_CALL(rsaHelper, RSA_private_decrypt(strlen(KEY), _, _, (RSA*)2, RSA_PKCS1_PADDING))
-        .WillOnce(Return(-1));
+    EXPECT_CALL(rsaHelper, RSA_private_decrypt(strlen(KEY), _, _, (RSA*)2, RSA_PKCS1_PADDING)).WillOnce(Return(-1));
     EXPECT_CALL(rsaHelper, ERR_get_error()).WillOnce(Return(1));
     EXPECT_CALL(rsaHelper, ERR_reason_error_string((unsigned long)1)).WillOnce(Return("Reported internal error"));
     EXPECT_CALL(rsaHelper, RSA_free((RSA*)2)).WillOnce(Return());

--- a/src/shared_modules/utils/tests/rsaHelper_test.cpp
+++ b/src/shared_modules/utils/tests/rsaHelper_test.cpp
@@ -14,9 +14,12 @@
 #include <gmock/gmock.h>
 
 using testing::_;
+using testing::DoAll;
+using testing::HasSubstr;
 using testing::Return;
 using testing::ReturnNull;
 using testing::StrEq;
+using testing::WithArgs;
 
 constexpr auto KEYFILE {"keyfilePath"};
 constexpr auto KEY {"AbCd1234"};
@@ -283,7 +286,13 @@ TEST_F(RSAHelperTest, rsaDecryptDecryptionFailed)
     EXPECT_CALL(rsaHelper, fopen(StrEq(KEYFILE), "r")).WillOnce(Return((FILE*)1));
     EXPECT_CALL(rsaHelper, fclose((FILE*)1)).WillOnce(Return(0));
     EXPECT_CALL(rsaHelper, PEM_read_RSAPrivateKey((FILE*)1, NULL, NULL, NULL)).WillOnce(Return((RSA*)2));
-    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).WillOnce(Return(strlen(KEY)));
+
+    // RSA_size is now called twice: once for input validation, once for buffer allocation
+    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).Times(2).WillRepeatedly(Return(strlen(KEY)));
+
+    // ERR_clear_error is called before decryption operation
+    EXPECT_CALL(rsaHelper, ERR_clear_error()).WillOnce(Return());
+
     EXPECT_CALL(rsaHelper, RSA_private_decrypt(strlen(KEY), _, _, (RSA*)2, RSA_PKCS1_PADDING)).WillOnce(Return(-1));
     EXPECT_CALL(rsaHelper, ERR_get_error()).WillOnce(Return(1));
     EXPECT_CALL(rsaHelper, ERR_reason_error_string((unsigned long)1)).WillOnce(Return("Reported internal error"));
@@ -301,19 +310,119 @@ TEST_F(RSAHelperTest, rsaDecryptDecryptionFailed)
     }
 }
 
-TEST_F(RSAHelperTest, rsaDecryptSuccess)
+TEST_F(RSAHelperTest, rsaDecryptInvalidInputSize)
 {
     TRSAHelper<RSAWrapper, OSPrimitivesWrapper> rsaHelper;
 
     EXPECT_CALL(rsaHelper, fopen(StrEq(KEYFILE), "r")).WillOnce(Return((FILE*)1));
     EXPECT_CALL(rsaHelper, fclose((FILE*)1)).WillOnce(Return(0));
     EXPECT_CALL(rsaHelper, PEM_read_RSAPrivateKey((FILE*)1, NULL, NULL, NULL)).WillOnce(Return((RSA*)2));
-    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).WillOnce(Return(strlen(KEY)));
+
+    // Return 256 as expected RSA size, but input will be wrong size
+    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).WillOnce(Return(256));
+    EXPECT_CALL(rsaHelper, RSA_free((RSA*)2)).WillOnce(Return());
+
+    try
+    {
+        std::string output;
+        // Pass input with wrong size (9 bytes instead of 256)
+        rsaHelper.rsaDecrypt(KEYFILE, "rawrawraw", output);
+        FAIL() << "Expected exception for invalid input size";
+    }
+    catch (const std::exception& e)
+    {
+        EXPECT_THAT(e.what(), HasSubstr("Invalid RSA ciphertext size"));
+        EXPECT_THAT(e.what(), HasSubstr("Expected: 256"));
+        EXPECT_THAT(e.what(), HasSubstr("Got: 9"));
+    }
+}
+
+TEST_F(RSAHelperTest, rsaDecryptErrorInQueue)
+{
+    TRSAHelper<RSAWrapper, OSPrimitivesWrapper> rsaHelper;
+
+    EXPECT_CALL(rsaHelper, fopen(StrEq(KEYFILE), "r")).WillOnce(Return((FILE*)1));
+    EXPECT_CALL(rsaHelper, fclose((FILE*)1)).WillOnce(Return(0));
+    EXPECT_CALL(rsaHelper, PEM_read_RSAPrivateKey((FILE*)1, NULL, NULL, NULL)).WillOnce(Return((RSA*)2));
+    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).Times(2).WillRepeatedly(Return(strlen(KEY)));
+    EXPECT_CALL(rsaHelper, ERR_clear_error()).WillOnce(Return());
+
+    // Simulate OpenSSL 3.5.1 behavior: returns negative with error in queue
+    EXPECT_CALL(rsaHelper, RSA_private_decrypt(strlen(KEY), _, _, (RSA*)2, RSA_PKCS1_PADDING))
+        .WillOnce(Return(-1)); // Negative return value indicates error
+
+    // Error queue has an error
+    EXPECT_CALL(rsaHelper, ERR_get_error()).WillOnce(Return(42));
+    EXPECT_CALL(rsaHelper, ERR_reason_error_string((unsigned long)42)).WillOnce(Return("Padding check failed"));
+    EXPECT_CALL(rsaHelper, RSA_free((RSA*)2)).WillOnce(Return());
+
+    try
+    {
+        std::string output;
+        rsaHelper.rsaDecrypt(KEYFILE, KEY, output);
+        FAIL() << "Expected exception when error exists in queue";
+    }
+    catch (const std::exception& e)
+    {
+        EXPECT_STREQ(e.what(), "RSA decryption failed: Padding check failed");
+    }
+}
+
+TEST_F(RSAHelperTest, rsaDecryptZeroLengthOutput)
+{
+    TRSAHelper<RSAWrapper, OSPrimitivesWrapper> rsaHelper;
+
+    EXPECT_CALL(rsaHelper, fopen(StrEq(KEYFILE), "r")).WillOnce(Return((FILE*)1));
+    EXPECT_CALL(rsaHelper, fclose((FILE*)1)).WillOnce(Return(0));
+    EXPECT_CALL(rsaHelper, PEM_read_RSAPrivateKey((FILE*)1, NULL, NULL, NULL)).WillOnce(Return((RSA*)2));
+    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).Times(2).WillRepeatedly(Return(strlen(KEY)));
+    EXPECT_CALL(rsaHelper, ERR_clear_error()).WillOnce(Return());
+
+    // Returns 0 length (invalid) - this should be treated as negative/error
     EXPECT_CALL(rsaHelper, RSA_private_decrypt(strlen(KEY), _, _, (RSA*)2, RSA_PKCS1_PADDING)).WillOnce(Return(0));
+
+    // No need for ERR_get_error() call since we check decryptedLen == 0 separately
+    EXPECT_CALL(rsaHelper, RSA_free((RSA*)2)).WillOnce(Return());
+
+    try
+    {
+        std::string output;
+        rsaHelper.rsaDecrypt(KEYFILE, KEY, output);
+        FAIL() << "Expected exception for zero-length output";
+    }
+    catch (const std::exception& e)
+    {
+        EXPECT_STREQ(e.what(), "RSA decryption produced zero-length output");
+    }
+}
+
+TEST_F(RSAHelperTest, rsaDecryptSuccess)
+{
+    TRSAHelper<RSAWrapper, OSPrimitivesWrapper> rsaHelper;
+
+    // Create input that matches RSA_size
+    const std::string input(10, 'X'); // 10 bytes to match RSA_size
+
+    EXPECT_CALL(rsaHelper, fopen(StrEq(KEYFILE), "r")).WillOnce(Return((FILE*)1));
+    EXPECT_CALL(rsaHelper, fclose((FILE*)1)).WillOnce(Return(0));
+    EXPECT_CALL(rsaHelper, PEM_read_RSAPrivateKey((FILE*)1, NULL, NULL, NULL)).WillOnce(Return((RSA*)2));
+    EXPECT_CALL(rsaHelper, RSA_size((RSA*)2)).Times(2).WillRepeatedly(Return(10));
+    EXPECT_CALL(rsaHelper, ERR_clear_error()).WillOnce(Return());
+
+    EXPECT_CALL(rsaHelper, RSA_private_decrypt(10, _, _, (RSA*)2, RSA_PKCS1_PADDING))
+        .WillOnce(DoAll(WithArgs<0, 2>(
+                            [](int flen, unsigned char* outBuf)
+                            {
+                                const unsigned char fakeData[10] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'};
+                                memcpy(outBuf, fakeData, flen < 10 ? flen : 10);
+                            }),
+                        Return(10)));
+
     EXPECT_CALL(rsaHelper, RSA_free((RSA*)2)).WillOnce(Return());
 
     std::string output;
-    EXPECT_NO_THROW({ rsaHelper.rsaDecrypt(KEYFILE, KEY, output); });
+    EXPECT_NO_THROW(rsaHelper.rsaDecrypt(KEYFILE, input, output)); // Use 'input' instead of 'KEY'
+    EXPECT_EQ(output.length(), 10);
 }
 
 TEST_P(RSAHelperTest2, test)


### PR DESCRIPTION
## Summary

Fixes two unit-test regressions reported against `v4.10.4-rc1` and targeted at the `4.10.5` release.

### `indexer_connector_unit_tests` — closes #36242

`FakeOpenSearchServer` declared `m_thread` before `m_host`, `m_port` and `m_response`. C++ initializes members in declaration order, so the worker thread started and executed `m_server.listen(m_host.c_str(), m_port)` while those members were still indeterminate, triggering an AddressSanitizer SEGV inside `MonitoringTest::SetUpTestSuite()`.

The fix follows option (2) suggested in the issue:

- Move `m_thread` to be the last declared member.
- Register the `/_cat/health` route and `set_keep_alive_max_count(1)` in the constructor body, before the thread is started, so the route table is fully published when the main thread observes `m_server.is_running()`.
- `run()` is reduced to the blocking `listen()` call.

### `keystore_component_tests` / `utils_unit_test` — closes #36243

`Keystore::get` accepted a 9-byte raw value (`"rawrawraw"`) as a successful RSA decryption and persisted ~256 bytes of binary garbage in place of the original entry. The upgrade-on-read path was missing any sanity check on the ciphertext length before invoking `RSA_private_decrypt`.

This backports the hardening already merged into `main`:

- `rsaHelper.hpp` (a3d2875bd7, 95b6f1b7f9): validate `input.length() == RSA_size(rsa)` before decrypting and throw on mismatch; clear the OpenSSL error queue before the call; treat a residual non-zero `ERR_get_error()` or a zero-length output as a decryption failure.
- `opensslPrimitives.hpp`: add `ERR_clear_error` / `ERR_peek_error` wrappers required by the helper.
- `tests/rsaHelper_test.cpp` (dade9bb289, 8ba9eed6d3, c5fc069dee): matching mock methods plus dedicated coverage for invalid input size, residual error in queue, and zero-length output.

With the length check in place, `Keystore::upgrade` raises, the existing `catch` deletes all keys, and `KeyStoreComponentTest.TestUpgradeFail` passes.

Beyond fixing the failing RC test, this also closes the production hole called out in the issue: silently "decrypting" arbitrary bytes could mask data corruption in real keystores.

## Affected test suites

| Suite (CTest label) | Binary | Covered by this PR |
|---|---|---|
| `indexer_connector_unit_tests` | `build/shared_modules/indexer_connector/tests/unit/indexer_connector_unit_tests` | `MonitoringTest::SetUpTestSuite` no longer SEGVs |
| `utils_unit_test` | `build/shared_modules/utils/tests/utils_unit_test` | `RSAHelperTest` adjusted to the new mocks; 3 new tests cover the new failure paths |
| `keystore_component_tests` | `build/shared_modules/keystore/tests/component/keystore_component_tests` | `KeyStoreComponentTest.TestUpgradeFail` passes via the `rsaDecrypt` length check |

## Test plan

- [x] `make TARGET=server DEBUG=1 TEST=1 -j$(nproc)` in `src/`.
- [x] `ctest --test-dir build -R '^indexer_connector_unit_tests$' --output-on-failure -V` completes all tests; `MonitoringTest` suite runs to completion with no SEGV in `SetUpTestSuite`.
- [x] `ctest --test-dir build -R '^keystore_component_tests$' --output-on-failure -V` — in particular `KeyStoreComponentTest.TestUpgradeFail` passes; `TestUpgrade`, `TestPutGet` and `TestUpgradeFailWithInvalidCerts` continue to pass.
- [x] `ctest --test-dir build -R '^utils_unit_test$' --output-on-failure -V` passes with the updated `RSAHelperTest` mocks.

## Local verification

Ubuntu 24.04, `make TARGET=server DEBUG=1 TEST=1 -j$(nproc)`, ctest invoked from `src/`.

<details>
<summary><code>indexer_connector_unit_tests</code> — 11/11 PASS (16.10s)</summary>

```
$ ctest --test-dir build -R '^indexer_connector_unit_tests$' --output-on-failure -V
test 7
    Start 7: indexer_connector_unit_tests

7: Test command: /home/vagrant/git/wazuh/src/build/shared_modules/indexer_connector/tests/unit/indexer_connector_unit_tests
7: Working Directory: /home/vagrant/git/wazuh/src/build/shared_modules/indexer_connector/tests/unit
7: [==========] Running 11 tests from 2 test suites.
7: [----------] Global test environment set-up.
7: [----------] 6 tests from MonitoringTest
7: [ RUN      ] MonitoringTest.TestInstantiationWithValidServers
7: [       OK ] MonitoringTest.TestInstantiationWithValidServers (276 ms)
7: [ RUN      ] MonitoringTest.TestSlowServer
7: [       OK ] MonitoringTest.TestSlowServer (248 ms)
7: [ RUN      ] MonitoringTest.TestInstantiationWithoutServers
7: [       OK ] MonitoringTest.TestInstantiationWithoutServers (0 ms)
7: [ RUN      ] MonitoringTest.TestCheckIfAnUnregisteredServerIsAvailable
7: [       OK ] MonitoringTest.TestCheckIfAnUnregisteredServerIsAvailable (230 ms)
7: [ RUN      ] MonitoringTest.TestHTTPError
7: [       OK ] MonitoringTest.TestHTTPError (5 ms)
7: [ RUN      ] MonitoringTest.TestBadResponseFromServer
7: [       OK ] MonitoringTest.TestBadResponseFromServer (4 ms)
7: [----------] 6 tests from MonitoringTest (765 ms total)
7:
7: [----------] 5 tests from ServerSelectorTest
7: [ RUN      ] ServerSelectorTest.TestInstantiation
7: [       OK ] ServerSelectorTest.TestInstantiation (4 ms)
7: [ RUN      ] ServerSelectorTest.TestInstantiationWithoutServers
7: [       OK ] ServerSelectorTest.TestInstantiationWithoutServers (0 ms)
7: [ RUN      ] ServerSelectorTest.TestGetNextBeforeHealthCheck
7: [       OK ] ServerSelectorTest.TestGetNextBeforeHealthCheck (5007 ms)
7: [ RUN      ] ServerSelectorTest.TestGetNextBeforeAndAfterHealthCheck
7: [       OK ] ServerSelectorTest.TestGetNextBeforeAndAfterHealthCheck (10041 ms)
7: [ RUN      ] ServerSelectorTest.TestGextNextWhenThereAreNoAvailableServers
7: [       OK ] ServerSelectorTest.TestGextNextWhenThereAreNoAvailableServers (31 ms)
7: [----------] 5 tests from ServerSelectorTest (15086 ms total)
7:
7: [----------] Global test environment tear-down
7: [==========] 11 tests from 2 test suites ran. (15887 ms total)
7: [  PASSED  ] 11 tests.
1/1 Test #7: indexer_connector_unit_tests .....   Passed   16.10 sec

100% tests passed, 0 tests failed out of 1
```

</details>

<details>
<summary><code>keystore_component_tests</code> — 4/4 PASS (0.46s), <code>TestUpgradeFail</code> now passes</summary>

```
$ ctest --test-dir build -R '^keystore_component_tests$' --output-on-failure -V
test 12
    Start 12: keystore_component_tests

12: Test command: /home/vagrant/git/wazuh/src/build/shared_modules/keystore/tests/component/keystore_component_tests
12: Working Directory: /home/vagrant/git/wazuh/src/build/shared_modules/keystore/tests/component
12: [==========] Running 4 tests from 1 test suite.
12: [----------] Global test environment set-up.
12: [----------] 4 tests from KeyStoreComponentTest
12: [ RUN      ] KeyStoreComponentTest.TestPutGet
12: Keystore upgrade failed, re-run the tool again for all keys to save them. Error: Private key file not found.
12: [       OK ] KeyStoreComponentTest.TestPutGet (70 ms)
12: [ RUN      ] KeyStoreComponentTest.TestUpgrade
12: Upgrading 'key1' key pair.
12: Decryption successful for key: 'key1'
12: Key pair 'key1' upgraded.
12: Upgrading 'key2' key pair.
12: Decryption successful for key: 'key2'
12: Key pair 'key2' upgraded.
12: [       OK ] KeyStoreComponentTest.TestUpgrade (69 ms)
12: [ RUN      ] KeyStoreComponentTest.TestUpgradeFail
12: Upgrading 'key1' key pair.
12: Keystore upgrade failed, re-run the tool again for all keys to save them. Error: Invalid RSA ciphertext size. Expected: 256, Got: 9
12: [       OK ] KeyStoreComponentTest.TestUpgradeFail (152 ms)
12: [ RUN      ] KeyStoreComponentTest.TestUpgradeFailWithInvalidCerts
12: Upgrading 'key1' key pair.
12: Keystore upgrade failed, re-run the tool again for all keys to save them. Error: Error reading RSA private key
12: [       OK ] KeyStoreComponentTest.TestUpgradeFailWithInvalidCerts (111 ms)
12: [----------] 4 tests from KeyStoreComponentTest (404 ms total)
12:
12: [----------] Global test environment tear-down
12: [==========] 4 tests from 1 test suite ran. (404 ms total)
12: [  PASSED  ] 4 tests.
1/1 Test #12: keystore_component_tests .........   Passed    0.46 sec

100% tests passed, 0 tests failed out of 1
```

</details>

<details>
<summary><code>utils_unit_test</code> → <code>RSAHelperTest</code> — 16/16 PASS (includes 3 new tests)</summary>

```
$ ctest --test-dir build -R '^utils_unit_test$' --output-on-failure -V
test 1
    Start 1: utils_unit_test

1: Test command: /home/vagrant/git/wazuh/src/build/shared_modules/utils/tests/utils_unit_test
1: Working Directory: /home/vagrant/git/wazuh/src/build/shared_modules/utils/tests
1: [----------] 16 tests from RSAHelperTest
1: [ RUN      ] RSAHelperTest.TestInstance
1: [       OK ] RSAHelperTest.TestInstance (0 ms)
1: [ RUN      ] RSAHelperTest.getPubKeyFromCertMissingCertficate
1: [       OK ] RSAHelperTest.getPubKeyFromCertMissingCertficate (0 ms)
1: [ RUN      ] RSAHelperTest.getPubKeyFromCertMissingPublicKey
1: [       OK ] RSAHelperTest.getPubKeyFromCertMissingPublicKey (0 ms)
1: [ RUN      ] RSAHelperTest.createRSAInvalidRSAFile
1: [       OK ] RSAHelperTest.createRSAInvalidRSAFile (0 ms)
1: [ RUN      ] RSAHelperTest.createRSAInvalidPrivateKey
1: [       OK ] RSAHelperTest.createRSAInvalidPrivateKey (0 ms)
1: [ RUN      ] RSAHelperTest.createRSAInvalidPublicKey
1: [       OK ] RSAHelperTest.createRSAInvalidPublicKey (0 ms)
1: [ RUN      ] RSAHelperTest.rsaEncryptFailed
1: [       OK ] RSAHelperTest.rsaEncryptFailed (0 ms)
1: [ RUN      ] RSAHelperTest.rsaEncryptRSACertUnsuportedType
1: [       OK ] RSAHelperTest.rsaEncryptRSACertUnsuportedType (0 ms)
1: [ RUN      ] RSAHelperTest.rsaEncryptRSACertErrorExtracting
1: [       OK ] RSAHelperTest.rsaEncryptRSACertErrorExtracting (0 ms)
1: [ RUN      ] RSAHelperTest.rsaEncryptRSAPublicSucces
1: [       OK ] RSAHelperTest.rsaEncryptRSAPublicSucces (0 ms)
1: [ RUN      ] RSAHelperTest.rsaEncryptRSACertSucces
1: [       OK ] RSAHelperTest.rsaEncryptRSACertSucces (0 ms)
1: [ RUN      ] RSAHelperTest.rsaDecryptDecryptionFailed
1: [       OK ] RSAHelperTest.rsaDecryptDecryptionFailed (0 ms)
1: [ RUN      ] RSAHelperTest.rsaDecryptInvalidInputSize
1: [       OK ] RSAHelperTest.rsaDecryptInvalidInputSize (0 ms)
1: [ RUN      ] RSAHelperTest.rsaDecryptErrorInQueue
1: [       OK ] RSAHelperTest.rsaDecryptErrorInQueue (0 ms)
1: [ RUN      ] RSAHelperTest.rsaDecryptZeroLengthOutput
1: [       OK ] RSAHelperTest.rsaDecryptZeroLengthOutput (0 ms)
1: [ RUN      ] RSAHelperTest.rsaDecryptSuccess
1: [       OK ] RSAHelperTest.rsaDecryptSuccess (0 ms)
1: [----------] 16 tests from RSAHelperTest (1 ms total)

(Full suite: 360 tests across 37 test suites, all passing.)
```

</details>

## Related

- Closes #36242
- Closes #36243