### PR TITLE
Add bump-issue-link support to bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -23,6 +23,10 @@ on:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
         type: string
+      bump-issue-link:
+        description: 'Issue link used in the original bump (required for revert if different from issue-link)'
+        required: false
+        type: string
       set_as_main:
         description: 'Update version values only, preserving main branch references in URLs'
         default: false
@@ -142,7 +146,13 @@ jobs:
         run: |
           ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
 
-          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+          if [ -n "${{ inputs.bump-issue-link }}" ]; then
+            BUMP_ISSUE_NUMBER=$(echo "${{ inputs.bump-issue-link }}" | awk -F'/' '{print $NF}')
+          else
+            BUMP_ISSUE_NUMBER=$ISSUE_NUMBER
+          fi
+
+          BUMP_BRANCH="enhancement/wqa${BUMP_ISSUE_NUMBER}-bump-${{ github.ref_name }}"
 
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 


### PR DESCRIPTION
Closes #36864

## Changes
- Added the optional `bump-issue-link` workflow input.
- Updated the revert step to search the original bump PR using `bump-issue-link` when it is provided.

## Validation
- Parsed `.github/workflows/5_bumper_repository.yml` successfully as YAML.

## Validation evidence
- Bump workflow run: https://github.com/wazuh/wazuh/actions/runs/27544688667
- Bump PR created and merged by the workflow: https://github.com/wazuh/wazuh/pull/36870
- Revert workflow run with `issue-link=https://github.com/wazuh/wazuh/issues/36864` and `bump-issue-link=https://github.com/wazuh/wazuh-qa-automation/issues/7352`: https://github.com/wazuh/wazuh/actions/runs/27544753661
- The revert run found the original bump PR with `Original PR found: #36870`.
- Revert PR created and merged by the workflow: https://github.com/wazuh/wazuh/pull/36871
