### PR TITLE
eBPF rename move detection

### DIFF
--- a/src/syscheckd/src/ebpf/src/modern.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern.bpf.c
@@ -98,6 +98,38 @@ struct {
 extern int LINUX_KERNEL_VERSION __kconfig;
 
 /*
+ * Minimal renamedata definition for kernels >= 5.12 where vfs_rename
+ * takes a single struct renamedata * argument instead of separate params.
+ * We only need old_dentry and new_dentry so we define just enough fields.
+ *
+ * The ___local suffix tells libbpf to use this local definition instead
+ * of looking it up in the kernel BTF, avoiding CO-RE failures on kernels
+ * where renamedata is not exposed in BTF (e.g. Ubuntu 22.04 / kernel 5.15).
+ *
+ * Field layout matches fs/namei.c in kernel 5.12-5.15 (6 pointer fields):
+ *   struct renamedata {
+ *       struct user_namespace *old_mnt_userns;  // offset  0
+ *       struct inode          *old_dir;         // offset  8
+ *       struct dentry         *old_dentry;      // offset 16
+ *       struct user_namespace *new_mnt_userns;  // offset 24  <-- must not be omitted
+ *       struct inode          *new_dir;         // offset 32
+ *       struct dentry         *new_dentry;      // offset 40
+ *       ...
+ *   };
+ * On kernel 6.3+ old_mnt_userns/new_mnt_userns became mnt_idmap/new_mnt_idmap
+ * but the layout (two pointer fields before each dir/dentry pair) is the same.
+ */
+struct renamedata___local {
+    void          *old_mnt_userns;  /* user_namespace* on 5.12-5.15, mnt_idmap* on 6.3+ */
+    struct inode  *old_dir;
+    struct dentry *old_dentry;
+    void          *new_mnt_userns;  /* mirrors old_mnt_userns; must be present or
+                                     * &rd->new_dentry reads new_dir (off-by-8) */
+    struct inode  *new_dir;
+    struct dentry *new_dentry;
+};
+
+/*
 * Concatenates a directory path and a filename into a full path.
 * The result is stored in out_buf->data.
 * The function returns the length of the concatenated string.
@@ -313,10 +345,15 @@ statfunc void submit_event(const char *filename,
     evt->inode = ino;
     evt->dev   = dev;
 
-    /* Clear buffers safely */
-    bpf_probe_read_kernel_str(evt->cwd, MAX_PATH_LEN, "");
-    bpf_probe_read_kernel_str(evt->parent_cwd, MAX_PATH_LEN, "");
-    bpf_probe_read_kernel_str(evt->parent_name, TASK_COMM_LEN, "");
+    /* Clear string fields with direct null-byte writes instead of
+     * bpf_probe_read_kernel_str(..., "") to avoid emitting a .rodata.str1.1
+     * ELF section.  libbpf < 0.6 cannot resolve relocations against that
+     * section, leaving the BPF object internally corrupted and causing a
+     * crash on subsequent load.  The effect is identical: both approaches
+     * write a single null byte to the first element of the destination. */
+    evt->cwd[0]         = '\0';
+    evt->parent_cwd[0]  = '\0';
+    evt->parent_name[0] = '\0';
 
     /* Get process cwd */
     get_task_cwd(evt->cwd, MAX_PATH_LEN, current_task);
@@ -574,21 +611,42 @@ int kprobe__vfs_rename(struct pt_regs *ctx)
     struct dentry *old_dentry;
     struct dentry *new_dentry;
 
+    /*
+     * Read BOTH old_dentry and new_dentry from the calling convention.
+     *
+     * This is a kprobe — it fires BEFORE vfs_rename executes — so new_dentry
+     * is a negative dentry (d_inode == NULL, no file exists at the destination
+     * yet).  We therefore use old_dentry->d_inode for all metadata validation
+     * (regular-file check, inode number, device, superblock/mount) and use
+     * new_dentry only for path reconstruction (the destination path FIM needs).
+     *
+     * Only one get_path_str_from_path call is made (new_dentry's path), so the
+     * jump-sequence count stays within the BPF verifier's 8192 limit on 5.15.
+     *
+     * Use PT_REGS_PARM*_CORE so the compiler goes through bpf_probe_read_kernel
+     * rather than emitting a direct "modified ctx pointer dereference" that the
+     * strict 5.15 verifier rejects.
+     *
+     * For kernel >= 5.12, PARM1 IS the renamedata pointer; cast it directly.
+     * Do NOT use bpf_probe_read_kernel to "dereference" PARM1 — that would
+     * read the first field of the struct (mnt_idmap) instead of the pointer.
+     */
     if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 12, 0)) {
         old_dentry = (struct dentry *)PT_REGS_PARM2_CORE(ctx);
         new_dentry = (struct dentry *)PT_REGS_PARM4_CORE(ctx);
     } else {
-        struct renamedata *rd = (struct renamedata *)PT_REGS_PARM1_CORE(ctx);
+        struct renamedata___local *rd =
+            (struct renamedata___local *)PT_REGS_PARM1_CORE(ctx);
         if (!rd)
             return 0;
-        old_dentry = BPF_CORE_READ(rd, old_dentry);
-        new_dentry = BPF_CORE_READ(rd, new_dentry);
+        bpf_probe_read_kernel(&old_dentry, sizeof(old_dentry), &rd->old_dentry);
+        bpf_probe_read_kernel(&new_dentry, sizeof(new_dentry), &rd->new_dentry);
     }
 
-    if (!old_dentry)
+    if (!old_dentry || !new_dentry)
         return 0;
 
-    /* Validate source inode: must be a regular file (S_IFREG = 0100000) */
+    /* Use old_dentry->d_inode: source file exists, new_dentry is negative. */
     struct inode *d_inode = NULL;
     bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &old_dentry->d_inode);
     if (!d_inode)
@@ -599,11 +657,9 @@ int kprobe__vfs_rename(struct pt_regs *ctx)
     if ((mode & 00170000) != 0100000)
         return 0;
 
-    /* Extract inode and device from the source file */
     __u64 inode = 0, dev = 0;
     get_inode_dev(d_inode, &inode, &dev);
 
-    /* Get filesystem mount info (same approach as vfs_unlink) */
     struct super_block *sb = NULL;
     bpf_probe_read_kernel(&sb, sizeof(sb), &d_inode->i_sb);
     if (!sb)
@@ -623,32 +679,20 @@ int kprobe__vfs_rename(struct pt_regs *ctx)
     if (!string_buf)
         return 0;
 
+    /* Reconstruct new_dentry's path (the destination). */
     u8 *full_path = NULL;
-
-    /* Submit event for OLD path (source: detects moves OUT of monitored dirs) */
-    struct path old_path = {
-        .dentry = old_dentry,
+    struct path new_path = {
+        .dentry = new_dentry,
         .mnt    = mnt
     };
 
-    if (get_path_str_from_path(&full_path, &old_path, string_buf) >= 0)
+    if (get_path_str_from_path(&full_path, &new_path, string_buf) >= 0)
         submit_event((const char *)full_path, inode, dev);
-
-    /* Submit event for NEW path (destination: detects moves INTO monitored dirs) */
-    if (new_dentry) {
-        struct path new_path = {
-            .dentry = new_dentry,
-            .mnt    = mnt
-        };
-
-        full_path = NULL;
-        if (get_path_str_from_path(&full_path, &new_path, string_buf) >= 0)
-            submit_event((const char *)full_path, inode, dev);
-    }
 
     return 0;
 }
 
+#ifdef ENABLE_BPF_LSM
 /*
 * LSM hook for file open. Reports newly-created or write-opened regular
 * files. Only invoked when "bpf" is part of the active LSM list
@@ -704,8 +748,9 @@ int BPF_PROG(file_open, struct file *file)
     submit_event((const char *)full_path, inode, dev);
     return 0;
 }
+#endif /* ENABLE_BPF_LSM */
 
-
+#ifdef ENABLE_BPF_LSM
 /*
 * LSM hook for path-based unlink. Same activation rules as lsm/file_open.
 * Requires CONFIG_SECURITY_PATH=y in the running kernel.
@@ -752,7 +797,9 @@ int BPF_PROG(path_unlink, struct path *path, struct dentry *dentry)
     submit_event((const char *)full_path, inode, dev);
     return 0;
 }
+#endif /* ENABLE_BPF_LSM */
 
+#ifdef ENABLE_BPF_LSM
 /*
 * LSM hook for path-based rename. Same activation rules as lsm/path_unlink.
 * Only invoked when "bpf" is part of the active LSM list.
@@ -798,20 +845,7 @@ int BPF_PROG(path_rename, struct path *old_dir, struct dentry *old_dentry,
     const char *file_name_ptr;
     int ret;
 
-    /* Submit event for OLD path (source: detects moves OUT of monitored dirs) */
-    ret = bpf_d_path(old_dir, dir_path, MAX_PATH_LEN);
-    if (ret >= 0) {
-        bpf_probe_read_kernel(&file_name_ptr, sizeof(file_name_ptr),
-                              &old_dentry->d_name.name);
-        if (file_name_ptr) {
-            full_path = NULL;
-            ret = concat_strings_bpf(&full_path, dir_path, file_name_ptr, string_buf);
-            if (ret >= 0)
-                submit_event((const char *)full_path, inode, dev);
-        }
-    }
-
-    /* Submit event for NEW path (destination: detects moves INTO monitored dirs) */
+    /* Only report the NEW path (destination) — same policy as kprobe/vfs_rename. */
     ret = bpf_d_path(new_dir, dir_path, MAX_PATH_LEN);
     if (ret >= 0) {
         bpf_probe_read_kernel(&file_name_ptr, sizeof(file_name_ptr),
@@ -826,5 +860,6 @@ int BPF_PROG(path_rename, struct path *old_dir, struct dentry *old_dentry,
 
     return 0;
 }
+#endif /* ENABLE_BPF_LSM */
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/syscheckd/src/ebpf/src/modern.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern.bpf.c
@@ -546,6 +546,110 @@ int kprobe__vfs_unlink(struct pt_regs *ctx)
 }
 
 /*
+* Intercepts vfs_rename calls to detect file move/rename operations.
+*
+* This program is always compiled in. The user-space loader decides
+* whether to autoload it based on whether BPF LSM hooks are active
+* on the running system (see ebpf_whodata.cpp).
+*
+* vfs_rename signature evolved across kernels:
+*   pre-5.12 :  vfs_rename(struct inode *old_dir,
+*                          struct dentry *old_dentry,        -> PARM2
+*                          struct inode *new_dir,
+*                          struct dentry *new_dentry,        -> PARM4
+*                          struct inode **delegated_inode,
+*                          unsigned int flags)
+*
+*   5.12+    :  vfs_rename(struct renamedata *rd)            -> PARM1
+*                          rd->old_dentry, rd->new_dentry
+*
+* Both old and new paths are submitted so FIM can detect:
+*   - Files moved INTO a monitored folder  (new path -> "added")
+*   - Files moved OUT OF a monitored folder (old path -> "deleted")
+*   - Files renamed WITHIN a monitored folder (both)
+*/
+SEC("kprobe/vfs_rename")
+int kprobe__vfs_rename(struct pt_regs *ctx)
+{
+    struct dentry *old_dentry;
+    struct dentry *new_dentry;
+
+    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 12, 0)) {
+        old_dentry = (struct dentry *)PT_REGS_PARM2_CORE(ctx);
+        new_dentry = (struct dentry *)PT_REGS_PARM4_CORE(ctx);
+    } else {
+        struct renamedata *rd = (struct renamedata *)PT_REGS_PARM1_CORE(ctx);
+        if (!rd)
+            return 0;
+        old_dentry = BPF_CORE_READ(rd, old_dentry);
+        new_dentry = BPF_CORE_READ(rd, new_dentry);
+    }
+
+    if (!old_dentry)
+        return 0;
+
+    /* Validate source inode: must be a regular file (S_IFREG = 0100000) */
+    struct inode *d_inode = NULL;
+    bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &old_dentry->d_inode);
+    if (!d_inode)
+        return 0;
+
+    __u32 mode = 0;
+    bpf_probe_read_kernel(&mode, sizeof(mode), &d_inode->i_mode);
+    if ((mode & 00170000) != 0100000)
+        return 0;
+
+    /* Extract inode and device from the source file */
+    __u64 inode = 0, dev = 0;
+    get_inode_dev(d_inode, &inode, &dev);
+
+    /* Get filesystem mount info (same approach as vfs_unlink) */
+    struct super_block *sb = NULL;
+    bpf_probe_read_kernel(&sb, sizeof(sb), &d_inode->i_sb);
+    if (!sb)
+        return 0;
+
+    struct mount *mnt_ptr = NULL;
+    bpf_probe_read_kernel(&mnt_ptr, sizeof(mnt_ptr), &sb->s_fs_info);
+    if (!mnt_ptr)
+        return 0;
+
+    struct vfsmount *mnt = NULL;
+    bpf_probe_read_kernel(&mnt, sizeof(mnt), &mnt_ptr->mnt);
+    if (!mnt)
+        return 0;
+
+    struct buffer *string_buf = bpf_map_lookup_elem(&heaps_map, &(u32){0});
+    if (!string_buf)
+        return 0;
+
+    u8 *full_path = NULL;
+
+    /* Submit event for OLD path (source: detects moves OUT of monitored dirs) */
+    struct path old_path = {
+        .dentry = old_dentry,
+        .mnt    = mnt
+    };
+
+    if (get_path_str_from_path(&full_path, &old_path, string_buf) >= 0)
+        submit_event((const char *)full_path, inode, dev);
+
+    /* Submit event for NEW path (destination: detects moves INTO monitored dirs) */
+    if (new_dentry) {
+        struct path new_path = {
+            .dentry = new_dentry,
+            .mnt    = mnt
+        };
+
+        full_path = NULL;
+        if (get_path_str_from_path(&full_path, &new_path, string_buf) >= 0)
+            submit_event((const char *)full_path, inode, dev);
+    }
+
+    return 0;
+}
+
+/*
 * LSM hook for file open. Reports newly-created or write-opened regular
 * files. Only invoked when "bpf" is part of the active LSM list
 * (CONFIG_LSM= or kernel cmdline lsm=...,bpf). The user-space loader
@@ -646,6 +750,80 @@ int BPF_PROG(path_unlink, struct path *path, struct dentry *dentry)
     get_inode_dev(d_inode, &inode, &dev);
 
     submit_event((const char *)full_path, inode, dev);
+    return 0;
+}
+
+/*
+* LSM hook for path-based rename. Same activation rules as lsm/path_unlink.
+* Only invoked when "bpf" is part of the active LSM list.
+* Requires CONFIG_SECURITY_PATH=y in the running kernel.
+*
+* security_path_rename signature:
+*   (struct path *old_dir, struct dentry *old_dentry,
+*    struct path *new_dir, struct dentry *new_dentry,
+*    unsigned int flags)
+*
+* Both old and new paths are submitted so FIM can detect:
+*   - Files moved INTO a monitored folder  (new path -> "added")
+*   - Files moved OUT OF a monitored folder (old path -> "deleted")
+*   - Files renamed WITHIN a monitored folder (both)
+*/
+SEC("lsm/path_rename")
+int BPF_PROG(path_rename, struct path *old_dir, struct dentry *old_dentry,
+             struct path *new_dir, struct dentry *new_dentry, unsigned int flags)
+{
+    /* Validate source inode: must be a regular file */
+    struct inode *d_inode = NULL;
+    bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &old_dentry->d_inode);
+    if (!d_inode)
+        return 0;
+
+    __u32 mode = 0;
+    bpf_probe_read_kernel(&mode, sizeof(mode), &d_inode->i_mode);
+    if ((mode & 00170000) != 0100000)
+        return 0;
+
+    __u64 inode = 0, dev = 0;
+    get_inode_dev(d_inode, &inode, &dev);
+
+    struct buffer *string_buf = bpf_map_lookup_elem(&heaps_map, &(u32){0});
+    if (!string_buf)
+        return 0;
+
+    char *dir_path = bpf_map_lookup_elem(&full_path_map, &(u32){0});
+    if (!dir_path)
+        return 0;
+
+    u8 *full_path = NULL;
+    const char *file_name_ptr;
+    int ret;
+
+    /* Submit event for OLD path (source: detects moves OUT of monitored dirs) */
+    ret = bpf_d_path(old_dir, dir_path, MAX_PATH_LEN);
+    if (ret >= 0) {
+        bpf_probe_read_kernel(&file_name_ptr, sizeof(file_name_ptr),
+                              &old_dentry->d_name.name);
+        if (file_name_ptr) {
+            full_path = NULL;
+            ret = concat_strings_bpf(&full_path, dir_path, file_name_ptr, string_buf);
+            if (ret >= 0)
+                submit_event((const char *)full_path, inode, dev);
+        }
+    }
+
+    /* Submit event for NEW path (destination: detects moves INTO monitored dirs) */
+    ret = bpf_d_path(new_dir, dir_path, MAX_PATH_LEN);
+    if (ret >= 0) {
+        bpf_probe_read_kernel(&file_name_ptr, sizeof(file_name_ptr),
+                              &new_dentry->d_name.name);
+        if (file_name_ptr) {
+            full_path = NULL;
+            ret = concat_strings_bpf(&full_path, dir_path, file_name_ptr, string_buf);
+            if (ret >= 0)
+                submit_event((const char *)full_path, inode, dev);
+        }
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Description

This PR fixes the eBPF FIM whodata provider missing `mv` (rename) events when a file is moved into a monitored directory. The `kprobe/vfs_rename` hook was not present in `modern.bpf.c`, so any operation that internally calls `vfs_rename` (e.g. `mv`, `rename()`, `renameat2()`) was silently ignored by syscheck.

**Proposed Release:** [v4.14.x / v5.0.x]
**Issue:** wazuh/wazuh#32466
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/syscheckd/src/ebpf/src/modern.bpf.c`.
- Added `kprobe/vfs_rename` hook to intercept file move/rename operations and emit an `added` FIM event for the destination path.
- Added `lsm/path_rename` hook (guarded by `#ifdef ENABLE_BPF_LSM`) as the LSM-based alternative for systems with BPF LSM enabled.
- Added local `struct renamedata___local` definition to avoid CO-RE BTF dependency on kernels where `renamedata` is not exposed in BTF (e.g. Ubuntu 22.04 / kernel 5.15).
- Fixed `.rodata.str1.1` ELF section emission in `submit_event`: replaced `bpf_probe_read_kernel_str(dst, size, "")` with `dst[0] = '\0'` to avoid crash with libbpf < 0.6.
- Wrapped all three LSM hooks (`lsm/file_open`, `lsm/path_unlink`, `lsm/path_rename`) in `#ifdef ENABLE_BPF_LSM` for compatibility with libbpf 0.5.0 (Ubuntu 22.04 system libbpf).

### Results and Evidence

The changes were validated on Ubuntu 22.04, kernel 5.15.0-25-generic, with Wazuh Agent 4.12.0 in eBPF whodata mode.

eBPF healthcheck passes with the new binary:

```
INFO: (6047): Initializing eBPF driver for FIM whodata.
INFO: (6048): Healthcheck for eBPF FIM whodata module success.
```

All five FIM operations verified in whodata eBPF mode:

```bash
# TEST 1: mv file from outside into monitored folder
echo "test" > /tmp/outside.txt
mv /tmp/outside.txt /tmp/test-ebpf/
# Result: FIM event "type":"added", "mode":"whodata", "process_name":"mv" ✅

# TEST 2: touch (create directly)
touch /tmp/test-ebpf/direct.txt
# Result: FIM event "type":"added", "mode":"whodata", "process_name":"touch" ✅

# TEST 3: echo >> (modify)
echo "change" >> /tmp/test-ebpf/direct.txt
# Result: FIM event "type":"modified", "mode":"whodata" ✅

# TEST 4: rm (delete)
rm /tmp/test-ebpf/direct.txt
# Result: FIM event "type":"deleted", "mode":"whodata", "process_name":"rm" ✅

# TEST 5: mv with different destination name
echo "renamed" > /tmp/original.txt
mv /tmp/original.txt /tmp/test-ebpf/new_name.txt
# Result: FIM event "type":"added", "mode":"whodata", "process_name":"mv" ✅
```

### Artifacts Affected

- `src/syscheckd/src/ebpf/src/modern.bpf.c`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual validation
- **Details:** Validated on Ubuntu 22.04 (kernel 5.15, x86_64) with Wazuh Agent 4.12.0. Tested all five FIM operations in eBPF whodata mode: file creation via `touch`, modification via `echo >>`, deletion via `rm`, and file move via `mv` (same name and different destination name). Confirmed `kprobe/vfs_rename` fires correctly and FIM generates the expected `added` event with `process_name: mv`.

## Technical notes

### Why `old_dentry->d_inode` instead of `new_dentry->d_inode`

`kprobe/vfs_rename` fires **before** the kernel executes `vfs_rename`, so `new_dentry` is a negative dentry (`d_inode == NULL` — the file does not yet exist at the destination). Inode validation, device info and superblock/mount resolution are read from `old_dentry->d_inode` (the source, which always exists). `new_dentry` is used only for path reconstruction.

### Why only the destination path is reported

Reporting both old and new paths would require two calls to `get_path_str_from_path` (a 320-iteration unrolled loop). The BPF verifier on kernel 5.15 imposes an 8192 jump-sequence complexity limit; two calls would exceed it. Since the issue specifically requests detecting files moved **into** monitored folders, only the destination path is submitted.

### `renamedata___local` struct layout

The `vfs_rename` signature changed at kernel 5.12 to take a single `struct renamedata *`. The struct has **6 pointer fields** on 5.12–5.15 (both `old_mnt_userns` and `new_mnt_userns` must be present or `new_dentry` lands at the wrong offset):

```
offset  0: old_mnt_userns
offset  8: old_dir
offset 16: old_dentry
offset 24: new_mnt_userns   ← must not be omitted
offset 32: new_dir
offset 40: new_dentry
```

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

    - [x] Linux (Ubuntu 22.04, kernel 5.15, x86_64)
    - [ ] Windows
    - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues