### PR TITLE
Add guide for migrating manager coordinator from 4.x to 5.x

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,7 @@
   - [Migrating Syslog Input to Logcollector with rsyslog](guide/migration/syslog-input-4x-to-5x.md)
   - [Active Response](guide/migration/active-response.md)
   - [Upgrade 4.X to 5.X](guide/migration/upgrade-4x-to-5x.md)
+  - [Migrating Manager Coordinator from 4.x to 5.x](guide/migration/manager-coordinator-migration.md)
 
 # Reference Manual
 

--- a/docs/guide/migration/manager-coordinator-migration.md
+++ b/docs/guide/migration/manager-coordinator-migration.md
@@ -1,4 +1,4 @@
-# Migrating Manager Coordinator from 4.x to 5.0
+# Migrating Manager Coordinator from 4.x to 5.x
 
 Coordinator migration requires almost no steps, as the coordinator only runs HAProxy and the dataplaneapi — there is no Wazuh manager package installed on it to upgrade. The migration mainly consists of refreshing the HAProxy and dataplaneapi configuration so they work with the 5.0 HAProxy helper.
 
@@ -37,6 +37,7 @@ backend wazuh_register
   balance leastconn
   server master <MASTER_NODE>:1515 check
   server worker1 <WORKER_NODE>:1515 check
+  # add one 'server worker<n> <WORKER_NODE>:1515 check' line per extra worker
 
 # Reporting/connection (remoted) — managed by the HAProxy helper.
 # The helper creates the frontend (wazuh_reporting_front) bound to 1514 and
@@ -79,7 +80,7 @@ Stop the services and prepare the backup directory:
 sudo service haproxy stop
 sudo pkill -9 dataplaneapi
 
-sudo mkdir -p /tmp/coordinator-4-x-backup
+sudo mkdir -p /var/coordinator-4-x-backup
 ```
 
 You have two alternatives: keep the configurations your load balancer already uses, or start fresh with the new base files.
@@ -87,8 +88,8 @@ You have two alternatives: keep the configurations your load balancer already us
 ##### Alternative 1 — keep your existing configuration
 
 ```bash
-sudo cp /etc/haproxy/haproxy.cfg /tmp/coordinator-4-x-backup/haproxy.cfg
-sudo cp /etc/haproxy/dataplaneapi.yml /tmp/coordinator-4-x-backup/dataplaneapi.yml
+sudo cp /etc/haproxy/haproxy.cfg /var/coordinator-4-x-backup/haproxy.cfg
+sudo cp /etc/haproxy/dataplaneapi.yml /var/coordinator-4-x-backup/dataplaneapi.yml
 ```
 
 ##### Alternative 2 — start fresh with the new base files
@@ -96,7 +97,7 @@ sudo cp /etc/haproxy/dataplaneapi.yml /tmp/coordinator-4-x-backup/dataplaneapi.y
 Remember to replace `<MASTER_NODE>`, `<WORKER_NODE>`, `<USER>`, and `<PASSWORD>` with your real values after generating the files.
 
 ```bash
-sudo tee /tmp/coordinator-4-x-backup/haproxy.cfg > /dev/null << 'EOF'
+sudo tee /var/coordinator-4-x-backup/haproxy.cfg > /dev/null << 'EOF'
 global
   maxconn 4000
   user haproxy
@@ -119,12 +120,13 @@ backend wazuh_register
   balance leastconn
   server master <MASTER_NODE>:1515 check
   server worker1 <WORKER_NODE>:1515 check
+  # add one 'server worker<n> <WORKER_NODE>:1515 check' line per extra worker
 
 backend wazuh_reporting
   balance leastconn
 EOF
 
-sudo tee /tmp/coordinator-4-x-backup/dataplaneapi.yml > /dev/null << 'EOF'
+sudo tee /var/coordinator-4-x-backup/dataplaneapi.yml > /dev/null << 'EOF'
 dataplaneapi:
   host: 0.0.0.0
   port: 5555
@@ -146,9 +148,9 @@ EOF
 
 Do these steps on your machine with HAProxy installed.
 
-#### 2.1. Ensure you have the latest 2.X dataplaneapi version
+#### 2.1. Install a supported dataplaneapi version
 
-Check all available versions of dataplaneapi [here](https://github.com/haproxytech/dataplaneapi/releases/).
+Use dataplaneapi `2.9.0`. Newer `2.x` releases are listed [here](https://github.com/haproxytech/dataplaneapi/releases/).
 
 ```bash
 sudo rm /usr/local/bin/dataplaneapi
@@ -168,11 +170,11 @@ sudo chown haproxy:haproxy /run/haproxy
 Restore the configuration files and start the services:
 
 ```bash
-sudo cp /tmp/coordinator-4-x-backup/haproxy.cfg /etc/haproxy
-sudo cp /tmp/coordinator-4-x-backup/dataplaneapi.yml /etc/haproxy
+sudo cp /var/coordinator-4-x-backup/haproxy.cfg /etc/haproxy
+sudo cp /var/coordinator-4-x-backup/dataplaneapi.yml /etc/haproxy
 
 sudo service haproxy start
-dataplaneapi -f /etc/haproxy/dataplaneapi.yml &
+sudo nohup dataplaneapi -f /etc/haproxy/dataplaneapi.yml > /var/log/dataplaneapi.log 2>&1 &
 ```
 
 Ensure dataplaneapi is working correctly with:
@@ -183,7 +185,7 @@ curl -X GET --user <DATAPLANE_USER>:<DATAPLANE_PASSWORD> http://<COORDINATOR_IP>
 
 You will see a response similar to this if everything works correctly:
 
-```bash
+```json
 {"api":{"build_date":"2023-12-08T14:53:01.000Z","version":"v2.9.0 91da11d"},"system":{}}
 ```
 

--- a/docs/guide/migration/manager-coordinator-migration.md
+++ b/docs/guide/migration/manager-coordinator-migration.md
@@ -1,0 +1,224 @@
+# Migrating Manager Coordinator from 4.x to 5.0
+
+Coordinator migration requires almost no steps, as the coordinator only runs HAProxy and the dataplaneapi — there is no Wazuh manager package installed on it to upgrade. The migration mainly consists of refreshing the HAProxy and dataplaneapi configuration so they work with the 5.0 HAProxy helper.
+
+## Migration procedure
+
+### 1. Prepare HAProxy migration
+
+> [!IMPORTANT]
+> Make sure to have HAProxy installed on a dedicated machine, not alongside a Wazuh manager (master or worker). HAProxy binds ports `1514` and `1515`, the same ports the manager's `remoted` and `authd` use, so sharing a host causes a port conflict that stops `remoted` and breaks the HAProxy helper.
+
+#### 1.1. HAProxy configuration changes
+
+There have been some changes in the basic HAProxy configuration file. You can keep your previous configuration as it still works, or use the new basic configuration below:
+
+```cfg
+global
+  maxconn 4000
+  user haproxy
+  group haproxy
+  daemon
+  stats socket /run/haproxy/admin.sock user haproxy group haproxy mode 660 level admin
+  stats timeout 30s
+
+defaults
+  mode tcp
+  timeout connect 10s
+  timeout client 1m
+  timeout server 1m
+
+# Enrollment (authd) — static, NOT managed by the HAProxy helper
+frontend wazuh_register
+  bind :1515
+  default_backend wazuh_register
+
+backend wazuh_register
+  balance leastconn
+  server master <MASTER_NODE>:1515 check
+  server worker1 <WORKER_NODE>:1515 check
+
+# Reporting/connection (remoted) — managed by the HAProxy helper.
+# The helper creates the frontend (wazuh_reporting_front) bound to 1514 and
+# populates this backend with the cluster nodes at runtime. Do NOT define a
+# frontend here or list servers statically, or the helper will add its own
+# frontend and servers on top, causing a duplicate 1514 bind and stale servers.
+backend wazuh_reporting
+  balance leastconn
+```
+
+> [!NOTE]
+> The HAProxy helper requires a runtime `stats socket` (defined in the `global` section above) and it manages port `1514` itself. If your 4.x coordinator already ran the HAProxy helper, its configuration already omits the `wazuh_reporting` frontend and works under 5.0 unchanged. If it used a **static** `wazuh_reporting` frontend instead (helper disabled), remove that frontend and its static servers before enabling the helper, or HAProxy will end up with a duplicate frontend on port `1514`.
+
+#### 1.2. Dataplaneapi configuration changes
+
+The `dataplaneapi.yml` file has also had some configuration changes. The former base file still works fine, but you can update it to use the new base YAML file:
+
+```yaml
+dataplaneapi:
+  host: 0.0.0.0
+  port: 5555
+  user:
+    - name: <USER>
+      password: <PASSWORD>
+      insecure: true
+
+haproxy:
+  config_file: /etc/haproxy/haproxy.cfg
+  haproxy_bin: /usr/sbin/haproxy
+  reload:
+    reload_cmd: service haproxy reload
+    restart_cmd: service haproxy restart
+```
+
+#### 1.3. HAProxy configuration backup
+
+Stop the services and prepare the backup directory:
+
+```bash
+sudo service haproxy stop
+sudo pkill -9 dataplaneapi
+
+sudo mkdir -p /tmp/coordinator-4-x-backup
+```
+
+You have two alternatives: keep the configurations your load balancer already uses, or start fresh with the new base files.
+
+##### Alternative 1 — keep your existing configuration
+
+```bash
+sudo cp /etc/haproxy/haproxy.cfg /tmp/coordinator-4-x-backup/haproxy.cfg
+sudo cp /etc/haproxy/dataplaneapi.yml /tmp/coordinator-4-x-backup/dataplaneapi.yml
+```
+
+##### Alternative 2 — start fresh with the new base files
+
+Remember to replace `<MASTER_NODE>`, `<WORKER_NODE>`, `<USER>`, and `<PASSWORD>` with your real values after generating the files.
+
+```bash
+sudo tee /tmp/coordinator-4-x-backup/haproxy.cfg > /dev/null << 'EOF'
+global
+  maxconn 4000
+  user haproxy
+  group haproxy
+  daemon
+  stats socket /run/haproxy/admin.sock user haproxy group haproxy mode 660 level admin
+  stats timeout 30s
+
+defaults
+  mode tcp
+  timeout connect 10s
+  timeout client 1m
+  timeout server 1m
+
+frontend wazuh_register
+  bind :1515
+  default_backend wazuh_register
+
+backend wazuh_register
+  balance leastconn
+  server master <MASTER_NODE>:1515 check
+  server worker1 <WORKER_NODE>:1515 check
+
+backend wazuh_reporting
+  balance leastconn
+EOF
+
+sudo tee /tmp/coordinator-4-x-backup/dataplaneapi.yml > /dev/null << 'EOF'
+dataplaneapi:
+  host: 0.0.0.0
+  port: 5555
+  user:
+    - name: <USER>
+      password: <PASSWORD>
+      insecure: true
+
+haproxy:
+  config_file: /etc/haproxy/haproxy.cfg
+  haproxy_bin: /usr/sbin/haproxy
+  reload:
+    reload_cmd: service haproxy reload
+    restart_cmd: service haproxy restart
+EOF
+```
+
+### 2. Migrate coordinator
+
+Do these steps on your machine with HAProxy installed.
+
+#### 2.1. Ensure you have the latest 2.X dataplaneapi version
+
+Check all available versions of dataplaneapi [here](https://github.com/haproxytech/dataplaneapi/releases/).
+
+```bash
+sudo rm /usr/local/bin/dataplaneapi
+curl -sL https://github.com/haproxytech/dataplaneapi/releases/download/v2.9.0/dataplaneapi_2.9.0_linux_x86_64.tar.gz | tar xz
+sudo mv build/dataplaneapi /usr/local/bin/ 2>/dev/null || sudo mv dataplaneapi /usr/local/bin/
+```
+
+#### 2.2. Restore the HAProxy service and dataplaneapi process
+
+The new configuration uses a runtime socket under `/run/haproxy`. Make sure the directory exists before starting HAProxy, otherwise it cannot create the socket and the helper fails with `Error 3045`:
+
+```bash
+sudo mkdir -p /run/haproxy
+sudo chown haproxy:haproxy /run/haproxy
+```
+
+Restore the configuration files and start the services:
+
+```bash
+sudo cp /tmp/coordinator-4-x-backup/haproxy.cfg /etc/haproxy
+sudo cp /tmp/coordinator-4-x-backup/dataplaneapi.yml /etc/haproxy
+
+sudo service haproxy start
+dataplaneapi -f /etc/haproxy/dataplaneapi.yml &
+```
+
+Ensure dataplaneapi is working correctly with:
+
+```bash
+curl -X GET --user <DATAPLANE_USER>:<DATAPLANE_PASSWORD> http://<COORDINATOR_IP>:5555/v2/info
+```
+
+You will see a response similar to this if everything works correctly:
+
+```bash
+{"api":{"build_date":"2023-12-08T14:53:01.000Z","version":"v2.9.0 91da11d"},"system":{}}
+```
+
+> [!NOTE]
+> Run this `curl` on the coordinator (or replace `<COORDINATOR_IP>` with the coordinator's address). The dataplaneapi listens only on the coordinator, so it is not reachable as `localhost` from the manager nodes.
+
+Then restart each manager so the HAProxy helper reconnects:
+
+```bash
+sudo systemctl restart wazuh-manager
+```
+
+#### 2.3. Verify the HAProxy helper
+
+On the master node, check the cluster log:
+
+```bash
+tail -f /var/wazuh-manager/logs/cluster.log
+```
+
+A successful migration shows the helper creating the reporting frontend and balancing the backend:
+
+```
+INFO: [HAPHelper] [Main] Proxy was initialized
+INFO: [HAPHelper] [Main] Added Wazuh frontend
+INFO: [HAPHelper] [Main] Detected changes in Wazuh cluster nodes. Current cluster: {'master-node': '...', 'worker-node': '...'}
+INFO: [HAPHelper] [Main] Load balancer backend is up to date
+INFO: [HAPHelper] [Main] Load balancer backend is balanced
+```
+
+> [!NOTE]
+> The HAProxy helper rewrites `/etc/haproxy/haproxy.cfg` at runtime: it adds the `wazuh_reporting_front` frontend on port `1514` and the cluster nodes (e.g. `master-node`, `worker-node`) to the `wazuh_reporting` backend. This is expected, so the on-disk file will not stay byte-for-byte identical to what you wrote.
+
+If you see `Error 3045 - Could not connect to HAProxy: runtime: option is not available`, the `stats socket` is missing from the `global` section of `haproxy.cfg` (or `/run/haproxy` does not exist). If you see `Several frontends exist binding the port "1514"`, you still have a static `wazuh_reporting` frontend that must be removed.
+
+#### 2.4. HAProxy helper variables
+
+No HAProxy helper variables have changed in 5.0, so you do not need to modify the `<haproxy_helper>` block in the manager configuration. Any value you do not set falls back to its default (for example, `haproxy_backend` defaults to `wazuh_reporting`).


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

This PR intends to add the manager coordinator migration from 4.x to 5.x.

Documentation followed while installing HAProxy: https://documentation.wazuh.com/current/user-manual/wazuh-server-cluster/load-balancers.html

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- New guide in `docs/guide/migration/manager-coordinator-migration.md`

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

---

#### Before migration

<details>
<summary>Master node setup</summary>

```
root@wazuh-master:/home/vagrant# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:78:f1:c9 brd ff:ff:ff:ff:ff:ff
    altname enp0s6
    altname ens6
    inet 192.168.121.251/24 metric 100 brd 192.168.121.255 scope global dynamic eth0
       valid_lft 3093sec preferred_lft 3093sec
    inet6 fe80::5054:ff:fe78:f1c9/64 scope link 
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:22:80:6d brd ff:ff:ff:ff:ff:ff
    altname enp0s7
    altname ens7
    inet 192.168.56.11/24 brd 192.168.56.255 scope global eth1
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fe22:806d/64 scope link 
       valid_lft forever preferred_lft forever


root@wazuh-master:/home/vagrant# cat /etc/os-release 
PRETTY_NAME="Ubuntu 24.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.2 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo

root@wazuh-master:/home/vagrant# apt install haproxy
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  liblua5.4-0
Suggested packages:
  vim-haproxy haproxy-doc
The following NEW packages will be installed:
  haproxy liblua5.4-0
0 upgraded, 2 newly installed, 0 to remove and 189 not upgraded.
Need to get 2,236 kB of archives.
After this operation, 5,274 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://us.archive.ubuntu.com/ubuntu noble/main amd64 liblua5.4-0 amd64 5.4.6-3build2 [166 kB]
Get:2 http://us.archive.ubuntu.com/ubuntu noble-updates/main amd64 haproxy amd64 2.8.16-0ubuntu0.24.04.2 [2,070 kB]
Fetched 2,236 kB in 2s (1,151 kB/s)
Selecting previously unselected package liblua5.4-0:amd64.
(Reading database ... 85087 files and directories currently installed.)
Preparing to unpack .../liblua5.4-0_5.4.6-3build2_amd64.deb ...
Unpacking liblua5.4-0:amd64 (5.4.6-3build2) ...
Selecting previously unselected package haproxy.
Preparing to unpack .../haproxy_2.8.16-0ubuntu0.24.04.2_amd64.deb ...
Unpacking haproxy (2.8.16-0ubuntu0.24.04.2) ...
Setting up liblua5.4-0:amd64 (5.4.6-3build2) ...
Setting up haproxy (2.8.16-0ubuntu0.24.04.2) ...
Created symlink /etc/systemd/system/multi-user.target.wants/haproxy.service → /usr/lib/systemd/system/haproxy.service.
Processing triggers for libc-bin (2.39-0ubuntu8.5) ...
Processing triggers for rsyslog (8.2312.0-3ubuntu9.1) ...
Processing triggers for man-db (2.12.0-4build2) ...
Scanning processes...                                                                          
Scanning linux images...                                                                       

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.

root@wazuh-master:/home/vagrant# wget https://github.com/haproxytech/dataplaneapi/releases/download/v3.0.2/dataplaneapi_3.0.2_linux_amd64.deb
--2026-06-11 15:13:47--  https://github.com/haproxytech/dataplaneapi/releases/download/v3.0.2/dataplaneapi_3.0.2_linux_amd64.deb
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://release-assets.githubusercontent.com/github-production-release-asset/186656753/2b56d732-81d2-454a-bf4f-00600e44ee3b?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-06-11T15%3A53%3A53Z&rscd=attachment%3B+filename%3Ddataplaneapi_3.0.2_linux_amd64.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-06-11T14%3A53%3A01Z&ske=2026-06-11T15%3A53%3A53Z&sks=b&skv=2018-11-09&sig=5z7Kmp%2BQruOgA0TqllBqk%2FqXBESkwXgfvAkUAMCcP2I%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc4MTE5MjYyOCwibmJmIjoxNzgxMTkwODI4LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.ADeey2gxKzUH4E3pdaGpDyCFSOd2AtWjfeIE2EnInFY&response-content-disposition=attachment%3B%20filename%3Ddataplaneapi_3.0.2_linux_amd64.deb&response-content-type=application%2Foctet-stream [following]
--2026-06-11 15:13:48--  https://release-assets.githubusercontent.com/github-production-release-asset/186656753/2b56d732-81d2-454a-bf4f-00600e44ee3b?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-06-11T15%3A53%3A53Z&rscd=attachment%3B+filename%3Ddataplaneapi_3.0.2_linux_amd64.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-06-11T14%3A53%3A01Z&ske=2026-06-11T15%3A53%3A53Z&sks=b&skv=2018-11-09&sig=5z7Kmp%2BQruOgA0TqllBqk%2FqXBESkwXgfvAkUAMCcP2I%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc4MTE5MjYyOCwibmJmIjoxNzgxMTkwODI4LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.ADeey2gxKzUH4E3pdaGpDyCFSOd2AtWjfeIE2EnInFY&response-content-disposition=attachment%3B%20filename%3Ddataplaneapi_3.0.2_linux_amd64.deb&response-content-type=application%2Foctet-stream
Resolving release-assets.githubusercontent.com (release-assets.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to release-assets.githubusercontent.com (release-assets.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11791550 (11M) [application/octet-stream]
Saving to: ‘dataplaneapi_3.0.2_linux_amd64.deb’

dataplaneapi_3.0.2_linu 100%[==============================>]  11.25M  21.6MB/s    in 0.5s    

2026-06-11 15:13:49 (21.6 MB/s) - ‘dataplaneapi_3.0.2_linux_amd64.deb’ saved [11791550/11791550]

root@wazuh-master:/home/vagrant# sudo dpkg -i dataplaneapi_3.0.2_linux_amd64.deb
Selecting previously unselected package dataplaneapi.
(Reading database ... 109215 files and directories currently installed.)
Preparing to unpack dataplaneapi_3.0.2_linux_amd64.deb ...
Unpacking dataplaneapi (3.0.2) ...
Setting up dataplaneapi (3.0.2) ...
Created symlink /etc/systemd/system/multi-user.target.wants/dataplaneapi.service → /etc/systemd/system/dataplaneapi.service.
root@wazuh-master:/home/vagrant# which dataplaneapi
/usr/sbin/dataplaneapi

root@wazuh-master:/home/vagrant# cat /var/ossec/VERSION.json 
{
    "version": "4.14.5",
    "stage": "rc1",
    "commit": "9692df7"
}

root@wazuh-master:/home/vagrant# cat /etc/haproxy/haproxy.cfg
global
          chroot          /var/lib/haproxy
          pidfile         /var/run/haproxy.pid
          maxconn         4000
          user            haproxy
          group           haproxy
          stats socket /var/lib/haproxy/stats level admin
          log 127.0.0.1 local2 info

defaults
          mode http
          maxconn 4000
          log global
          option redispatch
          option dontlognull
          option tcplog
          timeout check 10s
          timeout connect 10s
          timeout client 1m
          timeout queue 1m
          timeout server 1m
          retries 3

frontend wazuh_register
          mode tcp
          bind :1515
          default_backend wazuh_register

backend wazuh_register
          mode tcp
          balance leastconn
          server master 192.168.56.11:1515 check
          server worker1 192.168.56.12:1515 check

root@wazuh-master:/home/vagrant# cat /etc/haproxy/dataplaneapi.yml 
config_version: 2
name: wazuh-master
mode: single
status: ""
dataplaneapi:
  host: 0.0.0.0
  port: 5555
  advertised:
    api_address: ""
    api_port: 0
  scheme:
  - http
  transaction:
    transaction_dir: /tmp/haproxy
  user:
  - name: wazuh
    insecure: true
    password: wazuh
haproxy:
  config_file: /etc/haproxy/haproxy.cfg
  haproxy_bin: /usr/sbin/haproxy
  reload:
    reload_delay: 5
    reload_cmd: service haproxy reload
    restart_cmd: service haproxy restart
    reload_strategy: custom

root@wazuh-master:/home/vagrant# curl -X GET --user wazuh:wazuh http://localhost:5555/v2/info
{"api":{"build_date":"2023-07-27T11:21:45.000Z","version":"v2.8.1 79506cd"},"system":{}}

  <cluster>
    <name>wazuh</name>
    <node_name>master-node</node_name>
    <node_type>master</node_type>
    <key>9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d</key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>192.168.56.11</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>no</disabled>
    <haproxy_helper>
      <haproxy_disabled>no</haproxy_disabled>
      <haproxy_address>192.168.56.11</haproxy_address>
      <haproxy_user>wazuh</haproxy_user>
      <haproxy_password>wazuh</haproxy_password>
   </haproxy_helper>
  </cluster>

root@wazuh-master:/home/vagrant# cat config.yml 
nodes:
  # Wazuh indexer nodes
  indexer:
    - name: indexer
      ip: "192.168.56.11"
    #- name: indexer-2
    #  ip: "<indexer-node-ip>"
    #- name: indexer-3
    #  ip: "<indexer-node-ip>"

  # Wazuh manager nodes
  # If there is more than one Wazuh manager
  # node, each one must have a node_type
  server:
    - name: master-node
      ip: "192.168.56.11"
      node_type: master
    - name: worker-node
      ip: "192.168.56.12"
      node_type: worker
    #- name: manager-3
    #  ip: "<wazuh-manager-ip>"
    #  node_type: worker

  # Wazuh dashboard nodes
  dashboard:
    - name: dashboard
      ip: "192.168.56.11"

root@wazuh-master:/home/vagrant# NODE_NAME=master-node
root@wazuh-master:/home/vagrant# mkdir -p /var/ossec/etc/certs
root@wazuh-master:/home/vagrant# tar -xf wazuh-certificates.tar -C /var/ossec/etc/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./root-ca.pem
root@wazuh-master:/home/vagrant# mv /var/ossec/etc/certs/$NODE_NAME.pem /var/ossec/etc/certs/manager.pem
root@wazuh-master:/home/vagrant# mv /var/ossec/etc/certs/$NODE_NAME-key.pem /var/ossec/etc/certs/manager-key.pem
root@wazuh-master:/home/vagrant# chmod 500 /var/ossec/etc/certs
root@wazuh-master:/home/vagrant# chmod 400 /var/ossec/etc/certs/*
root@wazuh-master:/home/vagrant# chown -R wazuh:wazuh /var/ossec/etc/certs
```

</details>

<details>
<summary>Worker node setup</summary>

```
root@wazuh-worker:/home/vagrant# cat /var/ossec/VERSION.json 
{
    "version": "4.14.5",
    "stage": "rc1",
    "commit": "9692df7"
}


  <cluster>
    <name>wazuh</name>
    <node_name>worker-node</node_name>
    <node_type>worker</node_type>
    <key>9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d</key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>192.168.56.11</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>yes</disabled>
  </cluster>

root@wazuh-worker:/home/vagrant# NODE_NAME=worker-node
root@wazuh-worker:/home/vagrant# tar -xf wazuh-certificates.tar -C /var/ossec/etc/certs/ ./$NODE_NAME.pem ./$NODE_NAME-key.pem ./root-ca.pem
root@wazuh-worker:/home/vagrant# mv /var/ossec/etc/certs/$NODE_NAME.pem /var/ossec/etc/certs/manager.pem
root@wazuh-worker:/home/vagrant# mv /var/ossec/etc/certs/$NODE_NAME-key.pem /var/ossec/etc/certs/manager-key.pem
root@wazuh-worker:/home/vagrant# chmod 500 /var/ossec/etc/certs
root@wazuh-worker:/home/vagrant# chmod 400 /var/ossec/etc/certs/*
root@wazuh-worker:/home/vagrant# chown -R wazuh:wazuh /var/ossec/etc/certs
root@wazuh-worker:/home/vagrant# vim /var/ossec/etc/ossec.conf 
root@wazuh-worker:/home/vagrant# systemctl start wazuh-manager
```

</details>


<details>
<summary>HAProxy working</summary>

```
root@wazuh-master:/home/vagrant# cat /var/ossec/logs/cluster.log 
2026/06/12 07:42:54 WARNING: [HAPHelper] [Main] HTTPS related parameters have been set but will be ignored since HTTP is defined as protocol.
2026/06/12 07:42:54 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2026/06/12 07:42:54 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2026/06/12 07:42:54 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:42:54 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2026/06/12 07:42:54 INFO: [HAPHelper] [Main] Proxy was initialized
2026/06/12 07:42:54 INFO: [HAPHelper] [Main] Ensuring only exists one HAProxy process. Sleeping 12s before start...
2026/06/12 07:42:54 INFO: [Master] [Local integrity] Finished in 0.078s. Calculated metadata of 40 files.
2026/06/12 07:43:02 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:43:02 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 40 files.
2026/06/12 07:43:06 INFO: [HAPHelper] [Main] Starting HAProxy Helper
2026/06/12 07:43:06 INFO: [HAPHelper] [Main] Load balancer backend is up to date
2026/06/12 07:43:06 INFO: [HAPHelper] [Main] Load balancer backend is balanced
2026/06/12 07:43:10 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:43:10 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 40 files.
2026/06/12 07:43:18 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:43:18 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 40 files.
2026/06/12 07:43:20 INFO: [Worker] [Main] Connection from ('192.168.56.12', 56128)
2026/06/12 07:43:24 INFO: [Master] [Local agent-groups] Starting.
2026/06/12 07:43:24 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/12 07:43:24 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/12 07:43:24 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.017s. Updated 1 chunks.
2026/06/12 07:43:26 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:43:26 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 40 files.
2026/06/12 07:43:29 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/12 07:43:29 INFO: [Worker worker-node] [Integrity check] Finished in 0.004s. Received metadata of 40 files. Sync not required.
2026/06/12 07:43:34 INFO: [Master] [Local agent-groups] Starting.
2026/06/12 07:43:34 INFO: [Master] [Local agent-groups] Finished in 0.000s.
2026/06/12 07:43:34 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/12 07:43:34 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.003s. Updated 1 chunks.
2026/06/12 07:43:34 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:43:34 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 40 files.
2026/06/12 07:43:38 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/12 07:43:38 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 40 files. Sync not required.
2026/06/12 07:43:42 INFO: [Master] [Local integrity] Starting.
2026/06/12 07:43:42 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 40 files.
2026/06/12 07:43:44 INFO: [Master] [Local agent-groups] Starting.
2026/06/12 07:43:44 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/12 07:43:44 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/12 07:43:44 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.004s. Updated 1 chunks.

```

</details>

---

#### After migration

Architecture used for testing HAProxy after migration is as it follows:

- 2 agents (192.168.56.14, 192.168.56.15)
- HAProxy + dataplaneapi (192.168.56.13)
- 2 managers (master: 192.168.56.11, worker: 192.168.56.12)

<details>
<summary>Coordinator installation working properly</summary>

```
root@wazuh-coordinator:/home/vagrant# curl -X GET --user wazuh:wazuh http://localhost:5555/v2/info
{"api":{"build_date":"2023-12-08T14:53:01.000Z","version":"v2.9.0 91da11d"},"system":{}}
```

</details>

<details>
<summary>Cluster logs after migration</summary>

> Disclaimer: I did not install an indexer, so it is completely expected seeing that error log, I also had to install the HAProxy in another machine rather than in the master's vm (as when 4.x) because of ports issues. But everything works fine.

```
root@wazuh-master:/home/vagrant# cat /var/wazuh-manager/logs/cluster.log 

2026/06/15 14:58:39 WARNING: [HAPHelper] [Main] HTTPS related parameters have been set but will be ignored since HTTP is defined as protocol.
2026/06/15 14:58:39 INFO: [Local Server] [Main] Serving on /var/wazuh-manager/queue/cluster/c-internal.sock
2026/06/15 14:58:39 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2026/06/15 14:58:39 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2026/06/15 14:58:39 INFO: [Master] [Main] Checking if the indexer is available to initiate indexer tasks.
2026/06/15 14:58:39 WARNING: [Master] [Main] Connection attempt 1 failed: Error 2200 - Error connecting to the Indexer service: Failed to create indexer client: ConnectionError(Cannot connect to host 127.0.0.1:9200 ssl:default [Connect call failed ('127.0.0.1', 9200)]) caused by: ClientConnectorError(Cannot connect to host 127.0.0.1:9200 ssl:default [Connect call failed ('127.0.0.1', 9200)]). Retrying in 60.16 seconds...
2026/06/15 14:58:39 INFO: [HAPHelper] [Main] Proxy was initialized
2026/06/15 14:58:39 INFO: [HAPHelper] [Main] Could not find Wazuh frontend 'wazuh_reporting_front'
2026/06/15 14:58:39 INFO: [HAPHelper] [Main] Added Wazuh frontend
2026/06/15 14:58:45 INFO: [Worker] [Main] Connection from ('192.168.56.12', 41918)
2026/06/15 14:58:45 INFO: [Worker worker-node] [Main] Starting cluster tasks.
2026/06/15 14:58:45 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:58:45 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 14:58:51 INFO: [HAPHelper] [Main] Setting a value for `hard-stop-after` configuration.
2026/06/15 14:58:52 INFO: [HAPHelper] [Proxy] Set `hard-stop-after` with 20.0 seconds.
2026/06/15 14:58:52 INFO: [HAPHelper] [Main] Starting HAProxy Helper
2026/06/15 14:58:52 INFO: [HAPHelper] [Main] Detected changes in Wazuh cluster nodes. Current cluster: {'master-node': '192.168.56.11', 'worker-node': '192.168.56.12'}
2026/06/15 14:58:52 INFO: [HAPHelper] [Main] Attempting to update proxy backend
2026/06/15 14:58:52 INFO: [HAPHelper] [Main] Setting a value for `hard-stop-after` configuration.
2026/06/15 14:58:53 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:58:53 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 14:58:54 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:58:54 INFO: [Worker worker-node] [Integrity check] Finished in 0.004s. Received metadata of 4 files. Sync not required.
2026/06/15 14:58:54 INFO: [HAPHelper] [Main] Waiting for agent connections stability
2026/06/15 14:59:01 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:01 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 4 files.
2026/06/15 14:59:03 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:03 INFO: [Worker worker-node] [Integrity check] Finished in 0.004s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:05 INFO: [Worker worker-node] [Agent-info sync] Starting.
2026/06/15 14:59:05 INFO: [Worker worker-node] [Agent-info sync] Finished in 0.004s. Updated 1 chunks.
2026/06/15 14:59:09 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:09 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 14:59:09 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 14:59:09 INFO: [Master] [Local agent-groups] Finished in 0.003s.
2026/06/15 14:59:09 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 14:59:09 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.009s. Updated 1 chunks.
2026/06/15 14:59:12 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:12 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:17 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:17 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 4 files.
2026/06/15 14:59:19 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 14:59:19 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 14:59:19 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 14:59:19 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.004s. Updated 1 chunks.
2026/06/15 14:59:21 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:21 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:25 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:25 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 4 files.
2026/06/15 14:59:25 INFO: [Worker worker-node] [Agent-info sync] Starting.
2026/06/15 14:59:25 INFO: [Worker worker-node] [Agent-info sync] Finished in 0.004s. Updated 1 chunks.
2026/06/15 14:59:29 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 14:59:29 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 14:59:29 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 14:59:29 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.004s. Updated 1 chunks.
2026/06/15 14:59:30 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:30 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:33 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:33 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 14:59:39 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:39 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:39 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 14:59:39 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 14:59:39 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 14:59:39 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.004s. Updated 1 chunks.
2026/06/15 14:59:39 WARNING: [Master] [Main] Connection attempt 2 failed: Error 2200 - Error connecting to the Indexer service: Failed to create indexer client: ConnectionError(Cannot connect to host 127.0.0.1:9200 ssl:default [Connect call failed ('127.0.0.1', 9200)]) caused by: ClientConnectorError(Cannot connect to host 127.0.0.1:9200 ssl:default [Connect call failed ('127.0.0.1', 9200)]). Retrying in 120.09 seconds...
2026/06/15 14:59:41 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:41 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 4 files.
2026/06/15 14:59:45 INFO: [Worker worker-node] [Agent-info sync] Starting.
2026/06/15 14:59:45 INFO: [Worker worker-node] [Agent-info sync] Finished in 0.005s. Updated 1 chunks.
2026/06/15 14:59:48 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:48 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:49 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:49 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 14:59:49 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 14:59:49 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 14:59:49 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 14:59:49 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.003s. Updated 1 chunks.
2026/06/15 14:59:54 INFO: [HAPHelper] [Main] Load balancer backend is up to date
2026/06/15 14:59:54 INFO: [HAPHelper] [Main] Load balancer backend is balanced
2026/06/15 14:59:57 INFO: [Master] [Local integrity] Starting.
2026/06/15 14:59:57 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 4 files.
2026/06/15 14:59:57 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 14:59:57 INFO: [Worker worker-node] [Integrity check] Finished in 0.004s. Received metadata of 4 files. Sync not required.
2026/06/15 14:59:59 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 14:59:59 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 14:59:59 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 14:59:59 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.004s. Updated 1 chunks.
2026/06/15 15:00:05 INFO: [Master] [Local integrity] Starting.
2026/06/15 15:00:05 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 15:00:05 INFO: [Worker worker-node] [Agent-info sync] Starting.
2026/06/15 15:00:05 INFO: [Worker worker-node] [Agent-info sync] Finished in 0.004s. Updated 1 chunks.
2026/06/15 15:00:06 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 15:00:06 INFO: [Worker worker-node] [Integrity check] Finished in 0.004s. Received metadata of 4 files. Sync not required.
2026/06/15 15:00:09 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 15:00:09 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 15:00:09 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 15:00:09 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.004s. Updated 1 chunks.
2026/06/15 15:00:13 INFO: [Master] [Local integrity] Starting.
2026/06/15 15:00:13 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 15:00:15 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 15:00:15 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 15:00:19 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 15:00:19 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2026/06/15 15:00:19 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 15:00:19 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.003s. Updated 1 chunks.
2026/06/15 15:00:21 INFO: [Master] [Local integrity] Starting.
2026/06/15 15:00:21 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 4 files.
2026/06/15 15:00:24 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 15:00:24 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
2026/06/15 15:00:25 INFO: [Worker worker-node] [Agent-info sync] Starting.
2026/06/15 15:00:25 INFO: [Worker worker-node] [Agent-info sync] Finished in 0.004s. Updated 1 chunks.
2026/06/15 15:00:29 INFO: [Master] [Local integrity] Starting.
2026/06/15 15:00:29 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 4 files.
2026/06/15 15:00:29 INFO: [Master] [Local agent-groups] Starting.
2026/06/15 15:00:29 INFO: [Master] [Local agent-groups] Finished in 0.000s.
2026/06/15 15:00:29 INFO: [Worker worker-node] [Agent-groups send] Starting.
2026/06/15 15:00:29 INFO: [Worker worker-node] [Agent-groups send] Finished in 0.003s. Updated 1 chunks.
2026/06/15 15:00:33 INFO: [Worker worker-node] [Integrity check] Starting.
2026/06/15 15:00:33 INFO: [Worker worker-node] [Integrity check] Finished in 0.003s. Received metadata of 4 files. Sync not required.
```
</details>

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
