### PR TITLE
Extend FIM pause poll budget while first sync runs

### DIFF
--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -455,6 +455,7 @@ typedef struct _config {
 #endif // WIN32
     atomic_int_t fim_pause_requested;                  /* Flag to indicate scans should be paused (0=false, 1=true) */
     atomic_int_t fim_pausing_is_allowed;               /* Flag to indicate fim_run_integrity acknowledged pause (0=false, 1=true) */
+    atomic_int_t fim_first_sync_completed;             /* Flag to indicate the first post-start FIM sync iteration finished (0=false, 1=true) */
     rtfim *realtime;
     fdb_t *database;
 

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -893,6 +893,10 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
     bool first_sync_completed = fim_db_get_last_sync_time(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY) > 0;
     bool skip_initial_wait = !first_sync_completed;
 
+    if (first_sync_completed) {
+        atomic_int_set(&syscheck.fim_first_sync_completed, 1);
+    }
+
 #ifdef WIN32
     int table_count = 3;
     char* table_names[3] = {FIMDB_FILE_TABLE_NAME, FIMDB_REGISTRY_KEY_TABLENAME, FIMDB_REGISTRY_VALUE_TABLENAME};
@@ -959,6 +963,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             if (sync_result && !first_sync_completed) {
                 fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                 first_sync_completed = true;
+                atomic_int_set(&syscheck.fim_first_sync_completed, 1);
             }
         } else {
             // Take a snapshot of the current directories list to avoid holding the lock during integrity checks.
@@ -989,6 +994,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 if (!first_sync_completed) {
                     fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                     first_sync_completed = true;
+                    atomic_int_set(&syscheck.fim_first_sync_completed, 1);
                 }
 
                 for (int i = 0; i < table_count; i++) {

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -484,6 +484,7 @@ void fim_initialize() {
 #endif
     syscheck.fim_pause_requested = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
     syscheck.fim_pausing_is_allowed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
 
     notify_scan = syscheck.notify_first_scan;
 

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -386,6 +386,8 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
         // Call is_pause_completed function
         result = fim_execute_is_pause_completed();
 
+        bool first_sync_completed = atomic_int_get(&syscheck.fim_first_sync_completed) ? true : false;
+
         if (result == 1) {
             // Pause in progress
             status_item = cJSON_CreateNumber(MQ_SUCCESS);
@@ -394,6 +396,7 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
             if (data_item) {
                 cJSON_AddStringToObject(data_item, "module", "fim");
                 cJSON_AddStringToObject(data_item, "status", "in_progress");
+                cJSON_AddBoolToObject(data_item, "first_sync_completed", first_sync_completed);
             }
         } else if (result == 0) {
             // Pause completed successfully
@@ -404,6 +407,7 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
                 cJSON_AddStringToObject(data_item, "module", "fim");
                 cJSON_AddStringToObject(data_item, "status", "completed");
                 cJSON_AddStringToObject(data_item, "result", "success");
+                cJSON_AddBoolToObject(data_item, "first_sync_completed", first_sync_completed);
             }
         } else {
             // Unexpected result

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -65,6 +65,13 @@ class AgentInfoImpl
             m_flushPollDelayMs = delayMs < 0 ? 0 : delayMs;
         }
 
+        /// @brief Override the FIM pause poll delay (milliseconds). Only used in unit tests to avoid real sleeps.
+        /// Negative values are clamped to 0.
+        void setPausePollDelayMs(int delayMs)
+        {
+            m_pausePollDelayMs = delayMs < 0 ? 0 : delayMs;
+        }
+
         /// @brief Initialize the synchronization protocol with only in-memory synchronization
         /// @param moduleName Name of the module
         /// @param mqFuncs Message queue functions
@@ -266,6 +273,10 @@ class AgentInfoImpl
         /// @brief Delay in milliseconds between flush completion polls (10 seconds in production).
         /// Overridable in unit tests to avoid real sleeps.
         int m_flushPollDelayMs = 10000;
+
+        /// @brief Delay in milliseconds between FIM pause completion polls (1 second in production).
+        /// Overridable in unit tests to avoid real sleeps.
+        int m_pausePollDelayMs = 1000;
 
         /// @brief Condition variable for efficient sleep/wake mechanism
         std::condition_variable m_cv;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -36,7 +36,7 @@ constexpr auto AGENT_METADATA_TABLE = "agent_metadata";
 constexpr auto AGENT_GROUPS_TABLE = "agent_groups";
 
 // Module coordination configuration
-const std::vector<std::string> COORDINATION_MODULES = {SCA_WM_NAME, SYSCOLLECTOR_WM_NAME, FIM_NAME};
+const std::vector<std::string> COORDINATION_MODULES = {FIM_NAME, SCA_WM_NAME, SYSCOLLECTOR_WM_NAME};
 constexpr int MAX_COORDINATION_RETRIES = 3;
 constexpr int COORDINATION_RETRY_DELAY_MS = 1000;
 
@@ -1141,12 +1141,21 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
     // fim_run_integrity holds fim_scan_mutex (across the full sync iteration). Retries
     // are needed until the current sync cycle ends and the mutex becomes available.
     // 30 attempts at 1 s covers sync cycles that take up to ~30 s under high load.
-    constexpr int MAX_PAUSE_POLL_ATTEMPTS = 30; // 30 seconds max
-    constexpr int PAUSE_POLL_DELAY_MS = 1000;   // 1 second between polls
+    constexpr int MAX_PAUSE_POLL_ATTEMPTS = 30; // 30 seconds steady-state budget
+
+    // The first FIM sync after a 4.x -> 5.x upgrade rebuilds the agent_sync_protocol DB
+    // from scratch and can hold fim_scan_mutex for several minutes. The 30 seconds
+    // budget is too tight for that one-shot case, so when FIM reports first sync still
+    // in progress we extend to 600 s for this call only.
+    constexpr int FIRST_SYNC_PAUSE_POLL_ATTEMPTS = 600; // 10 minutes
+    const int PAUSE_POLL_DELAY_MS = m_pausePollDelayMs > 0 ? m_pausePollDelayMs : 1;
+
+    int maxAttempts = MAX_PAUSE_POLL_ATTEMPTS;
+    bool budgetExtended = false;
 
     m_logFunction(LOG_DEBUG_VERBOSE, "Polling " + moduleName + " for pause completion (async pause)");
 
-    for (int attempt = 1; attempt <= MAX_PAUSE_POLL_ATTEMPTS; ++attempt)
+    for (int attempt = 1; attempt <= maxAttempts; ++attempt)
     {
         std::string isPauseCompletedMessage = createJsonCommand("is_pause_completed");
         ModuleResponse pollResponse = queryModuleWithRetry(moduleName, isPauseCompletedMessage);
@@ -1155,7 +1164,7 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
         {
             m_logFunction(LOG_WARNING,
                           "Failed to poll pause status for " + moduleName + " (attempt " + std::to_string(attempt) +
-                          "/" + std::to_string(MAX_PAUSE_POLL_ATTEMPTS) + ")");
+                          "/" + std::to_string(maxAttempts) + ")");
             std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
             continue;
         }
@@ -1167,13 +1176,25 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
 
             if (pollJson.contains("data") && pollJson["data"].contains("status"))
             {
+                // Extend the poll budget while FIM is still completing its first post-start sync.
+                if (!budgetExtended && moduleName == FIM_NAME &&
+                        pollJson["data"].contains("first_sync_completed") &&
+                        pollJson["data"]["first_sync_completed"].is_boolean() &&
+                        pollJson["data"]["first_sync_completed"].get<bool>() == false)
+                {
+                    maxAttempts = FIRST_SYNC_PAUSE_POLL_ATTEMPTS;
+                    budgetExtended = true;
+                    m_logFunction(LOG_INFO,
+                                  "Extending FIM pause poll budget while first sync is in progress");
+                }
+
                 std::string status = pollJson["data"]["status"].get<std::string>();
 
                 if (status == "in_progress")
                 {
                     m_logFunction(LOG_DEBUG,
                                   moduleName + " pause still in progress (attempt " + std::to_string(attempt) + "/" +
-                                  std::to_string(MAX_PAUSE_POLL_ATTEMPTS) + ")");
+                                  std::to_string(maxAttempts) + ")");
                     std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
                     continue;
                 }
@@ -1204,7 +1225,7 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
     }
 
     m_logFunction(LOG_ERROR,
-                  moduleName + " pause did not complete within " + std::to_string(MAX_PAUSE_POLL_ATTEMPTS) +
+                  moduleName + " pause did not complete within " + std::to_string(maxAttempts) +
                   " seconds (scan mutex may be held by a long sync cycle, or IPC communication failure)");
     return false;
 }

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1155,8 +1155,20 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
 
     m_logFunction(LOG_DEBUG_VERBOSE, "Polling " + moduleName + " for pause completion (async pause)");
 
+    auto interruptibleDelay = [this, PAUSE_POLL_DELAY_MS]() -> bool
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_cv.wait_for(lock, std::chrono::milliseconds(PAUSE_POLL_DELAY_MS), [this] { return m_stopped; });
+    };
+
     for (int attempt = 1; attempt <= maxAttempts; ++attempt)
     {
+        if (m_stopped)
+        {
+            m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+            return false;
+        }
+
         std::string isPauseCompletedMessage = createJsonCommand("is_pause_completed");
         ModuleResponse pollResponse = queryModuleWithRetry(moduleName, isPauseCompletedMessage);
 
@@ -1165,7 +1177,13 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
             m_logFunction(LOG_WARNING,
                           "Failed to poll pause status for " + moduleName + " (attempt " + std::to_string(attempt) +
                           "/" + std::to_string(maxAttempts) + ")");
-            std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
+
+            if (interruptibleDelay())
+            {
+                m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+                return false;
+            }
+
             continue;
         }
 
@@ -1195,7 +1213,13 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
                     m_logFunction(LOG_DEBUG,
                                   moduleName + " pause still in progress (attempt " + std::to_string(attempt) + "/" +
                                   std::to_string(maxAttempts) + ")");
-                    std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
+
+                    if (interruptibleDelay())
+                    {
+                        m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+                        return false;
+                    }
+
                     continue;
                 }
                 else if (status == "completed")
@@ -1221,7 +1245,11 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
                           " - Response: " + pollResponse.response);
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
+        if (interruptibleDelay())
+        {
+            m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+            return false;
+        }
     }
 
     m_logFunction(LOG_ERROR,
@@ -1361,7 +1389,18 @@ bool AgentInfoImpl::pauseCoordinationModules(std::set<std::string>& pausedModule
             {
                 if (!pollFimPauseCompletion(module))
                 {
-                    m_logFunction(LOG_ERROR, module + " pause failed or timed out, aborting coordination");
+                    // Distinguish a genuine pause failure/timeout from a graceful
+                    // shutdown that interrupted the poll. On stop this is expected.
+                    if (m_stopped)
+                    {
+                        m_logFunction(LOG_INFO,
+                                      module + " pause aborted due to shutdown, stopping coordination");
+                    }
+                    else
+                    {
+                        m_logFunction(LOG_ERROR, module + " pause failed or timed out, aborting coordination");
+                    }
+
                     resumePausedModules(pausedModules);
                     return false;
                 }
@@ -1993,6 +2032,11 @@ bool AgentInfoImpl::performDeltaSync(const std::string& table)
         {
             m_logFunction(LOG_INFO, "Successfully coordinated " + table);
             resetSyncFlag(table);
+        }
+        else if (m_stopped)
+        {
+            // Coordination was interrupted by a graceful stop, not a real failure.
+            m_logFunction(LOG_INFO, "Coordination of " + table + " aborted due to shutdown");
         }
         else
         {

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -10,9 +10,12 @@
 #include <mock_filesystem_wrapper.hpp>
 #include <mock_sysinfo.hpp>
 
+#include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 class AgentInfoCoordinationTest : public ::testing::Test
@@ -1696,6 +1699,129 @@ TEST_F(AgentInfoCoordinationTest, PausePollBudgetExtendedWhileFimFirstSyncInProg
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Extending FIM pause poll budget while first sync is in progress"));
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("fim pause completed successfully"));
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete within")));
+}
+
+// Regression guard for issue #36408: while the (possibly extended) FIM pause
+// poll is in progress, a stop() request must abort the loop promptly instead of
+// running out the full budget. This keeps agent-info within the modulesd
+// shutdown deadline even with the extended first-sync budget.
+TEST_F(AgentInfoCoordinationTest, PausePollAbortsPromptlyOnStop)
+{
+    int selectRowsCalls = 0;
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([&selectRowsCalls](const nlohmann::json& /* query */,
+                                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        if (selectRowsCalls++ == 0)
+        {
+            nlohmann::json flagData;
+            flagData["should_sync_metadata"] = 1;
+            flagData["should_sync_groups"] = 0;
+            flagData["last_metadata_integrity"] = 0;
+            flagData["last_groups_integrity"] = 0;
+            flagData["is_first_run"] = 0;
+            flagData["is_first_groups_run"] = 0;
+            callback(SELECTED, flagData);
+        }
+    }));
+
+    // FIM never finishes pausing and reports first_sync_completed=false, so the
+    // poll would otherwise run the extended 600 s budget. stop() must cut it short.
+    std::atomic<int> fimPausePollCount {0};
+
+    auto queryModuleFunc = [&fimPausePollCount](const std::string & module_name,
+                                                const std::string & query,
+                                                char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            ++fimPausePollCount;
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = false;
+        }
+        else if (command == "is_pause_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setFlushPollDelayMs(0);
+    // Non-zero poll delay so stop() has a wait to interrupt.
+    m_agentInfo->setPausePollDelayMs(50);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+
+    // Wait until the FIM pause poll has actually started (at least a couple of
+    // in-progress polls observed), then request stop. Generous cap so coordination
+    // has time to reach the pause phase in the unit harness; we only fire stop()
+    // once we know we are inside the poll loop, so the abort path is exercised.
+    std::thread stopper([this, &fimPausePollCount]()
+    {
+        for (int i = 0; i < 2000 && fimPausePollCount.load() < 2; ++i)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+
+        m_agentInfo->stop();
+    });
+
+    const auto begin = std::chrono::steady_clock::now();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+    const auto elapsedMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+
+    stopper.join();
+
+    // Must abort well under the extended budget (600 s). The key guarantee is that
+    // stop() cuts the poll short rather than running the budget out; a generous
+    // upper bound keeps this stable on slow CI while still catching a real hang.
+    EXPECT_LT(elapsedMs, 30000);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Agent stopping, aborting FIM pause poll"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete within")));
+    // A shutdown-interrupted poll is NOT a failure: it must not emit the
+    // pause-timeout ERROR nor the "Failed to coordinate" WARNING noise.
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause failed or timed out")));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Failed to coordinate")));
 }
 
 // When FIM reports first_sync_completed=true (steady state),

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1589,6 +1589,301 @@ TEST_F(AgentInfoCoordinationTest, ParseResponseBufferWithSyncProtocol)
     SUCCEED();
 }
 
+// When FIM reports first_sync_completed=false on is_pause_completed, agent-info
+//  must extend the pause poll budget beyond the steady-state 30 attempts.
+// The first post-upgrade FIM sync on macOS can take several minutes. Without
+// the extended budget, coordination aborts and ossec.log gets ERROR spam.
+TEST_F(AgentInfoCoordinationTest, PausePollBudgetExtendedWhileFimFirstSyncInProgress)
+{
+    int selectRowsCalls = 0;
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([&selectRowsCalls](const nlohmann::json& /* query */,
+                                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        if (selectRowsCalls++ == 0)
+        {
+            nlohmann::json flagData;
+            flagData["should_sync_metadata"] = 1;
+            flagData["should_sync_groups"] = 0;
+            flagData["last_metadata_integrity"] = 0;
+            flagData["last_groups_integrity"] = 0;
+            flagData["is_first_run"] = 0;
+            flagData["is_first_groups_run"] = 0;
+            callback(SELECTED, flagData);
+        }
+    }));
+
+    // Return in_progress + first_sync_completed=false for the first 45 polls (past the steady-state
+    // 30 cap), then completed. This proves the budget was extended past 30.
+    int fimPausePollCount = 0;
+    constexpr int IN_PROGRESS_POLLS = 45;
+
+    auto queryModuleFunc = [&fimPausePollCount](const std::string & module_name,
+                                                const std::string & query,
+                                                char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            ++fimPausePollCount;
+
+            if (fimPausePollCount <= IN_PROGRESS_POLLS)
+            {
+                responseJson["data"]["status"] = "in_progress";
+                responseJson["data"]["first_sync_completed"] = false;
+            }
+            else
+            {
+                responseJson["data"]["status"] = "completed";
+                responseJson["data"]["result"] = "success";
+                responseJson["data"]["first_sync_completed"] = false;
+            }
+        }
+        else if (command == "is_pause_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setFlushPollDelayMs(0);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_GT(fimPausePollCount, 30);
+    EXPECT_GE(fimPausePollCount, IN_PROGRESS_POLLS + 1);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Extending FIM pause poll budget while first sync is in progress"));
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("fim pause completed successfully"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete within")));
+}
+
+// When FIM reports first_sync_completed=true (steady state),
+// the pause poll budget must stay at 30 attempts.
+// We must not silently widen the window for the
+// common case.
+TEST_F(AgentInfoCoordinationTest, PausePollBudgetRemains30WhenFirstSyncCompleted)
+{
+    int selectRowsCalls = 0;
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([&selectRowsCalls](const nlohmann::json& /* query */,
+                                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        if (selectRowsCalls++ == 0)
+        {
+            nlohmann::json flagData;
+            flagData["should_sync_metadata"] = 1;
+            flagData["should_sync_groups"] = 0;
+            flagData["last_metadata_integrity"] = 0;
+            flagData["last_groups_integrity"] = 0;
+            flagData["is_first_run"] = 0;
+            flagData["is_first_groups_run"] = 0;
+            callback(SELECTED, flagData);
+        }
+    }));
+
+    int fimPausePollCount = 0;
+
+    // FIM always reports in_progress + first_sync_completed=true. Budget should cap at 30.
+    auto queryModuleFunc = [&fimPausePollCount](const std::string & module_name,
+                                                const std::string & query,
+                                                char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            ++fimPausePollCount;
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+        else if (command == "is_pause_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setFlushPollDelayMs(0);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_EQ(fimPausePollCount, 30);
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Extending FIM pause poll budget")));
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("pause did not complete within 30"));
+}
+
+// FIM must be paused before SCA/syscollector so that those modules
+// are not left idle while pollFimPauseCompletion waits for FIM's scan mutex.
+TEST_F(AgentInfoCoordinationTest, CoordinationPausesFimBeforeOtherModules)
+{
+    int selectRowsCalls = 0;
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([&selectRowsCalls](const nlohmann::json& /* query */,
+                                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        if (selectRowsCalls++ == 0)
+        {
+            nlohmann::json flagData;
+            flagData["should_sync_metadata"] = 1;
+            flagData["should_sync_groups"] = 0;
+            flagData["last_metadata_integrity"] = 0;
+            flagData["last_groups_integrity"] = 0;
+            flagData["is_first_run"] = 0;
+            flagData["is_first_groups_run"] = 0;
+            callback(SELECTED, flagData);
+        }
+    }));
+
+    std::vector<std::string> pauseOrder;
+
+    auto queryModuleFunc = [&pauseOrder](const std::string & module_name,
+                                         const std::string & query,
+                                         char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        if (command == "pause")
+        {
+            pauseOrder.push_back(module_name);
+        }
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setFlushPollDelayMs(0);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    ASSERT_GE(pauseOrder.size(), 3U);
+    EXPECT_EQ(pauseOrder[0], "fim");
+    EXPECT_EQ(pauseOrder[1], "sca");
+    EXPECT_EQ(pauseOrder[2], "syscollector");
+}
+
 TEST_F(AgentInfoCoordinationTest, ParseResponseBufferWithoutSyncProtocol)
 {
     // Test parseResponseBuffer without sync protocol


### PR DESCRIPTION
## Description

Closes #36358

After upgrading a macOS agent from 4.14.5 to 5.0.0, the `agent-info` module could log a spurious coordination failure during the first post-upgrade synchronization. When a metadata change triggers `coordinateModules()` while the first FIM synchronization is still holding the scan mutex, the pause-completion poll exhausts its fixed 30 second budget and aborts the coordination cycle, emitting ERROR and WARNING lines into the agent log even though nothing is actually broken. The first sync after an upgrade rebuilds the FIM synchronization state from scratch and can legitimately hold the mutex longer than 30 seconds, so the fixed budget is too tight for that one-shot case.


<details><summary>Before this PR</summary>

```mermaid
sequenceDiagram
    participant AI as agent-info
    participant FIM as FIM (sync thread)

    Note over FIM: First post-upgrade sync rebuilds FIM state
    activate FIM
    Note right of FIM: scan mutex LOCKED<br/>(held for the whole sync, can exceed 30s)

    Note over AI: Metadata change triggers coordination
    AI->>FIM: pause (request)
    loop poll is_pause_completed, up to 30s
        AI->>FIM: is_pause_completed?
        FIM-->>AI: in progress (mutex still held)
    end
    Note over AI: 30s budget exhausted
    AI-->>AI: ERROR: fim pause did not complete within 30 seconds
    AI-->>AI: WARNING: Failed to coordinate agent_metadata (abort, retry next cycle)
    deactivate FIM
```

</details> 

This PR extends the pause-poll budget while the first synchronization is in progress, and reorders the coordination sequence so FIM is paused first.



<details><summary>After this PR</summary>

```mermaid
sequenceDiagram
    participant AI as agent-info
    participant FIM as FIM (sync thread)

    Note over FIM: First post-upgrade sync rebuilds FIM state
    activate FIM
    Note right of FIM: scan mutex LOCKED

    Note over AI: Metadata change triggers coordination
    AI->>FIM: pause (request) + is_pause_completed?
    FIM-->>AI: in progress, first_sync_completed = false
    Note over AI: Extend pause-poll budget to 600s<br/>while first sync is in progress
    loop poll until mutex is free
        AI->>FIM: is_pause_completed?
        FIM-->>AI: in progress (mutex still held)
    end

    Note over FIM: First sync finishes
    Note right of FIM: scan mutex UNLOCKED
    deactivate FIM

    AI->>FIM: is_pause_completed?
    FIM-->>AI: completed (mutex acquired for coordination)
    Note over AI: Coordination succeeds, no error
```

</details> 

## Proposed Changes

- Add a `fim_first_sync_completed` atomic to the syscheck configuration, primed from the persisted first-sync marker at startup and set when the first FIM synchronization iteration completes.
- Surface a `first_sync_completed` boolean on the existing `is_pause_completed` syscom response (no new IPC command).
- In `pollFimPauseCompletion()`, when FIM reports the first sync is still in progress, raise the pause-poll budget from 30 seconds to 600 seconds for that call only. The steady-state 30 second budget is unchanged.
- Reorder `COORDINATION_MODULES` so FIM is paused first, ahead of SCA and Syscollector, so those modules are not left idle while FIM completes a long pause poll.
- Add unit tests covering the extended-budget path, the steady-state guard, and the new pause ordering.

## Results and Evidence

To validate the fix, an automated loop drove the upgrade scenario end to end many times on macOS arm64 against a Wazuh 5.0 manager. Each iteration performed a clean install of the 4.x agent, enrolled it, upgraded it in place to a 5.0 build, and then forced a metadata change so that `agent-info` runs a coordination cycle while the first post-upgrade FIM synchronization is still holding the scan mutex. The agent log of every iteration was captured and scanned for the pause-timeout signatures and for the new extended-budget behavior. Each iteration also confirmed whether the running binary contained the fix.

The same loop was run first against a stock build to confirm the bug reproduces, and then against a build of this branch. On the stock build, the coordination-during-sync overlap produced the pause-timeout failure. On this branch, the overlap consistently engaged the extended pause-poll budget and the coordination completed cleanly, with none of the pause-timeout failures observed in any iteration. Representative log excerpts from both cases are shown below.

<details>
<summary>Before the fix - bug reproduced with ERROR log </summary>

The first coordination cycle that overlaps the in-flight FIM sync aborts after the 30 second budget elapses:

```sql
wazuh-modulesd:agent-info: INFO: Skipping stateless event for agent_metadata: only OS-related fields changed
wazuh-modulesd:agent-info: INFO: Starting module coordination process
wazuh-modulesd:agent-info: INFO: Pausing sca module for synchronization coordination
wazuh-modulesd:agent-info: INFO: Pausing syscollector module for synchronization coordination
wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
wazuh-modulesd:agent-info: ERROR: fim pause did not complete within 30 seconds (scan mutex may be held by a long sync cycle, or IPC communication failure)
wazuh-modulesd:agent-info: ERROR: fim pause failed or timed out, aborting coordination
wazuh-modulesd:agent-info: INFO: Resuming paused module: sca
wazuh-modulesd:agent-info: INFO: Resuming paused module: syscollector
wazuh-modulesd:agent-info: WARNING: Failed to coordinate agent_metadata, will retry in next cycle
```

Observed on the stock build whenever the metadata change coincided with an in-flight FIM sync.
</details>

<details>
<summary>After the fix - INFO log detected instead of ERROR</summary>

Across a 100-run upgrade loop, every coordination cycle that overlapped the first FIM sync (13 occurrences) extended the budget and completed cleanly. Pause order now starts with FIM:

```sql
wazuh-modulesd:agent-info: INFO: Skipping stateless event for agent_metadata: only OS-related fields changed
wazuh-modulesd:agent-info: INFO: Starting module coordination process
wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
wazuh-modulesd:agent-info: INFO: Extending FIM pause poll budget while first sync is in progress
wazuh-modulesd:agent-info: INFO: Pausing sca module for synchronization coordination
wazuh-modulesd:agent-info: INFO: Pausing syscollector module for synchronization coordination
```

No `fim pause did not complete`, `fim pause failed or timed out`, or `Failed to coordinate agent_metadata` lines appeared in any of the 100 runs.
</details>

#### Validation summary

| | Build | Iterations executed | Coordination-during-sync overlaps | Bug fired | Fix engaged |
|---|---|---|---|---|---|
| Before | main (nightly) | 20 | 2 observed | 2 / 2 | n/a |
| After | fix branch | 100 | 13 observed | 0 / 13 | 13 / 13 |

- Bug signatures across all 100 runs: 0.
- `Extending FIM pause poll budget while first sync is in progress`: present on every overlapping coordination cycle.


## Artifacts Affected

- `wazuh-modulesd` (agent-info module).
- `wazuh-syscheckd` (FIM: syscom response, run_check, config struct).
- Platforms: all agent platforms; the failure was observed on macOS.

## Configuration Changes

- N/A. No new configuration options. The first-sync state is tracked internally via the `fim_first_sync_completed` atomic and surfaced over the existing syscom interface. The steady-state 30 second pause budget is unchanged.

## Documentation Updates

- N/A.

## Tests Introduced

- `agent_info_coordination_test.cpp`:
  - Extended-budget path: when FIM reports `first_sync_completed=false`, the pause poll continues past the steady-state cap and succeeds without a timeout error.
  - Steady-state guard: when `first_sync_completed=true`, the budget stays at 30 and the timeout fires as before.
  - Pause ordering: FIM is paused first in `COORDINATION_MODULES`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
