### PR TITLE
Align remoted metrics shipper with new field names

### DIFF
--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -403,7 +403,10 @@ class MetricsSnapshotTasks:
         raw_queue_usage = queues.get("usage")
         raw_queue_capacity = queues.get("size")
         raw_tcp_sessions = m.get("tcp_sessions")
-        raw_evt_total = msgs_recv.get("event")
+        raw_evt_total = msgs_recv.get("events")
+        raw_evt_failed = msgs_recv.get("events_failed")
+        raw_states = msgs_recv.get("states")
+        raw_upgrade_ack = msgs_recv.get("upgrade_ack")
         raw_discarded = msgs_recv.get("discarded")
         raw_sent_bytes = bytes_info.get("sent")
         raw_recv_bytes = bytes_info.get("received")
@@ -430,7 +433,8 @@ class MetricsSnapshotTasks:
                 "events": {
                     "total": raw_evt_total
                     if raw_evt_total is not None
-                    else doc.get("evt_count")
+                    else doc.get("evt_count"),
+                    "failed": {"total": raw_evt_failed},
                 },
                 "queue": {
                     "size": raw_queue_usage
@@ -491,6 +495,8 @@ class MetricsSnapshotTasks:
                             else doc.get("ctrl_msg_processed")
                         },
                     },
+                    "states": {"total": raw_states},
+                    "upgrades": {"total": raw_upgrade_ack},
                 },
             }
         )

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -213,7 +213,8 @@ async def test_collect_agents(mock_wazuh_db_query_agents):
 # _collect_comms_all_nodes
 # ---------------------------------------------------------------------------
 
-# Normalized dotted-path field names expected in every comms document
+# Normalized dotted-path field names emitted regardless of whether the
+# input is v5.0 nested or legacy v4 flat.
 EXPECTED_COMMS_FIELDS = {
     "queue.size",
     "queue.capacity",
@@ -233,6 +234,14 @@ EXPECTED_COMMS_FIELDS = {
     "wazuh.cluster.name",
     "wazuh.cluster.node",
     "wazuh.schema.version",
+}
+
+# Additional fields only emitted from v5.0 input (counters that didn't
+# exist in the legacy flat format).
+EXPECTED_COMMS_FIELDS_V5_ONLY = {
+    "events.failed.total",
+    "messages.states.total",
+    "messages.upgrades.total",
 }
 
 
@@ -1828,7 +1837,10 @@ REMOTED_STATS_V5_ALL_ZEROS = {
         "queues": {"received": {"usage": 0, "size": 0}},
         "messages": {
             "received_breakdown": {
-                "event": 0,
+                "events": 0,
+                "events_failed": 0,
+                "states": 0,
+                "upgrade_ack": 0,
                 "discarded": 0,
                 "dequeued_after": 0,
                 "control": 0,
@@ -1851,7 +1863,10 @@ REMOTED_STATS_V5_NONZERO = {
         "queues": {"received": {"usage": 10, "size": 100}},
         "messages": {
             "received_breakdown": {
-                "event": 1000,
+                "events": 1000,
+                "events_failed": 4,
+                "states": 333,
+                "upgrade_ack": 2,
                 "discarded": 3,
                 "dequeued_after": 1,
                 "control": 200,
@@ -1886,7 +1901,7 @@ class TestNormalizeCommsDocZeroPreservation:
         assert len(docs) == 1
         doc = docs[0]
         flat_keys = _deep_keys(doc)
-        for field in EXPECTED_COMMS_FIELDS:
+        for field in EXPECTED_COMMS_FIELDS | EXPECTED_COMMS_FIELDS_V5_ONLY:
             assert field in flat_keys, (
                 f"Field '{field}' missing from normalized comms doc with all-zero v5.0 counters"
             )
@@ -1950,6 +1965,7 @@ class TestNormalizeCommsDocZeroPreservation:
         assert doc["queue"]["capacity"] == 100
         assert doc["tcp"]["sessions"] == 5
         assert doc["events"]["total"] == 1000
+        assert doc["events"]["failed"]["total"] == 4
         assert doc["discarded"]["total"] == 3
         assert doc["network"]["egress"]["bytes"] == 512
         assert doc["network"]["ingress"]["bytes"] == 256
@@ -1959,6 +1975,8 @@ class TestNormalizeCommsDocZeroPreservation:
         assert doc["messages"]["control"]["replaced"]["total"] == 8
         assert doc["messages"]["control"]["processed"]["total"] == 202
         assert doc["messages"]["control"]["dropped_on_close"]["total"] == 1
+        assert doc["messages"]["states"]["total"] == 333
+        assert doc["messages"]["upgrades"]["total"] == 2
 
     @pytest.mark.asyncio
     async def test_legacy_flat_format_still_works(self):


### PR DESCRIPTION
Follow-up to #36456. Updates `metrics_snapshot.py` so the documents shipped to `wazuh-metrics-comms-*` reflect the field rename in `wazuh-remoted` getstats output and surface three new counters under field names agreed with the indexer-plugins team in https://github.com/wazuh/wazuh-indexer-plugins/issues/1235.

## Changes

- `framework/wazuh/core/indexer/metrics_snapshot.py`:
  - Read `messages.received_breakdown.events` (renamed from `event` in #36456). Legacy v4 fallback `evt_count` preserved.
  - Surface three new fields in the indexed document:
    - `events.failed.total` ← from `events_failed`
    - `messages.states.total` ← from `states`
    - `messages.upgrades.total` ← from `upgrade_ack`
- `framework/wazuh/core/indexer/tests/test_metrics_snapshot.py`:
  - V5 fixtures updated with the new key names and the three new counters.
  - `EXPECTED_COMMS_FIELDS` split into common (legacy-compatible) and v5-only sets.
  - `test_v5_nonzero_counters_are_correct` asserts the three new fields.

## Dependencies

The index template `metrics-comms.json` lives in `wazuh/wazuh-indexer-plugins` (https://github.com/wazuh/wazuh-indexer-plugins/issues/1235) and must be updated there with the three new mappings under their respective parents (`events.failed.total`, `messages.states.total`, `messages.upgrades.total`, all `long`) before this can ship — otherwise the indexer will reject the new fields under `dynamic: strict`.



# Evidences

- Statistics dashboard:
<img width="1699" height="1066" alt="image" src="https://github.com/user-attachments/assets/613f6148-979d-46d7-b82d-3ea73429f661" />
<img width="1697" height="1125" alt="image" src="https://github.com/user-attachments/assets/645b1847-5407-46f4-be00-612e67f4c606" />


- Json event to wazuh-metrics-comms:
```
{
  "_index": ".ds-wazuh-metrics-comms-000001",
  "_id": "U-sDrJ4BsQA6mAuiPyWp",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2026-06-09T10:52:34Z",
    "wazuh": {
      "cluster": {
        "name": "wazuh",
        "node": "node01"
      },
      "schema": {
        "version": "1"
      }
    },
    "event": {
      "module": "remoted"
    },
    "events": {
      "total": 73,
      "failed": {
        "total": 0
      }
    },
    "queue": {
      "size": 0,
      "capacity": 131072
    },
    "tcp": {
      "sessions": 1
    },
    "discarded": {
      "total": 0
    },
    "network": {
      "egress": {
        "bytes": 7950
      },
      "ingress": {
        "bytes": 1434064
      }
    },
    "messages": {
      "total": 58,
      "control": {
        "dropped_on_close": {
          "total": 0
        },
        "usage": 0,
        "received": {
          "total": 58
        },
        "replaced": {
          "total": 0
        },
        "processed": {
          "total": 58
        }
      },
      "states": {
        "total": 117
      },
      "upgrades": {
        "total": 0
      }
    }
  },
  "fields": {
    "@timestamp": [
      "2026-06-09T10:52:34.000Z"
    ]
  },
  "sort": [
    1781002354000
  ]
}
```