### PR TITLE
Change log severity for recoverable and expected conditions

### DIFF
--- a/src/client-agent/src/sendmsg.c
+++ b/src/client-agent/src/sendmsg.c
@@ -57,7 +57,7 @@ int send_msg(const char *msg, ssize_t msg_length)
             mdebug2(CONN_REF);
             break;
         default:
-            mwarn(SEND_ERROR, "server", strerror(error));
+            minfo(SEND_ERROR, "server", strerror(error));
             break;
         }
 

--- a/src/config/src/rootcheck-config.c
+++ b/src/config/src/rootcheck-config.c
@@ -139,9 +139,9 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                 }
             }
         } else if (strcmp(node[i]->element, "windows_malware") == 0) {
-            mwarn("Rootcheck option 'windows_malware' is no longer supported. Use the SCA module instead.");
+            minfo("Rootcheck option 'windows_malware' is no longer supported. Use the SCA module instead.");
         } else if (strcmp(node[i]->element, "windows_apps") == 0) {
-            mwarn("Rootcheck option 'windows_apps' is no longer supported. Use the SCA module instead.");
+            minfo("Rootcheck option 'windows_apps' is no longer supported. Use the SCA module instead.");
         } else if (strcmp(node[i]->element, xml_base_dir) == 0) {
             os_strdup(node[i]->content, rootcheck->basedir);
         } else if (strcmp(node[i]->element, xml_check_dev) == 0) {

--- a/src/config/src/rootcheck-config.c
+++ b/src/config/src/rootcheck-config.c
@@ -151,7 +151,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, "check_files") == 0) {
-            mwarn("Rootcheck option 'check_files' is no longer supported. Use the FIM module instead.");
+            minfo("Rootcheck option 'check_files' is no longer supported. Use the FIM module instead.");
 
         } else if (strcmp(node[i]->element, xml_check_if) == 0) {
             rootcheck->checks.rc_if = eval_bool(node[i]->content);
@@ -178,15 +178,15 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                 return (OS_INVALID);
             }
         } else if (strcmp(node[i]->element, "check_trojans") == 0) {
-            mwarn("Rootcheck option 'check_trojans' is no longer supported. Use the FIM module instead.");
+            minfo("Rootcheck option 'check_trojans' is no longer supported. Use the FIM module instead.");
         } else if (strcmp(node[i]->element, "check_unixaudit") == 0) {
-            mwarn("Rootcheck option 'check_unixaudit' is no longer supported. Use the SCA module instead.");
+            minfo("Rootcheck option 'check_unixaudit' is no longer supported. Use the SCA module instead.");
         } else if (strcmp(node[i]->element, "check_winapps") == 0) {
-            mwarn("Rootcheck option 'check_winapps' is no longer supported. Use the SCA module instead.");
+            minfo("Rootcheck option 'check_winapps' is no longer supported. Use the SCA module instead.");
         } else if (strcmp(node[i]->element, "check_winaudit") == 0) {
-            mwarn("Rootcheck option 'check_winaudit' is no longer supported. Use the SCA module instead.");
+            minfo("Rootcheck option 'check_winaudit' is no longer supported. Use the SCA module instead.");
         } else if (strcmp(node[i]->element, "check_winmalware") == 0) {
-            mwarn("Rootcheck option 'check_winmalware' is no longer supported. Use the SCA module instead.");
+            minfo("Rootcheck option 'check_winmalware' is no longer supported. Use the SCA module instead.");
         } else {
             mwarn(XML_INVELEM, node[i]->element);
             return (OS_INVALID);

--- a/src/config/src/wmodules-config.c
+++ b/src/config/src/wmodules-config.c
@@ -13,6 +13,18 @@
 
 static const char *XML_NAME = "name";
 
+// Deprecated modules and their corresponding informational messages
+static const struct {
+    const char *name;
+    const char *message;
+} DEPRECATED_MODULES[] = {
+    { "cis-cat",   "The 'cis-cat' module is deprecated. Use the SCA module instead." },
+    { "osquery",   "The 'osquery' module is deprecated. Use the Syscollector module instead." },
+    { "open-scap", "The 'open-scap' module is deprecated. Use the SCA module instead." },
+};
+
+#define DEPRECATED_MODULES_COUNT (sizeof(DEPRECATED_MODULES) / sizeof(DEPRECATED_MODULES[0]))
+
 // Read wodle element
 
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
@@ -139,15 +151,22 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 #endif
     else {
         if (!strcmp(node->values[0], VU_WM_NAME)) {
-            mwarn("The '%s' module only works for the manager", node->values[0]);
-        } else if (!strcmp(node->values[0], "cis-cat")) {
-            mwarn("The 'cis-cat' module is deprecated. Use the SCA module instead.");
-        } else if (!strcmp(node->values[0], "osquery")) {
-            mwarn("The 'osquery' module is deprecated. Use the Syscollector module instead.");
-        } else if (!strcmp(node->values[0], "open-scap")) {
-            mwarn("The 'open-scap' module is deprecated. Use the SCA module instead.");
+            minfo("The '%s' module only works for the manager", node->values[0]);
         } else {
-            mwarn("Unknown module '%s'", node->values[0]);
+            const char *deprecated_message = NULL;
+
+            for (size_t i = 0; i < DEPRECATED_MODULES_COUNT; i++) {
+                if (!strcmp(node->values[0], DEPRECATED_MODULES[i].name)) {
+                    deprecated_message = DEPRECATED_MODULES[i].message;
+                    break;
+                }
+            }
+
+            if (deprecated_message) {
+                minfo("%s", deprecated_message);
+            } else {
+                mwarn("Unknown module '%s'", node->values[0]);
+            }
         }
     }
 

--- a/src/config/src/wmodules-config.c
+++ b/src/config/src/wmodules-config.c
@@ -140,8 +140,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     else {
         if (!strcmp(node->values[0], VU_WM_NAME)) {
             mwarn("The '%s' module only works for the manager", node->values[0]);
+        } else if (!strcmp(node->values[0], "cis-cat")) {
+            mwarn("The 'cis-cat' module is deprecated. Use the SCA module instead.");
+        } else if (!strcmp(node->values[0], "osquery")) {
+            mwarn("The 'osquery' module is deprecated. Use the Syscollector module instead.");
+        } else if (!strcmp(node->values[0], "open-scap")) {
+            mwarn("The 'open-scap' module is deprecated. Use the SCA module instead.");
         } else {
-            merror("Unknown module '%s'", node->values[0]);
+            mwarn("Unknown module '%s'", node->values[0]);
         }
     }
 

--- a/src/config/src/wmodules-sca.c
+++ b/src/config/src/wmodules-sca.c
@@ -428,7 +428,7 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
         }
         else if (!strcmp(nodes[i]->element, XML_SKIP_NFS))
         {
-            mwarn("Detected a deprecated configuration for SCA: 'skip_nfs' is no longer available.");
+            minfo("Detected a deprecated configuration for SCA: 'skip_nfs' is no longer available.");
         }
         else if (!strcmp(nodes[i]->element, XML_SYNC)) {
             // Synchronization section - Let's get the children node and iterate the values

--- a/src/shared/src/syscheck_op.c
+++ b/src/shared/src/syscheck_op.c
@@ -153,7 +153,7 @@ void ag_send_syscheck(char * message, size_t length) {
     int sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR);
 
     if (sock < 0) {
-        mwarn("dbsync: cannot connect to syscheck: %s (%d)", strerror(errno), errno);
+        minfo("dbsync: cannot connect to syscheck: %s (%d)", strerror(errno), errno);
         return;
     }
 

--- a/src/shared_modules/sync_protocol/src/mqueue_transport.cpp
+++ b/src/shared_modules/sync_protocol/src/mqueue_transport.cpp
@@ -24,7 +24,7 @@ bool MQueueTransport::checkStatus()
 {
     if (!ensureQueueAvailable())
     {
-        m_logger(LOG_ERROR, "Failed to open queue: " + std::string(DEFAULTQUEUE));
+        m_logger(LOG_WARNING, "Failed to open queue: " + std::string(DEFAULTQUEUE));
         return false;
     }
 

--- a/src/syscheckd/src/file/events.c
+++ b/src/syscheckd/src/file/events.c
@@ -109,7 +109,7 @@ void fim_calculate_dbsync_difference(const directory_t *configuration,
                  cJSON_AddStringToObject(old_attributes, "inode", cJSON_GetStringValue(aux));
                  cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("file.inode"));
              } else {
-                 mwarn(FIM_WARN_INODE_WRONG_TYPE);
+                 minfo(FIM_WARN_INODE_WRONG_TYPE);
              }
          }
      }
@@ -384,7 +384,7 @@ cJSON * fim_attributes_json(const cJSON *dbsync_event, const fim_file_data *data
                 if (cJSON_IsString(aux)) {
                     cJSON_AddStringToObject(attributes, "inode", cJSON_GetStringValue(aux));
                 } else {
-                    mwarn(FIM_WARN_INODE_WRONG_TYPE);
+                    minfo(FIM_WARN_INODE_WRONG_TYPE);
                 }
             }
         }

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1296,7 +1296,7 @@ void fim_file_scan() {
                 && IsLink(path) == 0) {
             char *link_target = realpath(path, NULL);
             if (link_target) {
-                mwarn(FIM_WARN_SYMLINK_NOFOLLOW, path, link_target, link_target);
+                minfo(FIM_WARN_SYMLINK_NOFOLLOW, path, link_target, link_target);
                 os_free(link_target);
             }
             dir_it->symlink_warned = true;

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -495,7 +495,7 @@ static void test_ag_send_syscheck_unable_to_connect(void **state) {
 
     errno = EADDRNOTAVAIL;
 
-    expect_string(__wrap__mwarn, formatted_msg, "dbsync: cannot connect to syscheck: Cannot assign requested address (99)");
+    expect_string(__wrap__minfo, formatted_msg, "dbsync: cannot connect to syscheck: Cannot assign requested address (99)");
 
     ag_send_syscheck(input, strlen(input));
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -2128,7 +2128,7 @@ static void test_fim_file_scan_symlink_warns_when_no_follow(void **state) {
     expect_string(__wrap_realpath, path, "/test/symdir");
     will_return(__wrap_realpath, strdup("/actual/dir"));
 
-    expect_string(__wrap__mwarn, formatted_msg,
+    expect_string(__wrap__minfo, formatted_msg,
         "(6961): Configured path '/test/symdir' is a symbolic link to '/actual/dir'. "
         "Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, "
         "not the directory contents. Consider monitoring '/actual/dir' directly or enabling "

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -2074,7 +2074,7 @@ bool AgentInfoImpl::performDeltaSync(const std::string& table)
         }
         else
         {
-            m_logFunction(LOG_WARNING, "Failed to coordinate " + table + ", will retry in next cycle");
+            m_logFunction(LOG_INFO, "Failed to coordinate " + table + ", will retry in next cycle");
             return false;
         }
     }

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1108,7 +1108,7 @@ AgentInfoImpl::ModuleResponse AgentInfoImpl::queryModuleWithRetry(const std::str
         }
     }
 
-    m_logFunction(LOG_WARNING,
+    m_logFunction(LOG_INFO,
                   "Failed to query " + moduleName + " after " + std::to_string(MAX_COORDINATION_RETRIES) + " attempts");
 
     // Return failure response with structured error JSON
@@ -1450,7 +1450,7 @@ AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(s
             else
             {
                 // Communication error or other failure - abort coordination
-                m_logFunction(LOG_WARNING,
+                m_logFunction(LOG_DEBUG,
                               "Failed to pause " + module + " (communication error " +
                               std::to_string(response.errorCode) +
                               "), aborting coordination: " + response.response);
@@ -1918,7 +1918,7 @@ void AgentInfoImpl::resetSyncFlag(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot reset sync flag: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot reset sync flag: DBSync not available");
                 return;
             }
         }


### PR DESCRIPTION
## Description

This PR fixes the failing GitHub Actions job **Unit-Tests (agent)** by aligning legacy unit test expectations with the logging severity changes introduced in the related source update.

## Proposed Changes

- Updated unit tests to expect `__wrap__minfo` instead of `__wrap__mwarn` where the production code now logs at info level:
  - `src/unit_tests/shared/test_syscheck_op.c`
  - `src/unit_tests/syscheckd/test_fim_scan.c`
- No production logic changes were introduced in this follow-up; this is a targeted CI-fix on test expectations.

### Results and Evidence

- Analyzed failing job logs from:
  - Check run ID: `80320565326`
  - Job URL: `https://github.com/wazuh/wazuh/actions/runs/27162933802/job/80320565326`
- Root cause in logs:
  - `No entries for symbol __wrap__minfo`
  - Failures in:
    - `test_fim_file_scan_symlink_warns_when_no_follow`
    - `test_ag_send_syscheck_unable_to_connect`
- Fix addresses both failing assertions by matching the updated log wrapper used by production code.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Legacy unit test sources:
  - `src/unit_tests/shared/test_syscheck_op.c`
  - `src/unit_tests/syscheckd/test_fim_scan.c`

### Configuration Changes

N/A

### Tests Introduced

No new tests were introduced. Existing tests were updated to reflect the intended log level behavior.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...