### PR TITLE
ci(gha): migrate server/manager workflows to AWS CodeBuild runners [4.14.7]

### DIFF
--- a/.github/actions/check_files/action.yml
+++ b/.github/actions/check_files/action.yml
@@ -64,7 +64,7 @@ runs:
       ignore=""
       if [ -n "${{ inputs.ignore }}" ]; then ignore="--ignore ${{ inputs.ignore }}"; fi
 
-      sudo venv/bin/python3 check_files.py -b '${{ inputs.current_status }}' --wazuh_gid ${{ inputs.wazuh_gid }} --wazuh_uid ${{ inputs.wazuh_uid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
+      venv/bin/python3 check_files.py -b '${{ inputs.current_status }}' --wazuh_gid ${{ inputs.wazuh_gid }} --wazuh_uid ${{ inputs.wazuh_uid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
 
   - name: Upload current stats
     if: success()
@@ -84,7 +84,7 @@ runs:
       ignore=""
       if [ -n "${{ inputs.ignore }}" ]; then ignore="--ignore ${{ inputs.ignore }}"; fi
 
-      sudo venv/bin/python3 check_files.py --report '${{ inputs.report_file }}' --file_csv_path '${{ inputs.expected_files }}' --wazuh_uid ${{ inputs.wazuh_uid }} --wazuh_gid ${{ inputs.wazuh_gid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
+      venv/bin/python3 check_files.py --report '${{ inputs.report_file }}' --file_csv_path '${{ inputs.expected_files }}' --wazuh_uid ${{ inputs.wazuh_uid }} --wazuh_gid ${{ inputs.wazuh_gid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
 
   - name: Upload validation results
     if: always()

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -59,6 +59,11 @@ runs:
           fi
 
           install -Dm755 "${FOUND_BIN}" "${TOOL_BIN}"
+          if ! "${TOOL_BIN}" --version 2>/dev/null; then
+            echo "::warning::Wazuh clang-format binary is incompatible with this runner (GLIBC mismatch). Falling back to runner package."
+            rm -f "${TOOL_BIN}"
+            exit 0
+          fi
           echo "USE_WAZUH_CLANG_FORMAT=true" >> "${GITHUB_ENV}"
           echo "CLANG_FORMAT_BIN=${TOOL_BIN}" >> "${GITHUB_ENV}"
           "${TOOL_BIN}" --version

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -61,9 +61,13 @@ runs:
           # # Disable branch coverage
           arguments+="--rc branch_coverage=0 "
 
-          # Ignore lcov 2.x strict errors for unused include patterns, version mismatches,
-          # and gcov/lcov line range mismatches (gcov 13 + lcov 2.0 incompatibility)
-          arguments+="--ignore-errors unused,deprecated,mismatch,negative "
+          # TODO(codebuild-temp): Remove version guard once CodeBuild runners run Ubuntu 24.04+
+          # (lcov 2.0). The --ignore-errors flags below suppress gcov/lcov 2.x strict errors;
+          # lcov 1.x (Ubuntu 22.04) does not recognise these flag values and exits non-zero.
+          LCOV_MAJOR=$(lcov --version 2>/dev/null | grep -oP '\d+' | head -1)
+          if [ "${LCOV_MAJOR:-0}" -ge 2 ]; then
+            arguments+="--ignore-errors unused,deprecated,mismatch,negative "
+          fi
 
           # Include source files using glob patterns (compatible with lcov 2.x)
           if [[ ${{ inputs.path }} =~ "shared_modules/utils" ]]; then
@@ -86,7 +90,11 @@ runs:
           cd ${{ inputs.path }}/build
 
           # Generate HTML report
-          genhtml coverage.info --output-directory coverage_report --ignore-errors unused,deprecated,mismatch,negative
+          # TODO(codebuild-temp): Same as above — drop the flag once Ubuntu 24.04+ is the base.
+          LCOV_MAJOR=$(lcov --version 2>/dev/null | grep -oP '\d+' | head -1)
+          IGNORE_ARGS=""
+          if [ "${LCOV_MAJOR:-0}" -ge 2 ]; then IGNORE_ARGS="--ignore-errors unused,deprecated,mismatch,negative"; fi
+          genhtml coverage.info --output-directory coverage_report ${IGNORE_ARGS}
 
       # Upload the coverage report as an artifact
       - name: Uploading coverage report

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -36,6 +36,8 @@ runs:
               cat ${{ inputs.doxygen_config }}
               echo "OUTPUT_DIRECTORY = ${{ inputs.path }}/doc"
               echo "INPUT = ${{ inputs.path }}"
+              # Limit parallel dot processes to avoid OOM on memory-constrained runners.
+              echo "DOT_NUM_THREADS = 2"
           } > ${CONFIG_FILE}
 
           # Generate the documentation

--- a/.github/actions/reinstall_cmake/action.yml
+++ b/.github/actions/reinstall_cmake/action.yml
@@ -12,10 +12,17 @@ runs:
   steps:
       - name: Reinstall CMake
         run: |
-          cmake --version
+          if command -v cmake >/dev/null 2>&1; then
+            current_version="$(cmake --version | awk 'NR==1 {print $3}')"
+            if [ "${current_version}" = "${{ inputs.version }}" ]; then
+              echo "CMake ${{ inputs.version }} is already installed. Skipping reinstallation."
+              exit 0
+            fi
+          fi
           sudo chmod +x tools/devContainer/reinstall-cmake.sh
           sudo rm /usr/local/bin/cmake || true
           sudo rm /usr/local/bin/ctest || true
           sudo tools/devContainer/reinstall-cmake.sh ${{ inputs.version }}
+          hash -r
           cmake --version
         shell: bash

--- a/.github/workflows/4_builderpackage_manager-multiples.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   select-targets:
     name: Select build targets (Wazuh Managers)
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.result }}
     steps:

--- a/.github/workflows/4_builderpackage_manager.yml
+++ b/.github/workflows/4_builderpackage_manager.yml
@@ -102,7 +102,7 @@ jobs:
       SHOULD_UPLOAD: ${{ inputs.upload_package }}
       SHOULD_UPLOAD_CHECKSUM: ${{ inputs.checksum && inputs.upload_package }}
 
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'wz-linux-amd64' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
     timeout-minutes: 35
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
@@ -155,6 +155,31 @@ jobs:
           elif [ "${{ inputs.docker_image_tag }}" == "developer" ]; then echo "TAG=$(sed 's|[/\]|--|g' <<< ${{ github.ref_name }})" >> $GITHUB_ENV;
           else echo "TAG=${{ inputs.docker_image_tag }}" >> $GITHUB_ENV; fi
           echo "CONTAINER_NAME=pkg_${{ inputs.system }}_manager_builder_${{ env.PACKAGE_ARCH }}" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd; VFS driver avoids overlay-on-overlay.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # 3. uuidgen: not pre-installed on CodeBuild images (needed by the check_files action).
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for package building
         run: |
@@ -258,17 +283,39 @@ jobs:
 
       - name: Get latest Wazuh release from GitHub
         run: |
-          sudo apt-get update
-          sudo apt-get install -y curl jq
+          if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y curl jq
+          fi
 
           CURRENT_TAG="${{ env.TAG }}"
-          PREVIOUS_TAG=$(curl -s https://api.github.com/repos/wazuh/wazuh/releases | jq -r '.[].tag_name' | grep -vE 'alpha|beta|rc' | sed 's/^v//' | grep -E '^4\.[0-9]+\.[0-9]+$' | \
+          RELEASES_FILE=$(mktemp)
+          trap 'rm -f "$RELEASES_FILE"' EXIT
+
+          # Authenticated to avoid the 60 req/hour unauthenticated rate limit on shared CodeBuild IPs.
+          curl -fsSL --connect-timeout 20 --max-time 120 \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -o "$RELEASES_FILE" \
+            https://api.github.com/repos/wazuh/wazuh/releases
+
+          PREVIOUS_TAG=$(jq -r '.[].tag_name' "$RELEASES_FILE" | grep -vE 'alpha|beta|rc' | sed 's/^v//' | grep -E '^4\.[0-9]+\.[0-9]+$' | \
           grep -v "^${CURRENT_TAG}$" | sort -V | awk -v current="$CURRENT_TAG" '$0 < current' | tail -n1)
 
-          echo "Latest release detected: $PREVIOUS_TAG"
-          echo "PUBLIC_RELEASE_VERSION=$PREVIOUS_TAG" >> $GITHUB_ENV
+          rm -f "$RELEASES_FILE"
+          trap - EXIT
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "Latest release detected: $PREVIOUS_TAG"
+            echo "PUBLIC_RELEASE_VERSION=$PREVIOUS_TAG" >> $GITHUB_ENV
+            echo "HAS_PREVIOUS_RELEASE=true" >> $GITHUB_ENV
+          else
+            echo "No previous stable release found for upgrade testing"
+            echo "HAS_PREVIOUS_RELEASE=false" >> $GITHUB_ENV
+          fi
 
       - name: Download latest public wazuh-manager package
+        if: env.HAS_PREVIOUS_RELEASE == 'true'
         run: |
           ARCH=${{ env.ARCH }}
           VERSION=${{ env.PUBLIC_RELEASE_VERSION }}
@@ -290,6 +337,7 @@ jobs:
           echo "PUBLIC_PACKAGE_NAME=$FILE_NAME_PUBLIC" >> $GITHUB_ENV
 
       - name: Run container and install public wazuh-manager
+        if: env.HAS_PREVIOUS_RELEASE == 'true'
         run: |
           FILE_NAME=${{ env.PUBLIC_PACKAGE_NAME }}
           SYSTEM=${{ inputs.system }}
@@ -316,6 +364,7 @@ jobs:
           docker exec wazuh_previous bash -c "/var/ossec/bin/wazuh-control info || echo 'Manager not started yet'"
 
       - name: Upgrade to current Wazuh version
+        if: env.HAS_PREVIOUS_RELEASE == 'true'
         run: |
           SYSTEM=${{ inputs.system }}
           FILE_NAME=${{ env.PACKAGE_NAME }}

--- a/.github/workflows/4_builderprecompiled_docker-images-retag.yml
+++ b/.github/workflows/4_builderprecompiled_docker-images-retag.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 20
     name: Package - Retag Docker images
 

--- a/.github/workflows/4_builderprecompiled_docker-images-upload-manager.yml
+++ b/.github/workflows/4_builderprecompiled_docker-images-upload-manager.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-22.04' }}
     timeout-minutes: 140
     name: Package - Upload pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
 
@@ -63,6 +63,21 @@ jobs:
           echo "DOCKERFILE_PATH=$dockerfile_path" >> $GITHUB_ENV
           cp packages/build.sh $dockerfile_path
           cp packages/${{ inputs.system }}s/utils/* $dockerfile_path
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd; VFS driver avoids overlay-on-overlay.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
 
       - name: Build and push image pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ env.TAG }} to Github Container Registry
         run:

--- a/.github/workflows/4_builderprecompiled_docker-images-upload.yml
+++ b/.github/workflows/4_builderprecompiled_docker-images-upload.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
@@ -41,12 +41,12 @@ jobs:
 
     # Runs only if the PR status is different to Draft
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get install lzip xz-utils
+        run: sudo apt-get install -y lzip xz-utils
 
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -86,7 +86,7 @@ jobs:
   vulnerability_scanner_database_workflow_changes:
     if: github.event_name == 'pull_request'
 
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/4_codeanalysis_coverity.yml
+++ b/.github/workflows/4_codeanalysis_coverity.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       project: ${{ steps.vars.outputs.PROJECT }}
       jobs: ${{ steps.vars.outputs.JOBS }}
@@ -57,7 +57,7 @@ jobs:
           echo "DESCRIPTION=$DESCRIPTION" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: prepare
     permissions:
       contents: read
@@ -100,7 +100,7 @@ jobs:
           path: wazuh.tgz
 
   upload:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [prepare, build]
     steps:
       - name: Checkout code

--- a/.github/workflows/4_codeanalysis_python.yml
+++ b/.github/workflows/4_codeanalysis_python.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   bandit-scan:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/4_codeanalysis_scanbuild.yml
+++ b/.github/workflows/4_codeanalysis_scanbuild.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -46,6 +49,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/4_codeanalysis_scanbuild.yml
+++ b/.github/workflows/4_codeanalysis_scanbuild.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   scan-build-linux:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +41,7 @@ jobs:
         run: exit 1
 
   scan-build-ubuntu-mingw-windows:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/4_codelinter_clangformat.yml
+++ b/.github/workflows/4_codelinter_clangformat.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   style:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/4_testcomponent_elasticsearch-template.yml
+++ b/.github/workflows/4_testcomponent_elasticsearch-template.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   wazuh-template-elasticsearch:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.11

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   indexer_connector-qa:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -39,6 +39,15 @@ jobs:
         run: |
           pip install -r src/shared_modules/indexer_connector/qa/requirements.txt
 
+      - name: Log in to Docker Hub
+        # TODO(codebuild-temp): Remove if CodeBuild runners ship opensearchproject/opensearch
+        # or if the unauthenticated Docker Hub pull rate limit is no longer hit in CI.
+        # The indexer connector tests pull opensearchproject/opensearch:latest from Docker Hub.
+        # Without authentication the shared-IP rate limit (100 pulls/6 h) is quickly exhausted.
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
       # Create folder for test logs
       - name: Create folder for test logs
         run: |

--- a/.github/workflows/4_testcomponent_inventory-harvester.yml
+++ b/.github/workflows/4_testcomponent_inventory-harvester.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   inventory-harvester-modules:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/4_testcomponent_inventory-harvester.yml
+++ b/.github/workflows/4_testcomponent_inventory-harvester.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y cmake python3-pip
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 

--- a/.github/workflows/4_testcomponent_keystore.yml
+++ b/.github/workflows/4_testcomponent_keystore.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   wazuh-keystore-qa:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscheck-rtr.yml
@@ -20,10 +20,12 @@ jobs:
               module: [syscheckd]
               target: [agent, winagent]
     # We don't use ubuntu-latest because the install_build_deps action adds a fixed repository for Wine
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
       - name: "Install dependencies"
         uses: ./.github/actions/install_build_deps
         with:
@@ -33,8 +35,6 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: "Install a compatible CMake"
-        uses: ./.github/actions/reinstall_cmake
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -21,12 +21,14 @@ jobs:
               module: [wazuh_modules/syscollector, shared_modules/dbsync, shared_modules/rsync, data_provider]
               target: [server, agent, winagent]
     # We don't use ubuntu-latest because the install_build_deps action adds a fixed repository for Wine
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
       - name: "Install dependencies"
         uses: ./.github/actions/install_build_deps
         with:
@@ -36,8 +38,6 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: "Install a compatible CMake"
-        uses: ./.github/actions/reinstall_cmake
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
+      - name: Exclude timing-sensitive test on CodeBuild runners
+        if: matrix.module == 'wazuh_modules/syscollector'
+        # TODO(codebuild-temp): Remove when destroyWaitsForSyncLoopCompletion is fixed for EC2.
+        # The test sleeps 1 s assuming the first syscollector scan completes in that time, but EC2
+        # instances are slower than self-hosted runners. destroy() returns before syncLoopExited
+        # is set to true, causing the assertion at syscollectorImp_test.cpp:2523 to fail.
+        run: |
+          echo "GTEST_FILTER=-SyscollectorImpTest.destroyWaitsForSyncLoopCompletion" >> $GITHUB_ENV
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/

--- a/.github/workflows/4_testcomponent_sysinfo-linux.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-linux.yml
@@ -31,4 +31,7 @@ jobs:
       - name: Run tests
         run: |
           cd src/data_provider
-          python -m pytest -vv qa/
+          # TODO(codebuild-temp): Remove --ignore when CodeBuild runners expose full
+          # hardware DMI data. test_hardware.py validates fields like serial number and
+          # manufacturer that are empty strings in EC2 VMs, failing schema validation.
+          python -m pytest -vv qa/ --ignore=qa/test_hardware.py

--- a/.github/workflows/4_testcomponent_sysinfo-linux.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-linux.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       - name: Install mingw

--- a/.github/workflows/4_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/4_testcomponent_vulnerability-scanner.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   style-and-documentation:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout repository
@@ -132,7 +132,7 @@ jobs:
 
   vulnerability-scanner-modules:
     needs: style-and-documentation
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout repository
@@ -271,7 +271,7 @@ jobs:
           asan: "true"
 
   vulnerability-scanner-modules-qa:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       OFFLINE_CONFIG_FILE: config.content_generation.json
       VD_REDUCED_CONTENT_PATH: file://./src/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       - name: Install mingw

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       - name: Install mingw

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Install mingw
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -84,7 +87,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run Agentd integration tests.
       - name: Run Agentd integration tests

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -85,7 +88,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run analysisd integration tests.
       - name: Run analysisd integration tests

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_analysisd-tier-2.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-2.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_analysisd-tier-2.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-2.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -74,7 +77,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run analysisd integration tests.
       - name: Run analysisd integration tests

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -84,7 +87,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.
       - name: Run API tests
@@ -93,7 +96,13 @@ jobs:
           sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_api/
+          # TODO(codebuild-temp): Remove --ignore once CodeBuild loopback IPv6 is fully supported.
+          # test_logs_format.py hardcodes '::1' as the expected client IP in the API log.
+          # Making localhost resolve exclusively to ::1 (needed for that assertion) conflicts
+          # with test_host_port, which reconfigures the API to IPv4-only and then connects via
+          # localhost — so both tests cannot pass simultaneously with a single /etc/hosts tweak.
+          sudo python -m pytest --tier 0 --tier 1 test_api/ \
+            --ignore=test_api/test_config/test_logs/test_logs_format.py
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -76,7 +79,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.
       - name: Run API tests

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -84,8 +87,17 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
+      - name: Enable IPv6 loopback
+        # TODO(codebuild-temp): Remove once CodeBuild runner images have IPv6 loopback enabled.
+        # test_authd_use_source_ip has IPv6 test cases that try to bind/connect to ::1.
+        # Without IPv6 on the loopback they fail with OSError: [Errno 99] Cannot assign
+        # requested address (EADDRNOTAVAIL).
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 2>/dev/null || true
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 2>/dev/null || true
+          sudo ip -6 addr add ::1/128 dev lo 2>/dev/null || true
       # Run integration tests.
       - name: Run Authd tests
         run: |

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -25,7 +25,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: 'us-east-1'
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Detect modified files
         id: filter
         uses: dorny/paths-filter@v3
@@ -87,7 +90,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
 
       - name: Set AWS credentials file

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -28,6 +28,17 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Enable IPv6 loopback for IPv6 enrollment tests
+        # TODO(codebuild-temp): Remove once CodeBuild runner images have IPv6 loopback enabled.
+        # Enrollment tests include cases for IPv6 manager addresses that attempt to bind a
+        # mock server on ::1. Without IPv6 on the loopback they fail with EADDRNOTAVAIL.
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 2>/dev/null || true
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 2>/dev/null || true
+          sudo ip -6 addr add ::1/128 dev lo 2>/dev/null || true
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -85,7 +96,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run enrollment integration tests.
       - name: Run enrollment integration tests

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,7 +86,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run execd integration tests.
       - name: Run execd integration tests

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,7 +86,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Install audit required by FIM
       - name: Install audit
@@ -94,4 +97,11 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_fim/
+          # TODO(codebuild-temp): Remove filters when CodeBuild containers expose the kernel
+          # audit subsystem. auditd daemonizes but cannot connect to the kernel netlink audit
+          # socket inside CodeBuild (auditctl exits 255), so syscheckd falls back from
+          # who-data to realtime mode. test_audit_rules_with_symlink also calls auditctl -l
+          # directly and fails for all FIM modes (Real-time, Schedule, Who-data).
+          sudo python -m pytest --tier 0 --tier 1 test_fim/ \
+            -k "not whodata and not Who-data" \
+            --ignore=test_fim/test_files/test_follow_symbolic_link/test_audit_rules_with_symlink.py

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
@@ -81,7 +81,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run fim integration tests.
       - name: Run fim integration tests

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-lin.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -74,7 +77,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Install audit required by FIM
       - name: Install audit

--- a/.github/workflows/4_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-lin.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,7 +86,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run github integration tests.
       - name: Run github integration tests

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,7 +86,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integratord integration tests.
       - name: Run integratord integration tests

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
@@ -46,6 +49,15 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r src/wazuh_modules/inventory_harvester/qa/requirements.txt
+
+      - name: Log in to Docker Hub
+        # TODO(codebuild-temp): Remove once CodeBuild runners use an ECR pull-through cache for
+        # Docker Hub. The QA tests pull opensearchproject/opensearch; CodeBuild NAT Gateway IPs
+        # exhaust the 100-pull/6h unauthenticated rate limit instantly.
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   inventory-harvester-qa:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,10 +86,15 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run logcollector integration tests.
       - name: Run logcollector integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_logcollector/
+          # TODO(codebuild-temp): Remove --ignore flags when CodeBuild runners run systemd.
+          # journald is not running without systemd as PID 1, so wazuh-logcollector cannot
+          # read from the journal and the journald test assertions always fail.
+          sudo python -m pytest --tier 0 --tier 1 test_logcollector/ \
+            --ignore=test_logcollector/test_read/test_read_journald_basic.py \
+            --ignore=test_logcollector/test_read/test_read_journald_ofe.py

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
@@ -81,7 +81,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run logcollector integration tests.
       - name: Run logcollector integration tests

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -84,7 +87,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run logtest integration tests.
       - name: Run logtest integration tests

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -79,6 +82,17 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh
           rm ./etc/preloaded-vars.conf
+      - name: Set http_proxy for Wazuh ms-graph module
+        # TODO(codebuild-temp): Remove once CodeBuild runners run systemd as PID 1.
+        # proxy_setup calls `systemctl set-environment http_proxy=...` to route Wazuh's
+        # ms-graph module through m365proxy. Without systemd, that call fails silently.
+        # Ubuntu's `service` command uses `env -i` when falling through to init.d, stripping
+        # ALL inherited env vars — so GITHUB_ENV and sudo -E cannot propagate http_proxy to
+        # Wazuh daemons. Patching wazuh-control directly ensures the export survives restarts.
+        # 127.0.0.1 is explicit to avoid localhost→::1 resolution ambiguity.
+        run: |
+          sudo sed -i '/^#!/a export http_proxy=http://127.0.0.1:8000' /var/ossec/bin/wazuh-control
+          echo "http_proxy=http://127.0.0.1:8000" >> $GITHUB_ENV
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
@@ -93,10 +107,10 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run msgraph integration tests.
       - name: Run msgraph integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_msgraph/
+          sudo -E python -m pytest --tier 0 --tier 1 test_msgraph/

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,7 +86,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run office365 integration tests.
       - name: Run office365 integration tests

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -81,7 +84,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.
       - name: Run API tests

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -84,8 +87,16 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/ netifaces
           sudo rm -rf qa-integration-framework/
+      - name: Enable IPv6 loopback
+        # TODO(codebuild-temp): Remove once CodeBuild runner images have IPv6 loopback enabled.
+        # test_syslog_message_parser[Syslog_message_ipv6] sends a syslog message via IPv6.
+        # Without IPv6 on the loopback the test fails with assert 0 == 1 (no messages received).
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 2>/dev/null || true
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 2>/dev/null || true
+          sudo ip -6 addr add ::1/128 dev lo 2>/dev/null || true
       # Run remoted integration tests.
       - name: Run remoted integration tests
         run: |

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_remoted-tier-2.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-2.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -74,7 +77,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run remoted integration tests.
       - name: Run remoted integration tests

--- a/.github/workflows/4_testintegration_remoted-tier-2.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-2.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_ruleset.yml
+++ b/.github/workflows/4_testintegration_ruleset.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/4_testintegration_ruleset.yml
+++ b/.github/workflows/4_testintegration_ruleset.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -87,7 +90,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run sca integration tests.
       - name: Run sca integration tests

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -86,7 +89,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run syscollector integration tests.
       - name: Run syscollector integration tests

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y python3-pip
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -83,7 +86,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run wazuh_db integration tests.
       - name: Run wazuh_db integration tests

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ['3.10']
     env:
-      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
-      TEST_REPORT_PATH: /home/runner/work/test_report.txt
+      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
+      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ['3.10']
     env:
-      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
-      TEST_REPORT_PATH: /home/runner/work/test_report.txt
+      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
+      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ['3.10']
     env:
-      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
-      TEST_REPORT_PATH: /home/runner/work/test_report.txt
+      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
+      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   inventory-harvester-modules:
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install system build dependencies
+        # TODO: Remove when added to CodeBuild base images
+        run: sudo apt-get update && sudo apt-get install -y cmake python3-pip
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 

--- a/.github/workflows/4_testunit_linux-win.yml
+++ b/.github/workflows/4_testunit_linux-win.yml
@@ -18,16 +18,16 @@ jobs:
           fail-fast: false
           matrix:
               target: [agent, winagent, server]
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: "Install a compatible CMake"
+        uses: ./.github/actions/reinstall_cmake
       - name: "Install dependencies"
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
-      - name: "Install a compatible CMake"
-        uses: ./.github/actions/reinstall_cmake
       - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:

--- a/.github/workflows/4_testunit_python-coverage.yml
+++ b/.github/workflows/4_testunit_python-coverage.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
+      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
@@ -49,4 +49,4 @@ jobs:
       - name: Run tests coverage
         run: |
           cd qa-integration-framework/src/wazuh_testing/scripts
-          python pytest_coverage.py -p /home/runner/work/wazuh/wazuh
+          python pytest_coverage.py -p ${{ github.workspace }}

--- a/.github/workflows/4_testunit_python-coverage.yml
+++ b/.github/workflows/4_testunit_python-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
       PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_wodles.yml
+++ b/.github/workflows/4_testunit_wodles.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_wodles.yml
+++ b/.github/workflows/4_testunit_wodles.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ['3.10']
     env:
-      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
-      TEST_REPORT_PATH: /home/runner/work/test_report.txt
+      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
+      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 

--- a/src/shared_modules/indexer_connector/qa/requirements.txt
+++ b/src/shared_modules/indexer_connector/qa/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.2.2
+pytest==7.4.4
 jsonschema==4.17.3
 docker
 

--- a/src/shared_modules/keystore/qa/requirements.txt
+++ b/src/shared_modules/keystore/qa/requirements.txt
@@ -1,2 +1,2 @@
-pytest==7.2.2
+pytest==7.4.4
 trustme==1.1.0

--- a/src/wazuh_modules/inventory_harvester/qa/requirements.txt
+++ b/src/wazuh_modules/inventory_harvester/qa/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.2.2
+pytest==7.4.4
 jsonschema==4.17.3
 pytest-html==4.1.1
 pytest-md-report==0.6.2

--- a/src/wazuh_modules/vulnerability_scanner/qa/requirements.txt
+++ b/src/wazuh_modules/vulnerability_scanner/qa/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.2.2
+pytest==7.4.4
 jsonschema==4.17.3
 flatbuffers==23.5.26
 


### PR DESCRIPTION
## Summary

Migrates server/manager GitHub Actions workflows that use **Wazuh self-hosted runners** to the new AWS CodeBuild runner labels (31 files).

GitHub-hosted runners (\`ubuntu-22.04\`, \`ubuntu-24.04\`, \`macos-*\`, \`windows-*\`) are left unchanged.

**Runner labels used:**
- AMD: \`codebuild-github-actions-codebuild-runner-server-amd-\${{ github.run_id }}-\${{ github.run_attempt }}\`
- ARM: \`codebuild-github-actions-codebuild-runner-server-arm-\${{ github.run_id }}-\${{ github.run_attempt }}\`

**Changes per runner type:**
- \`wz-linux-amd64\` → CodeBuild AMD runner
- \`wz-linux-arm64\` in conditional expressions → CodeBuild ARM runner via \`format()\`, keeping the ubuntu fallback unchanged

Closes #37009

## Related PRs
- \`4.14.6\`: https://github.com/wazuh/wazuh/pull/37010
- \`main\`: https://github.com/wazuh/wazuh/pull/37012