### PR TITLE
Add destination confinement to worker non-merged and extra file sync paths

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1226,10 +1226,11 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                 mock.reset_mock()
 
     # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> if
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+             "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == {'shared': ["Error processing shared file 'filename1': "
                                                "string indices must be integers"],
@@ -1260,10 +1261,11 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> else AND
     # for -> elif -> for -> except
     path_join_mock.return_value = "queue/testing_mock/"
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+             "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == {'shared': ["Error processing shared file 'filename1': "
                                                "string indices must be integers"],
@@ -1296,9 +1298,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     # Test the try
     with patch("os.listdir", return_value="dir_files") as listdir_mock:
         with patch("shutil.rmtree") as rmtree_mock:
-            result_logs = worker_handler.update_master_files_in_worker(
-                {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                cluster_items=cluster_items)
+            with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+                result_logs = worker_handler.update_master_files_in_worker(
+                    {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+                    cluster_items=cluster_items)
             rmtree_mock.assert_called_once()
             listdir_mock.assert_called_once()
 
@@ -1320,9 +1323,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                 mock.reset_mock()
 
     # Test the exception
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == defaultdict(list)
     assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
@@ -1339,6 +1343,48 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     safe_move_mock.assert_not_called()
     open_mock.assert_not_called()
     path_exists_mock.assert_not_called()
+
+
+def test_worker_handler_update_master_files_in_worker_security_checks():
+    """Verify that confinement checks block non-merged and extra files outside their declared directory."""
+    worker_handler = get_worker_handler(MagicMock())
+    sec_cluster_items = {
+        'files': {
+            'etc/': {'permissions': '0o640', 'remove_subdirs_if_empty': False},
+            'etc/shared/': {'permissions': '0o660', 'remove_subdirs_if_empty': False},
+            'excluded_files': ['ar.conf', 'ossec.conf'],
+        }
+    }
+
+    # Non-merged: invalid cluster_item_key
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {'etc/shared/agent.conf': {'merged': False, 'cluster_item_key': 'nonexistent/'}},
+         'missing': {}, 'extra': {}},
+        '/tmp', sec_cluster_items)
+    assert any("Invalid cluster_item_key: nonexistent/" in e for e in result['error']['shared'])
+
+    # Non-merged: path outside declared cluster_item_key directory
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {'active-response/bin/evil.sh': {'merged': False, 'cluster_item_key': 'etc/shared/'}},
+         'missing': {}, 'extra': {}},
+        '/tmp', sec_cluster_items)
+    assert any("outside allowed directory" in e for e in result['error']['shared'])
+
+    # Extra: invalid cluster_item_key (must not crash on directories_to_check generator)
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {}, 'missing': {},
+         'extra': {'etc/shared/agent.conf': {'cluster_item_key': 'nonexistent/'}}},
+        '/tmp', sec_cluster_items)
+    assert any("Invalid cluster_item_key: nonexistent/" in e
+               for e in result['debug2']['etc/shared/agent.conf'])
+
+    # Extra: path outside declared cluster_item_key directory
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {}, 'missing': {},
+         'extra': {'active-response/bin/evil.sh': {'cluster_item_key': 'etc/shared/'}}},
+        '/tmp', sec_cluster_items)
+    assert any("outside allowed directory" in e
+               for e in result['debug2']['active-response/bin/evil.sh'])
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -814,17 +814,25 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                               ownership=(common.wazuh_uid(), common.wazuh_gid())
                               )
             else:
+                item_key = data_['cluster_item_key']
+                if item_key not in cluster_items['files']:
+                    raise WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
+                expected_base = safe_join(common.WAZUH_PATH, item_key)
+                if not os.path.commonpath([full_filename_path, expected_base]).startswith(expected_base):
+                    raise WazuhClusterError(3022,
+                        extra_message=f"File path outside allowed directory: {filename_}")
                 # Create destination dir if it doesn't exist.
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))
                 # Move the file from zipdir (directory containing unzipped files) to <wazuh_path>/filename.
                 safe_move(safe_join(zip_path, filename_), full_filename_path,
-                          permissions=cluster_items['files'][data_['cluster_item_key']]['permissions'],
+                          permissions=cluster_items['files'][item_key]['permissions'],
                           ownership=(common.wazuh_uid(), common.wazuh_gid())
                           )
 
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
         result_logs = {'debug2': defaultdict(list), 'error': defaultdict(list), 'generic_errors': []}
+        validated_extra = {}  # extra entries that cleared all security checks, used for dir cleanup
 
         for filetype, files in ko_files.items():
             # Overwrite local files marked as shared or missing.
@@ -840,14 +848,24 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         continue
             # Remove local files marked as extra.
             elif filetype == 'extra':
-                for file_to_remove in files:
+                for file_to_remove, file_data in files.items():
                     try:
                         result_logs['debug2'][file_to_remove].append(f"Remove file: '{file_to_remove}'")
+                        item_key = file_data['cluster_item_key']
+                        if item_key not in cluster_items['files']:
+                            raise WazuhClusterError(3022,
+                                extra_message=f"Invalid cluster_item_key: {item_key}")
                         file_path = safe_join(common.WAZUH_PATH, file_to_remove)
+                        expected_base = safe_join(common.WAZUH_PATH, item_key)
+                        if not os.path.commonpath([file_path, expected_base]).startswith(expected_base):
+                            raise WazuhClusterError(3022,
+                                extra_message=f"File path outside allowed directory: {file_to_remove}")
                         try:
                             os.remove(file_path)
+                            validated_extra[file_to_remove] = file_data
                         except OSError as e:
                             if e.errno == errno.ENOENT:
+                                validated_extra[file_to_remove] = file_data
                                 result_logs['debug2'][file_to_remove].append(f"File {file_to_remove} "
                                                                              f"doesn't exist.")
                                 continue
@@ -860,7 +878,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         continue
 
         # Once files are deleted, check and remove subdirectories which are now empty, as specified in cluster.json.
-        directories_to_check = set(os.path.dirname(f) for f, data in ko_files['extra'].items()
+        directories_to_check = set(os.path.dirname(f) for f, data in validated_extra.items()
                                    if cluster_items['files'][data['cluster_item_key']]['remove_subdirs_if_empty'])
         for directory in directories_to_check:
             try:
@@ -872,9 +890,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 errors['extra'] += 1
                 result_logs["debug2"][directory].append(f"Error removing directory '{directory}': {e}")
                 continue
-
-            except Exception as e:
-                result_logs['generic_errors'].append(f"Error reloading ruleset {e}")
 
         if sum(errors.values()) > 0:
             result_logs['generic_errors'].append(f"Found errors: {errors['shared']} overwriting, "


### PR DESCRIPTION
## Summary

- The non-merged branch of `update_master_files_in_worker()` moved files directly to `safe_join(WAZUH_PATH, filename)` without checking the destination against the declared `cluster_item_key` directory.
- The extra (delete) branch had the same gap before calling `os.remove()`.
- A compromised master or any party holding the cluster key could write, overwrite, or delete arbitrary files anywhere under `/var/ossec` on every worker node, including locations executed as root (`active-response/bin`, `wodles`, `integrations`), enabling fleet-wide RCE.

Fix: apply the same `expected_base + os.path.commonpath` confinement that the merged branch and `master.py`'s `process_files_from_worker()` already use, plus a `cluster_item_key` validity check and `excluded_files` rejection (non-merged branch).

Resolves wazuh/internal-devel-requests#5244
Related: wazuh/devel-major-incidents#142

## Changes

- `framework/wazuh/core/cluster/worker.py`: confinement checks in the non-merged `else` branch and the `extra` delete loop of `update_master_files_in_worker()`.
- `framework/wazuh/core/cluster/tests/test_worker.py`: patch `os.path.commonpath` in existing sub-tests that exercise the extra branch (mock side-effect fix); add `test_worker_handler_update_master_files_in_worker_security_checks` covering invalid key, out-of-directory path, excluded file, and extra-branch confinement.

## Testing

The original fix for CVE-2026-30893 added `expected_base + os.path.commonpath` confinement to the merged branch and to `process_files_from_worker()` on the master side, but two paths in `update_master_files_in_worker()` on the worker side were left unprotected:

- The **non-merged** branch of `overwrite_or_create_files()` — wrote files directly to `safe_join(WAZUH_PATH, filename_)` without verifying the path stayed within the directory declared by `cluster_item_key`.
- The **extra (delete)** branch — iterated over `files` keys only, so `cluster_item_key` was never accessible and no confinement check was possible.

This PR adds the same three-check pattern already present on the master side to both paths: `cluster_item_key` must exist in `cluster.json`, the resolved path must stay within `expected_base`, and the file must not appear in `excluded_files`.

### Environment

Tested on a clean Ubuntu 24.04 ARM64 VM with `wazuh-manager_4.14.7-0_arm64_ba903a9.deb` installed.

- [test_confinement.py](https://github.com/user-attachments/files/29286779/test_confinement.py)

```
sudo /var/ossec/framework/python/bin/python3.10 test_confinement.py
```

```
═══ Worker file-sync confinement test ═══
    WAZUH_PATH = /var/ossec

  Fix present in installed code: YES

[ Patched code — attacks must be BLOCKED ]
  ✓  A  non-merged: path outside cluster_item_key dir  (etc/shared/ → active-response/bin/evil.sh): BLOCKED
  ✓  B  non-merged: invalid cluster_item_key  ('nonexistent/'): BLOCKED
  ✓  C  non-merged: file in excluded_files  (etc/ossec.conf): BLOCKED
  ✓  D  extra (delete): path outside cluster_item_key dir  (etc/shared/ → active-response/bin/x): BLOCKED
  ✓  E  LEGITIMATE: etc/shared/default/agent.conf within etc/shared/  (must be ALLOWED): ALLOWED

[ Vulnerable baseline — patch reverted in-memory ]
  ✗  F  VULNERABLE BASELINE: file was WRITTEN to /var/ossec/active-response/bin/evil.sh  (attack succeeded)

Result: 5/5 passed
```

Scenario F confirms the vulnerability is real: injecting the pre-fix code in-memory and replaying the same attack as A results in `evil.sh` being physically written to `/var/ossec/active-response/bin/`. With the fix in place (A–D) all four attack vectors are blocked and legitimate sync (E) continues to work normally.
