### PR TITLE
Downgrade transient manager-reported sync failures logs to debug

### DIFF
--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -620,7 +620,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
 
                 if (m_syncState.syncFailed)
                 {
-                    m_logger(LOG_ERROR, "Synchronization failed due to manager error.");
+                    m_logger(LOG_DEBUG, "Synchronization failed due to manager error.");
 
                     // Clean up metadata before returning
                     if (has_metadata)
@@ -980,7 +980,7 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
                 // Don't log error for checksum mismatch - it's an expected condition
                 if (m_syncState.lastSyncResult != SyncResult::CHECKSUM_ERROR)
                 {
-                    m_logger(LOG_ERROR, "Synchronization failed: Manager reported an error status.");
+                    m_logger(LOG_DEBUG, "Synchronization failed: Manager reported an error status.");
                 }
 
                 return false;
@@ -1096,7 +1096,7 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                         if (startAck->status() == Wazuh::SyncSchema::Status::Error ||
                                 startAck->status() == Wazuh::SyncSchema::Status::Offline)
                         {
-                            m_logger(LOG_ERROR, "Received StartAck with error status. Aborting synchronization.");
+                            m_logger(LOG_DEBUG, "Received StartAck with error status. Aborting synchronization.");
                             m_syncState.syncFailed = true;
                             m_syncState.cv.notify_all();
                             break;
@@ -1136,7 +1136,7 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                         if (endAck->status() == Wazuh::SyncSchema::Status::Offline)
                         {
                             m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
-                            m_logger(LOG_ERROR, "Received EndAck with Offline status. Aborting synchronization.");
+                            m_logger(LOG_DEBUG, "Received EndAck with Offline status. Aborting synchronization.");
                         }
                         else if (endAck->status() == Wazuh::SyncSchema::Status::ChecksumMismatch)
                         {
@@ -1146,7 +1146,7 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                         else if (endAck->status() == Wazuh::SyncSchema::Status::Error)
                         {
                             m_syncState.lastSyncResult = SyncResult::GENERIC_ERROR;
-                            m_logger(LOG_ERROR, "Received EndAck with Error status. Aborting synchronization.");
+                            m_logger(LOG_DEBUG, "Received EndAck with Error status. Aborting synchronization.");
                         }
 
                         m_syncState.syncFailed = true;

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -16,9 +16,11 @@
 #include "metadata_provider.h"
 
 #include <future>
+#include <mutex>
 #include <optional>
 #include <thread>
 #include <iostream>
+#include <utility>
 
 using ::testing::_;
 using ::testing::Return;
@@ -1587,6 +1589,43 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWhenNotWaitingForStartAck)
     EXPECT_TRUE(response);
 }
 
+// Thread-safe capture of (level, message) pairs emitted by the protocol logger,
+// so tests can assert the level a given sync message is logged at.
+struct LogCapture
+{
+    std::mutex mtx;
+    std::vector<std::pair<modules_log_level_t, std::string>> entries;
+
+    LoggerFunc logger()
+    {
+        return [this](modules_log_level_t level, const std::string & msg)
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            entries.emplace_back(level, msg);
+        };
+    }
+
+    // Asserts a message containing 'needle' was logged at LOG_DEBUG and never at LOG_ERROR.
+    void expectDebugNotError(const std::string& needle)
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        bool debugLogged = false;
+        bool errorLogged = false;
+
+        for (const auto& entry : entries)
+        {
+            if (entry.second.find(needle) != std::string::npos)
+            {
+                debugLogged = debugLogged || (entry.first == LOG_DEBUG);
+                errorLogged = errorLogged || (entry.first == LOG_ERROR);
+            }
+        }
+
+        EXPECT_TRUE(debugLogged) << "Expected '" << needle << "' to be logged at LOG_DEBUG";
+        EXPECT_FALSE(errorLogged) << "Did not expect '" << needle << "' to be logged at LOG_ERROR";
+    }
+};
+
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckError)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -1598,7 +1637,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckError)
             return 0;
         }
     };
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    LogCapture logCapture;
+    LoggerFunc testLogger = logCapture.logger();
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(max_timeout), retries, maxEps, mockQueue);
 
     // Enter in WaitingStartAck phase
@@ -1640,6 +1680,10 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckError)
     EXPECT_TRUE(response);
 
     syncThread.join();
+
+    // Transient manager-reported failures must be debug, not error (issue #36724).
+    logCapture.expectDebugNotError("Received StartAck with error status");
+    logCapture.expectDebugNotError("Synchronization failed due to manager error.");
 }
 
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckOffline)
@@ -1653,7 +1697,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckOffline)
             return 0;
         }
     };
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    LogCapture logCapture;
+    LoggerFunc testLogger = logCapture.logger();
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(max_timeout), retries, maxEps, mockQueue);
 
     // Enter in WaitingStartAck phase
@@ -1695,6 +1740,9 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckOffline)
     EXPECT_TRUE(response);
 
     syncThread.join();
+
+    // Offline StartAck is the same transient class: debug, not error (issue #36724).
+    logCapture.expectDebugNotError("Received StartAck with error status");
 }
 
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithStartAckSuccess)
@@ -1796,7 +1844,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckError)
             return 0;
         }
     };
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    LogCapture logCapture;
+    LoggerFunc testLogger = logCapture.logger();
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(max_timeout), retries, maxEps, mockQueue);
 
     // Enter in WaitingEndAck phase
@@ -1858,6 +1907,10 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckError)
     EXPECT_TRUE(response);
 
     syncThread.join();
+
+    // Transient manager-reported failures must be debug, not error (issue #36724).
+    logCapture.expectDebugNotError("Received EndAck with Error status");
+    logCapture.expectDebugNotError("Synchronization failed: Manager reported an error status.");
 }
 
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
@@ -1871,7 +1924,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
             return 0;
         }
     };
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    LogCapture logCapture;
+    LoggerFunc testLogger = logCapture.logger();
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(max_timeout), retries, maxEps, mockQueue);
 
     // Enter in WaitingEndAck phase
@@ -1933,6 +1987,9 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
     EXPECT_TRUE(response);
 
     syncThread.join();
+
+    // Offline EndAck is the same transient class: debug, not error (issue #36724).
+    logCapture.expectDebugNotError("Received EndAck with Offline status");
 }
 
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1208,7 +1208,9 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
         }
         else
         {
-            LoggingHelper::getInstance().log(LOG_ERROR, "SCA " + syncReason + " failed");
+            // Transient sync failure (manager reported an error / communication issue).
+            // The syncModule() caller emits the single WARNING; recovery retries later. (#36724)
+            LoggingHelper::getInstance().log(LOG_DEBUG, "SCA " + syncReason + " failed");
         }
 
         return success;


### PR DESCRIPTION
## Description

Closes #36724

When a module's synchronization fails because the **manager replies with an error/offline status** — a transient, recoverable condition that the agent simply retries on the next cycle — the agent logged multiple `ERROR`-level lines for a single failure. For FIM this produced two `ERROR`s plus one `WARNING`:

```
wazuh-syscheckd: ERROR: Received StartAck with error status. Aborting synchronization.
wazuh-syscheckd: ERROR: Synchronization failed due to manager error.
wazuh-syscheckd: WARNING: FIM synchronization failed.
```

These are not genuine agent-side errors; logging them at `ERROR` pollutes logs and triggers false alerts in monitoring/SIEM systems. This PR downgrades the intermediate messages to `DEBUG` and keeps a single `WARNING` as the user-visible failure signal (issue Option 1).

## Proposed Changes

The intermediate messages live in the **shared** `agent_sync_protocol` library, which FIM, SCA, Syscollector and agent_info all consume — so the core fix is centralized and covers all of them at once.

**`src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`** — downgrade the 5 transient *manager-reported-status* messages `LOG_ERROR` → `LOG_DEBUG`, symmetric across the Start and End phases:

| Message | Phase |
|---|---|
| `Received StartAck with error status. Aborting synchronization.` | StartAck |
| `Synchronization failed due to manager error.` | after StartAck |
| `Received EndAck with Offline status. Aborting synchronization.` | EndAck |
| `Received EndAck with Error status. Aborting synchronization.` | EndAck |
| `Synchronization failed: Manager reported an error status.` | after EndAck |

This mirrors how the sibling `ChecksumMismatch` status was already treated as an expected `DEBUG` condition.

**`src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp`** — the SCA full/recovery wrapper (`synchronizeDatabaseSnapshot`) logged an extra `LOG_ERROR "SCA <reason> failed"` that fired *alongside* the final `WARNING` on the initial-sync path. Downgraded to `LOG_DEBUG`; the `syncModule()` caller still emits the single `WARNING`, and recovery failures remain visible via the syscom `recovery_success` response.

**Retained / unchanged (by design):**
- The single per-module final signal stays at `WARNING`: `FIM synchronization failed.` (`run_check.c`), `Syscollector synchronization process failed.`, `SCA synchronization failed.`, and agent_info's shared-lib `WARNING`.
- Genuine agent-side failures stay at `ERROR`: retry/connection exhaustion, send failures, exceptions, and uninitialized-state errors (`DBSync is null`, `Sync protocol not initialized`).
- **Syscollector and agent_info already followed this pattern** and required no change. **Logcollector** has no manager-synchronization flow and is unaffected.

### Results and Evidence

Analysis of the four sync modules (the complete set that uses `agent_sync_protocol`):

| Module | Final failure signal | Recovery path | Action |
|---|---|---|---|
| FIM (syscheckd) | `WARNING` (`run_check.c`) | `DEBUG` (`recovery.c`) | shared-lib intermediates → DEBUG |
| Syscollector | `WARNING` (`syscollectorImp.cpp:2305`) | `DEBUG` (`:4575`) | already compliant — no change |
| SCA | `WARNING` (`sca_impl.cpp:538`) | was `ERROR` (`:1211`) → `DEBUG` | fixed |
| agent_info | `WARNING` (shared lib) | — | already compliant — no change |

A global sweep of the agent codebase for any remaining `ERROR`-level transient-sync message (`synchronization failed/error/abort`, `StartAck`, `EndAck`, `manager reported`, `integrity … failed`) returns empty after these changes.

Behavior after the change (FIM example) — a transient manager-status failure now logs only:
```
wazuh-syscheckd: WARNING: FIM synchronization failed.
```
with the StartAck/EndAck detail available under `DEBUG` logging for troubleshooting.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X — built and ran the `agent_sync_protocol` unit suite locally
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

**Unit test evidence** (`agent_sync_protocol_tests`, local macOS build):
```
[==========] 186 tests from 9 test suites ran.
[  PASSED  ] 186 tests.
```
The four `ParseResponseBufferWith{StartAck,EndAck}{Error,Offline}` tests now assert each message is logged at `DEBUG` and never at `ERROR`.

### Artifacts Affected

- `wazuh-syscheckd` (FIM)
- `wazuh-modulesd` (SCA, Syscollector, agent_info modules)
- Shared `agent_sync_protocol` library (`libagent_sync_protocol`)

No changes to executables' interfaces, default configuration files, or packaging.

### Configuration Changes

N/A — no new configuration parameters or default-value changes. The downgraded messages remain available at `DEBUG` log level.

### Tests Introduced

Augmented the existing StartAck/EndAck error/offline parse tests in `test_agent_sync_protocol.cpp` with a thread-safe `LogCapture` helper that asserts the affected messages are emitted at `LOG_DEBUG` and never at `LOG_ERROR`, locking the behavior against future regressions.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A — no doc-facing behavior change)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
