### PR TITLE
Fix enrollment key validation and improve input handling

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -339,6 +339,11 @@ int IDExist(const char *id, int discard_removed)
 /* Validate agent name */
 int OS_IsValidName(const char *u_name)
 {
+    /* Name must not be null */
+    if (!u_name) {
+        return (0);
+    }
+
     size_t i, uname_length = strlen(u_name);
 
     /* We must have something in the name */

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -472,7 +472,9 @@ static int w_enrollment_process_agent_key(char *buffer) {
 
     *tmpstr = '\0';
     char **entries = OS_StrBreak(' ', keys, 4);
-    if (OS_IsValidID(entries[ENTRY_ID]) && OS_IsValidName(entries[ENTRY_NAME]) &&
+    if (entries && entries[ENTRY_ID] && entries[ENTRY_NAME] &&
+            entries[ENTRY_IP] && entries[ENTRY_KEY] &&
+            OS_IsValidID(entries[ENTRY_ID]) && OS_IsValidName(entries[ENTRY_NAME]) &&
             OS_IsValidIP(entries[ENTRY_IP], NULL) && OS_IsValidName(entries[ENTRY_KEY])) {
         if( !w_enrollment_store_key_entry(keys) ) {
             // Key was stored
@@ -482,11 +484,13 @@ static int w_enrollment_process_agent_key(char *buffer) {
     } else {
         merror("One of the received key parameters does not have a valid format");
     }
-    int i;
-    for(i=0; i<4; i++){
-        os_free(entries[i]);
+    if (entries) {
+        int i;
+        for(i=0; i<4; i++){
+            os_free(entries[i]);
+        }
+        os_free(entries);
     }
-    os_free(entries);
     return ret;
 }
 

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -471,9 +471,9 @@ static int w_enrollment_process_agent_key(char *buffer) {
     }
 
     *tmpstr = '\0';
-    char **entrys = OS_StrBreak(' ', keys, 4);
-    if (OS_IsValidID(entrys[ENTRY_ID]) && OS_IsValidName(entrys[ENTRY_NAME]) &&
-            OS_IsValidIP(entrys[ENTRY_IP], NULL) && OS_IsValidName(entrys[ENTRY_KEY])) {
+    char **entries = OS_StrBreak(' ', keys, 4);
+    if (OS_IsValidID(entries[ENTRY_ID]) && OS_IsValidName(entries[ENTRY_NAME]) &&
+            OS_IsValidIP(entries[ENTRY_IP], NULL) && OS_IsValidName(entries[ENTRY_KEY])) {
         if( !w_enrollment_store_key_entry(keys) ) {
             // Key was stored
             minfo("Valid key received");
@@ -484,9 +484,9 @@ static int w_enrollment_process_agent_key(char *buffer) {
     }
     int i;
     for(i=0; i<4; i++){
-        os_free(entrys[i]);
+        os_free(entries[i]);
     }
-    os_free(entrys);
+    os_free(entries);
     return ret;
 }
 

--- a/src/unit_tests/addagent/test_validate.c
+++ b/src/unit_tests/addagent/test_validate.c
@@ -101,6 +101,9 @@ static void test_OS_IsValidName_length(void **state) {
 static void test_OS_IsValidName_edge_cases(void **state) {
     (void) state;
 
+    /* NULL name should be rejected */
+    assert_int_equal(OS_IsValidName(NULL), 0);
+
     /* Names starting with dots should be rejected */
     assert_int_equal(OS_IsValidName("."), 0);
     assert_int_equal(OS_IsValidName(".."), 0);

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -897,6 +897,27 @@ void test_w_enrollment_process_agent_key_invalid_key(void **state) {
     assert_int_equal(ret,-1);
 }
 
+void test_w_enrollment_process_agent_key_malformed_one_field(void **state) {
+    char key[] = "OSSEC K:'1'";
+    expect_string(__wrap__merror, formatted_msg, "One of the received key parameters does not have a valid format");
+    int ret = w_enrollment_process_agent_key(key);
+    assert_int_equal(ret,-1);
+}
+
+void test_w_enrollment_process_agent_key_malformed_two_fields(void **state) {
+    char key[] = "OSSEC K:'006 ubuntu1610'";
+    expect_string(__wrap__merror, formatted_msg, "One of the received key parameters does not have a valid format");
+    int ret = w_enrollment_process_agent_key(key);
+    assert_int_equal(ret,-1);
+}
+
+void test_w_enrollment_process_agent_key_malformed_three_fields(void **state) {
+    char key[] = "OSSEC K:'006 ubuntu1610 192.168.1.1'";
+    expect_string(__wrap__merror, formatted_msg, "One of the received key parameters does not have a valid format");
+    int ret = w_enrollment_process_agent_key(key);
+    assert_int_equal(ret,-1);
+}
+
 void test_w_enrollment_process_agent_key_valid_key(void **state) {
     char key[] = "OSSEC K:'006 ubuntu1610 192.168.1.1 95fefb8f0fe86bb8121f3f5621f2916c15a998728b3d50479aa64e6430b5a9f'";
     expect_string(__wrap_OS_IsValidIP, ip_address, "192.168.1.1");
@@ -1318,6 +1339,9 @@ int main() {
         cmocka_unit_test(test_w_enrollment_process_agent_key_short_buff),
         cmocka_unit_test(test_w_enrollment_process_agent_key_invalid_format),
         cmocka_unit_test(test_w_enrollment_process_agent_key_invalid_key),
+        cmocka_unit_test(test_w_enrollment_process_agent_key_malformed_one_field),
+        cmocka_unit_test(test_w_enrollment_process_agent_key_malformed_two_fields),
+        cmocka_unit_test(test_w_enrollment_process_agent_key_malformed_three_fields),
         cmocka_unit_test_setup_teardown(test_w_enrollment_process_agent_key_valid_key, setup_file_ops, teardown_file_ops),
         // w_enrollment_process_response
         cmocka_unit_test(test_w_enrollment_process_response_ssl_null),


### PR DESCRIPTION
## Description

This PR enhances the robustness of the agent enrollment process by adding defensive validation checks in the key parsing logic. The changes prevent potential crashes when processing malformed enrollment responses by ensuring all required fields are present before validation.

**Credits:** Thanks to Emre Koca (@kocaemre) for reporting this issue.

## Proposed Changes

### Code improvements

1. **Enhanced `OS_IsValidName()` validation** ([validate.c:340-347](src/addagent/validate.c#L340-L347))
   - Added NULL pointer check before string operations
   - Aligns behavior with other validators (`OS_IsValidID`, `OS_IsValidIP`)
2. **Strengthened enrollment key parsing** ([enrollment_op.c:473-478](src/shared/enrollment_op.c#L473-L478))
   - Verify all key fields exist before calling validators
   - Defense-in-depth approach with multiple validation layers
   - Fixed variable naming (`entrys` → `entries`)

### Results and Evidence

All unit tests pass successfully:

```
        Start  58: test_auth_validate
 58/190 Test  #58: test_auth_validate ......................................   Passed    0.02 sec
        Start 153: test_enrollment_op
153/190 Test #153: test_enrollment_op ......................................   Passed    0.05 sec
        Start 154: test_time_op

100% tests passed, 0 tests failed out of 190
```

### Artifacts Affected

- `agent-auth`
- `wazuh-agentd`

### Configuration Changes

No configuration changes required.

### Documentation Updates

No documentation updates required.

### Tests Introduced

1. **NULL pointer handling test** (test_validate.c)
   - Validates `OS_IsValidName(NULL)` returns 0 without crash
2. **Malformed enrollment response tests** (test_enrollment_op.c)
   - Tests with 1 field: `OSSEC K:'1'`
   - Tests with 2 fields: `OSSEC K:'006 ubuntu1610'`
   - Tests with 3 fields: `OSSEC K:'006 ubuntu1610 192.168.1.1'`
   - All correctly rejected with proper error messages

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
