### PR TITLE
Prevent indexer consumer wait during shutdown

### DIFF
--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -196,10 +196,26 @@ private:
             return true;
         }
 
+        if (context.spUpdaterBaseContext->spStopCondition->check())
+        {
+            logInfo(WM_CONTENTUPDATER,
+                    "IndexerDownloader: Stop requested before waiting for consumer '%s' to become idle.",
+                    consumerStatusId.c_str());
+            return false;
+        }
+
         IndexerConnectorSync syncConnector(m_config.at("indexer"), LoggingContext {WM_CONTENTUPDATER, {}});
 
         while (true)
         {
+            if (context.spUpdaterBaseContext->spStopCondition->check())
+            {
+                logInfo(WM_CONTENTUPDATER,
+                        "IndexerDownloader: Stop requested while waiting for consumer '%s' to become idle.",
+                        consumerStatusId.c_str());
+                return false;
+            }
+
             try
             {
                 switch (readConsumerStatus(syncConnector, consumerStatusIndex, consumerStatusId))


### PR DESCRIPTION
## Summary

Prevents `IndexerDownloader::waitUntilConsumerIdle()` from creating an `IndexerConnectorSync` and starting an Indexer health-check request when shutdown has already been requested.

## Root cause

The coredumps in #36811 show `wazuh-manager-modulesd` crashing in OpenSSL while the content updater scheduler is inside `IndexerDownloader::waitUntilConsumerIdle()`. The failing path creates an `IndexerConnectorSync`, which constructs monitoring state and immediately performs an HTTP health check through cURL/OpenSSL.

Both `SIGSEGV` cores show `pthread_rwlock_rdlock()` called from `CRYPTO_THREAD_read_lock()` with `x0 = 0x18` on ARM64, meaning OpenSSL received an invalid lock pointer. This appears to be exposed by shutdown/startup pressure while new HTTP work is still being started.

## Changes

- Check `spStopCondition` before constructing `IndexerConnectorSync` in `waitUntilConsumerIdle()`.
- Check `spStopCondition` before each consumer-status query attempt.
- Return early when shutdown is already in progress, avoiding new cURL/OpenSSL activity during teardown.
