### PR TITLE
5.x PR workflows improvements

### DIFF
--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -8,6 +8,10 @@ on:
       - "src/**"
       - "packages/**"
       - ".github/workflows/5_builderpackage_agent-linux-arm64.yml"
+      - ".github/actions/5_builderpackage_get-last-stable-version/**"
+      - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
+      - ".github/actions/5_builderpackage_linux-smoke-uninstall-test/**"
+      - ".github/actions/5_builderpackage_linux-smoke-upgrade-test/**"
   workflow_dispatch:
     inputs:
       architecture:

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -10,8 +10,14 @@ on:
       - "ruleset/**"
       - ".github/actions/check_files/**"
       - ".github/workflows/5_builderpackage_agent-linux.yml"
+      - ".github/workflows/5_testintegration_agent-start.yml"
       - ".github/workflows/5_testintegration_linux-integration-tests.yml"
       - ".github/test_modules_linux.json"
+      - ".github/actions/5_builderpackage_get-last-stable-version/**"
+      - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
+      - ".github/actions/5_builderpackage_linux-smoke-uninstall-test/**"
+      - ".github/actions/5_builderpackage_linux-smoke-upgrade-test/**"
+      - ".github/actions/5_testintegration_detect-changes/**"
   workflow_dispatch:
     inputs:
       architecture:

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -10,8 +10,13 @@ on:
       - "ruleset/**"
       - ".github/actions/check_files/**"
       - ".github/workflows/5_builderpackage_agent-macos.yml"
+      - ".github/workflows/5_testintegration_agent-start.yml"
       - ".github/workflows/5_testintegration_macos-integration-tests.yml"
       - ".github/test_modules_macos.json"
+      - ".github/actions/5_builderpackage_get-last-stable-version/**"
+      - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
+      - ".github/actions/5_builderpackage_macos-smoke-upgrade-test/**"
+      - ".github/actions/5_testintegration_detect-changes/**"
   workflow_dispatch:
     inputs:
       architecture:

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -11,7 +11,12 @@ on:
       - ".github/actions/check_files/**"
       - ".github/workflows/5_builderpackage_agent-windows.yml"
       - ".github/test-modules-windows.json"
+      - ".github/workflows/5_testintegration_agent-start.yml"
       - ".github/workflows/5_testintegration_windows-integration-tests.yml"
+      - ".github/actions/5_builderpackage_get-last-stable-version/**"
+      - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
+      - ".github/actions/5_builderpackage_windows-smoke-upgrade-test/**"
+      - ".github/actions/5_testintegration_detect-changes/**"
   workflow_dispatch:
     inputs:
       revision:

--- a/.github/workflows/5_builderpackage_engine-standalone.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on:
       group: ${{ matrix.arch == 'arm64' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
       labels: ${{ matrix.arch == 'arm64' && 'wz-linux-arm64' || 'wz-linux-amd64' }}
+    timeout-minutes: 60
     outputs:
       version: ${{ steps.set_version.outputs.version }}
     strategy:

--- a/.github/workflows/5_builderpackage_manager-multiples.yml
+++ b/.github/workflows/5_builderpackage_manager-multiples.yml
@@ -8,6 +8,7 @@ on:
       - "framework/**"
       - "src/**"
       - ".github/workflows/5_builderpackage_manager-multiples.yml"
+      - ".github/workflows/5_builderpackage_manager.yml"
       - "packages/*/SPECS/wazuh-manager/**"
       - "packages/*"
       - "packages/*/utils/*"
@@ -19,6 +20,29 @@ on:
       - "tests/integration/conftest.py"
       - "tests/integration/test_api/**"
       - "tests/integration/test_wazuh_db/**"
+      - "tests/integration/test_remoted/**"
+      - "tests/integration/test_authd/**"
+      # Agent-only trees, never built for the manager target (src/CMakeLists.txt gating)
+      - "!src/rootcheck/**"
+      - "!src/addagent/**"
+      - "!src/os_execd/**"
+      - "!src/win32/**"
+      # Manager build forces USE_SELINUX=no (src/Makefile); only agent specs package it
+      - "!src/selinux/**"
+      # Test trees: UNIT_TEST/WAZUH_ENGINE_TEST-gated or excluded from the wheel (setup.py)
+      - "!src/unit_tests/**"
+      - "!src/**/tests/**"
+      - "!src/**/integrationTests/**"
+      # qa/ suites run in other workflows; inventory_sync/qa stays (its IT is
+      # dispatched from here) and indexer_connector/** is detect-changes-mapped
+      - "!src/data_provider/qa/**"
+      - "!src/shared_modules/keystore/qa/**"
+      - "!src/wazuh_modules/vulnerability_scanner/qa/**"
+      - "!src/engine/test/**"
+      - "!src/engine/docs/**"
+      - "!framework/**/tests/**"
+      - "!api/**/test/**"
+      - "!api/test/**"
   workflow_dispatch:
     inputs:
       targets:

--- a/.github/workflows/5_builderpackage_manager-multiples.yml
+++ b/.github/workflows/5_builderpackage_manager-multiples.yml
@@ -259,7 +259,8 @@ jobs:
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
       needs.detect-changes.outputs.any_matched == 'true' &&
       needs.build-wazuh-manager.result == 'success'
-    name: ${{ matrix.name == 'none' && 'Integration tests - No relevant changes' || format('Integration tests - {0}', matrix.name) }}
+    # Static name: GitHub never evaluates name expressions on skipped matrix jobs
+    name: Integration tests
     needs: [build-wazuh-manager, detect-changes]
     strategy:
       fail-fast: false

--- a/.github/workflows/5_buildpackage_internal_tools.yml
+++ b/.github/workflows/5_buildpackage_internal_tools.yml
@@ -37,6 +37,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build ${{ matrix.system }} / ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_codeanalysis_api-rbac-db-version.yml
+++ b/.github/workflows/5_codeanalysis_api-rbac-db-version.yml
@@ -17,6 +17,7 @@ jobs:
   guard:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/5_codeanalysis_python_bandit_pr.yml
+++ b/.github/workflows/5_codeanalysis_python_bandit_pr.yml
@@ -21,6 +21,7 @@ jobs:
   bandit-scan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: wz-linux-amd64
+    timeout-minutes: 20
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/5_codeanalysis_scanbuild.yml
+++ b/.github/workflows/5_codeanalysis_scanbuild.yml
@@ -15,6 +15,7 @@ jobs:
   scan-build-linux:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +50,7 @@ jobs:
   scan-build-ubuntu-mingw-windows:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:
@@ -81,6 +83,7 @@ jobs:
   scan-build-macos-agent:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/5_codeanalysis_scanbuild.yml
+++ b/.github/workflows/5_codeanalysis_scanbuild.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/5_codeanalysis_scanbuild.yml"
+      - ".github/actions/reinstall_cmake/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_codelinter_clangformat.yml
+++ b/.github/workflows/5_codelinter_clangformat.yml
@@ -4,6 +4,16 @@ on:
   workflow_dispatch:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - .clang-format
+      - src/shared_modules/router/**
+      - src/shared_modules/indexer_connector/**
+      - src/shared_modules/content_manager/**
+      - src/shared_modules/utils/**
+      - src/wazuh_modules/inventory_sync/**
+      - src/wazuh_modules/vulnerability_scanner/**
+      - .github/workflows/5_codelinter_clangformat.yml
+      - .github/actions/clang_format/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_agent_info-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_info-rtr.yml
@@ -26,6 +26,7 @@ jobs:
         module: [wazuh_modules/agent_info]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
@@ -24,6 +24,7 @@ jobs:
         module: [shared_modules/agent_metadata]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_build-macos.yml
+++ b/.github/workflows/5_testcomponent_build-macos.yml
@@ -15,6 +15,7 @@ jobs:
   build-sonoma:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-15
+    timeout-minutes: 15
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_build-macos.yml
+++ b/.github/workflows/5_testcomponent_build-macos.yml
@@ -6,6 +6,27 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_build-macos.yml"
+      - "!src/engine/**"
+      - "!src/remoted/**"
+      - "!src/util/**"
+      # Windows-only, never built for the macOS agent
+      - "!src/win32/**"
+      - "!src/shared_modules/indexer_connector/**"
+      - "!src/shared_modules/keystore/**"
+      # Only src/ for these server trees: agent modules compile against their include/
+      - "!src/monitord/src/**"
+      - "!src/os_auth/src/**"
+      - "!src/wazuh_db/src/**"
+      - "!src/wazuh_db/schemas/**"
+      - "!src/shared_modules/content_manager/src/**"
+      - "!src/shared_modules/router/src/**"
+      - "!src/wazuh_modules/vulnerability_scanner/src/**"
+      - "!src/wazuh_modules/inventory_sync/src/**"
+      # Test trees: UNIT_TEST-gated, never built by this workflow
+      - "!src/unit_tests/**"
+      - "!src/**/tests/**"
+      - "!src/**/integrationTests/**"
+      - "!src/**/qa/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/5_testcomponent_contentmanager.yml
+++ b/.github/workflows/5_testcomponent_contentmanager.yml
@@ -17,6 +17,7 @@ jobs:
   contentmanager-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/5_testcomponent_contentmanager.yml
+++ b/.github/workflows/5_testcomponent_contentmanager.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/5_testcomponent_contentmanager.yml"
       - "src/shared_modules/utils/**"
       - "src/shared_modules/content_manager/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/test_cpp/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_indexer-connector.yml
+++ b/.github/workflows/5_testcomponent_indexer-connector.yml
@@ -8,6 +8,10 @@ on:
       - ".github/workflows/5_testcomponent_indexer-connector.yml"
       - "src/shared_modules/indexer_connector/**"
       - "src/shared_modules/utils/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/reinstall_cmake/**"
+      - ".github/actions/test_cpp/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_indexer-connector.yml
+++ b/.github/workflows/5_testcomponent_indexer-connector.yml
@@ -17,6 +17,7 @@ jobs:
   indexer-connector-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/5_testcomponent_keystore.yml
+++ b/.github/workflows/5_testcomponent_keystore.yml
@@ -17,6 +17,7 @@ jobs:
   keystore-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/5_testcomponent_keystore.yml
+++ b/.github/workflows/5_testcomponent_keystore.yml
@@ -8,6 +8,10 @@ on:
       - ".github/workflows/5_testcomponent_keystore.yml"
       - "src/shared_modules/keystore/**"
       - "src/shared_modules/utils/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/reinstall_cmake/**"
+      - ".github/actions/test_cpp/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_router.yml
+++ b/.github/workflows/5_testcomponent_router.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/5_testcomponent_router.yml"
       - "src/shared_modules/utils/**"
       - "src/shared_modules/router/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/test_cpp/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_router.yml
+++ b/.github/workflows/5_testcomponent_router.yml
@@ -17,6 +17,7 @@ jobs:
   router-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/5_testcomponent_sca-rtr.yml
+++ b/.github/workflows/5_testcomponent_sca-rtr.yml
@@ -26,6 +26,7 @@ jobs:
         module: [wazuh_modules/sca]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
+++ b/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
@@ -24,6 +24,7 @@ jobs:
         module: [shared_modules/file_helper]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
+++ b/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
@@ -24,6 +24,7 @@ jobs:
         module: [shared_modules/sync_protocol]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscheck-rtr.yml
@@ -26,6 +26,7 @@ jobs:
         module: [syscheckd]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscollector-rtr.yml
@@ -27,6 +27,7 @@ jobs:
               module: [wazuh_modules/syscollector, shared_modules/dbsync, data_provider]
               target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/5_testcomponent_vulnerability-scanner.yml
@@ -17,6 +17,7 @@ jobs:
   vulnerability-scanner-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -52,6 +53,7 @@ jobs:
   vulnerability-scanner-modules-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/5_testcomponent_vulnerability-scanner.yml
@@ -8,6 +8,10 @@ on:
       - ".github/workflows/5_testcomponent_vulnerability-scanner.yml"
       - "src/wazuh_modules/vulnerability_scanner/**"
       - "src/shared_modules/utils/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/reinstall_cmake/**"
+      - ".github/actions/test_cpp/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -7,6 +7,31 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_windows-dll-hijack.yml"
+      - ".github/actions/reinstall_cmake/**"
+      - "!src/engine/**"
+      - "!src/remoted/**"
+      - "!src/util/**"
+      - "!src/shared_modules/indexer_connector/**"
+      - "!src/shared_modules/keystore/**"
+      # Only src/ for these server trees: agent modules compile against their include/
+      - "!src/monitord/src/**"
+      - "!src/os_auth/src/**"
+      - "!src/wazuh_db/src/**"
+      - "!src/wazuh_db/schemas/**"
+      - "!src/shared_modules/content_manager/src/**"
+      - "!src/shared_modules/router/src/**"
+      - "!src/wazuh_modules/vulnerability_scanner/src/**"
+      - "!src/wazuh_modules/inventory_sync/src/**"
+      # Test trees: UNIT_TEST-gated, never built by this workflow
+      - "!src/unit_tests/**"
+      - "!src/**/tests/**"
+      - "!src/**/integrationTests/**"
+      # qa/ suites run in other workflows; win32/qa stays (executed here)
+      - "!src/data_provider/qa/**"
+      - "!src/shared_modules/indexer_connector/qa/**"
+      - "!src/shared_modules/keystore/qa/**"
+      - "!src/wazuh_modules/inventory_sync/qa/**"
+      - "!src/wazuh_modules/vulnerability_scanner/qa/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +62,7 @@ jobs:
 
   check_dll_on_windows:
     runs-on: windows-2025
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -6,6 +6,31 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_windows-files.yml"
+      - ".github/actions/reinstall_cmake/**"
+      - "!src/engine/**"
+      - "!src/remoted/**"
+      - "!src/util/**"
+      - "!src/shared_modules/indexer_connector/**"
+      - "!src/shared_modules/keystore/**"
+      # Only src/ for these server trees: agent modules compile against their include/
+      - "!src/monitord/src/**"
+      - "!src/os_auth/src/**"
+      - "!src/wazuh_db/src/**"
+      - "!src/wazuh_db/schemas/**"
+      - "!src/shared_modules/content_manager/src/**"
+      - "!src/shared_modules/router/src/**"
+      - "!src/wazuh_modules/vulnerability_scanner/src/**"
+      - "!src/wazuh_modules/inventory_sync/src/**"
+      # Test trees: UNIT_TEST-gated, never built by this workflow
+      - "!src/unit_tests/**"
+      - "!src/**/tests/**"
+      - "!src/**/integrationTests/**"
+      # qa/ suites run in other workflows; win32/qa stays (executed here)
+      - "!src/data_provider/qa/**"
+      - "!src/shared_modules/indexer_connector/qa/**"
+      - "!src/shared_modules/keystore/qa/**"
+      - "!src/wazuh_modules/inventory_sync/qa/**"
+      - "!src/wazuh_modules/vulnerability_scanner/qa/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Install mingw
@@ -47,6 +48,7 @@ jobs:
           path: src/bin_files
   check_binaries_details:
     runs-on: windows-2025
+    timeout-minutes: 30
     needs: build
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -6,6 +6,31 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/5_testcomponent_windows-installer-upgrade.yml"
+      - ".github/actions/reinstall_cmake/**"
+      - "!src/engine/**"
+      - "!src/remoted/**"
+      - "!src/util/**"
+      - "!src/shared_modules/indexer_connector/**"
+      - "!src/shared_modules/keystore/**"
+      # Only src/ for these server trees: agent modules compile against their include/
+      - "!src/monitord/src/**"
+      - "!src/os_auth/src/**"
+      - "!src/wazuh_db/src/**"
+      - "!src/wazuh_db/schemas/**"
+      - "!src/shared_modules/content_manager/src/**"
+      - "!src/shared_modules/router/src/**"
+      - "!src/wazuh_modules/vulnerability_scanner/src/**"
+      - "!src/wazuh_modules/inventory_sync/src/**"
+      # Test trees: UNIT_TEST-gated, never built by this workflow
+      - "!src/unit_tests/**"
+      - "!src/**/tests/**"
+      - "!src/**/integrationTests/**"
+      # qa/ suites run in other workflows; win32/qa stays (executed here)
+      - "!src/data_provider/qa/**"
+      - "!src/shared_modules/indexer_connector/qa/**"
+      - "!src/shared_modules/keystore/qa/**"
+      - "!src/wazuh_modules/inventory_sync/qa/**"
+      - "!src/wazuh_modules/vulnerability_scanner/qa/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Install mingw
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 -y
@@ -44,6 +45,7 @@ jobs:
           matrix:
               wazuh_version: [4.14.0-1]
     runs-on: windows-2025
+    timeout-minutes: 30
     needs: build
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testintegration_api-endpoints.yml
+++ b/.github/workflows/5_testintegration_api-endpoints.yml
@@ -32,6 +32,7 @@ jobs:
   api_endpoints_integration_tests_setup:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     outputs:
       custom_matrix: ${{ steps.test_files.outputs.files }}
     name: Generate execution matrix for API endpoints integration tests
@@ -138,6 +139,7 @@ jobs:
     needs: api_endpoints_integration_tests_setup
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     name: Build and cache Docker images for integration tests
     outputs:
       checksum: ${{ steps.calculate_checksum.outputs.checksum }}
@@ -182,6 +184,7 @@ jobs:
     needs: [api_endpoints_integration_tests_setup, build_docker_images]
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     name: Run smoke test for API endpoints
 
     steps:
@@ -219,6 +222,7 @@ jobs:
     needs: [api_endpoints_integration_tests_setup, build_docker_images, smoke_test]
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testintegration_engine.yml
+++ b/.github/workflows/5_testintegration_engine.yml
@@ -5,6 +5,8 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
+      - '.github/actions/reinstall_cmake/**'
+      - '.github/workflows/5_testintegration_engine.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testintegration_engine.yml
+++ b/.github/workflows/5_testintegration_engine.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Server
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -29,6 +29,7 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -11,6 +11,7 @@ on:
         - "src/Makefile"
         - "tests/integration/conftest.py"
         - "tests/integration/test_msgraph/**"
+        - ".github/actions/reinstall_cmake/**"
   workflow_dispatch:
     inputs:
       base_branch:

--- a/.github/workflows/5_testintegration_vulnerability-scanner.yml
+++ b/.github/workflows/5_testintegration_vulnerability-scanner.yml
@@ -9,6 +9,9 @@ on:
       - "src/shared_modules/content_manager/**"
       - "src/shared_modules/indexer_connector/**"
       - "src/wazuh_modules/inventory_sync/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/reinstall_cmake/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testintegration_vulnerability-scanner.yml
+++ b/.github/workflows/5_testintegration_vulnerability-scanner.yml
@@ -19,6 +19,7 @@ jobs:
   vulnerability-scanner-integration:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/5_testintegration_windows-integration-tests.yml
+++ b/.github/workflows/5_testintegration_windows-integration-tests.yml
@@ -92,6 +92,7 @@ jobs:
       AGENT_PACKAGE_REGEXP: wazuh-agent.*windows.*\.msi
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     runs-on: windows-2025
+    timeout-minutes: 240
     name: Run ${{ inputs.module_name }} integration tests (${{ inputs.shard_name }})
     steps:
       - name: No relevant changes

--- a/.github/workflows/5_testunit_api.yml
+++ b/.github/workflows/5_testunit_api.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testunit_api.yml
+++ b/.github/workflows/5_testunit_api.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/5_testunit_api.yml'
       - 'api/**'
+      - 'framework/requirements-dev.txt'
       - 'src/Makefile'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -7,6 +7,10 @@ on:
       - ".github/workflows/5_testunit_contentmanager.yml"
       - "src/shared_modules/utils/**"
       - "src/shared_modules/content_manager/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/test_cpp/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -17,6 +17,7 @@ jobs:
   contentmanager-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -56,6 +57,7 @@ jobs:
   contentmanager-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testunit_engine.yml
+++ b/.github/workflows/5_testunit_engine.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Manager
     runs-on: ubuntu-24.04
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/5_testunit_engine.yml
+++ b/.github/workflows/5_testunit_engine.yml
@@ -5,10 +5,13 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
+      - '.github/actions/reinstall_cmake/**'
+      - '.github/workflows/5_testunit_engine.yml'
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   BUILD_DIR: ${{github.workspace}}/src/build

--- a/.github/workflows/5_testunit_framework.yml
+++ b/.github/workflows/5_testunit_framework.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -7,6 +7,10 @@ on:
       - ".github/workflows/5_testunit_indexerconnector.yml"
       - "src/shared_modules/utils/**"
       - "src/shared_modules/indexer_connector/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/test_cpp/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -17,6 +17,7 @@ jobs:
   indexerconnector-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -56,6 +57,7 @@ jobs:
   indexerconnector-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -17,6 +17,7 @@ jobs:
   inventorysync-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -57,6 +58,7 @@ jobs:
   inventorysync-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -7,6 +7,10 @@ on:
       - ".github/workflows/5_testunit_inventorysync.yml"
       - "src/shared_modules/utils/**"
       - "src/wazuh_modules/inventory_sync/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/test_cpp/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -25,6 +25,7 @@ jobs:
           matrix:
               target: [agent, winagent, manager]
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -6,6 +6,11 @@ on:
     paths:
         - "src/**"
         - ".github/workflows/5_testunit_linux-win.yml"
+        - ".github/actions/build_test_flags/**"
+        - ".github/actions/install_build_deps/**"
+        - ".github/actions/legacy_unit_tests_build/**"
+        - ".github/actions/legacy_unit_tests_run/**"
+        - ".github/actions/reinstall_cmake/**"
   workflow_dispatch:
     inputs:
       base_branch:

--- a/.github/workflows/5_testunit_macos.yml
+++ b/.github/workflows/5_testunit_macos.yml
@@ -6,6 +6,18 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/5_testunit_macos.yml"
+      - "!src/engine/**"
+      - "!src/monitord/**"
+      - "!src/os_auth/**"
+      - "!src/remoted/**"
+      - "!src/util/**"
+      - "!src/wazuh_db/**"
+      - "!src/shared_modules/content_manager/**"
+      - "!src/shared_modules/indexer_connector/**"
+      - "!src/shared_modules/keystore/**"
+      - "!src/shared_modules/router/**"
+      - "!src/wazuh_modules/vulnerability_scanner/**"
+      - "!src/wazuh_modules/inventory_sync/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_macos.yml
+++ b/.github/workflows/5_testunit_macos.yml
@@ -7,17 +7,21 @@ on:
       - "src/**"
       - ".github/workflows/5_testunit_macos.yml"
       - "!src/engine/**"
-      - "!src/monitord/**"
-      - "!src/os_auth/**"
       - "!src/remoted/**"
       - "!src/util/**"
-      - "!src/wazuh_db/**"
-      - "!src/shared_modules/content_manager/**"
+      # Windows-only, never built for the macOS agent
+      - "!src/win32/**"
       - "!src/shared_modules/indexer_connector/**"
       - "!src/shared_modules/keystore/**"
-      - "!src/shared_modules/router/**"
-      - "!src/wazuh_modules/vulnerability_scanner/**"
-      - "!src/wazuh_modules/inventory_sync/**"
+      # Only src/ for these server trees: agent modules compile against their include/
+      - "!src/monitord/src/**"
+      - "!src/os_auth/src/**"
+      - "!src/wazuh_db/src/**"
+      - "!src/wazuh_db/schemas/**"
+      - "!src/shared_modules/content_manager/src/**"
+      - "!src/shared_modules/router/src/**"
+      - "!src/wazuh_modules/vulnerability_scanner/src/**"
+      - "!src/wazuh_modules/inventory_sync/src/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_macos.yml
+++ b/.github/workflows/5_testunit_macos.yml
@@ -16,6 +16,7 @@ jobs:
   build-sonoma:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: macos-15
+    timeout-minutes: 45
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testunit_python-coverage.yml
+++ b/.github/workflows/5_testunit_python-coverage.yml
@@ -6,7 +6,6 @@ on:
       - '.github/workflows/5_testunit_python-coverage.yml'
       - 'api/**'
       - 'framework/**'
-      - 'wodles/**'
   workflow_dispatch:
     inputs:
       base_branch:

--- a/.github/workflows/5_testunit_python-coverage.yml
+++ b/.github/workflows/5_testunit_python-coverage.yml
@@ -26,6 +26,7 @@ jobs:
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
       PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -17,6 +17,7 @@ jobs:
   router-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -56,6 +57,7 @@ jobs:
   router-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -7,6 +7,10 @@ on:
       - ".github/workflows/5_testunit_router.yml"
       - "src/shared_modules/utils/**"
       - "src/shared_modules/router/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/test_cpp/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -16,6 +16,7 @@ jobs:
   shared_modules_utils-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -55,6 +56,7 @@ jobs:
   shared_modules_utils-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - ".github/workflows/5_testunit_shared_modules_utils.yml"
       - "src/shared_modules/utils/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/test_cpp/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_vulnerability-scanner.yml
+++ b/.github/workflows/5_testunit_vulnerability-scanner.yml
@@ -7,6 +7,11 @@ on:
       - ".github/workflows/5_testunit_vulnerability-scanner.yml"
       - "src/wazuh_modules/vulnerability_scanner/**"
       - "src/shared_modules/utils/**"
+      - ".github/actions/build_external_deps/**"
+      - ".github/actions/build_target_cpp/**"
+      - ".github/actions/coverage_cpp/**"
+      - ".github/actions/reinstall_cmake/**"
+      - ".github/actions/test_cpp/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/5_testunit_vulnerability-scanner.yml
+++ b/.github/workflows/5_testunit_vulnerability-scanner.yml
@@ -17,6 +17,7 @@ jobs:
   vulnerability-scanner-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -59,6 +60,7 @@ jobs:
   vulnerability-scanner-modules-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testunit_wodles.yml
+++ b/.github/workflows/5_testunit_wodles.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This PR optimizes and simplifies the 5.x PR GitHub Actions workflows to cut unnecessary CI fan-out and cost and to fix under-triggering, without reducing required PR coverage. It is scoped to the server/manager side and cross-cutting CI hygiene.

The change set is CI-only: it touches `.github/workflows/**` (path filters, timeouts, dependency coverage, one skipped-job-name fix). No product source code, packages, or default configuration are modified.

Closes #36746

Expected fail (flaky) :[5.X - Build Wazuh agent Windows (MSI) / IT Windows - syscollector (tier-0-1) / Run syscollector integration tests (tier-0-1) (pull_request)](https://github.com/wazuh/wazuh/actions/runs/27273068429/job/80549912741?pr=36766)

## Proposed Changes

Seven commits:

1. **`chore(ci): add job timeouts to 5.x PR workflows`**
   - Added `timeout-minutes` to jobs across 39 PR-reachable workflows, sized from recent successful-run baselines, so a hung job fails fast instead of consuming GitHub's 360-min default.

2. **`fix(ci): trigger PR workflows on their action and workflow dependencies`**
   - Added `.github/actions/<name>/**` paths so workflows re-run when a composite action they consume changes (closes an under-triggering gap in ~23 workflows).
   - Added the called reusable workflows (`5_testintegration_agent-start.yml`, `5_builderpackage_manager.yml`) to the relevant builders' paths, and `framework/requirements-dev.txt` to the API unit test workflow (it installs from it).
   - Self-referenced `5_testunit_engine.yml` / `5_testintegration_engine.yml` in their own `paths` and added `cancel-in-progress: true` to `5_testunit_engine.yml` (it queued superseded runs instead of cancelling them).
   - Tightened the linux/macOS unit-test path filters (`5_testunit_macos.yml`, `5_testunit_linux-win.yml`) with the agent-built-tree scoping described below.

3. **`chore(ci): scope the clangformat linter to the modules it checks`**
   - Added `paths` to `5_codelinter_clangformat.yml` (it ran on 100% of PRs before) scoped to the 6 modules it actually lints, plus `.clang-format`, its own workflow, and `.github/actions/clang_format/**`.

4. **`chore(ci): scope macOS/Windows agent workflow paths to agent-built trees`**
   - Negated server-only paths (`!src/engine/**`, `!src/wazuh_db/**`, `!src/remoted/**`, …) — never compiled for the `agent`/`winagent` target — in the macOS/Windows component workflows (`build-macos`, `windows-dll-hijack`, `windows-files`, `windows-installer-upgrade`).
   - Added the missing `reinstall_cmake` dependency to the Windows component workflows.

5. **`chore(ci): scope manager builder paths to manager-built trees`**
   - Scoped `5_builderpackage_manager-multiples.yml` `paths` to the trees the manager package actually builds from.

6. **`fix(ci): render skipped integration test job names correctly`**
   - Gave the manager integration matrix job in `5_builderpackage_manager-multiples.yml` a static `name: Integration tests`. GitHub never evaluates the `name` expression of a skipped matrix reusable-workflow job (the matrix never expands), so the previous `${{ matrix.* }}` expression rendered as the raw template on draft PRs, no-relevant-changes runs and non-PR dispatches.
   - Scoped to the **manager builder only** .

7. **`chore(ci): drop wodles from the python coverage triggers`**
   - Removed `wodles/**` from `5_testunit_python-coverage.yml` `paths`. The workflow only adds `api/` and `framework/` to `PYTHONPATH` and reports coverage for those trees, so `wodles/` changes fired a run that never covered them. wodles coverage is handled through its own dedicated support.

### Results and Evidence

- **Path-filter selectivity** — macOS/Windows test workflows no longer run for changes confined to server-only code. Five workflows are scoped (`build-macos`, `testunit_macos`, `windows-dll-hijack`, `windows-files`, `windows-installer-upgrade`). The negated directories are backed by `src/CMakeLists.txt` (`if(NOT IS_AGENT)`) and `src/wazuh_modules/CMakeLists.txt` (`if(NOT winagent AND NOT agent)`), verified with **zero cross-includes** from agent/common code and confirmed against `agent.cmake`/`winagent.cmake` (server-only tests live only in `server.cmake`). The negations are ordered last in `paths` per GitHub's evaluation rules and fail safe (new agent dirs stay covered by `src/**`).
- **Under-triggering closed** — every PR workflow that depends on a composite action, a reusable workflow, the `.clang-format` config, or its own definition now lists it in `paths` (audited to 0 remaining gaps); all added paths resolve to existing files.
- **Coverage scope tightened** — `wodles/**` was dropped from the Python coverage workflow's triggers because it only measures `api/` + `framework/` (the only entries on its `PYTHONPATH`); wodles changes no longer fire a run that never covers them.
- **Timeout coverage** — all PR-reachable jobs have explicit `timeout-minutes` except a small set of immediate setup/matrix/detect helper jobs, documented as intentional exceptions.
- **Skipped-job naming** — the manager integration matrix job now renders a stable `Integration tests` even when skipped, instead of the raw `${{ matrix.* }}` template (GitHub cannot resolve `matrix.*` for a skipped matrix reusable-workflow job).
- **Deferred work documented with evidence** — caching (correctness-key + 10 GB cache-size + no measurable benefit), reusable C++ workflow (deferred to its own PR; the generic `detect-changes` machinery exists but the unit/component shapes differ) and CI-definition linting (`actionlint` reproduced **398 findings / 97 warning+ / 1 hard error** of pre-existing debt — a blocking gate would be red from day one).

A representative-PR-run validation against the live PR checks is the remaining Definition-of-Done item.

### Relationship to #35319

[#35319](https://github.com/wazuh/wazuh/pull/35319) (agent team, repo-wide actions modernization) edits a large overlapping set of `5_*` workflows, so the scope is split:

- **Only here:** timeouts, macOS/Windows server-only negations, clangformat scoping, engine `cancel-in-progress`, the manager job-name fix, the `reinstall_cmake` paths and the wodles drop.
- **Ceded to #35319:** the `fkirc/skip-duplicate-actions` removal and the action-version / Node 20→24 bumps — this PR does not touch them.
- **On rebase:** replace the granular C++ action paths with `.github/actions/cpp_test_pipeline/**` (the composite #35319 introduces) and resolve fkirc to its version.

### Manual tests with their corresponding evidence

This PR modifies only CI workflow definitions under `.github/`; it builds no binaries and changes no product behavior. The compilation/memory/engine/API checks below do not apply.


### Artifacts Affected

- `.github/workflows/5_*.yml` (45 workflow files touched across the branch).
- No executables, packages, or default configuration files are affected.

### Configuration Changes

N/A 

### Tests Introduced

N/A 

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
