### PR TITLE
Fix manager reload/restart silently fails

### DIFF
--- a/src/unit_tests/wazuh_modules/control/test_wm_control.c
+++ b/src/unit_tests/wazuh_modules/control/test_wm_control.c
@@ -78,7 +78,7 @@ static void test_dispatch_restart(void **state) {
     expect_string(__wrap__mtdebug2, formatted_msg, "Dispatching command: 'restart'");
     expect_check_systemd_not_available();
     expect_string(__wrap__mtinfo, tag, WM_CONTROL_TEST_LOGTAG);
-    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using wazuh-control");
+    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using bin/wazuh-manager-control");
     will_return(__wrap_fork, 1234);
 
     size_t ret = wm_control_dispatch(command, &output);
@@ -98,7 +98,7 @@ static void test_dispatch_reload(void **state) {
     expect_string(__wrap__mtdebug2, formatted_msg, "Dispatching command: 'reload'");
     expect_check_systemd_not_available();
     expect_string(__wrap__mtinfo, tag, WM_CONTROL_TEST_LOGTAG);
-    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'reload' on wazuh-manager using wazuh-control");
+    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'reload' on wazuh-manager using bin/wazuh-manager-control");
     will_return(__wrap_fork, 5678);
 
     size_t ret = wm_control_dispatch(command, &output);
@@ -119,7 +119,7 @@ static void test_dispatch_restart_with_args(void **state) {
     expect_string(__wrap__mtdebug2, formatted_msg, "Dispatching command: 'restart'");
     expect_check_systemd_not_available();
     expect_string(__wrap__mtinfo, tag, WM_CONTROL_TEST_LOGTAG);
-    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using wazuh-control");
+    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using bin/wazuh-manager-control");
     will_return(__wrap_fork, 1234);
 
     size_t ret = wm_control_dispatch(command, &output);
@@ -159,7 +159,7 @@ static void test_execute_action_fork_fails(void **state) {
 
     expect_check_systemd_not_available();
     expect_string(__wrap__mtinfo, tag, WM_CONTROL_TEST_LOGTAG);
-    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using wazuh-control");
+    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using bin/wazuh-manager-control");
 
     will_return(__wrap_fork, -1);
     expect_string(__wrap__mterror, tag, WM_CONTROL_TEST_LOGTAG);
@@ -179,7 +179,7 @@ static void test_execute_action_restart_no_systemd(void **state) {
 
     expect_check_systemd_not_available();
     expect_string(__wrap__mtinfo, tag, WM_CONTROL_TEST_LOGTAG);
-    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using wazuh-control");
+    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'restart' on wazuh-manager using bin/wazuh-manager-control");
 
     will_return(__wrap_fork, 1234); /* Simulate parent process */
 
@@ -215,7 +215,7 @@ static void test_execute_action_reload_no_systemd(void **state) {
 
     expect_check_systemd_not_available();
     expect_string(__wrap__mtinfo, tag, WM_CONTROL_TEST_LOGTAG);
-    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'reload' on wazuh-manager using wazuh-control");
+    expect_string(__wrap__mtinfo, formatted_msg, "Executing 'reload' on wazuh-manager using bin/wazuh-manager-control");
 
     will_return(__wrap_fork, 5678); /* Simulate parent process */
 

--- a/src/wazuh_modules/src/wm_control.c
+++ b/src/wazuh_modules/src/wm_control.c
@@ -124,6 +124,15 @@ bool wm_control_wait_for_service_active(const char *service) {
     return false;
 }
 
+const char *wm_control_get_bin(void) {
+    /* 5.0 rename: manager ships wazuh-manager-control, agent ships wazuh-control. */
+#ifdef CLIENT
+    return "bin/wazuh-control";
+#else
+    return "bin/wazuh-manager-control";
+#endif
+}
+
 size_t wm_control_execute_action(const char *action, const char *service, char **output) {
 #ifdef __APPLE__
     /* On macOS, do not run wazuh-control directly from here. Forking it from
@@ -178,6 +187,7 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
     }
 #else
     bool use_systemd = wm_control_check_systemd();
+    const char *control_bin = wm_control_get_bin();
     char *exec_cmd[4] = {NULL};
 
     if (use_systemd) {
@@ -186,9 +196,9 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
         exec_cmd[2] = (char *)service;
         mtinfo(WM_CONTROL_LOGTAG, "Executing '%s' on %s using systemctl", action, service);
     } else {
-        exec_cmd[0] = "bin/wazuh-control";
+        exec_cmd[0] = (char *)control_bin;
         exec_cmd[1] = (char *)action;
-        mtinfo(WM_CONTROL_LOGTAG, "Executing '%s' on %s using wazuh-control", action, service);
+        mtinfo(WM_CONTROL_LOGTAG, "Executing '%s' on %s using %s", action, service, control_bin);
     }
 
     switch (fork()) {
@@ -199,16 +209,16 @@ size_t wm_control_execute_action(const char *action, const char *service, char *
         case 0:
             if (use_systemd && strcmp(action, "reload") == 0) {
                 if (!wm_control_wait_for_service_active(service)) {
-                    mtwarn(WM_CONTROL_LOGTAG, "Service %s not active for systemctl, falling back to wazuh-control", service);
-                    char *fallback_cmd[] = {"bin/wazuh-control", (char *)action, NULL};
+                    mtwarn(WM_CONTROL_LOGTAG, "Service %s not active for systemctl, falling back to %s", service, control_bin);
+                    char *fallback_cmd[] = {(char *)control_bin, (char *)action, NULL};
                     if (execvp(fallback_cmd[0], fallback_cmd) < 0) {
-                        mterror(WM_CONTROL_LOGTAG, "Error executing %s command via wazuh-control: %s (%d)", action, strerror(errno), errno);
+                        mterror(WM_CONTROL_LOGTAG, "Error executing %s command via %s: %s (%d)", action, control_bin, strerror(errno), errno);
                     }
                     _exit(1);
                 }
             }
             if (execvp(exec_cmd[0], exec_cmd) < 0) {
-                mterror(WM_CONTROL_LOGTAG, "Error executing %s command: %s (%d)", action, strerror(errno), errno);
+                mterror(WM_CONTROL_LOGTAG, "Error executing %s command (%s): %s (%d)", action, exec_cmd[0], strerror(errno), errno);
             }
             _exit(1);
         default:

--- a/src/wazuh_modules/src/wm_control.h
+++ b/src/wazuh_modules/src/wm_control.h
@@ -55,9 +55,21 @@ bool wm_control_check_systemd();
 bool wm_control_wait_for_service_active(const char *service);
 
 /**
+ * @brief Get the control binary path used by the direct-exec fallback
+ *
+ * Selected at compile time: "bin/wazuh-control" on agent builds (CLIENT),
+ * "bin/wazuh-manager-control" on manager builds. The path is relative to the
+ * install directory (modulesd chdir()s there at startup).
+ *
+ * @return const char* Relative path to the control binary
+ */
+const char *wm_control_get_bin(void);
+
+/**
  * @brief Execute restart or reload action on a Wazuh service
  *
- * Detects if systemd is available and uses systemctl, otherwise falls back to wazuh-control.
+ * Detects if systemd is available and uses systemctl, otherwise falls back to the
+ * control binary (see wm_control_get_bin()).
  * For reload actions, waits for service to be active before proceeding (systemd only).
  *
  * @param action "restart" or "reload"


### PR DESCRIPTION
## Description

On a manager without systemd, `restart` and `reload` requested through the API (`PUT /manager/restart`), the dashboard, or the control socket failed silently: the operation reported `ok` but nothing was restarted or reloaded.

The `wm_control` module (running inside `wazuh-manager-modulesd`) falls back to executing the control binary directly when `systemctl` is not available, using the hardcoded relative path `bin/wazuh-control`. A manager ships only `bin/wazuh-manager-control` (no `bin/wazuh-control`, no symlink), so `execvp` failed with `ENOENT`. Because the fork is fire-and-forget (the parent returns `ok` without waiting for the child), the failed exec was never reported to the caller.

This is the 5.0 `wazuh-control` -> `wazuh-manager-control` rename that was applied to the installed binary and the systemd unit, but not to this runtime fallback.

Closes #36865

## Proposed Changes

- Add `wm_control_get_bin()` to select the control binary at compile time: `bin/wazuh-control` on agent builds (`CLIENT`), `bin/wazuh-manager-control` on manager builds. The path is defined once so both exec sites stay in sync.
- Use the helper at both `execvp` fallback sites of `wm_control_execute_action()`: the non-systemd path and the systemd `reload` fallback (when the service is not active).
- Log the resolved control binary in the fallback info/warn/error messages.

Affected files:
- `src/wazuh_modules/src/wm_control.c`
- `src/wazuh_modules/src/wm_control.h`
- `src/unit_tests/wazuh_modules/control/test_wm_control.c`

### Results and Evidence

Manual runtime test on a real manager (Wazuh v5.0.0, installed at `/var/wazuh-manager`). The bug only triggers when the manager does not run under systemd, so the host is forced into the non-systemd branch by hiding `/run/systemd/system` inside a private mount namespace (`unshare -m` + `tmpfs`), which makes `wm_control_check_systemd()` return false. A `restart`/`reload` is then requested through the control socket (`queue/sockets/control`, the same path the API uses), and the outcome is checked in three places: the socket reply, `logs/wazuh-manager.log`, and whether the daemons actually restart (witnessed by the `analysisd` PID). The same procedure is run twice: with the released pre-fix binary (BUG) and with `wazuh-manager-modulesd` built from this branch (FIX).

<details><summary>BUG</summary>

```console
# 0) Control: with systemd, reload uses systemctl (branch not affected by the bug)
$ printf 'reload' | sudo socat - UNIX-CONNECT:/var/wazuh-manager/queue/sockets/control; echo
ok
$ sudo grep -i control /var/wazuh-manager/logs/wazuh-manager.log | tail -2
... wazuh-manager-modulesd:control: INFO: Executing 'reload' on wazuh-manager using systemctl
... wazuh-manager-modulesd:control: INFO: Starting control thread.

# 1) Start the manager WITHOUT systemd (force the buggy branch)
$ sudo systemctl stop wazuh-manager
$ sudo unshare -m bash -c '
    mount -t tmpfs tmpfs /run/systemd      # /run/systemd/system disappears -> non-systemd
    /var/wazuh-manager/bin/wazuh-manager-control start'
Starting Wazuh v5.0.0...
Started wazuh-manager-modulesd...
Completed.

# 2) analysisd PID BEFORE the restart (witness; the stable PID is the real daemon)
$ sudo pgrep -f wazuh-manager-analysisd
30324      # <- real analysisd (witness)
31348
31349

# 3) Request 'restart' through the control socket (same path the API uses)
$ printf 'restart' | sudo socat - UNIX-CONNECT:/var/wazuh-manager/queue/sockets/control; echo
ok         # <- the client receives "ok " (looks successful)

# 4) Log shows the restart failed silently
$ sudo grep -iE 'using|Error executing' /var/wazuh-manager/logs/wazuh-manager.log | tail -2
... wazuh-manager-modulesd:control: INFO: Executing 'restart' on wazuh-manager using wazuh-control
... wazuh-manager-modulesd:control: ERROR: Error executing restart command: No such file or directory (2)

# 5) analysisd PID AFTER the restart -> unchanged: it did NOT restart
$ sudo pgrep -f wazuh-manager-analysisd
30324      # <- same PID as step 2 -> analysisd did NOT restart
31611
31612
```

Result: the non-systemd fallback execs the old `bin/wazuh-control`, which does not exist on a 5.x manager (`ENOENT`). The parent had already replied `ok` right after the `fork()`, so the caller reports success while nothing restarts — exactly the silent failure described in #36865.

</details>

<details><summary>FIX</summary>

Same procedure as BUG, now running `wazuh-manager-modulesd` built from this branch (installed at `/var/wazuh-manager/bin/wazuh-manager-modulesd`).

```console
# 1) Start the manager WITHOUT systemd (force the non-systemd branch)
$ sudo unshare -m bash -c '
    mount -t tmpfs tmpfs /run/systemd
    /var/wazuh-manager/bin/wazuh-manager-control start'
Starting Wazuh v5.0.0...
Started wazuh-manager-modulesd...
Completed.

# 2) analysisd PID BEFORE the restart (witness)
$ cat /var/wazuh-manager/var/run/wazuh-manager-analysisd-*.pid
36846

# 3) Request 'restart' through the control socket (same path the API uses)
$ printf 'restart' | sudo socat - UNIX-CONNECT:/var/wazuh-manager/queue/sockets/control; echo
ok

# 4) Log: correct binary resolved, NO "No such file or directory" error
$ sudo grep -iE 'using|Error executing' /var/wazuh-manager/logs/wazuh-manager.log | tail -1
... wazuh-manager-modulesd:control: INFO: Executing 'restart' on wazuh-manager using bin/wazuh-manager-control

# 5) analysisd PID AFTER the restart -> CHANGED -> it actually restarted
$ cat /var/wazuh-manager/var/run/wazuh-manager-analysisd-*.pid
38851
$ ps -o pid,lstart,comm -p 38851
    PID                  STARTED COMMAND
  38851 Wed Jun 17 10:48:42 2026 wazuh-manager-a
```

Result: the non-systemd fallback now resolves and execs `bin/wazuh-manager-control`; there is no `ENOENT`, and the request triggers a real restart (analysisd PID `36846` -> `38851`, fresh start time `10:48:42`). Compare with the BUG, where the same request logged `using wazuh-control` + `No such file or directory (2)` and left the PID untouched.

Note on test scope: the non-systemd branch was forced on a systemd host with a private mount namespace (`unshare -m` + `tmpfs` over `/run/systemd`), starting the stack by hand. A `wazuh-manager-control status` taken right after the restart showed `clusterd`/`modulesd`/`monitord`/`remoted` not yet running while `analysisd`/`db`/`authd`/`apid` were running — a partial cycle. That is an artifact of self-restarting the whole stack inside this manual harness (the `restart` tears down `modulesd`, the very daemon that launched the command) and is independent of the binary-selection fix; it does not arise under systemd, where the restart is delegated to `systemctl` out-of-band. The fix under test — selecting and executing the correct control binary so the fallback no longer fails silently — is confirmed by steps 4 and 5.

</details>

### Manual tests with their corresponding evidence

  - Compilation without warnings on every supported platform
    - [x] Linux
  - Manager .deb package built and installed locally; fix validated E2E on a non-systemd environment (unshare -m
  masking /run/systemd):
    - [x] restart logs using bin/wazuh-manager-control and restarts daemons (analysisd PID 53143 → 54105) — no
  longer silent.
    - [x] reload logs using bin/wazuh-manager-control and triggers restart_service.
  - Manager UT: ctest -R test_wm_control passes.
  - Build from sources: manager (TARGET=server) and agent (TARGET=agent) compile without warnings.

### Artifacts Affected

- `wazuh-manager-modulesd` (the `wm_control` module compiled into modulesd). Behavior changes only for manager builds; agent builds are unchanged (`CLIENT` already selects `bin/wazuh-control`).

### Configuration Changes

N/A. No configuration parameters, defaults, or file formats change.

### Tests Introduced

- The `wazuh_modules/control` cmocka suite asserts the resolved binary (`bin/wazuh-manager-control` on a manager build) in the fallback log messages, exercised through the `wm_control_dispatch` / `wm_control_execute_action` path.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A - no doc-facing change)
- [ ] Meets requirements and/or definition of done (manual run done; pending CI)
- [ ] No unresolved dependencies with other issues
