### PR TITLE
Update manager upgrade block message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -904,6 +904,21 @@ validateUpgradeCompatibility()
     UPGRADE_BLOCKED="no"
     ERROR_MESSAGE=""
 
+    printUnsupportedManagerUpgrade()
+    {
+        DETECTED_VERSION=$(echo "${1:-unknown}" | sed 's/^v//')
+        cat <<EOF
+==============================================================
+ERROR: Upgrade from Wazuh manager versions prior to 5.x is not supported.
+
+Detected installed version: ${DETECTED_VERSION}
+
+A clean installation of Wazuh manager 5.x is required.
+Refer to the 5.x migration guide for more information.
+==============================================================
+EOF
+    }
+
     if [ "$USER_INSTALL_TYPE" = "agent" ]; then
         # Agent upgrades are supported only from >= 4.14.0.
         if [ -n "$OLD_MAJOR" ] && [ -n "$OLD_MINOR" ]; then
@@ -916,18 +931,18 @@ Upgrade to Wazuh 5.0.0 is only supported from version 4.14.0 or later."
             fi
         fi
     else
-        # Manager upgrades from 4.x to 5.x are blocked.
+        # Manager upgrades from versions prior to 5.x are blocked.
         if [ -n "$OLD_MAJOR" ] && [ "$OLD_MAJOR" -lt 5 ]; then
             UPGRADE_BLOCKED="yes"
-            ERROR_MESSAGE="Current version: $USER_OLD_VERSION
-Target version:  5.0.0
-
-Upgrade to Wazuh 5.0.0 is not supported from version 4.x.
-A clean installation is required for managers."
         fi
     fi
 
     if [ "$UPGRADE_BLOCKED" = "yes" ]; then
+        if [ "$USER_INSTALL_TYPE" != "agent" ]; then
+            printUnsupportedManagerUpgrade "$USER_OLD_VERSION"
+            exit 1
+        fi
+
         echo ""
         echo "═════════════════════════════════════════════════════════════════"
         echo "  UPGRADE BLOCKED: Incompatible version detected"

--- a/packages/debs/SPECS/wazuh-manager/debian/preinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/preinst
@@ -36,23 +36,31 @@ backup_upgrade_preserve() {
     fi
 }
 
+print_unsupported_manager_upgrade() {
+    DETECTED_VERSION=$(echo "${1:-unknown}" | sed 's/^v//')
+    cat <<EOF >&2
+==============================================================
+ERROR: Upgrade from Wazuh manager versions prior to 5.x is not supported.
+
+Detected installed version: ${DETECTED_VERSION}
+
+A clean installation of Wazuh manager 5.x is required.
+Refer to the 5.x migration guide for more information.
+==============================================================
+EOF
+}
+
 case "$1" in
     install|upgrade)
 
-        # HARD BLOCK: Prevent upgrade from 4.X to 5.X
+        # HARD BLOCK: Prevent upgrade from versions prior to 5.x.
         if [ "$1" = "upgrade" ] && [ -n "$2" ]; then
             # $2 contains the old version in upgrade scenarios
             OLD_VERSION="$2"
-            OLD_MAJOR=$(echo "$OLD_VERSION" | cut -d. -f1)
+            OLD_MAJOR=$(echo "$OLD_VERSION" | sed 's/^v//' | cut -d. -f1)
 
             if [ -n "$OLD_MAJOR" ] && [ "$OLD_MAJOR" -le 4 ] 2>/dev/null; then
-                cat <<EOF
-==============================================================
-ERROR: Direct upgrade from Wazuh Manager 4.X to 5.X is not supported.
-
-Detected installed version: $OLD_VERSION
-==============================================================
-EOF
+                print_unsupported_manager_upgrade "$OLD_VERSION"
                 exit 1
             fi
         fi
@@ -73,37 +81,13 @@ EOF
             # Determine if upgrade should be blocked
             if [ -z "$MAJOR_VER" ]; then
                 ERROR_TYPE="no_version"
-                ERROR_TITLE="Cannot detect current version"
-                ERROR_MESSAGE="Unable to detect the currently installed Wazuh version.
-This indicates a very old installation (pre-4.x)."
             elif [ "$MAJOR_VER" -lt 5 ]; then
                 ERROR_TYPE="old_version"
-                ERROR_TITLE="Clean installation required"
-                ERROR_MESSAGE="Current version: $OLD_VERSION
-Target version:  5.0.0
-
-Direct upgrade from 4.x to 5.0.0 is NOT supported for Wazuh Manager
-due to breaking changes in database schema and architecture."
             fi
 
             # If any error was detected, show message and block
             if [ -n "$ERROR_TYPE" ]; then
-                cat <<EOF >&2
-═════════════════════════════════════════════════════════════════
-  UPGRADE BLOCKED: $ERROR_TITLE
-═════════════════════════════════════════════════════════════════
-
-$ERROR_MESSAGE
-
-Required action:
-  1. Backup your configuration and data
-  2. Perform a clean installation of Wazuh 5.0.0
-  3. Restore configuration as needed
-
-For migration guide, visit:
-  https://documentation.wazuh.com/current/migration-guide/
-═════════════════════════════════════════════════════════════════
-EOF
+                print_unsupported_manager_upgrade "$OLD_VERSION"
                 exit 1
             fi
 

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -120,10 +120,24 @@ exit 0
 %pre
 
 # ============================================================
-# HARD BLOCK: Prevent upgrade from 4.X to 5.X
+# HARD BLOCK: Prevent upgrade from versions prior to 5.x
 # ============================================================
+print_unsupported_manager_upgrade() {
+  DETECTED_VERSION=$(echo "${1:-unknown}" | sed 's/^v//')
+  cat <<EOF >&2
+==============================================================
+ERROR: Upgrade from Wazuh manager versions prior to 5.x is not supported.
+
+Detected installed version: ${DETECTED_VERSION}
+
+A clean installation of Wazuh manager 5.x is required.
+Refer to the 5.x migration guide for more information.
+==============================================================
+EOF
+}
+
 if [ "$1" -eq 2 ]; then
-  # Check if this is an upgrade from 4.X
+  # Check if this is an upgrade from versions prior to 5.x.
   if [ -f %{_sysconfdir}/ossec-init.conf ]; then
     . %{_sysconfdir}/ossec-init.conf
     OLD_VERSION="${VERSION}"
@@ -134,13 +148,7 @@ if [ "$1" -eq 2 ]; then
   if [ -n "${OLD_VERSION}" ]; then
     OLD_MAJOR=$(echo "${OLD_VERSION}" | sed 's/^v//' | cut -d. -f1)
     if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" -le 4 ] 2>/dev/null; then
-      cat <<EOF
-==============================================================
-ERROR: Direct upgrade from Wazuh Manager 4.X to 5.X is not supported.
-
-Detected installed version: ${OLD_VERSION}
-==============================================================
-EOF
+      print_unsupported_manager_upgrade "${OLD_VERSION}"
       exit 1
     fi
   fi
@@ -174,36 +182,13 @@ if [ "$1" -eq 2 ]; then
   # Determine if upgrade should be blocked
   if [ -z "$MAJOR" ]; then
     ERROR_TYPE="no_version"
-    ERROR_TITLE="Cannot detect current version"
-    ERROR_MESSAGE="Unable to detect the currently installed Wazuh version."
   elif [ "$MAJOR" -lt 5 ]; then
     ERROR_TYPE="old_version"
-    ERROR_TITLE="Clean installation required"
-    ERROR_MESSAGE="Current version: $OLD_VERSION
-Target version:  5.0.0
-
-Direct upgrade from 4.x to 5.0.0 is NOT supported for Wazuh Manager
-due to breaking changes in database schema and architecture."
   fi
 
   # If any error was detected, show message and block
   if [ -n "$ERROR_TYPE" ]; then
-    cat <<EOF >&2
-═════════════════════════════════════════════════════════════════
-  UPGRADE BLOCKED: $ERROR_TITLE
-═════════════════════════════════════════════════════════════════
-
-$ERROR_MESSAGE
-
-Required action:
-  1. Backup your configuration and data
-  2. Perform a clean installation of Wazuh 5.0.0
-  3. Restore configuration as needed
-
-For migration guide, visit:
-  https://documentation.wazuh.com/current/migration-guide/
-═════════════════════════════════════════════════════════════════
-EOF
+    print_unsupported_manager_upgrade "${OLD_VERSION}"
     exit 1
   fi
 fi


### PR DESCRIPTION
# Description

Updates the unsupported manager upgrade message for source, Debian, and RPM installation flows.

Closes #36988.

## Evidence
- Source install block:

```
root@ubuntu24:/home/vagrant/git/wazuh/src# ../install.sh
 Wazuh v5.0.0 (Rev. beta3) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux ubuntu24 6.8.0-86-generic (ubuntu 24.04)
  - User: root
  - Host: ubuntu24



1- Installation type:
   1) manager
   2) agent
   Select an option [1-2]: 1

  - Manager installation chosen.

2- Existing manager installation detected at:
   /var/ossec
   1) Update existing installation
   2) Clean install in same directory (existing data will be removed)
   3) Exit
   Select an option [1-3]: 1
==============================================================
ERROR: Upgrade from Wazuh manager versions prior to 5.x is not supported.

Detected installed version: 4.14.5

A clean installation of Wazuh manager 5.x is required.
Refer to the 5.x migration guide for more information.
==============================================================
```

- Package install block:
```
root@ubuntu24:/home/vagrant/git/wazuh/packages# apt install /tmp/wazuh-manager_5.0.0-0_arm64_fbca553.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of '/tmp/wazuh-manager_5.0.0-0_arm64_fbca553.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 145 not upgraded.
Need to get 0 B/97.6 MB of archives.
After this operation, 616 MB disk space will be freed.
Get:1 /tmp/wazuh-manager_5.0.0-0_arm64_fbca553.deb wazuh-manager arm64 5.0.0-0 [97.6 MB]
(Reading database ... 145848 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_5.0.0-0_arm64_fbca553.deb ...
==============================================================
ERROR: Upgrade from Wazuh manager versions prior to 5.x is not supported.

Detected installed version: 4.14.5-1

A clean installation of Wazuh manager 5.x is required.
Refer to the 5.x migration guide for more information.
==============================================================
dpkg: error processing archive /tmp/wazuh-manager_5.0.0-0_arm64_fbca553.deb (--unpack):
 new wazuh-manager package pre-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 /tmp/wazuh-manager_5.0.0-0_arm64_fbca553.deb
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
```