### PR TITLE
Drop libcrypt dependency from Python dep

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1388,7 +1388,7 @@ TAR := tar -xf
 GUNZIP := gunzip
 GZIP := gzip
 CURL := curl -so
-DEPS_VERSION = 52
+DEPS_VERSION = 53
 RESOURCES_URL_BASE := https://packages.wazuh.com/deps/
 RESOURCES_URL := $(RESOURCES_URL_BASE)$(DEPS_VERSION)
 CPYTHON := cpython
@@ -2503,7 +2503,7 @@ ifeq (,${INSTALLDIR})
 endif
 
 ifeq (,$(wildcard ${EXTERNAL_CPYTHON}/python))
-	export WPATH_LIB="'\$$\$$ORIGIN/../../../lib'" && export SOURCE_PATH=${ROUTE_PATH} && export WAZUH_FFI_PATH=${EXTERNAL_LIBFFI} && export LD_LIBRARY_PATH=${ROUTE_PATH} && cd ${EXTERNAL_CPYTHON} && ./configure --prefix="${WPYTHON_DIR}" --libdir="${WPYTHON_DIR}/lib" --enable-shared --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="${ARCH_FLAGS} -L${ROUTE_PATH} -L${ROUTE_PATH}/${EXTERNAL_SQLITE} -L${ROUTE_PATH}/${EXTERNAL_LIBFFI}${TARGET}/.libs -Wl,-rpath,'\$$\$$ORIGIN/../../../lib',--disable-new-dtags" CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include -I${ROUTE_PATH}/${EXTERNAL_SQLITE} -I${ROUTE_PATH}/${EXTERNAL_LIBFFI}include" LIBS="-lwazuhext" $(CPYTHON_FLAGS) && ${MAKE}
+	export WPATH_LIB="'\$$\$$ORIGIN/../../../lib'" && export SOURCE_PATH=${ROUTE_PATH} && export WAZUH_FFI_PATH=${EXTERNAL_LIBFFI} && export LD_LIBRARY_PATH=${ROUTE_PATH} && export ac_cv_header_crypt_h=no && export ac_cv_lib_crypt_crypt=no && cd ${EXTERNAL_CPYTHON} && ./configure --prefix="${WPYTHON_DIR}" --libdir="${WPYTHON_DIR}/lib" --enable-shared --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="${ARCH_FLAGS} -L${ROUTE_PATH} -L${ROUTE_PATH}/${EXTERNAL_SQLITE} -L${ROUTE_PATH}/${EXTERNAL_LIBFFI}${TARGET}/.libs -Wl,-rpath,'\$$\$$ORIGIN/../../../lib',--disable-new-dtags" CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include -I${ROUTE_PATH}/${EXTERNAL_SQLITE} -I${ROUTE_PATH}/${EXTERNAL_LIBFFI}include" LIBS="-lwazuhext" $(CPYTHON_FLAGS) && ${MAKE}
 endif
 
 build_python: $(WAZUHEXT_LIB)


### PR DESCRIPTION
## Summary

Fixes the regression where `wazuh-manager` 4.14.6 fails to start on RHEL 10 (and any system without `libxcrypt-compat`) due to the embedded Python interpreter being linked against the legacy `libcrypt.so.1` SONAME:

```
/var/ossec/framework/python/bin/python3: error while loading shared libraries:
libcrypt.so.1: cannot open shared object file: No such file or directory
wazuh-apid: Configuration error. Exiting
```

Resolves issue #36728.

## Root cause

CPython 3.10's `configure.ac` uses `AC_SEARCH_LIBS(..., crypt)`, which permanently adds `-lcrypt` to the global `LIBS` variable once a libcrypt is detected at build time. As a consequence, every subsequent link command (including the one that produces `libpython3.10.so.1.0`) ends up with `libcrypt.so.1` in its `NEEDED` list, even though Wazuh code does not use the stdlib `crypt` module anywhere.

This is the same bug fixed upstream in [python/cpython#28881](https://github.com/python/cpython/pull/28881), which was **not backported** to 3.10 by the CPython team.

The regression became visible between 4.14.5 (DEPS 51, `libpython` clean) and 4.14.6 (DEPS 52, `libpython` linked against `libcrypt.so.1`) after PR #35982 moved `-lwazuhext` from `LDFLAGS` to `LIBS` in the CPython `./configure` invocation. With the old form, `AC_SEARCH_LIBS(crypt)` found `crypt()` transitively via `-lwazuhext` and never appended `-lcrypt`; with the new form, it falls through to the `-lcrypt` branch and contaminates `LIBS` for the rest of the build.

## Changes

1. **`src/Makefile` (build_python target)**: export `ac_cv_header_crypt_h=no` and `ac_cv_lib_crypt_crypt=no` before `./configure`. These autoconf cache variables short-circuit `AC_SEARCH_LIBS(crypt)` so it concludes the library is not present, preventing `LIBS` contamination. The `_crypt` extension module is also skipped automatically (it's now built without `libcrypt`, which has no effect because Wazuh does not import `crypt`).

2. **`src/Makefile` (`DEPS_VERSION`)**: temporarily bumped from `52` to `52-36728` to consume the cpython artifacts that have been rebuilt without the libcrypt dependency (`libraries/linux/amd64/cpython.tar.gz`, `libraries/linux/aarch64/cpython.tar.gz`, `libraries/sources/cpython_x86_64.tar.gz`, `libraries/sources/cpython_arm64.tar.gz`). **This `52-36728` value is for testing/validation only and must be replaced with the next official deps bundle number before merge.**

## Verification

`readelf -d` of the rebuilt `libpython3.10.so.1.0` (both amd64 and arm64) confirms `libcrypt.so.1` is no longer in `NEEDED`:

```
amd64:
 0x0000000000000001 (NEEDED)  Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)  Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)  Shared library: [libwazuhext.so]
 0x0000000000000001 (NEEDED)  Shared library: [libutil.so.1]
 0x0000000000000001 (NEEDED)  Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)  Shared library: [libc.so.6]
 0x000000000000000e (SONAME)  Library soname: [libpython3.10.so.1.0]
 0x000000000000000f (RPATH)   Library rpath: [\$ORIGIN/../../../lib]
```

## Manager package validation

Tested the Wazuh manager RPM package on ARM64 Docker containers:

- Amazon Linux 2023: `amazonlinux:2023`
- RHEL 10: `registry.access.redhat.com/ubi10/ubi:latest`

Package installed:

```text
wazuh-manager-4.14.6-0.aarch64
```

Indexer certificate files were created as empty placeholders before startup:

```text
/var/wazuh-manager/etc/certs/root-ca.pem
/var/wazuh-manager/etc/certs/manager.pem
/var/wazuh-manager/etc/certs/manager-key.pem
```

### Amazon Linux 2023

```text
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...
```

### RHEL 10

```text
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-apid is running...
```

No errors entries were found in `ossec.log`.


