### PR TITLE
Downgrade expected modulesd socket warnings/errors during agent restart to debug

### DIFF
--- a/src/shared/src/mq_op.c
+++ b/src/shared/src/mq_op.c
@@ -188,7 +188,9 @@ STATIC int SendBinaryMSGAction(int queue, const void *message, size_t message_le
     if ((__mq_rcode = OS_SendUnix(queue, tmpstr, total_len)) < 0) {
         // Error on the socket
         if (__mq_rcode == OS_SOCKTERR) {
-            merror("socketerr (not available).");
+            // The socket being unavailable is a transient, caller-handled condition
+            // (e.g. expected during agent restart). Log at debug, like SendMSGAction().
+            mdebug1("socketerr (not available).");
             close(queue);
             return (-1);
         }

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -610,7 +610,9 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         {
             if (!sendFlatBufferMessageAsString(messageVector))
             {
-                m_logger(LOG_WARNING, "Failed to send Start message.");
+                // During shutdown the local socket is gone; the failure is expected, so
+                // log at debug instead of warning to avoid misleading restart noise.
+                m_logger(shouldStop() ? LOG_DEBUG : LOG_WARNING, "Failed to send Start message.");
                 continue;
             }
 
@@ -642,7 +644,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
                 return true;
             }
 
-            m_logger(LOG_WARNING, "Timed out waiting for StartAck. Retrying...");
+            m_logger(shouldStop() ? LOG_DEBUG : LOG_WARNING, "Timed out waiting for StartAck. Retrying...");
         }
 
         // Clean up metadata if we successfully retrieved it
@@ -651,7 +653,15 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
             metadata_provider_free_metadata(&metadata);
         }
 
-        m_logger(LOG_ERROR, "Exceeded maximum retries for Start message. Exiting...");
+        if (shouldStop())
+        {
+            // Expected during agent restart/shutdown: keep it as a debug breadcrumb.
+            m_logger(LOG_DEBUG, "Sync Start message retries exhausted because module is stopping.");
+        }
+        else
+        {
+            m_logger(LOG_ERROR, "Exceeded maximum retries for Start message. Exiting...");
+        }
 
         return false;
     }
@@ -945,7 +955,9 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         {
             if (resendEnd && !sendFlatBufferMessageAsString(messageVector))
             {
-                m_logger(LOG_WARNING, "Failed to send End message.");
+                // During shutdown the local socket is gone; the failure is expected, so
+                // log at debug instead of warning to avoid misleading restart noise.
+                m_logger(shouldStop() ? LOG_DEBUG : LOG_WARNING, "Failed to send End message.");
                 attempt++;
                 continue;
             }
@@ -1040,7 +1052,8 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
 
         if (shouldStop())
         {
-            m_logger(LOG_INFO, "Sync End message retries exhausted because module is stopping.");
+            // Expected during agent restart/shutdown: keep it as a debug breadcrumb.
+            m_logger(LOG_DEBUG, "Sync End message retries exhausted because module is stopping.");
         }
         else
         {

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -5886,9 +5886,9 @@ namespace
 } // namespace
 
 // Verifies that when End-message retries are exhausted while the module is stopping,
-// the event is logged at INFO (not ERROR), because retry exhaustion during shutdown
+// the event is logged at DEBUG (not ERROR/INFO), because retry exhaustion during shutdown
 // is expected and should not appear as an anomaly in the logs.
-TEST_F(AgentSyncProtocolTest, EndMessageRetryExhaustionDuringStopLogsInfo)
+TEST_F(AgentSyncProtocolTest, EndMessageRetryExhaustionDuringStopLogsDebug)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
 
@@ -5986,16 +5986,223 @@ TEST_F(AgentSyncProtocolTest, EndMessageRetryExhaustionDuringStopLogsInfo)
 
     syncThread.join();
 
-    // The "retries exhausted" message must be logged at INFO, not ERROR.
+    // The "retries exhausted" message must be logged at DEBUG, not ERROR/INFO.
     auto it = std::find_if(capturedLogs.begin(), capturedLogs.end(),
                            [](const std::pair<modules_log_level_t, std::string>& entry)
     {
         return entry.second.find("retries exhausted") != std::string::npos;
     });
     ASSERT_NE(it, capturedLogs.end()) << "'retries exhausted' log entry not found";
-    EXPECT_EQ(it->first, LOG_INFO)
-            << "Expected LOG_INFO but got level " << it->first
+    EXPECT_EQ(it->first, LOG_DEBUG)
+            << "Expected LOG_DEBUG but got level " << it->first
             << " for message: " << it->second;
+}
+
+namespace
+{
+    std::mutex END_FAIL_TEST_MTX;
+    std::condition_variable END_FAIL_TEST_CV;
+    int END_FAIL_TEST_MSG_COUNT = 0;
+    std::atomic<bool> END_FAIL_TEST_FAIL_MODE{false};
+
+    int endFailTestSendBinary(int, const void*, size_t, const char*, char)
+    {
+        // Once fail mode is on, simulate the local socket being gone (as during restart).
+        if (END_FAIL_TEST_FAIL_MODE.load())
+        {
+            return -1;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(END_FAIL_TEST_MTX);
+            ++END_FAIL_TEST_MSG_COUNT;
+        }
+        END_FAIL_TEST_CV.notify_all();
+        return 0;
+    }
+} // namespace
+
+// Verifies that when the End message cannot be sent while the module is stopping, the
+// per-attempt failure is logged at DEBUG (not WARNING), because a send failure during
+// shutdown is expected and must not look like an anomaly. Regression test for #36663.
+TEST_F(AgentSyncProtocolTest, FailedToSendEndMessageDuringStopLogsDebug)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+
+    {
+        std::lock_guard<std::mutex> lock(END_FAIL_TEST_MTX);
+        END_FAIL_TEST_MSG_COUNT = 0;
+    }
+    END_FAIL_TEST_FAIL_MODE.store(false);
+
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = endFailTestSendBinary
+    };
+
+    std::vector<std::pair<modules_log_level_t, std::string>> capturedLogs;
+    std::mutex logMtx;
+    LoggerFunc testLogger = [&capturedLogs, &logMtx](modules_log_level_t level, const std::string & msg)
+    {
+        std::lock_guard<std::mutex> lock(logMtx);
+        capturedLogs.push_back({level, msg});
+    };
+
+    // syncEndDelay=0 so End is sent immediately after data, then stop() interrupts it.
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger,
+                                                   std::chrono::seconds(0),
+                                                   std::chrono::seconds(min_timeout),
+                                                   retries, maxEps, mockQueue);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, resetSyncingItems()).Times(1);
+
+    std::thread syncThread([this]()
+    {
+        bool result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(result);
+    });
+
+    auto stopAndJoin = [&]()
+    {
+        END_FAIL_TEST_FAIL_MODE.store(true);
+        protocol->stop();
+
+        if (syncThread.joinable())
+        {
+            syncThread.join();
+        }
+    };
+
+    // Wait for the Start message to be sent.
+    bool startSent;
+    {
+        std::unique_lock<std::mutex> lock(END_FAIL_TEST_MTX);
+        startSent = END_FAIL_TEST_CV.wait_for(lock, std::chrono::seconds(10),
+                                              [] { return END_FAIL_TEST_MSG_COUNT >= 1; });
+    }
+
+    if (!startSent)
+    {
+        stopAndJoin();
+        FAIL() << "Timed out waiting for Start message to be sent";
+    }
+
+    // StartAck so the protocol advances to Data + End.
+    {
+        flatbuffers::FlatBufferBuilder builder;
+        Wazuh::SyncSchema::StartAckBuilder startAckBuilder(builder);
+        startAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+        startAckBuilder.add_session(session);
+        auto offset = startAckBuilder.Finish();
+        builder.Finish(Wazuh::SyncSchema::CreateMessage(
+                           builder, Wazuh::SyncSchema::MessageType::StartAck, offset.Union()));
+        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
+    }
+
+    // Wait until the first End message has been sent (Start + Data + End = 3 sends).
+    bool endSent;
+    {
+        std::unique_lock<std::mutex> lock(END_FAIL_TEST_MTX);
+        endSent = END_FAIL_TEST_CV.wait_for(lock, std::chrono::seconds(10),
+                                            [] { return END_FAIL_TEST_MSG_COUNT >= 3; });
+    }
+
+    if (!endSent)
+    {
+        stopAndJoin();
+        FAIL() << "Timed out waiting for End message to be sent";
+    }
+
+    // Now make every further send fail (socket gone) and request stop: the End retry loop
+    // tries to resend End, fails, and must log "Failed to send End message" at DEBUG.
+    END_FAIL_TEST_FAIL_MODE.store(true);
+    protocol->stop();
+
+    syncThread.join();
+
+    std::lock_guard<std::mutex> lock(logMtx);
+    auto failIt = std::find_if(capturedLogs.begin(), capturedLogs.end(),
+                               [](const std::pair<modules_log_level_t, std::string>& entry)
+    {
+        return entry.second.find("Failed to send End message") != std::string::npos;
+    });
+    ASSERT_NE(failIt, capturedLogs.end()) << "'Failed to send End message' log entry not found";
+    EXPECT_EQ(failIt->first, LOG_DEBUG)
+            << "Expected LOG_DEBUG but got level " << failIt->first
+            << " for message: " << failIt->second;
+}
+
+// Verifies that when the Start message cannot be sent while the module is stopping, both the
+// per-attempt failure and the retry-exhaustion are logged at DEBUG (not WARNING/ERROR), since
+// send failures during shutdown are expected and must not look like anomalies. For #36663.
+TEST_F(AgentSyncProtocolTest, FailedToSendStartMessageDuringStopLogsDebug)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions failingSendStartMqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return -1;    // Socket gone: every Start send fails (as during restart)
+        }
+    };
+
+    std::vector<std::pair<modules_log_level_t, std::string>> capturedLogs;
+    LoggerFunc testLogger = [&capturedLogs](modules_log_level_t level, const std::string & msg)
+    {
+        capturedLogs.push_back({level, msg});
+    };
+
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", failingSendStartMqFuncs, testLogger,
+                                                   std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout),
+                                                   retries, maxEps, mockQueue);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, resetSyncingItems()).Times(1);
+
+    // Request stop *before* synchronizing so shouldStop() is true while Start is attempted.
+    protocol->stop();
+
+    bool result = protocol->synchronizeModule(Mode::DELTA);
+    EXPECT_FALSE(result);
+
+    auto findLog = [&capturedLogs](const std::string & needle)
+    {
+        return std::find_if(capturedLogs.begin(), capturedLogs.end(),
+                            [&needle](const std::pair<modules_log_level_t, std::string>& entry)
+        {
+            return entry.second.find(needle) != std::string::npos;
+        });
+    };
+
+    auto failIt = findLog("Failed to send Start message");
+    ASSERT_NE(failIt, capturedLogs.end()) << "'Failed to send Start message' log entry not found";
+    EXPECT_EQ(failIt->first, LOG_DEBUG) << "Expected LOG_DEBUG but got level " << failIt->first;
+
+    auto exhaustedIt = findLog("Sync Start message retries exhausted because module is stopping");
+    ASSERT_NE(exhaustedIt, capturedLogs.end()) << "Start retry-exhaustion (stopping) log entry not found";
+    EXPECT_EQ(exhaustedIt->first, LOG_DEBUG) << "Expected LOG_DEBUG but got level " << exhaustedIt->first;
+
+    // The misleading WARNING/ERROR variants must NOT appear while stopping.
+    for (const auto& entry : capturedLogs)
+    {
+        EXPECT_FALSE(entry.first == LOG_WARNING
+                     && entry.second.find("Failed to send Start message") != std::string::npos);
+        EXPECT_FALSE(entry.first == LOG_ERROR
+                     && entry.second.find("Exceeded maximum retries for Start message") != std::string::npos);
+    }
 }
 
 // Verifies that m_syncInProgress guards against concurrent synchronizeModule() calls.

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -545,7 +545,7 @@ void test_SendBinaryMSGAction_socket_error(void **state) {
     expect_value(__wrap_OS_SendUnix, size, 19);
     will_return(__wrap_OS_SendUnix, OS_SOCKTERR);
 
-    expect_string(__wrap__merror, formatted_msg, "socketerr (not available).");
+    expect_string(__wrap__mdebug1, formatted_msg, "socketerr (not available).");
 
     int ret = SendBinaryMSG(queue, payload, payload_len, "location", 's');
 


### PR DESCRIPTION
## Description

Closes #36663

When a Wazuh agent **restarts**, `wazuh-agentd` tears down its local message socket while the `wazuh-modulesd` modules (`syscollector`, `sca`, and — via the shared sync protocol — FIM and `agent_info`) are still flushing an in-flight synchronization. The final `Start`/`End` sync messages then fail to send, and the agent logs misleading `ERROR`/`WARNING` lines for a condition that is entirely expected during shutdown:

```text
wazuh-modulesd: ERROR: socketerr (not available).
wazuh-modulesd:sca: WARNING: Failed to send Start message.
wazuh-modulesd:sca: ERROR: Exceeded maximum retries for Start message. Exiting...
wazuh-modulesd:syscollector: WARNING: Failed to send End message.
wazuh-modulesd:syscollector: INFO: Sync End message retries exhausted because module is stopping.
```

These are not genuine agent-side failures — the socket is simply gone because the agent is restarting — so logging them at `ERROR`/`WARNING` pollutes logs and triggers false alerts in monitoring/SIEM systems.

This is the local-socket / send-failure counterpart to the *manager-reported* sync failures handled in #36724 (#36744).

## Proposed Changes

The noise comes from two shared layers, so the fix is centralized and covers all four sync modules at once.

**`src/shared/src/mq_op.c`** — `SendBinaryMSGAction` logged `socketerr (not available)` at `merror` (`ERROR`), while the equivalent text path `SendMSGAction` already logged the *identical* `OS_SOCKTERR` condition at `mdebug1` (`DEBUG`). Bring the binary path in line: `merror` → `mdebug1`. Socket-unavailable is a transient, caller-handled condition (the mqueue transport reinitializes and retries).

**`src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`** — gate the Start- and End-phase send/retry logs on the existing `shouldStop()` flag (set by `stop()` during shutdown), symmetric across both phases:

| Message | Phase | Before | After |
|---|---|---|---|
| `Failed to send Start message.` | Start send | `WARNING` | `DEBUG` while stopping, else `WARNING` |
| `Timed out waiting for StartAck. Retrying...` | Start | `WARNING` | `DEBUG` while stopping, else `WARNING` |
| `Exceeded maximum retries for Start message. Exiting...` | Start exhaustion | `ERROR` | `DEBUG` ("Sync Start message retries exhausted because module is stopping.") while stopping, else `ERROR` |
| `Failed to send End message.` | End send | `WARNING` | `DEBUG` while stopping, else `WARNING` |
| `Sync End message retries exhausted because module is stopping.` | End exhaustion | `INFO` | `DEBUG` |

Genuine agent-side failures stay loud: when `shouldStop()` is false (a real mid-operation failure), the messages remain `WARNING`/`ERROR`.

### Results and Evidence

Reproduced on an Ubuntu agent (container) by lowering both modules' `<synchronization><interval>` to `5s` and repeatedly running `wazuh-control restart` to interrupt in-flight syncs.

**Before** — at the default log level, a restart produced (counts over 8 restarts):

```text
12  wazuh-modulesd:sca: WARNING: Failed to send Start message.
 4  wazuh-modulesd: ERROR: socketerr (not available).
 3  wazuh-modulesd:syscollector: WARNING: Failed to send End message.
 3  wazuh-modulesd:sca: ERROR: Exceeded maximum retries for Start message. Exiting...
 1  wazuh-modulesd:syscollector: INFO: Sync End message retries exhausted because module is stopping.
```

**After (default log level)** — a restart is clean: the patterns above no longer appear.

**After (`wazuh_modules.debug=2`)** — the same events are still observable, now at `DEBUG` (downgraded, not removed), e.g.:

```text
wazuh-modulesd: mq_op.c:193 at SendBinaryMSGAction(): DEBUG: socketerr (not available).
wazuh-modulesd:syscollector: DEBUG: Failed to send End message.
wazuh-modulesd:syscollector: DEBUG: Sync End message retries exhausted because module is stopping.
wazuh-modulesd:syscollector: DEBUG: Failed to send Start message.
wazuh-modulesd:syscollector: DEBUG: Sync Start message retries exhausted because module is stopping.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — built the agent and the unit suites in a Linux container
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer — `test_mq_op` (cmocka) ran under ASAN with no findings
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

Unit suites (Linux container, on this branch rebased onto current `main`):
- `agent_sync_protocol_tests` — **188/188 passed**, including the new `FailedToSendStartMessageDuringStopLogsDebug` / `FailedToSendEndMessageDuringStopLogsDebug` and the updated retry-exhaustion test.
- `test_mq_op` — **27/27 passed**, including `test_SendBinaryMSGAction_socket_error` (now asserts `mdebug1`).

### Artifacts Affected

- `wazuh-modulesd` (agent) and the shared `libwazuh` / `agent_sync_protocol` libraries — log severity only; no behavioral change to the sync flow.

### Configuration Changes

N/A

### Tests Introduced

- `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp` — added `FailedToSendStartMessageDuringStopLogsDebug` and `FailedToSendEndMessageDuringStopLogsDebug`; updated the End retry-exhaustion-during-stop test to assert `DEBUG`.
- `src/unit_tests/shared/test_mq_op.c` — `test_SendBinaryMSGAction_socket_error` now expects `mdebug1` (matching `test_SendMSGAction_socket_error`).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [x] Developer documentation reflects the changes (N/A)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues (complementary to #36724/#36744; rebased on top of it)
