### PR TITLE
Prevent data race in schema validator factory concurrent initialization

### DIFF
--- a/.github/workflows/5_testcomponent_schema_validator-rtr.yml
+++ b/.github/workflows/5_testcomponent_schema_validator-rtr.yml
@@ -1,0 +1,50 @@
+name: 5.X - Running RTR. Module schema_validator for agent/winagent targets
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "src/ci/**"
+      - "src/build.py"
+      - "src/shared_modules/schema_validator/**"
+      - ".github/workflows/5_testcomponent_schema_validator-rtr.yml"
+      - ".github/actions/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  rtr:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [shared_modules/schema_validator]
+        target: [agent, winagent]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: "Install dependencies"
+        uses: ./.github/actions/install_build_deps
+        with:
+          target: ${{ matrix.target }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: ".github/workflows/.python-version"
+          architecture: x64
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
+      - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
+        run: |
+          cd src/
+          python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
+      - name: Uploading coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_report ${{ matrix.target }}
+          path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_schema_validator-rtr.yml
+++ b/.github/workflows/5_testcomponent_schema_validator-rtr.yml
@@ -24,6 +24,7 @@ jobs:
         module: [shared_modules/schema_validator]
         target: [agent, winagent]
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/src/ci/build_tools.py
+++ b/src/ci/build_tools.py
@@ -19,6 +19,7 @@ DELETE_FOLDER_DIC = {
     'shared_modules/dbsync':        ['build', 'smokeTests/output'],
     'shared_modules/sync_protocol': ['build', 'smokeTests/output', 'coverage_report'],
     'shared_modules/agent_metadata': ['build', 'smokeTests/output', 'coverage_report'],
+    'shared_modules/schema_validator': ['build', 'smokeTests/output', 'coverage_report'],
     'shared_modules/file_helper':   ['build'],
     'data_provider':                ['build', 'smokeTests/output'],
     'syscheckd':                    ['build', 'src/db/smokeTests/output',

--- a/src/ci/input/test_tool_config.json
+++ b/src/ci/input/test_tool_config.json
@@ -81,6 +81,14 @@
             "args": []
         }
     ],
+    "shared_modules/schema_validator":
+    [
+        {
+            "test_tool_name": "schema_validator_test_tool",
+            "is_smoke_with_configuration": false,
+            "args": []
+        }
+    ],
     "data_provider":
     [
         {

--- a/src/ci/utils.py
+++ b/src/ci/utils.py
@@ -40,6 +40,7 @@ HEADER_DIR = {
 }
 MODULE_LIST = ['wazuh_modules/syscollector', 'shared_modules/dbsync',
                'shared_modules/sync_protocol', 'shared_modules/agent_metadata',
+               'shared_modules/schema_validator',
                'shared_modules/file_helper', 'data_provider', 'syscheckd', 'wazuh_modules/sca', 'wazuh_modules/agent_info']
 MODULE_LIST_STR = '|'.join(MODULE_LIST)
 TARGET_LIST = ['agent', 'manager', 'winagent']

--- a/src/shared_modules/schema_validator/CMakeLists.txt
+++ b/src/shared_modules/schema_validator/CMakeLists.txt
@@ -146,3 +146,5 @@ if(UNIT_TEST)
   add_coverage_libraries(schema_validator)
   add_subdirectory(tests)
 endif()
+
+add_subdirectory(testtool)

--- a/src/shared_modules/schema_validator/include/schemaValidator_c.h
+++ b/src/shared_modules/schema_validator/include/schemaValidator_c.h
@@ -46,8 +46,8 @@ EXPORTED bool schema_validator_is_initialized(void);
  * @return true if message is valid, false if invalid
  */
 EXPORTED bool schema_validator_validate(const char* indexPattern,
-                                          const char* message,
-                                          char** errorMessage);
+                                        const char* message,
+                                        char** errorMessage);
 
 #ifdef __cplusplus
 }

--- a/src/shared_modules/schema_validator/src/schemaValidator.cpp
+++ b/src/shared_modules/schema_validator/src/schemaValidator.cpp
@@ -2,6 +2,8 @@
 #include "schemaResources.hpp"
 #include <sstream>
 #include <map>
+#include <mutex>
+#include <shared_mutex>
 #include <regex>
 #include <ctime>
 #include <iomanip>
@@ -397,6 +399,12 @@ namespace SchemaValidator
         public:
             std::map<std::string, std::shared_ptr<ISchemaValidatorEngine>> m_validators;
             bool m_initialized;
+            // The factory is a process-wide singleton (see getInstance) that is
+            // initialized from several modules (syscollector, sca)
+            // running concurrently in the same process. Guard all access to
+            // m_validators/m_initialized so concurrent initialize() calls cannot race
+            // on the underlying std::map. Exclusive lock for mutation, shared for reads.
+            mutable std::shared_mutex m_mutex;
 
             Impl()
                 : m_initialized(false)
@@ -429,6 +437,7 @@ namespace SchemaValidator
                 }
             }
 
+            // Assumes the caller already holds an exclusive lock on m_mutex.
             bool initializeFromEmbeddedResources()
             {
                 try
@@ -451,6 +460,16 @@ namespace SchemaValidator
 
             bool initialize(std::map<std::string, std::shared_ptr<ISchemaValidatorEngine>> customValidators)
             {
+                std::unique_lock<std::shared_mutex> lock(m_mutex);
+
+                // Idempotent: the singleton is shared across modules, each of which calls
+                // initialize() at startup. Once loaded, return success without re-loading
+                // (and without mutating the map while another thread may be reading it).
+                if (m_initialized)
+                {
+                    return true;
+                }
+
                 if (!customValidators.empty())
                 {
                     // Use injected custom validators (for testing or extensibility)
@@ -465,6 +484,8 @@ namespace SchemaValidator
 
             std::shared_ptr<ISchemaValidatorEngine> getValidator(const std::string& indexPattern)
             {
+                std::shared_lock<std::shared_mutex> lock(m_mutex);
+
                 auto it = m_validators.find(indexPattern);
 
                 if (it != m_validators.end())
@@ -473,6 +494,19 @@ namespace SchemaValidator
                 }
 
                 return nullptr;
+            }
+
+            bool isInitialized() const
+            {
+                std::shared_lock<std::shared_mutex> lock(m_mutex);
+                return m_initialized;
+            }
+
+            void reset()
+            {
+                std::unique_lock<std::shared_mutex> lock(m_mutex);
+                m_validators.clear();
+                m_initialized = false;
             }
     };
 
@@ -501,13 +535,12 @@ namespace SchemaValidator
 
     bool SchemaValidatorFactory::isInitialized() const
     {
-        return m_impl->m_initialized;
+        return m_impl->isInitialized();
     }
 
     void SchemaValidatorFactory::reset()
     {
-        m_impl->m_validators.clear();
-        m_impl->m_initialized = false;
+        m_impl->reset();
     }
 
 } // namespace SchemaValidator

--- a/src/shared_modules/schema_validator/src/schemaValidator.cpp
+++ b/src/shared_modules/schema_validator/src/schemaValidator.cpp
@@ -41,6 +41,19 @@ namespace SchemaValidator
         struct in_addr addr4;
         struct in6_addr addr6;
 
+        // An address may carry an RFC 4007 zone/scope id (e.g. "fe80::1%eth0").
+        // inet_pton() rejects the "%zone" suffix, but OpenSearch's IpFieldMapper
+        // (InetAddresses.ipStringToBytes) ignores everything from the first '%'
+        // before parsing, so a value OpenSearch would index as "fe80::1" must be
+        // considered valid here too. Mirror that by stripping from the first '%'.
+        std::string ipCandidate = ipStr;
+        const std::size_t zonePos = ipStr.find('%');
+
+        if (zonePos != std::string::npos)
+        {
+            ipCandidate = ipStr.substr(0, zonePos);
+        }
+
 #ifdef _WIN32
         // Windows: Use GetProcAddress pattern (same as windowsHelper.h)
         typedef INT (WINAPI * inet_pton_t)(INT, PCSTR, PVOID);
@@ -66,13 +79,13 @@ namespace SchemaValidator
         }
 
         // Try IPv4 first
-        if (pfnInetPton(AF_INET, ipStr.c_str(), &addr4) == 1)
+        if (pfnInetPton(AF_INET, ipCandidate.c_str(), &addr4) == 1)
         {
             return true;
         }
 
         // Try IPv6
-        if (pfnInetPton(AF_INET6, ipStr.c_str(), &addr6) == 1)
+        if (pfnInetPton(AF_INET6, ipCandidate.c_str(), &addr6) == 1)
         {
             return true;
         }
@@ -81,12 +94,12 @@ namespace SchemaValidator
 #else
 
         // Linux/Unix: Use inet_pton directly
-        if (inet_pton(AF_INET, ipStr.c_str(), &addr4) == 1)
+        if (inet_pton(AF_INET, ipCandidate.c_str(), &addr4) == 1)
         {
             return true;
         }
 
-        if (inet_pton(AF_INET6, ipStr.c_str(), &addr6) == 1)
+        if (inet_pton(AF_INET6, ipCandidate.c_str(), &addr6) == 1)
         {
             return true;
         }

--- a/src/shared_modules/schema_validator/src/schemaValidator.cpp
+++ b/src/shared_modules/schema_validator/src/schemaValidator.cpp
@@ -12,11 +12,11 @@
 
 // Network headers for inet_pton
 #ifdef _WIN32
-    #include <winsock2.h>
-    #include <ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #else
-    #include <arpa/inet.h>
-    #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 
 namespace SchemaValidator
@@ -50,10 +50,12 @@ namespace SchemaValidator
         if (!initialized)
         {
             auto hWs2_32 = GetModuleHandleA("ws2_32.dll");
+
             if (hWs2_32)
             {
                 pfnInetPton = reinterpret_cast<inet_pton_t>(GetProcAddress(hWs2_32, "inet_pton"));
             }
+
             initialized = true;
         }
 
@@ -77,6 +79,7 @@ namespace SchemaValidator
 
         return false;
 #else
+
         // Linux/Unix: Use inet_pton directly
         if (inet_pton(AF_INET, ipStr.c_str(), &addr4) == 1)
         {

--- a/src/shared_modules/schema_validator/src/schemaValidator_c.cpp
+++ b/src/shared_modules/schema_validator/src/schemaValidator_c.cpp
@@ -65,7 +65,14 @@ extern "C" {
 
             if (!validator)
             {
-                return true; // No validator for this index, consider it valid
+                // No validator for this index: be restrictive and reject the message
+                // instead of letting it through unvalidated.
+                if (errorMessage)
+                {
+                    *errorMessage = strdup("No schema validator found for index");
+                }
+
+                return false;
             }
 
             auto result = validator->validate(std::string(message));

--- a/src/shared_modules/schema_validator/src/schemaValidator_c.cpp
+++ b/src/shared_modules/schema_validator/src/schemaValidator_c.cpp
@@ -12,10 +12,13 @@ extern "C" {
             auto& factory = SchemaValidator::SchemaValidatorFactory::getInstance();
             return factory.initialize();
         }
+        // LCOV_EXCL_START
         catch (...)
         {
             return false;
         }
+
+        // LCOV_EXCL_STOP
     }
 
     bool schema_validator_is_initialized(void)
@@ -25,10 +28,13 @@ extern "C" {
             auto& factory = SchemaValidator::SchemaValidatorFactory::getInstance();
             return factory.isInitialized();
         }
+        // LCOV_EXCL_START
         catch (...)
         {
             return false;
         }
+
+        // LCOV_EXCL_STOP
     }
 
     bool schema_validator_validate(const char* indexPattern,
@@ -90,10 +96,13 @@ extern "C" {
             // Message is valid
             return true;
         }
+        // LCOV_EXCL_START
         catch (...)
         {
             return false;
         }
+
+        // LCOV_EXCL_STOP
     }
 
 } // extern "C"

--- a/src/shared_modules/schema_validator/tests/schemaValidatorConcurrency_test.cpp
+++ b/src/shared_modules/schema_validator/tests/schemaValidatorConcurrency_test.cpp
@@ -128,6 +128,8 @@ TEST_F(SchemaValidatorConcurrencyTest, ConcurrentInitializeDoesNotLoseValidators
                 while (!go.load())
                 {
                     // Spin so all threads hit initialize() at the same time.
+                    // Yield to stay friendly under valgrind's serialized scheduler.
+                    std::this_thread::yield();
                 }
 
                 if (!factory.isInitialized())
@@ -140,6 +142,7 @@ TEST_F(SchemaValidatorConcurrencyTest, ConcurrentInitializeDoesNotLoseValidators
         while (ready.load() < kThreads)
         {
             // Wait until every thread is parked on the barrier.
+            std::this_thread::yield();
         }
 
         go.store(true);

--- a/src/shared_modules/schema_validator/tests/schemaValidatorConcurrency_test.cpp
+++ b/src/shared_modules/schema_validator/tests/schemaValidatorConcurrency_test.cpp
@@ -1,0 +1,160 @@
+/*
+ * Regression tests for the schema validator factory concurrent-initialization
+ * data race.
+ *
+ * SchemaValidatorFactory is a process-wide singleton initialized from several
+ * modules running in the same wazuh-modulesd process (syscollector, sca), each with a check-then-act guard
+ * (if (!isInitialized()) initialize();) living outside the factory. Before the
+ * fix the factory had no synchronization, so concurrent initialize() calls
+ * mutated the same std::map at the same time (undefined behaviour): a validator
+ * that had been loaded could become unreachable, which surfaced in production as
+ * spurious "No schema validator found for index: ..." warnings (and could also
+ * crash or hang the process).
+ *
+ * These tests exercise the same scenario and assert that no validator reachable
+ * after a single-threaded initialization is ever lost when initialize() is
+ * called concurrently from many threads.
+ */
+
+#include "schemaValidator.hpp"
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace SchemaValidator;
+
+namespace
+{
+    // Indices that the embedded schemas may register. The test only requires the
+    // subset that is actually present in the build, so it adapts to whatever is
+    // embedded instead of hard-coding a fixed count.
+    const std::vector<std::string> kCandidateIndices =
+    {
+        "wazuh-states-inventory-system",
+        "wazuh-states-inventory-hardware",
+        "wazuh-states-inventory-hotfixes",
+        "wazuh-states-inventory-packages",
+        "wazuh-states-inventory-processes",
+        "wazuh-states-inventory-ports",
+        "wazuh-states-inventory-interfaces",
+        "wazuh-states-inventory-protocols",
+        "wazuh-states-inventory-networks",
+        "wazuh-states-inventory-users",
+        "wazuh-states-inventory-groups",
+        "wazuh-states-inventory-services",
+        "wazuh-states-inventory-browser-extensions",
+        "wazuh-states-fim-files",
+        "wazuh-states-fim-registry-keys",
+        "wazuh-states-fim-registry-values",
+        "wazuh-states-sca",
+    };
+
+    std::vector<std::string> reachableIndices(SchemaValidatorFactory& factory)
+    {
+        std::vector<std::string> reachable;
+
+        for (const auto& index : kCandidateIndices)
+        {
+            if (factory.getValidator(index))
+            {
+                reachable.push_back(index);
+            }
+        }
+
+        return reachable;
+    }
+}
+
+class SchemaValidatorConcurrencyTest : public ::testing::Test
+{
+    protected:
+        void TearDown() override
+        {
+            // Leave the shared singleton in an initialized state for any test
+            // that runs afterwards (initialize() is idempotent).
+            SchemaValidatorFactory::getInstance().initialize();
+        }
+};
+
+// Baseline: a single-threaded initialization reaches a non-empty set of
+// validators. Guards the concurrency test below against a build with no embedded
+// schemas (which would make the regression check vacuously pass).
+TEST_F(SchemaValidatorConcurrencyTest, SingleThreadedInitializeReachesSchemas)
+{
+    auto& factory = SchemaValidatorFactory::getInstance();
+
+    factory.reset();
+    ASSERT_TRUE(factory.initialize());
+    ASSERT_TRUE(factory.isInitialized());
+    ASSERT_FALSE(reachableIndices(factory).empty())
+            << "No schemas embedded; cannot exercise the concurrency regression.";
+}
+
+// Regression: many threads run the same check-then-act guard as the real modules
+// and call initialize() simultaneously. The factory must end up initialized and
+// every validator reachable after a clean single-threaded init must still be
+// reachable (no key lost to a corrupted std::map).
+TEST_F(SchemaValidatorConcurrencyTest, ConcurrentInitializeDoesNotLoseValidators)
+{
+    auto& factory = SchemaValidatorFactory::getInstance();
+
+    // Establish the expected reachable set with a clean single-threaded init.
+    factory.reset();
+    ASSERT_TRUE(factory.initialize());
+    const auto expected = reachableIndices(factory);
+    ASSERT_FALSE(expected.empty());
+
+    constexpr int kIterations = 100;
+    constexpr int kThreads = 8;
+
+    for (int iteration = 0; iteration < kIterations; ++iteration)
+    {
+        factory.reset();
+
+        std::atomic<int> ready {0};
+        std::atomic<bool> go {false};
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+
+        for (int t = 0; t < kThreads; ++t)
+        {
+            threads.emplace_back([&]()
+            {
+                ready.fetch_add(1);
+
+                while (!go.load())
+                {
+                    // Spin so all threads hit initialize() at the same time.
+                }
+
+                if (!factory.isInitialized())
+                {
+                    factory.initialize();
+                }
+            });
+        }
+
+        while (ready.load() < kThreads)
+        {
+            // Wait until every thread is parked on the barrier.
+        }
+
+        go.store(true);
+
+        for (auto& thread : threads)
+        {
+            thread.join();
+        }
+
+        ASSERT_TRUE(factory.isInitialized()) << "factory not initialized at iteration " << iteration;
+
+        for (const auto& index : expected)
+        {
+            EXPECT_NE(factory.getValidator(index), nullptr)
+                    << "validator lost for index '" << index << "' at iteration " << iteration;
+        }
+    }
+}

--- a/src/shared_modules/schema_validator/tests/schemaValidator_test.cpp
+++ b/src/shared_modules/schema_validator/tests/schemaValidator_test.cpp
@@ -5,56 +5,71 @@ using namespace SchemaValidator;
 
 class SchemaValidatorTest : public ::testing::Test
 {
-protected:
-    void SetUp() override
-    {
-        // Create test schema in memory
-        createTestSchema();
-    }
+    protected:
+        void SetUp() override
+        {
+            // Create test schema in memory
+            createTestSchema();
+        }
 
-    void createTestSchema()
-    {
-        nlohmann::json schema = {
-            {"index_patterns", {"test-index*"}},
-            {"priority", 1},
-            {"template", {
-                {"settings", {
-                    {"index", {
-                        {"number_of_replicas", "0"},
-                        {"number_of_shards", "1"}
-                    }}
-                }},
-                {"mappings", {
-                    {"date_detection", false},
-                    {"dynamic", "strict"},
-                    {"properties", {
-                        {"name", {{"type", "keyword"}, {"ignore_above", 1024}}},
-                        {"age", {{"type", "integer"}}},
-                        {"score", {{"type", "long"}}},
-                        {"email", {{"type", "keyword"}}},
-                        {"created_at", {{"type", "date"}}},
-                        {"is_active", {{"type", "boolean"}}},
-                        {"ip_address", {{"type", "ip"}}},
-                        {"port", {{"type", "short"}}},
-                        {"counter", {{"type", "unsigned_long"}}},
-                        {"price", {{"type", "scaled_float"}}},
-                        {"description", {{"type", "match_only_text"}}},
-                        {"metadata", {{"type", "object"}}},
-                        {"address", {
-                            {"properties", {
-                                {"street", {{"type", "keyword"}}},
-                                {"city", {{"type", "keyword"}}}
-                            }}
-                        }}
-                    }}
-                }}
-            }}
-        };
+        void createTestSchema()
+        {
+            nlohmann::json schema =
+            {
+                {"index_patterns", {"test-index*"}},
+                {"priority", 1},
+                {
+                    "template", {
+                        {
+                            "settings", {
+                                {
+                                    "index", {
+                                        {"number_of_replicas", "0"},
+                                        {"number_of_shards", "1"}
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "mappings", {
+                                {"date_detection", false},
+                                {"dynamic", "strict"},
+                                {
+                                    "properties", {
+                                        {"name", {{"type", "keyword"}, {"ignore_above", 1024}}},
+                                        {"age", {{"type", "integer"}}},
+                                        {"score", {{"type", "long"}}},
+                                        {"email", {{"type", "keyword"}}},
+                                        {"created_at", {{"type", "date"}}},
+                                        {"is_active", {{"type", "boolean"}}},
+                                        {"ip_address", {{"type", "ip"}}},
+                                        {"port", {{"type", "short"}}},
+                                        {"counter", {{"type", "unsigned_long"}}},
+                                        {"price", {{"type", "scaled_float"}}},
+                                        {"description", {{"type", "match_only_text"}}},
+                                        {"metadata", {{"type", "object"}}},
+                                        {
+                                            "address", {
+                                                {
+                                                    "properties", {
+                                                        {"street", {{"type", "keyword"}}},
+                                                        {"city", {{"type", "keyword"}}}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
 
-        m_testSchemaString = schema.dump();
-    }
+            m_testSchemaString = schema.dump();
+        }
 
-    std::string m_testSchemaString;
+        std::string m_testSchemaString;
 };
 
 TEST_F(SchemaValidatorTest, LoadSchemaSuccess)
@@ -75,14 +90,16 @@ TEST_F(SchemaValidatorTest, ValidateValidMessage)
     SchemaValidatorEngine validator;
     validator.loadSchemaFromString(m_testSchemaString);
 
-    nlohmann::json message = {
+    nlohmann::json message =
+    {
         {"name", "John Doe"},
         {"age", 30},
         {"score", 12345},
         {"email", "john@example.com"},
         {"created_at", "2025-12-29T10:00:00.000Z"},
         {"is_active", true},
-        {"address", {{"street", "123 Main St"}, {"city", "New York"}}}};
+        {"address", {{"street", "123 Main St"}, {"city", "New York"}}}
+    };
 
     ValidationResult result = validator.validate(message);
     EXPECT_TRUE(result.isValid);
@@ -133,8 +150,10 @@ TEST_F(SchemaValidatorTest, ValidateStrictModeExtraField)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch rejects extra fields with non-null values in strict mode
-    nlohmann::json message = {
-        {"name", "John Doe"}, {"age", 30}, {"extra_field", "not allowed"}};
+    nlohmann::json message =
+    {
+        {"name", "John Doe"}, {"age", 30}, {"extra_field", "not allowed"}
+    };
 
     ValidationResult result = validator.validate(message);
     EXPECT_FALSE(result.isValid);
@@ -148,8 +167,10 @@ TEST_F(SchemaValidatorTest, ValidateStrictModeExtraFieldNull)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch ACCEPTS extra fields if their value is null in strict mode
-    nlohmann::json message = {
-        {"name", "John Doe"}, {"age", 30}, {"extra_field", nullptr}};
+    nlohmann::json message =
+    {
+        {"name", "John Doe"}, {"age", 30}, {"extra_field", nullptr}
+    };
 
     ValidationResult result = validator.validate(message);
     EXPECT_TRUE(result.isValid);
@@ -162,7 +183,8 @@ TEST_F(SchemaValidatorTest, ValidateStrictModeNestedExtraFieldNull)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch ACCEPTS extra fields in nested objects if value is null
-    nlohmann::json message = {
+    nlohmann::json message =
+    {
         {"name", "John Doe"},
         {"age", 30},
         {"address", {{"street", "123 Main St"}, {"city", "New York"}, {"extra", nullptr}}}
@@ -179,7 +201,8 @@ TEST_F(SchemaValidatorTest, ValidateStrictModeNestedExtraFieldNonNull)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch REJECTS extra fields in nested objects if value is non-null
-    nlohmann::json message = {
+    nlohmann::json message =
+    {
         {"name", "John Doe"},
         {"age", 30},
         {"address", {{"street", "123 Main St"}, {"city", "New York"}, {"extra", "not allowed"}}}
@@ -197,8 +220,9 @@ TEST_F(SchemaValidatorTest, ValidateNestedObject)
     validator.loadSchemaFromString(m_testSchemaString);
 
     nlohmann::json message = {{"name", "John Doe"},
-                              {"age", 30},
-                              {"address", {{"street", "123 Main St"}, {"city", "New York"}}}};
+        {"age", 30},
+        {"address", {{"street", "123 Main St"}, {"city", "New York"}}}
+    };
 
     ValidationResult result = validator.validate(message);
     EXPECT_TRUE(result.isValid);
@@ -276,7 +300,8 @@ TEST_F(SchemaValidatorTest, ValidateNullValues)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch allows null for any field
-    nlohmann::json message = {
+    nlohmann::json message =
+    {
         {"name", nullptr},
         {"age", nullptr},
         {"created_at", nullptr},
@@ -294,7 +319,8 @@ TEST_F(SchemaValidatorTest, ValidateNullForNestedObject)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch allows null for nested objects too
-    nlohmann::json message = {
+    nlohmann::json message =
+    {
         {"name", "John Doe"},
         {"age", 30},
         {"address", nullptr}  // Nested object can be null
@@ -401,7 +427,8 @@ TEST_F(SchemaValidatorTest, ValidateDateAsArray)
     validator.loadSchemaFromString(m_testSchemaString);
 
     // OpenSearch accepts both single values and arrays for date fields
-    nlohmann::json message = {
+    nlohmann::json message =
+    {
         {"name", "John Doe"},
         {"age", 30},
         {"created_at", nlohmann::json::array({1735468800000, "2025-12-29T10:00:00.000Z"})}
@@ -534,6 +561,7 @@ TEST_F(SchemaValidatorTest, FactoryGetValidator)
     // This test depends on embedded schemas being available
     // In a real deployment, the schemas would be embedded at build time
     auto validator = factory.getValidator("wazuh-states-fim-file");
+
     // May be nullptr if schemas weren't embedded during build
     // Just verify the API works without crashing
     if (validator)

--- a/src/shared_modules/schema_validator/tests/schemaValidator_test.cpp
+++ b/src/shared_modules/schema_validator/tests/schemaValidator_test.cpp
@@ -1,5 +1,12 @@
 #include <gtest/gtest.h>
 #include "schemaValidator.hpp"
+#include "schemaValidator_c.h"
+
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 using namespace SchemaValidator;
 
@@ -1041,6 +1048,188 @@ TEST_F(SchemaValidatorTest, ValidateLongAsArray)
     nlohmann::json message = {{"score", nlohmann::json::array({100, 200, 300})}};
     ValidationResult result = validator.validate(message);
     EXPECT_TRUE(result.isValid);
+}
+
+// ---------------------------------------------------------------------------
+// Engine edge cases
+// ---------------------------------------------------------------------------
+
+TEST_F(SchemaValidatorTest, LoadSchemaWithoutPropertiesFails)
+{
+    SchemaValidatorEngine validator;
+    // No template.mappings.properties -> parseAndInitializeSchema returns false.
+    EXPECT_FALSE(validator.loadSchemaFromString(
+                     R"({"index_patterns":["x*"],"template":{"mappings":{}}})"));
+}
+
+TEST_F(SchemaValidatorTest, SchemaNameFromIndexPatternWithoutWildcard)
+{
+    SchemaValidatorEngine validator;
+    // index_patterns without '*' -> the schema name is used verbatim.
+    ASSERT_TRUE(validator.loadSchemaFromString(
+                    R"({"index_patterns":["exact-index-name"],"template":{"mappings":{"properties":{"a":{"type":"keyword"}}}}})"));
+    EXPECT_EQ(validator.getSchemaName(), "exact-index-name");
+}
+
+TEST_F(SchemaValidatorTest, NonObjectTopLevelMessageIsInvalid)
+{
+    SchemaValidatorEngine validator;
+    validator.loadSchemaFromString(m_testSchemaString);
+
+    // Top-level value is an array, not an object.
+    ValidationResult result = validator.validate(std::string("[1, 2, 3]"));
+    EXPECT_FALSE(result.isValid);
+    EXPECT_FALSE(result.errors.empty());
+}
+
+TEST_F(SchemaValidatorTest, NestedObjectFieldWithNonObjectValueIsInvalid)
+{
+    SchemaValidatorEngine validator;
+    validator.loadSchemaFromString(m_testSchemaString);
+
+    // "address" is a nested object in the schema, but the message gives a scalar.
+    ValidationResult result = validator.validate(std::string(R"({"address": "not-an-object"})"));
+    EXPECT_FALSE(result.isValid);
+    EXPECT_FALSE(result.errors.empty());
+}
+
+TEST_F(SchemaValidatorTest, FactoryInitializeWithCustomValidators)
+{
+    auto& factory = SchemaValidatorFactory::getInstance();
+    factory.reset();
+
+    auto engine = std::make_shared<SchemaValidatorEngine>();
+    ASSERT_TRUE(engine->loadSchemaFromString(
+                    R"({"index_patterns":["custom-index*"],"template":{"mappings":{"properties":{"a":{"type":"keyword"}}}}})"));
+
+    std::map<std::string, std::shared_ptr<ISchemaValidatorEngine>> customValidators;
+    customValidators["custom-index"] = engine;
+
+    EXPECT_TRUE(factory.initialize(std::move(customValidators)));
+    EXPECT_TRUE(factory.isInitialized());
+    EXPECT_NE(factory.getValidator("custom-index"), nullptr);
+
+    // Restore embedded validators for any test that runs afterwards.
+    factory.reset();
+    factory.initialize();
+}
+
+// ---------------------------------------------------------------------------
+// C interface (schemaValidator_c.cpp)
+// ---------------------------------------------------------------------------
+
+namespace
+{
+    // Return the first embedded index that has a registered validator, or "" if
+    // none are embedded (so a test can skip instead of asserting vacuously).
+    std::string firstEmbeddedIndex()
+    {
+        auto& factory = SchemaValidatorFactory::getInstance();
+        factory.initialize();
+
+        const std::vector<std::string> candidates =
+        {
+            "wazuh-states-inventory-hardware",
+            "wazuh-states-inventory-system",
+            "wazuh-states-fim-files",
+            "wazuh-states-sca",
+        };
+
+        for (const auto& index : candidates)
+        {
+            if (factory.getValidator(index))
+            {
+                return index;
+            }
+        }
+
+        return "";
+    }
+}
+
+TEST_F(SchemaValidatorTest, CApiInitializeAndIsInitialized)
+{
+    EXPECT_TRUE(schema_validator_initialize());
+    EXPECT_TRUE(schema_validator_is_initialized());
+}
+
+TEST_F(SchemaValidatorTest, CApiValidateNullArgumentsReturnFalse)
+{
+    char* errorMessage = nullptr;
+    EXPECT_FALSE(schema_validator_validate(nullptr, "{}", &errorMessage));
+    EXPECT_FALSE(schema_validator_validate("some-index", nullptr, &errorMessage));
+}
+
+TEST_F(SchemaValidatorTest, CApiValidateWhenNotInitializedReturnsTrue)
+{
+    // Backward-compatibility path: with no validators loaded, validation is a no-op.
+    SchemaValidatorFactory::getInstance().reset();
+
+    char* errorMessage = nullptr;
+    EXPECT_TRUE(schema_validator_validate("wazuh-states-inventory-hardware", "{}", &errorMessage));
+    EXPECT_EQ(errorMessage, nullptr);
+
+    SchemaValidatorFactory::getInstance().initialize(); // restore for other tests
+}
+
+TEST_F(SchemaValidatorTest, CApiValidateUnknownIndexReturnsTrue)
+{
+    schema_validator_initialize();
+
+    char* errorMessage = nullptr;
+    EXPECT_TRUE(schema_validator_validate("there-is-no-such-index", "{}", &errorMessage));
+    EXPECT_EQ(errorMessage, nullptr);
+}
+
+TEST_F(SchemaValidatorTest, CApiValidateValidMessageReturnsTrue)
+{
+    const std::string index = firstEmbeddedIndex();
+
+    if (index.empty())
+    {
+        GTEST_SKIP() << "No embedded schemas in this build.";
+    }
+
+    char* errorMessage = nullptr;
+    EXPECT_TRUE(schema_validator_validate(index.c_str(), "{}", &errorMessage));
+    EXPECT_EQ(errorMessage, nullptr);
+}
+
+TEST_F(SchemaValidatorTest, CApiValidateInvalidMessageSetsErrorMessage)
+{
+    const std::string index = firstEmbeddedIndex();
+
+    if (index.empty())
+    {
+        GTEST_SKIP() << "No embedded schemas in this build.";
+    }
+
+    // The inventory/fim/sca templates are strict, so unknown non-null fields are
+    // rejected. Two unknown fields produce two errors, exercising the newline
+    // join used to concatenate them into the C error string.
+    const char* message = "{\"this_field_does_not_exist\": \"x\", \"another_bad_field\": \"y\"}";
+
+    char* errorMessage = nullptr;
+    EXPECT_FALSE(schema_validator_validate(index.c_str(), message, &errorMessage));
+    ASSERT_NE(errorMessage, nullptr);
+    EXPECT_NE(std::string(errorMessage).find("this_field_does_not_exist"), std::string::npos);
+    EXPECT_NE(std::string(errorMessage).find('\n'), std::string::npos);
+    free(errorMessage);
+}
+
+TEST_F(SchemaValidatorTest, CApiValidateInvalidMessageWithNullErrorPointer)
+{
+    const std::string index = firstEmbeddedIndex();
+
+    if (index.empty())
+    {
+        GTEST_SKIP() << "No embedded schemas in this build.";
+    }
+
+    // errorMessage == nullptr: the invalid result is reported without building a string.
+    EXPECT_FALSE(schema_validator_validate(index.c_str(),
+                                           "{\"this_field_does_not_exist\": \"x\"}",
+                                           nullptr));
 }
 
 int main(int argc, char** argv)

--- a/src/shared_modules/schema_validator/tests/schemaValidator_test.cpp
+++ b/src/shared_modules/schema_validator/tests/schemaValidator_test.cpp
@@ -1172,13 +1172,15 @@ TEST_F(SchemaValidatorTest, CApiValidateWhenNotInitializedReturnsTrue)
     SchemaValidatorFactory::getInstance().initialize(); // restore for other tests
 }
 
-TEST_F(SchemaValidatorTest, CApiValidateUnknownIndexReturnsTrue)
+TEST_F(SchemaValidatorTest, CApiValidateUnknownIndexReturnsFalse)
 {
     schema_validator_initialize();
 
+    // Restrictive behaviour: no validator for the index -> reject the message.
     char* errorMessage = nullptr;
-    EXPECT_TRUE(schema_validator_validate("there-is-no-such-index", "{}", &errorMessage));
-    EXPECT_EQ(errorMessage, nullptr);
+    EXPECT_FALSE(schema_validator_validate("there-is-no-such-index", "{}", &errorMessage));
+    ASSERT_NE(errorMessage, nullptr);
+    free(errorMessage);
 }
 
 TEST_F(SchemaValidatorTest, CApiValidateValidMessageReturnsTrue)

--- a/src/shared_modules/schema_validator/testtool/CMakeLists.txt
+++ b/src/shared_modules/schema_validator/testtool/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(schema_validator_test_tool)
+
+if(NOT DEFINED WAZUH_MAIN_PROJECT)
+  get_filename_component(SRC_FOLDER ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
+endif()
+
+include_directories(${SRC_FOLDER})
+include_directories(${SRC_FOLDER}/external/nlohmann)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS
+    "-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2 -pthread"
+)
+
+add_executable(schema_validator_test_tool ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+set_target_properties(
+  schema_validator_test_tool PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+                                        "${CMAKE_BINARY_DIR}/bin")
+
+target_link_libraries(schema_validator_test_tool PRIVATE schema_validator pthread)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT CMAKE_SYSTEM_NAME STREQUAL
+                                                "Darwin")
+  target_link_libraries(schema_validator_test_tool PRIVATE dl)
+endif()

--- a/src/shared_modules/schema_validator/testtool/main.cpp
+++ b/src/shared_modules/schema_validator/testtool/main.cpp
@@ -1,0 +1,113 @@
+/*
+ * Wazuh Schema Validator Test tool
+ *
+ * Smoke test used by the RTR / ASAN checks. It exercises the process-wide
+ * SchemaValidatorFactory singleton the same way the agent modules do
+ * (concurrent check-then-act initialization from several threads) and then
+ * validates a sample message against an embedded schema.
+ */
+
+#include <atomic>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "schemaValidator.hpp"
+
+using namespace SchemaValidator;
+
+int main()
+{
+    try
+    {
+        auto& factory = SchemaValidatorFactory::getInstance();
+
+        // Initialize the factory concurrently, mirroring the syscollector / sca /
+        // vulnerability_scanner startup in wazuh-modulesd (each runs the same
+        // check-then-act guard against the shared singleton).
+        constexpr int kThreads = 8;
+        std::atomic<bool> go {false};
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+
+        for (int t = 0; t < kThreads; ++t)
+        {
+            threads.emplace_back([&]()
+            {
+                while (!go.load())
+                {
+                    // Align the start so all threads hit initialize() together.
+                    std::this_thread::yield();
+                }
+
+                if (!factory.isInitialized())
+                {
+                    factory.initialize();
+                }
+            });
+        }
+
+        go.store(true);
+
+        for (auto& thread : threads)
+        {
+            thread.join();
+        }
+
+        if (!factory.isInitialized())
+        {
+            std::cout << "[Test schema_validator] No embedded schemas; nothing to validate." << std::endl;
+            return 0;
+        }
+
+        // Validate a sample message against the first available index. An empty
+        // object is valid for these strict-mode templates (all fields optional,
+        // no extra fields present).
+        const std::vector<std::string> candidates =
+        {
+            "wazuh-states-inventory-hardware",
+            "wazuh-states-inventory-system",
+            "wazuh-states-fim-files",
+            "wazuh-states-sca",
+        };
+
+        for (const auto& index : candidates)
+        {
+            auto validator = factory.getValidator(index);
+
+            if (validator)
+            {
+                auto result = validator->validate(std::string("{}"));
+                std::cout << "[Test schema_validator] validated against '" << index << "': "
+                          << (result.isValid ? "OK" : "FAIL") << std::endl;
+
+                if (!result.isValid)
+                {
+                    for (const auto& error : result.errors)
+                    {
+                        std::cerr << "  " << error << std::endl;
+                    }
+
+                    return 1;
+                }
+
+                std::cout << "OK" << std::endl;
+                return 0;
+            }
+        }
+
+        std::cout << "[Test schema_validator] No candidate index embedded; OK." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "[Test schema_validator] Unhandled exception: " << e.what() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "[Test schema_validator] Unknown unhandled exception" << std::endl;
+        return 1;
+    }
+}

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -967,7 +967,10 @@ bool SCAEventHandler::ValidateAndHandleStatefulMessage(const nlohmann::json& sta
 
     if (!validator)
     {
-        return true;
+        // No validator for this index: be restrictive and discard the message.
+        LoggingHelper::getInstance().log(LOG_WARNING,
+                                         "No schema validator found for index: " + std::string(SCA_SYNC_INDEX) + ". Discarding message.");
+        return false;
     }
 
     std::string statefulData = statefulEvent.dump();

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1180,6 +1180,13 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
                         shouldPersist = false;
                     }
                 }
+                else
+                {
+                    // No validator for this index: be restrictive and discard the message.
+                    LoggingHelper::getInstance().log(LOG_WARNING,
+                                                     "No schema validator found for index: " + std::string(SCA_SYNC_INDEX) + ". Discarding message.");
+                    shouldPersist = false;
+                }
             }
 
             if (shouldPersist)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -2402,8 +2402,8 @@ TEST_F(SCAEventHandlerTest, ValidateAndHandleStatefulMessage_ValidationFailure)
         }
         else
         {
-            // No validator for this index, should return true
-            EXPECT_TRUE(result);
+            // No validator for this index: restrictive behaviour, should return false
+            EXPECT_FALSE(result);
         }
     }
     else

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -4599,13 +4599,15 @@ bool Syscollector::validateSchemaAndLog(const std::string& data, const std::stri
 
     if (!validator)
     {
-        // Validator not found for this index, log warning and allow message through
+        // No validator for this index: be restrictive and discard the message
+        // instead of queuing it unvalidated, since we cannot guarantee it matches
+        // the schema the indexer expects.
         if (m_logFunction)
         {
-            m_logFunction(LOG_WARNING, "No schema validator found for index: " + index + ". Queuing message without validation.");
+            m_logFunction(LOG_WARNING, "No schema validator found for index: " + index + ". Discarding message.");
         }
 
-        return true;
+        return false;
     }
 
     auto validationResult = validator->validate(data);

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -210,6 +210,7 @@ void SyscollectorImpTest::SetUp()
     mockValidators["wazuh-states-inventory-hardware"] = m_mockValidator;
     mockValidators["wazuh-states-inventory-system"] = m_mockValidator;
     mockValidators["wazuh-states-inventory-interfaces"] = m_mockValidator;
+    mockValidators["wazuh-states-inventory-protocols"] = m_mockValidator;
     mockValidators["wazuh-states-inventory-networks"] = m_mockValidator;
     mockValidators["wazuh-states-inventory-ports"] = m_mockValidator;
     mockValidators["wazuh-states-inventory-packages"] = m_mockValidator;
@@ -5005,8 +5006,9 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
     EXPECT_TRUE(foundDeferredDeletion) << "Expected deferred deletion log not found";
 }
 
-// Test for missing validator: factory is initialized but no validator for the index
-TEST_F(SyscollectorImpTest, schemaValidationQueuesWhenValidatorNotFound)
+// Test for missing validator: factory is initialized but no validator for the index.
+// The message must be discarded (restrictive behaviour) and a warning logged.
+TEST_F(SyscollectorImpTest, schemaValidationDiscardsWhenValidatorNotFound)
 {
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
 
@@ -5043,8 +5045,8 @@ TEST_F(SyscollectorImpTest, schemaValidationQueuesWhenValidatorNotFound)
         }
     };
 
-    // Expect persist callback for hardware data (should be queued despite missing validator)
-    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(1);
+    // No persist callback expected: with no validator for the index the message is discarded
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(0);
 
     // Capture log messages to verify warning is logged
     // Use shared_ptr to prevent dangling references after test completes


### PR DESCRIPTION
## Description

`SchemaValidator::SchemaValidatorFactory` is a process-wide singleton (`getInstance()` returns a function-local `static`) that is initialized from several modules running in the same `wazuh-modulesd` process — `syscollector`, `sca` — each with a *check-then-act* guard (`if (!isInitialized()) initialize();`) that lives **outside** the factory.

The factory had **no synchronization**: `m_validators` (`std::map`) and `m_initialized` (`bool`) were plain members, and `initializeFromEmbeddedResources()` mutates the map in a loop. On an agent, `syscollector` and `sca` initialize the singleton concurrently at startup, so two threads can enter `initialize()` and insert into the **same** `std::map` simultaneously. This is a data race / undefined behaviour: the red-black tree gets corrupted, which manifests as a lost (unreachable) key, a `SIGSEGV`, or an infinite loop.

The observed production symptom is the "soft" variant of the corruption — a validator that was loaded becomes unreachable while the factory reports itself initialized:

```
2026/06/06 04:49:27 wazuh-modulesd:syscollector: WARNING: No schema validator found for index: wazuh-states-inventory-hardware. Queuing message without validation.
```

(The schema **is** correctly embedded in `libschema_validator.so`; this was verified by unpacking the deployed WPK — all 17 schemas are present and valid and the index strings match. The warning is therefore not a build/embedding problem.)

This PR makes the factory thread-safe and the initialization idempotent. It also adds a CI **RTR workflow** for the `schema_validator` module (which previously had no CI coverage), and along the way fixes a pre-existing IPv6 validation bug and raises the module's test coverage above the gate — both surfaced by enabling that CI.

Closes #36787

## Proposed Changes

### 1. Thread-safe, idempotent factory (the fix)

- Add a `std::shared_mutex` to `SchemaValidatorFactory::Impl`.
- `initialize()`: take an **exclusive** lock and return early if already initialized (the check-then-act is now atomic and the embedded resources are loaded exactly once, never while another thread reads the map).
- `getValidator()` / `isInitialized()`: take a **shared** lock — concurrent validation across modules is still allowed; reads only block during init/reset.
- `reset()`: exclusive lock.
- `initializeFromEmbeddedResources()` documented as "caller holds the exclusive lock".

### 2. IPv6 zone/scope id validation (pre-existing bug, surfaced by the new CI)

- `isValidIP` relied on `inet_pton`, which rejects the RFC 4007 zone suffix (e.g. `fe80::1%eth0`), whereas OpenSearch's `IpFieldMapper` (`InetAddresses.ipStringToBytes`) ignores everything from the first `%` before parsing and indexes the bare address. The validator now mirrors that — it strips from the first `%` — so values the indexer accepts (link-local IPv6 in `inventory-networks`/`inventory-protocols` `ip` fields: `network.ip`, `network.gateway`, `wazuh.agent.host.ip`, …) are no longer flagged invalid. Fixes the `ValidateIPv6WithZone` test (previously only run on Linux, now exercised in CI).

### 3. RTR workflow + CI enablement

- New `.github/workflows/5_testcomponent_schema_validator-rtr.yml` (mirrors `sync_protocol-rtr`): runs `build.py --readytoreview shared_modules/schema_validator` for the **agent** and **winagent** targets (cppcheck, AStyle, unit tests, coverage, valgrind, ASAN).
- Register the module in the CI scripts so RTR can run it: `MODULE_LIST` (`ci/utils.py`), `DELETE_FOLDER_DIC` (`ci/build_tools.py`), and a `test_tool_config.json` entry.
- Add a `testtool` (`schema_validator_test_tool`) used by the RTR ASAN phase; it exercises the concurrent-init path and validates a sample message.

### 4. Restrictive handling when no validator exists for an index

Independently of the race, the consumer fallback was wrong. When `getValidator()` returned no validator for an index, `syscollector` and `sca` logged a warning and **let the message through unvalidated** (`return true` / "Queuing message without validation"). That defeats the purpose of validation: a message for an index we have no schema for could reach the indexer with a shape it does not expect.

This PR flips that fallback to be restrictive — when there is no validator for the index, the message is **discarded** (`return false`) and a warning is logged ("…Discarding message."). Validation is now fail-closed: a message is only forwarded when a validator exists and accepts it.

- `syscollector` (`syscollectorImp.cpp`, `validateSchemaAndLog`): `return true` → `return false` in the missing-validator branch; log text updated.
- `sca` (`sca_impl.cpp`, `sca_event_handler.cpp`): same fail-closed change on the missing-validator path.

### 5. Tests

- A concurrency regression test (the harness below, adapted to the repo's gtest setup).
- C-API and engine/edge-case tests to clear the 90% line-coverage gate (see *Tests Introduced*).
- Updated the syscollector/sca "missing validator" tests to assert the message is now discarded (no persist callback) instead of queued.

### Results and Evidence

A standalone harness reproduces the production scenario: 8 threads released by a barrier run the same check-then-act guard as the real modules, all hitting `initialize()` simultaneously; afterwards every schema is looked up and missing validators are counted. The factory source is compiled in two variants — current `main` (unfixed) and the working tree (fixed) — and run under **ThreadSanitizer** (deterministic race detection) and without sanitizer (functional behaviour). ASLR disabled (`setarch -R`) to avoid the unrelated TSan memory-mapping issue.

#### Before the fix — ThreadSanitizer reports the race (26 reports + 1 SEGV in a 100×8 run)

The races point exactly at two threads mutating the same red-black tree inside `loadSchemaFromString` via `initialize()`:

```
WARNING: ThreadSanitizer: data race (pid=123301)
  Read of size 8 at 0x7b1000000028 by thread T6:
    #0 std::_Rb_tree<...>::_M_get_insert_hint_unique_pos(...)
    #1 std::_Rb_tree<...>::_M_emplace_hint_unique<...>(...)
    #2 SchemaValidator::SchemaValidatorFactory::Impl::loadSchemaFromString(std::string const&)
    #3 SchemaValidator::SchemaValidatorFactory::Impl::initializeFromEmbeddedResources() schemaValidator.cpp:440
    #4 SchemaValidator::SchemaValidatorFactory::Impl::initialize(...)                    schemaValidator.cpp:463
    #5 SchemaValidator::SchemaValidatorFactory::initialize(...)                          schemaValidator.cpp:494
    #6 operator() race_test.cpp:44                       # module-style: if(!isInitialized()) initialize();
    ...

  Previous write of size 8 at 0x7b1000000028 by thread T4:
    #0 std::_Rb_tree<...>::_M_emplace_hint_unique<...>(...)
    #1 SchemaValidator::SchemaValidatorFactory::Impl::loadSchemaFromString(std::string const&)
    #2 SchemaValidator::SchemaValidatorFactory::Impl::initializeFromEmbeddedResources() schemaValidator.cpp:440
    #3 SchemaValidator::SchemaValidatorFactory::Impl::initialize(...)                    schemaValidator.cpp:463
    ...

  Location is heap block of size 56 ... allocated by main thread:
    #1 std::make_unique<SchemaValidator::SchemaValidatorFactory::Impl>()
    #2 SchemaValidator::SchemaValidatorFactory::SchemaValidatorFactory()  schemaValidator.cpp:480
    #3 SchemaValidator::SchemaValidatorFactory::getInstance()             schemaValidator.cpp:488
```

```
ORIG TSan data races: 26   SEGV: 1   (exit 66)
```

#### Before the fix — without sanitizer the corruption crashes or hangs

```
--- ORIG (functional, 2000 iters x 8 threads) ---
run1: 44302 Segmentation fault (core dumped)  ./func_orig 2000 8   (exit 139)
run2: hung (infinite loop traversing the corrupted tree) — had to be killed
```

#### After the fix — no race, no missing validators, no crash/hang

```
##### AFTER FIX: ThreadSanitizer (100 iters x 8 threads) #####
=== bad iterations: 0/100, total missing lookups: 0 ===
FIXED TSan warnings: 0   races: 0   (exit 0)

##### AFTER FIX: functional, no sanitizer (3 runs x 3000 iters x 8 threads) #####
run1: exit=0 | === bad iterations: 0/3000, total missing lookups: 0 ===
run2: exit=0 | === bad iterations: 0/3000, total missing lookups: 0 ===
run3: exit=0 | === bad iterations: 0/3000, total missing lookups: 0 ===
```

### Artifacts Affected

Source / library:
- `src/shared_modules/schema_validator/src/schemaValidator.cpp` — thread-safety + IPv6 zone fix.
- `src/shared_modules/schema_validator/src/schemaValidator_c.cpp` — `LCOV_EXCL` markers on the defensive `catch(...)` blocks.
- `src/shared_modules/schema_validator/CMakeLists.txt` — build the new `testtool`.

The library's public API is unchanged. Consumers benefit from the thread-safety transparently; in addition, the `syscollector` and `sca` missing-validator fallback is changed to fail-closed (see Proposed Changes §4):
- `src/wazuh_modules/syscollector/src/syscollectorImp.cpp` — discard instead of queue when no validator for the index.
- `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp`, `src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp` — same fail-closed change.

CI:
- `.github/workflows/5_testcomponent_schema_validator-rtr.yml` (new).
- `src/ci/utils.py`, `src/ci/build_tools.py`, `src/ci/input/test_tool_config.json` — register the module for RTR.
- `src/shared_modules/schema_validator/testtool/{main.cpp,CMakeLists.txt}` (new).

Tests:
- `src/shared_modules/schema_validator/tests/schemaValidatorConcurrency_test.cpp` (new).
- `src/shared_modules/schema_validator/tests/schemaValidator_test.cpp` — C-API and engine/edge-case tests.
- `src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp` and `src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp` — updated for the fail-closed missing-validator behaviour.

### Configuration Changes

No runtime/agent configuration changes. CI-only: the `schema_validator` module is registered in the RTR helpers (`MODULE_LIST`, `DELETE_FOLDER_DIC`, `test_tool_config.json`) and a new workflow is added.

### Documentation Updates

None required (internal thread-safety fix; public API unchanged).

### Tests Introduced

- **Concurrency regression** (`schemaValidatorConcurrency_test.cpp`): N threads run the same check-then-act guard as the real modules against the shared singleton; asserts the factory ends up initialized and no validator reachable after a single-threaded init is ever lost. Fails (data race / lost validator) on the unfixed code, passes on the fix.
- **C-API and engine coverage** (added to `schemaValidator_test.cpp`): `schema_validator_initialize` / `is_initialized` / `validate` (null args, uninitialized, unknown index, valid, invalid with/without an error pointer, multi-error join); engine edge cases (schema without `properties`, `index_patterns` without wildcard, non-object top-level message, nested-object field with a scalar value, `initialize()` with custom validators); and the `ValidateIPv6WithZone` case now passes.
- RTR coverage gate: module line coverage **85.7% → ~96.7%** (90% threshold). The only remaining uncovered lines in `schemaValidator_c.cpp` are the unreachable `catch(...)` handlers, marked with `LCOV_EXCL`.
- All RTR checks pass for both **agent** and **winagent** targets.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
