### PR TITLE
Fix sca check for etc/shadow

### DIFF
--- a/ruleset/sca/generic/sca_distro_independent_linux.yml
+++ b/ruleset/sca/generic/sca_distro_independent_linux.yml
@@ -3335,7 +3335,7 @@ checks:
       - iso_27001-2013: ["A.10.1.1"]
       - nist_sp_800-53: ["IA-5", "IA-5 (1)"]
       - pci_dss_v3.2.1: ["3.2", "8.2.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:stat -Lc "%a %A %u %U %g %G" /etc/gshadow- -> r:640|600|500|400|0 && r:0 root 0 root'
       - 'c:stat -Lc "%a %A %u %U %g %G" /etc/gshadow- -> r:640|600|500|400|0 && r:0 root \d+ shadow'


### PR DESCRIPTION
## Description

Rule 36177 in [sca_distro_independent_linux.yml](file:///home/miguevr/Work/wazuh/ruleset/sca/generic/sca_distro_independent_linux.yml#L3338) check for `/etc/gshadow-` permissions was configured with `condition: all` when checking for two different group owners (`root` and `shadow`). Since a file cannot be owned by two groups simultaneously, the check always failed.

Closes https://github.com/wazuh/wazuh/issues/34528

## Proposed Changes

- Changed the rule condition from `all` to `any` in check ID 36177 within [sca_distro_independent_linux.yml](file:///home/miguevr/Work/wazuh/ruleset/sca/generic/sca_distro_independent_linux.yml#L3338) to allow passing when `/etc/gshadow-` is owned by either `root` or `shadow` group.

### Results and Evidence

#### Before / After comparison
```diff
-    condition: all
+    condition: any
```

### Artifacts Affected

- [sca_distro_independent_linux.yml](file:///home/miguevr/Work/wazuh/ruleset/sca/generic/sca_distro_independent_linux.yml)

### Configuration Changes

**N/A**

### Tests Introduced

**N/A**

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (**N/A**)
- [ ] Configuration changes documented (**N/A**)
- [ ] Developer documentation reflects the changes (**N/A**)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
