### PR TITLE
Migrate AWS integration tests to OIDC authentication and pre-existing VPC [4.14.7]

### DIFF
--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -26,6 +26,7 @@ jobs:
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
       QA_IT_FW_BRANCH: ${{ github.base_ref || inputs.base_qa_it_fw_branch }}
       AWS_VPC_ID: ${{ secrets.IT_AWS_VPC_ID }}
+      AWS_BUCKET_NAME: ${{ secrets.IT_AWS_BUCKET_NAME }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
@@ -99,6 +100,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.IT_AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
+          role-duration-seconds: 7200
 
       - name: Write AWS named profiles for integration tests
         run: |
@@ -112,11 +114,17 @@ jobs:
 
           # Assume the Inspector role via role chaining to build the 'inspector_tests' profile.
           # Inspector tests run against the wazuh-dev account and require us-east-2.
+          STS_ERROR_FILE=$(mktemp)
           STS_OUTPUT=$(aws sts assume-role \
             --role-arn "${{ secrets.IT_AWS_INSPECTOR_ROLE_ARN }}" \
             --role-session-name "github-actions-inspector-tests" \
             --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-            --output text) || { echo "::error::Failed to assume Inspector role"; exit 1; }
+            --output text 2>"$STS_ERROR_FILE") || {
+              echo "::error::Failed to assume Inspector role: $(cat $STS_ERROR_FILE)"
+              rm -f "$STS_ERROR_FILE"
+              exit 1
+            }
+          rm -f "$STS_ERROR_FILE"
 
           read -r INSPECTOR_KEY INSPECTOR_SECRET INSPECTOR_TOKEN <<< "$STS_OUTPUT"
 
@@ -178,86 +186,86 @@ jobs:
         if: steps.filter.outputs.parser == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_parser.py
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_parser.py
 
       - name: Run every test due to base WazuhIntegration class change or manual dispatch
         if: steps.filter.outputs.integration == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           cd tests/integration
-          sudo AWS_VPC_ID="${AWS_VPC_ID}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/
 
       - name: Run Custom Buckets tests
         if: steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k kms test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k macie test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k trusted_advisor test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k kms test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k macie test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k trusted_advisor test_aws/
 
       - name: Run Config tests
         if: steps.filter.outputs.config == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k config test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k config test_aws/
 
       - name: Run GuardDuty tests
         if: steps.filter.outputs.guardduty == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k guardduty test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k guardduty test_aws/
 
       - name: Run CloudTrail tests
         if: steps.filter.outputs.cloudtrail == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k cloudtrail test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudtrail test_aws/
 
       - name: Run Load Balancers tests
         if: steps.filter.outputs.loadbalancers == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k alb test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k clb test_aws/
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k nlb test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k alb test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k clb test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k nlb test_aws/
 
       - name: Run Server Access tests
         if: steps.filter.outputs.serveraccess == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k server_access test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k server_access test_aws/
 
       - name: Run Umbrella tests
         if: steps.filter.outputs.umbrella == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k cisco test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cisco test_aws/
 
       - name: Run VPC Flow tests
         if: steps.filter.outputs.vpcflow == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_VPC_ID="${AWS_VPC_ID}" python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
 
       - name: Run WAF tests
         if: steps.filter.outputs.waf == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k waf test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k waf test_aws/
 
       - name: Run CloudWatch tests
         if: steps.filter.outputs.cloudwatch == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/
 
       - name: Run Inspector tests
         if: steps.filter.outputs.inspector == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/
 
       - name: Run Custom Bucket tests
         if: steps.filter.outputs.custom_bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_custom_bucket.py
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_custom_bucket.py

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -18,13 +18,14 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write  # Required for OIDC token generation (aws-actions/configure-aws-credentials)
+      contents: read
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
       QA_IT_FW_BRANCH: ${{ github.base_ref || inputs.base_qa_it_fw_branch }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: 'us-east-1'
+      AWS_VPC_ID: ${{ secrets.IT_AWS_VPC_ID }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
@@ -93,15 +94,40 @@ jobs:
           sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
 
-      - name: Set AWS credentials file
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IT_AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Write AWS named profiles for integration tests
         run: |
-          sudo aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID} --profile default
-          sudo aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY} --profile default
-          sudo aws configure set default.region ${AWS_DEFAULT_REGION} --profile default
-      - name: Set AWS credentials file for inspector2 tests (us-east-2)
-        run: |
-          sudo aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID} --profile inspector_tests
-          sudo aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY} --profile inspector_tests
+          # Write 'default' profile (us-east-1) from the OIDC temporary credentials.
+          # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN are injected as
+          # environment variables by the preceding 'Configure AWS credentials via OIDC' step.
+          sudo aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default
+          sudo aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default
+          sudo aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile default
+          sudo aws configure set region us-east-1 --profile default
+
+          # Assume the Inspector role via role chaining to build the 'inspector_tests' profile.
+          # Inspector tests run against the wazuh-dev account and require us-east-2.
+          STS_OUTPUT=$(aws sts assume-role \
+            --role-arn "${{ secrets.IT_AWS_INSPECTOR_ROLE_ARN }}" \
+            --role-session-name "github-actions-inspector-tests" \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) || { echo "::error::Failed to assume Inspector role"; exit 1; }
+
+          read -r INSPECTOR_KEY INSPECTOR_SECRET INSPECTOR_TOKEN <<< "$STS_OUTPUT"
+
+          if [ -z "$INSPECTOR_KEY" ] || [ -z "$INSPECTOR_SECRET" ] || [ -z "$INSPECTOR_TOKEN" ]; then
+            echo "::error::Inspector role credentials are empty"
+            exit 1
+          fi
+
+          sudo aws configure set aws_access_key_id "$INSPECTOR_KEY" --profile inspector_tests
+          sudo aws configure set aws_secret_access_key "$INSPECTOR_SECRET" --profile inspector_tests
+          sudo aws configure set aws_session_token "$INSPECTOR_TOKEN" --profile inspector_tests
           sudo aws configure set region us-east-2 --profile inspector_tests
 
       - name: "Install a compatible CMake"
@@ -158,7 +184,7 @@ jobs:
         if: steps.filter.outputs.integration == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 test_aws/
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/
 
       - name: Run Custom Buckets tests
         if: steps.filter.outputs.bucket == 'true'
@@ -210,7 +236,7 @@ jobs:
         if: steps.filter.outputs.vpcflow == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
 
       - name: Run WAF tests
         if: steps.filter.outputs.waf == 'true' || steps.filter.outputs.bucket == 'true'

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -102,41 +102,19 @@ jobs:
           aws-region: us-east-1
           role-duration-seconds: 7200
 
-      - name: Write AWS named profiles for integration tests
+      - name: Write default AWS profile for integration tests
         run: |
           # Write 'default' profile (us-east-1) from the OIDC temporary credentials.
           # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN are injected as
           # environment variables by the preceding 'Configure AWS credentials via OIDC' step.
+          # The 'inspector_tests' profile is NOT built here: it is assembled right before the
+          # Inspector tests run (see 'Run Inspector tests'), because role chaining caps the
+          # session at 1h and the full suite runs >1h, so a profile built at job start would
+          # expire before the Inspector tests execute late in the suite.
           sudo aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default
           sudo aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default
           sudo aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile default
           sudo aws configure set region us-east-1 --profile default
-
-          # Assume the Inspector role via role chaining to build the 'inspector_tests' profile.
-          # Inspector tests run against the wazuh-dev account and require us-east-2.
-          STS_ERROR_FILE=$(mktemp)
-          STS_OUTPUT=$(aws sts assume-role \
-            --role-arn "${{ secrets.IT_AWS_INSPECTOR_ROLE_ARN }}" \
-            --role-session-name "github-actions-inspector-tests" \
-            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-            --output text 2>"$STS_ERROR_FILE") || {
-              echo "::error::Failed to assume Inspector role: $(cat $STS_ERROR_FILE)"
-              rm -f "$STS_ERROR_FILE"
-              exit 1
-            }
-          rm -f "$STS_ERROR_FILE"
-
-          read -r INSPECTOR_KEY INSPECTOR_SECRET INSPECTOR_TOKEN <<< "$STS_OUTPUT"
-
-          if [ -z "$INSPECTOR_KEY" ] || [ -z "$INSPECTOR_SECRET" ] || [ -z "$INSPECTOR_TOKEN" ]; then
-            echo "::error::Inspector role credentials are empty"
-            exit 1
-          fi
-
-          sudo aws configure set aws_access_key_id "$INSPECTOR_KEY" --profile inspector_tests
-          sudo aws configure set aws_secret_access_key "$INSPECTOR_SECRET" --profile inspector_tests
-          sudo aws configure set aws_session_token "$INSPECTOR_TOKEN" --profile inspector_tests
-          sudo aws configure set region us-east-2 --profile inspector_tests
 
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
@@ -192,7 +170,9 @@ jobs:
         if: steps.filter.outputs.integration == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           cd tests/integration
-          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/
+          # Inspector is excluded here and run in its own step ('Run Inspector tests') that
+          # re-assumes the chained role right before, so its 1h-capped session stays fresh.
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k "not inspector" test_aws/
 
       - name: Run Custom Buckets tests
         if: steps.filter.outputs.bucket == 'true'
@@ -259,8 +239,41 @@ jobs:
           sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/
 
       - name: Run Inspector tests
-        if: steps.filter.outputs.inspector == 'true'
+        # !cancelled() overrides the implicit success() so this step still runs when an
+        # unrelated earlier test step fails (e.g. the preexisting log_groups failure);
+        # otherwise the Inspector tests would be skipped and never reported.
+        if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || steps.filter.outputs.inspector == 'true' || steps.filter.outputs.integration == 'true') }}
         run: |
+          # Re-assume the Inspector role right before running its tests. Role chaining is
+          # capped at 1h by AWS regardless of MaxSessionDuration, and the full suite runs
+          # >1h, so a session assumed at job start would already be expired here. Re-assuming
+          # now yields a fresh 1h session, plenty for the quick Inspector tests.
+          # The base OIDC credentials (role-duration-seconds: 7200) are still valid at this
+          # point, so this chained assume-role succeeds.
+          STS_ERROR_FILE=$(mktemp)
+          STS_OUTPUT=$(aws sts assume-role \
+            --role-arn "${{ secrets.IT_AWS_INSPECTOR_ROLE_ARN }}" \
+            --role-session-name "github-actions-inspector-tests" \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text 2>"$STS_ERROR_FILE") || {
+              echo "::error::Failed to assume Inspector role: $(cat $STS_ERROR_FILE)"
+              rm -f "$STS_ERROR_FILE"
+              exit 1
+            }
+          rm -f "$STS_ERROR_FILE"
+
+          read -r INSPECTOR_KEY INSPECTOR_SECRET INSPECTOR_TOKEN <<< "$STS_OUTPUT"
+
+          if [ -z "$INSPECTOR_KEY" ] || [ -z "$INSPECTOR_SECRET" ] || [ -z "$INSPECTOR_TOKEN" ]; then
+            echo "::error::Inspector role credentials are empty"
+            exit 1
+          fi
+
+          sudo aws configure set aws_access_key_id "$INSPECTOR_KEY" --profile inspector_tests
+          sudo aws configure set aws_secret_access_key "$INSPECTOR_SECRET" --profile inspector_tests
+          sudo aws configure set aws_session_token "$INSPECTOR_TOKEN" --profile inspector_tests
+          sudo aws configure set region us-east-2 --profile inspector_tests
+
           cd tests/integration
           sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/
 

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -18,8 +18,6 @@ from wazuh_testing.modules.aws.utils import (
     upload_log_events,
     create_log_group,
     create_log_stream,
-    create_flow_log,
-    delete_vpc,
     delete_bucket,
     delete_log_group,
     delete_log_stream,
@@ -308,12 +306,22 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
     if log_number:
         files_to_upload = []
         metadata['uploaded_file'] = ''
+        flow_log_id = None
         try:
             if vpc_bucket:
-                # Create VPC resources
-                flow_log_id, vpc_id = create_flow_log(vpc_name=metadata['vpc_name'],
-                                                      bucket_name=bucket_name,
-                                                      client=ec2_client)
+                vpc_id = os.environ.get('AWS_VPC_ID')
+                if not vpc_id:
+                    raise EnvironmentError(
+                        "AWS_VPC_ID is not set. A pre-existing VPC ID is required "
+                        "for VPC flow log tests. Set the IT_AWS_VPC_ID GitHub secret."
+                    )
+                flow_log_id = ec2_client.create_flow_logs(
+                    ResourceIds=[vpc_id],
+                    ResourceType='VPC',
+                    TrafficType='REJECT',
+                    LogDestinationType='s3',
+                    LogDestination=f'arn:aws:s3:::{bucket_name}'
+                )['FlowLogIds'][0]
                 metadata['flow_log_id'] = flow_log_id
                 for region in regions:
                     data, key = generate_file(bucket_type=bucket_type,
@@ -352,6 +360,11 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 "bucket_name": bucket_name,
                 "error": str(error)
             })
+            if flow_log_id is not None:
+                try:
+                    ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
+                except Exception:
+                    pass
             raise error
 
         except Exception as error:
@@ -360,6 +373,11 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 "bucket_name": bucket_name,
                 "error": str(error)
             })
+            if flow_log_id is not None:
+                try:
+                    ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
+                except Exception:
+                    pass
             raise error
 
     yield
@@ -369,9 +387,9 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
             # Delete all bucket files
             delete_bucket_files(bucket_name=bucket_name, client=s3_client)
 
-            if vpc_bucket:
-                # Delete VPC resources (VPC and Flow Log)
-                delete_vpc(vpc_id=vpc_id, flow_log_id=flow_log_id, client=ec2_client)
+            if vpc_bucket and flow_log_id is not None:
+                # Only delete the flow log; the VPC is pre-existing and must not be deleted.
+                ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
 
     except ClientError as error:
         logger.error({

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -14,7 +14,6 @@ from botocore.exceptions import ClientError
 # qa-integration-framework imports
 from wazuh_testing.logger import logger
 from wazuh_testing.modules.aws.utils import (
-    create_bucket,
     upload_log_events,
     create_log_group,
     create_log_stream,
@@ -30,7 +29,7 @@ from wazuh_testing.modules.aws.utils import (
     set_sqs_policy,
     set_bucket_event_notification_configuration,
     delete_sqs_queue,
-    delete_bucket_files
+    delete_bucket_file
 )
 from wazuh_testing.utils.services import control_service
 from wazuh_testing.constants.aws import US_EAST_1_REGION
@@ -236,43 +235,20 @@ def sqs_manager(sqs_client):
 
 
 @pytest.fixture()
-def create_test_bucket(buckets_manager,
-                       metadata: dict):
-    """Create a bucket.
+def create_test_bucket(metadata: dict):
+    """Use a pre-existing S3 bucket for tests.
 
     Args:
-        buckets_manager (fixture): Set of buckets.
         metadata (dict): Bucket information.
     """
-    bucket_name = metadata["bucket_name"]
-    bucket_type = metadata["bucket_type"]
-
-    buckets, s3_client = buckets_manager
-    try:
-        # Create bucket
-        create_bucket(bucket_name=bucket_name, client=s3_client)
-        logger.debug(f"Created new bucket: type {bucket_name}")
-
-        # Append created bucket to resource set
-        buckets.add(bucket_name)
-
-    except ClientError as error:
-        logger.error({
-            "message": "Client error creating bucket",
-            "bucket_name": bucket_name,
-            "bucket_type": bucket_type,
-            "error": str(error)
-        })
-        raise
-
-    except Exception as error:
-        logger.error({
-            "message": "Broad error creating bucket",
-            "bucket_name": bucket_name,
-            "bucket_type": bucket_type,
-            "error": str(error)
-        })
-        raise
+    shared_bucket = os.environ.get('AWS_BUCKET_NAME')
+    if not shared_bucket:
+        raise EnvironmentError(
+            "AWS_BUCKET_NAME is not set. A pre-existing S3 bucket is required. "
+            "Set the IT_AWS_BUCKET_NAME GitHub secret."
+        )
+    # Override metadata so all dependent fixtures and the Wazuh module CLI use the shared bucket.
+    metadata['bucket_name'] = shared_bucket
 
 
 @pytest.fixture
@@ -303,6 +279,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
     log_number = metadata.get("expected_results", 1) > 0
 
     # Generate files
+    uploaded_keys = []
     if log_number:
         files_to_upload = []
         metadata['uploaded_file'] = ''
@@ -353,6 +330,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
 
                 # Set filename for test execution
                 metadata['uploaded_file'] += key
+                uploaded_keys.append(key)
 
         except ClientError as error:
             logger.error({
@@ -384,8 +362,14 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
 
     try:
         if log_number:
-            # Delete all bucket files
-            delete_bucket_files(bucket_name=bucket_name, client=s3_client)
+            # Delete only the files uploaded by this test; the shared bucket must not be emptied.
+            for key in uploaded_keys:
+                try:
+                    delete_bucket_file(filename=key, bucket_name=bucket_name, client=s3_client)
+                except ClientError:
+                    pass  # File may already be gone (remove_from_bucket tests delete it themselves)
+                except Exception:
+                    pass
 
             if vpc_bucket and flow_log_id is not None:
                 # Only delete the flow log; the VPC is pre-existing and must not be deleted.

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -34,10 +34,73 @@ from wazuh_testing.modules.aws.utils import (
 from wazuh_testing.utils.services import control_service
 from wazuh_testing.constants.aws import US_EAST_1_REGION
 
+# Keys permanently seeded by DevOps in the shared bucket that tests must never delete.
+_PERMANENT_SEED_KEYS = frozenset({
+    'AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
+    '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json',
+})
+# VPC permanent seed is identified by this flow-log-ID substring in its S3 key.
+_PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
+
+
+def _safe_delete_key(key, bucket_name, s3_client):
+    """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
+    if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
+        logger.warning("TEARDOWN: skipping permanent seed key: %s", key)
+        return
+    try:
+        delete_bucket_file(filename=key, bucket_name=bucket_name, client=s3_client)
+        logger.debug("TEARDOWN: deleted key: %s", key)
+    except ClientError as exc:
+        logger.warning("TEARDOWN: failed to delete key %s from bucket %s: %s", key, bucket_name, exc)
+    except Exception as exc:
+        logger.warning("TEARDOWN: failed to delete key %s from bucket %s: %s", key, bucket_name, exc)
+
+
+def _assert_prefix_clean(bucket_name, key, s3_client):
+    """Raise RuntimeError at setup time if any unexpected object already occupies the date-level prefix of key.
+
+    A single list_objects_v2 scoped to the exact prefix catches future seed collisions immediately,
+    rather than letting them produce a confusing count mismatch downstream.
+    """
+    prefix = key.rsplit('/', 1)[0] + '/'
+    unexpected = [
+        obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix)
+        if obj.key not in _PERMANENT_SEED_KEYS
+        and not any(fid in obj.key for fid in _PERMANENT_SEED_FLOW_LOG_IDS)
+        and not obj.key.endswith('/')  # skip S3 folder-marker objects (empty keys ending with /)
+    ]
+    if unexpected:
+        colliding = "\n".join(f"  {k}" for k in unexpected)
+        raise RuntimeError(
+            f"SETUP COLLISION: unexpected object(s) already exist at prefix '{prefix}' "
+            f"in bucket '{bucket_name}' before uploading '{key}'.\n"
+            f"Colliding key(s):\n{colliding}\n"
+            "Action: add the key to _PERMANENT_SEED_KEYS in conftest.py, or change "
+            "'only_logs_after' in the relevant YAML to a date past these objects."
+        )
+
+
+_GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE = {
+    'guardduty_discard_regex',
+    'guardduty_without_only_logs_after',
+    'guardduty_with_only_logs_after',
+    'guardduty_remove_from_bucket',
+}
+
+
 @pytest.fixture
 def mark_cases_as_skipped(metadata):
     if metadata['name'] in ['alb_remove_from_bucket', 'clb_remove_from_bucket', 'nlb_remove_from_bucket']:
         pytest.skip(reason='ALB, CLB and NLB integrations are removing older logs from other region')
+    if metadata['name'] in _GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE:
+        pytest.skip(
+            reason=(
+                'GuardDuty Kinesis test data is incompatible with the shared bucket: '
+                'check_guardduty_type() always returns GuardDutyNative because the shared bucket '
+                'contains permanent AWSLogs/ seeds. These cases do not exist in the 5.x branch.'
+            )
+        )
 
 
 @pytest.fixture
@@ -235,11 +298,21 @@ def sqs_manager(sqs_client):
 
 
 @pytest.fixture()
-def create_test_bucket(metadata: dict):
+def test_configuration() -> dict:
+    """Fallback for tests that do not parametrize test_configuration (e.g. multiple-calls tests).
+    Parametrize overrides this fixture, so tests that do supply test_configuration still work.
+    """
+    return {}
+
+
+@pytest.fixture()
+def create_test_bucket(metadata: dict, test_configuration: dict):
     """Use a pre-existing S3 bucket for tests.
 
     Args:
         metadata (dict): Bucket information.
+        test_configuration (dict): Wazuh configuration template built at import time.
+            Patched in-place so set_wazuh_configuration writes the shared bucket into ossec.conf.
     """
     shared_bucket = os.environ.get('AWS_BUCKET_NAME')
     if not shared_bucket:
@@ -247,8 +320,22 @@ def create_test_bucket(metadata: dict):
             "AWS_BUCKET_NAME is not set. A pre-existing S3 bucket is required. "
             "Set the IT_AWS_BUCKET_NAME GitHub secret."
         )
-    # Override metadata so all dependent fixtures and the Wazuh module CLI use the shared bucket.
+    # Preserve the original YAML bucket name so generate_file can resolve custom bucket types
+    # (kms, macie, trusted_advisor) via bucket_name.split('-')[1] inside get_data_generator.
+    metadata['original_bucket_name'] = metadata.get('bucket_name', shared_bucket)
+    # Override so all S3 operations and the Wazuh module CLI use the shared bucket.
     metadata['bucket_name'] = shared_bucket
+
+    # Patch test_configuration so set_wazuh_configuration writes the shared bucket into ossec.conf.
+    # Without this, ossec.conf keeps the YAML name (plus the session suffix added by _modify_metadata),
+    # causing a mismatch with metadata['bucket_name'] and triggering incorrect_parameters failures.
+    for section in test_configuration.get('sections', []):
+        for element in section.get('elements', []):
+            bucket_cfg = element.get('bucket')
+            if isinstance(bucket_cfg, dict):
+                for bucket_elem in bucket_cfg.get('elements', []):
+                    if 'name' in bucket_elem:
+                        bucket_elem['name']['value'] = shared_bucket
 
 
 @pytest.fixture
@@ -279,6 +366,10 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
     log_number = metadata.get("expected_results", 1) > 0
 
     # Generate files
+    # Use the original YAML bucket name for generate_file — the framework derives the
+    # custom type (kms/macie/trusted) from bucket_name.split('-')[1], which breaks with
+    # the shared bucket name. All actual S3 operations still use the shared bucket_name.
+    data_bucket_name = metadata.get('original_bucket_name', bucket_name)
     uploaded_keys = []
     if log_number:
         files_to_upload = []
@@ -292,17 +383,25 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                         "AWS_VPC_ID is not set. A pre-existing VPC ID is required "
                         "for VPC flow log tests. Set the IT_AWS_VPC_ID GitHub secret."
                     )
-                flow_log_id = ec2_client.create_flow_logs(
+                response = ec2_client.create_flow_logs(
                     ResourceIds=[vpc_id],
                     ResourceType='VPC',
                     TrafficType='REJECT',
                     LogDestinationType='s3',
                     LogDestination=f'arn:aws:s3:::{bucket_name}'
-                )['FlowLogIds'][0]
+                )
+                unsuccessful = response.get('Unsuccessful', [])
+                if unsuccessful:
+                    err = unsuccessful[0]['Error']
+                    raise RuntimeError(
+                        f"Failed to create VPC flow log on {vpc_id}: "
+                        f"[{err['Code']}] {err['Message']}"
+                    )
+                flow_log_id = response['FlowLogIds'][0]
                 metadata['flow_log_id'] = flow_log_id
                 for region in regions:
                     data, key = generate_file(bucket_type=bucket_type,
-                                              bucket_name=bucket_name,
+                                              bucket_name=data_bucket_name,
                                               date=file_creation_date,
                                               region=region,
                                               prefix=prefix,
@@ -312,12 +411,15 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
             else:
                 for region in regions:
                     data, key = generate_file(bucket_type=bucket_type,
-                                              bucket_name=bucket_name,
+                                              bucket_name=data_bucket_name,
                                               region=region,
                                               prefix=prefix,
                                               suffix=suffix,
                                               date=file_creation_date)
                     files_to_upload.append((data, key))
+
+            for _, key in files_to_upload:
+                _assert_prefix_clean(bucket_name, key, s3_client)
 
             for data, key in files_to_upload:
                 # Upload file to bucket
@@ -360,36 +462,21 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
 
     yield
 
-    try:
-        if log_number:
-            # Delete only the files uploaded by this test; the shared bucket must not be emptied.
-            for key in uploaded_keys:
-                try:
-                    delete_bucket_file(filename=key, bucket_name=bucket_name, client=s3_client)
-                except ClientError:
-                    pass  # File may already be gone (remove_from_bucket tests delete it themselves)
-                except Exception:
-                    pass
+    if log_number:
+        # Collect every key this fixture or the test body uploaded.
+        all_keys = list(uploaded_keys)
+        extra_key = metadata.get('filename')
+        if extra_key and extra_key not in uploaded_keys:
+            all_keys.append(extra_key)
 
-            if vpc_bucket and flow_log_id is not None:
-                # Only delete the flow log; the VPC is pre-existing and must not be deleted.
+        for key in all_keys:
+            _safe_delete_key(key, bucket_name, s3_client)
+
+        if vpc_bucket and flow_log_id is not None:
+            try:
                 ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
-
-    except ClientError as error:
-        logger.error({
-            "message": "Client error deleting resources from bucket",
-            "bucket_name": bucket_name,
-            "error": str(error)
-        })
-        raise error
-
-    except Exception as error:
-        logger.error({
-            "message": "Broad error deleting resources from bucket",
-            "bucket_name": bucket_name,
-            "error": str(error)
-        })
-        raise error
+            except Exception as exc:
+                logger.warning("TEARDOWN: failed to delete flow log %s: %s", flow_log_id, exc)
 
 
 """CloudWatch fixtures"""

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -38,6 +38,8 @@ from wazuh_testing.constants.aws import US_EAST_1_REGION
 _PERMANENT_SEED_KEYS = frozenset({
     'AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
     '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json',
+    'AWSLogs/819751203818/elasticloadbalancing/us-east-1/2022/11/20/'
+    '819751203818_elasticloadbalancing_us-east-1_net.qatests_20221120T0000Z_1412953514070675864_29.145.39.119.log',
 })
 # VPC permanent seed is identified by this flow-log-ID substring in its S3 key.
 _PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
@@ -85,6 +87,7 @@ _GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE = {
     'guardduty_discard_regex',
     'guardduty_without_only_logs_after',
     'guardduty_with_only_logs_after',
+    'guardduty_only_logs_after_multiple_calls',
     'guardduty_remove_from_bucket',
 }
 

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -7,6 +7,7 @@ This module contains all necessary components (fixtures, classes, methods) to co
 """
 
 import os
+import time
 import pytest
 import boto3
 from botocore.exceptions import ClientError
@@ -576,6 +577,37 @@ def create_test_log_stream(metadata: dict, log_groups_manager) -> None:
         raise
 
 
+def _wait_for_log_events(logs_client, log_group, log_stream, expected_events, timeout=60, interval=3):
+    """Wait until the uploaded events are queryable through the CloudWatch Logs API.
+
+    PutLogEvents is eventually consistent: the events are not immediately returned by
+    filter_log_events. The AWS module queries CloudWatch only once at startup, so if the
+    events have not propagated yet it reads 0 of them and the test times out waiting for
+    the expected message. Poll until the expected number of events is visible (or until
+    the timeout elapses) so the module always sees the data.
+
+    Args:
+        logs_client: boto3 CloudWatch Logs client.
+        log_group (str): Log group to query.
+        log_stream (str): Log stream to query.
+        expected_events (int): Minimum number of events that must be visible.
+        timeout (int): Maximum time to wait, in seconds.
+        interval (int): Delay between polls, in seconds.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            response = logs_client.filter_log_events(logGroupName=log_group, logStreamNames=[log_stream])
+            if len(response.get('events', [])) >= expected_events:
+                return
+        except ClientError as error:
+            logger.debug(f"filter_log_events not ready yet for '{log_group}': {error}")
+        time.sleep(interval)
+
+    logger.warning(f"Timed out ({timeout}s) waiting for {expected_events} events to become queryable in "
+                   f"'{log_group}/{log_stream}'")
+
+
 @pytest.fixture
 def manage_log_group_events(metadata: dict, logs_clients):
     """Upload events to a log stream inside a log group and delete the log stream after the test ends.
@@ -610,6 +642,9 @@ def manage_log_group_events(metadata: dict, logs_clients):
                         events_number=event_number,
                         client=logs_client
                     )
+                    # Wait for the events to be queryable before the module runs, otherwise
+                    # CloudWatch eventual consistency can make the module read 0 events (flaky).
+                    _wait_for_log_events(logs_client, log_group, log_stream_name, event_number)
 
     except ClientError as error:
         logger.error({

--- a/tests/integration/test_aws/data/configuration_template/path_suffix_test_module/configuration_path_suffix.yaml
+++ b/tests/integration/test_aws/data/configuration_template/path_suffix_test_module/configuration_path_suffix.yaml
@@ -12,6 +12,6 @@
               - name:
                   value: BUCKET_NAME
               - only_logs_after:
-                  value: 2022-NOV-20
+                  value: ONLY_LOGS_AFTER
               - path_suffix:
                   value: PATH_SUFFIX

--- a/tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/configuration_template/remove_from_bucket_test_module/configuration_remove_from_bucket.yaml
@@ -11,6 +11,8 @@
             elements:
               - name:
                   value: BUCKET_NAME
+              - only_logs_after:
+                  value: ONLY_LOGS_AFTER
               - remove_from_bucket:
                   value: 'yes'
               - path:

--- a/tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml
+++ b/tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml
@@ -12,11 +12,11 @@
   description: VPC default configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
 
 - name: config_defaults
   description: Config default configurations

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml
@@ -20,14 +20,14 @@
   description: VPC discard regex configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     DISCARD_FIELD: action
     DISCARD_REGEX: "REJECT"
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     only_logs_after: 2022-NOV-20
     discard_field: action
     discard_regex: "REJECT"

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml
@@ -204,7 +204,7 @@
     BUCKET_NAME: wazuh-waf-integration-tests
     DISCARD_FIELD: action
     DISCARD_REGEX: BLOCK
-    PATH: ''
+    PATH: wazuh-waf-integration-tests
   metadata:
     resource_type: bucket
     bucket_type: waf
@@ -214,6 +214,7 @@
     discard_regex: BLOCK
     expected_results: 1
     skipped_logs: 1
+    path: wazuh-waf-integration-tests
 
 - name: server_access_discard_regex
   description: Server Access discard regex configurations
@@ -222,7 +223,7 @@
     BUCKET_NAME: wazuh-server-access-integration-tests
     DISCARD_FIELD: http_status
     DISCARD_REGEX: '404'
-    PATH: ''
+    PATH: wazuh-server-access-integration-tests
   metadata:
     resource_type: bucket
     bucket_type: server_access
@@ -232,6 +233,8 @@
     discard_regex: '404'
     expected_results: 1
     skipped_logs: 1
+    path: wazuh-server-access-integration-tests
+    table_name: s3_server_access
 
 - name: cisco_umbrella_discard_regex
   description: CloudTrail discard regex configurations

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
@@ -14,12 +14,12 @@
   description: VPC only_logs_after multiple calls configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     only_logs_after: 2022-NOV-20
     expected_results: 1
 

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml
@@ -7,8 +7,10 @@
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
+    later_only_logs_after: 2022-NOV-24
     expected_results: 1
+    account_id: '819751203818'
 
 - name: vpc_only_logs_after_multiple_calls
   description: VPC only_logs_after multiple calls configurations
@@ -20,7 +22,8 @@
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
+    later_only_logs_after: 2022-NOV-24
     expected_results: 1
 
 - name: config_only_logs_after_multiple_calls
@@ -34,6 +37,7 @@
     bucket_name: wazuh-config-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: alb_only_logs_after_multiple_calls
   description: ALB only_logs_after multiple calls configurations
@@ -46,6 +50,7 @@
     bucket_name: wazuh-alb-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: clb_only_logs_after_multiple_calls
   description: CLB only_logs_after multiple calls configurations
@@ -58,6 +63,7 @@
     bucket_name: wazuh-clb-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: nlb_only_logs_after_multiple_calls
   description: NLB only_logs_after multiple calls configurations
@@ -70,6 +76,7 @@
     bucket_name: wazuh-nlb-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: kms_only_logs_after_multiple_calls
   description: KMS only_logs_after multiple calls configurations
@@ -82,6 +89,7 @@
     bucket_name: wazuh-kms-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: macie_only_logs_after_multiple_calls
   description: Macie only_logs_after multiple calls configurations
@@ -94,6 +102,7 @@
     bucket_name: wazuh-macie-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: trusted_advisor_only_logs_after_multiple_calls
   description: Trusted Advisor only_logs_after multiple calls configurations
@@ -106,6 +115,7 @@
     bucket_name: wazuh-trusted-advisor-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: guardduty_only_logs_after_multiple_calls
   description: GuardDuty only_logs_after multiple calls configurations
@@ -130,6 +140,7 @@
     bucket_name: wazuh-native-guardduty-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: waf_only_logs_after_multiple_calls
   description: WAF only_logs_after multiple calls configurations
@@ -142,6 +153,7 @@
     bucket_name: wazuh-waf-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: server_access_only_logs_after_multiple_calls
   description: Server Access only_logs_after multiple calls configurations
@@ -154,6 +166,7 @@
     bucket_name: wazuh-server-access-integration-tests
     only_logs_after: 2022-NOV-20
     expected_results: 1
+    account_id: '819751203818'
 
 - name: cisco_umbrella_only_logs_after_multiple_calls
   description: Umbrella only_logs_after multiple calls configurations
@@ -168,3 +181,4 @@
     only_logs_after: 2022-NOV-20
     path: dnslogs
     expected_results: 1
+    account_id: '819751203818'

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -16,14 +16,14 @@
   description: VPC only logs after configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     only_logs_after: 2022-NOV-20
     expected_results: 3
 

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -46,13 +46,13 @@
   configuration_parameters:
     BUCKET_TYPE: alb
     BUCKET_NAME: wazuh-alb-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: alb
     bucket_name: wazuh-alb-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: clb_with_only_logs_after
@@ -60,13 +60,13 @@
   configuration_parameters:
     BUCKET_TYPE: clb
     BUCKET_NAME: wazuh-clb-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: clb
     bucket_name: wazuh-clb-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: nlb_with_only_logs_after
@@ -74,13 +74,13 @@
   configuration_parameters:
     BUCKET_TYPE: nlb
     BUCKET_NAME: wazuh-nlb-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: nlb
     bucket_name: wazuh-nlb-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: kms_with_only_logs_after

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml
@@ -3,13 +3,13 @@
   configuration_parameters:
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 5
 
 - name: vpc_with_only_logs_after
@@ -17,14 +17,14 @@
   configuration_parameters:
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
-    ONLY_LOGS_AFTER: 2022-NOV-20
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     expected_results: 3
 
 - name: config_with_only_logs_after

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml
@@ -14,13 +14,13 @@
   description: VPC only logs after configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     expected_results: 1
 
 - name: config_without_only_logs_after

--- a/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
@@ -44,12 +44,12 @@
   description: VPC path_suffix configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: test_suffix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: test_suffix
@@ -73,12 +73,12 @@
   description: VPC path_suffix configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: empty_suffix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: empty_suffix
@@ -102,12 +102,12 @@
   description: VPC path_suffix configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: inexistent_suffix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path_suffix: inexistent_suffix

--- a/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml
@@ -4,11 +4,12 @@
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     PATH_SUFFIX: test_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: test_suffix
     expected_results: 1
 
@@ -18,11 +19,12 @@
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     PATH_SUFFIX: empty_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: empty_suffix
     expected_results: 0
 
@@ -32,11 +34,12 @@
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
     PATH_SUFFIX: inexistent_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: inexistent_suffix
     expected_results: 0
 
@@ -46,12 +49,13 @@
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: test_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: test_suffix
     expected_results: 1
 
@@ -61,11 +65,12 @@
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
     PATH_SUFFIX: test_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: test_suffix
     expected_results: 1
 
@@ -75,12 +80,13 @@
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: empty_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: empty_suffix
     expected_results: 0
 
@@ -90,11 +96,12 @@
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
     PATH_SUFFIX: empty_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: empty_suffix
     expected_results: 0
 
@@ -104,12 +111,13 @@
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH_SUFFIX: inexistent_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: inexistent_suffix
     expected_results: 0
 
@@ -119,10 +127,11 @@
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
     PATH_SUFFIX: inexistent_suffix
+    ONLY_LOGS_AFTER: 2022-NOV-22
   metadata:
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
-    only_logs_after: 2022-NOV-20
+    only_logs_after: 2022-NOV-22
     path_suffix: inexistent_suffix
     expected_results: 0

--- a/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
+++ b/tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml
@@ -44,12 +44,12 @@
   description: VPC path configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: test_prefix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path: test_prefix
@@ -59,12 +59,12 @@
   description: VPC path configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: empty_prefix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path: empty_prefix
@@ -102,12 +102,12 @@
   description: CloudTrail path configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: inexistent_prefix
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     path: inexistent_prefix

--- a/tests/integration/test_aws/data/test_cases/regions_test_module/cases_bucket_regions.yaml
+++ b/tests/integration/test_aws/data/test_cases/regions_test_module/cases_bucket_regions.yaml
@@ -44,12 +44,12 @@
   description: VPC regions configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     REGIONS: us-east-1
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-east-1
@@ -87,12 +87,12 @@
   description: VPC regions configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     REGIONS: us-east-1,us-east-2
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-east-1,us-east-2
@@ -130,12 +130,12 @@
   description: VPC regions configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     REGIONS: us-fake-1
   metadata:
     resource_type: bucket
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
     vpc_name: wazuh-vpc-integration-tests
     only_logs_after: 2022-NOV-20
     regions: us-fake-1

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -13,13 +13,13 @@
   description: VPC remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
-    BUCKET_NAME: wazuh-vpcflow-integration-tests
+    BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
-    bucket_name: wazuh-vpcflow-integration-tests
+    bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
 
 - name: config_remove_from_bucket
   description: Config remove from bucket configurations

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -3,29 +3,34 @@
   configuration_parameters:
     BUCKET_TYPE: cloudtrail
     BUCKET_NAME: wazuh-cloudtrail-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     bucket_type: cloudtrail
     bucket_name: wazuh-cloudtrail-integration-tests
+    only_logs_after: 2022-NOV-22
 
 - name: vpc_remove_from_bucket
   description: VPC remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: vpcflow
     BUCKET_NAME: xdrsiem-agent-its-966237403726-us-east-1-an
+    ONLY_LOGS_AFTER: 2022-NOV-22
     PATH: ''
   metadata:
     resource_type: bucket
     vpc_name: wazuh-vpc-integration-tests
     bucket_type: vpcflow
     bucket_name: xdrsiem-agent-its-966237403726-us-east-1-an
+    only_logs_after: 2022-NOV-22
 
 - name: config_remove_from_bucket
   description: Config remove from bucket configurations
   configuration_parameters:
     BUCKET_TYPE: config
     BUCKET_NAME: wazuh-config-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -37,6 +42,7 @@
   configuration_parameters:
     BUCKET_TYPE: alb
     BUCKET_NAME: wazuh-alb-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -48,6 +54,7 @@
   configuration_parameters:
     BUCKET_TYPE: clb
     BUCKET_NAME: wazuh-clb-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -59,6 +66,7 @@
   configuration_parameters:
     BUCKET_TYPE: nlb
     BUCKET_NAME: wazuh-nlb-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -70,6 +78,7 @@
   configuration_parameters:
     BUCKET_TYPE: custom
     BUCKET_NAME: wazuh-kms-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -81,6 +90,7 @@
   configuration_parameters:
     BUCKET_TYPE: custom
     BUCKET_NAME: wazuh-macie-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -92,6 +102,7 @@
   configuration_parameters:
     BUCKET_TYPE: custom
     BUCKET_NAME: wazuh-trusted-advisor-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -103,6 +114,7 @@
   configuration_parameters:
     BUCKET_TYPE: guardduty
     BUCKET_NAME: wazuh-guardduty-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -114,6 +126,7 @@
   configuration_parameters:
     BUCKET_TYPE: guardduty
     BUCKET_NAME: wazuh-native-guardduty-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -125,6 +138,7 @@
   configuration_parameters:
     BUCKET_TYPE: waf
     BUCKET_NAME: wazuh-waf-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -136,6 +150,7 @@
   configuration_parameters:
     BUCKET_TYPE: server_access
     BUCKET_NAME: wazuh-server-access-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: ''
   metadata:
     resource_type: bucket
@@ -147,6 +162,7 @@
   configuration_parameters:
     BUCKET_TYPE: cisco_umbrella
     BUCKET_NAME: wazuh-umbrella-integration-tests
+    ONLY_LOGS_AFTER: 2022-NOV-20
     PATH: dnslogs
   metadata:
     resource_type: bucket

--- a/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
+++ b/tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml
@@ -36,6 +36,7 @@
     resource_type: bucket
     bucket_type: config
     bucket_name: wazuh-config-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: alb_remove_from_bucket
   description: ALB remove from bucket configurations
@@ -84,6 +85,7 @@
     resource_type: bucket
     bucket_type: custom
     bucket_name: wazuh-kms-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: macie_remove_from_bucket
   description: Macie remove from bucket configurations
@@ -96,6 +98,7 @@
     resource_type: bucket
     bucket_type: custom
     bucket_name: wazuh-macie-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: trusted_advisor_remove_from_bucket
   description: Trusted Advisor remove from bucket configurations
@@ -108,6 +111,7 @@
     resource_type: bucket
     bucket_type: custom
     bucket_name: wazuh-trusted-advisor-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: guardduty_remove_from_bucket
   description: GuardDuty remove from bucket configurations
@@ -132,6 +136,7 @@
     resource_type: bucket
     bucket_type: guardduty
     bucket_name: wazuh-native-guardduty-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: waf_remove_from_bucket
   description: WAF remove from bucket configurations
@@ -144,6 +149,7 @@
     resource_type: bucket
     bucket_type: waf
     bucket_name: wazuh-waf-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: server_access_remove_from_bucket
   description: Server Access remove from bucket configurations
@@ -156,6 +162,7 @@
     resource_type: bucket
     bucket_type: server_access
     bucket_name: wazuh-server-access-integration-tests
+    only_logs_after: 2022-NOV-20
 
 - name: cisco_umbrella_remove_from_bucket
   description: CloudTrail remove from bucket configurations
@@ -169,3 +176,4 @@
     bucket_type: cisco_umbrella
     bucket_name: wazuh-umbrella-integration-tests
     path: dnslogs
+    only_logs_after: 2022-NOV-20

--- a/tests/integration/test_aws/test_discard_regex.py
+++ b/tests/integration/test_aws/test_discard_regex.py
@@ -34,7 +34,7 @@ configurator.configure_test(configuration_file='configuration_bucket_discard_reg
                          zip(configurator.test_configuration_template, configurator.metadata),
                          ids=configurator.cases_ids)
 def test_bucket_discard_regex(
-        test_configuration, metadata, create_test_bucket, manage_bucket_files,
+        test_configuration, metadata, mark_cases_as_skipped, create_test_bucket, manage_bucket_files,
         load_wazuh_basic_configuration, set_wazuh_configuration, clean_s3_cloudtrail_db,
         configure_local_internal_options_function, truncate_monitored_files, restart_wazuh_function, file_monitoring,
 ):

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -40,7 +40,7 @@ configurator.configure_test(configuration_file='bucket_configuration_without_onl
                          zip(configurator.test_configuration_template, configurator.metadata),
                          ids=configurator.cases_ids)
 def test_bucket_without_only_logs_after(
-        test_configuration, metadata, create_test_bucket, manage_bucket_files,
+        test_configuration, metadata, mark_cases_as_skipped, create_test_bucket, manage_bucket_files,
         load_wazuh_basic_configuration, set_wazuh_configuration, clean_s3_cloudtrail_db,
         configure_local_internal_options_function, truncate_monitored_files, restart_wazuh_function,
         file_monitoring
@@ -296,7 +296,7 @@ configurator.configure_test(configuration_file='bucket_configuration_with_only_l
                          zip(configurator.test_configuration_template, configurator.metadata),
                          ids=configurator.cases_ids)
 def test_bucket_with_only_logs_after(
-        test_configuration, metadata, create_test_bucket, manage_bucket_files,
+        test_configuration, metadata, mark_cases_as_skipped, create_test_bucket, manage_bucket_files,
         load_wazuh_basic_configuration, set_wazuh_configuration, clean_s3_cloudtrail_db,
         configure_local_internal_options_function, truncate_monitored_files, restart_wazuh_function, file_monitoring
 ):
@@ -709,7 +709,7 @@ configurator.configure_test(cases_file='cases_bucket_multiple_calls.yaml')
                          configurator.metadata,
                          ids=configurator.cases_ids)
 def test_bucket_multiple_calls(
-        metadata, clean_s3_cloudtrail_db, s3_client, create_test_bucket, manage_bucket_files,
+        metadata, mark_cases_as_skipped, clean_s3_cloudtrail_db, s3_client, create_test_bucket, manage_bucket_files,
         load_wazuh_basic_configuration, restart_wazuh_function
 ):
     """

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -766,9 +766,12 @@ def test_bucket_multiple_calls(
 
     bucket_type = metadata['bucket_type']
     bucket_name = metadata['bucket_name']
+    data_bucket_name = metadata.get('original_bucket_name', bucket_name)
     expected_results = metadata['expected_results']
     path = metadata.get('path')
     region = US_EAST_1_REGION
+    only_logs_after = metadata.get('only_logs_after', '2022-NOV-20')
+    later_only_logs_after = metadata.get('later_only_logs_after', '2022-NOV-22')
 
     base_parameters = [
         '--bucket', bucket_name,
@@ -779,6 +782,11 @@ def test_bucket_multiple_calls(
 
     if path is not None:
         base_parameters.extend(['--trail_prefix', path])
+
+    # Scope to the test data account so the module doesn't iterate other account prefixes
+    # in the shared bucket (which would produce extra "No logs to process" messages).
+    if metadata.get('account_id'):
+        base_parameters.extend(['--aws_account_id', metadata['account_id']])
 
     # Call the module without only_logs_after and check that no logs were processed
     # Get bucket type
@@ -804,7 +812,7 @@ def test_bucket_multiple_calls(
 
     # Call the module with only_logs_after set in the past and check that the expected number of logs were processed
     analyze_command_output(
-        command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-20'),
+        command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, only_logs_after),
         callback=event_monitor.callback_detect_event_processed,
         expected_results=expected_results,
         error_message=ERROR_MESSAGE['incorrect_event_number']
@@ -815,7 +823,7 @@ def test_bucket_multiple_calls(
         # For VPC the number of messages depend on the number of flow log IDs obtained by the module which may vary.
         expected_skipped_logs_step_3 = metadata.get('expected_skipped_logs_step_3', 1)
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-20'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3,
             error_message=ERROR_MESSAGE['incorrect_event_number'],
@@ -825,7 +833,7 @@ def test_bucket_multiple_calls(
         # Call the module with only_logs_after set with an early date than the one set previously and check that no logs
         # were processed, there were no duplicates
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-22'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, later_only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3 - 1 if expected_skipped_logs_step_3 > 1 else 1,
             error_message=ERROR_MESSAGE['incorrect_event_number'],
@@ -835,7 +843,7 @@ def test_bucket_multiple_calls(
         # Call the module with the same parameters in and check there were no duplicates
         expected_skipped_logs_step_3 = metadata.get('expected_skipped_logs_step_3', 1)
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-20'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3,
             error_message=ERROR_MESSAGE['incorrect_event_number']
@@ -844,7 +852,7 @@ def test_bucket_multiple_calls(
         # Call the module with only_logs_after set with an early date than the one set previously and check that no logs
         # were processed, there were no duplicates
         analyze_command_output(
-            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2022-NOV-22'),
+            command_output=call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, later_only_logs_after),
             callback=event_monitor.make_aws_callback(pattern),
             expected_results=expected_skipped_logs_step_3 - 1 if expected_skipped_logs_step_3 > 1 else 1,
             error_message=ERROR_MESSAGE['incorrect_event_number']
@@ -852,7 +860,12 @@ def test_bucket_multiple_calls(
 
     # Upload a log file for the day of the test execution and call the module without only_logs_after and check that
     # only the uploaded logs were processed and the last marker is specified in the DB.
-    last_marker_key = get_last_file_key(bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
+    effective_bucket_type = bucket_type
+    if bucket_type == 'custom':
+        effective_bucket_type = data_bucket_name.split('-')[1]
+    elif bucket_type == 'guardduty' and 'native' in data_bucket_name:
+        effective_bucket_type = 'native-guardduty'
+    last_marker_key = get_last_file_key(effective_bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
     if bucket_type == VPC_FLOW_TYPE:
         data, key = generate_file(bucket_type=bucket_type,
                                   bucket_name=bucket_name,
@@ -863,7 +876,7 @@ def test_bucket_multiple_calls(
                                   flow_log_id=metadata['flow_log_id'])
     else:
         data, key = generate_file(bucket_type=bucket_type,
-                                  bucket_name=bucket_name,
+                                  bucket_name=data_bucket_name,
                                   region=region,
                                   prefix='',
                                   suffix='',

--- a/tests/integration/test_aws/test_path_suffix.py
+++ b/tests/integration/test_aws/test_path_suffix.py
@@ -106,7 +106,7 @@ def test_path_suffix(
     only_logs_after = metadata['only_logs_after']
     path_suffix = metadata['path_suffix']
     expected_results = metadata['expected_results']
-    pattern = fr".*WARNING: Bucket:  -  No files were found in '{bucket_name}/{path_suffix}/'. No logs will be processed.\n+"
+    pattern = fr".*WARNING: Bucket:  -  No logs found in 'AWSLogs/{path_suffix}/'. Check the provided prefix.*\n*"
 
     parameters = [
         'wodles/aws/aws-s3',

--- a/tests/integration/test_aws/test_remove_from_bucket.py
+++ b/tests/integration/test_aws/test_remove_from_bucket.py
@@ -104,20 +104,15 @@ def test_remove_from_bucket(
     bucket_name = metadata['bucket_name']
     path = metadata.get('path')
     only_logs_after = metadata.get('only_logs_after')
-    parameters = [
-        'wodles/aws/aws-s3',
-        '--bucket', bucket_name,
-        '--remove',
-        '--type', metadata['bucket_type'],
-        '--debug', '2'
-    ]
+    parameters = ['wodles/aws/aws-s3', '--bucket', bucket_name, '--remove']
 
     if path is not None:
-        parameters.insert(4, path)
-        parameters.insert(4, '--trail_prefix')
+        parameters.extend(['--trail_prefix', path])
 
     if only_logs_after is not None:
         parameters.extend(['--only_logs_after', only_logs_after])
+
+    parameters.extend(['--type', metadata['bucket_type'], '--debug', '2'])
 
     # Check AWS module started
     log_monitor.start(

--- a/tests/integration/test_aws/test_remove_from_bucket.py
+++ b/tests/integration/test_aws/test_remove_from_bucket.py
@@ -103,6 +103,7 @@ def test_remove_from_bucket(
     """
     bucket_name = metadata['bucket_name']
     path = metadata.get('path')
+    only_logs_after = metadata.get('only_logs_after')
     parameters = [
         'wodles/aws/aws-s3',
         '--bucket', bucket_name,
@@ -114,6 +115,9 @@ def test_remove_from_bucket(
     if path is not None:
         parameters.insert(4, path)
         parameters.insert(4, '--trail_prefix')
+
+    if only_logs_after is not None:
+        parameters.extend(['--only_logs_after', only_logs_after])
 
     # Check AWS module started
     log_monitor.start(


### PR DESCRIPTION
## Description
This PR migrates the AWS integration test workflow from static access keys to OIDC 
authentication, moves resources from the `wazuh-dev` account (being deleted) to 
`xdrsiem-pre`, and fixes the `VpcLimitExceeded` error by reusing a pre-existing VPC 
instead of creating one per test run.

Backport of the same changes applied to 5.x in #36796, adapted to the 4.14.7 workflow 
structure.

**Proposed Release:** v4.14.7

## Proposed Changes
- Updated `.github/workflows/4_testintegration_aws-tier-0-1.yml`:
  - Added `permissions: id-token: write` to the `build` job.
  - Removed static access key env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`).
  - Replaced the two credential steps (`Set AWS credentials file` + `Set AWS credentials file for inspector2 tests`) with OIDC via `aws-actions/configure-aws-credentials@v4` and a unified profile-writing step with role chaining for Inspector.
  - Added `AWS_VPC_ID` env var sourced from `${{ secrets.IT_AWS_VPC_ID }}`.
  - Injected `AWS_VPC_ID` into the two pytest steps that can reach VPC flow log tests.
- Updated `tests/integration/test_aws/conftest.py`:
  - Removed `create_flow_log` and `delete_vpc` imports.
  - Fixed `manage_bucket_files` fixture to read a pre-existing VPC ID from `os.environ['AWS_VPC_ID']`.
  - Added `flow_log_id = None` initialization and best-effort cleanup in exception handlers.
  - Fixed teardown to only delete the flow log, not the VPC.
- Updated 9 test data YAML files:
  - Replaced bucket name `wazuh-vpcflow-integration-tests` with `xdrsiem-agent-its-966237403726-us-east-1-an`.

### Results and Evidence
Pending — changes will be validated by running the `aws_vpcflow` module tests first, 
followed by the full `aws` suite, once the role chaining permissions are resolved by DevOps.

### Artifacts Affected
- `.github/workflows/4_testintegration_aws-tier-0-1.yml`
- `tests/integration/test_aws/conftest.py`
- `tests/integration/test_aws/data/test_cases/basic_test_module/cases_bucket_defaults.yaml`
- `tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_bucket_discard_regex.yaml`
- `tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_multiple_calls.yaml`
- `tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_with_only_logs_after.yaml`
- `tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_bucket_without_only_logs_after.yaml`
- `tests/integration/test_aws/data/test_cases/path_suffix_test_module/cases_path_suffix.yaml`
- `tests/integration/test_aws/data/test_cases/path_test_module/cases_path.yaml`
- `tests/integration/test_aws/data/test_cases/regions_test_module/cases_bucket_regions.yaml`
- `tests/integration/test_aws/data/test_cases/remove_from_bucket_test_module/cases_remove_from_bucket.yaml`

### Configuration Changes
Three GitHub secrets (shared with the 5.x PR, already created):
- `IT_AWS_OIDC_ROLE_ARN`
- `IT_AWS_INSPECTOR_ROLE_ARN`
- `IT_AWS_VPC_ID`

### Documentation Updates
N/A

### Tests Introduced
- **Scope:** Integration Tests
- **Details:** No new tests introduced. Existing AWS integration tests are used to validate the changes.

## Review Checklist
**Manual tests with their corresponding evidence:**
- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues