### PR TITLE
Skip vanished /proc entries during ports scan

### DIFF
--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -305,6 +305,7 @@
         "src/config/src/wmodules-syscollector.c",
         "src/wazuh_modules/src/wm_syscollector.c",
         "src/wazuh_modules/syscollector/**",
+        "src/data_provider/**",
         "src/Makefile",
         "tests/integration/conftest.py",
         "tests/integration/test_syscollector/**"

--- a/.github/test_modules_windows.json
+++ b/.github/test_modules_windows.json
@@ -6,7 +6,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/client-agent/**",
         "src/config/src/buffer-config.c",
         "src/config/src/client-config.c",
@@ -23,7 +23,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/client-agent/**",
         "src/config/src/buffer-config.c",
         "src/config/src/client-config.c",
@@ -42,7 +42,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/active-response/**",
         "src/os_execd/**",
         "src/win32/**",
@@ -59,7 +59,7 @@
       "start_service": true,
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/config/src/syscheck-config.c",
         "src/config/include/syscheck-config.h",
         "src/syscheckd/**",
@@ -74,7 +74,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/config/src/wmodules-github.c",
         "src/wazuh_modules/src/wm_github.h",
         "src/wazuh_modules/src/wm_github.c",
@@ -90,7 +90,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/config/src/localfile-config.c",
         "src/config/include/localfile-config.h",
         "src/logcollector/**",
@@ -105,7 +105,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/config/src/wmodules-office365.c",
         "src/wazuh_modules/src/wm_office365.h",
         "src/wazuh_modules/src/wm_office365.c",
@@ -122,7 +122,7 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/config/src/wmodules-sca.c",
         "src/wazuh_modules/src/wm_sca.c",
         "src/wazuh_modules/src/wm_sca.h",
@@ -139,10 +139,11 @@
       "tiers": ["0 1"],
       "paths": [
         ".github/workflows/5_testintegration_windows-integration-tests.yml",
-        ".github/test-modules-windows.json",
+        ".github/test_modules_windows.json",
         "src/config/src/wmodules-syscollector.c",
         "src/wazuh_modules/src/wm_syscollector.c",
         "src/wazuh_modules/syscollector/**",
+        "src/data_provider/**",
         "src/win32/**",
         "src/Makefile",
         "tests/integration/conftest.py",

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -10,8 +10,8 @@ on:
       - "ruleset/**"
       - ".github/actions/check_files/**"
       - ".github/workflows/5_builderpackage_agent-windows.yml"
-      - ".github/test-modules-windows.json"
       - ".github/workflows/5_testintegration_agent-start.yml"
+      - ".github/test_modules_windows.json"
       - ".github/workflows/5_testintegration_windows-integration-tests.yml"
       - ".github/actions/5_builderpackage_get-last-stable-version/**"
       - ".github/actions/5_builderpackage_get-upgrade-test-package-url/**"
@@ -63,7 +63,7 @@ jobs:
         id: detect
         uses: ./.github/actions/5_testintegration_detect-changes
         with:
-          modules-config: .github/test-modules-windows.json
+          modules-config: .github/test_modules_windows.json
           none-matrix: '{"include":[{"name":"none","shard_name":"none","pytest_target":"test_none\\","pytest_extra_args":"","pytest_tier_args":"","pytest_ignore_args":"","start_service":false,"skip_tests":true}]}'
           field-defaults: '{"pytest_extra_args":"","pytest_ignore_args":"","start_service":false,"skip_tests":false}'
 

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -443,6 +443,22 @@ ProcessInfo portProcessInfo(const std::string& procPath, const std::deque<int64_
 
     const file_system::FileSystemWrapper fs;
 
+    // A process can disappear between listing /proc and inspecting it (a short-lived process).
+    // The throwing std::filesystem::is_directory would then raise an ESRCH/ENOENT
+    // filesystem_error that, if it escaped, would abort the whole ports scan and log a misleading
+    // error. Treat a vanished entry as "not a directory" so we simply skip that PID and continue.
+    auto safeIsDirectory = [&fs](const std::filesystem::path & path) -> bool
+    {
+        try
+        {
+            return fs.is_directory(path);
+        }
+        catch (const std::filesystem::filesystem_error&)
+        {
+            return false;
+        }
+    };
+
     if (fs.is_directory(procPath))
     {
         auto procFiles = fs.list_directory(procPath);
@@ -453,12 +469,12 @@ ProcessInfo portProcessInfo(const std::string& procPath, const std::deque<int64_
             // Only directories that represent a PID are inspected.
             std::string procFileName = procFile.filename().string();
 
-            if (Utils::isNumber(procFileName) && fs.is_directory(procFile))
+            if (Utils::isNumber(procFileName) && safeIsDirectory(procFile))
             {
                 // Only fd directory is inspected.
                 const std::filesystem::path pidFilePath = procFile / "fd";
 
-                if (fs.is_directory(pidFilePath))
+                if (safeIsDirectory(pidFilePath))
                 {
                     std::vector<std::filesystem::path> fdFiles;
 


### PR DESCRIPTION
## Description

On Linux agents, syscollector occasionally logged:

```
wazuh-modulesd:syscollector: ERROR: filesystem error: status: No such process [/proc/<pid>/fd]
```

This is a **TOCTOU race** in the ports collector. `SysInfo::portProcessInfo`
(`src/data_provider/src/sysInfoLinux.cpp`) maps socket inodes → PID by scanning `/proc/<pid>/fd`. It
lists `/proc`, then for each PID checks `fs.is_directory(/proc/<pid>)` and `fs.is_directory(/proc/<pid>/fd)`.
`file_system::FileSystemWrapper::is_directory` calls the **throwing** overload of
`std::filesystem::is_directory` (no `std::error_code`). When a process **exits between the `/proc`
listing and these checks**, accessing its
`/proc/<pid>` entry can return **`ESRCH` ("No such process")**, and `is_directory` throws a
`std::filesystem::filesystem_error`.

Those two per‑PID `is_directory` calls were **outside any try/catch** (unlike the `list_directory` and
`is_socket` calls in the same loop, which already catch and continue). So the exception propagated out
of `portProcessInfo` → `getPorts` → `scanPorts`, where the `TRY_CATCH_TASK` macro
(`syscollectorImp.cpp:42‑56`) caught it and logged the raw `what()` at `LOG_ERROR`. Net effect: **a
single unrelated process that legitimately exited mid‑scan aborted the entire ports inventory for that
cycle and logged a misleading ERROR.**

### Fix

Guard the per‑PID existence checks with a small local helper that treats a vanished/inaccessible
entry as "not a directory", so that PID is simply skipped and the scan continues:

```cpp
auto safeIsDirectory = [&fs](const std::filesystem::path & path) -> bool
{
    try
    {
        return fs.is_directory(path);
    }
    catch (const std::filesystem::filesystem_error&)
    {
        return false;
    }
};
...
if (Utils::isNumber(procFileName) && safeIsDirectory(procFile))      // /proc/<pid>
{
    const std::filesystem::path pidFilePath = procFile / "fd";
    if (safeIsDirectory(pidFilePath))                               // /proc/<pid>/fd  (reported site)
    { ... }
}
```

The top‑level `if (fs.is_directory(procPath))` (where `procPath == "/proc/"`) is **left unguarded on
purpose**: `/proc` is the stable kernel mount root, it does not take part in the per‑process vanish
race.

Closes #36803 (the `filesystem error: status: No such process [/proc/<pid>/fd]` part)

## Proposed Changes

- `src/data_provider/src/sysInfoLinux.cpp` — add the `safeIsDirectory` helper in `portProcessInfo` and
  use it for the `/proc/<pid>` and `/proc/<pid>/fd` checks. Localized change; does not alter
  `FileSystemWrapper::is_directory` semantics for any other caller.
- **CI (`detect-changes`)** — syscollector consumes the `data_provider` (sysinfo) library, but its
  integration-test trigger did not include it, so this fix's change to `src/data_provider/**` matched no
  module and the syscollector ITs were skipped. Added `src/data_provider/**` to the `syscollector`
  module paths in `.github/test_modules_linux.json` and `.github/test_modules_windows.json`. Also
  renamed `.github/test-modules-windows.json` → `.github/test_modules_windows.json` for consistency with
  the other platform files (updated its self-references and the references in
  `.github/workflows/5_builderpackage_agent-windows.yml`).

### Results and Evidence

Verified with a deterministic before/after that exercises the real `FileSystemWrapper::is_directory`
and replicates `portProcessInfo`'s per‑PID loop, against a `/proc/<pid>/fd` entry made to throw a
`filesystem_error`:

```
###### WITHOUT FIX ######
[BUGGY] scan ABORTED (exception escaped, whole ports scan lost): filesystem error: status: ... [/proc/<pid>/fd]

###### WITH FIX ######
[FIXED] scan COMPLETED, PIDs processed = 1
```

- **Without the fix:** the exception from `is_directory(/proc/<pid>/fd)` escapes and aborts the whole
  ports scan (in production it is then logged as the reported ERROR and the cycle's ports inventory is
  lost).
- **With the fix:** the offending PID is skipped and the scan completes normally.

The fix catches any `std::filesystem::filesystem_error`, so it handles the field's `ESRCH` (process
vanished mid‑scan) and any other errno identically.

### Artifacts Affected

- `src/data_provider/src/sysInfoLinux.cpp`
- `.github/test_modules_linux.json`
- `.github/test_modules_windows.json` (renamed from `.github/test-modules-windows.json`)
- `.github/workflows/5_builderpackage_agent-windows.yml`

No behavior change other than: a per‑PID `/proc` entry that vanishes or is momentarily inaccessible
during the scan is now skipped (the ports scan completes for all other PIDs) instead of aborting the
scan and logging a misleading ERROR. The CI changes only affect which integration tests are selected.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
