### PR TITLE
Change duplicated link to intented one

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,7 +22,7 @@
   - [OSquery to IT Hygiene](guide/migration/osquery-to-it-hygiene.md)
   - [Migrating Agent Groups](guide/migration/agent-groups-migration.md)
   - [Integratord to notifications plugin](guide/migration/integratord-notifications.md)
-  - [Migrating Agent Groups](guide/migration/agent-groups-migration.md)
+  - [Migrating Syslog Input to Logcollector with rsyslog](guide/migration/syslog-input-4x-to-5x.md)
 
 # Reference Manual
 


### PR DESCRIPTION
## Description

Fixes the duplicate entry in `docs/SUMMARY.md` that was introduced in PR #36781 and caused the nightly build to fail.

Closes https://github.com/wazuh/wazuh/issues/36793

## Proposed Changes

- Replaced the duplicate `Migrating Agent Groups` entry on line 25 of `docs/SUMMARY.md` with the correct `Migrating Syslog Input to Logcollector with rsyslog` pointing to `guide/migration/syslog-input-4x-to-5x.md`.

### Results and Evidence

- Verified that `bash build.sh` compiles the documentation successfully:
  ```bash
  INFO Book building has started
  INFO Running the html backend
  INFO HTML book written to /home/miguevr/Work/wazuh/docs/book
  ```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform: `N/A`
- Wazuh server API/Framework: `N/A`
- Memory tests: `N/A`
- Engine tests: `N/A`

### Artifacts Affected

- `docs/SUMMARY.md`

### Configuration Changes

- `N/A`

### Tests Introduced

- `N/A`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
