### PR TITLE
Preserve wazuh-syscheckd Full Disk Access attribution on macOS reload

### DIFF
--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -92,10 +92,26 @@ chmod u=rw-,go=r-- $STARTUP
 
 echo '#!/bin/sh
 
+# Wazuh-launcher: anchor process of the launchd job (com.wazuh.agent).
+# It starts the agent and then stays alive, polling for control requests
+# dropped by wazuh-modulesd. Running reload/restart from here -- a shell
+# launched by launchd -- preserves the same TCC "responsible process" lineage
+# as boot, so wazuh-syscheckd keeps its own Full Disk Access entry instead of
+# inheriting wazuh-modulesd as the responsible process. See
+# src/wazuh_modules/src/wm_control.c (writer of the request flag).
+
+CONTROL_REQUEST='${INSTALLATION_PATH}'/var/run/wazuh-control.request
+CONTROL_REQUEST_INFLIGHT="$CONTROL_REQUEST.inflight"
+
 capture_sigterm() {
     '${INSTALLATION_PATH}'/bin/wazuh-control stop
     exit $?
 }
+
+# Drop any request left over from a previous run: the agent is about to start
+# fresh with the current configuration, so a stale request must not trigger a
+# spurious reload.
+rm -f "$CONTROL_REQUEST" "$CONTROL_REQUEST_INFLIGHT" "$CONTROL_REQUEST.tmp"
 
 if ! '${INSTALLATION_PATH}'/bin/wazuh-control start; then
     '${INSTALLATION_PATH}'/bin/wazuh-control stop
@@ -103,6 +119,17 @@ fi
 
 while : ; do
     trap capture_sigterm SIGTERM
+    # Atomically claim the request via rename: if mv succeeds we own it, which
+    # closes the read-then-remove race against the writer.
+    if mv "$CONTROL_REQUEST" "$CONTROL_REQUEST_INFLIGHT" 2>/dev/null; then
+        action=`cat "$CONTROL_REQUEST_INFLIGHT" 2>/dev/null`
+        rm -f "$CONTROL_REQUEST_INFLIGHT"
+        case "$action" in
+            reload|restart)
+                '${INSTALLATION_PATH}'/bin/wazuh-control "$action"
+                ;;
+        esac
+    fi
     sleep 3
 done
 ' > $LAUNCHER_SCRIPT

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -125,6 +125,46 @@ bool wm_control_wait_for_service_active(const char *service) {
 }
 
 size_t wm_control_execute_action(const char *action, const char *service, char **output) {
+#ifdef __APPLE__
+    /* On macOS, do not run wazuh-control directly from here. Forking it from
+     * wazuh-modulesd makes modulesd the TCC "responsible process" of the
+     * respawned daemons, so wazuh-syscheckd's Full Disk Access entry gets filed
+     * under wazuh-modulesd and syscheckd never appears in the FDA list. Instead
+     * we drop a request flag that Wazuh-launcher (the launchd job anchor, a
+     * shell) polls; it runs `wazuh-control <action>` in the same launchd-clean
+     * lineage as boot, so tccd files the FDA entry under wazuh-syscheckd itself.
+     * See src/init/darwin-init.sh (Wazuh-launcher loop). */
+    (void)service;
+    {
+        /* Path is relative to the install dir, matching the "bin/wazuh-control"
+         * convention used in the non-Apple branch below. We write a temp file
+         * and rename() it onto the final flag so the launcher (the reader)
+         * never observes a partially written request: rename(2) is atomic
+         * within the same directory. */
+        const char *flag = "var/run/wazuh-control.request";
+        const char *flag_tmp = "var/run/wazuh-control.request.tmp";
+
+        FILE *fp = fopen(flag_tmp, "w");
+        if (fp == NULL) {
+            mterror(WM_CONTROL_LOGTAG, "Cannot create control request flag '%s': %s (%d)", flag_tmp, strerror(errno), errno);
+            os_strdup("err Cannot write control flag", *output);
+            return strlen(*output);
+        }
+        fprintf(fp, "%s\n", action);
+        fclose(fp);
+
+        if (rename(flag_tmp, flag) != 0) {
+            mterror(WM_CONTROL_LOGTAG, "Cannot commit control request flag '%s': %s (%d)", flag, strerror(errno), errno);
+            unlink(flag_tmp);
+            os_strdup("err Cannot write control flag", *output);
+            return strlen(*output);
+        }
+
+        mtinfo(WM_CONTROL_LOGTAG, "Requested '%s' via Wazuh-launcher (flag '%s')", action, flag);
+        os_strdup("ok ", *output);
+        return strlen(*output);
+    }
+#else
     bool use_systemd = wm_control_check_systemd();
     char *exec_cmd[4] = {NULL};
 
@@ -163,6 +203,7 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
             os_strdup("ok ", *output);
             return strlen(*output);
     }
+#endif
 }
 
 size_t wm_control_dispatch(char *command, char **output) {

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -150,8 +150,20 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
             os_strdup("err Cannot write control flag", *output);
             return strlen(*output);
         }
-        fprintf(fp, "%s\n", action);
-        fclose(fp);
+        if (fprintf(fp, "%s\n", action) < 0) {
+            mterror(WM_CONTROL_LOGTAG, "Cannot write control request flag '%s': %s (%d)", flag_tmp, strerror(errno), errno);
+            fclose(fp);
+            unlink(flag_tmp);
+            os_strdup("err Cannot write control flag", *output);
+            return strlen(*output);
+        }
+
+        if (fclose(fp) != 0) {
+            mterror(WM_CONTROL_LOGTAG, "Cannot flush control request flag '%s': %s (%d)", flag_tmp, strerror(errno), errno);
+            unlink(flag_tmp);
+            os_strdup("err Cannot write control flag", *output);
+            return strlen(*output);
+        }
 
         if (rename(flag_tmp, flag) != 0) {
             mterror(WM_CONTROL_LOGTAG, "Cannot commit control request flag '%s': %s (%d)", flag, strerror(errno), errno);


### PR DESCRIPTION
## Description

On macOS, `wazuh-syscheckd` fails to read protected user folders (e.g. `/Users/<user>/Downloads`) and does **not** appear in *System Settings → Privacy & Security → Full Disk Access (FDA)* when the monitored directory is delivered through a **reload** (via `agent.conf` → `merged.mg`). The same configuration works when present at boot.

Root cause is the macOS TCC *responsible process* model. TCC files the FDA entry under a process's responsible process, not under the process that performs the access:

- At **boot**, the daemons are spawned by `Wazuh-launcher` (a shell launched by launchd with *disclaim*), so each daemon self-attributes and `wazuh-syscheckd` gets its own FDA entry.
- On **reload**, `wazuh-modulesd` ran `wazuh-control` directly via `fork()+execvp()`, so the respawned `wazuh-syscheckd` inherited `wazuh-modulesd` as its responsible process and the FDA entry was filed under `wazuh-modulesd` instead. Since the default configuration ships without user-folder entries, the first access to a protected path only happens after one is added through `agent.conf` — i.e. in this contaminated reload path.

This PR makes the reload run from the same launchd-clean lineage as boot, keeping a single launchd service and the existing reload semantics.

Closes #36262

## Proposed Changes

On macOS, `wm_control_execute_action()` no longer forks `wazuh-control` from `wazuh-modulesd`. Instead it drops a request flag, and `Wazuh-launcher` (the launchd job anchor, a shell) consumes it and runs `wazuh-control <action>` from its own clean process lineage. The reload's process tree then becomes identical to boot's, so TCC files the FDA entry under `wazuh-syscheckd` itself.

- `src/wazuh_modules/src/wm_control.c`: under `#ifdef __APPLE__`, `wm_control_execute_action()` writes the requested action to `var/run/wazuh-control.request`. The write is atomic (write to a `.tmp` file, then `rename()` onto the final flag) so the reader never observes a partially written request. The non-Apple (Linux/systemd) branch is unchanged.
- `src/init/darwin-init.sh`: the generated `Wazuh-launcher` loop now atomically claims the request with `mv` (rename to `.inflight`, closing the read-then-remove race), reads the action and runs `wazuh-control <action>`. Any stale request left from a previous run is cleared before the loop so it cannot trigger a spurious reload. The existing `start`/`stop`/`SIGTERM` handling is left untouched (additive change only).
- `src/syscheckd/src/main.c`: removes the previous POC `opendir` probe (and its `<pwd.h>`/`<dirent.h>` includes), no longer needed with this approach.

No new launchd service, no `launchctl kickstart`, no private symbols, and `wazuh-agentd` is not restarted on reload. The change relies only on POSIX shell builtins and `fopen`/`rename`/`unlink`, so it is compatible with all supported macOS versions (the reload reuses the same lineage as boot, whose TCC behavior is already correct per version).

### Results and Evidence

FDA list with no modules listed prior to agent installation:
<img width="762" height="665" alt="image" src="https://github.com/user-attachments/assets/93833f36-704b-4286-abcd-1b1bd0d33d0b" />

Agent installation and startup:

```
sh-3.2# echo "WAZUH_MANAGER='192.168.1.233'" > /tmp/wazuh_envs && sudo installer -pkg wazuh-agent_5.0.0-1_intel64_096daf7.pkg -target /
installer: Package name is wazuh-agent_5.0.0-1_intel64_096daf7
installer: Installing at base path /
installer: The install was successful.
sh-3.2# launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
sh-3.2#
```

FDA list: the agent is running, but no FIM configuration has been added yet that attempts to monitor `/Users/<user>/` : 

<img width="765" height="652" alt="image" src="https://github.com/user-attachments/assets/d98626fd-b08f-42a2-86f1-654a48577e1f" />

Added the` /Users/testmacos26/Downloads` directory to be monitored by FIM:

<img width="757" height="276" alt="image" src="https://github.com/user-attachments/assets/511f6afe-5b2e-44c6-9e23-38603e705ec2" />

```
2026/06/04 10:31:48 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/06/04 10:31:48 wazuh-modulesd:control: INFO: Requested 'reload' via Wazuh-launcher (flag 'var/run/wazuh-control.request')
2026/06/04 10:31:51 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/06/04 10:31:51 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/06/04 10:31:51 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/06/04 10:31:51 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/06/04 10:31:51 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/06/04 10:31:52 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/06/04 10:31:52 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/06/04 10:31:52 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/06/04 10:31:53 wazuh-modulesd:syscollector: INFO: Module finished.
2026/06/04 10:31:53 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/06/04 10:31:53 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/06/04 10:31:54 wazuh-execd: INFO: Started (pid: 44241).
2026/06/04 10:31:56 wazuh-rootcheck: INFO: Started (pid: 44256).
2026/06/04 10:31:56 wazuh-syscheckd: INFO: Started (pid: 44256).
2026/06/04 10:31:56 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/06/04 10:31:56 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/06/04 10:31:56 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/06/04 10:31:56 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/06/04 10:31:56 wazuh-syscheckd: WARNING: (6922): Cannot open '/Users/testmacos26/Downloads': Operation not permitted
```

Although the warning Operation not permitted is still displayed, wazuh-syscheckd now appears in the FDA list:

```
2026/06/04 10:31:56 wazuh-syscheckd: WARNING: (6922): Cannot open '/Users/testmacos26/Downloads': Operation not permitted
```
<img width="747" height="641" alt="image" src="https://github.com/user-attachments/assets/a8b5ea93-0dbd-4fdc-a7ea-a9d70ae8782f" />

After granting FDA permission to wazuh-syscheckd, the warning disappears:

<img width="736" height="637" alt="image" src="https://github.com/user-attachments/assets/6e961744-e607-4fc1-96d0-b319aa242b03" />

```
2026/06/04 12:48:15 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/06/04 12:48:15 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/06/04 12:48:18 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
```

### Artifacts Affected

- `wazuh-modulesd` (control module) and the macOS `Wazuh-launcher` script. macOS agent only — Linux/Windows behavior is unchanged.

### Configuration Changes

- None. No changes to default configuration, plists, packaging, or the number of services.

### Documentation Updates

None

### Tests Introduced

None

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
