### PR TITLE
Lower agent_sync_protocol and module sync log levels to reduce false-alarm noise

### DIFF
--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -294,7 +294,7 @@ bool AgentSyncProtocol::requiresFullSync(const std::string& index,
 
     if (!sendStartAndWaitAck(Mode::CHECK, 0, indices))
     {
-        m_logger(LOG_ERROR, "Failed to send Start message for integrity check");
+        m_logger(LOG_DEBUG, "Failed to send Start message for integrity check");
         clearSyncState();
         return false; // Return false as this is not a checksum error from manager
     }
@@ -302,7 +302,7 @@ bool AgentSyncProtocol::requiresFullSync(const std::string& index,
     // Step 2: Send ChecksumModule message
     if (!sendChecksumMessage(m_syncState.session, index, checksum))
     {
-        m_logger(LOG_ERROR, "Failed to send ChecksumModule message");
+        m_logger(LOG_DEBUG, "Failed to send ChecksumModule message");
         clearSyncState();
         return false; // Return false as this is not a checksum error from manager
     }
@@ -329,7 +329,7 @@ bool AgentSyncProtocol::requiresFullSync(const std::string& index,
             ? "Checksum validation failed, full sync required"
             : "Manager is offline";
 
-        m_logger(LOG_WARNING, "Module integrity check failed for index: " + index + " - " + message);
+        m_logger(LOG_DEBUG, "Module integrity check failed for index: " + index + " - " + message);
 
         clearSyncState();
         return result;
@@ -387,7 +387,7 @@ bool AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     }
     else
     {
-        m_logger(LOG_WARNING, "Synchronization failed for metadata/groups mode");
+        m_logger(LOG_DEBUG, "Synchronization failed for metadata/groups mode");
     }
 
     clearSyncState();
@@ -459,7 +459,7 @@ bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,
         }
         else
         {
-            m_logger(LOG_WARNING, "DataClean notification failed.");
+            m_logger(LOG_DEBUG, "DataClean notification failed.");
         }
     }
     catch (const std::exception& e)
@@ -527,7 +527,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         }
         else
         {
-            m_logger(LOG_WARNING, "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.");
+            m_logger(LOG_DEBUG, "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.");
 
             if (has_metadata)
             {
@@ -610,9 +610,9 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         {
             if (!sendFlatBufferMessageAsString(messageVector))
             {
-                // During shutdown the local socket is gone; the failure is expected, so
-                // log at debug instead of warning to avoid misleading restart noise.
-                m_logger(shouldStop() ? LOG_DEBUG : LOG_WARNING, "Failed to send Start message.");
+                // Internal transport retry: the calling module owns the user-facing
+                // warning for a failed synchronization, so log this at debug only.
+                m_logger(LOG_DEBUG, "Failed to send Start message.");
                 continue;
             }
 
@@ -644,7 +644,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
                 return true;
             }
 
-            m_logger(shouldStop() ? LOG_DEBUG : LOG_WARNING, "Timed out waiting for StartAck. Retrying...");
+            m_logger(LOG_DEBUG, "Timed out waiting for StartAck. Retrying...");
         }
 
         // Clean up metadata if we successfully retrieved it
@@ -660,7 +660,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         }
         else
         {
-            m_logger(LOG_ERROR, "Exceeded maximum retries for Start message. Exiting...");
+            m_logger(LOG_DEBUG, "Exceeded maximum retries for Start message.");
         }
 
         return false;
@@ -727,7 +727,7 @@ bool AgentSyncProtocol::sendDataMessages(uint64_t session,
 
             if (!sendFlatBufferMessageAsString(messageVector))
             {
-                m_logger(LOG_ERROR, "Failed to send DataBatch message.");
+                m_logger(LOG_DEBUG, "Failed to send DataBatch message.");
                 return false;
             }
 
@@ -823,7 +823,7 @@ bool AgentSyncProtocol::sendDataContextMessages(uint64_t session,
 
             if (!sendFlatBufferMessageAsString(messageVector))
             {
-                m_logger(LOG_ERROR, "Failed to send Data context message.");
+                m_logger(LOG_DEBUG, "Failed to send Data context message.");
                 return false;
             }
         }
@@ -863,7 +863,7 @@ bool AgentSyncProtocol::sendChecksumMessage(uint64_t session,
 
         if (!sendFlatBufferMessageAsString(messageVector))
         {
-            m_logger(LOG_ERROR, "Failed to send Checksum message.");
+            m_logger(LOG_DEBUG, "Failed to send Checksum message.");
             return false;
         }
 
@@ -902,7 +902,7 @@ bool AgentSyncProtocol::sendDataCleanMessages(uint64_t session,
 
             if (!sendFlatBufferMessageAsString(messageVector))
             {
-                m_logger(LOG_ERROR, "Failed to send Dataclean message.");
+                m_logger(LOG_DEBUG, "Failed to send Dataclean message.");
                 return false;
             }
         }
@@ -955,9 +955,9 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         {
             if (resendEnd && !sendFlatBufferMessageAsString(messageVector))
             {
-                // During shutdown the local socket is gone; the failure is expected, so
-                // log at debug instead of warning to avoid misleading restart noise.
-                m_logger(shouldStop() ? LOG_DEBUG : LOG_WARNING, "Failed to send End message.");
+                // Internal transport retry: the calling module owns the user-facing
+                // warning for a failed synchronization, so log this at debug only.
+                m_logger(LOG_DEBUG, "Failed to send End message.");
                 attempt++;
                 continue;
             }
@@ -1013,7 +1013,7 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
 
                 if (ranges.empty())
                 {
-                    m_logger(LOG_ERROR, "Received ReqRet with empty ranges. Aborting current sync attempt.");
+                    m_logger(LOG_DEBUG, "Received ReqRet with empty ranges. Aborting current sync attempt.");
                     return false;
                 }
 
@@ -1021,13 +1021,13 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
 
                 if (rangeData.empty())
                 {
-                    m_logger(LOG_ERROR, "ReqRet asked for ranges that yield no data. Aborting.");
+                    m_logger(LOG_DEBUG, "ReqRet asked for ranges that yield no data. Aborting.");
                     return false;
                 }
 
                 if (!sendDataMessages(session, rangeData))
                 {
-                    m_logger(LOG_ERROR, "Failed to resend data for ReqRet.");
+                    m_logger(LOG_DEBUG, "Failed to resend data for ReqRet.");
                     return false;
                 }
 
@@ -1057,7 +1057,7 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         }
         else
         {
-            m_logger(LOG_ERROR, "Exceeded maximum retries for End message. Exiting...");
+            m_logger(LOG_DEBUG, "Exceeded maximum retries for End message.");
         }
 
         return false;

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -92,7 +92,7 @@ void PersistentQueue::clearSyncedItems()
     }
     catch (const std::exception& ex)
     {
-        m_logger(LOG_ERROR, std::string("PersistentQueue: Error clrearing synchronized items: ") + ex.what());
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error clearing synchronized items: ") + ex.what());
         throw;
     }
 }

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -2539,7 +2539,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncSendChecksumMessageFails)
     std::string loggedMessage;
     LoggerFunc testLogger = [&loggedMessage](modules_log_level_t level, const std::string & message)
     {
-        if (level == LOG_ERROR && message.find("Failed to send ChecksumModule message") != std::string::npos)
+        if (level == LOG_DEBUG && message.find("Failed to send ChecksumModule message") != std::string::npos)
         {
             loggedMessage = message;
         }

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -255,7 +255,7 @@ STATIC bool handle_all_paths_removed(void) {
     mdebug1("All monitored paths removed from configuration but database has data. Initiating DataClean process.");
 
     if (!syscheck.sync_handle) {
-        merror("Sync protocol not initialized, cannot send DataClean notification.");
+        minfo("Sync protocol not initialized, cannot send DataClean notification.");
         return false;
     }
 

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -1442,7 +1442,7 @@ void test_handle_all_paths_removed_no_sync_handle(void **state) {
     will_return(__wrap_fim_db_get_count_file_entry, 10);
 
     expect_string(__wrap__mdebug1, formatted_msg, "All monitored paths removed from configuration but database has data. Initiating DataClean process.");
-    expect_string(__wrap__merror, formatted_msg, "Sync protocol not initialized, cannot send DataClean notification.");
+    expect_string(__wrap__minfo, formatted_msg, "Sync protocol not initialized, cannot send DataClean notification.");
 
     bool result = handle_all_paths_removed();
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -338,7 +338,7 @@ bool AgentInfoImpl::parseResponseBuffer(const uint8_t* data, size_t length)
         return m_spSyncProtocol->parseResponseBuffer(data, length);
     }
 
-    m_logFunction(LOG_ERROR, "Sync protocol not initialized or invalid data");
+    m_logFunction(LOG_WARNING, "Sync protocol not initialized or invalid data");
     return false;
 }
 
@@ -1135,7 +1135,7 @@ void AgentInfoImpl::resumePausedModules(const std::set<std::string>& pausedModul
 
         if (!response.success)
         {
-            m_logFunction(LOG_ERROR, "Failed to resume module " + module + ": " + response.response);
+            m_logFunction(LOG_WARNING, "Failed to resume module " + module + ": " + response.response);
         }
     }
 }
@@ -1247,7 +1247,7 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
 
                     if (!pauseSucceeded)
                     {
-                        m_logFunction(LOG_ERROR, moduleName + " pause completed with error");
+                        m_logFunction(LOG_WARNING, moduleName + " pause completed with error");
                         return PauseProbeResult::Failed;
                     }
 
@@ -1278,7 +1278,7 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
         m_deferralLogged = false;
     }
 
-    m_logFunction(LOG_ERROR,
+    m_logFunction(LOG_WARNING,
                   moduleName + " pause did not complete within " + std::to_string(MAX_PAUSE_POLL_ATTEMPTS) +
                   " seconds (scan mutex may be held by a long sync cycle, or IPC communication failure)");
     return PauseProbeResult::Failed;
@@ -1311,7 +1311,7 @@ bool AgentInfoImpl::pollFlushCompletion(std::set<std::string> pendingModules)
 
             if (!pollResponse.success)
             {
-                m_logFunction(LOG_WARNING,
+                m_logFunction(LOG_DEBUG,
                               "Failed to poll flush status for " + moduleName + " (attempt " +
                               std::to_string(attempt) + "), will retry...");
                 continue;
@@ -1483,7 +1483,7 @@ bool AgentInfoImpl::triggerModuleFlush(const std::set<std::string>& pausedModule
 
         if (!response.success)
         {
-            m_logFunction(LOG_ERROR,
+            m_logFunction(LOG_WARNING,
                           "Failed to trigger flush for " + module + " (error " + std::to_string(response.errorCode) +
                           "), aborting coordination");
             return false;
@@ -1517,7 +1517,7 @@ int AgentInfoImpl::calculateNewVersion(const std::set<std::string>& pausedModule
 
         if (!response.success)
         {
-            m_logFunction(LOG_ERROR,
+            m_logFunction(LOG_WARNING,
                           "Failed to get version from " + module + " (error " + std::to_string(response.errorCode) +
                           "), aborting coordination");
             return -1;
@@ -1544,7 +1544,7 @@ int AgentInfoImpl::calculateNewVersion(const std::set<std::string>& pausedModule
         }
         catch (const std::exception& e)
         {
-            m_logFunction(LOG_ERROR,
+            m_logFunction(LOG_WARNING,
                           "Failed to parse JSON response from " + module + ": " + std::string(e.what()) +
                           " - Response: " + response.response);
             return -1;
@@ -1703,7 +1703,7 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
         }
         else
         {
-            m_logFunction(LOG_WARNING, "Sync protocol not available, skipping synchronization");
+            m_logFunction(LOG_INFO, "Sync protocol not available, skipping synchronization");
         }
 
         m_logFunction(LOG_INFO, "Synchronization coordination completed successfully");
@@ -2104,7 +2104,7 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
 
         if (!m_spSyncProtocol)
         {
-            m_logFunction(LOG_WARNING, "Sync protocol not available, skipping integrity check");
+            m_logFunction(LOG_INFO, "Sync protocol not available, skipping integrity check");
             return false;
         }
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -756,7 +756,7 @@ int SecurityConfigurationAssessment::executeFlushSync()
 
     if (!m_spSyncProtocol)
     {
-        LoggingHelper::getInstance().log(LOG_WARNING, "SCA sync protocol not initialized, flush skipped");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "SCA sync protocol not initialized, flush skipped");
         return 0;  // Not an error - just nothing to flush
     }
 
@@ -1049,7 +1049,7 @@ bool SecurityConfigurationAssessment::checkIfRecoveryRequired(const std::string&
 {
     if (!m_spSyncProtocol)
     {
-        LoggingHelper::getInstance().log(LOG_ERROR, "Sync protocol not initialized, cannot check recovery status");
+        LoggingHelper::getInstance().log(LOG_DEBUG, "Sync protocol not initialized, cannot check recovery status");
         return false;
     }
 
@@ -1096,7 +1096,7 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
 
         if (!m_spSyncProtocol)
         {
-            LoggingHelper::getInstance().log(LOG_ERROR, "Sync protocol not initialized, cannot synchronize SCA snapshot");
+            LoggingHelper::getInstance().log(LOG_DEBUG, "Sync protocol not initialized, cannot synchronize SCA snapshot");
             return false;
         }
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2804,7 +2804,7 @@ int Syscollector::executeFlushSync()
     {
         if (m_logFunction)
         {
-            m_logFunction(LOG_WARNING, "Syscollector sync protocol not initialized, flush skipped");
+            m_logFunction(LOG_INFO, "Syscollector sync protocol not initialized, flush skipped");
         }
 
         return 0; // Not an error - just nothing to flush
@@ -4098,7 +4098,7 @@ bool Syscollector::notifyDisableCollectorsDataClean()
     {
         if (m_logFunction)
         {
-            m_logFunction(LOG_ERROR, "Sync protocol not initialized, cannot notify data clean");
+            m_logFunction(LOG_INFO, "Sync protocol not initialized, cannot notify data clean");
         }
 
         return false;

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -4253,8 +4253,8 @@ TEST_F(SyscollectorImpTest, notifyDisableCollectorsDataCleanWithDisabledCollecto
     // This tests the error handling path
     EXPECT_FALSE(Syscollector::instance().notifyDisableCollectorsDataClean());
 
-    // Verify error log for missing sync protocol
-    EXPECT_TRUE(logCapture.contains(LOG_ERROR, "Sync protocol not initialized, cannot notify data clean"));
+    // Verify info log for missing sync protocol
+    EXPECT_TRUE(logCapture.contains(LOG_INFO, "Sync protocol not initialized, cannot notify data clean"));
 
     Syscollector::instance().destroy();
 }
@@ -4411,8 +4411,8 @@ TEST_F(SyscollectorImpTest, allCollectorsDisabledWithData)
     // We can verify this by calling notifyDisableCollectorsDataClean (will fail without sync protocol)
     EXPECT_FALSE(Syscollector::instance().notifyDisableCollectorsDataClean());
 
-    // Verify error log for missing sync protocol
-    EXPECT_TRUE(logCapture.contains(LOG_ERROR, "Sync protocol not initialized, cannot notify data clean"));
+    // Verify info log for missing sync protocol
+    EXPECT_TRUE(logCapture.contains(LOG_INFO, "Sync protocol not initialized, cannot notify data clean"));
 
     Syscollector::instance().destroy();
 }
@@ -4467,8 +4467,8 @@ TEST_F(SyscollectorImpTest, networkCollectorDisabledThreeIndices)
     // Verify by attempting notification (will fail without sync protocol but tests the detection)
     EXPECT_FALSE(Syscollector::instance().notifyDisableCollectorsDataClean());
 
-    // Verify error log for missing sync protocol
-    EXPECT_TRUE(logCapture.contains(LOG_ERROR, "Sync protocol not initialized, cannot notify data clean"));
+    // Verify info log for missing sync protocol
+    EXPECT_TRUE(logCapture.contains(LOG_INFO, "Sync protocol not initialized, cannot notify data clean"));
 
     // Cleanup should work even without sync protocol
     EXPECT_NO_THROW(Syscollector::instance().deleteDisableCollectorsData());


### PR DESCRIPTION
## Description

In several test runs, occasional `ERROR`/`WARNING` messages were reported coming from the agent data **synchronization** flow and from the shared **`agent_sync_protocol`** component. Most of these describe **transient or recoverable** conditions (internal transport retries, timeouts that retry, the manager not having synchronized the groups yet, the sync protocol/DBSync not initialized during startup/shutdown). Logged at `ERROR`/`WARNING`, they produce noise and false alarms even though the protocol recovers on its own or the calling module already reports the outcome.

This PR recalibrates the log levels of the synchronization flow following a single **layer-ownership principle**:

> `agent_sync_protocol` is an internal mechanism. Every public method already **returns its outcome** to the module that invoked it, and the calling module (`agent-info`, `syscollector`, `sca`, `fim`/`syscheckd`) **already logs its own user-facing message with actionable context** (which table/index/module failed).

Therefore, for a synchronization failure the user should see a **single** user-facing message — the one emitted by the module — and **not** a duplicate from `agent_sync_protocol` describing the same failure.

**Example — before:**

```
wazuh-modulesd:agent-info: INFO: Starting Synchronization ....
wazuh-modulesd:agent-info: WARNING: Synchronization failed for metadata/groups mode   <- agent_sync_protocol (internal)
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_metadata               <- module (owns the signal)
```

**After:**

```
wazuh-modulesd:agent-info: INFO: Starting Synchronization ....
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_metadata
```

This is a focused spin-off of the log-severity validation tracked in #36803, scoped exclusively to the synchronization / `agent_sync_protocol` logs.

Closes #36814 

## Proposed Changes

#### `agent_sync_protocol` (shared component)

**`src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`** — 18 statements demoted to `DEBUG`. These are internal protocol mechanics whose failure result is already surfaced by the calling module:

- Internal transport retries: `Failed to send Start message for integrity check`, `Failed to send ChecksumModule message`, `Failed to send DataBatch message.`, `Failed to send Data context message.`, `Failed to send Checksum message.`, `Failed to send Dataclean message.`, `Failed to send Start message.`, `Failed to send End message.`
- Retry/timeout flow: `Timed out waiting for StartAck. Retrying...`, `Exceeded maximum retries for Start message.`, `Exceeded maximum retries for End message.`
- Sync outcomes already reported by the module: `Module integrity check failed for index: ...`, `Synchronization failed for metadata/groups mode`, `DataClean notification failed.`, `No groups available in metadata. Waiting for the server to synchronize the groups. ...`
- `ReqRet` handling: `Received ReqRet with empty ranges. Aborting current sync attempt.`, `ReqRet asked for ranges that yield no data. Aborting.`, `Failed to resend data for ReqRet.`

Removed the now-redundant `shouldStop() ? LOG_DEBUG : LOG_WARNING` conditional at the Start/StartAck/End send paths (they are plain `DEBUG` now).

Kept at `ERROR` the genuine internal faults the module cannot contextualize: transport/persistent-queue initialization failure, invalid synchronization mode, invalid/malformed buffer or FlatBuffer, DB/storage errors and unexpected exceptions.

**`src/shared_modules/sync_protocol/src/persistent_queue.cpp`** — fixed a typo in an `ERROR` message (`clrearing` → `clearing`); level unchanged.

#### Consumer modules

Graceful "sync protocol / DBSync not initialized — skipping" conditions (expected during startup/shutdown) demoted so they no longer surface as `ERROR`, while the single user-facing report with table/index context is preserved:

- **FIM / syscheckd** — `src/syscheckd/src/run_check.c`: `Sync protocol not initialized, cannot send DataClean notification.` `ERROR` → `INFO`.
- **Syscollector** — `src/wazuh_modules/syscollector/src/syscollectorImp.cpp`:
  - `Syscollector sync protocol not initialized, flush skipped` `WARNING` → `INFO`.
  - `Sync protocol not initialized, cannot notify data clean` `ERROR` → `INFO`.
- **SCA** — `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp`:
  - `SCA sync protocol not initialized, flush skipped` `WARNING` → `DEBUG`.
  - `Sync protocol not initialized, cannot check recovery status` `ERROR` → `DEBUG`.
  - `Sync protocol not initialized, cannot synchronize SCA snapshot` `ERROR` → `DEBUG`.
- **Agent-info** — `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp`:
  - Recoverable coordination failures demoted `ERROR` → `WARNING` (they abort the current coordination cycle but are retried): `Sync protocol not initialized or invalid data`, `Failed to resume module ...`, `<module> pause completed with error`, `<module> pause did not complete within ... seconds ...`, `Failed to trigger flush for ... aborting coordination`, `Failed to get version from ... aborting coordination`, `Failed to parse JSON response from ...`.
  - Transient poll failure inside the async-flush polling loop demoted `WARNING` → `DEBUG` (the module is re-polled on the next iteration; the message itself states "will retry..."): `Failed to poll flush status for <module> (attempt N), will retry...`.
  - Expected "skip" conditions demoted `WARNING` → `INFO`: `Sync protocol not available, skipping synchronization`, `Sync protocol not available, skipping integrity check`.

### Results and Evidence

Synchronization failure (metadata/groups) — only the module-owned message remains:

```
# Before
wazuh-modulesd:agent-info: WARNING: Synchronization failed for metadata/groups mode
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_metadata

# After
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_metadata
```

Agent startup before the manager has synchronized groups — no longer a `WARNING`:

```
# Before
wazuh-modulesd:agent-info: WARNING: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.

# After (DEBUG, hidden at default log level)
wazuh-modulesd:agent-info: DEBUG: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
```

### Artifacts Affected

- `src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp`
- `src/shared_modules/sync_protocol/src/persistent_queue.cpp`
- `src/syscheckd/src/run_check.c`
- `src/wazuh_modules/syscollector/src/syscollectorImp.cpp`
- `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp`
- `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp`

No behavioral/control-flow changes: every modified statement is a log-severity change only (return values and branching are untouched). The typo fix does not change the message level.

### Configuration Changes

None.

### Documentation Updates

None

### Tests Introduced

No new tests; updated existing unit tests whose assertions were coupled to the changed log levels:

- `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp` — `RequiresFullSyncSendChecksumMessageFails` now asserts `Failed to send ChecksumModule message` at `LOG_DEBUG`.
- `src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp` — three assertions on `Sync protocol not initialized, cannot notify data clean` updated from `LOG_ERROR` to `LOG_DEBUG`.

Other module tests (agent-info integrity/coordination) assert message text in a level-agnostic capture, so they remain valid.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
