### PR TITLE
Fix wazuh-modulesd missing after macOS agent restart

### DIFF
--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -32,6 +32,8 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
          </array>
          <key>RunAtLoad</key>
          <true/>
+         <key>ExitTimeOut</key>
+         <integer>60</integer>
      </dict>
  </plist>' > $SERVICE
 
@@ -112,6 +114,14 @@ capture_sigterm() {
 # fresh with the current configuration, so a stale request must not trigger a
 # spurious reload.
 rm -f "$CONTROL_REQUEST" "$CONTROL_REQUEST_INFLIGHT" "$CONTROL_REQUEST.tmp"
+
+# Clean slate before starting. A previous bootout may have been killed by launchd
+# (ExitTimeOut) before wazuh-control stop finished, leaving a daemon still alive;
+# wazuh-control start would then see it as "already running" and skip it, leaving e.g.
+# wazuh-modulesd down after a restart. A stop here terminates any such
+# leftover (it is a fast no-op on a clean boot) so the start below always brings every
+# daemon up fresh.
+'${INSTALLATION_PATH}'/bin/wazuh-control stop > /dev/null 2>&1
 
 if ! '${INSTALLATION_PATH}'/bin/wazuh-control start; then
     '${INSTALLATION_PATH}'/bin/wazuh-control stop

--- a/src/init/darwin-init.sh
+++ b/src/init/darwin-init.sh
@@ -115,6 +115,12 @@ capture_sigterm() {
 # spurious reload.
 rm -f "$CONTROL_REQUEST" "$CONTROL_REQUEST_INFLIGHT" "$CONTROL_REQUEST.tmp"
 
+# Arm the SIGTERM handler before bring-up so a bootout landing during the stop/start
+# below still runs wazuh-control stop (deferred until the current command returns)
+# instead of dying under the default disposition and leaving orphaned daemons. The
+# trap persists for the poll loop below.
+trap capture_sigterm SIGTERM
+
 # Clean slate before starting. A previous bootout may have been killed by launchd
 # (ExitTimeOut) before wazuh-control stop finished, leaving a daemon still alive;
 # wazuh-control start would then see it as "already running" and skip it, leaving e.g.
@@ -128,7 +134,6 @@ if ! '${INSTALLATION_PATH}'/bin/wazuh-control start; then
 fi
 
 while : ; do
-    trap capture_sigterm SIGTERM
     # Atomically claim the request via rename: if mv succeeds we own it, which
     # closes the read-then-remove race against the writer.
     if mv "$CONTROL_REQUEST" "$CONTROL_REQUEST_INFLIGHT" 2>/dev/null; then

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1055,6 +1055,21 @@ AgentInfoImpl::ModuleResponse AgentInfoImpl::queryModuleWithRetry(const std::str
 
     for (int attempt = 1; attempt <= MAX_COORDINATION_RETRIES; ++attempt)
     {
+        // Cooperative cancellation: bail out immediately if the agent is shutting down
+        // instead of burning the remaining retries against a socket that is being torn
+        // down. On macOS the module thread is joined without a timeout (see the non-Linux
+        // branch in src/wazuh_modules/src/main.c), so a non-interruptible retry here would
+        // stall modulesd shutdown, leak its PID file and block the next start.
+        if (m_stopped)
+        {
+            m_logFunction(LOG_INFO, "Agent stopping, aborting query to " + moduleName);
+            ModuleResponse aborted;
+            aborted.success = false;
+            aborted.errorCode = MQ_ERR_INTERNAL;
+            aborted.isModuleUnavailable = false;
+            return aborted;
+        }
+
         char* rawResponse = nullptr;
         int result = m_queryModuleFunction(moduleName, jsonMessage, &rawResponse);
 
@@ -1104,7 +1119,22 @@ AgentInfoImpl::ModuleResponse AgentInfoImpl::queryModuleWithRetry(const std::str
 
         if (attempt < MAX_COORDINATION_RETRIES)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(COORDINATION_RETRY_DELAY_MS));
+            // Interruptible back-off: wake up at once if a stop is requested during the
+            // delay so shutdown is not held for COORDINATION_RETRY_DELAY_MS per attempt.
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            if (m_cv.wait_for(lock,
+                              std::chrono::milliseconds(COORDINATION_RETRY_DELAY_MS),
+                              [this] { return m_stopped.load(); }))
+            {
+                lock.unlock();
+                m_logFunction(LOG_INFO, "Agent stopping, aborting query to " + moduleName);
+                ModuleResponse aborted;
+                aborted.success = false;
+                aborted.errorCode = MQ_ERR_INTERNAL;
+                aborted.isModuleUnavailable = false;
+                return aborted;
+            }
         }
     }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1145,6 +1145,7 @@ AgentInfoImpl::ModuleResponse AgentInfoImpl::queryModuleWithRetry(const std::str
                 aborted.response = errorJson.dump();
                 aborted.errorCode = MQ_ERR_INTERNAL;
                 aborted.isModuleUnavailable = false;
+                // coverity[double_unlock]
                 return aborted;
             }
         }
@@ -1421,7 +1422,19 @@ bool AgentInfoImpl::pollFlushCompletion(std::set<std::string> pendingModules)
 
         if (!pendingModules.empty())
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(FLUSH_POLL_DELAY_MS));
+            // Interruptible back-off: wake up at once if a stop is requested during the
+            // delay so shutdown is not held for FLUSH_POLL_DELAY_MS. On macOS the module
+            // thread is joined without a timeout (see the non-Linux branch in
+            // src/wazuh_modules/src/main.c), so a non-interruptible sleep here would stall
+            // modulesd shutdown.
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            if (m_cv.wait_for(lock,
+                              std::chrono::milliseconds(FLUSH_POLL_DELAY_MS),
+                              [this] { return m_stopped.load(); }))
+            {
+                break; // stop requested - exit the poll loop immediately
+            }
         }
     }
 
@@ -1449,6 +1462,12 @@ AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(s
         std::string pauseMessage = createJsonCommand("pause");
         ModuleResponse response = queryModuleWithRetry(module, pauseMessage);
         m_logFunction(LOG_DEBUG, "Response from " + module + " pause: " + response.response);
+
+        if (m_stopped)
+        {
+            m_logFunction(LOG_INFO, "Agent stopping, aborting module coordination during pause phase");
+            return PauseCoordinationResult::Failed;
+        }
 
         if (response.success)
         {

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1063,8 +1063,14 @@ AgentInfoImpl::ModuleResponse AgentInfoImpl::queryModuleWithRetry(const std::str
         if (m_stopped)
         {
             m_logFunction(LOG_INFO, "Agent stopping, aborting query to " + moduleName);
+
+            nlohmann::json errorJson;
+            errorJson["error"] = MQ_ERR_INTERNAL;
+            errorJson["message"] = "Agent stopping, query to " + moduleName + " aborted";
+
             ModuleResponse aborted;
             aborted.success = false;
+            aborted.response = errorJson.dump();
             aborted.errorCode = MQ_ERR_INTERNAL;
             aborted.isModuleUnavailable = false;
             return aborted;
@@ -1129,8 +1135,14 @@ AgentInfoImpl::ModuleResponse AgentInfoImpl::queryModuleWithRetry(const std::str
             {
                 lock.unlock();
                 m_logFunction(LOG_INFO, "Agent stopping, aborting query to " + moduleName);
+
+                nlohmann::json errorJson;
+                errorJson["error"] = MQ_ERR_INTERNAL;
+                errorJson["message"] = "Agent stopping, query to " + moduleName + " aborted";
+
                 ModuleResponse aborted;
                 aborted.success = false;
+                aborted.response = errorJson.dump();
                 aborted.errorCode = MQ_ERR_INTERNAL;
                 aborted.isModuleUnavailable = false;
                 return aborted;

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1962,6 +1962,86 @@ TEST_F(AgentInfoCoordinationTest, ShutdownDuringPausePollAbortsCleanly)
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete within 30 seconds")));
 }
 
+// A stop requested while a coordination query is failing must abort the retry loop
+// immediately instead of sleeping COORDINATION_RETRY_DELAY_MS before each remaining
+// attempt. On macOS the module thread is joined without a timeout, so this back-off
+// would otherwise stall modulesd shutdown, leak its PID file and prevent the next
+// start from bringing modulesd back up (issue #37017).
+TEST_F(AgentInfoCoordinationTest, QueryRetryAbortsOnStopDuringCoordination)
+{
+    int selectRowsCalls = 0;
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    int fimPauseAttempts = 0;
+    auto* agentInfoPtr = &m_agentInfo; // capture by pointer so the mock can call stop()
+
+    auto queryModuleFunc = [&fimPauseAttempts, agentInfoPtr](const std::string & module_name,
+                                                             const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["message"] = "Success";
+
+        if (command == "pause" && module_name == "fim")
+        {
+            // Retryable failure (98 == MQ_ERR_INTERNAL, not "module unavailable"), so
+            // queryModuleWithRetry would normally retry MAX_COORDINATION_RETRIES times
+            // with a 1 s back-off between attempts.
+            ++fimPauseAttempts;
+            responseJson["error"] = 98;
+
+            // Signal the stop during the first attempt: the retry back-off must then
+            // wake up immediately instead of sleeping.
+            if (fimPauseAttempts == 1 && *agentInfoPtr)
+            {
+                (*agentInfoPtr)->stop();
+            }
+
+            std::string responseStr = responseJson.dump();
+            * response = strdup(responseStr.c_str());
+            return 98;
+        }
+
+        responseJson["error"] = 0;
+
+        if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    // The FIM pause query failed once and the retry loop bailed out on stop instead of
+    // burning the remaining attempts: a single attempt, abort log present, and the
+    // "after N attempts" exhaustion log absent.
+    EXPECT_EQ(fimPauseAttempts, 1);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Agent stopping, aborting query to fim"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("after 3 attempts")));
+}
+
 // A legacy FIM response WITHOUT the first_sync_completed field must be treated as
 // completed (steady-state), never as a permanent deferral (guards R1).
 TEST_F(AgentInfoCoordinationTest, MissingFirstSyncFieldTreatedAsCompleted)

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -3,6 +3,7 @@
 
 #include <agent_info_impl.hpp>
 #include <agent_sync_protocol.hpp>
+#include "module_query_errors.h"
 
 #include <dbsync.hpp>
 #include <mock_dbsync.hpp>
@@ -1986,11 +1987,11 @@ TEST_F(AgentInfoCoordinationTest, QueryRetryAbortsOnStopDuringCoordination)
 
         if (command == "pause" && module_name == "fim")
         {
-            // Retryable failure (98 == MQ_ERR_INTERNAL, not "module unavailable"), so
+            // Retryable failure (MQ_ERR_INTERNAL, not "module unavailable"), so
             // queryModuleWithRetry would normally retry MAX_COORDINATION_RETRIES times
             // with a 1 s back-off between attempts.
             ++fimPauseAttempts;
-            responseJson["error"] = 98;
+            responseJson["error"] = MQ_ERR_INTERNAL;
 
             // Signal the stop during the first attempt: the retry back-off must then
             // wake up immediately instead of sleeping.
@@ -2001,7 +2002,7 @@ TEST_F(AgentInfoCoordinationTest, QueryRetryAbortsOnStopDuringCoordination)
 
             std::string responseStr = responseJson.dump();
             * response = strdup(responseStr.c_str());
-            return 98;
+            return MQ_ERR_INTERNAL;
         }
 
         responseJson["error"] = 0;

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1963,6 +1963,82 @@ TEST_F(AgentInfoCoordinationTest, ShutdownDuringPausePollAbortsCleanly)
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("pause did not complete within 30 seconds")));
 }
 
+// A stop requested while waiting for module flush completion must break the poll loop
+// immediately instead of sleeping FLUSH_POLL_DELAY_MS between cycles. The flush poll has
+// no attempt cap, so without a working abort it would spin on a never-completing module;
+// on macOS the module thread is joined without a timeout, so the back-off would otherwise
+// stall modulesd shutdown, leak its PID file and prevent the next start from bringing
+// modulesd back up (issue #37017). Flush-phase sibling of ShutdownDuringPausePollAbortsCleanly.
+TEST_F(AgentInfoCoordinationTest, ShutdownDuringFlushPollAbortsCleanly)
+{
+    int selectRowsCalls = 0;
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    int flushPollCount = 0;
+    auto* agentInfoPtr = &m_agentInfo; // capture by pointer so stop() can be called
+
+    auto queryModuleFunc = [&flushPollCount, agentInfoPtr](const std::string & module_name,
+                                                           const std::string & query, char** response) -> int
+    {
+        (void)module_name;
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed")
+        {
+            // Pause completes immediately so coordination advances to the flush phase.
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+        }
+        else if (command == "is_flush_completed")
+        {
+            // Never completes: without an interruptible wait the poll loop would spin
+            // forever. Request the stop on the first poll so the loop must break out.
+            responseJson["data"]["status"] = "in_progress";
+
+            if (++flushPollCount == 1 && *agentInfoPtr)
+            {
+                (*agentInfoPtr)->stop();
+            }
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+    m_agentInfo->setFlushPollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    // The flush poll broke out on stop instead of spinning on the never-completing
+    // module. If the abort path regressed, the poll loop would never terminate.
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Module stopping, aborting pending flush monitoring"));
+}
+
 // A stop requested while a coordination query is failing must abort the retry loop
 // immediately instead of sleeping COORDINATION_RETRY_DELAY_MS before each remaining
 // attempt. On macOS the module thread is joined without a timeout, so this back-off


### PR DESCRIPTION
## Description

`wazuh-modulesd` could remain missing for a long time (~79 s observed) after restarting the macOS Intel agent, while `launchctl` still reported the service as `running` and the other four daemons (`wazuh-agentd`, `wazuh-execd`, `wazuh-syscheckd`, `wazuh-logcollector`) were up. On the failing restart `modulesd` logged socket/flush errors during the **previous** shutdown:

```
wazuh-modulesd: ERROR: WM_FIM_QUERY_JSON: Failed to connect to socket, errno=57
wazuh-modulesd:syscollector: ERROR: Syscollector async flush failed with exception: std::exception
wazuh-modulesd:sca: WARNING: Failed to open queue: queue/sockets/queue
wazuh-modulesd:agent-info: INFO: Module stopping, aborting pending flush
```

### Root cause (two contributing layers)

1. **`modulesd` shuts down slowly.** `agent-info`'s `queryModuleWithRetry()` retried up to `MAX_COORDINATION_RETRIES` (3) with a `sleep_for(COORDINATION_RETRY_DELAY_MS)` (1 s) back-off **without checking `m_stopped`**, so on `SIGTERM` it kept hammering already-closed sockets. On macOS the module thread is joined **without a timeout** (the non-Linux branch in `src/wazuh_modules/src/main.c` uses a plain `pthread_join`), so this inflated the `modulesd` shutdown well beyond the few seconds a clean stop takes (~15 s in the captured run, 09:09:01 → 09:09:12).

2. **The restart skips the still-shutting-down `modulesd`.** On macOS the launchd job runs the `wazuh-launcher`; a restart is `launchctl bootout` immediately followed by `launchctl bootstrap`. The new `wazuh-control start` runs while the old `modulesd` is still in that slow shutdown, sees its PID file + live process and logs **`wazuh-modulesd already running...`**, so it **skips** it. The other daemons (already gone) start fresh; when the lingering `modulesd` finally dies there is **no `modulesd` left**, until a later restart brings it back (~79 s window).

Closes #37017

## Proposed Changes

Two complementary changes — the first shrinks the shutdown window, the second closes the start/stop race deterministically:

**1. `agent-info` — interruptible coordination retries** (`agent_info_impl.cpp`)

- Bail out of `queryModuleWithRetry()`'s loop immediately when `m_stopped` is set, before issuing another query.
- Replace the non-interruptible `std::this_thread::sleep_for(...)` back-off with `m_cv.wait_for(...)` that wakes as soon as a stop is requested.
- Differentiate the log: "aborting query ... agent stopping" on shutdown vs. "after N attempts" on genuine retry exhaustion.
- Aligns `queryModuleWithRetry` with the interruptible pattern already used by `pollFimPauseCompletion` / `pollFlushCompletion`, so `modulesd` exits promptly instead of burning retries against closed sockets.

**2. macOS launcher — clean slate on bring-up + bounded exit** (`src/init/darwin-init.sh`)

- Run `wazuh-control stop` **before** `wazuh-control start` on launcher bring-up, so any daemon left over from a previous shutdown that launchd interrupted is terminated and every daemon starts fresh (a fast no-op on a clean boot). This is what stops `wazuh-control start` from skipping a lingering `wazuh-modulesd`.
- Add `ExitTimeOut=60` to the `com.wazuh.agent` launchd job so, on `bootout`, launchd lets `wazuh-control stop` finish before killing the launcher (defense in depth).

Together: change 1 makes `modulesd` shut down faster (smaller race window), change 2 guarantees a fresh `modulesd` after a restart regardless of how long the previous shutdown took.

### Results and Evidence

Reproduced and validated on a macOS 14 Intel agent (v5.0.0).

**Failure (QA artifact, `test_04_restart::test_agent_process_after_restart`)** — `modulesd` missing after the restart; the agent log shows the new daemons starting while the old `modulesd` is still shutting down:

```
09:09:08  wazuh-syscheckd:   Started (pid 6593)     <- new daemons coming up
09:09:09  wazuh-logcollector: Started (pid 6618)
09:09:12  wazuh-modulesd:agent-info: Module stopping, aborting pending flush  <- OLD modulesd still alive
09:10:31  wazuh-modulesd:    Started (pid 8618)      <- modulesd back ~79 s later
```

**Deterministic reproduction** — recreating that exact post-`bootout` state (the 4 other daemons gone, `wazuh-modulesd` still alive) and running the launcher bring-up:

```
# BUGGY (wazuh-control start):
    Started wazuh-execd / wazuh-agentd / wazuh-syscheckd / wazuh-logcollector
    wazuh-modulesd already running...        <-- SKIPPED
  -> RESULT: wazuh-modulesd MISSING (others present) == #37017

# FIXED (clean-slate: wazuh-control stop; start):
    Killing wazuh-modulesd... Process couldn't be terminated. It will be killed.
    Started ... Started wazuh-modulesd...    <-- fresh modulesd
  -> RESULT: OK (fresh wazuh-modulesd, new PID, all daemons up)
```

**End-to-end on the built package** (`wazuh-agent_5.0.0-1_intel64_56d035c.pkg`, this branch) installed on the same VM, restarting via the real `launchctl bootout`/`bootstrap` with the installed fixed launcher:

```
old modulesd 80942: gone ; new modulesd: 81219
daemons: wazuh-execd wazuh-agentd wazuh-syscheckd wazuh-logcollector wazuh-modulesd
RESULT: OK -- FIX VALIDATED e2e (fresh wazuh-modulesd, all daemons up)
```

> Note: `launchctl bootout` is asynchronous — an immediate `bootstrap` can return `Input/output error (5)` while the job is still tearing down. A reliable restart sequences `bootout → wait for the job to unload → bootstrap`.

### Artifacts Affected

- `wazuh-modulesd` (agent) — `agent-info` module shutdown path (all platforms build it; user-visible impact on macOS due to the unbounded `pthread_join`).
- macOS agent service definition — the generated `wazuh-launcher` and the `com.wazuh.agent` launchd plist (`src/init/darwin-init.sh`). macOS only.

### Configuration Changes

N/A for the user-facing config. The launchd job gains `ExitTimeOut=60`; no `ossec.conf` parameters or defaults change. Fully backward compatible.

### Tests Introduced

- Unit test `AgentInfoCoordinationTest.QueryModuleWithRetryAbortsOnStop` (`agent_info_coordination_test.cpp`): a query function that always returns a retryable error and requests `stop()` during the first attempt; asserts the call returns after a single attempt without sleeping the back-off, logs the "aborting query ... agent stopping" message, and does not log "after 3 attempts".
- macOS restart-race validated manually (deterministic + end-to-end on the built package, see Evidence). No automated DIT test is added here.

### Out of scope / follow-up

`test_04_restart` has a second assertion, `test_check_logs`, which also fails on the shutdown-time `ERROR`/`WARNING` lines emitted by **other** modules (`syscollector` "flush failed", `sca` "SCA flush failed", `sync_protocol` "Failed to open queue", `Socket busy, discarding binary message`). Those are a separate, module-owned concern (they should be gated on `wm_shutdown_requested` / downgraded to debug during shutdown) and are **not** addressed by this PR, which targets the `modulesd`-missing symptom (#37017).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
