### PR TITLE
fix off-by-one buffer overflow in postgresql and mssql log readers

### DIFF
--- a/src/logcollector/src/read_mssql_log.c
+++ b/src/logcollector/src/read_mssql_log.c
@@ -136,10 +136,10 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add additional message to the saved buffer */
-            if (sizeof(buffer) - buffer_len > str_len) {
-                /* Here we make sure that the size of the buffer
-                 * minus what was used (strlen) is greater than
-                 * the length of the received message.
+            if (sizeof(buffer) - buffer_len > str_len + 1) {
+                /* Here we make sure that the buffer has room for the
+                 * separator, the received message and the terminating
+                 * null byte before appending.
                  */
                 buffer[buffer_len] = ' ';
                 buffer[buffer_len + 1] = '\0';

--- a/src/logcollector/src/read_postgresql_log.c
+++ b/src/logcollector/src/read_postgresql_log.c
@@ -130,10 +130,10 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
             }
 
             /* Add additional message to the saved buffer */
-            if (sizeof(buffer) - buffer_len > str_len) {
-                /* Here we make sure that the size of the buffer
-                 * minus what was used (strlen) is greater than
-                 * the length of the received message.
+            if (sizeof(buffer) - buffer_len > str_len + 1) {
+                /* Here we make sure that the buffer has room for the
+                 * separator, the received message and the terminating
+                 * null byte before appending.
                  */
                 buffer[buffer_len] = ' ';
                 buffer[buffer_len + 1] = '\0';


### PR DESCRIPTION
tighten the length check in the multiline branch of read_postgresql_log and read_mssql_log so the separator space and the trailing null are counted, otherwise a tab-indented continuation line whose length exactly fills the space left in buffer[OS_MAX_LOG_SIZE] makes strncat write one null byte past the end.