### PR TITLE
wazuh-engine: Improve log messages and logger

### DIFF
--- a/src/engine/source/api/event/src/handlers.cpp
+++ b/src/engine/source/api/event/src/handlers.cpp
@@ -24,7 +24,7 @@ adapter::RouteHandler pushEvent(const std::shared_ptr<::router::IRouterAPI>& orc
         auto orchestratorRef = weakOrchestrator.lock();
         if (!orchestratorRef)
         {
-            LOG_ERROR_L(lambdaName.c_str(), "Received request but orchestrator is not available");
+            LOG_ERROR_L(lambdaName.c_str(), "[API::Event] Received request but orchestrator is not available");
             res.status = httplib::StatusCode::InternalServerError_500;
             res.set_content("{\"error\": \"Internal server error\", \"code\": 500}", "application/json");
             return;
@@ -58,7 +58,7 @@ adapter::RouteHandler pushEvent(const std::shared_ptr<::router::IRouterAPI>& orc
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING_L(lambdaName.c_str(), "Failed to parse request: '{}'", e.what());
+            LOG_WARNING_L(lambdaName.c_str(), "[API::Event] Failed to parse request: '{}'", e.what());
             res.status = httplib::StatusCode::BadRequest_400;
             res.set_content(fmt::format("{{\"error\": \"{}\", \"code\": 400}}", e.what()), "application/json");
             return;

--- a/src/engine/source/api/ioccrud/src/handlersSync.cpp
+++ b/src/engine/source/api/ioccrud/src/handlersSync.cpp
@@ -310,8 +310,8 @@ adapter::RouteHandler syncIoc(const std::shared_ptr<::ioc::kvdb::IKVDBManager>& 
             if (base::isError(createResult))
             {
                 LOG_WARNING_L(lambdaName.c_str(),
-                              LOG_MODULE_NAME,
                               "[{}] Failed to create IOC status document: {}",
+                              LOG_MODULE_NAME,
                               base::getError(createResult).message);
             }
         }

--- a/src/engine/source/api/ioccrud/src/handlersSync.cpp
+++ b/src/engine/source/api/ioccrud/src/handlersSync.cpp
@@ -22,7 +22,7 @@ namespace api::ioccrud::handlers
 namespace eIoc = com::wazuh::api::engine::ioc;
 namespace eEngine = com::wazuh::api::engine;
 
-constexpr std::string_view LOG_MODULE_NAME = "API::IOC";
+constexpr std::string_view LOG_MODULE_NAME = "API::IOC"; ///< Log module name for IOC CRUD handlers
 
 namespace detail
 {

--- a/src/engine/source/api/ioccrud/src/handlersSync.cpp
+++ b/src/engine/source/api/ioccrud/src/handlersSync.cpp
@@ -22,6 +22,8 @@ namespace api::ioccrud::handlers
 namespace eIoc = com::wazuh::api::engine::ioc;
 namespace eEngine = com::wazuh::api::engine;
 
+constexpr std::string_view LOG_MODULE_NAME = "API::IOC";
+
 namespace detail
 {
 std::atomic<bool> g_syncInProgress {false}; ///< Flag to indicate if an IOC synchronization is currently in progress
@@ -68,7 +70,7 @@ void updateIOCStatus(const std::shared_ptr<store::IStore>& storeRef,
     catch (const std::exception& e)
     {
         auto lambdaName = logging::getLambdaName("syncIoc", "updateStatus");
-        LOG_WARNING_L(lambdaName.c_str(), "Failed to update IOC status: {}", e.what());
+        LOG_WARNING_L(lambdaName.c_str(), "[{}] Failed to update IOC status: {}", LOG_MODULE_NAME, e.what());
     }
 }
 
@@ -86,7 +88,7 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
                     const std::string& fileHash)
 {
     auto lambdaName = logging::getLambdaName("syncIoc", "asyncTask");
-    LOG_INFO_L(lambdaName.c_str(), "Starting IOC synchronization from file: {}", filePath);
+    LOG_INFO_L(lambdaName.c_str(), "[{}] Starting IOC synchronization from file: {}", LOG_MODULE_NAME, filePath);
 
     // Ensure the flag is released when task finishes (RAII pattern)
     struct SyncGuard
@@ -97,7 +99,7 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
     auto kvdbManager = weakKvdbManager.lock();
     if (!kvdbManager)
     {
-        LOG_WARNING_L(lambdaName.c_str(), "KVDB Manager is not available, aborting IOC sync");
+        LOG_WARNING_L(lambdaName.c_str(), "[{}] KVDB Manager is not available, aborting IOC sync", LOG_MODULE_NAME);
         if (auto store = weakStore.lock())
         {
             updateIOCStatus(store, "", "KVDB Manager is not available");
@@ -108,7 +110,7 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
     auto storeRef = weakStore.lock();
     if (!storeRef)
     {
-        LOG_WARNING_L(lambdaName.c_str(), "Store is not available, aborting IOC sync");
+        LOG_WARNING_L(lambdaName.c_str(), "[{}] Store is not available, aborting IOC sync", LOG_MODULE_NAME);
         return;
     }
 
@@ -118,7 +120,7 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
         std::ifstream file(filePath);
         if (!file.is_open())
         {
-            LOG_WARNING_L(lambdaName.c_str(), "Failed to open file: {}", filePath);
+            LOG_WARNING_L(lambdaName.c_str(), "[{}] Failed to open file: {}", LOG_MODULE_NAME, filePath);
             updateIOCStatus(storeRef, "", fmt::format("Failed to open file: {}", filePath));
             return;
         }
@@ -162,7 +164,7 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
             catch (const std::exception& e)
             {
                 // Skip this line (unsupported DB type or missing key)
-                LOG_DEBUG_L(lambdaName.c_str(), "Skipping line {}: {}", lineNumber, e.what());
+                LOG_DEBUG_L(lambdaName.c_str(), "[{}] Skipping line {}: {}", LOG_MODULE_NAME, lineNumber, e.what());
                 ++skippedLines;
                 // Only store the last error to avoid excessive logging, but include line number for context
                 lastSkipError = fmt::format("Line {}: {}", lineNumber, e.what());
@@ -176,14 +178,15 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
         if (skippedLines > 0)
         {
             LOG_WARNING_L(lambdaName.c_str(),
-                          "Processed {} IOC entries, skipped {} invalid lines. Last error: {}",
+                          "[{}] Processed {} IOC entries, skipped {} invalid lines. Last error: {}",
+                          LOG_MODULE_NAME,
                           processedLines,
                           skippedLines,
                           lastSkipError);
         }
         else
         {
-            LOG_DEBUG_L(lambdaName.c_str(), "Processed {} IOC entries from file", processedLines);
+            LOG_DEBUG_L(lambdaName.c_str(), "[{}] Processed {} IOC entries from file", LOG_MODULE_NAME, processedLines);
         }
 
         // Perform hot-swap for ALL temporary databases to production
@@ -195,28 +198,37 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
 
             if (!kvdbManager->exists(originalDbName))
             {
-                LOG_WARNING_L(
-                    lambdaName.c_str(), "Original DB {} does not exist, skipping hot-swap for this DB", originalDbName);
+                LOG_WARNING_L(lambdaName.c_str(),
+                              "[{}] Original DB {} does not exist, skipping hot-swap for this DB",
+                              LOG_MODULE_NAME,
+                              originalDbName);
                 // Clean up the temporary database since production DB doesn't exist
                 try
                 {
                     kvdbManager->remove(tmpDbName);
-                    LOG_DEBUG_L(lambdaName.c_str(), "Deleted unused temporary DB: {}", tmpDbName);
+                    LOG_DEBUG_L(lambdaName.c_str(), "[{}] Deleted unused temporary DB: {}", LOG_MODULE_NAME, tmpDbName);
                 }
                 catch (const std::exception& e)
                 {
-                    LOG_WARNING_L(lambdaName.c_str(), "Failed to delete temporary DB {}: {}", tmpDbName, e.what());
+                    LOG_WARNING_L(lambdaName.c_str(),
+                                  "[{}] Failed to delete temporary DB {}: {}",
+                                  LOG_MODULE_NAME,
+                                  tmpDbName,
+                                  e.what());
                 }
                 continue;
             }
 
             // Hot-swap: move tmp DB to production (even if empty)
             kvdbManager->hotSwap(tmpDbName, originalDbName);
-            LOG_DEBUG_L(lambdaName.c_str(), "Hot-swap completed for DB: {}", originalDbName);
+            LOG_DEBUG_L(lambdaName.c_str(), "[{}] Hot-swap completed for DB: {}", LOG_MODULE_NAME, originalDbName);
             ++dbsUpdated;
         }
 
-        LOG_INFO_L(lambdaName.c_str(), "IOC synchronization completed successfully. {} DBs updated.", dbsUpdated);
+        LOG_INFO_L(lambdaName.c_str(),
+                   "[{}] IOC synchronization completed successfully, {} DBs updated",
+                   LOG_MODULE_NAME,
+                   dbsUpdated);
 
         // Update the hash in the store after successful synchronization
         std::string message =
@@ -227,7 +239,7 @@ void performIOCSync(const std::weak_ptr<::ioc::kvdb::IKVDBManager>& weakKvdbMana
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING_L(lambdaName.c_str(), "IOC sync failed: {}", e.what());
+        LOG_WARNING_L(lambdaName.c_str(), "[{}] IOC sync failed: {}", LOG_MODULE_NAME, e.what());
         // Store error without updating hash
         updateIOCStatus(storeRef, "", fmt::format("IOC sync failed: {}", e.what()));
     }
@@ -289,14 +301,17 @@ adapter::RouteHandler syncIoc(const std::shared_ptr<::ioc::kvdb::IKVDBManager>& 
         {
             // Document doesn't exist, create it with empty hash
             auto lambdaName = logging::getLambdaName("syncIoc", "handler");
-            LOG_DEBUG_L(lambdaName.c_str(), "IOC status document does not exist, will be created on first sync");
+            LOG_DEBUG_L(lambdaName.c_str(),
+                        "[{}] IOC status document does not exist, will be created on first sync",
+                        LOG_MODULE_NAME);
             store::Doc statusDoc;
             statusDoc.setString("", detail::DOC_HASH_KEY);
             auto createResult = storeRef->upsertDoc(detail::IOC_STATUS_DOC, statusDoc);
             if (base::isError(createResult))
             {
                 LOG_WARNING_L(lambdaName.c_str(),
-                              "Failed to create IOC status document: {}",
+                              LOG_MODULE_NAME,
+                              "[{}] Failed to create IOC status document: {}",
                               base::getError(createResult).message);
             }
         }
@@ -310,8 +325,10 @@ adapter::RouteHandler syncIoc(const std::shared_ptr<::ioc::kvdb::IKVDBManager>& 
         if (fileHash == storedHash)
         {
             auto lambdaName = logging::getLambdaName("syncIoc", "handler");
-            LOG_DEBUG_L(
-                lambdaName.c_str(), "IOC file hash matches stored hash ({}), skipping synchronization", fileHash);
+            LOG_DEBUG_L(lambdaName.c_str(),
+                        "[{}] IOC file hash matches stored hash ({}), skipping synchronization",
+                        LOG_MODULE_NAME,
+                        fileHash);
             ResponseType eResponse;
             eResponse.set_status(eEngine::ReturnStatus::OK);
             eResponse.set_error("IOC data is already up to date");

--- a/src/engine/source/api/ioccrud/test/src/unit/handlers_test.cpp
+++ b/src/engine/source/api/ioccrud/test/src/unit/handlers_test.cpp
@@ -10,6 +10,7 @@
 
 #include <api/adapter/adapter.hpp>
 #include <api/ioccrud/handlers.hpp>
+#include <base/logging.hpp>
 #include <eMessages/engine.pb.h>
 #include <eMessages/ioc.pb.h>
 #include <iockvdb/mockManager.hpp>
@@ -56,6 +57,7 @@ class SyncIocHandlerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
+        logging::testInit();
         // Reset static flag before each test
         // Note: This accesses a private global, may need friend declaration or alternative approach
         m_kvdbManager = std::make_shared<ioc::kvdb::MockKVDBManager>();
@@ -481,12 +483,16 @@ TEST_F(SyncIocHandlerTest, PerformIOCSync_Success_UpdatesHashAndClearsError)
             [](std::string_view dbName)
             {
                 // Check if it's one of the known production DB names
-                static const std::array<std::string_view, 6> prodDBs = {
-                    "ioc_connections", "ioc_urls_full", "ioc_urls_domain",
-                    "ioc_hashes_md5", "ioc_hashes_sha1", "ioc_hashes_sha256"
-                };
-                for (const auto& prodDB : prodDBs) {
-                    if (dbName == prodDB) return true;
+                static const std::array<std::string_view, 6> prodDBs = {"ioc_connections",
+                                                                        "ioc_urls_full",
+                                                                        "ioc_urls_domain",
+                                                                        "ioc_hashes_md5",
+                                                                        "ioc_hashes_sha1",
+                                                                        "ioc_hashes_sha256"};
+                for (const auto& prodDB : prodDBs)
+                {
+                    if (dbName == prodDB)
+                        return true;
                 }
                 return false; // Temp DBs or non-existent
             });
@@ -732,16 +738,22 @@ TEST_F(SyncIocHandlerTest, PerformIOCSync_MixedValidInvalid_ProcessesValid)
 
     // Setup mocks - expect processing of valid IOCs
     EXPECT_CALL(*m_kvdbManager, exists(_))
-        .WillRepeatedly([](std::string_view dbName) {
-            static const std::array<std::string_view, 6> prodDBs = {
-                "ioc_connections", "ioc_urls_full", "ioc_urls_domain",
-                "ioc_hashes_md5", "ioc_hashes_sha1", "ioc_hashes_sha256"
-            };
-            for (const auto& prodDB : prodDBs) {
-                if (dbName == prodDB) return true;
-            }
-            return false;
-        });
+        .WillRepeatedly(
+            [](std::string_view dbName)
+            {
+                static const std::array<std::string_view, 6> prodDBs = {"ioc_connections",
+                                                                        "ioc_urls_full",
+                                                                        "ioc_urls_domain",
+                                                                        "ioc_hashes_md5",
+                                                                        "ioc_hashes_sha1",
+                                                                        "ioc_hashes_sha256"};
+                for (const auto& prodDB : prodDBs)
+                {
+                    if (dbName == prodDB)
+                        return true;
+                }
+                return false;
+            });
     EXPECT_CALL(*m_kvdbManager, add(_)).Times(AtLeast(1));
     EXPECT_CALL(*m_kvdbManager, get(_, _)).WillRepeatedly(Return(std::nullopt));
     EXPECT_CALL(*m_kvdbManager, put(_, _, _)).Times(AtLeast(3)); // 3 valid IOCs
@@ -789,16 +801,22 @@ TEST_F(SyncIocHandlerTest, PerformIOCSync_MultipleTypes_CreatesMultipleDatabases
 
     // Setup mocks - expect 6 different temp DBs to be created
     EXPECT_CALL(*m_kvdbManager, exists(_))
-        .WillRepeatedly([](std::string_view dbName) {
-            static const std::array<std::string_view, 6> prodDBs = {
-                "ioc_connections", "ioc_urls_full", "ioc_urls_domain",
-                "ioc_hashes_md5", "ioc_hashes_sha1", "ioc_hashes_sha256"
-            };
-            for (const auto& prodDB : prodDBs) {
-                if (dbName == prodDB) return true;
-            }
-            return false;
-        });
+        .WillRepeatedly(
+            [](std::string_view dbName)
+            {
+                static const std::array<std::string_view, 6> prodDBs = {"ioc_connections",
+                                                                        "ioc_urls_full",
+                                                                        "ioc_urls_domain",
+                                                                        "ioc_hashes_md5",
+                                                                        "ioc_hashes_sha1",
+                                                                        "ioc_hashes_sha256"};
+                for (const auto& prodDB : prodDBs)
+                {
+                    if (dbName == prodDB)
+                        return true;
+                }
+                return false;
+            });
 
     EXPECT_CALL(*m_kvdbManager, add(_)).Times(AtLeast(6));
     EXPECT_CALL(*m_kvdbManager, get(_, _)).WillRepeatedly(Return(std::nullopt));
@@ -915,16 +933,22 @@ TEST_F(SyncIocHandlerTest, PerformIOCSync_DuplicateIOCs_AppendsToArray)
 
     // Setup mocks
     EXPECT_CALL(*m_kvdbManager, exists(_))
-        .WillRepeatedly([](std::string_view dbName) {
-            static const std::array<std::string_view, 6> prodDBs = {
-                "ioc_connections", "ioc_urls_full", "ioc_urls_domain",
-                "ioc_hashes_md5", "ioc_hashes_sha1", "ioc_hashes_sha256"
-            };
-            for (const auto& prodDB : prodDBs) {
-                if (dbName == prodDB) return true;
-            }
-            return false;
-        });
+        .WillRepeatedly(
+            [](std::string_view dbName)
+            {
+                static const std::array<std::string_view, 6> prodDBs = {"ioc_connections",
+                                                                        "ioc_urls_full",
+                                                                        "ioc_urls_domain",
+                                                                        "ioc_hashes_md5",
+                                                                        "ioc_hashes_sha1",
+                                                                        "ioc_hashes_sha256"};
+                for (const auto& prodDB : prodDBs)
+                {
+                    if (dbName == prodDB)
+                        return true;
+                }
+                return false;
+            });
     EXPECT_CALL(*m_kvdbManager, add(_)).Times(AtLeast(1));
 
     // First get returns nullopt, subsequent gets return the stored value

--- a/src/engine/source/base/include/base/libwazuhshared.hpp
+++ b/src/engine/source/base/include/base/libwazuhshared.hpp
@@ -45,6 +45,15 @@ void shutdown();
 void* getLibPtr();
 
 /**
+ * @brief Check whether the shared library has been loaded.
+ * @return true if init() has been called successfully.
+ */
+inline bool isInitialized()
+{
+    return getLibPtr() != nullptr;
+}
+
+/**
  * @brief Deleted function to prevent usage without template argument.
  *
  * This overload is explicitly deleted to force users to specify the function
@@ -85,7 +94,6 @@ FuncType getFunction(std::string_view name)
     }
     return func;
 }
-
 
 /**
  * @brief Set the logger tag for the shared library.

--- a/src/engine/source/base/include/base/logging.hpp
+++ b/src/engine/source/base/include/base/logging.hpp
@@ -373,23 +373,34 @@ inline bool should_log(logging::Level lvl)
         return getDefaultLogger()->should_log(SEVERITY_LEVEL.at(lvl));
     }
 
-    // TODO: CHECK THIS BECAUSE SOME TESTS DO NOT USE STANDALONE MODE AND FAIL BECAUSE THEY DO NOT HAVE LIBWAZUHSHARED
-    // // In Wazuh mode, check debug flag from the C logging system
-    // // isDebug() returns: 0 = Info+, 1 = Debug+, 2+ = Trace+
-    // using IsDebugFnType = int (*)();
-    // const auto isDebugFn = base::libwazuhshared::getFunction<IsDebugFnType>("isDebug");
-    // const int debugLevel = isDebugFn();
+    // If libwazuhshared is not loaded (e.g. unit tests that run in non-standalone mode),
+    // mirror backend_log()'s Log::Logger::* fallback: those functions already guard with
+    // if (GLOBAL_LOG_FUNCTION) and silently discard when unset, treating it as debug-level 0.
+    if (!base::libwazuhshared::isInitialized())
+    {
+        switch (lvl)
+        {
+            case logging::Level::Trace:
+            case logging::Level::Debug: return false;
+            default: return true;
+        }
+    }
 
-    // switch (lvl)
-    // {
-    //     case logging::Level::Trace: return debugLevel >= 2;
-    //     case logging::Level::Debug: return debugLevel >= 1;
-    //     case logging::Level::Info:
-    //     case logging::Level::Warn:
-    //     case logging::Level::Err:
-    //     case logging::Level::Critical: return true; // Always log these levels
-    //     default: return false;
-    // }
+    // Cache the function pointer — calling getFunction() (dlsym) on every log check is too slow.
+    using IsDebugFnType = int (*)();
+    static const IsDebugFnType isDebugFn = base::libwazuhshared::getFunction<IsDebugFnType>("isDebug");
+    const int debugLevel = isDebugFn();
+
+    switch (lvl)
+    {
+        case logging::Level::Trace: return debugLevel >= 2;
+        case logging::Level::Debug: return debugLevel >= 1;
+        case logging::Level::Info:
+        case logging::Level::Warn:
+        case logging::Level::Err:
+        case logging::Level::Critical: return true;
+        default: return false;
+    }
     return true;
 }
 

--- a/src/engine/source/base/src/logging.cpp
+++ b/src/engine/source/base/src/logging.cpp
@@ -149,16 +149,17 @@ void stop()
 
 void testInit(Level lvl)
 {
-    auto logger = spdlog::get("default");
+    // Set standalone mode BEFORE start() so the isStandaloneModeEnable() static cache
+    // is primed to true during logger initialization.
+    setenv(base::process::ENV_ENGINE_STANDALONE, "true", 1);
 
+    auto logger = spdlog::get("default");
     if (!logger)
     {
         LoggingConfig logConfig;
         logConfig.level = lvl;
         start(logConfig);
     }
-
-    setenv(base::process::ENV_ENGINE_STANDALONE, "true", 1);
 }
 
 void initializeFullLogFunction(

--- a/src/engine/source/bk/src/rx/exprBuilder.hpp
+++ b/src/engine/source/bk/src/rx/exprBuilder.hpp
@@ -148,10 +148,10 @@ private:
                     }
                     catch (const std::exception& e)
                     {
-                        LOG_ERROR("Unexpected error processing term: {} in '{}' with {}.",
-                                  e.what(),
-                                  name,
-                                  result->payload()->str());
+                        LOG_WARNING("[BK::pipeline] Unexpected error processing term: {} in '{}' with {}",
+                                    e.what(),
+                                    name,
+                                    result->payload()->str());
                         const std::string errorMsg =
                             fmt::format(R"([{}] -> Failure: operation throw exception.)", name);
                         *result = base::result::makeFailure(result->payload(), errorMsg);

--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -151,8 +151,11 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING_L(
-                functionName.c_str(), "[CM::CRUD] Rollback delete failed for '{}': {}", id.toStr(), ex.what());
+            LOG_WARNING_L(functionName.c_str(),
+                          "[CM::CRUD] Rollback delete failed "
+                          "for '{}': {}",
+                          id.toStr(),
+                          ex.what());
         }
     };
 
@@ -163,8 +166,9 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
         // Reject if destination namespace already exists
         if (store->existsNamespace(nsId))
         {
-            throw std::runtime_error(fmt::format(
-                "Namespace '{}' already exists. Import is only allowed into a new namespace.", nsId.toStr()));
+            throw std::runtime_error(fmt::format("Namespace '{}' already exists. "
+                                                 "Import is only allowed into a new namespace.",
+                                                 nsId.toStr()));
         }
 
         // Parse and validate input JSON structure

--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -167,7 +167,7 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
         if (store->existsNamespace(nsId))
         {
             throw std::runtime_error(fmt::format("Namespace '{}' already exists. "
-                                                 "Import is only allowed into a new namespace.",
+                                                 "Import is only allowed into a new namespace",
                                                  nsId.toStr()));
         }
 
@@ -360,8 +360,9 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     // Reject if destination namespace already exists
     if (store->existsNamespace(nsId))
     {
-        throw std::runtime_error(
-            fmt::format("Namespace '{}' already exists. Import is only allowed into a new namespace.", nsId.toStr()));
+        throw std::runtime_error(fmt::format("Namespace '{}' already exists. "
+                                             "Import is only allowed into a new namespace",
+                                             nsId.toStr()));
     }
 
     // Create empty destination namespace

--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -136,9 +136,9 @@ void CrudService::deleteNamespace(const cm::store::NamespaceId& nsId)
 }
 
 cm::store::dataType::Policy CrudService::importNamespace(const cm::store::NamespaceId& nsId,
-                                  std::string_view jsonDocument,
-                                  std::string_view originSpace,
-                                  bool force)
+                                                         std::string_view jsonDocument,
+                                                         std::string_view originSpace,
+                                                         bool force)
 {
     auto store = getStore();
 
@@ -151,7 +151,8 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING_L(functionName.c_str(), "Rollback delete failed for '{}': {}", id.toStr(), ex.what());
+            LOG_WARNING_L(
+                functionName.c_str(), "[CM::CRUD] Rollback delete failed for '{}': {}", id.toStr(), ex.what());
         }
     };
 

--- a/src/engine/source/cmcrud/test/src/unit/cmcrudservice_test.cpp
+++ b/src/engine/source/cmcrud/test/src/unit/cmcrudservice_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <base/json.hpp>
+#include <base/logging.hpp>
 #include <builder/ivalidator.hpp>
 #include <builder/mockValidator.hpp>
 #include <cmstore/detail.hpp>
@@ -50,7 +51,7 @@ protected:
 class CrudServiceCtorTest : public ::testing::Test
 {
 protected:
-    void SetUp() override {}
+    void SetUp() override { logging::testInit(); }
     void TearDown() override {}
 };
 
@@ -1526,6 +1527,7 @@ protected:
 
     void SetUp() override
     {
+        logging::testInit();
         CrudServiceBase::SetUp();
 
         nsPtr = std::make_shared<NiceMock<MockICMstoreNS>>();

--- a/src/engine/source/cmstore/src/storens.cpp
+++ b/src/engine/source/cmstore/src/storens.cpp
@@ -7,7 +7,7 @@
 
 namespace
 {
-constexpr std::string_view LOG_MODULE_NAME = "CM::Store::NS"; ///< Log module name for CMStoreNS
+inline constexpr std::string_view LOG_MODULE_NAME = "CM::Store::NS"; ///< Log module name for CMStoreNS
 }
 
 namespace cm::store

--- a/src/engine/source/cmstore/src/storens.cpp
+++ b/src/engine/source/cmstore/src/storens.cpp
@@ -5,6 +5,8 @@
 #include "fileutils.hpp"
 #include "storens.hpp"
 
+constexpr std::string_view LOG_MODULE_NAME = "CM::Store::NS";
+
 namespace cm::store
 {
 
@@ -16,7 +18,7 @@ void CMStoreNS::flushCacheToDisk()
     if (error.has_value())
     {
         // This never should happen.
-        LOG_ERROR("Failed to dump cache of namespace to disk: {}", error.value());
+        LOG_ERROR("[{}] Failed to dump cache of namespace to disk: {}", LOG_MODULE_NAME, error.value());
         throw std::runtime_error("Failed to dump cache to disk: " + error.value());
     }
     LOG_TRACE("Cache flushed to disk successfully at {}", m_cachePath.string());
@@ -32,7 +34,8 @@ void CMStoreNS::loadCacheFromDisk()
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING("Failed to load cache from disk: {}. Rebuilding cache from storage.", e.what());
+        LOG_WARNING(
+            "[{}] Failed to load cache from disk: {}. Rebuilding cache from storage", LOG_MODULE_NAME, e.what());
         rebuildCacheFromStorage();
         flushCacheToDisk();
     }
@@ -76,7 +79,8 @@ void CMStoreNS::rebuildCacheFromStorage()
         }
         else
         {
-            LOG_WARNING("Unknown resource type directory '{}' found in storage, skipping.", dirName);
+            LOG_WARNING(
+                "[{}] Unknown resource type directory '{}' found in storage, skipping", LOG_MODULE_NAME, dirName);
             continue;
         }
 
@@ -126,7 +130,10 @@ void CMStoreNS::rebuildCacheFromStorage()
             }
             catch (const std::exception& e)
             {
-                LOG_WARNING("Failed to process resource file '{}': {}", fileEntry.path().string(), e.what());
+                LOG_WARNING("[{}] Failed to process resource file '{}': {}",
+                            LOG_MODULE_NAME,
+                            fileEntry.path().string(),
+                            e.what());
             }
         }
     }

--- a/src/engine/source/cmstore/src/storens.cpp
+++ b/src/engine/source/cmstore/src/storens.cpp
@@ -7,7 +7,7 @@
 
 namespace
 {
-constexpr std::string_view LOG_MODULE_NAME = "CM::Store::NS";
+constexpr std::string_view LOG_MODULE_NAME = "CM::Store::NS"; ///< Log module name for CMStoreNS
 }
 
 namespace cm::store
@@ -37,8 +37,10 @@ void CMStoreNS::loadCacheFromDisk()
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING(
-            "[{}] Failed to load cache from disk: {}. Rebuilding cache from storage", LOG_MODULE_NAME, e.what());
+        LOG_WARNING("[{}] Failed to load cache from disk: {}."
+                    " Rebuilding cache from storage",
+                    LOG_MODULE_NAME,
+                    e.what());
         rebuildCacheFromStorage();
         flushCacheToDisk();
     }
@@ -82,8 +84,10 @@ void CMStoreNS::rebuildCacheFromStorage()
         }
         else
         {
-            LOG_WARNING(
-                "[{}] Unknown resource type directory '{}' found in storage, skipping", LOG_MODULE_NAME, dirName);
+            LOG_WARNING("[{}] Unknown resource type directory '{}' "
+                        "found in storage, skipping",
+                        LOG_MODULE_NAME,
+                        dirName);
             continue;
         }
 

--- a/src/engine/source/cmstore/src/storens.cpp
+++ b/src/engine/source/cmstore/src/storens.cpp
@@ -5,7 +5,10 @@
 #include "fileutils.hpp"
 #include "storens.hpp"
 
+namespace
+{
 constexpr std::string_view LOG_MODULE_NAME = "CM::Store::NS";
+}
 
 namespace cm::store
 {

--- a/src/engine/source/cmstore/test/src/component/cmstore_test.cpp
+++ b/src/engine/source/cmstore/test/src/component/cmstore_test.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <base/logging.hpp>
 #include <cmstore/cmstore.hpp>
 
 // ======================================================================
@@ -146,6 +147,7 @@ class CMStoreComponentTest : public ::testing::Test
 protected:
     void SetUp() override
     {
+        logging::testInit();
         m_baseDir = std::make_unique<TempDir>("cmstore_base");
         m_outputsDir = std::make_unique<TempDir>("cmstore_outputs");
         std::filesystem::create_directories(m_outputsDir->path() / "default");
@@ -217,8 +219,7 @@ TEST_F(CMStoreComponentTest, FullFilterLifecycle)
     auto store = createStore();
     auto ns = store->createNamespace(cm::store::NamespaceId("filterlife"));
 
-    auto uuid =
-        ns->createResource("filter/allow/0", cm::store::ResourceType::FILTER, makeFilterJson("filter/allow/0"));
+    auto uuid = ns->createResource("filter/allow/0", cm::store::ResourceType::FILTER, makeFilterJson("filter/allow/0"));
     EXPECT_FALSE(uuid.empty());
 
     EXPECT_TRUE(ns->assetExistsByName(base::Name("filter/allow/0")));
@@ -504,8 +505,7 @@ TEST_F(CMStoreComponentTest, UpdateResourceByUUID)
     auto store = createStore();
     auto ns = store->createNamespace(cm::store::NamespaceId("updns"));
 
-    auto uuid =
-        ns->createResource("decoder/upd/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/upd/0"));
+    auto uuid = ns->createResource("decoder/upd/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/upd/0"));
 
     EXPECT_NO_THROW(ns->updateResourceByUUID(uuid, makeDecoderJson("decoder/upd/0", uuid, false)));
 
@@ -528,7 +528,8 @@ TEST_F(CMStoreComponentTest, UpdateWithMismatchedUUIDAThrows)
 
     // Update with a different UUID in content
     auto badJson = makeDecoderJson("decoder/m/0", "00000000-0000-4000-a000-000000000000");
-    EXPECT_THROW(ns->updateResourceByName("decoder/m/0", cm::store::ResourceType::DECODER, badJson), std::runtime_error);
+    EXPECT_THROW(ns->updateResourceByName("decoder/m/0", cm::store::ResourceType::DECODER, badJson),
+                 std::runtime_error);
     EXPECT_THROW(ns->updateResourceByUUID(uuid, badJson), std::runtime_error);
 }
 
@@ -539,8 +540,9 @@ TEST_F(CMStoreComponentTest, CreateDuplicateResourceThrows)
 
     ns->createResource("decoder/dup/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/dup/0"));
 
-    EXPECT_THROW(ns->createResource("decoder/dup/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/dup/0")),
-                 std::runtime_error);
+    EXPECT_THROW(
+        ns->createResource("decoder/dup/0", cm::store::ResourceType::DECODER, makeDecoderJson("decoder/dup/0")),
+        std::runtime_error);
 }
 
 TEST_F(CMStoreComponentTest, DeleteNonexistentResourceThrows)

--- a/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
+++ b/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <unistd.h>
 
+#include <base/logging.hpp>
 #include <base/name.hpp>
 #include <base/utils/generator.hpp>
 #include <gmock/gmock.h>
@@ -26,6 +27,7 @@ protected:
 
     void SetUp() override
     {
+        logging::testInit();
         const auto suffix = base::utils::generators::generateUUIDv4();
         m_root = std::filesystem::temp_directory_path() / ("cmstore-test-" + suffix);
         m_outputs = m_root / "default_outputs";
@@ -582,6 +584,7 @@ class CMStoreNSTest : public ::testing::Test
 protected:
     void SetUp() override
     {
+        logging::testInit();
         m_storageDir = std::make_unique<TempDir>();
         m_outputsDir = std::make_unique<TempDir>();
         std::filesystem::create_directories(m_outputsDir->path() / "default");
@@ -920,6 +923,7 @@ class CMStoreTest : public ::testing::Test
 protected:
     void SetUp() override
     {
+        logging::testInit();
         m_baseDir = std::make_unique<TempDir>();
         m_outputsDir = std::make_unique<TempDir>();
         std::filesystem::create_directories(m_outputsDir->path() / "default");

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -18,9 +18,9 @@ namespace
 
 const base::Name STORE_NAME_CMSYNC {"cmsync/status/0"};          ///< Name of the internal store document
 const cm::store::NamespaceId DUMMY_NAMESPACE_ID {"dummy_ns_id"}; ///< Dummy namespace ID
-constexpr std::string_view COMPONENT_NAME = "CMSync";            ///< Component name for logging
 constexpr std::string_view STANDARD_SPACE_NAME = "standard";     ///< Standard space name
 constexpr std::string_view CUSTOM_SPACE_NAME = "custom";         ///< Custom space name
+const std::string COMPONENT_NAME = "CMSync";                     ///< Component name for logging
 
 constexpr std::string_view LOG_MODULE_NAME = "CM::Sync"; ///< Log module name for CMSync
 
@@ -263,7 +263,7 @@ bool CMSync::existSpaceInRemote(std::string_view space)
     auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
 
     return base::utils::executeWithRetry([&indexerPtr, space]() { return indexerPtr->existsPolicy(space); },
-                                         fmt::format("{}", COMPONENT_NAME),
+                                         COMPONENT_NAME,
                                          fmt::format("Check '{}' space in wazuh-indexer", space),
                                          m_attempts,
                                          m_waitSeconds,
@@ -280,7 +280,7 @@ bool CMSync::downloadNamespace(std::string_view originSpace,
     // Download policy from wazuh-indexer (with optional consumer validation in PIT)
     auto policyResource = base::utils::executeWithRetry(
         [&indexerPtr, originSpace, &consumerId]() { return indexerPtr->getPolicy(originSpace, consumerId); },
-        fmt::format("{}::downloadNamespace()", COMPONENT_NAME),
+        COMPONENT_NAME,
         fmt::format("Download '{}' space from wazuh-indexer", originSpace),
         m_attempts,
         m_waitSeconds,
@@ -311,7 +311,7 @@ bool CMSync::downloadNamespace(std::string_view originSpace,
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING("[{}::downloadNamespace] Failed to rollback namespace '{}' after import failure: {}",
+            LOG_WARNING("[{}] Failed to rollback namespace '{}' after import failure: {}",
                         LOG_MODULE_NAME,
                         dstNamespace.toStr(),
                         ex.what());
@@ -330,7 +330,7 @@ CMSync::getPolicyHashAndEnabledFromRemote(std::string_view space, const std::opt
 
     return base::utils::executeWithRetry(
         [&indexerPtr, space, &consumerId]() { return indexerPtr->getPolicyHashAndEnabled(space, consumerId); },
-        fmt::format("{}::getInfoFromRemote()", COMPONENT_NAME),
+        COMPONENT_NAME,
         fmt::format("Get policy hash and enabled status for '{}' space from wazuh-indexer", space),
         m_attempts,
         m_waitSeconds,
@@ -379,7 +379,7 @@ CMSync::downloadAndEnrichNamespace(std::string_view originSpace, const std::opti
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING("[{}::downloadAndEnrichNamespace] Failed to rollback temporary namespace '{}' after asset "
+            LOG_WARNING("[{}] Failed to rollback temporary namespace '{}' after asset "
                         "addition failure: {}",
                         LOG_MODULE_NAME,
                         newNs.toStr(),
@@ -594,7 +594,7 @@ void CMSync::synchronize()
                 const bool ready = base::utils::executeWithRetry(
                     [&indexerPtr, &consumerId = nsState.getConsumerId().value()]()
                     { return indexerPtr->isConsumerReadyForSync(consumerId); },
-                    fmt::format("{}", COMPONENT_NAME),
+                    COMPONENT_NAME,
                     fmt::format("Check consumer readiness for space '{}'", nsState.getOriginSpace()),
                     m_attempts,
                     m_waitSeconds,
@@ -821,7 +821,7 @@ void CMSync::synchronize()
         }
     }
 
-    LOG_DEBUG("[{}] Finished synchronization of spaces", LOG_MODULE_NAME,);
+    LOG_DEBUG("[{}] Finished synchronization of spaces", LOG_MODULE_NAME);
 
     updateSpacesStatusSnapshot();
 }

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -22,6 +22,8 @@ constexpr std::string_view COMPONENT_NAME = "CMSync";            ///< Component 
 constexpr std::string_view STANDARD_SPACE_NAME = "standard";     ///< Standard space name
 constexpr std::string_view CUSTOM_SPACE_NAME = "custom";         ///< Custom space name
 
+constexpr std::string_view LOG_MODULE_NAME = "CM::Sync"; ///< Log module name for CMSync
+
 /**
  * @brief Generate a random namespace ID for the given origin space
  *
@@ -244,7 +246,7 @@ CMSync::CMSync(const std::shared_ptr<wiconnector::IWIndexerConnector>& indexerPt
         return;
     }
 
-    LOG_DEBUG("[CMSync] First setup detected, initializing default sync spaces");
+    LOG_DEBUG("[{}] First setup detected, initializing default sync spaces", LOG_MODULE_NAME);
 
     // Populate directly and dump once to avoid multiple unnecessary store writes
     m_namespacesState.emplace_back(STANDARD_SPACE_NAME,
@@ -309,7 +311,8 @@ bool CMSync::downloadNamespace(std::string_view originSpace,
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING("[CMSync::downloadNamespace] Failed to rollback namespace '{}' after import failure: {}",
+            LOG_WARNING("[{}::downloadNamespace] Failed to rollback namespace '{}' after import failure: {}",
+                        LOG_MODULE_NAME,
                         dstNamespace.toStr(),
                         ex.what());
         }
@@ -376,8 +379,9 @@ CMSync::downloadAndEnrichNamespace(std::string_view originSpace, const std::opti
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING("[CMSync::downloadAndEnrichNamespace] Failed to rollback temporary namespace '{}' after asset "
+            LOG_WARNING("[{}::downloadAndEnrichNamespace] Failed to rollback temporary namespace '{}' after asset "
                         "addition failure: {}",
+                        LOG_MODULE_NAME,
                         newNs.toStr(),
                         ex.what());
         }
@@ -449,7 +453,7 @@ void CMSync::addSpaceToSync(std::string_view space)
     // Add the new space to the sync list (constructor already sets DUMMY_NAMESPACE_ID)
     m_namespacesState.emplace_back(space);
 
-    LOG_DEBUG("[CMSync] Added space '{}' to the sync list", space);
+    LOG_DEBUG("[{}] Added space '{}' to the sync list", LOG_MODULE_NAME, space);
 
     dumpStateToStore();
 }
@@ -468,7 +472,7 @@ void CMSync::removeSpaceFromSync(std::string_view space)
 
     m_namespacesState.erase(it, m_namespacesState.end());
 
-    LOG_INFO("[CMSync] Removed space '{}' from the sync list", space);
+    LOG_INFO("[{}] Removed space '{}' from the sync list", LOG_MODULE_NAME, space);
 
     dumpStateToStore();
 }
@@ -522,7 +526,7 @@ void CMSync::dumpStateToStore()
 void CMSync::synchronize()
 {
 
-    LOG_DEBUG("[CMSync] Checking for namespace updates to synchronize");
+    LOG_DEBUG("[{}] Checking for namespace updates to synchronize", LOG_MODULE_NAME);
 
     const auto cmcrudPtr = base::utils::lockWeakPtr(m_cmcrudPtr, "CMCrud Service");
     const auto routerPtr = base::utils::lockWeakPtr(m_router, "RouterAPI");
@@ -536,7 +540,7 @@ void CMSync::synchronize()
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING("[CMSync] Failed to dump sync state to store: {}", e.what());
+            LOG_WARNING("[{}] Failed to dump sync state to store: {}", LOG_MODULE_NAME, e.what());
         }
     };
 
@@ -545,14 +549,14 @@ void CMSync::synchronize()
         // Check abort at the start of each namespace iteration
         if (m_shutdownRequested.load(std::memory_order_relaxed))
         {
-            LOG_INFO("[CMSync] Synchronization aborted during namespace iteration");
+            LOG_INFO("[{}] Synchronization aborted during namespace iteration", LOG_MODULE_NAME);
             updateSpacesStatusSnapshot();
             return;
         }
 
         try
         {
-            LOG_DEBUG("[CMSync] Synchronizing namespace for space '{}'", nsState.getOriginSpace());
+            LOG_DEBUG("[{}] Synchronizing namespace for space '{}'", LOG_MODULE_NAME, nsState.getOriginSpace());
 
             // Check the route in the router FIRST (router is local, works even if the indexer is down).
             // This refreshes availability up front, so a route removed out-of-band is reflected even if
@@ -567,7 +571,8 @@ void CMSync::synchronize()
 
             if (!existSpaceInRemote(nsState.getOriginSpace()))
             {
-                LOG_WARNING("[CMSync] Space '{}' does not exist in wazuh-indexer, skipping synchronization",
+                LOG_WARNING("[{}] Space '{}' does not exist in wazuh-indexer, skipping synchronization",
+                            LOG_MODULE_NAME,
                             nsState.getOriginSpace());
                 continue;
             }
@@ -575,7 +580,8 @@ void CMSync::synchronize()
             // Get remote policy hash and enabled status (with consumer validation in PIT if configured)
             if (m_shutdownRequested.load(std::memory_order_relaxed))
             {
-                LOG_INFO("[CMSync] Synchronization aborted before getting policy info for space '{}'",
+                LOG_INFO("[{}] Synchronization aborted before getting policy info for space '{}'",
+                         LOG_MODULE_NAME,
                          nsState.getOriginSpace());
                 updateSpacesStatusSnapshot();
                 return;
@@ -596,8 +602,9 @@ void CMSync::synchronize()
 
                 if (!ready)
                 {
-                    LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer consumer '{}' is "
+                    LOG_INFO("[{}] Synchronization skipped for space '{}' because wazuh-indexer consumer '{}' is "
                              "not ready for sync (might be updating or no data)",
+                             LOG_MODULE_NAME,
                              nsState.getOriginSpace(),
                              nsState.getConsumerId().value());
                     continue;
@@ -608,8 +615,9 @@ void CMSync::synchronize()
                 getPolicyHashAndEnabledFromRemote(nsState.getOriginSpace(), nsState.getConsumerId());
             if (!hashResult.has_value())
             {
-                LOG_INFO("[CMSync] Synchronization skipped for space '{}' because wazuh-indexer is updating the policy "
+                LOG_INFO("[{}] Synchronization skipped for space '{}' because wazuh-indexer is updating the policy "
                          "or consumer is not idle (consumer ID: '{}')",
+                         LOG_MODULE_NAME,
                          nsState.getOriginSpace(),
                          nsState.getConsumerId().value_or("unknown"));
                 continue;
@@ -665,12 +673,14 @@ void CMSync::synchronize()
                 if (routeConfig.has_value())
                 {
                     const auto& [_ignore, nsId, routeHash] = *routeConfig;
-                    LOG_INFO("[CMSync] Policy for space '{}' is disabled in indexer, removing route and namespace",
+                    LOG_INFO("[{}] Policy for space '{}' is disabled in indexer, removing route and namespace",
+                             LOG_MODULE_NAME,
                              nsState.getOriginSpace());
 
                     if (auto err = routerPtr->deleteEntry(nsState.getRouteName()); base::isError(err))
                     {
-                        LOG_WARNING("[CMSync] Failed to delete route '{}' for space '{}': {}",
+                        LOG_WARNING("[{}] Failed to delete route '{}' for space '{}': {}",
+                                    LOG_MODULE_NAME,
                                     nsState.getRouteName(),
                                     nsState.getOriginSpace(),
                                     err->message);
@@ -683,7 +693,8 @@ void CMSync::synchronize()
                     }
                     catch (const std::exception& e)
                     {
-                        LOG_WARNING("[CMSync] Failed to delete namespace '{}' for space '{}': {}",
+                        LOG_WARNING("[{}] Failed to delete namespace '{}' for space '{}': {}",
+                                    LOG_MODULE_NAME,
                                     nsId.toStr(),
                                     nsState.getOriginSpace(),
                                     e.what());
@@ -691,7 +702,8 @@ void CMSync::synchronize()
                 }
                 else
                 {
-                    LOG_DEBUG("[CMSync] Policy for space '{}' is disabled in indexer and no route exists, skipping",
+                    LOG_DEBUG("[{}] Policy for space '{}' is disabled in indexer and no route exists, skipping",
+                              LOG_MODULE_NAME,
                               nsState.getOriginSpace());
                 }
                 nsState.setRouteState(false, false, ""); // route removed / absent → not available
@@ -704,14 +716,15 @@ void CMSync::synchronize()
                 const auto& [enabledRoute, nsId, routeHash] = *routeConfig;
                 if (enabledRoute && routeHash == remoteHash)
                 {
-                    LOG_DEBUG("[CMSync] No changes detected for space '{}', skipping synchronization",
+                    LOG_DEBUG("[{}] No changes detected for space '{}', skipping synchronization",
+                              LOG_MODULE_NAME,
                               nsState.getOriginSpace());
                     continue; // Case 4: No changes, skip synchronization
                 }
             }
 
             // Cases 3 and 4: Changes detected, perform synchronization
-            LOG_INFO("[CMSync] Changes detected for space '{}', updating...", nsState.getOriginSpace());
+            LOG_INFO("[{}] Changes detected for space '{}', updating...", LOG_MODULE_NAME, nsState.getOriginSpace());
 
             // Mark this space as running
             nsState.setSyncStatus(base::SyncStatus::UPDATING);
@@ -720,7 +733,8 @@ void CMSync::synchronize()
             // Check abort before download (most expensive operation)
             if (m_shutdownRequested.load(std::memory_order_relaxed))
             {
-                LOG_INFO("[CMSync] Synchronization aborted before downloading namespace for space '{}'",
+                LOG_INFO("[{}] Synchronization aborted before downloading namespace for space '{}'",
+                         LOG_MODULE_NAME,
                          nsState.getOriginSpace());
                 nsState.setSyncStatus(base::SyncStatus::READY);
                 updateSpacesStatusSnapshot();
@@ -731,7 +745,8 @@ void CMSync::synchronize()
             const auto newNsIdOpt = downloadAndEnrichNamespace(nsState.getOriginSpace(), nsState.getConsumerId());
             if (!newNsIdOpt.has_value())
             {
-                LOG_INFO("[CMSync] Download skipped for space '{}' because consumer is not idle",
+                LOG_INFO("[{}] Download skipped for space '{}' because consumer is not idle",
+                         LOG_MODULE_NAME,
                          nsState.getOriginSpace());
                 nsState.setSyncStatus(base::SyncStatus::READY);
                 updateSpacesStatusSnapshot();
@@ -753,12 +768,14 @@ void CMSync::synchronize()
                 }
                 catch (const std::exception& ex)
                 {
-                    LOG_WARNING("[CMSync::synchronize] Failed to rollback temporary namespace '{}' after route sync "
+                    LOG_WARNING("[{}::synchronize] Failed to rollback temporary namespace '{}' after route sync "
                                 "failure: {}",
+                                LOG_MODULE_NAME,
                                 newNsId.toStr(),
                                 ex.what());
                 }
-                LOG_ERROR("[CMSync] Failed to sync namespace in route for space '{}': {}",
+                LOG_ERROR("[{}] Failed to sync namespace in route for space '{}': {}",
+                          LOG_MODULE_NAME,
                           nsState.getOriginSpace(),
                           e.what());
                 nsState.setSyncStatus(base::SyncStatus::FAILED);
@@ -781,14 +798,15 @@ void CMSync::synchronize()
                 }
                 catch (const std::exception& e)
                 {
-                    LOG_WARNING("[CMSync] Failed to delete old namespace '{}' for space '{}': {}",
+                    LOG_WARNING("[{}] Failed to delete old namespace '{}' for space '{}': {}",
+                                LOG_MODULE_NAME,
                                 oldNsId.toStr(),
                                 nsState.getOriginSpace(),
                                 e.what());
                 }
             }
 
-            LOG_INFO("[CMSync] Successfully synchronized space '{}'", nsState.getOriginSpace());
+            LOG_INFO("[{}] Successfully synchronized space '{}'", LOG_MODULE_NAME, nsState.getOriginSpace());
             // Route now deployed for an enabled policy at the remote hash.
             nsState.setRouteState(true, remoteEnabled, remoteHash);
             nsState.setSyncStatus(base::SyncStatus::READY);
@@ -799,11 +817,11 @@ void CMSync::synchronize()
             nsState.setSyncStatus(base::SyncStatus::FAILED);
             updateSpacesStatusSnapshot();
             LOG_WARNING(
-                "[CMSync] Failed to synchronize namespace for space '{}': {}", nsState.getOriginSpace(), e.what());
+                "[{}] Failed to synchronize namespace for space '{}': {}", LOG_MODULE_NAME, nsState.getOriginSpace(), e.what());
         }
     }
 
-    LOG_DEBUG("[CMSync] Finished synchronization of spaces");
+    LOG_DEBUG("[{}] Finished synchronization of spaces", LOG_MODULE_NAME,);
 
     updateSpacesStatusSnapshot();
 }
@@ -811,7 +829,7 @@ void CMSync::synchronize()
 void CMSync::requestShutdown()
 {
     m_shutdownRequested.store(true, std::memory_order_relaxed);
-    LOG_INFO("[CMSync] Shutdown requested");
+    LOG_INFO("[{}] Shutdown requested", LOG_MODULE_NAME);
 }
 
 void CMSync::updateSpacesStatusSnapshot()

--- a/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
+++ b/src/engine/source/cmsync/test/src/unit/cmsync_test.cpp
@@ -99,6 +99,8 @@ protected:
         std::make_shared<::testing::StrictMock<store::mocks::MockStore>>()};
     std::shared_ptr<::testing::StrictMock<router::mocks::MockRouterAPI>> router {
         std::make_shared<::testing::StrictMock<router::mocks::MockRouterAPI>>()};
+
+    void SetUp() override { logging::testInit(); }
 };
 
 class CMSyncSynchronizeTest : public ::testing::Test
@@ -123,6 +125,8 @@ protected:
 
         return std::make_unique<cm::sync::CMSync>(indexer, crud, store, router, DEFAULT_ATTEMPTS, DEFAULT_WAIT_SECONDS);
     }
+
+    void SetUp() override { logging::testInit(); }
 };
 
 } // namespace

--- a/src/engine/source/conf/include/conf/conf.hpp
+++ b/src/engine/source/conf/include/conf/conf.hpp
@@ -22,7 +22,7 @@ namespace conf
 namespace
 {
 
-constexpr std::string_view LOG_MODULE_NAME = "Config"; ///< Log module name for configuration
+inline constexpr std::string_view LOG_MODULE_NAME = "Config"; ///< Log module name for configuration
 
 template<typename U>
 std::string toStr(const U& value)
@@ -174,7 +174,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}"
+            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}. "
                         " Falling back to file or default value.",
                         LOG_MODULE_NAME,
                         key,
@@ -339,7 +339,7 @@ public:
             }
             catch (const std::exception& e)
             {
-                LOG_WARNING("Failed to convert value '{}' for key '{}': {}. "
+                LOG_WARNING("[{}] Failed to convert value '{}' for key '{}': {}. "
                             "Using default value",
                             LOG_MODULE_NAME,
                             rawValue,

--- a/src/engine/source/conf/include/conf/conf.hpp
+++ b/src/engine/source/conf/include/conf/conf.hpp
@@ -174,7 +174,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}."
+            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}"
                         " Falling back to file or default value.",
                         LOG_MODULE_NAME,
                         key,
@@ -340,7 +340,7 @@ public:
             catch (const std::exception& e)
             {
                 LOG_WARNING("Failed to convert value '{}' for key '{}': {}. "
-                            "Using default value.",
+                            "Using default value",
                             LOG_MODULE_NAME,
                             rawValue,
                             key,

--- a/src/engine/source/conf/include/conf/conf.hpp
+++ b/src/engine/source/conf/include/conf/conf.hpp
@@ -21,6 +21,9 @@ namespace conf
 
 namespace
 {
+
+constexpr std::string_view LOG_MODULE_NAME = "Config"; ///< Log module name for configuration
+
 template<typename U>
 std::string toStr(const U& value)
 {
@@ -161,7 +164,8 @@ public:
         {
             if (const auto envValue = unit->template getEnvValue<T>())
             {
-                LOG_DEBUG("Using configuration key '{}' from environment variable '{}': '{}'",
+                LOG_DEBUG("[{}] Using configuration key '{}' from environment variable '{}': '{}'",
+                          LOG_MODULE_NAME,
                           key,
                           unit->getEnv(),
                           toStr<T>(envValue.value()));
@@ -170,7 +174,10 @@ public:
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING("Failed to retrieve or convert environment variable for key '{}': {}", key, e.what());
+            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}",
+                        LOG_MODULE_NAME,
+                        key,
+                        e.what());
         }
 
         // 2. Configuration file
@@ -182,7 +189,7 @@ public:
             {
                 if constexpr (std::is_same_v<T, std::string>)
                 {
-                    LOG_DEBUG("Using configuration key '{}' from file: '{}'", key, rawValue);
+                    LOG_DEBUG("[{}] Using configuration key '{}' from file: '{}'", LOG_MODULE_NAME, key, rawValue);
                     return rawValue;
                 }
                 else if constexpr (std::is_same_v<T, bool>)
@@ -199,7 +206,7 @@ public:
                     }
 
                     bool value = (lowerValue == "true");
-                    LOG_DEBUG("Using configuration key '{}' from file: '{}'", key, value);
+                    LOG_DEBUG("[{}] Using configuration key '{}' from file: '{}'", LOG_MODULE_NAME, key, value);
                     return value;
                 }
                 else if constexpr (std::is_same_v<T, int>)
@@ -213,20 +220,22 @@ public:
                             throw std::runtime_error(
                                 fmt::format("Extra characters after int: '{}'", rawValue.substr(pos)));
                         }
-                        LOG_DEBUG("Using configuration key '{}' from file: '{}'", key, value);
+                        LOG_DEBUG("[{}] Using configuration key '{}' from file: '{}'", LOG_MODULE_NAME, key, value);
                         return value;
                     }
                     catch (const std::invalid_argument& e)
                     {
-                        throw std::runtime_error(fmt::format(
-                            "Invalid configuration type for key '{}'. Could not parse '{}'.", key, rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Could not parse '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
                     catch (const std::out_of_range& e)
                     {
-                        throw std::runtime_error(
-                            fmt::format("Invalid configuration type for key '{}'. Value out of range for int: '{}'.",
-                                        key,
-                                        rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Value out of range for int: '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
                 }
                 else if constexpr (std::is_same_v<T, int64_t>)
@@ -240,30 +249,32 @@ public:
                             throw std::runtime_error(
                                 fmt::format("Extra characters after int64: '{}'", rawValue.substr(pos)));
                         }
-                        LOG_DEBUG("Using configuration key '{}' from file: '{}'", key, value);
+                        LOG_DEBUG("[{}] Using configuration key '{}' from file: '{}'", LOG_MODULE_NAME, key, value);
                         return value;
                     }
                     catch (const std::invalid_argument& e)
                     {
-                        throw std::runtime_error(fmt::format(
-                            "Invalid configuration type for key '{}'. Could not parse '{}'.", key, rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Could not parse '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
                     catch (const std::out_of_range& e)
                     {
-                        throw std::runtime_error(
-                            fmt::format("Invalid configuration type for key '{}'. Value out of range for int64: '{}'.",
-                                        key,
-                                        rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Value out of range for int64: '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
                 }
                 else if constexpr (std::is_same_v<T, size_t>)
                 {
                     if (!base::utils::string::isNumber(rawValue))
                     {
-                        throw std::runtime_error(
-                            fmt::format("Invalid configuration type for key '{}'. Expected unsigned integer, got '{}'.",
-                                        key,
-                                        rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Expected unsigned integer, got '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
 
                     std::size_t pos = 0;
@@ -275,20 +286,22 @@ public:
                             throw std::runtime_error(
                                 fmt::format("Extra characters after size_t: '{}'", rawValue.substr(pos)));
                         }
-                        LOG_DEBUG("Using configuration key '{}' from file: '{}'", key, value);
+                        LOG_DEBUG("[{}] Using configuration key '{}' from file: '{}'", LOG_MODULE_NAME, key, value);
                         return value;
                     }
                     catch (const std::invalid_argument& e)
                     {
-                        throw std::runtime_error(fmt::format(
-                            "Invalid configuration type for key '{}'. Could not parse '{}'.", key, rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Could not parse '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
                     catch (const std::out_of_range& e)
                     {
-                        throw std::runtime_error(
-                            fmt::format("Invalid configuration type for key '{}'. Value out of range for size_t: '{}'.",
-                                        key,
-                                        rawValue));
+                        throw std::runtime_error(fmt::format("Invalid configuration type for key '{}'. "
+                                                             "Value out of range for size_t: '{}'.",
+                                                             key,
+                                                             rawValue));
                     }
                 }
                 else if constexpr (std::is_same_v<T, std::vector<std::string>>)
@@ -325,8 +338,12 @@ public:
             }
             catch (const std::exception& e)
             {
-                LOG_WARNING(
-                    "Failed to convert value '{}' for key '{}': {}. Using default value.", rawValue, key, e.what());
+                LOG_WARNING("Failed to convert value '{}' for key '{}': {}. "
+                            "Using default value.",
+                            LOG_MODULE_NAME,
+                            rawValue,
+                            key,
+                            e.what());
             }
         }
 
@@ -343,7 +360,7 @@ public:
             return strVal;
         }();
 
-        LOG_DEBUG("Using configuration key '{}' from default: '{}'", key, strVal);
+        LOG_DEBUG("[{}] Using configuration key '{}' from default: '{}'", LOG_MODULE_NAME, key, strVal);
 
         return value;
     }

--- a/src/engine/source/conf/include/conf/conf.hpp
+++ b/src/engine/source/conf/include/conf/conf.hpp
@@ -174,7 +174,8 @@ public:
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}",
+            LOG_WARNING("[{}] Failed to retrieve or convert environment variable for key '{}': {}."
+                        " Falling back to file or default value.",
                         LOG_MODULE_NAME,
                         key,
                         e.what());

--- a/src/engine/source/conf/include/conf/fileLoader.hpp
+++ b/src/engine/source/conf/include/conf/fileLoader.hpp
@@ -7,7 +7,6 @@ namespace conf
 {
 
 using OptionMap = std::unordered_map<std::string, std::string>; // (full_key, value)
-constexpr auto WAZUH_LDEFINES = "/var/wazuh-manager/etc/wazuh-manager-internal-options.conf";
 
 struct IFileLoader
 {
@@ -38,7 +37,7 @@ private:
     std::filesystem::path m_path;
 
 public:
-    FileLoader(std::filesystem::path path = WAZUH_LDEFINES)
+    FileLoader(std::filesystem::path path)
         : m_path(std::move(path))
     {
     }

--- a/src/engine/source/confremote/src/confremotemanager.cpp
+++ b/src/engine/source/confremote/src/confremotemanager.cpp
@@ -13,8 +13,9 @@ namespace confremote
 
 namespace
 {
-const base::Name REMOTE_CONF_CACHE_DOC {"remote-config/engine-cnf/0"};
-}
+const base::Name REMOTE_CONF_CACHE_DOC {"remote-config/engine-cnf/0"}; ///< Store doc name for caching config
+constexpr std::string_view LOG_MODULE_NAME = "RemoteConfig";           ///< Log module name for ConfRemoteManager
+} // namespace
 
 ConfRemoteManager::ConfRemoteManager(const std::shared_ptr<wiconnector::IWIndexerConnector>& indexerConnector,
                                      const std::shared_ptr<store::IStore>& store,
@@ -35,7 +36,7 @@ void ConfRemoteManager::synchronize()
 {
     if (m_shutdownRequested.load(std::memory_order_relaxed))
     {
-        LOG_INFO("[ConfRemote] Synchronization aborted before start");
+        LOG_INFO("[{}] Synchronization aborted before start", LOG_MODULE_NAME);
         return;
     }
 
@@ -55,18 +56,18 @@ void ConfRemoteManager::synchronize()
     {
         if (m_shutdownRequested.load(std::memory_order_relaxed))
         {
-            LOG_INFO("[ConfRemote] Synchronization aborted during remote fetch");
+            LOG_INFO("[{}] Synchronization aborted during remote fetch", LOG_MODULE_NAME);
             return;
         }
 
-        LOG_WARNING("[ConfRemote] Failed to synchronize remote settings: {}. Keeping current state.", e.what());
+        LOG_WARNING("[{}] Failed to synchronize remote settings: {}. Keeping current state.", LOG_MODULE_NAME, e.what());
         return;
     }
 
     const auto fields = remoteSettings.getObject();
     if (!fields.has_value())
     {
-        LOG_WARNING("Remote config payload is not a valid JSON object. Skipping synchronize.");
+        LOG_WARNING("[{}] Remote config payload is not a valid JSON object. Skipping synchronize", LOG_MODULE_NAME);
         return;
     }
 
@@ -77,14 +78,14 @@ void ConfRemoteManager::synchronize()
     {
         if (m_shutdownRequested.load(std::memory_order_relaxed))
         {
-            LOG_INFO("[ConfRemote] Synchronization aborted during settings application");
+            LOG_INFO("[{}] Synchronization aborted during settings application", LOG_MODULE_NAME);
             return;
         }
 
         const auto it = m_settings.find(key);
         if (it == m_settings.end() || !it->second.onConfigChange)
         {
-            LOG_DEBUG("Ignoring unregistered remote setting '{}'.", key);
+            LOG_DEBUG("[{}] Ignoring unregistered remote setting '{}'", LOG_MODULE_NAME, key);
             continue;
         }
 
@@ -99,8 +100,12 @@ void ConfRemoteManager::synchronize()
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING(
-                "Remote setting '{}' rejected (value: {}): {}. Keeping current value.", key, value.str(), e.what());
+            LOG_WARNING("[{}] Remote setting '{}' rejected (value: {}): {}. "
+                        "Keeping current value.",
+                        LOG_MODULE_NAME,
+                        key,
+                        value.str(),
+                        e.what());
             continue;
         }
 
@@ -110,14 +115,14 @@ void ConfRemoteManager::synchronize()
 
     if (stateChanged)
     {
-        LOG_INFO("Remote settings synchronized: changes detected and applied.");
+        LOG_INFO("[{}] Remote settings synchronized: changes detected and applied", LOG_MODULE_NAME);
         try
         {
             saveSettingsToStore();
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING("Failed to persist remote settings cache: {}", e.what());
+            LOG_WARNING("[{}] Failed to persist remote settings cache: {}", LOG_MODULE_NAME, e.what());
         }
     }
 }
@@ -125,7 +130,7 @@ void ConfRemoteManager::synchronize()
 void ConfRemoteManager::requestShutdown()
 {
     m_shutdownRequested.store(true, std::memory_order_relaxed);
-    LOG_INFO("[ConfRemote] Shutdown requested");
+    LOG_INFO("[{}] Shutdown requested", LOG_MODULE_NAME);
 }
 
 json::Json ConfRemoteManager::addTrigger(std::string_view key,
@@ -150,8 +155,9 @@ void ConfRemoteManager::loadSettingsFromStore()
     const auto docResp = m_store.lock()->readDoc(REMOTE_CONF_CACHE_DOC);
     if (base::isError(docResp))
     {
-        throw std::runtime_error(
-            fmt::format("Failed to load remote settings from store: {}", base::getError(docResp).message));
+        throw std::runtime_error(fmt::format("Failed to load remote settings "
+                                             "from store: {}",
+                                             base::getError(docResp).message));
     }
 
     const auto& cached = base::getResponse(docResp);
@@ -189,8 +195,9 @@ void ConfRemoteManager::saveSettingsToStore() const
     auto storePtr = base::utils::lockWeakPtr(m_store, "StoreInternal");
     if (auto err = storePtr->upsertDoc(REMOTE_CONF_CACHE_DOC, persisted); base::isError(err))
     {
-        throw std::runtime_error(
-            fmt::format("Failed to save remote settings to store: {}", base::getError(err).message));
+        throw std::runtime_error(fmt::format("Failed to save remote settings "
+                                             "to store: {}",
+                                             base::getError(err).message));
     }
 }
 

--- a/src/engine/source/confremote/src/confremotemanager.cpp
+++ b/src/engine/source/confremote/src/confremotemanager.cpp
@@ -101,7 +101,7 @@ void ConfRemoteManager::synchronize()
         catch (const std::exception& e)
         {
             LOG_WARNING("[{}] Remote setting '{}' rejected (value: {}): {}. "
-                        "Keeping current value.",
+                        "Keeping current value",
                         LOG_MODULE_NAME,
                         key,
                         value.str(),

--- a/src/engine/source/confremote/test/src/component/confremote_refresh_test.cpp
+++ b/src/engine/source/confremote/test/src/component/confremote_refresh_test.cpp
@@ -6,6 +6,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <base/logging.hpp>
 #include <confremote/confremotemanager.hpp>
 #include <rawevtindexer/raweventindexer.hpp>
 #include <store/mockStore.hpp>
@@ -25,7 +26,12 @@ constexpr int waitSeconds = 5;
 
 } // namespace
 
-TEST(ConfRemoteRefreshComponentTest, SynchronizePropagatesChangedValue)
+class ConfRemoteRefreshComponentTest : public ::testing::Test
+{
+    void SetUp() override { logging::testInit(); }
+};
+
+TEST_F(ConfRemoteRefreshComponentTest, SynchronizePropagatesChangedValue)
 {
     auto store = std::make_shared<StrictMock<store::mocks::MockStore>>();
     EXPECT_CALL(*store, existsDoc(_)).WillOnce(Return(false));
@@ -62,7 +68,7 @@ TEST(ConfRemoteRefreshComponentTest, SynchronizePropagatesChangedValue)
     EXPECT_TRUE(received[1]);
 }
 
-TEST(ConfRemoteRefreshComponentTest, PersistedValueIsReturnedByAddTriggerOnRecreation)
+TEST_F(ConfRemoteRefreshComponentTest, PersistedValueIsReturnedByAddTriggerOnRecreation)
 {
     // First manager: synchronize applies a value, which is persisted via upsertDoc
     std::optional<json::Json> capturedDoc;
@@ -82,7 +88,7 @@ TEST(ConfRemoteRefreshComponentTest, PersistedValueIsReturnedByAddTriggerOnRecre
 
     {
         confremote::ConfRemoteManager manager(connector, store1, attempts, waitSeconds);
-        manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) { }, json::Json("false"));
+        manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) {}, json::Json("false"));
         manager.synchronize();
     }
 
@@ -102,14 +108,15 @@ TEST(ConfRemoteRefreshComponentTest, PersistedValueIsReturnedByAddTriggerOnRecre
     EXPECT_EQ(result, json::Json("true"));
 }
 
-TEST(ConfRemoteRefreshComponentTest, FreshInstallKeepsRawEventIndexerDisabled)
+TEST_F(ConfRemoteRefreshComponentTest, FreshInstallKeepsRawEventIndexerDisabled)
 {
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
     auto store = std::make_shared<NiceMock<store::mocks::MockStore>>();
     auto rawIndexer = std::make_shared<raweventindexer::RawEventIndexer>(connector);
 
     EXPECT_CALL(*store, existsDoc(_)).WillOnce(Return(false));
-    EXPECT_CALL(*connector, getEngineRemoteConfig()).WillRepeatedly(::testing::Throw(std::runtime_error("network down")));
+    EXPECT_CALL(*connector, getEngineRemoteConfig())
+        .WillRepeatedly(::testing::Throw(std::runtime_error("network down")));
 
     confremote::ConfRemoteManager manager(connector, store, attempts, waitSeconds);
     const auto initialValue = manager.addTrigger(
@@ -123,7 +130,7 @@ TEST(ConfRemoteRefreshComponentTest, FreshInstallKeepsRawEventIndexerDisabled)
     EXPECT_FALSE(rawIndexer->isEnabled());
 }
 
-TEST(ConfRemoteRefreshComponentTest, RestartWithCachedSettingsWhenRemoteUnavailableUsesLastValidValue)
+TEST_F(ConfRemoteRefreshComponentTest, RestartWithCachedSettingsWhenRemoteUnavailableUsesLastValidValue)
 {
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
     auto store = std::make_shared<StrictMock<store::mocks::MockStore>>();
@@ -132,7 +139,8 @@ TEST(ConfRemoteRefreshComponentTest, RestartWithCachedSettingsWhenRemoteUnavaila
     EXPECT_CALL(*store, existsDoc(_)).WillOnce(Return(true));
     EXPECT_CALL(*store, readDoc(_))
         .WillOnce(Return(store::mocks::storeReadDocResp(json::Json(R"({"index_raw_events":true})"))));
-    EXPECT_CALL(*connector, getEngineRemoteConfig()).WillRepeatedly(::testing::Throw(std::runtime_error("network down")));
+    EXPECT_CALL(*connector, getEngineRemoteConfig())
+        .WillRepeatedly(::testing::Throw(std::runtime_error("network down")));
 
     confremote::ConfRemoteManager manager(connector, store, attempts, waitSeconds);
     const auto initialValue = manager.addTrigger(
@@ -146,7 +154,7 @@ TEST(ConfRemoteRefreshComponentTest, RestartWithCachedSettingsWhenRemoteUnavaila
     EXPECT_TRUE(rawIndexer->isEnabled());
 }
 
-TEST(ConfRemoteRefreshComponentTest, SynchronizeTogglesRawEventIndexer)
+TEST_F(ConfRemoteRefreshComponentTest, SynchronizeTogglesRawEventIndexer)
 {
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
     auto store = std::make_shared<NiceMock<store::mocks::MockStore>>();

--- a/src/engine/source/confremote/test/src/unit/confremotemanager_test.cpp
+++ b/src/engine/source/confremote/test/src/unit/confremotemanager_test.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <base/logging.hpp>
 #include <confremote/confremotemanager.hpp>
 #include <store/mockStore.hpp>
 #include <wiconnector/mockswindexerconnector.hpp>
@@ -57,28 +58,33 @@ std::shared_ptr<StrictMock<store::mocks::MockStore>> makeCachedStore(std::string
 
 } // namespace
 
-TEST(ConfRemoteManagerUnitTest, CanConstructWithStoreAndNullConnector)
+class ConfRemoteManagerUnitTest : public ::testing::Test
+{
+    void SetUp() override { logging::testInit(); }
+};
+
+TEST_F(ConfRemoteManagerUnitTest, CanConstructWithStoreAndNullConnector)
 {
     auto store = makeEmptyStore();
     std::shared_ptr<wiconnector::IWIndexerConnector> connector;
     EXPECT_NO_THROW((confremote::ConfRemoteManager {connector, store, attempts, waitSeconds}));
 }
 
-TEST(ConfRemoteManagerUnitTest, CanConstructWithZeroAttempts)
+TEST_F(ConfRemoteManagerUnitTest, CanConstructWithZeroAttempts)
 {
     auto store = makeEmptyStore();
     std::shared_ptr<wiconnector::IWIndexerConnector> connector;
     EXPECT_NO_THROW((confremote::ConfRemoteManager {connector, store, 0, waitSeconds}));
 }
 
-TEST(ConfRemoteManagerUnitTest, CanConstructWithZeroWaitSeconds)
+TEST_F(ConfRemoteManagerUnitTest, CanConstructWithZeroWaitSeconds)
 {
     auto store = makeEmptyStore();
     std::shared_ptr<wiconnector::IWIndexerConnector> connector;
     EXPECT_NO_THROW((confremote::ConfRemoteManager {connector, store, attempts, 0}));
 }
 
-TEST(ConfRemoteManagerUnitTest, AddTriggerReturnsDefaultWhenStoreIsEmpty)
+TEST_F(ConfRemoteManagerUnitTest, AddTriggerReturnsDefaultWhenStoreIsEmpty)
 {
     auto store = makeEmptyStore();
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
@@ -90,19 +96,18 @@ TEST(ConfRemoteManagerUnitTest, AddTriggerReturnsDefaultWhenStoreIsEmpty)
     EXPECT_EQ(result, defaultVal);
 }
 
-TEST(ConfRemoteManagerUnitTest, AddTriggerReturnsPersistedValueWhenStoreHasCache)
+TEST_F(ConfRemoteManagerUnitTest, AddTriggerReturnsPersistedValueWhenStoreHasCache)
 {
     auto store = makeCachedStore(REMOTE_INDEX_RAW_EVENTS, json::Json("true"));
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
     confremote::ConfRemoteManager manager(connector, store, attempts, waitSeconds);
 
-    const auto result =
-        manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) {}, json::Json("false"));
+    const auto result = manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) {}, json::Json("false"));
 
     EXPECT_EQ(result, json::Json("true"));
 }
 
-TEST(ConfRemoteManagerUnitTest, AddTriggerThrowsWhenKeyIsAlreadyRegistered)
+TEST_F(ConfRemoteManagerUnitTest, AddTriggerThrowsWhenKeyIsAlreadyRegistered)
 {
     auto store = makeEmptyStore();
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
@@ -110,12 +115,12 @@ TEST(ConfRemoteManagerUnitTest, AddTriggerThrowsWhenKeyIsAlreadyRegistered)
 
     manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) {}, json::Json("false"));
 
-    EXPECT_THROW(
-        manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) {}, json::Json("false")),
-        std::invalid_argument);
+    EXPECT_THROW(manager.addTrigger(
+                     REMOTE_INDEX_RAW_EVENTS, [](const json::Json&) {}, json::Json("false")),
+                 std::invalid_argument);
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeSkipsCallbackWhenValueDoesNotChange)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeSkipsCallbackWhenValueDoesNotChange)
 {
     // lastConfig loaded from store = false; remote also returns false -> no callback, no persist
     auto store = makeCachedStore(REMOTE_INDEX_RAW_EVENTS, json::Json(R"(false)"));
@@ -126,17 +131,14 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeSkipsCallbackWhenValueDoesNotChange)
     confremote::ConfRemoteManager manager(connector, store, attempts, waitSeconds);
 
     int calls = 0;
-    manager.addTrigger(
-        REMOTE_INDEX_RAW_EVENTS,
-        [&calls](const json::Json&) { ++calls; },
-        json::Json("false"));
+    manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [&calls](const json::Json&) { ++calls; }, json::Json("false"));
 
     manager.synchronize();
 
     EXPECT_EQ(calls, 0);
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeNotifiesWhenValueChanges)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeNotifiesWhenValueChanges)
 {
     // lastConfig = false from store; remote returns true -> callback called, value persisted
     auto store = makeCachedStore(REMOTE_INDEX_RAW_EVENTS, json::Json(R"(false)"));
@@ -163,7 +165,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeNotifiesWhenValueChanges)
     EXPECT_TRUE(captured);
 }
 
-TEST(ConfRemoteManagerUnitTest, RejectedCallbackDoesNotCommitValue)
+TEST_F(ConfRemoteManagerUnitTest, RejectedCallbackDoesNotCommitValue)
 {
     auto store = makeEmptyStore();
     // No upsertDoc expected: callback rejects -> no state change
@@ -188,7 +190,7 @@ TEST(ConfRemoteManagerUnitTest, RejectedCallbackDoesNotCommitValue)
     EXPECT_EQ(calls, 1);
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeCallbackRejectsWrongTypeAndPreservesCurrentState)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeCallbackRejectsWrongTypeAndPreservesCurrentState)
 {
     auto store = makeEmptyStore();
     EXPECT_CALL(*store, upsertDoc(_, _)).WillOnce(Return(store::mocks::storeOk())); // first sync only
@@ -220,7 +222,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeCallbackRejectsWrongTypeAndPreservesC
     EXPECT_TRUE(applied[0]);
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeWithFetchFailureKeepsCurrentState)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeWithFetchFailureKeepsCurrentState)
 {
     auto store = makeEmptyStore();
     // No upsertDoc expected: fetch fails -> no change
@@ -231,16 +233,13 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeWithFetchFailureKeepsCurrentState)
     confremote::ConfRemoteManager manager(connector, store, attempts, waitSeconds);
 
     int calls = 0;
-    manager.addTrigger(
-        REMOTE_INDEX_RAW_EVENTS,
-        [&calls](const json::Json&) { ++calls; },
-        json::Json("false"));
+    manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [&calls](const json::Json&) { ++calls; }, json::Json("false"));
 
     EXPECT_NO_THROW(manager.synchronize());
     EXPECT_EQ(calls, 0);
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeIgnoresUnregisteredKeys)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeIgnoresUnregisteredKeys)
 {
     auto store = makeEmptyStore();
     // No upsertDoc expected: key not registered -> nothing applied
@@ -254,7 +253,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeIgnoresUnregisteredKeys)
     EXPECT_NO_THROW(manager.synchronize());
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeIgnoresCachedKeysWithoutRegisteredCallback)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeIgnoresCachedKeysWithoutRegisteredCallback)
 {
     // Store has persisted data from a previous session but no addTrigger is registered
     auto store = makeCachedStore(REMOTE_INDEX_RAW_EVENTS, json::Json("true"));
@@ -269,7 +268,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeIgnoresCachedKeysWithoutRegisteredCal
     EXPECT_NO_THROW(manager.synchronize());
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeWithNullConnectorDoesNotThrow)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeWithNullConnectorDoesNotThrow)
 {
     auto store = makeEmptyStore();
     std::shared_ptr<wiconnector::IWIndexerConnector> connector;
@@ -278,7 +277,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeWithNullConnectorDoesNotThrow)
     EXPECT_NO_THROW(manager.synchronize());
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeRemovedKeyKeepsCurrentState)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeRemovedKeyKeepsCurrentState)
 {
     auto store = makeEmptyStore();
     EXPECT_CALL(*store, upsertDoc(_, _)).WillOnce(Return(store::mocks::storeOk()));
@@ -310,7 +309,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeRemovedKeyKeepsCurrentState)
     EXPECT_TRUE(values[0]);
 }
 
-TEST(ConfRemoteManagerUnitTest, AddTriggerAfterFirstSynchronizeIsAppliedOnNextSynchronize)
+TEST_F(ConfRemoteManagerUnitTest, AddTriggerAfterFirstSynchronizeIsAppliedOnNextSynchronize)
 {
     auto store = makeEmptyStore();
     EXPECT_CALL(*store, upsertDoc(_, _)).WillOnce(Return(store::mocks::storeOk()));
@@ -326,17 +325,14 @@ TEST(ConfRemoteManagerUnitTest, AddTriggerAfterFirstSynchronizeIsAppliedOnNextSy
     manager.synchronize(); // trigger not yet registered -> key ignored
 
     int calls = 0;
-    manager.addTrigger(
-        REMOTE_INDEX_RAW_EVENTS,
-        [&calls](const json::Json&) { ++calls; },
-        json::Json("false"));
+    manager.addTrigger(REMOTE_INDEX_RAW_EVENTS, [&calls](const json::Json&) { ++calls; }, json::Json("false"));
 
     manager.synchronize(); // trigger registered, value changed -> callback(true)
 
     EXPECT_EQ(calls, 1);
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeAbortsBeforeFetchWhenShutdownRequested)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeAbortsBeforeFetchWhenShutdownRequested)
 {
     auto store = makeEmptyStore();
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
@@ -347,7 +343,7 @@ TEST(ConfRemoteManagerUnitTest, SynchronizeAbortsBeforeFetchWhenShutdownRequeste
     EXPECT_NO_THROW(manager.synchronize());
 }
 
-TEST(ConfRemoteManagerUnitTest, SynchronizeAbortsDuringRetryWaitWhenShutdownRequested)
+TEST_F(ConfRemoteManagerUnitTest, SynchronizeAbortsDuringRetryWaitWhenShutdownRequested)
 {
     auto store = makeEmptyStore();
 

--- a/src/engine/source/fastmetrics/test/src/unit/pullMetric_test.cpp
+++ b/src/engine/source/fastmetrics/test/src/unit/pullMetric_test.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include <base/logging.hpp>
 #include <fastmetrics/manager.hpp>
 #include <fastmetrics/pullMetric.hpp>
 #include <fastmetrics/registry.hpp>
@@ -218,6 +219,8 @@ class ManagerWriteAllMetricsTest : public ::testing::Test
 {
 protected:
     Manager manager;
+
+    void SetUp() override { logging::testInit(); }
 
     void TearDown() override { manager.clear(); }
 

--- a/src/engine/source/geo/src/manager.cpp
+++ b/src/engine/source/geo/src/manager.cpp
@@ -36,7 +36,7 @@ Manager::Manager(const std::shared_ptr<store::IStore>& store, const std::shared_
     auto docResp = m_store->readDoc(base::Name(INTERNAL_NAME));
     if (base::isError(docResp))
     {
-        LOG_DEBUG("Geo module do not have dbs in the store: {}", base::getError(docResp).message);
+        LOG_DEBUG("[Geo::Manager] Geo module do not have dbs in the store: {}", base::getError(docResp).message);
         updateGeoStatusSnapshot(); // Publish initial status even with no dbs
         return;
     }
@@ -53,7 +53,10 @@ Manager::Manager(const std::shared_ptr<store::IStore>& store, const std::shared_
             auto addResp = addDbUnsafe(pathStr, hashStr, createdAt.value(), type);
             if (base::isError(addResp))
             {
-                LOG_ERROR("Geo cannot add {} db '{}': {}", typeName(type), pathStr, base::getError(addResp).message);
+                LOG_ERROR("[Geo::Manager] Geo cannot add {} db '{}': {}",
+                          typeName(type),
+                          pathStr,
+                          base::getError(addResp).message);
             }
             else
             {
@@ -70,7 +73,7 @@ Manager::Manager(const std::shared_ptr<store::IStore>& store, const std::shared_
         }
         else
         {
-            LOG_WARNING("Geo store has incomplete {} database information, skipping", typeName(type));
+            LOG_WARNING("[Geo::Manager] Geo store has incomplete {} database information, skipping", typeName(type));
         }
     };
 
@@ -426,7 +429,7 @@ void Manager::remoteUpsert(const std::string& manifestUrl, const std::string& ci
 void Manager::requestShutdown()
 {
     m_shouldRun->store(false);
-    LOG_INFO("[Geo::Manager] Shutdown requested.");
+    LOG_INFO("[Geo::Manager] Shutdown requested");
 }
 
 Result<std::shared_ptr<ILocator>> Manager::getLocator(Type type) const

--- a/src/engine/source/geo/test/src/unit/locator_test.cpp
+++ b/src/engine/source/geo/test/src/unit/locator_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <base/json.hpp>
+#include <base/logging.hpp>
 #include <base/utils/hash.hpp>
 #include <filesystem>
 #include <fstream>
@@ -89,6 +90,7 @@ protected:
 
     void SetUp() override
     {
+        logging::testInit();
         mockStore = std::make_shared<store::mocks::MockStore>();
         mockDownloader = std::make_shared<mocks::MockDownloader>();
 

--- a/src/engine/source/hlp/src/parsers/date.cpp
+++ b/src/engine/source/hlp/src/parsers/date.cpp
@@ -19,6 +19,8 @@ namespace
 using namespace hlp;
 using namespace hlp::parser;
 
+constexpr std::string_view LOG_MODULE_NAME = "hlp::timezone"; ///< Log module name for timezone parser
+
 Mapper getMapper(std::string&& parsed, std::string_view targetField)
 {
     return [parsed = std::move(parsed), targetField](json::Json& event)
@@ -181,12 +183,12 @@ bool loadTimeZoneDB(const std::string& version, bool autoUpdate)
     try
     {
         const auto& db = date::get_tzdb();
-        LOG_DEBUG("Loaded timezone database version: '{}'", db.version);
+        LOG_DEBUG("[{}] Loaded timezone database version: '{}'", LOG_MODULE_NAME, db.version);
         return !(autoUpdate && db.version != version);
     }
     catch (std::exception& e)
     {
-        LOG_WARNING("Failed to load timezone database: '{}', try to download it", e.what());
+        LOG_WARNING("[{}] Failed to load timezone database: '{}', try to download it", LOG_MODULE_NAME, e.what());
         return false;
     }
 }
@@ -226,14 +228,14 @@ void initTZDB(const std::string& path, bool autoUpdate, const std::string& force
 
     if (autoUpdate)
     {
-        LOG_INFO("Auto-update for timezone database is enabled");
+        LOG_INFO("[{}] Auto-update for timezone database is enabled", LOG_MODULE_NAME);
         rv = date::remote_version();
     }
-    LOG_DEBUG("Remote timezone database version: '{}'", rv);
+    LOG_DEBUG("[{}] Remote timezone database version: '{}'", LOG_MODULE_NAME, rv);
 
     if (!forceVersion.empty())
     {
-        LOG_INFO("Forcing timezone database version: '{}'", forceVersion);
+        LOG_INFO("[{}] Forcing timezone database version: '{}'", LOG_MODULE_NAME, forceVersion);
         rv = forceVersion;
         autoUpdate = true;
     }
@@ -250,7 +252,7 @@ void initTZDB(const std::string& path, bool autoUpdate, const std::string& force
 
     downloadAndInstallTimeZoneDB(rv);
     const auto& db = date::get_tzdb(); // Check if the database is loaded correctly
-    LOG_INFO("Timezone database updated to version: '{}'", db.version);
+    LOG_INFO("[{}] Timezone database updated to version: '{}'", LOG_MODULE_NAME, db.version);
 }
 
 namespace parsers

--- a/src/engine/source/httpsrv/src/server.cpp
+++ b/src/engine/source/httpsrv/src/server.cpp
@@ -248,7 +248,7 @@ void Server::start(const std::filesystem::path& socketPath, bool useThread)
     }
     else
     {
-        LOG_INFO("[Server]  Starting {} at {}", m_id, socketPath.string());
+        LOG_INFO("[Server] Starting {} at {}", m_id, socketPath.string());
         if (!bindAndListen())
         {
             throw std::runtime_error(fmt::format("[Server] {} failed to start at {}", m_id, socketPath.string()));

--- a/src/engine/source/httpsrv/src/server.cpp
+++ b/src/engine/source/httpsrv/src/server.cpp
@@ -248,7 +248,7 @@ void Server::start(const std::filesystem::path& socketPath, bool useThread)
     }
     else
     {
-        LOG_INFO("Starting server {} at {}", m_id, socketPath.string());
+        LOG_INFO("[Server]  Starting {} at {}", m_id, socketPath.string());
         if (!bindAndListen())
         {
             throw std::runtime_error(fmt::format("[Server] {} failed to start at {}", m_id, socketPath.string()));

--- a/src/engine/source/iockvdb/src/manager.cpp
+++ b/src/engine/source/iockvdb/src/manager.cpp
@@ -98,7 +98,8 @@ public:
         switch (ret)
         {
             case json::RetGet::NotFound: throw std::runtime_error("DBState::fromJson: Missing instance_path field");
-            case json::RetGet::WrongType: throw std::runtime_error("DBState::fromJson: instance_path field is not a string");
+            case json::RetGet::WrongType:
+                throw std::runtime_error("DBState::fromJson: instance_path field is not a string");
             case json::RetGet::Success:
                 if (path.empty())
                     throw std::runtime_error("DBState::fromJson: instance_path field cannot be empty");
@@ -256,7 +257,6 @@ void KVDBManager::add(std::string_view name)
     // Opportunistic cleanup of retired instances
     tryCleanRetired();
 }
-
 
 bool KVDBManager::exists(std::string_view dbName) const noexcept
 {
@@ -598,7 +598,8 @@ void KVDBManager::loadStateFromStore()
                     }
                     else
                     {
-                        LOG_WARNING("[{}] Failed to open DB '{}': {}", LOG_MODULE_NAME, dbState.getName(), status.ToString());
+                        LOG_WARNING(
+                            "[{}] Failed to open DB '{}': {}", LOG_MODULE_NAME, dbState.getName(), status.ToString());
                     }
                 }
 

--- a/src/engine/source/iockvdb/src/manager.cpp
+++ b/src/engine/source/iockvdb/src/manager.cpp
@@ -20,7 +20,9 @@
 namespace
 {
 
-const base::Name KVDB_STORE_NAME {"kvdb-ioc/status/0"}; ///< Store document name for KVDB state
+const base::Name KVDB_STORE_NAME {"kvdb-ioc/status/0"};   ///< Store document name for KVDB state
+constexpr std::string_view LOG_MODULE_NAME = "IOC::KVDB"; ///< Log module name for KVDBManager
+
 /**
  * @brief Represents the persisted state of a KVDB instance
  */
@@ -245,7 +247,7 @@ void KVDBManager::add(std::string_view name)
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING("[KVDB IOC] Failed to persist state after add: {}.", e.what());
+        LOG_WARNING("[{}] Failed to persist state after add: {}", LOG_MODULE_NAME, e.what());
     }
 
     // Mark as successful - prevent rollback
@@ -448,7 +450,7 @@ void KVDBManager::hotSwap(std::string_view sourceDb, std::string_view targetDb)
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING("[KVDB IOC] Failed to persist state after hot-swap: {}.", e.what());
+        LOG_WARNING("[{}] Failed to persist state after hot-swap: {}", LOG_MODULE_NAME, e.what());
     }
 
     // Opportunistic cleanup of retired instances
@@ -500,7 +502,7 @@ void KVDBManager::remove(std::string_view name)
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING("[KVDB IOC] Failed to persist state after removal: {}.", e.what());
+        LOG_WARNING("[{}] Failed to persist state after removal: {}", LOG_MODULE_NAME, e.what());
     }
 
     // Opportunistic cleanup of retired instances
@@ -596,7 +598,7 @@ void KVDBManager::loadStateFromStore()
                     }
                     else
                     {
-                        LOG_WARNING("[KVDB IOC] Failed to open DB '{}': {}.", dbState.getName(), status.ToString());
+                        LOG_WARNING("[{}] Failed to open DB '{}': {}", LOG_MODULE_NAME, dbState.getName(), status.ToString());
                     }
                 }
 
@@ -605,7 +607,8 @@ void KVDBManager::loadStateFromStore()
             }
             catch (const std::exception& e)
             {
-                LOG_WARNING("[KVDB IOC] Failed to restore DB '{}' from '{}': {}.",
+                LOG_WARNING("[{}] Failed to restore DB '{}' from '{}': {}",
+                            LOG_MODULE_NAME,
                             dbState.getName(),
                             dbState.getInstancePath(),
                             e.what());
@@ -614,7 +617,7 @@ void KVDBManager::loadStateFromStore()
     }
     catch (const std::exception& e)
     {
-        LOG_WARNING("[KVDB IOC] Failed to load persisted state: {}. Starting fresh.", e.what());
+        LOG_WARNING("[{}] Failed to load persisted state: {}. Starting fresh", LOG_MODULE_NAME, e.what());
     }
 }
 
@@ -645,7 +648,7 @@ void KVDBManager::saveStateToStore()
     }
     catch (const std::exception& e)
     {
-        LOG_DEBUG("[KVDB IOC] Could not preload previous persisted paths: {}.", e.what());
+        LOG_DEBUG("[{}] Could not preload previous persisted paths: {}", LOG_MODULE_NAME, e.what());
     }
 
     {

--- a/src/engine/source/iockvdb/test/src/component/kvdb_test.cpp
+++ b/src/engine/source/iockvdb/test/src/component/kvdb_test.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <base/logging.hpp>
 #include <iockvdb/manager.hpp>
 #include <store/mockStore.hpp>
 
@@ -20,6 +21,7 @@ class KVDBComponentTest : public ::testing::Test
 protected:
     void SetUp() override
     {
+        logging::testInit();
         // Use unique directory per test to allow parallel execution
         auto testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
         std::string testName = std::string(testInfo->test_suite_name()) + "_" + std::string(testInfo->name());
@@ -1675,10 +1677,10 @@ TEST_F(KVDBComponentTest, LoadStateRestoresSubsequentEntriesWhenOneDiskPathIsMis
     auto writerStore = std::make_shared<::testing::NiceMock<store::mocks::MockStore>>();
     ON_CALL(*writerStore, existsDoc(::testing::_)).WillByDefault(::testing::Return(false));
     EXPECT_CALL(*writerStore, upsertDoc(::testing::_, ::testing::_))
-        .WillRepeatedly(::testing::DoAll(
-            ::testing::Invoke([&persistedState](const base::Name&, const json::Json& j)
-                              { persistedState = std::make_shared<json::Json>(j.str().c_str()); }),
-            ::testing::Return(std::nullopt)));
+        .WillRepeatedly(
+            ::testing::DoAll(::testing::Invoke([&persistedState](const base::Name&, const json::Json& j)
+                                               { persistedState = std::make_shared<json::Json>(j.str().c_str()); }),
+                             ::testing::Return(std::nullopt)));
 
     {
         ioc::kvdb::KVDBManager manager(testDir, writerStore);
@@ -1761,10 +1763,10 @@ TEST_F(KVDBComponentTest, SaveStatePreservesPreviousInstancePathForHandleWithout
     auto mockStore = std::make_shared<::testing::NiceMock<store::mocks::MockStore>>();
 
     EXPECT_CALL(*mockStore, upsertDoc(::testing::_, ::testing::_))
-        .WillRepeatedly(::testing::DoAll(
-            ::testing::Invoke([&capturedState](const base::Name&, const json::Json& j)
-                              { capturedState = std::make_shared<json::Json>(j.str().c_str()); }),
-            ::testing::Return(std::nullopt)));
+        .WillRepeatedly(
+            ::testing::DoAll(::testing::Invoke([&capturedState](const base::Name&, const json::Json& j)
+                                               { capturedState = std::make_shared<json::Json>(j.str().c_str()); }),
+                             ::testing::Return(std::nullopt)));
 
     {
         ON_CALL(*mockStore, existsDoc(::testing::_)).WillByDefault(::testing::Return(false));
@@ -1790,10 +1792,10 @@ TEST_F(KVDBComponentTest, SaveStatePreservesPreviousInstancePathForHandleWithout
 
     std::shared_ptr<json::Json> finalState;
     EXPECT_CALL(*mockStore, upsertDoc(::testing::_, ::testing::_))
-        .WillRepeatedly(::testing::DoAll(
-            ::testing::Invoke([&finalState](const base::Name&, const json::Json& j)
-                              { finalState = std::make_shared<json::Json>(j.str().c_str()); }),
-            ::testing::Return(std::nullopt)));
+        .WillRepeatedly(
+            ::testing::DoAll(::testing::Invoke([&finalState](const base::Name&, const json::Json& j)
+                                               { finalState = std::make_shared<json::Json>(j.str().c_str()); }),
+                             ::testing::Return(std::nullopt)));
 
     {
         ioc::kvdb::KVDBManager manager(testDir, mockStore);

--- a/src/engine/source/iocsync/src/iocsync.cpp
+++ b/src/engine/source/iocsync/src/iocsync.cpp
@@ -225,22 +225,29 @@ bool IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
         // Consumer is not idle — rollback and signal caller
         if (!processedDocsOpt.has_value())
         {
-            LOG_DEBUG(
-                "[IOC::Sync] Consumer is not idle for IOC type '{}', rolling back database '{}'", iocType, dbName);
+            LOG_DEBUG("[IOC::Sync] Consumer is not idle for IOC type '{}', "
+                      "rolling back database '{}'",
+                      iocType,
+                      dbName);
             try
             {
                 kvdbiocPtr->remove(dbName);
             }
             catch (const std::exception& ex)
             {
-                LOG_WARNING(
-                    "[IOC::Sync] Failed to rollback database '{}' after consumer not idle: {}", dbName, ex.what());
+                LOG_WARNING("[IOC::Sync] Failed to rollback database '{}' after consumer "
+                            "not idle: {}",
+                            dbName,
+                            ex.what());
             }
             return false;
         }
 
-        LOG_DEBUG(
-            "[IOC::Sync] Downloaded {} IOCs of type '{}' (processed {} docs)", stored, iocType, *processedDocsOpt);
+        LOG_DEBUG("[IOC::Sync] Downloaded {} IOCs of type '{}' "
+                  "(processed {} docs)",
+                  stored,
+                  iocType,
+                  *processedDocsOpt);
 
         if (stored == 0)
         {
@@ -256,9 +263,7 @@ bool IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
         }
         catch (const std::exception& ex)
         {
-            LOG_WARNING("[IocSync::downloadAndPopulateDB] Failed to rollback database '{}' after download failure: {}",
-                        dbName,
-                        ex.what());
+            LOG_WARNING("[IOC::Sync] Failed to rollback database '{}' after download failure: {}", dbName, ex.what());
         }
         throw std::runtime_error(fmt::format("Failed to download IOCs to database '{}': {}", dbName, e.what()));
     }

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -555,8 +555,7 @@ int main(int argc, char* argv[])
         {
             rawEventIndexer = std::make_shared<raweventindexer::RawEventIndexer>(
                 indexerConnector, raweventindexer::RawEventIndexer::DEFAULT_INDEX_NAME);
-            LOG_INFO("Raw Event Indexer initialized (index: {}).",
-                     raweventindexer::RawEventIndexer::DEFAULT_INDEX_NAME);
+            LOG_INFO("Raw Event Indexer initialized");
 
             if (remoteConf)
             {

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -198,7 +198,8 @@ int main(int argc, char* argv[])
     }
 
     // Load the configuration
-    auto confManager = conf::Conf(std::make_shared<conf::FileLoader>(base::process::getWazuhHome() / "etc/wazuh-manager-internal-options.conf"));
+    const auto confPath = base::process::getWazuhHome() / "etc/wazuh-manager-internal-options.conf";
+    auto confManager = conf::Conf(std::make_shared<conf::FileLoader>(confPath));
     try
     {
         confManager.load();

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char* argv[])
     }
 
     // Load the configuration
-    auto confManager = conf::Conf(std::make_shared<conf::FileLoader>());
+    auto confManager = conf::Conf(std::make_shared<conf::FileLoader>(base::process::getWazuhHome() / "etc/wazuh-manager-internal-options.conf"));
     try
     {
         confManager.load();

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
 
         if (logConfig.enableRotation)
         {
-            LOG_INFO("Logging initialized in standalone mode with rotation enabled.");
+            LOG_INFO("Logging initialized in standalone mode with rotation enabled");
             LOG_INFO("Log file: {}", logConfig.filePath);
             LOG_INFO("Rotation policy: Daily at {}:{:02d} OR when file reaches {} MB",
                      logConfig.rotationHour,
@@ -303,27 +303,27 @@ int main(int argc, char* argv[])
             auto fileStorage = confManager.get<std::string>(conf::key::STORE_PATH);
             auto fileDriver = std::make_shared<store::drivers::FileDriver>(fileStorage);
             store = std::make_shared<store::Store>(fileDriver);
-            LOG_INFO("Store initialized.");
+            LOG_INFO("Store initialized");
         }
 
         // Content Manager
         {
             cmStore = std::make_shared<cm::store::CMStore>(confManager.get<std::string>(conf::key::CM_RULESET_PATH),
                                                            confManager.get<std::string>(conf::key::OUTPUTS_PATH));
-            LOG_INFO("Content Manager initialized.");
+            LOG_INFO("Content Manager initialized");
         }
 
         // KVDB
         {
             kvdbManager = std::make_shared<kvdbstore::KVDBManager>();
-            LOG_INFO("KVDB initialized.");
+            LOG_INFO("KVDB initialized");
         }
 
         // KVDB IOC
         {
             auto kvdbPath = std::filesystem::path(confManager.get<std::string>(conf::key::KVDB_IOC_PATH));
             IOCkvdb = std::make_shared<ioc::kvdb::KVDBManager>(kvdbPath, store);
-            LOG_INFO("IOC initialized.");
+            LOG_INFO("IOC initialized");
             // Initialize required DBs for iocs
             ioc::kvdb::details::initializeDBs(IOCkvdb);
         }
@@ -334,13 +334,13 @@ int main(int argc, char* argv[])
             auto geoDownloader = std::make_shared<geo::Downloader>(geoDownloadTimeout);
             geoManager = std::make_shared<geo::Manager>(store, geoDownloader);
             geoDownloader->setShouldRun(geoManager->shouldRunFlag());
-            LOG_INFO("GEO initialized.");
+            LOG_INFO("GEO initialized");
         }
 
         // Fast Metrics
         {
             fastmetrics::registerManager();
-            LOG_INFO("Fast metrics initialized.");
+            LOG_INFO("Fast metrics initialized");
         }
 
         // Schema
@@ -350,14 +350,14 @@ int main(int argc, char* argv[])
             if (std::holds_alternative<base::Error>(result))
             {
                 LOG_WARNING("Error loading schema definition: {}", std::get<base::Error>(result).message);
-                LOG_WARNING("Engine running without schema, consistency with indexer mappings is not guaranteed.");
+                LOG_WARNING("Engine running without schema, consistency with indexer mappings is not guaranteed");
             }
             else
             {
                 auto schemaJson = std::get<json::Json>(result);
                 schemaValidator->load(schemaJson);
             }
-            LOG_INFO("Schema initialized.");
+            LOG_INFO("Schema initialized");
         }
 
         // HLP
@@ -379,13 +379,13 @@ int main(int argc, char* argv[])
             logpar = std::make_shared<hlp::logpar::Logpar>(
                 base::getResponse<store::Doc>(res), std::static_pointer_cast<schemf::IValidator>(schemaValidator));
             hlp::registerParsers(logpar);
-            LOG_INFO("HLP initialized.");
+            LOG_INFO("HLP initialized");
         }
 
         // Scheduler -> Should be terminated before all modules to ensure any scheduled are stopped before shutdown
         {
             scheduler = std::make_shared<scheduler::Scheduler>();
-            LOG_INFO("Scheduler initialized.");
+            LOG_INFO("Scheduler initialized");
             exitHandler.add([scheduler]() { scheduler->stop(); });
         }
 
@@ -462,12 +462,12 @@ int main(int argc, char* argv[])
                 const auto pendingEvents = indexerConnector->getQueueSize();
                 if (pendingEvents > 0)
                 {
-                    LOG_INFO("Indexer Connector initialized with {} pending events from previous session.",
+                    LOG_INFO("Indexer Connector initialized with {} pending events from previous session",
                              pendingEvents);
                 }
                 else
                 {
-                    LOG_INFO("Indexer Connector initialized.");
+                    LOG_INFO("Indexer Connector initialized");
                 }
             }
             catch (const std::exception& e)
@@ -477,7 +477,7 @@ int main(int argc, char* argv[])
         }
         else
         {
-            LOG_INFO("Indexer Connector DISABLED - events will not be indexed.");
+            LOG_INFO("Indexer Connector DISABLED - events will not be indexed");
         }
 
         // Stream log for alerts an archive
@@ -487,7 +487,7 @@ int main(int argc, char* argv[])
             streamLogger = std::make_shared<streamlog::LogManager>(store, scheduler);
             exitHandler.add([streamLogger]() { streamLogger->requestShutdown(); });
 
-            LOG_INFO("Stream logger initialized.");
+            LOG_INFO("Stream logger initialized");
         }
 
         // Builder and registry
@@ -518,7 +518,7 @@ int main(int argc, char* argv[])
             {
                 LOG_DEBUG("Could not load 'schema/allowed-fields/0' document, {}",
                           std::get<base::Error>(allowedFieldsDoc).message);
-                LOG_WARNING("Allowed fields not found, assets will not have restrictions.");
+                LOG_WARNING("Allowed fields not found, assets will not have restrictions");
 
                 allowedFields = std::make_shared<builder::AllowedFields>();
             }
@@ -530,13 +530,13 @@ int main(int argc, char* argv[])
 
             builder =
                 std::make_shared<builder::Builder>(cmStore, schemaValidator, defs, allowedFields, builderDeps, store);
-            LOG_INFO("Builder initialized.");
+            LOG_INFO("Builder initialized");
         }
 
         // Crud Service
         {
             cmCrudService = std::make_shared<cm::crud::CrudService>(cmStore, builder);
-            LOG_INFO("Content Manager CRUD Service initialized.");
+            LOG_INFO("Content Manager CRUD Service initialized");
         }
 
         // Remote runtime settings manager
@@ -603,7 +603,7 @@ int main(int argc, char* argv[])
             auto retryInterval = confManager.get<size_t>(conf::key::CMSYNC_INDEXER_CONNECTOR_RETRY_INTERVAL);
             cmSyncService = std::make_shared<cm::sync::CMSync>(
                 indexerConnector, cmCrudService, store, orchestrator, maxRetries, retryInterval);
-            LOG_INFO("Content Manager Sync Service initialized.");
+            LOG_INFO("Content Manager Sync Service initialized");
 
             exitHandler.add([cmSyncService]() { cmSyncService->requestShutdown(); });
         }
@@ -617,7 +617,7 @@ int main(int argc, char* argv[])
             auto iocSyncBatchSize = confManager.get<size_t>(conf::key::IOC_INDEXER_CONNECTOR_SYNC_BATCH_SIZE);
             iocSyncService = std::make_shared<ioc::sync::IocSync>(
                 indexerConnector, IOCkvdb, store, maxRetries, retryInterval, iocSyncBatchSize);
-            LOG_INFO("IOC Sync Service initialized.");
+            LOG_INFO("IOC Sync Service initialized");
 
             exitHandler.add([iocSyncService]() { iocSyncService->requestShutdown(); });
 
@@ -625,14 +625,12 @@ int main(int argc, char* argv[])
             auto iocSyncInterval = confManager.get<std::size_t>(conf::key::IOC_SYNC_INTERVAL);
             if (iocSyncInterval > 0)
             {
-                scheduler->scheduleTask("ioc-sync-task",
-                                        scheduler::TaskConfig {.interval = iocSyncInterval,
-                                                               .runImmediately = true,
-                                                               .CPUPriority = 0,
-                                                               .taskFunction = [iocSyncService]()
-                                                               {
-                                                                   iocSyncService->synchronize();
-                                                               }});
+                scheduler->scheduleTask(
+                    "ioc-sync-task",
+                    scheduler::TaskConfig {.interval = iocSyncInterval,
+                                           .runImmediately = true,
+                                           .CPUPriority = 0,
+                                           .taskFunction = [iocSyncService]() { iocSyncService->synchronize(); }});
                 LOG_DEBUG("IOC Sync task scheduled with interval: {} seconds, {} max retries, {} seconds for retry "
                           "interval and {} for batch size",
                           iocSyncInterval,
@@ -666,10 +664,8 @@ int main(int argc, char* argv[])
                                            .runImmediately = true,
                                            .CPUPriority = 0,
                                            .taskFunction = [geoManager, manifestUrl, cityPath, asnPath]()
-                                           {
-                                               geoManager->remoteUpsert(manifestUrl, cityPath, asnPath);
-                                           }});
-                LOG_DEBUG("Geo sync scheduled with interval: {} seconds.", geoSyncInterval);
+                                           { geoManager->remoteUpsert(manifestUrl, cityPath, asnPath); }});
+                LOG_DEBUG("Geo sync scheduled with interval: {} seconds", geoSyncInterval);
             }
             else
             {
@@ -691,7 +687,7 @@ int main(int argc, char* argv[])
                 .maxAccumulatedSize = confManager.get<size_t>(conf::key::STREAMLOG_MAX_ACCUMULATED_SIZE)};
             dumper = std::make_shared<dumper::Dumper>(
                 streamLogger, dumperConfig, confManager.get<bool>(conf::key::DUMPER_ENABLED));
-            LOG_INFO("Dumper Events initialized.");
+            LOG_INFO("Dumper Events initialized");
             exitHandler.add([dumper, functionName = logging::getLambdaName(__FUNCTION__, "exitHandler")]()
                             { dumper->deactivate(); });
         }
@@ -700,15 +696,13 @@ int main(int argc, char* argv[])
         if (enableProcessing)
         {
             const auto remoteConfSyncInterval = confManager.get<std::size_t>(conf::key::REMOTE_CONF_SYNC_INTERVAL);
-            scheduler->scheduleTask("remote-conf-sync",
-                                    scheduler::TaskConfig {.interval = remoteConfSyncInterval,
-                                                           .runImmediately = true,
-                                                           .CPUPriority = 0,
-                                                           .taskFunction = [remoteConf]()
-                                                           {
-                                                               remoteConf->synchronize();
-                                                           }});
-            LOG_DEBUG("Remote configuration synchronize scheduled with interval: {} seconds.", remoteConfSyncInterval);
+            scheduler->scheduleTask(
+                "remote-conf-sync",
+                scheduler::TaskConfig {.interval = remoteConfSyncInterval,
+                                       .runImmediately = true,
+                                       .CPUPriority = 0,
+                                       .taskFunction = [remoteConf]() { remoteConf->synchronize(); }});
+            LOG_DEBUG("Remote configuration synchronize scheduled with interval: {} seconds", remoteConfSyncInterval);
         }
 
         // Create and configure the api endpoints
@@ -738,30 +732,30 @@ int main(int argc, char* argv[])
                 std::shared_ptr<fastmetrics::IManager>(&fastmetrics::manager(), [](fastmetrics::IManager*) {});
             api::metrics::handlers::registerHandlers(
                 metricsManager, apiServer, "wazuh-manager-analysisd", engineUptimeISO);
-            LOG_DEBUG("Metrics API registered.");
+            LOG_DEBUG("Metrics API registered");
 
             // Geo
             api::geo::handlers::registerHandlers(geoManager, apiServer);
-            LOG_DEBUG("Geo API registered.");
+            LOG_DEBUG("Geo API registered");
 
             // Router
             api::router::handlers::registerHandlers(orchestrator, cmStore, apiServer);
-            LOG_DEBUG("Router API registered.");
+            LOG_DEBUG("Router API registered");
 
             // Tester
             api::tester::handlers::registerHandlers(
                 orchestrator, cmStore, std::static_pointer_cast<schemf::IValidator>(schemaValidator), apiServer);
-            LOG_DEBUG("Tester API registered.");
+            LOG_DEBUG("Tester API registered");
 
             // Dumper Events
             api::dumper::handlers::registerHandlers(dumper, apiServer);
-            LOG_DEBUG("Dumper Events API registered.");
+            LOG_DEBUG("Dumper Events API registered");
 
             // Raw Event Indexer
             if (rawEventIndexer)
             {
                 api::rawevtindexer::handlers::registerHandlers(rawEventIndexer, apiServer);
-                LOG_DEBUG("Raw Event Indexer API registered.");
+                LOG_DEBUG("Raw Event Indexer API registered");
             }
 
             // Crud Manager
@@ -770,11 +764,11 @@ int main(int argc, char* argv[])
                 confManager.get<int64_t>(conf::key::API_RESOURCE_KVDB_PAYLOAD_MAX_BYTES);
             api::cmcrud::handlers::registerHandlers(
                 cmCrudService, orchestrator, apiServer, apiResourcePayloadMaxBytes, apiResourceKvdbPayloadMaxBytes);
-            LOG_DEBUG("Content Manager CRUD API registered.");
+            LOG_DEBUG("Content Manager CRUD API registered");
 
             // IOC CRUD
             api::ioccrud::handlers::registerHandlers(IOCkvdb, scheduler, store, apiServer);
-            LOG_DEBUG("IOC CRUD API registered.");
+            LOG_DEBUG("IOC CRUD API registered");
 
             // Status
             api::status::handlers::registerHandlers(cmSyncService, iocSyncService, geoManager, apiServer);
@@ -805,9 +799,7 @@ int main(int argc, char* argv[])
                                                      .runImmediately = false,
                                                      .CPUPriority = 0,
                                                      .taskFunction = [metricsWriter, metricsManager]()
-                                                     {
-                                                         metricsManager->writeAllMetrics(metricsWriter);
-                                                     }};
+                                                     { metricsManager->writeAllMetrics(metricsWriter); }};
 
                 scheduler->scheduleTask("MetricsLogger", std::move(metricsConfig));
                 LOG_INFO("Metrics stream logging enabled (interval: {} seconds, on-demand channel creation).",
@@ -815,7 +807,7 @@ int main(int argc, char* argv[])
             }
             else if (!confManager.get<bool>(conf::key::METRICS_LOG_ENABLED))
             {
-                LOG_DEBUG("Metrics stream logging DISABLED.");
+                LOG_DEBUG("Metrics stream logging DISABLED");
             }
         }
 
@@ -832,20 +824,20 @@ int main(int argc, char* argv[])
             // starting in a new thread
             engineRemoteServer->start(confManager.get<std::string>(conf::key::SERVER_ENRICHED_EVENTS_SOCKET));
 
-            LOG_INFO("Remote engine's server initialized and started.");
+            LOG_INFO("Remote engine's server initialized and started");
         }
         else
         {
-            LOG_INFO("Remote engine's HTTP event server DISABLED - events will not be received via HTTP.");
+            LOG_INFO("Remote engine's HTTP event server DISABLED - events will not be received via HTTP");
         }
 
         if (base::process::isStandaloneModeEnable())
         {
-            LOG_INFO("Engine started in standalone mode.");
+            LOG_INFO("Engine started in standalone mode");
         }
         else
         {
-            LOG_INFO("Engine started.");
+            LOG_INFO("Engine started");
         }
 
         if (enableProcessing)
@@ -875,11 +867,11 @@ int main(int argc, char* argv[])
                 if (shouldWarn)
                 {
                     LOG_WARNING("[CMSync] No active routes available. Incoming events will be discarded "
-                                "until content synchronization completes.");
+                                "until content synchronization completes");
                 }
                 else
                 {
-                    LOG_INFO("[CMSync] Event processing is now active.");
+                    LOG_INFO("[CMSync] Event processing is now active");
                 }
             };
 
@@ -908,14 +900,14 @@ int main(int argc, char* argv[])
             scheduler->scheduleTaskFirst("cm-sync-task");
 
             scheduler->start();
-            LOG_INFO("Scheduler started.");
+            LOG_INFO("Scheduler started");
 
             while (engineRemoteServer->isRunning())
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 if (g_shutdown_requested)
                 {
-                    LOG_INFO("Shutdown requested (signal: {}), stopping the engine.", g_shutdown_requested);
+                    LOG_INFO("Shutdown requested (signal: {}), stopping the engine", g_shutdown_requested);
                     engineRemoteServer->stop();
                 }
             }
@@ -924,14 +916,14 @@ int main(int argc, char* argv[])
         else
         {
             scheduler->start();
-            LOG_INFO("Scheduler started.");
+            LOG_INFO("Scheduler started");
             // Event processing disabled, just wait for shutdown signal
             LOG_INFO("Waiting for shutdown signal (event processing is disabled)...");
             while (!g_shutdown_requested)
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
-            LOG_INFO("Shutdown requested (signal: {}), stopping the engine.", g_shutdown_requested);
+            LOG_INFO("Shutdown requested (signal: {}), stopping the engine", g_shutdown_requested);
         }
     }
     catch (const std::exception& e)
@@ -943,7 +935,7 @@ int main(int argc, char* argv[])
     }
     catch (...)
     {
-        LOG_ERROR("An unknown error occurred while initializing the modules.");
+        LOG_ERROR("An unknown error occurred while initializing the modules");
         exitHandler.execute();
         exit(EXIT_FAILURE);
     }

--- a/src/engine/source/rawevtindexer/src/raweventindexer.cpp
+++ b/src/engine/source/rawevtindexer/src/raweventindexer.cpp
@@ -7,8 +7,7 @@
 namespace raweventindexer
 {
 
-RawEventIndexer::RawEventIndexer(std::weak_ptr<wiconnector::IWIndexerConnector> connector,
-                                 std::string_view indexName)
+RawEventIndexer::RawEventIndexer(std::weak_ptr<wiconnector::IWIndexerConnector> connector, std::string_view indexName)
     : m_enabled(false)
     , m_connector(std::move(connector))
     , m_indexName(indexName)
@@ -29,14 +28,7 @@ void RawEventIndexer::index(const std::string& data)
     auto connector = m_connector.lock();
     if (connector)
     {
-        try
-        {
-            connector->index(m_indexName, data);
-        }
-        catch (const std::exception& e)
-        {
-            LOG_WARNING("Failed to index raw event: {}", e.what());
-        }
+        connector->index(m_indexName, data);
     }
 }
 
@@ -55,14 +47,7 @@ void RawEventIndexer::index(const char* data)
     auto connector = m_connector.lock();
     if (connector)
     {
-        try
-        {
-            connector->index(m_indexName, std::string_view(data));
-        }
-        catch (const std::exception& e)
-        {
-            LOG_WARNING("Failed to index raw event: {}", e.what());
-        }
+        connector->index(m_indexName, std::string_view(data));
     }
 }
 
@@ -81,14 +66,7 @@ void RawEventIndexer::index(std::string_view data)
     auto connector = m_connector.lock();
     if (connector)
     {
-        try
-        {
-            connector->index(m_indexName, data);
-        }
-        catch (const std::exception& e)
-        {
-            LOG_WARNING("Failed to index raw event: {}", e.what());
-        }
+        connector->index(m_indexName, data);
     }
 }
 
@@ -111,8 +89,7 @@ void RawEventIndexer::hotReloadConf(const json::Json& value)
 {
     if (!value.isBool())
     {
-        throw std::invalid_argument(
-            fmt::format("Expected boolean for 'index_raw_events', got: {}", value.str()));
+        throw std::invalid_argument(fmt::format("Expected boolean for 'index_raw_events', got: {}", value.str()));
     }
 
     value.getBool().value() ? enable() : disable();

--- a/src/engine/source/rawevtindexer/test/src/component/raweventindexer_test.cpp
+++ b/src/engine/source/rawevtindexer/test/src/component/raweventindexer_test.cpp
@@ -39,22 +39,6 @@ TEST(RawEventIndexerComponentTest, EndToEndWorkflowWithDefaultIndex)
     indexer.index(std::string {"ignored-after-disable"});
 }
 
-TEST(RawEventIndexerComponentTest, ConnectorFailuresAreHandledAndFlowContinues)
-{
-    auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();
-    raweventindexer::RawEventIndexer indexer(connector, "wazuh-events-raw-v5-app");
-    indexer.enable();
-
-    EXPECT_CALL(*connector, index(Eq(std::string_view {"wazuh-events-raw-v5-app"}), Eq(std::string_view {"will-fail"})))
-        .WillOnce(::testing::Throw(std::runtime_error("forced index failure")));
-
-    EXPECT_CALL(*connector,
-                index(Eq(std::string_view {"wazuh-events-raw-v5-app"}), Eq(std::string_view {"will-pass"})));
-
-    EXPECT_NO_THROW(indexer.index(std::string {"will-fail"}));
-    EXPECT_NO_THROW(indexer.index(std::string {"will-pass"}));
-}
-
 TEST(RawEventIndexerComponentTest, SupportsConcurrentIndexingWhenEnabled)
 {
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();

--- a/src/engine/source/rawevtindexer/test/src/unit/raweventindexer_test.cpp
+++ b/src/engine/source/rawevtindexer/test/src/unit/raweventindexer_test.cpp
@@ -98,15 +98,6 @@ TEST_F(RawEventIndexerUnitTest, IndexStringViewWhenEnabledCallsConnector)
     indexer.index(std::string_view {"payload-sv"});
 }
 
-TEST_F(RawEventIndexerUnitTest, IndexSwallowsConnectorExceptions)
-{
-    raweventindexer::RawEventIndexer indexer(m_connector, "custom-raw-index");
-    indexer.enable();
-
-    EXPECT_CALL(*m_connector, index(::testing::_, ::testing::_)).WillOnce(::testing::Throw(std::runtime_error("boom")));
-    EXPECT_NO_THROW(indexer.index(std::string {"payload"}));
-}
-
 TEST_F(RawEventIndexerUnitTest, IndexNoThrowIfConnectorExpiresAfterConstruction)
 {
     auto connector = std::make_shared<StrictMock<wiconnector::mocks::MockWIndexerConnector>>();

--- a/src/engine/source/router/src/orchestrator.cpp
+++ b/src/engine/source/router/src/orchestrator.cpp
@@ -109,7 +109,7 @@ void saveConfig(const std::weak_ptr<store::IStore>& wStore, const base::Name& st
     auto store = wStore.lock();
     if (!store)
     {
-        LOG_ERROR("Store is unavailable for dumping entries");
+        LOG_ERROR("[Orchestrator] Store is unavailable for dumping entries");
     }
     else
     {
@@ -154,7 +154,7 @@ std::vector<EntryConverter> getEntriesFromStore(const std::shared_ptr<store::ISt
     const auto jsonEntry = store->readDoc(tableName);
     if (base::isError(jsonEntry))
     {
-        LOG_DEBUG("Router: {} table not found in store. Creating new table: {}",
+        LOG_DEBUG("[Orchestrator] {} table not found in store. Creating new table: {}",
                   tableName.toStr(),
                   base::getError(jsonEntry).message);
         store->createDoc(tableName, json::Json {"[]"});
@@ -164,7 +164,7 @@ std::vector<EntryConverter> getEntriesFromStore(const std::shared_ptr<store::ISt
     auto json = base::getResponse(jsonEntry);
     if (json.isEmpty())
     {
-        LOG_DEBUG("Router: {} table is empty", tableName.toStr());
+        LOG_DEBUG("[Orchestrator] {} table is empty", tableName.toStr());
     }
     // Create empty table.
 
@@ -254,7 +254,8 @@ void Orchestrator::postEvent(IngestEvent&& event)
 
     m_lastContentionWarningUsec.store(nowUsec, std::memory_order_relaxed);
 
-    LOG_WARNING("Event queue has remained contended for at least {} seconds. Dropped events during contention: {}. "
+    LOG_WARNING("[Orchestrator::Router] Event queue has remained contended for at least {} seconds. Dropped events "
+                "during contention: {}. "
                 "Approx queue size: {}, approx free slots: {}.",
                 CONTENTION_WARNING_INTERVAL_SEC,
                 m_droppedEventsInContention.load(std::memory_order_relaxed),
@@ -355,7 +356,8 @@ Orchestrator::Orchestrator(const Options& opt)
         {
             numThreads = 1; // Fallback if hardware_concurrency cannot be determined
         }
-        LOG_DEBUG("No thread count provided. Using {} worker threads based on system hardware.", numThreads);
+        LOG_DEBUG("[Orchestrator] No thread count provided. Using {} worker threads based on system hardware.",
+                  numThreads);
     }
 
     m_targetWorkerCount = numThreads;
@@ -368,19 +370,21 @@ Orchestrator::Orchestrator(const Options& opt)
         auto r = std::make_shared<router::RouterWorker>(m_envBuilder, m_eventQueue, m_rawIndexer, m_epsRate);
         if (auto err = initRouterWorker(r, routerEntries))
         {
-            LOG_ERROR("Router: Cannot load initial states from store for primary worker: {}", err->message);
+            LOG_ERROR("[Orchestrator::Router] Cannot load initial states from store for primary worker: {}",
+                      err->message);
         }
         m_routerWorkers.emplace_back(std::move(r));
     }
-    LOG_DEBUG("Router: Primary worker initialized. Target pool size: {} (expansion requires explicit call to "
-              "expandWorkerPool).",
-              m_targetWorkerCount);
+    LOG_DEBUG(
+        "[Orchestrator::Router] Primary worker initialized. Target pool size: {} (expansion requires explicit call to "
+        "expandWorkerPool).",
+        m_targetWorkerCount);
 
     {
         auto t = std::make_shared<router::TesterWorker>(m_envBuilder, m_testQueue);
         if (auto err = initTesterWorker(t, testerEntries))
         {
-            LOG_ERROR("Tester: Cannot load initial states from store: {}", err->message);
+            LOG_ERROR("[Orchestrator::Tester] Cannot load initial states from store: {}", err->message);
         }
         m_testerWorker = std::move(t);
     }
@@ -571,7 +575,7 @@ base::OptError Orchestrator::hotSwapNamespace(const std::string& name, const cm:
     // Save the updated configuration (lock already held, use Internal version)
     dumpRoutersInternal();
 
-    LOG_INFO("[Router::hotSwapSpace] Hot swapped namespace for entry '{}' to '{}'", name, newNamespace.toStr());
+    LOG_INFO("[Orchestrator] Hot swapped namespace for entry '{}' to '{}'", name, newNamespace.toStr());
     return std::nullopt;
 }
 

--- a/src/engine/source/router/src/orchestrator.cpp
+++ b/src/engine/source/router/src/orchestrator.cpp
@@ -154,7 +154,7 @@ std::vector<EntryConverter> getEntriesFromStore(const std::shared_ptr<store::ISt
     const auto jsonEntry = store->readDoc(tableName);
     if (base::isError(jsonEntry))
     {
-        LOG_DEBUG("[Orchestrator] {} table not found in store. Creating new table: {}",
+        LOG_DEBUG("[Orchestrator] {} table not found in store ({}). Creating new table",
                   tableName.toStr(),
                   base::getError(jsonEntry).message);
         store->createDoc(tableName, json::Json {"[]"});

--- a/src/engine/source/router/test/src/unit/orchestrator_test.cpp
+++ b/src/engine/source/router/test/src/unit/orchestrator_test.cpp
@@ -652,6 +652,7 @@ protected:
 
     void SetUp() override
     {
+        logging::testInit();
         m_orchestrator = std::make_shared<OrchestratorToTest>();
 
         // Add 5 mock workers
@@ -1075,8 +1076,7 @@ TEST_F(OrchestratorTest, hotSwapNamespaceSuccess)
     {
         EXPECT_CALL(*mock, get()).WillRepeatedly(testing::Return(irouterMock));
     }
-    EXPECT_CALL(*routerMock, hotSwapNamespace("myEntry", testing::_))
-        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(*routerMock, hotSwapNamespace("myEntry", testing::_)).WillRepeatedly(testing::Return(std::nullopt));
     EXPECT_CALL(*routerMock, getEntries()).WillRepeatedly(testing::Return(std::list<prod::Entry> {}));
 
     EXPECT_CALL(*(m_orchestrator->m_mockstore), upsertDoc(testing::_, testing::_))
@@ -1160,7 +1160,8 @@ TEST_F(OrchestratorTest, renameTestEntryWorkerFails)
     auto itesterMock = std::static_pointer_cast<router::ITester>(testerMock);
 
     EXPECT_CALL(*m_orchestrator->m_testerWorkerMock, get()).WillOnce(testing::Return(itesterMock));
-    EXPECT_CALL(*testerMock, renameEntry("oldName", "newName")).WillOnce(testing::Return(base::Error {"rename failed"}));
+    EXPECT_CALL(*testerMock, renameEntry("oldName", "newName"))
+        .WillOnce(testing::Return(base::Error {"rename failed"}));
 
     EXPECT_TRUE(m_orchestrator->renameTestEntry("oldName", "newName").has_value());
 }
@@ -1328,8 +1329,7 @@ protected:
             .WillByDefault(
                 [](const std::string&, std::function<uint64_t()>, const std::string&, const std::string&) {});
         ON_CALL(*mockMetrics, registerPullMetricDouble(testing::_, testing::_, testing::_, testing::_))
-            .WillByDefault(
-                [](const std::string&, std::function<double()>, const std::string&, const std::string&) {});
+            .WillByDefault([](const std::string&, std::function<double()>, const std::string&, const std::string&) {});
     }
 
     void TearDown() override { SingletonLocator::unregisterManager<fastmetrics::IManager>(); }
@@ -1433,11 +1433,10 @@ TEST_F(OrchestratorConstructorTest, ConstructorSuccessWithEmptyStore)
         .WillRepeatedly(testing::Return(store::mocks::storeOk()));
     auto opt = makeValidOptions(1);
 
-    ASSERT_NO_THROW(
-        {
-            Orchestrator orch(opt);
-            orch.stop();
-        });
+    ASSERT_NO_THROW({
+        Orchestrator orch(opt);
+        orch.stop();
+    });
 }
 
 TEST_F(OrchestratorConstructorTest, ConstructorSuccessWithMultipleThreads)
@@ -1447,11 +1446,10 @@ TEST_F(OrchestratorConstructorTest, ConstructorSuccessWithMultipleThreads)
         .WillRepeatedly(testing::Return(store::mocks::storeOk()));
     auto opt = makeValidOptions(3);
 
-    ASSERT_NO_THROW(
-        {
-            Orchestrator orch(opt);
-            orch.stop();
-        });
+    ASSERT_NO_THROW({
+        Orchestrator orch(opt);
+        orch.stop();
+    });
 }
 
 TEST_F(OrchestratorConstructorTest, ConstructorStoreReadErrorCreatesDoc)
@@ -1465,11 +1463,10 @@ TEST_F(OrchestratorConstructorTest, ConstructorStoreReadErrorCreatesDoc)
         .WillRepeatedly(testing::Return(store::mocks::storeOk()));
 
     auto opt = makeValidOptions(1);
-    ASSERT_NO_THROW(
-        {
-            Orchestrator orch(opt);
-            orch.stop();
-        });
+    ASSERT_NO_THROW({
+        Orchestrator orch(opt);
+        orch.stop();
+    });
 }
 
 TEST_F(OrchestratorConstructorTest, ConstructorStartStop)
@@ -1502,8 +1499,7 @@ TEST_F(OrchestratorConstructorTest, ConstructorRequestShutdown)
 TEST_F(OrchestratorConstructorTest, ConstructorWithRouterEntries)
 {
     // JSON array with a valid router entry (has "priority" field)
-    const std::string routerJson =
-        R"([{"name":"route1","namespace":"policy","priority":10}])";
+    const std::string routerJson = R"([{"name":"route1","namespace":"policy","priority":10}])";
     const std::string testerJson = R"([])";
 
     EXPECT_CALL(*m_mockStore, readDoc(testing::_))
@@ -1518,8 +1514,7 @@ TEST_F(OrchestratorConstructorTest, ConstructorWithRouterEntries)
     std::unordered_set<base::Name> fakeAssets {base::Name("decoder/test/0")};
     const std::string hash = "hash123";
 
-    EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_))
-        .WillRepeatedly(testing::Return(mockPolicy));
+    EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_)).WillRepeatedly(testing::Return(mockPolicy));
     EXPECT_CALL(*mockPolicy, assets()).WillRepeatedly(testing::ReturnRefOfCopy(fakeAssets));
     EXPECT_CALL(*mockPolicy, expression()).WillRepeatedly(testing::ReturnRefOfCopy(base::Expression {}));
     EXPECT_CALL(*mockPolicy, hash()).WillRepeatedly(testing::ReturnRefOfCopy(hash));
@@ -1528,19 +1523,17 @@ TEST_F(OrchestratorConstructorTest, ConstructorWithRouterEntries)
     EXPECT_CALL(*mockController, stop()).Times(testing::AnyNumber());
 
     auto opt = makeValidOptions(1);
-    ASSERT_NO_THROW(
-        {
-            Orchestrator orch(opt);
-            orch.stop();
-        });
+    ASSERT_NO_THROW({
+        Orchestrator orch(opt);
+        orch.stop();
+    });
 }
 
 TEST_F(OrchestratorConstructorTest, ConstructorWithTesterEntries)
 {
     // JSON array with a valid tester entry (has "lifetime" field)
     const std::string routerJson = R"([])";
-    const std::string testerJson =
-        R"([{"name":"test1","namespace":"policy","lifetime":3600}])";
+    const std::string testerJson = R"([{"name":"test1","namespace":"policy","lifetime":3600}])";
 
     EXPECT_CALL(*m_mockStore, readDoc(testing::_))
         .WillOnce(testing::Return(store::mocks::storeReadDocResp(json::Json {routerJson.c_str()})))
@@ -1554,8 +1547,7 @@ TEST_F(OrchestratorConstructorTest, ConstructorWithTesterEntries)
     std::unordered_set<base::Name> fakeAssets {base::Name("decoder/test/0")};
     const std::string hash = "hashT";
 
-    EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_))
-        .WillRepeatedly(testing::Return(mockPolicy));
+    EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_)).WillRepeatedly(testing::Return(mockPolicy));
     EXPECT_CALL(*mockPolicy, assets()).WillRepeatedly(testing::ReturnRefOfCopy(fakeAssets));
     EXPECT_CALL(*mockPolicy, expression()).WillRepeatedly(testing::ReturnRefOfCopy(base::Expression {}));
     EXPECT_CALL(*mockPolicy, hash()).WillRepeatedly(testing::ReturnRefOfCopy(hash));
@@ -1564,20 +1556,17 @@ TEST_F(OrchestratorConstructorTest, ConstructorWithTesterEntries)
     EXPECT_CALL(*mockController, stop()).Times(testing::AnyNumber());
 
     auto opt = makeValidOptions(1);
-    ASSERT_NO_THROW(
-        {
-            Orchestrator orch(opt);
-            orch.stop();
-        });
+    ASSERT_NO_THROW({
+        Orchestrator orch(opt);
+        orch.stop();
+    });
 }
 
 TEST_F(OrchestratorConstructorTest, ConstructorWithBothEntries)
 {
     // Both router and tester entries with lastUse for tester
-    const std::string routerJson =
-        R"([{"name":"route1","namespace":"policy","priority":10}])";
-    const std::string testerJson =
-        R"([{"name":"test1","namespace":"policy","lifetime":3600,"lastUse":99999}])";
+    const std::string routerJson = R"([{"name":"route1","namespace":"policy","priority":10}])";
+    const std::string testerJson = R"([{"name":"test1","namespace":"policy","lifetime":3600,"lastUse":99999}])";
 
     EXPECT_CALL(*m_mockStore, readDoc(testing::_))
         .WillOnce(testing::Return(store::mocks::storeReadDocResp(json::Json {routerJson.c_str()})))
@@ -1590,8 +1579,7 @@ TEST_F(OrchestratorConstructorTest, ConstructorWithBothEntries)
     std::unordered_set<base::Name> fakeAssets {base::Name("decoder/test/0")};
     const std::string hash = "hashBoth";
 
-    EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_))
-        .WillRepeatedly(testing::Return(mockPolicy));
+    EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_)).WillRepeatedly(testing::Return(mockPolicy));
     EXPECT_CALL(*mockPolicy, assets()).WillRepeatedly(testing::ReturnRefOfCopy(fakeAssets));
     EXPECT_CALL(*mockPolicy, expression()).WillRepeatedly(testing::ReturnRefOfCopy(base::Expression {}));
     EXPECT_CALL(*mockPolicy, hash()).WillRepeatedly(testing::ReturnRefOfCopy(hash));
@@ -1600,11 +1588,10 @@ TEST_F(OrchestratorConstructorTest, ConstructorWithBothEntries)
     EXPECT_CALL(*mockController, stop()).Times(testing::AnyNumber());
 
     auto opt = makeValidOptions(1);
-    ASSERT_NO_THROW(
-        {
-            Orchestrator orch(opt);
-            orch.stop();
-        });
+    ASSERT_NO_THROW({
+        Orchestrator orch(opt);
+        orch.stop();
+    });
 }
 
 /**************************************************************************
@@ -1644,7 +1631,6 @@ TEST_F(OrchestratorTest, dumpRoutersWhenShutdown)
     ASSERT_NO_THROW(m_orchestrator->callDumpRouters());
 }
 
-
 /**************************************************************************
  * Worker pool expansion tests
  *************************************************************************/
@@ -1654,7 +1640,11 @@ class ExpansionTest : public ::testing::Test
 protected:
     std::unique_ptr<OrchestratorToTest> m_orch;
 
-    void SetUp() override { m_orch = std::make_unique<OrchestratorToTest>(); }
+    void SetUp() override
+    {
+        logging::testInit();
+        m_orch = std::make_unique<OrchestratorToTest>();
+    }
     void TearDown() override { m_orch.reset(); }
 };
 

--- a/src/engine/source/router/test/src/unit/router_test.cpp
+++ b/src/engine/source/router/test/src/unit/router_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <base/logging.hpp>
 #include <bk/mockController.hpp>
 #include <builder/mockBuilder.hpp>
 #include <builder/mockPolicy.hpp>
@@ -22,6 +23,7 @@ protected:
 public:
     void SetUp() override
     {
+        logging::testInit();
         m_mockBuilder = std::make_shared<builder::mocks::MockBuilder>();
         m_mockControllerMaker = std::make_shared<bk::mocks::MockMakerController>();
         m_mockController = std::make_shared<bk::mocks::MockController>();
@@ -48,8 +50,7 @@ public:
 
     void makeControllerBuildPolicySuccess()
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_))
-            .WillOnce(::testing::Return(m_mockPolicy));
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_)).WillOnce(::testing::Return(m_mockPolicy));
     }
 
     void makeControllerPolicyAssetsFailure(router::prod::EntryPost entryPost)

--- a/src/engine/source/streamlog/src/channel.cpp
+++ b/src/engine/source/streamlog/src/channel.cpp
@@ -117,7 +117,10 @@ ChannelHandler::RotationRequirement ChannelHandler::needsRotation(const size_t m
     }
     catch (const std::exception& e)
     {
-        LOG_ERROR("[Stream logger] Error checking rotation for channel '{}': {}", m_channelName, e.what());
+        LOG_ERROR("[Stream logger] Error checking rotation for channel '{}': {}. "
+                  "Closing channel and discarding messages",
+                  m_channelName,
+                  e.what());
         m_stateData.channelState->store(ChannelState::ErrorClosed, std::memory_order_relaxed);
     }
 
@@ -176,14 +179,19 @@ bool ChannelHandler::rotateFile(RotationRequirement rotationType)
             std::filesystem::create_directories(newParentPath, ec);
             if (ec)
             {
-                LOG_WARNING(
-                    "[Stream logger] Failed to create directories for {}: {}", newParentPath.string(), ec.message());
+                LOG_WARNING("[Stream logger] Failed to create directories for "
+                            "{}: {}",
+                            newParentPath.string(),
+                            ec.message());
             }
         }
     }
     catch (const std::exception& e)
     {
-        LOG_ERROR("[Stream logger] Failed to generate new file path for channel '{}': {}", m_channelName, e.what());
+        LOG_ERROR("[Stream logger] Failed to generate new file path for channel '{}': {}."
+                  "Closing channel and discarding messages.",
+                  m_channelName,
+                  e.what());
         // Restore previous state — nothing changed on disk
         m_stateData.counter = previousCounter;
         m_stateData.channelState->store(ChannelState::ErrorClosed, std::memory_order_relaxed);
@@ -211,10 +219,10 @@ bool ChannelHandler::rotateFile(RotationRequirement rotationType)
     }
     catch (const std::runtime_error& e)
     {
-        LOG_ERROR(
-            "[Stream logger] Failed to rotate file for channel '{}': {}. Closing channel and discarding messages.",
-            m_channelName,
-            e.what());
+        LOG_ERROR("[Stream logger] Failed to rotate file for channel '{}': {}. "
+                  "Closing channel and discarding messages.",
+                  m_channelName,
+                  e.what());
         // Restore previous state — the old file is still the active one on disk
         m_stateData.currentFile = previousFile;
         m_stateData.counter = previousCounter;
@@ -255,9 +263,9 @@ bool ChannelHandler::rotateFile(RotationRequirement rotationType)
         }
         else
         {
-            LOG_WARNING(
-                "[Stream logger] Scheduler is no longer available; cannot schedule compression for channel '{}'",
-                m_channelName);
+            LOG_WARNING("[Stream logger] Scheduler is no longer available; "
+                        "cannot schedule compression for channel '{}'",
+                        m_channelName);
         }
     }
     if (previousFile != m_stateData.currentFile)
@@ -818,6 +826,7 @@ void ChannelHandler::compressLogFile(const std::filesystem::path& filePath,
 
     try
     {
+        LOG_INFO("[Stream logger] Compressing log file '{}'", filePath.string());
         Utils::ZlibHelper::gzipCompress(filePath, filePath.string() + ".gz", compressionLevel, *flag);
     }
     catch (const std::exception& e)
@@ -836,7 +845,7 @@ void ChannelHandler::compressLogFile(const std::filesystem::path& filePath,
     }
     else
     {
-        LOG_DEBUG("[Stream logger] Successfully compressed log file '{}'", filePath.string());
+        LOG_INFO("[Stream logger] Successfully compressed log file '{}'", filePath.string());
     }
 }
 
@@ -1332,10 +1341,9 @@ void ChannelHandler::clearCurrentRotationStateFromStore() const
 
         if (base::isError(state))
         {
-            LOG_DEBUG(
-                "[Stream logger] Failed to read rotation state for channel '{}' from store: {}. Nothing to clear.",
-                m_channelName,
-                base::getError(state).message);
+            LOG_DEBUG("[Stream logger] Failed to read rotation state for channel '{}' from store: {}. Nothing to clear",
+                      m_channelName,
+                      base::getError(state).message);
             return;
         }
 

--- a/src/engine/source/streamlog/src/logger.cpp
+++ b/src/engine/source/streamlog/src/logger.cpp
@@ -86,7 +86,7 @@ RotationConfig& LogManager::isolatedBasePath(const std::string& channelName, Rot
 void LogManager::requestShutdown()
 {
     m_compressionShouldRun->store(false, std::memory_order_relaxed);
-    LOG_INFO("[Stream logger] Shutdown requested.");
+    LOG_INFO("[Stream logger] Shutdown requested");
     std::unique_lock lock(m_channelsMutex);
     m_channels.clear();
 }

--- a/src/engine/tools/devContainer/e2e/wazuh-indexer/Dockerfile
+++ b/src/engine/tools/devContainer/e2e/wazuh-indexer/Dockerfile
@@ -12,8 +12,6 @@ COPY . .
 # Install wazuh-indexer
 RUN apt install -y /tmp/wazuh-install/wazuh-indexer_5.0.0-latest_amd64.deb
 
-# Configure knn memory circuit breaker limit
-RUN echo "knn.memory.circuit_breaker.limit: 4096mb" >> /etc/wazuh-indexer/opensearch.yml
 
 # Add Java security policy permissions for cgroup access
 RUN cat <<'EOF' >> /etc/wazuh-indexer/jvm.options


### PR DESCRIPTION
## Description

Closes #35260

This PR contains three groups of changes:

**1. Complete `should_log()` for wazuh-manager mode.** The function was added to avoid formatting log messages whose level would be discarded, but its non-standalone branch was left commented-out with a TODO. This PR implements it: queries `isDebug()` from `libwazuhshared`, caches the function pointer, and guards against the library being absent in test contexts.

**2. Log message style normalization across engine modules.** Trailing periods removed from all log messages, and component prefixes standardized to the `[ComponentName]` convention (e.g., `[Orchestrator]`, `[Orchestrator::Router]`, `[CMSync]`, `[Geo::Manager]`, `[Stream logger]`). Several modules now use a `LOG_MODULE_NAME` constant to keep the tag consistent with the source location.

**3. Remove unnecessary try/catch around indexer connector calls in `raweventindexer`.** `IWIndexerConnector::index()` handles errors internally and does not throw; the surrounding catch blocks were dead code and have been removed.

## Proposed Changes

- **`base/include/base/libwazuhshared.hpp`** — add `isInitialized()` inline helper that returns `getLibPtr() != nullptr`. Lets callers check library availability without catching exceptions.

- **`base/include/base/logging.hpp` — `should_log()`** — replace the fully-commented-out non-standalone branch with a proper implementation:
  - If `libwazuhshared` is not initialized, fall back to the same behavior as `Log::Logger::*` (discard Debug/Trace, pass Info+). This is safe and matches what `GLOBAL_LOG_FUNCTION`-guarded calls already do when the library is absent.
  - Otherwise call the cached `isDebug()` pointer and apply the level thresholds (`0` = Info+, `1` = Debug+, `2+` = Trace+).
  - The `isDebug` function pointer is stored in a `static const` local variable so `dlsym` is invoked exactly once per process, not on every log check.

- **`base/src/logging.cpp` — `testInit()`** — move `setenv(ENV_ENGINE_STANDALONE, "true", 1)` to execute before `logging::start()`. The `isStandaloneModeEnable()` function caches its result on first call; if that first call happened during `start()` with the variable unset, the cache was poisoned to `false`, defeating the intent of `testInit()`.

- **Log message normalization** (modules: `api`, `bk`, `cmcrud`, `cmstore`, `cmsync`, `conf`, `confremote`, `geo`, `hlp`, `httpsrv`, `iockvdb`, `main`, `orchestrator`, `rawevtindexer`, `streamlog`):
  - Removed trailing periods from every `LOG_*` call site.
  - Standardized component prefixes to the `[ComponentName]` format where missing or inconsistent (e.g., bare `"Router:"` → `"[Orchestrator::Router]"`). Several modules now define a `LOG_MODULE_NAME` constant to keep the prefix consistent.
  - Minor clarifications to a few error messages (e.g., stream-logger rotation errors now state `"Closing channel and discarding messages"` explicitly).

- **`rawevtindexer/src/raweventindexer.cpp`** — remove three try/catch blocks wrapping `connector->index(...)` calls. `IWIndexerConnector::index()` is a fire-and-forget operation that handles errors internally; it does not throw, making the catch paths unreachable dead code.

### Results and Evidence

`conf_utest` (190 tests) and `conf_ctest` (22 tests) now pass without crashing:

```
[==========] Running 190 tests from 17 test suites.
[  PASSED  ] 190 tests.

[==========] Running 22 tests from 1 test suite.
[  PASSED  ] 22 tests.
```

`base_utest` regression check (369 tests) passes without regressions:

```
[==========] Running 369 tests from 48 test suites.
[  PASSED  ] 369 tests.
```

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

- `wazuh-engine` — runtime logging behavior in wazuh-manager mode (non-standalone) and log output format
- `ctest/utests` — Set `logging::testInit()` for individual test suites.

### Configuration Changes


N/A

### Tests Introduced

N/A

The log-message and try/catch changes are refactors, removing dead code test

## Review Checklist



- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
