### PR TITLE
Fix wrap PolicyBanner stat in 'sh -c' so glob expands in macOS SCA check 41062

### DIFF
--- a/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
+++ b/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
@@ -1376,7 +1376,7 @@ checks:
     condition: all
     rules:
       - "d:/Library/Security -> r:^PolicyBanner"
-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
 
   # 5.9 Ensure Legacy EFI Is Valid and Updating. (Automated) - Not Implemented
 

--- a/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
+++ b/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
@@ -1364,7 +1364,7 @@ checks:
     condition: all
     rules:
       - "d:/Library/Security -> r:^PolicyBanner"
-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
 
   # 5.9 Ensure the Guest Home Folder Does Not Exist. (Automated)
   - id: 34059

--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -1346,7 +1346,7 @@ checks:
     condition: all
     rules:
       - "d:/Library/Security -> r:^PolicyBanner"
-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
 
   # 5.9 Ensure the Guest Home Folder Does Not Exist. (Automated)
   - id: 35059

--- a/ruleset/sca/darwin/25/cis_apple_macOS_26.x.yml
+++ b/ruleset/sca/darwin/25/cis_apple_macOS_26.x.yml
@@ -1464,7 +1464,7 @@ checks:
     condition: all
     rules:
       - "d:/Library/Security -> r:^PolicyBanner"
-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
 
   # 5.9 Ensure the Guest Home Folder Does Not Exist. (Automated)
   - id: 41063 


### PR DESCRIPTION
## Description

macOS SCA check `41062` ("Ensure a Login Window Banner Exists.") was reported as a **false failure**: the check is marked `failed` even on endpoints that fully comply (a `/Library/Security/PolicyBanner.txt` file exists, owned `root:wheel`, mode `644`).

The root cause is in the second rule of the check:

```yaml
- 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
```

The SCA engine does **not** run `c:` command checks through a shell. The command string is tokenized (`w_strtok`, `src/shared/string_op.c`) and executed directly via `execvp()` (`src/wazuh_modules/wm_exec.c`), with no `/bin/sh` involved. As a result the `*` wildcard is **never expanded**: `stat` receives the literal argument `/Library/Security/PolicyBanner.*`, fails with *"No such file or directory"* (exit 1) and never prints the permission digits, so the `r:\d\d4` pattern can never match — the check fails regardless of the real system state.

This is a ruleset bug, not an engine or reporting bug, and it is **not** macOS 26-specific: the same line was present in the macOS 13.x, 14.x, 15.x and 26.x policies.

The fix wraps the command in `sh -c` so the shell performs the glob expansion — the same pattern already used by other command rules in our macOS policies (e.g. `c:sh -c "..."`).

Closes #36757

## Proposed Changes

Replace the bare `stat` command (which relies on shell glob expansion that the SCA engine does not provide) with a shell-wrapped command in the macOS PolicyBanner check `41062`:

```diff
-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
```

### Results and Evidence

Verified end-to-end on a live macOS 26.3 (build 25D125) endpoint running Wazuh agent v4.14.5, with a compliant `/Library/Security/PolicyBanner.txt` (mode `644`, `root:wheel`).

**Before the fix** — command as the agent actually runs it (no shell, literal glob):

```
$ /usr/bin/stat -f %A '/Library/Security/PolicyBanner.*'
stat: /Library/Security/PolicyBanner.*: stat: No such file or directory     # exit 1 → check FAILED
```

**After the fix** — command wrapped in a shell so the glob expands:

```
$ /bin/sh -c 'stat -f %A /Library/Security/PolicyBanner.*'
644                                                                          # exit 0 → matches \d\d4
```

**Live agent SCA scan after applying the fix** (`wazuh_modules.debug=2`):

```
sca: Running command: 'sh -c "stat -f %A /Library/Security/PolicyBanner.*"'
sca: Command 'sh -c "stat -f %A /Library/Security/PolicyBanner.*"' returned code 0
sca: Command output matched.
sca: Result for check id: 41062 'Ensure a Login Window Banner Exists.' -> 1
sca: ID: 41062; Result: 'passed'
sca: Evaluation finished for policy '/Library/Ossec/ruleset/sca/cis_apple_macOS_26.x.yml'
```

The check now evaluates to `passed` and is reported as such to the manager / dashboard.

Before the proposed fix:

<img width="1485" height="617" alt="Image" src="https://github.com/user-attachments/assets/eb92a810-5c2d-4075-ac38-65ac771a9ff2" />

After the proposed fix:

<img width="1446" height="623" alt="Image" src="https://github.com/user-attachments/assets/a06b3336-adc9-4593-8a1a-36c356b728a6" />

### Artifacts Affected

- `ruleset/sca/darwin/25/cis_apple_macOS_26.x.yml`
- `ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml`
- `ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml`
- `ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml`

### Configuration Changes

None.

### Documentation Updates

None required (ruleset content fix only).

### Tests Introduced

Manual reproduction and verification on a live macOS 26.3 endpoint (evidence above): check `41062` goes from `failed` to `passed` once a compliant PolicyBanner file is present, confirming the false negative is resolved. No automated SCA ruleset test exists for this check.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
