### PR TITLE
Fix AWS cross-account SQS queue URL when using iam_role_arn

### DIFF
--- a/wodles/aws/subscribers/sqs_queue.py
+++ b/wodles/aws/subscribers/sqs_queue.py
@@ -52,8 +52,6 @@ class AWSSQSQueue(wazuh_integration.WazuhIntegration):
                                                     sts_endpoint=sts_endpoint, skip_on_error=skip_on_error,
                                                     iam_role_duration=iam_role_duration,
                                                     **kwargs)
-        self.sts_client = self.get_sts_client(None, None, profile)
-        self.account_id = self.sts_client.get_caller_identity().get('Account')
         self.sqs_url = self._get_sqs_url()
         self.iam_role_arn = iam_role_arn
         self.iam_role_duration = iam_role_duration
@@ -76,8 +74,7 @@ class AWSSQSQueue(wazuh_integration.WazuhIntegration):
             The URL of the AWS SQS queue
         """
         try:
-            url = self.client.get_queue_url(QueueName=self.sqs_name,
-                                            QueueOwnerAWSAccountId=self.account_id)['QueueUrl']
+            url = self.client.get_queue_url(QueueName=self.sqs_name)['QueueUrl']
             aws_tools.debug(f'The SQS queue is: {url}', 2)
             return url
         except botocore.exceptions.ClientError:

--- a/wodles/aws/tests/test_sqs_queue.py
+++ b/wodles/aws/tests/test_sqs_queue.py
@@ -58,14 +58,29 @@ def test_aws_sqs_queue_initializes_properly(mock_wazuh_integration, mock_get_sqs
     assert integration.iam_role_arn == kwargs['iam_role_arn']
     mock_get_sqs_url.assert_called_once()
     mock_bucket_log_handler_init.assert_called_once()
-    mock_sts_client.assert_called_with(None, None, None)
-    mock_client.get_caller_identity.assert_called_once()
+
+
+# both configs must omit the owner id when resolving the queue URL
+@pytest.mark.parametrize('iam_role_arn', [
+    utils.TEST_IAM_ROLE_ARN,  # cross-/same-account via assumed role
+    None,                     # direct credentials, no role
+])
+@patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
+def test_aws_sqs_queue_get_sqs_url_omits_queue_owner_account_id(mock_wazuh_integration, iam_role_arn):
+    """Test '_get_sqs_url' resolves the queue URL without passing QueueOwnerAWSAccountId.
+
+    The SQS client is already scoped to the iam_role_arn target (or to the direct credentials),
+    so SQS derives the queue owner from the caller account. Passing an account id would break the
+    cross-account case (queue looked up in the manager's account instead of the role's account).
+    """
+    instance = utils.get_mocked_aws_sqs_queue(iam_role_arn=iam_role_arn)
+    # asserting the exact kwargs guarantees QueueOwnerAWSAccountId is not passed
+    instance.client.get_queue_url.assert_called_once_with(QueueName=instance.sqs_name)
 
 
 @patch('sqs_queue.AWSSQSQueue._get_sqs_url', return_value=SAMPLE_URL)
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
-def test_aws_sqs_queue_delete_message(mock_wazuh_integration, mock_sts_client, mock_get_url):
+def test_aws_sqs_queue_delete_message(mock_wazuh_integration, mock_get_url):
     """Test 'delete_message' method sends the given message to SQS."""
     instance = utils.get_mocked_aws_sqs_queue()
     instance.delete_message(SAMPLE_MESSAGE)

--- a/wodles/aws/tests/test_sqs_queue.py
+++ b/wodles/aws/tests/test_sqs_queue.py
@@ -25,16 +25,14 @@ SAMPLE_MESSAGE = {"handle": SAMPLE_RAW_MESSAGE['Messages'][0]['ReceiptHandle']}
 SAMPLE_URL = "sqs-test-url.com"
 
 
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.get_client')
 @patch('s3_log_handler.AWSS3LogHandler.__init__', return_value=None)
 @patch('sqs_message_processor.AWSQueueMessageProcessor.__init__')
 @patch('sqs_queue.AWSSQSQueue._get_sqs_url')
-@patch('wazuh_integration.WazuhIntegration.__init__', side_effet=wazuh_integration.WazuhIntegration.__init__)
+@patch('wazuh_integration.WazuhIntegration.__init__', return_value=None)
 def test_aws_sqs_queue_initializes_properly(mock_wazuh_integration, mock_get_sqs_url, mock_message_processor,
-                                            mock_bucket_log_handler_init, mock_client, mock_sts_client):
+                                            mock_bucket_log_handler_init, mock_client):
     """Test if the instances of AWSSQSQueue are created properly."""
-    mock_sts_client.return_value = mock_client
     kwargs = utils.get_aws_sqs_queue_parameters(name=utils.TEST_SQS_NAME,
                                                 external_id=utils.TEST_EXTERNAL_ID,
                                                 service_endpoint=utils.TEST_SERVICE_ENDPOINT,
@@ -88,9 +86,8 @@ def test_aws_sqs_queue_delete_message(mock_wazuh_integration, mock_get_url):
     instance.client.delete_message.assert_called_with(QueueUrl=SAMPLE_URL, ReceiptHandle=SAMPLE_MESSAGE["handle"])
 
 
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
-def test_aws_sqs_queue_delete_message_handles_exception_when_deleting_message(mock_wazuh_integration, mock_sts_client):
+def test_aws_sqs_queue_delete_message_handles_exception_when_deleting_message(mock_wazuh_integration):
     """Test 'delete_message' handles exceptions raised when trying to delete a message from SQS."""
     instance = utils.get_mocked_aws_sqs_queue()
     instance.client.delete_message.side_effect = Exception
@@ -101,9 +98,8 @@ def test_aws_sqs_queue_delete_message_handles_exception_when_deleting_message(mo
 
 
 @patch('sqs_queue.AWSSQSQueue._get_sqs_url', return_value=SAMPLE_URL)
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
-def test_aws_sqs_queue_fetch_messages(mock_wazuh_integration, mock_sts_client, mock_get_url):
+def test_aws_sqs_queue_fetch_messages(mock_wazuh_integration, mock_get_url):
     """Test 'fetch_messages' method retrieves one or more messages from the specified queue."""
     instance = utils.get_mocked_aws_sqs_queue()
     mock_receive = instance.client.receive_message
@@ -116,9 +112,8 @@ def test_aws_sqs_queue_fetch_messages(mock_wazuh_integration, mock_sts_client, m
     assert type(raw_messages) is dict
 
 
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
-def test_aws_sqs_queue_fetch_messages_handles_exception_when_getting_messages(mock_wazuh_integration, mock_sts_client):
+def test_aws_sqs_queue_fetch_messages_handles_exception_when_getting_messages(mock_wazuh_integration):
     """Test 'fetch_messages' handles exceptions raised when trying to retrieve messages from SQS."""
     instance = utils.get_mocked_aws_sqs_queue()
 
@@ -131,9 +126,8 @@ def test_aws_sqs_queue_fetch_messages_handles_exception_when_getting_messages(mo
 
 
 @patch('sqs_queue.AWSSQSQueue.fetch_messages', return_value=SAMPLE_RAW_MESSAGE)
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
-def test_aws_sqs_queue_get_messages(mock_wazuh_integration, mock_sts_client, mock_fetch):
+def test_aws_sqs_queue_get_messages(mock_wazuh_integration, mock_fetch):
     """Test 'get_messages' method returns parsed messages."""
     instance = utils.get_mocked_aws_sqs_queue()
     mocked_processor_extract = instance.message_processor.extract_message_info
@@ -141,9 +135,8 @@ def test_aws_sqs_queue_get_messages(mock_wazuh_integration, mock_sts_client, moc
     mocked_processor_extract.assert_called_with(SAMPLE_RAW_MESSAGE['Messages'])
 
 
-@patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
-def test_aws_sqs_queue_sync_events(mock_wazuh_integration, mock_sts_client):
+def test_aws_sqs_queue_sync_events(mock_wazuh_integration):
     """Test 'sync_events' method gets messages from the SQS queue, sends them to AnalysisD
     and deletes from the queue until it is empty."""
     instance = utils.get_mocked_aws_sqs_queue()


### PR DESCRIPTION
## Description

The AWS SQS subscriber wodle (`wodles/aws/subscribers/sqs_queue.py`) fails with `Queue does not exist, verify the given name` (exit code 20) when configured with an `iam_role_arn` pointing to a role in a different AWS account than the one the manager runs in.

The SQS client (`self.client`) is correctly authenticated with the assumed-role (Account B) credentials, but a side-channel STS client built without `iam_role_arn` was used to compute `self.account_id` which returns the manager's account (Account A). That wrong ID was then forwarded to `get_queue_url` as `QueueOwnerAWSAccountId`, so SQS looked for the queue in Account A and failed.

Closes #36197 

## Proposed Changes

- Removed `QueueOwnerAWSAccountId` from the `get_queue_url` call in `_get_sqs_url`. The SQS client is already scoped to the `iam_role_arn` target (or to the direct credentials), so SQS resolves the queue owner from the caller account which is the correct account in every supported topology.
- Removed the now unused side-channel STS client (`self.sts_client` / `self.account_id`). These existed only to feed the wrong account ID into the call. Removing them also drops a per-run `sts:GetCallerIdentity` network call and its IAM permission requirement.

### Results and Evidence

Before fix:

```text
2026/06/09 14:52:58 wazuh-modulesd:aws-s3: INFO: Module AWS started
2026/06/09 14:52:58 wazuh-modulesd:aws-s3: INFO: Starting fetching of logs.
2026/06/09 14:52:58 wazuh-modulesd:aws-s3: INFO: Executing Subscriber fetch: (Type and SQS: security_hub security-hub-rules-testing)
2026/06/09 14:53:01 wazuh-modulesd:aws-s3: WARNING: Subscriber: security_hub security-hub-rules-testing  -  Returned exit code 20
2026/06/09 14:53:01 wazuh-modulesd:aws-s3: WARNING: Subscriber: security_hub security-hub-rules-testing  -  Queue does not exist, verify the given name
2026/06/09 14:53:01 wazuh-modulesd:aws-s3: INFO: Fetching logs finished.
```

After fix:

```text
2026/06/09 14:22:11 wazuh-modulesd:aws-s3: INFO: Module AWS started
2026/06/09 14:22:11 wazuh-modulesd:aws-s3: INFO: Starting fetching of logs.
2026/06/09 14:22:11 wazuh-modulesd:aws-s3: INFO: Executing Subscriber fetch: (Type and SQS: security_hub security-hub-rules-testing)
2026/06/09 14:22:58 wazuh-modulesd:aws-s3: INFO: Fetching logs finished.
```

Test logs appear in `wazuh-alerts-*`:

<img width="2510" height="1203" alt="Screenshot 2026-06-09 at 3 08 44 PM" src="https://github.com/user-attachments/assets/ab5c5ec7-c2ab-4645-8e77-e82847bff038" />

Unit tests:

```console
→ python -m pytest tests/test_sqs_queue.py -v
================================= test session starts =================================
...
collected 9 items

tests/test_sqs_queue.py::test_aws_sqs_queue_initializes_properly PASSED         [ 11%]
tests/test_sqs_queue.py::test_aws_sqs_queue_get_sqs_url_omits_queue_owner_account_id[arn:aws:iam::123455678912:role/Role] PASSED [ 22%]
tests/test_sqs_queue.py::test_aws_sqs_queue_get_sqs_url_omits_queue_owner_account_id[None] PASSED [ 33%]
tests/test_sqs_queue.py::test_aws_sqs_queue_delete_message PASSED               [ 44%]
tests/test_sqs_queue.py::test_aws_sqs_queue_delete_message_handles_exception_when_deleting_message PASSED [ 55%]
tests/test_sqs_queue.py::test_aws_sqs_queue_fetch_messages PASSED               [ 66%]
tests/test_sqs_queue.py::test_aws_sqs_queue_fetch_messages_handles_exception_when_getting_messages PASSED [ 77%]
tests/test_sqs_queue.py::test_aws_sqs_queue_get_messages PASSED                 [ 88%]
tests/test_sqs_queue.py::test_aws_sqs_queue_sync_events PASSED                  [100%]
...
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== 9 passed, 10 warnings in 0.17s ============================
```

### Artifacts Affected

- `wodles/aws/subscribers/sqs_queue.py`, shipped on the manager (all platforms).

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- Added `test_aws_sqs_queue_get_sqs_url_omits_queue_owner_account_id`, parametrized over `iam_role_arn` (assumed-role and direct-credentials configs), asserting `get_queue_url` is called with `QueueName` only and never passes `QueueOwnerAWSAccountId`.
- Updated `test_aws_sqs_queue_initializes_properly` to drop the obsolete `get_sts_client` / `get_caller_identity` assertions.
- Removed the now-dead `get_sts_client` patches/parameters across the file and replaced a pre-existing typo `side_effet=...` -> `return_value=None`.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
