### PR TITLE
Defer module coordination while FIM first sync is in progress

### DIFF
--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -455,6 +455,7 @@ typedef struct _config {
 #endif // WIN32
     atomic_int_t fim_pause_requested;                  /* Flag to indicate scans should be paused (0=false, 1=true) */
     atomic_int_t fim_pausing_is_allowed;               /* Flag to indicate fim_run_integrity acknowledged pause (0=false, 1=true) */
+    atomic_int_t fim_first_sync_completed;             /* Flag (0=false, 1=true): the first post-start FIM sync iteration finished. Read by the IPC thread to report first_sync_completed in is_pause_completed. */
     rtfim *realtime;
     fdb_t *database;
 

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -902,6 +902,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
 #endif
 
     if (first_sync_completed) {
+        atomic_int_set(&syscheck.fim_first_sync_completed, 1);
         mdebug1("FIM first synchronization already completed in a previous run. Keeping startup synchronization delay.");
     } else {
         mdebug1("Initial FIM scan data is ready. Triggering first synchronization without startup delay.");
@@ -959,6 +960,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             if (sync_result && !first_sync_completed) {
                 fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                 first_sync_completed = true;
+                atomic_int_set(&syscheck.fim_first_sync_completed, 1);
             }
         } else {
             // Take a snapshot of the current directories list to avoid holding the lock during integrity checks.
@@ -973,12 +975,6 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 continue;
             }
 
-            // Lock FIM's scheduled and realtime scans during sync and recovery process
-            w_mutex_lock(&syscheck.fim_scan_mutex);
-            w_mutex_lock(&syscheck.fim_realtime_mutex);
-            #ifdef WIN32
-            w_mutex_lock(&syscheck.fim_registry_scan_mutex);
-            #endif
             minfo("Starting FIM synchronization.");
 
             bool sync_result = asp_sync_module(syscheck.sync_handle,
@@ -989,7 +985,30 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 if (!first_sync_completed) {
                     fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                     first_sync_completed = true;
+                    atomic_int_set(&syscheck.fim_first_sync_completed, 1);
                 }
+            } else {
+                minfo("FIM synchronization failed.");
+            }
+
+            // If a flush was triggered while paused but processed here (after resume),
+            // clear the flush state so pollFlushCompletion() can return "completed".
+            // Touches only atomics, so it stays outside the scan mutex.
+            if (flush_request_detected) {
+                int result = sync_result ? 0 : -1;
+                atomic_int_set(&fim_flush_result, result);
+                atomic_int_set(&fim_flush_in_progress, 0);
+                mdebug1("Pending flush request completed via normal sync path.");
+            }
+
+            // Lock FIM's scheduled and realtime scans only for the recovery/integrity
+            // process, which reads and writes the file_entry table.
+            if (sync_result) {
+                w_mutex_lock(&syscheck.fim_scan_mutex);
+                w_mutex_lock(&syscheck.fim_realtime_mutex);
+                #ifdef WIN32
+                w_mutex_lock(&syscheck.fim_registry_scan_mutex);
+                #endif
 
                 for (int i = 0; i < table_count; i++) {
                     if (fim_recovery_integrity_interval_has_elapsed(table_names[i], syscheck.integrity_interval)) {
@@ -1006,26 +1025,16 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                         fim_db_update_last_sync_time(table_names[i]);
                     }
                 }
-            } else {
-                minfo("FIM synchronization failed.");
-            }
 
-            // If a flush was triggered while paused but processed here (after resume),
-            // clear the flush state so pollFlushCompletion() can return "completed".
-            if (flush_request_detected) {
-                int result = sync_result ? 0 : -1;
-                atomic_int_set(&fim_flush_result, result);
-                atomic_int_set(&fim_flush_in_progress, 0);
-                mdebug1("Pending flush request completed via normal sync path.");
+                #ifdef WIN32
+                w_mutex_unlock(&syscheck.fim_registry_scan_mutex);
+                #endif
+                w_mutex_unlock(&syscheck.fim_realtime_mutex);
+                w_mutex_unlock(&syscheck.fim_scan_mutex);
             }
 
             // Clean up the directories snapshot
             OSList_Destroy(directories_snapshot);
-            #ifdef WIN32
-            w_mutex_unlock(&syscheck.fim_registry_scan_mutex);
-            #endif
-            w_mutex_unlock(&syscheck.fim_realtime_mutex);
-            w_mutex_unlock(&syscheck.fim_scan_mutex);
             mdebug1("FIM synchronization finished, waiting for %d seconds before next run.", syscheck.sync_interval);
         }
     }

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -533,6 +533,16 @@ int send_log_msg(const char * msg)
 
 // LCOV_EXCL_START
 // Periodically run the integrity checker
+// Prime the in-memory first-sync flag from the persisted marker. On a restart where the
+// first sync already completed in a previous run, this lets syscom report
+// first_sync_completed=true immediately so agent-info does not defer coordination during
+// the startup baseline-scan window (before fim_run_integrity sets the flag itself).
+STATIC void prime_fim_first_sync_from_marker(void) {
+    if (fim_db_get_last_sync_time(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY) > 0) {
+        atomic_int_set(&syscheck.fim_first_sync_completed, 1);
+    }
+}
+
 void start_daemon()
 {
     int day_scanned = 0;
@@ -626,6 +636,11 @@ void start_daemon()
         mdebug2(FIM_LIMIT_UNLIMITED, "registry");
     }
 #endif
+
+    // Prime the first-sync flag from the persisted marker so that on a restart — where the
+    // first sync already completed in a previous run — agent-info does not defer coordination
+    // during the startup baseline-scan window, before fim_run_integrity sets it.
+    prime_fim_first_sync_from_marker();
 
     // Create File integrity monitoring base-line
     minfo(FIM_FREQUENCY_TIME, syscheck.time);

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -596,6 +596,7 @@ void start_daemon()
 
     if (syscheck.disabled) {
         handle_fim_disabled();
+        atomic_int_set(&syscheck.fim_first_sync_completed, 1);
         minfo("Syscheck is disabled. Exiting.");
         return;
     }
@@ -605,6 +606,7 @@ void start_daemon()
     if (!fim_has_configured_paths()) {
         mdebug1("Syscheck enabled but no monitored paths configured. Checking for orphaned data.");
         handle_all_paths_removed();
+        atomic_int_set(&syscheck.fim_first_sync_completed, 1);
         minfo("No monitored paths configured. FIM module exiting after DataClean.");
         return;
     }

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -439,6 +439,15 @@ bool fetch_document_limits_from_agentd(){
 }
 
 void fim_initialize() {
+    // Initialize the coordination atomics first, before any early return below.
+    // On Windows (winpthreads) PTHREAD_MUTEX_INITIALIZER is a non-zero sentinel,
+    // so a zero-initialized global mutex is invalid: if fim_db_init() fails and we
+    // return early, the disabled path in start_daemon() would call atomic_int_set()
+    // on an uninitialized mutex and abort. They are also read by the syscom thread.
+    syscheck.fim_pause_requested = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+    syscheck.fim_pausing_is_allowed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+
     // Create store data
 #ifndef WIN32
     FIMDBErrorCode ret_val = fim_db_init(FIM_DB_DISK,
@@ -482,9 +491,6 @@ void fim_initialize() {
 #else
     w_mutex_init(&syscheck.fim_symlink_mutex, NULL);
 #endif
-    syscheck.fim_pause_requested = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
-    syscheck.fim_pausing_is_allowed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
-    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
 
     notify_scan = syscheck.notify_first_scan;
 

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -484,6 +484,7 @@ void fim_initialize() {
 #endif
     syscheck.fim_pause_requested = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
     syscheck.fim_pausing_is_allowed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
 
     notify_scan = syscheck.notify_first_scan;
 

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -63,9 +63,9 @@ int fim_execute_is_pause_completed(void) {
     }
 
     // Use trylock so the IPC thread never blocks. fim_run_integrity holds
-    // fim_scan_mutex for the full sync operation (asp_sync_module + integrity
-    // validation), which can take minutes on large trees. Blocking here would
-    // reintroduce the pause window this PR is eliminating.
+    // fim_scan_mutex only for the integrity/recovery loop (asp_sync_module now
+    // runs unlocked), which can still take minutes on large trees. Blocking here
+    // would reintroduce the pause window this PR is eliminating.
     //
     // If a scan is in progress, return 1 (in-progress) so pollFimPauseCompletion()
     // retries in ~1 second. The mutex becomes free as soon as the current sync

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -386,7 +386,8 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
         // Call is_pause_completed function
         result = fim_execute_is_pause_completed();
 
-        int first_sync_completed = atomic_int_get(&syscheck.fim_first_sync_completed) ? 1 : 0;
+        int first_sync_completed = (!syscheck.enable_synchronization ||
+                                    atomic_int_get(&syscheck.fim_first_sync_completed)) ? 1 : 0;
 
         if (result == 1) {
             // Pause in progress

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -386,6 +386,8 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
         // Call is_pause_completed function
         result = fim_execute_is_pause_completed();
 
+        int first_sync_completed = atomic_int_get(&syscheck.fim_first_sync_completed) ? 1 : 0;
+
         if (result == 1) {
             // Pause in progress
             status_item = cJSON_CreateNumber(MQ_SUCCESS);
@@ -394,6 +396,7 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
             if (data_item) {
                 cJSON_AddStringToObject(data_item, "module", "fim");
                 cJSON_AddStringToObject(data_item, "status", "in_progress");
+                cJSON_AddBoolToObject(data_item, "first_sync_completed", first_sync_completed);
             }
         } else if (result == 0) {
             // Pause completed successfully
@@ -404,6 +407,7 @@ size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
                 cJSON_AddStringToObject(data_item, "module", "fim");
                 cJSON_AddStringToObject(data_item, "status", "completed");
                 cJSON_AddStringToObject(data_item, "result", "success");
+                cJSON_AddBoolToObject(data_item, "first_sync_completed", first_sync_completed);
             }
         } else {
             // Unexpected result

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -56,6 +56,9 @@ bool fim_has_configured_directories(void);
 bool fim_has_configured_paths(void);
 bool fim_has_data_in_database(void);
 bool handle_all_paths_removed(void);
+
+/* First-sync flag priming (start_daemon helper) */
+void prime_fim_first_sync_from_marker(void);
 #ifdef WIN32
 bool fim_has_configured_registries(void);
 DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args);
@@ -1360,6 +1363,43 @@ void test_fim_has_configured_paths_with_directories(void **state) {
     assert_true(result);
 }
 
+// When the persisted marker indicates the first sync already completed in a previous run,
+// start_daemon must prime fim_first_sync_completed to 1 before fim_scan() so agent-info does
+// not defer coordination during the startup baseline-scan window.
+void test_prime_fim_first_sync_from_marker_sets_flag_when_present(void **state) {
+    (void)state;
+
+    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 123456);
+
+    prime_fim_first_sync_from_marker();
+
+    assert_int_equal(syscheck.fim_first_sync_completed.data, 1);
+}
+
+// On a genuine first-ever run there is no marker, so the flag stays 0 and coordination is
+// correctly deferred until the first sync actually completes.
+void test_prime_fim_first_sync_from_marker_keeps_flag_clear_when_absent(void **state) {
+    (void)state;
+
+    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
+    expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
+    will_return(__wrap_fim_db_get_last_sync_time, 0);
+
+    prime_fim_first_sync_from_marker();
+
+    assert_int_equal(syscheck.fim_first_sync_completed.data, 0);
+}
+
 void test_fim_has_data_in_database_no_entries(void **state) {
     will_return(__wrap_fim_db_get_count_file_entry, 0);
 #ifdef WIN32
@@ -1437,6 +1477,8 @@ int main(void) {
         cmocka_unit_test(test_fim_has_configured_directories_null_list),
         cmocka_unit_test(test_fim_has_configured_directories_with_directories),
         cmocka_unit_test(test_fim_has_configured_paths_with_directories),
+        cmocka_unit_test(test_prime_fim_first_sync_from_marker_sets_flag_when_present),
+        cmocka_unit_test(test_prime_fim_first_sync_from_marker_keeps_flag_clear_when_absent),
         cmocka_unit_test(test_fim_has_data_in_database_no_entries),
         cmocka_unit_test(test_fim_has_data_in_database_with_file_entries),
         cmocka_unit_test(test_handle_all_paths_removed_no_data_in_db),

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -154,6 +154,7 @@ static int setup_group(void ** state) {
     fim_flush_result.data = 0;
     syscheck.fim_pause_requested = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
     syscheck.fim_pausing_is_allowed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
+    syscheck.fim_first_sync_completed = (atomic_int_t)ATOMIC_INT_INITIALIZER(0);
 
 #ifdef TEST_WINAGENT
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
@@ -297,6 +298,7 @@ static int teardown_group(void **state) {
     fim_flush_result.data = 0;
     syscheck.fim_pause_requested.data = 0;
     syscheck.fim_pausing_is_allowed.data = 0;
+    syscheck.fim_first_sync_completed.data = 0;
 
 #ifdef TEST_WINAGENT
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -306,12 +306,6 @@ class AgentInfoImpl
         /// complete, or the FIM probe gives up (timeout/IPC failure) without deferring.
         bool m_deferralLogged = false;
 
-        /// @brief Number of consecutive coordination cycles deferred waiting for FIM's
-        /// first sync. Used to escalate the throttled log to WARNING when the first sync
-        /// is taking abnormally long, so a stuck first sync is operator-visible instead of
-        /// silently deferring forever. Reset whenever the deferral episode ends.
-        int m_consecutiveDeferrals = 0;
-
         /// @brief Condition variable for efficient sleep/wake mechanism
         std::condition_variable m_cv;
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -301,8 +301,9 @@ class AgentInfoImpl
         int m_pausePollDelayMs = 1000;
 
         /// @brief True once the current deferral streak has logged its INFO line, so
-        /// repeated deferrals during the same first sync stay at DEBUG
-        /// Reset when coordination finally completes.
+        /// repeated deferrals during the same first sync stay at DEBUG.
+        /// Reset as soon as FIM reports the first sync is complete (the deferral
+        /// episode ends), independent of whether later coordination steps succeed.
         bool m_deferralLogged = false;
 
         /// @brief Condition variable for efficient sleep/wake mechanism

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -302,9 +302,15 @@ class AgentInfoImpl
 
         /// @brief True once the current deferral streak has logged its INFO line, so
         /// repeated deferrals during the same first sync stay at DEBUG.
-        /// Reset as soon as FIM reports the first sync is complete (the deferral
-        /// episode ends), independent of whether later coordination steps succeed.
+        /// Reset when the deferral episode ends: either FIM reports the first sync is
+        /// complete, or the FIM probe gives up (timeout/IPC failure) without deferring.
         bool m_deferralLogged = false;
+
+        /// @brief Number of consecutive coordination cycles deferred waiting for FIM's
+        /// first sync. Used to escalate the throttled log to WARNING when the first sync
+        /// is taking abnormally long, so a stuck first sync is operator-visible instead of
+        /// silently deferring forever. Reset whenever the deferral episode ends.
+        int m_consecutiveDeferrals = 0;
 
         /// @brief Condition variable for efficient sleep/wake mechanism
         std::condition_variable m_cv;

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -11,6 +11,7 @@
 
 #include <json.hpp>
 
+#include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <map>
@@ -62,14 +63,14 @@ class AgentInfoImpl
         /// Negative values are clamped to 0.
         void setFlushPollDelayMs(int delayMs)
         {
-            m_flushPollDelayMs = delayMs < 0 ? 0 : delayMs;
+            m_flushPollDelayMs = clampNonNegative(delayMs);
         }
 
         /// @brief Override the FIM pause-completion poll delay (milliseconds). Only used in unit tests
         /// to avoid real sleeps. Negative values are clamped to 0.
         void setPausePollDelayMs(int delayMs)
         {
-            m_pausePollDelayMs = delayMs < 0 ? 0 : delayMs;
+            m_pausePollDelayMs = clampNonNegative(delayMs);
         }
 
         /// @brief Initialize the synchronization protocol with only in-memory synchronization
@@ -121,6 +122,12 @@ class AgentInfoImpl
         /// @param agentMetadata Agent metadata JSON
         /// @param groups List of agent groups
         void updateMetadataProvider(const nlohmann::json& agentMetadata, const std::vector<std::string>& groups);
+
+        /// @brief Clamp a delay value to be non-negative (shared by the poll-delay setters).
+        static int clampNonNegative(int delayMs)
+        {
+            return delayMs < 0 ? 0 : delayMs;
+        }
 
         /// @brief Result of probing FIM for pause completion
         /// Deferred means FIM's first sync is still in progress: the caller must not
@@ -280,8 +287,10 @@ class AgentInfoImpl
         /// @brief Sync configuration: maximum events per second
         long m_syncMaxEps = 10;
 
-        /// @brief Flag to track if module has been stopped
-        bool m_stopped = false;
+        /// @brief Flag to track if module has been stopped.
+        /// Atomic so the poll loops can read it without holding m_mutex while
+        /// stop() writes it from another thread (avoids a data race).
+        std::atomic<bool> m_stopped{false};
 
         /// @brief Delay in milliseconds between flush completion polls (10 seconds in production).
         /// Overridable in unit tests to avoid real sleeps.
@@ -290,6 +299,11 @@ class AgentInfoImpl
         /// @brief Delay in milliseconds between FIM pause completion polls (1 second in production).
         /// Overridable in unit tests to avoid real sleeps.
         int m_pausePollDelayMs = 1000;
+
+        /// @brief True once the current deferral streak has logged its INFO line, so
+        /// repeated deferrals during the same first sync stay at DEBUG
+        /// Reset when coordination finally completes.
+        bool m_deferralLogged = false;
 
         /// @brief Condition variable for efficient sleep/wake mechanism
         std::condition_variable m_cv;

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -65,6 +65,13 @@ class AgentInfoImpl
             m_flushPollDelayMs = delayMs < 0 ? 0 : delayMs;
         }
 
+        /// @brief Override the FIM pause-completion poll delay (milliseconds). Only used in unit tests
+        /// to avoid real sleeps. Negative values are clamped to 0.
+        void setPausePollDelayMs(int delayMs)
+        {
+            m_pausePollDelayMs = delayMs < 0 ? 0 : delayMs;
+        }
+
         /// @brief Initialize the synchronization protocol with only in-memory synchronization
         /// @param moduleName Name of the module
         /// @param mqFuncs Message queue functions
@@ -115,11 +122,23 @@ class AgentInfoImpl
         /// @param groups List of agent groups
         void updateMetadataProvider(const nlohmann::json& agentMetadata, const std::vector<std::string>& groups);
 
+        /// @brief Result of probing FIM for pause completion
+        /// Deferred means FIM's first sync is still in progress: the caller must not
+        /// treat this as an error, must resume FIM, and must retry next cycle.
+        enum class PauseProbeResult { Completed, Deferred, Failed };
+
+        /// @brief Result of a module coordination cycle. Deferred is distinct from
+        /// Failed so the caller can retry quietly (no WARNING) and keep the sync flag set.
+        enum class CoordinationResult { Success, Deferred, Failed };
+
+        /// @brief Result of pausing the coordination modules.
+        enum class PauseCoordinationResult { Success, Deferred, Failed };
+
         /// @brief Coordinate modules for version synchronization
         /// This method manages the coordination process: pause, flush, sync versions, set version, sync table, resume
         /// @param table Table name (AGENT_METADATA_TABLE or AGENT_GROUPS_TABLE)
-        /// @return true if coordination was successful, false otherwise
-        bool coordinateModules(const std::string& table);
+        /// @return CoordinationResult: Success, Deferred (FIM first sync in progress, retry), or Failed
+        CoordinationResult coordinateModules(const std::string& table);
 
         /// @brief Get the create statement for the database
         std::string GetCreateStatement() const;
@@ -197,8 +216,9 @@ class AgentInfoImpl
 
         /// @brief Poll FIM module for pause completion
         /// @param moduleName Module name (should be FIM)
-        /// @return true if pause completed successfully, false otherwise
-        bool pollFimPauseCompletion(const std::string& moduleName);
+        /// @return Completed (pause acknowledged), Deferred (FIM first sync still running,
+        ///         caller should defer coordination), or Failed (timeout/error/shutdown)
+        PauseProbeResult pollFimPauseCompletion(const std::string& moduleName);
 
         /// @brief Poll all requested module flushes until completion.
         /// @param pendingModules Set of modules with an accepted flush request.
@@ -207,8 +227,8 @@ class AgentInfoImpl
 
         /// @brief Pause all coordination modules
         /// @param pausedModules Output parameter for successfully paused modules
-        /// @return true if at least one module was paused successfully
-        bool pauseCoordinationModules(std::set<std::string>& pausedModules);
+        /// @return Success, Deferred (FIM first sync in progress; modules resumed, retry next cycle), or Failed
+        PauseCoordinationResult pauseCoordinationModules(std::set<std::string>& pausedModules);
 
         /// @brief Trigger flush on all paused modules (fire-and-forget, does not wait for completion)
         /// @param pausedModules Set of paused modules to flush
@@ -266,6 +286,10 @@ class AgentInfoImpl
         /// @brief Delay in milliseconds between flush completion polls (10 seconds in production).
         /// Overridable in unit tests to avoid real sleeps.
         int m_flushPollDelayMs = 10000;
+
+        /// @brief Delay in milliseconds between FIM pause completion polls (1 second in production).
+        /// Overridable in unit tests to avoid real sleeps.
+        int m_pausePollDelayMs = 1000;
 
         /// @brief Condition variable for efficient sleep/wake mechanism
         std::condition_variable m_cv;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -45,6 +45,13 @@ const std::vector<std::string> COORDINATION_MODULES = {FIM_NAME, SCA_WM_NAME, SY
 constexpr int MAX_COORDINATION_RETRIES = 3;
 constexpr int COORDINATION_RETRY_DELAY_MS = 1000;
 
+// After this many consecutive coordination cycles deferred waiting for FIM's first
+// sync, escalate the throttled deferral log from DEBUG to a periodic WARNING so an
+// abnormally long (or stuck) first sync becomes operator-visible. Deferral is still
+// the correct action — coordination must not run during FIM's first sync — this only
+// raises visibility. Emitted once at the threshold and every interval thereafter.
+constexpr int DEFERRAL_WARNING_INTERVAL = 10;
+
 // Map DBSync callback results to operation strings for stateless events
 static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
 {
@@ -1200,11 +1207,21 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
 
                 if (moduleName == FIM_NAME && !firstSyncCompleted)
                 {
+                    ++m_consecutiveDeferrals;
+
                     if (!m_deferralLogged)
                     {
                         m_logFunction(LOG_INFO,
                                       "Deferring coordination until FIM first sync completes, will retry next cycle");
                         m_deferralLogged = true;
+                    }
+                    else if (m_consecutiveDeferrals % DEFERRAL_WARNING_INTERVAL == 0)
+                    {
+                        // Escalate to WARNING so an abnormally long (or stuck) first sync is
+                        // operator-visible instead of silently deferring forever at DEBUG.
+                        m_logFunction(LOG_WARNING,
+                                      "FIM first sync still not complete after " + std::to_string(m_consecutiveDeferrals) +
+                                      " consecutive coordination cycles; agent metadata/groups synchronization remains deferred");
                     }
                     else
                     {
@@ -1222,6 +1239,7 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
                 if (moduleName == FIM_NAME)
                 {
                     m_deferralLogged = false;
+                    m_consecutiveDeferrals = 0;
                 }
 
                 std::string status = pollJson["data"]["status"].get<std::string>();
@@ -1268,6 +1286,15 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
             m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
             return PauseProbeResult::Failed;
         }
+    }
+
+    // The probe gave up without FIM ever reporting first-sync completion, so any deferral
+    // episode ends here too. Clear the throttle (and the deferral counter) so a later
+    // deferral episode logs its INFO marker again instead of being stuck at DEBUG.
+    if (moduleName == FIM_NAME)
+    {
+        m_deferralLogged = false;
+        m_consecutiveDeferrals = 0;
     }
 
     m_logFunction(LOG_ERROR,

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -45,13 +45,6 @@ const std::vector<std::string> COORDINATION_MODULES = {FIM_NAME, SCA_WM_NAME, SY
 constexpr int MAX_COORDINATION_RETRIES = 3;
 constexpr int COORDINATION_RETRY_DELAY_MS = 1000;
 
-// After this many consecutive coordination cycles deferred waiting for FIM's first
-// sync, escalate the throttled deferral log from DEBUG to a periodic WARNING so an
-// abnormally long (or stuck) first sync becomes operator-visible. Deferral is still
-// the correct action — coordination must not run during FIM's first sync — this only
-// raises visibility. Emitted once at the threshold and every interval thereafter.
-constexpr int DEFERRAL_WARNING_INTERVAL = 10;
-
 // Map DBSync callback results to operation strings for stateless events
 static const std::map<ReturnTypeCallback, std::string> OPERATION_MAP
 {
@@ -1207,21 +1200,11 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
 
                 if (moduleName == FIM_NAME && !firstSyncCompleted)
                 {
-                    ++m_consecutiveDeferrals;
-
                     if (!m_deferralLogged)
                     {
                         m_logFunction(LOG_INFO,
                                       "Deferring coordination until FIM first sync completes, will retry next cycle");
                         m_deferralLogged = true;
-                    }
-                    else if (m_consecutiveDeferrals % DEFERRAL_WARNING_INTERVAL == 0)
-                    {
-                        // Escalate to WARNING so an abnormally long (or stuck) first sync is
-                        // operator-visible instead of silently deferring forever at DEBUG.
-                        m_logFunction(LOG_WARNING,
-                                      "FIM first sync still not complete after " + std::to_string(m_consecutiveDeferrals) +
-                                      " consecutive coordination cycles; agent metadata/groups synchronization remains deferred");
                     }
                     else
                     {
@@ -1239,7 +1222,6 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
                 if (moduleName == FIM_NAME)
                 {
                     m_deferralLogged = false;
-                    m_consecutiveDeferrals = 0;
                 }
 
                 std::string status = pollJson["data"]["status"].get<std::string>();
@@ -1294,7 +1276,6 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
     if (moduleName == FIM_NAME)
     {
         m_deferralLogged = false;
-        m_consecutiveDeferrals = 0;
     }
 
     m_logFunction(LOG_ERROR,

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -173,7 +173,7 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
     }
 
     // Initial delay before first run to allow other modules to start
-    m_cv.wait_for(lock, std::chrono::seconds(5), [this] { return m_stopped; });
+    m_cv.wait_for(lock, std::chrono::seconds(5), [this] { return m_stopped.load(); });
 
     // Run at least once
     do
@@ -240,7 +240,7 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
         if (shouldLoop && !m_stopped)
         {
             // Wait for the interval or until stop is signaled
-            m_cv.wait_for(lock, std::chrono::seconds(interval), [this] { return m_stopped; });
+            m_cv.wait_for(lock, std::chrono::seconds(interval), [this] { return m_stopped.load(); });
         }
 
     }
@@ -1149,7 +1149,7 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
     auto waitOrStopped = [this]() -> bool
     {
         std::unique_lock<std::mutex> lock(m_mutex);
-        return m_cv.wait_for(lock, std::chrono::milliseconds(m_pausePollDelayMs), [this] { return m_stopped; });
+        return m_cv.wait_for(lock, std::chrono::milliseconds(m_pausePollDelayMs), [this] { return m_stopped.load(); });
     };
 
     for (int attempt = 1; attempt <= MAX_PAUSE_POLL_ATTEMPTS; ++attempt)
@@ -1195,8 +1195,18 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
 
                 if (moduleName == FIM_NAME && !firstSyncCompleted)
                 {
-                    m_logFunction(LOG_INFO,
-                                  "Deferring coordination until FIM first sync completes, will retry next cycle");
+                    if (!m_deferralLogged)
+                    {
+                        m_logFunction(LOG_INFO,
+                                      "Deferring coordination until FIM first sync completes, will retry next cycle");
+                        m_deferralLogged = true;
+                    }
+                    else
+                    {
+                        m_logFunction(LOG_DEBUG,
+                                      "Still deferring coordination until FIM first sync completes");
+                    }
+
                     return PauseProbeResult::Deferred;
                 }
 
@@ -1673,6 +1683,8 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
         {
             m_logFunction(LOG_WARNING, "Sync protocol not available, skipping synchronization");
         }
+
+        m_deferralLogged = false;
 
         m_logFunction(LOG_INFO, "Synchronization coordination completed successfully");
         m_logFunction(LOG_DEBUG,

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -35,8 +35,13 @@ constexpr auto QUEUE_SIZE = 4096;
 constexpr auto AGENT_METADATA_TABLE = "agent_metadata";
 constexpr auto AGENT_GROUPS_TABLE = "agent_groups";
 
-// Module coordination configuration
-const std::vector<std::string> COORDINATION_MODULES = {SCA_WM_NAME, SYSCOLLECTOR_WM_NAME, FIM_NAME};
+// Module coordination configuration.
+// FIM is listed first so its async pause-completion probe runs before the other
+// modules are paused: while FIM's first sync is in progress the probe defers the
+// whole cycle, and pausing SCA/Syscollector first would freeze them for nothing
+// (every cycle for the entire first-sync window). Probing FIM first means a
+// deferral pauses and resumes only FIM, leaving the other modules untouched.
+const std::vector<std::string> COORDINATION_MODULES = {FIM_NAME, SCA_WM_NAME, SYSCOLLECTOR_WM_NAME};
 constexpr int MAX_COORDINATION_RETRIES = 3;
 constexpr int COORDINATION_RETRY_DELAY_MS = 1000;
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1135,19 +1135,31 @@ void AgentInfoImpl::resumePausedModules(const std::set<std::string>& pausedModul
     }
 }
 
-bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
+AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
 {
     // fim_execute_is_pause_completed() uses trylock: it returns in-progress while
     // fim_run_integrity holds fim_scan_mutex (across the full sync iteration). Retries
     // are needed until the current sync cycle ends and the mutex becomes available.
     // 30 attempts at 1 s covers sync cycles that take up to ~30 s under high load.
     constexpr int MAX_PAUSE_POLL_ATTEMPTS = 30; // 30 seconds max
-    constexpr int PAUSE_POLL_DELAY_MS = 1000;   // 1 second between polls
 
     m_logFunction(LOG_DEBUG_VERBOSE, "Polling " + moduleName + " for pause completion (async pause)");
 
+    // Interruptible wait: returns true if the agent was stopped during the wait.
+    auto waitOrStopped = [this]() -> bool
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_cv.wait_for(lock, std::chrono::milliseconds(m_pausePollDelayMs), [this] { return m_stopped; });
+    };
+
     for (int attempt = 1; attempt <= MAX_PAUSE_POLL_ATTEMPTS; ++attempt)
     {
+        if (m_stopped)
+        {
+            m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+            return PauseProbeResult::Failed;
+        }
+
         std::string isPauseCompletedMessage = createJsonCommand("is_pause_completed");
         ModuleResponse pollResponse = queryModuleWithRetry(moduleName, isPauseCompletedMessage);
 
@@ -1156,7 +1168,13 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
             m_logFunction(LOG_WARNING,
                           "Failed to poll pause status for " + moduleName + " (attempt " + std::to_string(attempt) +
                           "/" + std::to_string(MAX_PAUSE_POLL_ATTEMPTS) + ")");
-            std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
+
+            if (waitOrStopped())
+            {
+                m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+                return PauseProbeResult::Failed;
+            }
+
             continue;
         }
 
@@ -1167,6 +1185,21 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
 
             if (pollJson.contains("data") && pollJson["data"].contains("status"))
             {
+                bool firstSyncCompleted = true;
+
+                if (pollJson["data"].contains("first_sync_completed") &&
+                        pollJson["data"]["first_sync_completed"].is_boolean())
+                {
+                    firstSyncCompleted = pollJson["data"]["first_sync_completed"].get<bool>();
+                }
+
+                if (moduleName == FIM_NAME && !firstSyncCompleted)
+                {
+                    m_logFunction(LOG_INFO,
+                                  "Deferring coordination until FIM first sync completes, will retry next cycle");
+                    return PauseProbeResult::Deferred;
+                }
+
                 std::string status = pollJson["data"]["status"].get<std::string>();
 
                 if (status == "in_progress")
@@ -1174,7 +1207,13 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
                     m_logFunction(LOG_DEBUG,
                                   moduleName + " pause still in progress (attempt " + std::to_string(attempt) + "/" +
                                   std::to_string(MAX_PAUSE_POLL_ATTEMPTS) + ")");
-                    std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
+
+                    if (waitOrStopped())
+                    {
+                        m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+                        return PauseProbeResult::Failed;
+                    }
+
                     continue;
                 }
                 else if (status == "completed")
@@ -1185,11 +1224,11 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
                     if (!pauseSucceeded)
                     {
                         m_logFunction(LOG_ERROR, moduleName + " pause completed with error");
-                        return false;
+                        return PauseProbeResult::Failed;
                     }
 
                     m_logFunction(LOG_DEBUG, moduleName + " pause completed successfully");
-                    return true;
+                    return PauseProbeResult::Completed;
                 }
             }
         }
@@ -1200,13 +1239,17 @@ bool AgentInfoImpl::pollFimPauseCompletion(const std::string& moduleName)
                           " - Response: " + pollResponse.response);
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(PAUSE_POLL_DELAY_MS));
+        if (waitOrStopped())
+        {
+            m_logFunction(LOG_INFO, "Agent stopping, aborting FIM pause poll for " + moduleName);
+            return PauseProbeResult::Failed;
+        }
     }
 
     m_logFunction(LOG_ERROR,
                   moduleName + " pause did not complete within " + std::to_string(MAX_PAUSE_POLL_ATTEMPTS) +
                   " seconds (scan mutex may be held by a long sync cycle, or IPC communication failure)");
-    return false;
+    return PauseProbeResult::Failed;
 }
 
 bool AgentInfoImpl::pollFlushCompletion(std::set<std::string> pendingModules)
@@ -1317,14 +1360,14 @@ bool AgentInfoImpl::pollFlushCompletion(std::set<std::string> pendingModules)
     return false;
 }
 
-bool AgentInfoImpl::pauseCoordinationModules(std::set<std::string>& pausedModules)
+AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(std::set<std::string>& pausedModules)
 {
     for (const auto& module : COORDINATION_MODULES)
     {
         if (m_stopped)
         {
             m_logFunction(LOG_INFO, "Agent stopping, aborting module coordination during pause phase");
-            return false;
+            return PauseCoordinationResult::Failed;
         }
 
         m_logFunction(LOG_INFO, "Pausing " + module + " module for synchronization coordination");
@@ -1338,11 +1381,20 @@ bool AgentInfoImpl::pauseCoordinationModules(std::set<std::string>& pausedModule
             // FIM-specific: Poll for pause completion (pause is async for FIM)
             if (module == FIM_NAME)
             {
-                if (!pollFimPauseCompletion(module))
+                PauseProbeResult probe = pollFimPauseCompletion(module);
+
+                if (probe == PauseProbeResult::Deferred)
                 {
-                    m_logFunction(LOG_ERROR, module + " pause failed or timed out, aborting coordination");
+                    pausedModules.insert(module);
                     resumePausedModules(pausedModules);
-                    return false;
+                    return PauseCoordinationResult::Deferred;
+                }
+
+                if (probe == PauseProbeResult::Failed)
+                {
+                    pausedModules.insert(module);
+                    resumePausedModules(pausedModules);
+                    return PauseCoordinationResult::Failed;
                 }
             }
             else
@@ -1371,14 +1423,14 @@ bool AgentInfoImpl::pauseCoordinationModules(std::set<std::string>& pausedModule
                               std::to_string(response.errorCode) +
                               "), aborting coordination: " + response.response);
                 resumePausedModules(pausedModules);
-                return false;
+                return PauseCoordinationResult::Failed;
             }
         }
     }
 
-    // Return true even if pausedModules is empty - this means all modules are unavailable,
+    // Return Success even if pausedModules is empty - this means all modules are unavailable,
     // which is a valid state (not an error)
-    return true;
+    return PauseCoordinationResult::Success;
 }
 
 bool AgentInfoImpl::triggerModuleFlush(const std::set<std::string>& pausedModules)
@@ -1506,13 +1558,13 @@ int AgentInfoImpl::calculateNewVersion(const std::set<std::string>& pausedModule
     return newVersion;
 }
 
-bool AgentInfoImpl::coordinateModules(const std::string& table)
+AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::string& table)
 {
     // Check if query function is available
     if (!m_queryModuleFunction)
     {
         m_logFunction(LOG_WARNING, "Module query function not available, skipping coordination");
-        return false;
+        return CoordinationResult::Failed;
     }
 
     // Determine if we should increment version based on table
@@ -1530,15 +1582,24 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
     try
     {
         // Step 1: Pause all coordination modules
-        if (!pauseCoordinationModules(pausedModules))
+        PauseCoordinationResult pauseResult = pauseCoordinationModules(pausedModules);
+
+        if (pauseResult == PauseCoordinationResult::Deferred)
         {
-            return false;
+            // FIM first sync still in progress: modules already resumed inside
+            // pauseCoordinationModules. Retry on the next cycle, no error.
+            return CoordinationResult::Deferred;
+        }
+
+        if (pauseResult == PauseCoordinationResult::Failed)
+        {
+            return CoordinationResult::Failed;
         }
 
         if (pausedModules.empty())
         {
             m_logFunction(LOG_DEBUG, "No modules available for coordination, skipping synchronization");
-            return true;
+            return CoordinationResult::Success;
         }
 
         // Step 2: Get versions, calculate new version, and set it on all modules
@@ -1547,7 +1608,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
         if (newVersion < 0)
         {
             resumePausedModules(pausedModules);
-            return false;
+            return CoordinationResult::Failed;
         }
 
         // Step 3: Trigger flush while still paused.
@@ -1557,7 +1618,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
         if (!triggerModuleFlush(pausedModules))
         {
             resumePausedModules(pausedModules);
-            return false;
+            return CoordinationResult::Failed;
         }
 
         // Step 4: Resume all modules immediately. The pause window is now minimized to:
@@ -1577,7 +1638,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
             m_logFunction(LOG_INFO,
                           "One or more module flushes did not complete; aborting version sync to avoid "
                           "indexer inconsistency — coordination will be retried in the next cycle");
-            return false;
+            return CoordinationResult::Failed;
         }
 
         // Step 6: Build indices list based on enabled modules and synchronize.
@@ -1603,7 +1664,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
             if (!syncSuccess)
             {
                 m_logFunction(LOG_WARNING, "Failed to synchronize " + table);
-                return false;
+                return CoordinationResult::Failed;
             }
 
             m_logFunction(LOG_DEBUG, "Successfully synchronized " + table);
@@ -1618,7 +1679,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
                       "Coordinated modules: " + std::to_string(coordinatedModulesCount) +
                       ", New version: " + std::to_string(newVersion));
 
-        return true;
+        return CoordinationResult::Success;
     }
     catch (const std::exception& e)
     {
@@ -1629,7 +1690,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
             resumePausedModules(pausedModules);
         }
 
-        return false;
+        return CoordinationResult::Failed;
     }
     catch (...)
     {
@@ -1640,7 +1701,7 @@ bool AgentInfoImpl::coordinateModules(const std::string& table)
             resumePausedModules(pausedModules);
         }
 
-        return false;
+        return CoordinationResult::Failed;
     }
 }
 
@@ -1966,19 +2027,24 @@ bool AgentInfoImpl::performDeltaSync(const std::string& table)
     try
     {
         m_logFunction(LOG_DEBUG, "Synchronization needed for " + table);
-        bool success = coordinateModules(table);
+        CoordinationResult result = coordinateModules(table);
 
-        if (success)
+        if (result == CoordinationResult::Success)
         {
             m_logFunction(LOG_INFO, "Successfully coordinated " + table);
             resetSyncFlag(table);
+            return true;
+        }
+        else if (result == CoordinationResult::Deferred)
+        {
+            m_logFunction(LOG_DEBUG, "Coordination of " + table + " deferred, sync flag retained for retry");
+            return false;
         }
         else
         {
             m_logFunction(LOG_WARNING, "Failed to coordinate " + table + ", will retry in next cycle");
+            return false;
         }
-
-        return success;
     }
     catch (const std::exception& e)
     {

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1210,6 +1210,15 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
                     return PauseProbeResult::Deferred;
                 }
 
+                // FIM first sync is no longer in progress: the deferral episode (if any)
+                // has ended. Clear the throttle here rather than only on full coordination
+                // success, so a failure later in the cycle does not leave it stuck true and
+                // suppress the operator-visible INFO on a future deferral episode.
+                if (moduleName == FIM_NAME)
+                {
+                    m_deferralLogged = false;
+                }
+
                 std::string status = pollJson["data"]["status"].get<std::string>();
 
                 if (status == "in_progress")
@@ -1683,8 +1692,6 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
         {
             m_logFunction(LOG_WARNING, "Sync protocol not available, skipping synchronization");
         }
-
-        m_deferralLogged = false;
 
         m_logFunction(LOG_INFO, "Synchronization coordination completed successfully");
         m_logFunction(LOG_DEBUG,

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -10,6 +10,7 @@
 #include <mock_filesystem_wrapper.hpp>
 #include <mock_sysinfo.hpp>
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>
@@ -1616,4 +1617,397 @@ TEST_F(AgentInfoCoordinationTest, ParseResponseBufferWithoutSyncProtocol)
     // by ensuring the system works correctly without sync protocol initialization
     // The method would return false if called when m_spSyncProtocol is null
     SUCCEED();
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #36358: deferral while FIM first sync is in progress (Option C, Part 1).
+// These tests are independent from PR #36736's extend-budget tests.
+// ───────────────────────────────────────────────────────────────────────────
+
+namespace
+{
+    // Sets up MockDBSync so the first selectRows reports should_sync_groups=1 (with
+    // is_first_groups_run=0) so the coordination cycle actually runs once.
+    void expectGroupsSyncNeeded(const std::shared_ptr<MockDBSync>& mockDBSync, int& selectRowsCalls)
+    {
+        EXPECT_CALL(*mockDBSync, handle())
+        .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+
+        EXPECT_CALL(*mockDBSync, addTableRelationship(::testing::_))
+        .WillRepeatedly(::testing::Return());
+
+        EXPECT_CALL(*mockDBSync, selectRows(::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Invoke([&selectRowsCalls](const nlohmann::json& /* query */,
+                                          std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+        {
+            if (selectRowsCalls++ == 0)
+            {
+                nlohmann::json flagData;
+                flagData["should_sync_metadata"] = 1;
+                flagData["should_sync_groups"] = 0;
+                flagData["last_metadata_integrity"] = 0;
+                flagData["last_groups_integrity"] = 0;
+                flagData["is_first_run"] = 0;
+                flagData["is_first_groups_run"] = 0;
+                callback(SELECTED, flagData);
+            }
+        }));
+    }
+}
+
+// Deferral: FIM reports first_sync_completed=false -> coordination is deferred with
+// an INFO log, no timeout/abort ERROR, and the sync flag is retained (no success).
+TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenFimFirstSyncNotCompleted)
+{
+    int selectRowsCalls = 0;
+    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = false;
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        *response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Deferring coordination until FIM first sync completes"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete")));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("aborting coordination")));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Failed to coordinate")));
+    // Sync flag retained -> coordination was NOT marked successful this cycle.
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Successfully coordinated")));
+}
+
+// Deferral must resume EVERY paused module, including FIM (which accepted the pause
+// request but is not yet in pausedModules at the deferral point — guards R2).
+TEST_F(AgentInfoCoordinationTest, DeferralResumesAllPausedModulesIncludingFim)
+{
+    int selectRowsCalls = 0;
+    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    std::vector<std::string> resumeLog;
+
+    auto queryModuleFunc = [&resumeLog](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        if (command == "resume")
+        {
+            resumeLog.push_back(module_name);
+        }
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = false;
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        *response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_NE(std::find(resumeLog.begin(), resumeLog.end(), "fim"), resumeLog.end());
+    EXPECT_NE(std::find(resumeLog.begin(), resumeLog.end(), "sca"), resumeLog.end());
+    EXPECT_NE(std::find(resumeLog.begin(), resumeLog.end(), "syscollector"), resumeLog.end());
+}
+
+// Steady state (first_sync_completed=true): pause completes normally, no deferral,
+// coordination proceeds.
+TEST_F(AgentInfoCoordinationTest, SteadyStateNormalPauseWhenFirstSyncCompleted)
+{
+    int selectRowsCalls = 0;
+    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        *response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+    m_agentInfo->setFlushPollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("fim pause completed successfully"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Deferring coordination")));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete")));
+}
+
+// Steady state with a genuine stuck pause (always in_progress, first_sync_completed=true)
+// must still hit the 30s budget and log the timeout/abort ERROR (behavior unchanged).
+TEST_F(AgentInfoCoordinationTest, SteadyStateGenuineTimeoutStillLogsError)
+{
+    int selectRowsCalls = 0;
+    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            // Never completes; first sync already done -> no deferral, real timeout.
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        *response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("pause did not complete within 30 seconds"));
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Failed to coordinate"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Deferring coordination")));
+}
+
+// Shutdown during the pause poll aborts cleanly (no 30s timeout), via the new
+// interruptible wait. The mock signals stop on the 2nd poll.
+TEST_F(AgentInfoCoordinationTest, ShutdownDuringPausePollAbortsCleanly)
+{
+    int selectRowsCalls = 0;
+    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    int fimPausePollCount = 0;
+    auto* agentInfoPtr = &m_agentInfo; // capture by pointer so stop() can be called
+
+    auto queryModuleFunc = [&fimPausePollCount, agentInfoPtr](const std::string & module_name,
+                           const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = true;
+
+            if (++fimPausePollCount == 2 && *agentInfoPtr)
+            {
+                (*agentInfoPtr)->stop();
+            }
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        *response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    // Aborted on stop, not on the 30-poll budget.
+    EXPECT_LT(fimPausePollCount, 30);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Agent stopping, aborting FIM pause poll"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete within 30 seconds")));
+}
+
+// A legacy FIM response WITHOUT the first_sync_completed field must be treated as
+// completed (steady-state), never as a permanent deferral (guards R1).
+TEST_F(AgentInfoCoordinationTest, MissingFirstSyncFieldTreatedAsCompleted)
+{
+    int selectRowsCalls = 0;
+    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed")
+        {
+            // Legacy shape: no first_sync_completed field.
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        *response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+    m_agentInfo->setFlushPollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Deferring coordination")));
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("fim pause completed successfully"));
 }

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -2170,101 +2170,6 @@ TEST_F(AgentInfoCoordinationTest, RepeatedDeferralLogsInfoOnce)
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Still deferring coordination"));
 }
 
-// Counts substring occurrences in the captured log output.
-static size_t countLogOccurrences(const std::string& hay, const std::string& needle)
-{
-    size_t n = 0, pos = 0;
-
-    while ((pos = hay.find(needle, pos)) != std::string::npos)
-    {
-        ++n;
-        pos += needle.size();
-    }
-
-    return n;
-}
-
-// After DEFERRAL_WARNING_INTERVAL (10) consecutive deferrals, the throttled log escalates
-// to WARNING so an abnormally long / stuck first sync is operator-visible instead of
-// deferring forever at DEBUG. The one-time INFO marker still appears exactly once.
-// The loop is driven off the per-cycle FIM "pause" count (one per cycle) rather than the
-// shouldContinue call count, because shouldContinue is invoked twice per loop iteration.
-// interval=0 keeps the loop from sleeping between iterations so the test stays sub-second.
-TEST_F(AgentInfoCoordinationTest, EscalatesToWarningAfterRepeatedDeferrals)
-{
-    EXPECT_CALL(*m_mockDBSync, handle())
-    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
-    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
-    .WillRepeatedly(::testing::Return());
-    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
-    .WillRepeatedly(::testing::Invoke([](const nlohmann::json& /* query */,
-                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
-    {
-        nlohmann::json flagData;
-        flagData["should_sync_metadata"] = 1;
-        flagData["should_sync_groups"] = 0;
-        flagData["last_metadata_integrity"] = 0;
-        flagData["last_groups_integrity"] = 0;
-        flagData["is_first_run"] = 0;
-        flagData["is_first_groups_run"] = 0;
-        callback(SELECTED, flagData);
-    }));
-
-    // One FIM pause is issued per coordination cycle (only FIM is paused on a deferral).
-    auto fimPauseCount = std::make_shared<int>(0);
-
-    auto queryModuleFunc = [fimPauseCount](const std::string & module_name, const std::string & query, char** response) -> int
-    {
-        nlohmann::json commandJson = nlohmann::json::parse(query);
-        const auto command = commandJson["command"].get<std::string>();
-
-        if (command == "pause" && module_name == "fim")
-        {
-            ++(*fimPauseCount);
-        }
-
-        nlohmann::json responseJson;
-        responseJson["error"] = 0;
-        responseJson["message"] = "Success";
-
-        if (command == "is_pause_completed" && module_name == "fim")
-        {
-            responseJson["data"]["status"] = "in_progress";
-            responseJson["data"]["first_sync_completed"] = false;  // keep deferring
-        }
-        else if (command == "get_version")
-        {
-            responseJson["data"]["version"] = 5;
-        }
-
-        std::string responseStr = responseJson.dump();
-        * response = strdup(responseStr.c_str());
-        return 0;
-    };
-
-    m_agentInfo = std::make_shared<AgentInfoImpl>(
-                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
-                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
-    m_agentInfo->setPausePollDelayMs(0);
-
-    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
-    .WillRepeatedly(::testing::Return(false));
-
-    nlohmann::json osData = {{"os_name", "TestOS"}};
-    EXPECT_CALL(*m_mockSysInfo, os())
-    .WillRepeatedly(::testing::Return(osData));
-
-    m_logOutput.clear();
-    // Run 12 coordination cycles (> the 10-deferral escalation threshold).
-    m_agentInfo->start(0, 86400, [fimPauseCount]()
-    {
-        return *fimPauseCount < 12;
-    });
-
-    EXPECT_EQ(countLogOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 1U);
-    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("FIM first sync still not complete after"));
-}
-
 // The deferral throttle must reset when the FIM probe gives up (timeout / no status) without
 // FIM ever reporting first-sync completion, so a later deferral episode logs its INFO marker
 // again instead of being stuck at DEBUG. Cycle 1 defers (INFO #1), cycle 2 times out (resets),
@@ -2350,6 +2255,19 @@ TEST_F(AgentInfoCoordinationTest, DeferralThrottleResetsAfterProbeGivesUp)
         return *fimPauseCount < 3;
     });
 
+    auto countOccurrences = [](const std::string & hay, const std::string & needle)
+    {
+        size_t n = 0, pos = 0;
+
+        while ((pos = hay.find(needle, pos)) != std::string::npos)
+        {
+            ++n;
+            pos += needle.size();
+        }
+
+        return n;
+    };
+
     // INFO appears in cycle 1 and again in cycle 3 (throttle reset by the cycle-2 give-up).
-    EXPECT_EQ(countLogOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 2U);
+    EXPECT_EQ(countOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 2U);
 }

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1712,21 +1712,27 @@ TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenFimFirstSyncNotCompleted)
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Successfully coordinated")));
 }
 
-// Deferral must resume EVERY paused module, including FIM (which accepted the pause
-// request but is not yet in pausedModules at the deferral point — guards R2).
-TEST_F(AgentInfoCoordinationTest, DeferralResumesAllPausedModulesIncludingFim)
+// FIM is probed first, so a deferral pauses and resumes only FIM and never touches
+// SCA/Syscollector. FIM accepted the pause request but is not yet in pausedModules
+// at the deferral point, so it must still be resumed (guards R2).
+TEST_F(AgentInfoCoordinationTest, DeferralResumesFimOnlyAndSkipsOtherModulePauses)
 {
     int selectRowsCalls = 0;
     expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
+    std::vector<std::string> pauseLog;
     std::vector<std::string> resumeLog;
 
-    auto queryModuleFunc = [&resumeLog](const std::string & module_name, const std::string & query, char** response) -> int
+    auto queryModuleFunc = [&pauseLog, &resumeLog](const std::string & module_name, const std::string & query, char** response) -> int
     {
         nlohmann::json commandJson = nlohmann::json::parse(query);
         const auto command = commandJson["command"].get<std::string>();
 
-        if (command == "resume")
+        if (command == "pause")
+        {
+            pauseLog.push_back(module_name);
+        }
+        else if (command == "resume")
         {
             resumeLog.push_back(module_name);
         }
@@ -1767,9 +1773,13 @@ TEST_F(AgentInfoCoordinationTest, DeferralResumesAllPausedModulesIncludingFim)
         return false;
     });
 
+    // FIM is paused (and resumed) because it is probed first; the deferral aborts the
+    // cycle before SCA/Syscollector are ever paused.
     EXPECT_NE(std::find(resumeLog.begin(), resumeLog.end(), "fim"), resumeLog.end());
-    EXPECT_NE(std::find(resumeLog.begin(), resumeLog.end(), "sca"), resumeLog.end());
-    EXPECT_NE(std::find(resumeLog.begin(), resumeLog.end(), "syscollector"), resumeLog.end());
+    EXPECT_EQ(std::find(pauseLog.begin(), pauseLog.end(), "sca"), pauseLog.end());
+    EXPECT_EQ(std::find(pauseLog.begin(), pauseLog.end(), "syscollector"), pauseLog.end());
+    EXPECT_EQ(std::find(resumeLog.begin(), resumeLog.end(), "sca"), resumeLog.end());
+    EXPECT_EQ(std::find(resumeLog.begin(), resumeLog.end(), "syscollector"), resumeLog.end());
 }
 
 // Steady state (first_sync_completed=true): pause completes normally, no deferral,

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -2169,3 +2169,187 @@ TEST_F(AgentInfoCoordinationTest, RepeatedDeferralLogsInfoOnce)
     EXPECT_EQ(countOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 1U);
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Still deferring coordination"));
 }
+
+// Counts substring occurrences in the captured log output.
+static size_t countLogOccurrences(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+
+    while ((pos = hay.find(needle, pos)) != std::string::npos)
+    {
+        ++n;
+        pos += needle.size();
+    }
+
+    return n;
+}
+
+// After DEFERRAL_WARNING_INTERVAL (10) consecutive deferrals, the throttled log escalates
+// to WARNING so an abnormally long / stuck first sync is operator-visible instead of
+// deferring forever at DEBUG. The one-time INFO marker still appears exactly once.
+// The loop is driven off the per-cycle FIM "pause" count (one per cycle) rather than the
+// shouldContinue call count, because shouldContinue is invoked twice per loop iteration.
+// interval=0 keeps the loop from sleeping between iterations so the test stays sub-second.
+TEST_F(AgentInfoCoordinationTest, EscalatesToWarningAfterRepeatedDeferrals)
+{
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([](const nlohmann::json& /* query */,
+                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        nlohmann::json flagData;
+        flagData["should_sync_metadata"] = 1;
+        flagData["should_sync_groups"] = 0;
+        flagData["last_metadata_integrity"] = 0;
+        flagData["last_groups_integrity"] = 0;
+        flagData["is_first_run"] = 0;
+        flagData["is_first_groups_run"] = 0;
+        callback(SELECTED, flagData);
+    }));
+
+    // One FIM pause is issued per coordination cycle (only FIM is paused on a deferral).
+    auto fimPauseCount = std::make_shared<int>(0);
+
+    auto queryModuleFunc = [fimPauseCount](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        if (command == "pause" && module_name == "fim")
+        {
+            ++(*fimPauseCount);
+        }
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = false;  // keep deferring
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    // Run 12 coordination cycles (> the 10-deferral escalation threshold).
+    m_agentInfo->start(0, 86400, [fimPauseCount]()
+    {
+        return *fimPauseCount < 12;
+    });
+
+    EXPECT_EQ(countLogOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 1U);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("FIM first sync still not complete after"));
+}
+
+// The deferral throttle must reset when the FIM probe gives up (timeout / no status) without
+// FIM ever reporting first-sync completion, so a later deferral episode logs its INFO marker
+// again instead of being stuck at DEBUG. Cycle 1 defers (INFO #1), cycle 2 times out (resets),
+// cycle 3 defers again (INFO #2). The cycle is identified by the per-cycle FIM "pause" count.
+// interval=0 + pausePollDelay=0 keep the test sub-second.
+TEST_F(AgentInfoCoordinationTest, DeferralThrottleResetsAfterProbeGivesUp)
+{
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([](const nlohmann::json& /* query */,
+                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        nlohmann::json flagData;
+        flagData["should_sync_metadata"] = 1;
+        flagData["should_sync_groups"] = 0;
+        flagData["last_metadata_integrity"] = 0;
+        flagData["last_groups_integrity"] = 0;
+        flagData["is_first_run"] = 0;
+        flagData["is_first_groups_run"] = 0;
+        callback(SELECTED, flagData);
+    }));
+
+    // One FIM pause is issued per coordination cycle, so this counts the current cycle.
+    auto fimPauseCount = std::make_shared<int>(0);
+
+    auto queryModuleFunc = [fimPauseCount](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        if (command == "pause" && module_name == "fim")
+        {
+            ++(*fimPauseCount);
+        }
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            if (*fimPauseCount == 2)
+            {
+                // Cycle 2: respond without data.status so the probe never reaches the
+                // first-sync branch and eventually times out -> Failed (the give-up path).
+                responseJson["data"]["unrelated"] = 1;
+            }
+            else
+            {
+                responseJson["data"]["status"] = "in_progress";
+                responseJson["data"]["first_sync_completed"] = false;  // defer
+            }
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    // Run exactly 3 coordination cycles: defer, give-up, defer.
+    m_agentInfo->start(0, 86400, [fimPauseCount]()
+    {
+        return *fimPauseCount < 3;
+    });
+
+    // INFO appears in cycle 1 and again in cycle 3 (throttle reset by the cycle-2 give-up).
+    EXPECT_EQ(countLogOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 2U);
+}

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1626,9 +1626,9 @@ TEST_F(AgentInfoCoordinationTest, ParseResponseBufferWithoutSyncProtocol)
 
 namespace
 {
-    // Sets up MockDBSync so the first selectRows reports should_sync_groups=1 (with
-    // is_first_groups_run=0) so the coordination cycle actually runs once.
-    void expectGroupsSyncNeeded(const std::shared_ptr<MockDBSync>& mockDBSync, int& selectRowsCalls)
+    // Sets up MockDBSync so the first selectRows reports should_sync_metadata=1
+    // (with is_first_run=0) so the coordination cycle actually runs once.
+    void expectMetadataSyncNeeded(const std::shared_ptr<MockDBSync>& mockDBSync, int& selectRowsCalls)
     {
         EXPECT_CALL(*mockDBSync, handle())
         .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
@@ -1638,7 +1638,7 @@ namespace
 
         EXPECT_CALL(*mockDBSync, selectRows(::testing::_, ::testing::_))
         .WillRepeatedly(::testing::Invoke([&selectRowsCalls](const nlohmann::json& /* query */,
-                                          std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+                                                             std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
         {
             if (selectRowsCalls++ == 0)
             {
@@ -1660,7 +1660,7 @@ namespace
 TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenFimFirstSyncNotCompleted)
 {
     int selectRowsCalls = 0;
-    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
     auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
     {
@@ -1682,7 +1682,7 @@ TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenFimFirstSyncNotCompleted)
         }
 
         std::string responseStr = responseJson.dump();
-        *response = strdup(responseStr.c_str());
+        * response = strdup(responseStr.c_str());
         return 0;
     };
 
@@ -1717,7 +1717,7 @@ TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenFimFirstSyncNotCompleted)
 TEST_F(AgentInfoCoordinationTest, DeferralResumesAllPausedModulesIncludingFim)
 {
     int selectRowsCalls = 0;
-    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
     std::vector<std::string> resumeLog;
 
@@ -1746,7 +1746,7 @@ TEST_F(AgentInfoCoordinationTest, DeferralResumesAllPausedModulesIncludingFim)
         }
 
         std::string responseStr = responseJson.dump();
-        *response = strdup(responseStr.c_str());
+        * response = strdup(responseStr.c_str());
         return 0;
     };
 
@@ -1777,7 +1777,7 @@ TEST_F(AgentInfoCoordinationTest, DeferralResumesAllPausedModulesIncludingFim)
 TEST_F(AgentInfoCoordinationTest, SteadyStateNormalPauseWhenFirstSyncCompleted)
 {
     int selectRowsCalls = 0;
-    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
     auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
     {
@@ -1805,7 +1805,7 @@ TEST_F(AgentInfoCoordinationTest, SteadyStateNormalPauseWhenFirstSyncCompleted)
         }
 
         std::string responseStr = responseJson.dump();
-        *response = strdup(responseStr.c_str());
+        * response = strdup(responseStr.c_str());
         return 0;
     };
 
@@ -1838,7 +1838,7 @@ TEST_F(AgentInfoCoordinationTest, SteadyStateNormalPauseWhenFirstSyncCompleted)
 TEST_F(AgentInfoCoordinationTest, SteadyStateGenuineTimeoutStillLogsError)
 {
     int selectRowsCalls = 0;
-    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
     auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
     {
@@ -1861,7 +1861,7 @@ TEST_F(AgentInfoCoordinationTest, SteadyStateGenuineTimeoutStillLogsError)
         }
 
         std::string responseStr = responseJson.dump();
-        *response = strdup(responseStr.c_str());
+        * response = strdup(responseStr.c_str());
         return 0;
     };
 
@@ -1893,13 +1893,13 @@ TEST_F(AgentInfoCoordinationTest, SteadyStateGenuineTimeoutStillLogsError)
 TEST_F(AgentInfoCoordinationTest, ShutdownDuringPausePollAbortsCleanly)
 {
     int selectRowsCalls = 0;
-    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
     int fimPausePollCount = 0;
     auto* agentInfoPtr = &m_agentInfo; // capture by pointer so stop() can be called
 
     auto queryModuleFunc = [&fimPausePollCount, agentInfoPtr](const std::string & module_name,
-                           const std::string & query, char** response) -> int
+                                                              const std::string & query, char** response) -> int
     {
         nlohmann::json commandJson = nlohmann::json::parse(query);
         const auto command = commandJson["command"].get<std::string>();
@@ -1924,7 +1924,7 @@ TEST_F(AgentInfoCoordinationTest, ShutdownDuringPausePollAbortsCleanly)
         }
 
         std::string responseStr = responseJson.dump();
-        *response = strdup(responseStr.c_str());
+        * response = strdup(responseStr.c_str());
         return 0;
     };
 
@@ -1957,7 +1957,7 @@ TEST_F(AgentInfoCoordinationTest, ShutdownDuringPausePollAbortsCleanly)
 TEST_F(AgentInfoCoordinationTest, MissingFirstSyncFieldTreatedAsCompleted)
 {
     int selectRowsCalls = 0;
-    expectGroupsSyncNeeded(m_mockDBSync, selectRowsCalls);
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
 
     auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
     {
@@ -1985,7 +1985,7 @@ TEST_F(AgentInfoCoordinationTest, MissingFirstSyncFieldTreatedAsCompleted)
         }
 
         std::string responseStr = responseJson.dump();
-        *response = strdup(responseStr.c_str());
+        * response = strdup(responseStr.c_str());
         return 0;
     };
 
@@ -2010,4 +2010,152 @@ TEST_F(AgentInfoCoordinationTest, MissingFirstSyncFieldTreatedAsCompleted)
 
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Deferring coordination")));
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("fim pause completed successfully"));
+}
+
+// When FIM synchronization is disabled, syscom reports first_sync_completed=true
+// (there is no first sync to wait for), so agent-info must
+// coordinate normally and NEVER defer. Modeled by a FIM response that completes with
+// first_sync_completed=true — the exact shape sync-disabled produces.
+TEST_F(AgentInfoCoordinationTest, SyncDisabledReportsCompletedAndDoesNotDefer)
+{
+    int selectRowsCalls = 0;
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+            responseJson["data"]["first_sync_completed"] = true;  // sync disabled -> reported completed
+        }
+        else if (command == "is_flush_completed")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+    m_agentInfo->setFlushPollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Deferring coordination")));
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("fim pause completed successfully"));
+}
+
+// Repeated deferrals within the same first sync log the INFO line ONCE,
+// then drop to DEBUG ("Still deferring..."). The mock keeps first_sync_completed=false
+// across several coordination cycles in one start() window.
+TEST_F(AgentInfoCoordinationTest, RepeatedDeferralLogsInfoOnce)
+{
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+    // Report should_sync_metadata=1 on EVERY selectRows so coordination runs each
+    // loop iteration and keeps deferring.
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([](const nlohmann::json& /* query */,
+                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        nlohmann::json flagData;
+        flagData["should_sync_metadata"] = 1;
+        flagData["should_sync_groups"] = 0;
+        flagData["last_metadata_integrity"] = 0;
+        flagData["last_groups_integrity"] = 0;
+        flagData["is_first_run"] = 0;
+        flagData["is_first_groups_run"] = 0;
+        callback(SELECTED, flagData);
+    }));
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "in_progress";
+            responseJson["data"]["first_sync_completed"] = false;  // keep deferring
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    // Run a few loop iterations so coordination defers more than once.
+    int iterations = 0;
+    m_agentInfo->start(1, 86400, [&iterations]()
+    {
+        return ++iterations < 3;  // keep looping for 3 iterations
+    });
+
+    // The INFO deferral line must appear exactly once across repeated deferrals.
+    auto countOccurrences = [](const std::string & hay, const std::string & needle)
+    {
+        size_t n = 0, pos = 0;
+
+        while ((pos = hay.find(needle, pos)) != std::string::npos)
+        {
+            ++n;
+            pos += needle.size();
+        }
+
+        return n;
+    };
+    EXPECT_EQ(countOccurrences(m_logOutput, "Deferring coordination until FIM first sync completes"), 1U);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Still deferring coordination"));
 }


### PR DESCRIPTION
# Description

`wazuh-modulesd`'s agent-info module pauses FIM before pushing a metadata/groups sync, then polls FIM's `is_pause_completed` query under a hard 30 s budget (`MAX_PAUSE_POLL_ATTEMPTS = 30`). During FIM's **first** synchronization the module rebuilds its database and holds `fim_scan_mutex` for minutes, so the budget is exceeded: agent-info logged an ERROR, aborted coordination, and retried — repeatedly — until the first sync finished. This change makes agent-info **defer** coordination while the first sync is in progress (instead of timing out), narrows `fim_scan_mutex` so the delta-sync step runs unlocked, and primes the first-sync flag at startup so a restart does not re-defer. Resolves #36358.

## Proposed Changes

- **Narrow `fim_scan_mutex` (`src/syscheckd/src/run_check.c`):** `asp_sync_module()` (the delta sync) now runs **unlocked**; only the recovery/integrity loop — which reads/writes the `file_entry` table — holds `fim_scan_mutex` (plus `fim_realtime_mutex`, and `fim_registry_scan_mutex` on Windows). This removes the long mutex hold that caused the pause poll to time out.
- **Expose first-sync state to agent-info:** added the `fim_first_sync_completed` atomic (`src/config/include/syscheck-config.h`), set it on first-sync completion in `fim_run_integrity`, and report it as a `first_sync_completed` field in FIM's `is_pause_completed` response (`src/syscheckd/src/syscom.c`). When synchronization is disabled, it reports `true` so coordination is never blocked.
- **Defer instead of time out (`src/wazuh_modules/agent_info/agent_info_impl/`):** `pollFimPauseCompletion` returns `Deferred` while `first_sync_completed=false`; `coordinateModules` propagates `CoordinationResult::Deferred` and retries on the next cycle with no ERROR/abort. The deferral is logged at INFO once per episode, then DEBUG.
- **Probe FIM first (`COORDINATION_MODULES = {fim, sca, syscollector}`):** FIM is paused and probed before the other modules, so a deferral pauses and resumes **only FIM** and never disrupts SCA/Syscollector during the first-sync window.
- **Throttle reset:** the one-time INFO marker is reset both when the first sync completes and when the probe gives up (timeout/IPC failure), so a later deferral episode is still visible.
- **Windows-safe atomic init (`src/syscheckd/src/syscheck.c`):** the coordination atomics are initialized at the top of `fim_initialize()`, before any early return. On mingw-w64 winpthreads `PTHREAD_MUTEX_INITIALIZER` is a non-zero sentinel, so a zero-initialized mutex would make `w_mutex_lock` abort the Windows agent; this guarantees the atomic is valid before any reader.
- **Prime from the persisted marker (`start_daemon`):** `prime_fim_first_sync_from_marker()` sets the flag from the persisted `first_sync_completed` DB marker **before** `fim_scan()`, so on a restart (where the first sync already completed in a previous run) coordination is not deferred during the startup baseline scan.
- Minor: extracted a `clampNonNegative()` helper shared by the poll-delay setters.

### Results and Evidence

The reproduction seeds a large monitored tree and wipes the FIM DB so the first sync genuinely holds the scan mutex, then forces a coordination delta so agent-info pauses FIM *during* that long first sync.

**Before the fix (`main`) — bug reproduced.** agent-info pauses all three modules, then the FIM pause poll exhausts its 30-attempt / 30-second budget while the first sync holds the scan mutex, logs an ERROR, aborts coordination, and drops the cycle (`Failed to coordinate agent_groups, will retry in next cycle`).

<details><summary>Before fix (main) — FIM pause times out after 30 attempts and coordination is aborted</summary>

```bash
ossec.log fingerprint counts (build verdict: PREFIX):
  'pause did not complete within 30 seconds'           : 1
  'pause failed or timed out, aborting coordination'   : 1
  'Failed to coordinate'                               : 1

2026/06/04 03:18:14 wazuh-modulesd:agent-info: INFO: Starting module coordination process
2026/06/04 03:18:14 wazuh-modulesd:agent-info: INFO: Pausing sca module for synchronization coordination
2026/06/04 03:18:14 wazuh-modulesd:agent-info: INFO: Pausing syscollector module for synchronization coordination
2026/06/04 03:18:14 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/04 03:18:27 wazuh-modulesd:agent-info: WARNING: Failed to poll pause status for fim (attempt 14/30)
2026/06/04 03:18:28 wazuh-modulesd:agent-info: WARNING: Failed to poll pause status for fim (attempt 15/30)
[... attempts 16–28/30 omitted for brevity ...]
2026/06/04 03:18:42 wazuh-modulesd:agent-info: WARNING: Failed to poll pause status for fim (attempt 29/30)
2026/06/04 03:18:43 wazuh-modulesd:agent-info: WARNING: Failed to poll pause status for fim (attempt 30/30)
2026/06/04 03:18:44 wazuh-modulesd:agent-info: ERROR: fim pause did not complete within 30 seconds (scan mutex may be held by a long sync cycle, or IPC communication failure)
2026/06/04 03:18:44 wazuh-modulesd:agent-info: ERROR: fim pause failed or timed out, aborting coordination
2026/06/04 03:18:44 wazuh-modulesd:agent-info: INFO: Resuming paused module: sca
2026/06/04 03:18:44 wazuh-modulesd:agent-info: INFO: Resuming paused module: syscollector
2026/06/04 03:18:44 wazuh-modulesd:agent-info: WARNING: Failed to coordinate agent_groups, will retry in next cycle
```

</details>

**After the fix** — verified on Linux deb and rpm agents (`deb-agent-36358`, `rpm-agent-36358`) enrolled to `wazuh-aio-36358`, running the fix build. Across both agents there are **zero** pre-fix timeout/abort lines, coordination defers while the first sync runs, and once the sync completes coordination proceeds and succeeds.

<details><summary>Fix build confirmed — defer marker present in the installed agent-info binary (both agents)</summary>

```bash
--- deb-agent-36358 ---
/var/ossec/lib/libagent_info.so:Deferring coordination until FIM first sync completes
/var/ossec/lib/libsyscollector.so:first_sync_completed
--- rpm-agent-36358 ---
/var/ossec/lib/libagent_info.so:Deferring coordination until FIM first sync completes
/var/ossec/lib/libsyscollector.so:first_sync_completed
```

</details>

<details><summary>ossec.log fingerprint counts — no pre-fix timeout/abort; defer + successful coordination (both agents)</summary>

```bash
=== deb-agent-36358 — ossec.log fingerprint counts ===
  pre-fix: pause-did-not-complete = 0
  pre-fix: aborting-coordination  = 0
  pre-fix: failed-to-coordinate   = 0
  fix:     deferring-coordination  = 2
  flow:    successfully-coordinated = 1

=== rpm-agent-36358 — ossec.log fingerprint counts ===
  pre-fix: pause-did-not-complete = 0
  pre-fix: aborting-coordination  = 0
  pre-fix: failed-to-coordinate   = 0
  fix:     deferring-coordination  = 2
  flow:    successfully-coordinated = 1
```

</details>

<details><summary>Full defer → first-sync-completes → coordinate → success flow (deb-agent-36358)</summary>

```bash
2026/06/08 20:22:09 wazuh-modulesd:agent-info: INFO: Starting module coordination process
2026/06/08 20:22:09 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/08 20:22:09 wazuh-modulesd:agent-info: INFO: Deferring coordination until FIM first sync completes, will retry next cycle
2026/06/08 20:22:09 wazuh-modulesd:agent-info: INFO: Resuming paused module: fim
2026/06/08 20:22:33 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/08 20:22:33 wazuh-modulesd:agent-info: INFO: Deferring coordination until FIM first sync completes, will retry next cycle
2026/06/08 20:22:33 wazuh-modulesd:agent-info: INFO: Resuming paused module: fim
2026/06/08 20:23:33 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/08 20:23:33 wazuh-modulesd:agent-info: INFO: Pausing sca module for synchronization coordination
2026/06/08 20:23:33 wazuh-modulesd:agent-info: INFO: Pausing syscollector module for synchronization coordination
2026/06/08 20:23:36 wazuh-modulesd:agent-info: INFO: Resuming paused module: fim
2026/06/08 20:23:36 wazuh-modulesd:agent-info: INFO: Resuming paused module: sca
2026/06/08 20:23:36 wazuh-modulesd:agent-info: INFO: Resuming paused module: syscollector
2026/06/08 20:23:46 wazuh-modulesd:agent-info: INFO: fim pending operations completed with result: success (took 20 seconds)
2026/06/08 20:23:46 wazuh-modulesd:agent-info: INFO: sca pending operations completed with result: success (took 20 seconds)
2026/06/08 20:23:56 wazuh-modulesd:agent-info: INFO: syscollector pending operations completed with result: success (took 30 seconds)
2026/06/08 20:24:00 wazuh-modulesd:agent-info: INFO: Synchronization coordination completed successfully
2026/06/08 20:24:00 wazuh-modulesd:agent-info: INFO: Successfully coordinated agent_groups
```

</details>

<details><summary>Reorder verified — during the deferral window only FIM is paused; SCA/Syscollector are paused only once coordination proceeds (deb-agent-36358)</summary>

```bash
2026/06/08 20:22:09 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/08 20:22:09 wazuh-modulesd:agent-info: INFO: Deferring coordination until FIM first sync completes, will retry next cycle
2026/06/08 20:22:33 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/08 20:22:33 wazuh-modulesd:agent-info: INFO: Deferring coordination until FIM first sync completes, will retry next cycle
2026/06/08 20:23:33 wazuh-modulesd:agent-info: INFO: Pausing fim module for synchronization coordination
2026/06/08 20:23:33 wazuh-modulesd:agent-info: INFO: Pausing sca module for synchronization coordination
2026/06/08 20:23:33 wazuh-modulesd:agent-info: INFO: Pausing syscollector module for synchronization coordination
```

</details>

### Artifacts Affected

- `libagent_info.so` / `agent_info.dll` (agent-info module) — coordination/deferral logic.
- `wazuh-syscheckd` and `libfimdb.so` / `libfimdb.dll` (FIM) — mutex narrowing, first-sync flag, `is_pause_completed` response.
- `wazuh-modulesd` (hosts the agent-info module on Linux/macOS); `wazuh-agent.exe` on Windows (modulesd is linked in).
- Wazuh **agent** package (all platforms).

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._ The change is internal coordination behavior; the only user-visible difference is new INFO/DEBUG log lines (e.g. "Deferring coordination until FIM first sync completes") replacing the previous pause-timeout ERROR/abort lines.

### Tests Introduced

- `src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp`:
  - `DeferCoordinationWhenFimFirstSyncNotCompleted`
  - `DeferralResumesFimOnlyAndSkipsOtherModulePauses`
  - `SteadyStateNormalPauseWhenFirstSyncCompleted`
  - `SteadyStateGenuineTimeoutStillLogsError`
  - `ShutdownDuringPausePollAbortsCleanly`
  - `MissingFirstSyncFieldTreatedAsCompleted`
  - `SyncDisabledReportsCompletedAndDoesNotDefer`
  - `RepeatedDeferralLogsInfoOnce`
  - `DeferralThrottleResetsAfterProbeGivesUp`
- `src/unit_tests/syscheckd/test_run_check.c`:
  - `test_prime_fim_first_sync_from_marker_sets_flag_when_present`
  - `test_prime_fim_first_sync_from_marker_keeps_flag_clear_when_absent`
  - Fixture now initializes `fim_first_sync_completed` (winpthreads safety).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
