### PR TITLE
Normalize numeric inode to string events (6960)

### DIFF
--- a/src/syscheckd/src/file/events.c
+++ b/src/syscheckd/src/file/events.c
@@ -108,6 +108,11 @@ void fim_calculate_dbsync_difference(const directory_t *configuration,
              if (cJSON_IsString(aux)) {
                  cJSON_AddStringToObject(old_attributes, "inode", cJSON_GetStringValue(aux));
                  cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("file.inode"));
+             } else if (cJSON_IsNumber(aux)) {
+                 char inode_str[32];
+                 snprintf(inode_str, sizeof(inode_str), "%llu", (unsigned long long)cJSON_GetNumberValue(aux));
+                 cJSON_AddStringToObject(old_attributes, "inode", inode_str);
+                 cJSON_AddItemToArray(changed_attributes, cJSON_CreateString("file.inode"));
              } else {
                  minfo(FIM_WARN_INODE_WRONG_TYPE);
              }
@@ -383,6 +388,10 @@ cJSON * fim_attributes_json(const cJSON *dbsync_event, const fim_file_data *data
             if ((aux = cJSON_GetObjectItem(dbsync_event, "inode")) != NULL) {
                 if (cJSON_IsString(aux)) {
                     cJSON_AddStringToObject(attributes, "inode", cJSON_GetStringValue(aux));
+                } else if (cJSON_IsNumber(aux)) {
+                    char inode_str[32];
+                    snprintf(inode_str, sizeof(inode_str), "%llu", (unsigned long long)cJSON_GetNumberValue(aux));
+                    cJSON_AddStringToObject(attributes, "inode", inode_str);
                 } else {
                     minfo(FIM_WARN_INODE_WRONG_TYPE);
                 }

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -4123,7 +4123,7 @@ static void test_dbsync_attributes_json(void **state) {
  * (the column is INTEGER), it must be normalized to a string instead of
  * being dropped and logged. No __wrap__minfo expectation is set on purpose:
  * the buggy code path calls minfo(FIM_WARN_INODE_WRONG_TYPE) -> cmocka fails. */
-void test_fim_attributes_json_inode_number(void **state) {
+static void test_fim_attributes_json_inode_number(void **state) {
     (void) state;
     directory_t configuration = { .options = CHECK_INODE };
 
@@ -4145,7 +4145,7 @@ void test_fim_attributes_json_inode_number(void **state) {
 
 /* Same fix, "changed/old" path: numeric inode must become a string in
  * old_attributes and "file.inode" must be reported as a changed field. */
-void test_fim_calculate_dbsync_difference_inode_number(void **state) {
+static void test_fim_calculate_dbsync_difference_inode_number(void **state) {
     (void) state;
     directory_t configuration = { .options = CHECK_INODE };
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -4119,11 +4119,64 @@ static void test_dbsync_attributes_json(void **state) {
     free(json_attributes_str);
 }
 
+/* Validates fix for (6960): when dbsync delivers `inode` as a JSON number
+ * (the column is INTEGER), it must be normalized to a string instead of
+ * being dropped and logged. No __wrap__minfo expectation is set on purpose:
+ * the buggy code path calls minfo(FIM_WARN_INODE_WRONG_TYPE) -> cmocka fails. */
+void test_fim_attributes_json_inode_number(void **state) {
+    (void) state;
+    directory_t configuration = { .options = CHECK_INODE };
+
+    // inode arrives as a NUMBER (note: no quotes), and a large >INT_MAX value
+    // to prove %llu is required (a %d/valueint conversion would truncate it).
+    cJSON *dbsync_event = cJSON_Parse("{\"inode\":4294967296}");
+
+    cJSON *attributes = fim_attributes_json(dbsync_event, NULL, &configuration);
+
+    assert_non_null(attributes);
+    cJSON *inode = cJSON_GetObjectItem(attributes, "inode");
+    assert_non_null(inode);
+    assert_true(cJSON_IsString(inode));
+    assert_string_equal(inode->valuestring, "4294967296");
+
+    cJSON_Delete(dbsync_event);
+    cJSON_Delete(attributes);
+}
+
+/* Same fix, "changed/old" path: numeric inode must become a string in
+ * old_attributes and "file.inode" must be reported as a changed field. */
+void test_fim_calculate_dbsync_difference_inode_number(void **state) {
+    (void) state;
+    directory_t configuration = { .options = CHECK_INODE };
+
+    cJSON *changed_data_json   = cJSON_Parse("{\"inode\":4294967296}");
+    cJSON *old_attributes      = cJSON_CreateObject();
+    cJSON *changed_attributes  = cJSON_CreateArray();
+
+    fim_calculate_dbsync_difference(&configuration,
+                                    changed_data_json,
+                                    changed_attributes,
+                                    old_attributes);
+
+    cJSON *inode = cJSON_GetObjectItem(old_attributes, "inode");
+    assert_non_null(inode);
+    assert_true(cJSON_IsString(inode));
+    assert_string_equal(inode->valuestring, "4294967296");
+
+    assert_int_equal(cJSON_GetArraySize(changed_attributes), 1);
+    assert_string_equal(cJSON_GetArrayItem(changed_attributes, 0)->valuestring, "file.inode");
+
+    cJSON_Delete(changed_data_json);
+    cJSON_Delete(old_attributes);
+    cJSON_Delete(changed_attributes);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         /* fim_attributes_json */
         cmocka_unit_test_teardown(test_fim_attributes_json, teardown_delete_json),
         cmocka_unit_test_setup_teardown(test_dbsync_attributes_json, setup_json_event_attributes, teardown_json_event_attributes),
+        cmocka_unit_test(test_fim_attributes_json_inode_number),
 
         /* fim_audit_json */
         cmocka_unit_test_teardown(test_fim_audit_json, teardown_delete_json),
@@ -4263,6 +4316,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_create_unix_who_data_events, setup_fim_data, teardown_fim_data),
         cmocka_unit_test_setup_teardown(test_fim_db_remove_entry, setup_fim_entry, teardown_fim_entry),
         cmocka_unit_test_setup_teardown(test_fim_db_process_missing_entry, setup_fim_entry, teardown_fim_entry),
+        cmocka_unit_test(test_fim_calculate_dbsync_difference_inode_number),
     };
     const struct CMUnitTest fim_regex_tests[] = {
         /* fim_check_ignore */


### PR DESCRIPTION
## Description

Description

On agent startup, wazuh-syscheckd logged the message:

(6960): Inode field received with a wrong type, it must be a string.

The inode column is declared INTEGER in the FIM database (db/src/fimDB.hpp) and serialized as a number (db/src/dbFileItem.cpp), so dbsync delivers inode as a JSON number. The real-time/whodata path (fim_db_file_update) already normalizes it to a string via convert_inode, but the scan/transaction path — the one that runs at startup — does not. As a result, fim_attributes_json() and fim_calculate_dbsync_difference() (src/syscheckd/src/file/events.c) only accepted a string inode; on a number they emitted message 6960 and dropped the field from the event.

This is why the message appeared only around agent startup (driven by the initial scan through the transaction path) and not during steady-state real-time events.

## Proposed Changes

- Handle the numeric inode case in both events.c call sites, mirroring how the adjacent device and mtime fields already do it: convert the number with snprintf(..., "%llu", (unsigned long long)cJSON_GetNumberValue(aux)) and add it as a string.
- %llu is used (instead of the %d/valueint used by device) because inode is a 64-bit value and would otherwise be truncated.
- The genuine "wrong type" case (neither string nor number) still logs 6960, so the diagnostic is preserved.

This removes the spurious message on startup and, more importantly, correctly populates the inode attribute that was previously discarded from FIM events generated by the scan path.


<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence
- https://github.com/wazuh/wazuh/pull/36837#issuecomment-4694624447
<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
N-A

### Configuration Changes
N-A

### Tests Introduced
test_fim_attributes_json_inode_number, test_fim_calculate_dbsync_difference_inode_number

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

