### PR TITLE
Migrate AWS integration tests to OIDC authentication and pre-existing VPC [5.0.0]

### DIFF
--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -20,6 +20,7 @@
     {
       "name": "aws",
       "pytest_target": "test_aws/",
+      "pytest_extra_args": "-k \"not inspector\"",
       "tiers": ["0 1"],
       "timeout_minutes": 120,
       "setup_aws_credentials": true,
@@ -44,7 +45,16 @@
       "setup_aws_credentials": true,
       "paths": [
         "wodles/aws/services/inspector.py",
-        "wodles/aws/services/aws_service.py"
+        "wodles/aws/services/aws_service.py",
+        "wodles/aws/wazuh_integration.py",
+        "tests/integration/conftest.py",
+        "tests/integration/test_aws/**",
+        ".github/workflows/5_testintegration_linux-integration-tests.yml",
+        ".github/test_modules_linux.json",
+        "src/config/src/wmodules-aws.c",
+        "src/wazuh_modules/src/wm_aws.c",
+        "src/wazuh_modules/src/wm_aws.h",
+        "src/Makefile"
       ]
     },
     {

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -852,6 +852,10 @@ jobs:
     if: >
       needs.upload-deb-to-s3.result == 'success' &&
       needs.detect-changes.result == 'success'
+    # Required so that the reusable workflow can obtain an OIDC token for AWS authentication.
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -75,7 +75,7 @@ on:
         required: false
         default: ''
       setup_aws_credentials:
-        description: 'Configure AWS credentials from IT_AWS_KEY_ID / IT_AWS_SECRET_ACCESS_KEY secrets'
+        description: 'Configure AWS credentials via OIDC for AWS integration tests'
         required: false
         default: 'false'
 
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes || 120 }}
     name: Run integration tests
     permissions:
-      id-token: write
+      id-token: write  # Required for OIDC token generation (aws-actions/configure-aws-credentials)
       contents: read
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -172,17 +172,49 @@ jobs:
           sudo python3 -m pip install --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials via OIDC
         if: inputs.setup_aws_credentials == true || inputs.setup_aws_credentials == 'true'
-        env:
-          AWS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
-          AWS_SECRET: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IT_AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+          role-duration-seconds: 7200
+
+      - name: Write AWS named profiles for integration tests
+        if: inputs.setup_aws_credentials == true || inputs.setup_aws_credentials == 'true'
         run: |
-          sudo aws configure set aws_access_key_id "${AWS_KEY_ID}" --profile default
-          sudo aws configure set aws_secret_access_key "${AWS_SECRET}" --profile default
-          sudo aws configure set default.region us-east-1 --profile default
-          sudo aws configure set aws_access_key_id "${AWS_KEY_ID}" --profile inspector_tests
-          sudo aws configure set aws_secret_access_key "${AWS_SECRET}" --profile inspector_tests
+          # Write the 'default' profile (us-east-1) from the OIDC temporary credentials.
+          # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN are injected as
+          # environment variables by the preceding 'Configure AWS credentials via OIDC' step.
+          sudo aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default
+          sudo aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default
+          sudo aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile default
+          sudo aws configure set region us-east-1 --profile default
+
+          # Assume the Inspector role via role chaining to build the 'inspector_tests' profile.
+          # Inspector tests run against the wazuh-dev account and require us-east-2.
+          STS_ERROR_FILE=$(mktemp)
+          STS_OUTPUT=$(aws sts assume-role \
+            --role-arn "${{ secrets.IT_AWS_INSPECTOR_ROLE_ARN }}" \
+            --role-session-name "github-actions-inspector-tests" \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text 2>"$STS_ERROR_FILE") || {
+              echo "::error::Failed to assume Inspector role: $(cat $STS_ERROR_FILE)"
+              rm -f "$STS_ERROR_FILE"
+              exit 1
+            }
+          rm -f "$STS_ERROR_FILE"
+
+          read -r INSPECTOR_KEY INSPECTOR_SECRET INSPECTOR_TOKEN <<< "$STS_OUTPUT"
+
+          if [ -z "$INSPECTOR_KEY" ] || [ -z "$INSPECTOR_SECRET" ] || [ -z "$INSPECTOR_TOKEN" ]; then
+            echo "::error::Inspector role credentials are empty"
+            exit 1
+          fi
+
+          sudo aws configure set aws_access_key_id "$INSPECTOR_KEY" --profile inspector_tests
+          sudo aws configure set aws_secret_access_key "$INSPECTOR_SECRET" --profile inspector_tests
+          sudo aws configure set aws_session_token "$INSPECTOR_TOKEN" --profile inspector_tests
           sudo aws configure set region us-east-2 --profile inspector_tests
 
       - name: Run pre-install steps
@@ -190,10 +222,15 @@ jobs:
         run: ${{ inputs.pre_install }}
 
       - name: Run ${{ inputs.module_name }} integration tests (${{ inputs.shard_name }})
+        env:
+          AWS_VPC_ID: ${{ secrets.IT_AWS_VPC_ID }}
+          AWS_BUCKET_NAME: ${{ secrets.IT_AWS_BUCKET_NAME }}
         run: |
           cd tests/integration
           set +e
           sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" \
+            AWS_VPC_ID="${AWS_VPC_ID}" \
+            AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" \
             python -m pytest ${{ inputs.pytest_extra_args }} ${{ inputs.pytest_tier_args }} ${{ inputs.pytest_target }} \
             --html=results.html --self-contained-html
           EXIT_CODE=$?

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -14,12 +14,9 @@ from botocore.exceptions import ClientError
 # qa-integration-framework imports
 from wazuh_testing.logger import logger
 from wazuh_testing.modules.aws.utils import (
-    create_bucket,
     upload_log_events,
     create_log_group,
     create_log_stream,
-    create_flow_log,
-    delete_vpc,
     delete_bucket,
     delete_log_group,
     delete_log_stream,
@@ -32,7 +29,7 @@ from wazuh_testing.modules.aws.utils import (
     set_sqs_policy,
     set_bucket_event_notification_configuration,
     delete_sqs_queue,
-    delete_bucket_files
+    delete_bucket_file
 )
 from wazuh_testing.utils.services import control_service
 from wazuh_testing.constants.aws import US_EAST_1_REGION
@@ -225,43 +222,23 @@ def sqs_manager(sqs_client):
 
 
 @pytest.fixture()
-def create_test_bucket(buckets_manager,
-                       metadata: dict):
-    """Create a bucket.
+def create_test_bucket(metadata: dict):
+    """Use a pre-existing S3 bucket for tests.
 
     Args:
-        buckets_manager (fixture): Set of buckets.
         metadata (dict): Bucket information.
     """
-    bucket_name = metadata["bucket_name"]
-    bucket_type = metadata["bucket_type"]
-
-    buckets, s3_client = buckets_manager
-    try:
-        # Create bucket
-        create_bucket(bucket_name=bucket_name, client=s3_client)
-        logger.debug(f"Created new bucket: type {bucket_name}")
-
-        # Append created bucket to resource set
-        buckets.add(bucket_name)
-
-    except ClientError as error:
-        logger.error({
-            "message": "Client error creating bucket",
-            "bucket_name": bucket_name,
-            "bucket_type": bucket_type,
-            "error": str(error)
-        })
-        raise
-
-    except Exception as error:
-        logger.error({
-            "message": "Broad error creating bucket",
-            "bucket_name": bucket_name,
-            "bucket_type": bucket_type,
-            "error": str(error)
-        })
-        raise
+    shared_bucket = os.environ.get('AWS_BUCKET_NAME')
+    if not shared_bucket:
+        raise EnvironmentError(
+            "AWS_BUCKET_NAME is not set. A pre-existing S3 bucket is required. "
+            "Set the IT_AWS_BUCKET_NAME GitHub secret."
+        )
+    # Preserve the original YAML bucket name so generate_file can resolve custom bucket types
+    # (kms, macie, trusted_advisor) via bucket_name.split('-')[1] inside get_data_generator.
+    metadata['original_bucket_name'] = metadata.get('bucket_name', shared_bucket)
+    # Override so all S3 operations and the Wazuh module CLI use the shared bucket.
+    metadata['bucket_name'] = shared_bucket
 
 
 @pytest.fixture
@@ -292,19 +269,42 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
     log_number = metadata.get("expected_results", 1) > 0
 
     # Generate files
+    # Use the original YAML bucket name for generate_file — the framework derives the
+    # custom type (kms/macie/trusted) from bucket_name.split('-')[1], which breaks with
+    # the shared bucket name. All actual S3 operations still use the shared bucket_name.
+    data_bucket_name = metadata.get('original_bucket_name', bucket_name)
+    uploaded_keys = []
     if log_number:
         files_to_upload = []
         metadata['uploaded_file'] = ''
+        flow_log_id = None
         try:
             if vpc_bucket:
-                # Create VPC resources
-                flow_log_id, vpc_id = create_flow_log(vpc_name=metadata['vpc_name'],
-                                                      bucket_name=bucket_name,
-                                                      client=ec2_client)
+                vpc_id = os.environ.get('AWS_VPC_ID')
+                if not vpc_id:
+                    raise EnvironmentError(
+                        "AWS_VPC_ID is not set. A pre-existing VPC ID is required "
+                        "for VPC flow log tests. Set the IT_AWS_VPC_ID GitHub secret."
+                    )
+                response = ec2_client.create_flow_logs(
+                    ResourceIds=[vpc_id],
+                    ResourceType='VPC',
+                    TrafficType='REJECT',
+                    LogDestinationType='s3',
+                    LogDestination=f'arn:aws:s3:::{bucket_name}'
+                )
+                unsuccessful = response.get('Unsuccessful', [])
+                if unsuccessful:
+                    err = unsuccessful[0]['Error']
+                    raise RuntimeError(
+                        f"Failed to create VPC flow log on {vpc_id}: "
+                        f"[{err['Code']}] {err['Message']}"
+                    )
+                flow_log_id = response['FlowLogIds'][0]
                 metadata['flow_log_id'] = flow_log_id
                 for region in regions:
                     data, key = generate_file(bucket_type=bucket_type,
-                                              bucket_name=bucket_name,
+                                              bucket_name=data_bucket_name,
                                               date=file_creation_date,
                                               region=region,
                                               prefix=prefix,
@@ -314,7 +314,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
             else:
                 for region in regions:
                     data, key = generate_file(bucket_type=bucket_type,
-                                              bucket_name=bucket_name,
+                                              bucket_name=data_bucket_name,
                                               region=region,
                                               prefix=prefix,
                                               suffix=suffix,
@@ -332,6 +332,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
 
                 # Set filename for test execution
                 metadata['uploaded_file'] += key
+                uploaded_keys.append(key)
 
         except ClientError as error:
             logger.error({
@@ -339,6 +340,11 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 "bucket_name": bucket_name,
                 "error": str(error)
             })
+            if flow_log_id is not None:
+                try:
+                    ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
+                except Exception:
+                    pass
             raise error
 
         except Exception as error:
@@ -347,18 +353,29 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 "bucket_name": bucket_name,
                 "error": str(error)
             })
+            if flow_log_id is not None:
+                try:
+                    ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
+                except Exception:
+                    pass
             raise error
 
     yield
 
     try:
         if log_number:
-            # Delete all bucket files
-            delete_bucket_files(bucket_name=bucket_name, client=s3_client)
+            # Delete only the files uploaded by this test; the shared bucket must not be emptied.
+            for key in uploaded_keys:
+                try:
+                    delete_bucket_file(filename=key, bucket_name=bucket_name, client=s3_client)
+                except ClientError:
+                    pass  # File may already be gone (remove_from_bucket tests delete it themselves)
+                except Exception:
+                    pass
 
-            if vpc_bucket:
-                # Delete VPC resources (VPC and Flow Log)
-                delete_vpc(vpc_id=vpc_id, flow_log_id=flow_log_id, client=ec2_client)
+            if vpc_bucket and flow_log_id is not None:
+                # Only delete the flow log; the VPC is pre-existing and must not be deleted.
+                ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
 
     except ClientError as error:
         logger.error({

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -34,6 +34,29 @@ from wazuh_testing.modules.aws.utils import (
 from wazuh_testing.utils.services import control_service
 from wazuh_testing.constants.aws import US_EAST_1_REGION
 
+# Keys permanently seeded by DevOps in the shared bucket that tests must never delete.
+_PERMANENT_SEED_KEYS = frozenset({
+    'AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
+    '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json',
+})
+# VPC permanent seed is identified by this flow-log-ID substring in its S3 key.
+_PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
+
+
+def _safe_delete_key(key, bucket_name, s3_client):
+    """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
+    if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
+        logger.warning("TEARDOWN: skipping permanent seed key: %s", key)
+        return
+    try:
+        delete_bucket_file(filename=key, bucket_name=bucket_name, client=s3_client)
+        logger.debug("TEARDOWN: deleted key: %s", key)
+    except ClientError as exc:
+        logger.warning("TEARDOWN: failed to delete key %s from bucket %s: %s", key, bucket_name, exc)
+    except Exception as exc:
+        logger.warning("TEARDOWN: failed to delete key %s from bucket %s: %s", key, bucket_name, exc)
+
+
 @pytest.fixture
 def mark_cases_as_skipped(metadata):
     if metadata['name'] in ['alb_remove_from_bucket', 'clb_remove_from_bucket', 'nlb_remove_from_bucket']:
@@ -222,11 +245,21 @@ def sqs_manager(sqs_client):
 
 
 @pytest.fixture()
-def create_test_bucket(metadata: dict):
+def test_configuration() -> dict:
+    """Fallback for tests that do not parametrize test_configuration (e.g. multiple-calls tests).
+    Parametrize overrides this fixture, so tests that do supply test_configuration still work.
+    """
+    return {}
+
+
+@pytest.fixture()
+def create_test_bucket(metadata: dict, test_configuration: dict):
     """Use a pre-existing S3 bucket for tests.
 
     Args:
         metadata (dict): Bucket information.
+        test_configuration (dict): Wazuh configuration template built at import time.
+            Patched in-place so set_wazuh_configuration writes the shared bucket into ossec.conf.
     """
     shared_bucket = os.environ.get('AWS_BUCKET_NAME')
     if not shared_bucket:
@@ -239,6 +272,17 @@ def create_test_bucket(metadata: dict):
     metadata['original_bucket_name'] = metadata.get('bucket_name', shared_bucket)
     # Override so all S3 operations and the Wazuh module CLI use the shared bucket.
     metadata['bucket_name'] = shared_bucket
+
+    # Patch test_configuration so set_wazuh_configuration writes the shared bucket into ossec.conf.
+    # Without this, ossec.conf keeps the YAML name (plus the session suffix added by _modify_metadata),
+    # causing a mismatch with metadata['bucket_name'] and triggering incorrect_parameters failures.
+    for section in test_configuration.get('sections', []):
+        for element in section.get('elements', []):
+            bucket_cfg = element.get('bucket')
+            if isinstance(bucket_cfg, dict):
+                for bucket_elem in bucket_cfg.get('elements', []):
+                    if 'name' in bucket_elem:
+                        bucket_elem['name']['value'] = shared_bucket
 
 
 @pytest.fixture
@@ -362,36 +406,21 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
 
     yield
 
-    try:
-        if log_number:
-            # Delete only the files uploaded by this test; the shared bucket must not be emptied.
-            for key in uploaded_keys:
-                try:
-                    delete_bucket_file(filename=key, bucket_name=bucket_name, client=s3_client)
-                except ClientError:
-                    pass  # File may already be gone (remove_from_bucket tests delete it themselves)
-                except Exception:
-                    pass
+    if log_number:
+        # Collect every key this fixture or the test body uploaded.
+        all_keys = list(uploaded_keys)
+        extra_key = metadata.get('filename')
+        if extra_key and extra_key not in uploaded_keys:
+            all_keys.append(extra_key)
 
-            if vpc_bucket and flow_log_id is not None:
-                # Only delete the flow log; the VPC is pre-existing and must not be deleted.
+        for key in all_keys:
+            _safe_delete_key(key, bucket_name, s3_client)
+
+        if vpc_bucket and flow_log_id is not None:
+            try:
                 ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
-
-    except ClientError as error:
-        logger.error({
-            "message": "Client error deleting resources from bucket",
-            "bucket_name": bucket_name,
-            "error": str(error)
-        })
-        raise error
-
-    except Exception as error:
-        logger.error({
-            "message": "Broad error deleting resources from bucket",
-            "bucket_name": bucket_name,
-            "error": str(error)
-        })
-        raise error
+            except Exception as exc:
+                logger.warning("TEARDOWN: failed to delete flow log %s: %s", flow_log_id, exc)
 
 
 """CloudWatch fixtures"""

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -57,6 +57,30 @@ def _safe_delete_key(key, bucket_name, s3_client):
         logger.warning("TEARDOWN: failed to delete key %s from bucket %s: %s", key, bucket_name, exc)
 
 
+def _assert_prefix_clean(bucket_name, key, s3_client):
+    """Raise RuntimeError at setup time if any unexpected object already occupies the date-level prefix of key.
+
+    A single list_objects_v2 scoped to the exact prefix catches future seed collisions immediately,
+    rather than letting them produce a confusing count mismatch downstream.
+    """
+    prefix = key.rsplit('/', 1)[0] + '/'
+    unexpected = [
+        obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix)
+        if obj.key not in _PERMANENT_SEED_KEYS
+        and not any(fid in obj.key for fid in _PERMANENT_SEED_FLOW_LOG_IDS)
+        and not obj.key.endswith('/')  # skip S3 folder-marker objects (empty keys ending with /)
+    ]
+    if unexpected:
+        colliding = "\n".join(f"  {k}" for k in unexpected)
+        raise RuntimeError(
+            f"SETUP COLLISION: unexpected object(s) already exist at prefix '{prefix}' "
+            f"in bucket '{bucket_name}' before uploading '{key}'.\n"
+            f"Colliding key(s):\n{colliding}\n"
+            "Action: add the key to _PERMANENT_SEED_KEYS in conftest.py, or change "
+            "'only_logs_after' in the relevant YAML to a date past these objects."
+        )
+
+
 @pytest.fixture
 def mark_cases_as_skipped(metadata):
     if metadata['name'] in ['alb_remove_from_bucket', 'clb_remove_from_bucket', 'nlb_remove_from_bucket']:
@@ -364,6 +388,9 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                                               suffix=suffix,
                                               date=file_creation_date)
                     files_to_upload.append((data, key))
+
+            for _, key in files_to_upload:
+                _assert_prefix_clean(bucket_name, key, s3_client)
 
             for data, key in files_to_upload:
                 # Upload file to bucket

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -7,6 +7,7 @@ This module contains all necessary components (fixtures, classes, methods) to co
 """
 
 import os
+import time
 import pytest
 import boto3
 from botocore.exceptions import ClientError
@@ -546,6 +547,37 @@ def create_test_log_stream(metadata: dict, log_groups_manager) -> None:
         raise
 
 
+def _wait_for_log_events(logs_client, log_group, log_stream, expected_events, timeout=60, interval=3):
+    """Wait until the uploaded events are queryable through the CloudWatch Logs API.
+
+    PutLogEvents is eventually consistent: the events are not immediately returned by
+    filter_log_events. The AWS module queries CloudWatch only once at startup, so if the
+    events have not propagated yet it reads 0 of them and the test times out waiting for
+    the expected message. Poll until the expected number of events is visible (or until
+    the timeout elapses) so the module always sees the data.
+
+    Args:
+        logs_client: boto3 CloudWatch Logs client.
+        log_group (str): Log group to query.
+        log_stream (str): Log stream to query.
+        expected_events (int): Minimum number of events that must be visible.
+        timeout (int): Maximum time to wait, in seconds.
+        interval (int): Delay between polls, in seconds.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            response = logs_client.filter_log_events(logGroupName=log_group, logStreamNames=[log_stream])
+            if len(response.get('events', [])) >= expected_events:
+                return
+        except ClientError as error:
+            logger.debug(f"filter_log_events not ready yet for '{log_group}': {error}")
+        time.sleep(interval)
+
+    logger.warning(f"Timed out ({timeout}s) waiting for {expected_events} events to become queryable in "
+                   f"'{log_group}/{log_stream}'")
+
+
 @pytest.fixture
 def manage_log_group_events(metadata: dict, logs_clients):
     """Upload events to a log stream inside a log group and delete the log stream after the test ends.
@@ -580,6 +612,9 @@ def manage_log_group_events(metadata: dict, logs_clients):
                         events_number=event_number,
                         client=logs_client
                     )
+                    # Wait for the events to be queryable before the module runs, otherwise
+                    # CloudWatch eventual consistency can make the module read 0 events (flaky).
+                    _wait_for_log_events(logs_client, log_group, log_stream_name, event_number)
 
     except ClientError as error:
         logger.error({

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -38,6 +38,8 @@ from wazuh_testing.constants.aws import US_EAST_1_REGION
 _PERMANENT_SEED_KEYS = frozenset({
     'AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
     '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json',
+    'AWSLogs/819751203818/elasticloadbalancing/us-east-1/2022/11/20/'
+    '819751203818_elasticloadbalancing_us-east-1_net.qatests_20221120T0000Z_1412953514070675864_29.145.39.119.log',
 })
 # VPC permanent seed is identified by this flow-log-ID substring in its S3 key.
 _PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})

--- a/tests/integration/test_aws/data/configuration_template/path_suffix_test_module/configuration_path_suffix.yaml
+++ b/tests/integration/test_aws/data/configuration_template/path_suffix_test_module/configuration_path_suffix.yaml
@@ -12,6 +12,6 @@
               - name:
                   value: BUCKET_NAME
               - only_logs_after:
-                  value: 2022-NOV-20
+                  value: ONLY_LOGS_AFTER
               - path_suffix:
                   value: PATH_SUFFIX

--- a/tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml
@@ -11,6 +11,8 @@
             elements:
               - name:
                   value: BUCKET_NAME
+              - only_logs_after:
+                  value: ONLY_LOGS_AFTER
               - remove_from_bucket:
                   value: 'yes'
               - path:

--- a/tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml
+++ b/tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml
@@ -12,11 +12,11 @@
   description: VPC default configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
 
 - name: config_defaults
   description: Config default configurations

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml
@@ -20,14 +20,14 @@
   description: VPC discard regex configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     DISCARD_FIELD: action
     DISCARD_REGEX: "REJECT"
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     only_logs_after: 2022-NOV-20
     discard_field: action
     discard_regex: "REJECT"

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
@@ -9,17 +9,18 @@
     bucket_name: wazuh-cloudtrail-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: vpc_only_logs_after_multiple_calls
   description: VPC only_logs_after multiple calls configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     only_logs_after: 2022-NOV-20
     expected_results: 1
 
@@ -34,6 +35,7 @@
     bucket_name: wazuh-config-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: alb_only_logs_after_multiple_calls
   description: ALB only_logs_after multiple calls configurations
@@ -46,6 +48,7 @@
     bucket_name: wazuh-alb-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: clb_only_logs_after_multiple_calls
   description: CLB only_logs_after multiple calls configurations
@@ -58,6 +61,7 @@
     bucket_name: wazuh-clb-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: nlb_only_logs_after_multiple_calls
   description: NLB only_logs_after multiple calls configurations
@@ -70,6 +74,7 @@
     bucket_name: wazuh-nlb-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: kms_only_logs_after_multiple_calls
   description: KMS only_logs_after multiple calls configurations
@@ -82,6 +87,7 @@
     bucket_name: wazuh-kms-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: macie_only_logs_after_multiple_calls
   description: Macie only_logs_after multiple calls configurations
@@ -94,6 +100,7 @@
     bucket_name: wazuh-macie-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: trusted_advisor_only_logs_after_multiple_calls
   description: Trusted Advisor only_logs_after multiple calls configurations
@@ -106,6 +113,7 @@
     bucket_name: wazuh-trusted-advisor-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: native_guardduty_only_logs_after_multiple_calls
   description: Native GuardDuty only_logs_after multiple calls configurations
@@ -118,6 +126,7 @@
     bucket_name: wazuh-native-guardduty-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: waf_only_logs_after_multiple_calls
   description: WAF only_logs_after multiple calls configurations
@@ -130,6 +139,7 @@
     bucket_name: wazuh-waf-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: server_access_only_logs_after_multiple_calls
   description: Server Access only_logs_after multiple calls configurations
@@ -142,6 +152,7 @@
     bucket_name: wazuh-server-access-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: cisco_umbrella_only_logs_after_multiple_calls
   description: Umbrella only_logs_after multiple calls configurations
@@ -156,3 +167,4 @@
     only_logs_after: 2022-NOV-20
     path: dnslogs
     expected_results: 1
+    account_id: '819751203818'

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
@@ -7,7 +7,8 @@
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
+    later_only_logs_after: 2022-NOV-24
     expected_results: 1
     account_id: '819751203818'
 
@@ -21,7 +22,8 @@
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
+    later_only_logs_after: 2022-NOV-24
     expected_results: 1
 
 - name: config_only_logs_after_multiple_calls

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -16,14 +16,14 @@
   description: VPC only logs after configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     only_logs_after: 2022-NOV-20
     expected_results: 3
 

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -46,13 +46,13 @@
   configuration_parameters:
     BUCKET_TYPE: alb
     BUCKET_NAME: wazuh-alb-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: alb
     bucket_name: wazuh-alb-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: clb_with_only_logs_after
@@ -60,13 +60,13 @@
   configuration_parameters:
     BUCKET_TYPE: clb
     BUCKET_NAME: wazuh-clb-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: clb
     bucket_name: wazuh-clb-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: nlb_with_only_logs_after
@@ -74,13 +74,13 @@
   configuration_parameters:
     BUCKET_TYPE: nlb
     BUCKET_NAME: wazuh-nlb-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: nlb
     bucket_name: wazuh-nlb-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: kms_with_only_logs_after

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -3,13 +3,13 @@
   configuration_parameters:
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: vpc_with_only_logs_after
@@ -17,14 +17,14 @@
   configuration_parameters:
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 3
 
 - name: config_with_only_logs_after

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml
@@ -14,13 +14,13 @@
   description: VPC only logs after configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     expected_results: 1
 
 - name: config_without_only_logs_after

--- a/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
@@ -44,12 +44,12 @@
   description: VPC path_suffix configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: test_suffix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: test_suffix
@@ -73,12 +73,12 @@
   description: VPC path_suffix configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: empty_suffix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: empty_suffix
@@ -102,12 +102,12 @@
   description: VPC path_suffix configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: inexistent_suffix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: inexistent_suffix

--- a/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
@@ -4,11 +4,12 @@
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     PATH_SUFFIX: test_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: test_suffix
     expected_results: 1
 
@@ -18,11 +19,12 @@
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     PATH_SUFFIX: empty_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: empty_suffix
     expected_results: 0
 
@@ -32,11 +34,12 @@
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     PATH_SUFFIX: inexistent_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: inexistent_suffix
     expected_results: 0
 
@@ -46,12 +49,13 @@
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: test_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: test_suffix
     expected_results: 1
 
@@ -61,11 +65,12 @@
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
     PATH_SUFFIX: test_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: test_suffix
     expected_results: 1
 
@@ -75,12 +80,13 @@
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: empty_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: empty_suffix
     expected_results: 0
 
@@ -90,11 +96,12 @@
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
     PATH_SUFFIX: empty_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: empty_suffix
     expected_results: 0
 
@@ -104,12 +111,13 @@
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: inexistent_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: inexistent_suffix
     expected_results: 0
 
@@ -119,10 +127,11 @@
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
     PATH_SUFFIX: inexistent_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: inexistent_suffix
     expected_results: 0

--- a/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
@@ -44,12 +44,12 @@
   description: VPC path configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: test_prefix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path: test_prefix
@@ -59,12 +59,12 @@
   description: VPC path configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: empty_prefix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path: empty_prefix
@@ -102,12 +102,12 @@
   description: CloudTrail path configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: inexistent_prefix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path: inexistent_prefix

--- a/tests/integration/test_aws/data/test_cases/regions_test_module/cases_bucket_regions.yaml
+++ b/tests/integration/test_aws/data/test_cases/regions_test_module/cases_bucket_regions.yaml
@@ -44,12 +44,12 @@
   description: VPC regions configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     REGIONS: us-east-1
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-east-1
@@ -87,12 +87,12 @@
   description: VPC regions configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     REGIONS: us-east-1,us-east-2
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-east-1,us-east-2
@@ -130,12 +130,12 @@
   description: VPC regions configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     REGIONS: us-fake-1
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-fake-1

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -13,13 +13,13 @@
   description: VPC remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
 
 - name: config_remove_from_bucket
   description: Config remove from bucket configurations

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -3,142 +3,168 @@
   configuration_parameters:
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
+    only_logs_after: 2022-NOV-22
 
 - name: vpc_remove_from_bucket
   description: VPC remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
+    only_logs_after: 2022-NOV-22
 
 - name: config_remove_from_bucket
   description: Config remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: alb_remove_from_bucket
   description: ALB remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: alb
     BUCKET_NAME: wazuh-alb-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: alb
     bucket_name: wazuh-alb-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: clb_remove_from_bucket
   description: CLB remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: clb
     BUCKET_NAME: wazuh-clb-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: clb
     bucket_name: wazuh-clb-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: nlb_remove_from_bucket
   description: NLB remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: nlb
     BUCKET_NAME: wazuh-nlb-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: nlb
     bucket_name: wazuh-nlb-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: kms_remove_from_bucket
   description: KMS remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: custom
     BUCKET_NAME: wazuh-kms-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: custom
     bucket_name: wazuh-kms-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: macie_remove_from_bucket
   description: Macie remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: custom
     BUCKET_NAME: wazuh-macie-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: custom
     bucket_name: wazuh-macie-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: trusted_advisor_remove_from_bucket
   description: Trusted Advisor remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: custom
     BUCKET_NAME: wazuh-trusted-advisor-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: custom
     bucket_name: wazuh-trusted-advisor-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: native_guardduty_remove_from_bucket
   description: Native GuardDuty remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: guardduty
     BUCKET_NAME: wazuh-native-guardduty-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: guardduty
     bucket_name: wazuh-native-guardduty-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: waf_remove_from_bucket
   description: WAF remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: waf
     BUCKET_NAME: wazuh-waf-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: waf
     bucket_name: wazuh-waf-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: server_access_remove_from_bucket
   description: Server Access remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: server_access
     BUCKET_NAME: wazuh-server-access-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: server_access
     bucket_name: wazuh-server-access-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: cisco_umbrella_remove_from_bucket
   description: CloudTrail remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: cisco_umbrella
     BUCKET_NAME: wazuh-umbrella-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: dnslogs
   metadata:
     resource_type: bucket
     bucket_type: cisco_umbrella
     bucket_name: wazuh-umbrella-integration-tests
     path: dnslogs
+    only_logs_after: 2022-NOV-20

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -766,13 +766,12 @@ def test_bucket_multiple_calls(
 
     bucket_type = metadata['bucket_type']
     bucket_name = metadata['bucket_name']
-    data_bucket_name = metadata.get('original_bucket_name', bucket_name)
     expected_results = metadata['expected_results']
     path = metadata.get('path')
     region = US_EAST_1_REGION
-    # Use the original YAML bucket name for generate_file / get_last_file_key so the
-    # framework can resolve custom types (kms/macie/trusted) via bucket_name.split('-')[1].
     data_bucket_name = metadata.get('original_bucket_name', bucket_name)
+    only_logs_after = metadata.get('only_logs_after', '2022-NOV-20')
+    later_only_logs_after = metadata.get('later_only_logs_after', '2022-NOV-22')
 
     base_parameters = [
         '--bucket', bucket_name,
@@ -813,7 +812,7 @@ def test_bucket_multiple_calls(
 
     # Call the module with only_logs_after set in the past and check that the expected number of logs were processed
     analyze_command_output(
-        command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-20'),
+        command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, only_logs_after),
         callback=event_monitor.callback_detect_event_processed,
         expected_results=expected_results,
         error_message=ERROR_MESSAGE['incorrect_event_number']
@@ -824,7 +823,7 @@ def test_bucket_multiple_calls(
         # For VPC the number of messages depend on the number of flow log IDs obtained by the module which may vary.
         expected_skipped_logs_step_3 = metadata.get('expected_skipped_logs_step_3', 1)
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-20'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3,
             error_message=ERROR_MESSAGE['incorrect_event_number'],
@@ -834,7 +833,7 @@ def test_bucket_multiple_calls(
         # Call the module with only_logs_after set with an early date than the one set previously and check that no logs
         # were processed, there were no duplicates
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-22'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, later_only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3 - 1 if expected_skipped_logs_step_3 > 1 else 1,
             error_message=ERROR_MESSAGE['incorrect_event_number'],
@@ -844,7 +843,7 @@ def test_bucket_multiple_calls(
         # Call the module with the same parameters in and check there were no duplicates
         expected_skipped_logs_step_3 = metadata.get('expected_skipped_logs_step_3', 1)
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-20'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3,
             error_message=ERROR_MESSAGE['incorrect_event_number']
@@ -853,7 +852,7 @@ def test_bucket_multiple_calls(
         # Call the module with only_logs_after set with an early date than the one set previously and check that no logs
         # were processed, there were no duplicates
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-22'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, later_only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3 - 1 if expected_skipped_logs_step_3 > 1 else 1,
             error_message=ERROR_MESSAGE['incorrect_event_number']
@@ -861,7 +860,15 @@ def test_bucket_multiple_calls(
 
     # Upload a log file for the day of the test execution and call the module without only_logs_after and check that
     # only the uploaded logs were processed and the last marker is specified in the DB.
-    last_marker_key = get_last_file_key(bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
+    # Pre-resolve the effective type from the YAML bucket name so get_last_file_key doesn't try to infer the type
+    # from the shared bucket name via split('-')[1] (which produces 'agent' and causes KeyError).
+    # bucket_name (shared bucket) is still passed for the actual S3 Bucket object access inside get_last_file_key.
+    effective_bucket_type = bucket_type
+    if bucket_type == 'custom':
+        effective_bucket_type = data_bucket_name.split('-')[1]
+    elif bucket_type == 'guardduty' and 'native' in data_bucket_name:
+        effective_bucket_type = 'native-guardduty'
+    last_marker_key = get_last_file_key(effective_bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
     if bucket_type == VPC_FLOW_TYPE:
         data, key = generate_file(bucket_type=bucket_type,
                                   bucket_name=data_bucket_name,

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -766,6 +766,7 @@ def test_bucket_multiple_calls(
 
     bucket_type = metadata['bucket_type']
     bucket_name = metadata['bucket_name']
+    data_bucket_name = metadata.get('original_bucket_name', bucket_name)
     expected_results = metadata['expected_results']
     path = metadata.get('path')
     region = US_EAST_1_REGION
@@ -860,7 +861,7 @@ def test_bucket_multiple_calls(
 
     # Upload a log file for the day of the test execution and call the module without only_logs_after and check that
     # only the uploaded logs were processed and the last marker is specified in the DB.
-    last_marker_key = get_last_file_key(bucket_type, data_bucket_name, datetime.utcnow(), region, s3_client)
+    last_marker_key = get_last_file_key(bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
     if bucket_type == VPC_FLOW_TYPE:
         data, key = generate_file(bucket_type=bucket_type,
                                   bucket_name=data_bucket_name,

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -769,6 +769,9 @@ def test_bucket_multiple_calls(
     expected_results = metadata['expected_results']
     path = metadata.get('path')
     region = US_EAST_1_REGION
+    # Use the original YAML bucket name for generate_file / get_last_file_key so the
+    # framework can resolve custom types (kms/macie/trusted) via bucket_name.split('-')[1].
+    data_bucket_name = metadata.get('original_bucket_name', bucket_name)
 
     base_parameters = [
         '--bucket', bucket_name,
@@ -779,6 +782,11 @@ def test_bucket_multiple_calls(
 
     if path is not None:
         base_parameters.extend(['--trail_prefix', path])
+
+    # Scope to the test data account so the module doesn't iterate other account prefixes
+    # in the shared bucket (which would produce extra "No logs to process" messages).
+    if metadata.get('account_id'):
+        base_parameters.extend(['--aws_account_id', metadata['account_id']])
 
     # Call the module without only_logs_after and check that no logs were processed
     # Get bucket type
@@ -852,10 +860,10 @@ def test_bucket_multiple_calls(
 
     # Upload a log file for the day of the test execution and call the module without only_logs_after and check that
     # only the uploaded logs were processed and the last marker is specified in the DB.
-    last_marker_key = get_last_file_key(bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
+    last_marker_key = get_last_file_key(bucket_type, data_bucket_name, datetime.utcnow(), region, s3_client)
     if bucket_type == VPC_FLOW_TYPE:
         data, key = generate_file(bucket_type=bucket_type,
-                                  bucket_name=bucket_name,
+                                  bucket_name=data_bucket_name,
                                   region=region,
                                   prefix='',
                                   suffix='',
@@ -863,7 +871,7 @@ def test_bucket_multiple_calls(
                                   flow_log_id=metadata['flow_log_id'])
     else:
         data, key = generate_file(bucket_type=bucket_type,
-                                  bucket_name=bucket_name,
+                                  bucket_name=data_bucket_name,
                                   region=region,
                                   prefix='',
                                   suffix='',

--- a/tests/integration/test_aws/test_path_suffix.py
+++ b/tests/integration/test_aws/test_path_suffix.py
@@ -104,7 +104,7 @@ def test_path_suffix(
     only_logs_after = metadata['only_logs_after']
     path_suffix = metadata['path_suffix']
     expected_results = metadata['expected_results']
-    pattern = fr".*WARNING: Bucket:  -  No files were found in '{bucket_name}/{path_suffix}/'. No logs will be processed.\n+"
+    pattern = fr".*WARNING: Bucket:  -  No logs found in 'AWSLogs/{path_suffix}/'. Check the provided prefix.*\n*"
 
     parameters = [
         'wodles/aws/aws-s3',

--- a/tests/integration/test_aws/test_remove_from_bucket.py
+++ b/tests/integration/test_aws/test_remove_from_bucket.py
@@ -100,17 +100,16 @@ def test_remove_from_bucket(
     """
     bucket_name = metadata['bucket_name']
     path = metadata.get('path')
-    parameters = [
-        'wodles/aws/aws-s3',
-        '--bucket', bucket_name,
-        '--remove',
-        '--type', metadata['bucket_type'],
-        '--debug', '2'
-    ]
+    only_logs_after = metadata.get('only_logs_after')
+    parameters = ['wodles/aws/aws-s3', '--bucket', bucket_name, '--remove']
 
     if path is not None:
-        parameters.insert(4, path)
-        parameters.insert(4, '--trail_prefix')
+        parameters.extend(['--trail_prefix', path])
+
+    if only_logs_after is not None:
+        parameters.extend(['--only_logs_after', only_logs_after])
+
+    parameters.extend(['--type', metadata['bucket_type'], '--debug', '2'])
 
     # Check AWS module started
     log_monitor.start(


### PR DESCRIPTION
## Description
This PR migrates the AWS integration test workflows from static access keys to OIDC authentication, moves the S3/VPC resources from the `wazuh-dev` account (being deleted) to the new `xdrsiem` account (`966237403726`), and fixes the `VpcLimitExceeded` error by reusing a pre-existing VPC instead of creating one per run. It also includes the follow-up fixes required to make the suite pass against the new shared-bucket model.

**Base branch:** `5.0.0`  
**Proposed Release:** v5.0.0

## Proposed Changes
**Auth / resources (core migration)**
- `.github/workflows/5_testintegration_linux-integration-tests.yml`: replaced static `aws configure set` keys with `aws-actions/configure-aws-credentials@v4` (OIDC, `role-to-assume`); added `permissions: id-token: write`; sourced `AWS_VPC_ID` from secret. Inspector profile built via chained `assume-role`.
- `.github/workflows/5_builderpackage_agent-linux.yml`: added `permissions: id-token: write` to the calling job.
- `tests/integration/test_aws/conftest.py`: reuse a pre-existing VPC from `AWS_VPC_ID` (only the flow log is created/deleted, never the VPC).

**Shared-bucket adaptation fixes**
- Permanent-seed protection in `conftest.py` (`_PERMANENT_SEED_KEYS`, `_PERMANENT_SEED_FLOW_LOG_IDS`) + `_assert_prefix_clean` pre-upload collision guard, so tests never delete DevOps seed objects.
- `test_path_suffix.py`: expected warning aligned with the message the module emits on the shared bucket (`find_account_ids()` "No logs found in 'AWSLogs/...'").
- `test_remove_from_bucket.py`: scoped with `only_logs_after` and corrected CLI parameter order to match `wm_aws.c`, preventing deletion of permanent seeds.
- `test_only_logs_after.py`: account-id scoping and date adjustments for the shared bucket.
- `conftest.py`: bounded CloudWatch event-propagation wait (poll `filter_log_events` before the module runs) to remove eventual-consistency flakiness.
- YAML cases/config: point to the shared bucket and bump `only_logs_after` (e.g. 2022-NOV-22) to land uploads clear of the permanent seeds.

**CI matrix (Inspector coverage / credential lifetime)**
- `.github/test_modules_linux.json`: excluded Inspector from the full `aws` module (`-k "not inspector"`) and broadened `aws_inspector` triggers to the same paths as `aws`, so Inspector runs once in its own short-lived-credential shard and keeps coverage on broad changes (parity with 4.14.7's dedicated Inspector step). NOTE: JSON has no comments — `aws` and `aws_inspector` paths must stay in sync.

### Results and Evidence
All checks green on the latest run (AWS integration tests + DEB/RPM build + packaging). Retargeting to the released `5.0.0` base also resolved the earlier packaging failure (the `5.1` dev dependency set was not yet published on the mirror).

https://github.com/wazuh/wazuh/actions/runs/30001054732

### Artifacts Affected
- `.github/workflows/5_testintegration_linux-integration-tests.yml`
- `.github/workflows/5_builderpackage_agent-linux.yml`
- `.github/test_modules_linux.json`
- `tests/integration/test_aws/conftest.py`
- `tests/integration/test_aws/test_path_suffix.py`
- `tests/integration/test_aws/test_only_logs_after.py`
- `tests/integration/test_aws/test_remove_from_bucket.py`
- `tests/integration/test_aws/data/configuration_template/path_suffix_test_module/configuration_path_suffix.yaml`
- `tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml`
- `tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml`
- `tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml`
- `tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml`
- `tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml`
- `tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml`
- `tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml`
- `tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml`
- `tests/integration/test_aws/data/test_cases/regions_test_module/cases_bucket_regions.yaml`
- `tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml`

### Configuration Changes
GitHub secrets used:
- `IT_AWS_OIDC_ROLE_ARN`: OIDC role in the new `xdrsiem` account.
- `IT_AWS_VPC_ID`: pre-existing VPC in `us-east-1`.
- `IT_AWS_INSPECTOR_ROLE_ARN`: Inspector role — **still in `wazuh-dev` (us-east-2)**. Known follow-up: migrate this role + Inspector data to the new account before `wazuh-dev` is decommissioned (otherwise the Inspector tests will break). Tracked separately.

### Documentation Updates
N/A

### Tests Introduced
- **Scope:** Integration Tests
- **Details:** No new tests; existing AWS integration tests validate the migration.

## Review Checklist
**Manual tests with their corresponding evidence:**
- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues