### PR TITLE
Reduce indexer connection warning noise

### DIFF
--- a/docs/ref/modules/engine/ref-helper-functions.md
+++ b/docs/ref/modules/engine/ref-helper-functions.md
@@ -1614,7 +1614,7 @@ field: index_unclassified_events()
 
 | Path | Type | Possible values |
 | ---- | ---- | --------------- |
-| wazuh.integration.category | string | unclassified, access-management, applications, cloud-services, network-activity, other, security, system-activity |
+| wazuh.integration.category | string | Any string |
 
 
 ## Description
@@ -1626,9 +1626,9 @@ This filter returns true if and only if:
 3. 'wazuh.integration.category' equals the string "unclassified"
 
 This helper is used in output routing to decide whether to index events that the
-root decoder tagged as unclassified (no integration decoder matched) when the policy
-allows it. If the policy flag is disabled, the category differs from "unclassified",
-or the field is missing / not a string, the validation fails.
+root decoder tagged as unclassified (no integration decoder matched) when the
+policy allows it. If the policy flag is disabled, the category differs from
+"unclassified", or the field is missing / not a string, the validation fails.
 
 Note: This helper does not accept any arguments, rejects any target field other than
 'wazuh.integration.category', and depends on the policy context configured at build time.
@@ -1719,9 +1719,7 @@ check:
 #### Input Event
 
 ```json
-{
-  "wazuh.integration.category": ""
-}
+{}
 ```
 
 *The check was performed with errors*
@@ -4460,6 +4458,70 @@ check:
 
 
 
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
+
 ---
 # kvdb_not_match
 
@@ -4584,6 +4646,70 @@ check:
 *The check was successful*
 
 
+
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
 
 ---
 # match_value
@@ -14630,6 +14756,70 @@ normalize:
 
 
 
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
+
 ---
 # kvdb_get
 
@@ -14919,6 +15109,70 @@ normalize:
 *The operation was successful*
 
 
+
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
 
 ---
 # kvdb_get_array
@@ -15286,6 +15540,70 @@ normalize:
 
 
 
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
+
 ---
 # kvdb_get_merge
 
@@ -15621,6 +15939,70 @@ normalize:
 *The operation was successful*
 
 
+
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
 
 ---
 # kvdb_get_merge_recursive
@@ -15969,6 +16351,70 @@ normalize:
 *The operation was successful*
 
 
+
+## Test KVDB
+
+The examples for this helper use the following KVDB resource during tests:
+
+```json
+{
+  "id": "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10",
+  "metadata": {
+    "title": "windows_kerberos_status_code_to_code_name",
+    "author": "Wazuh Inc.",
+    "date": "2025-10-06T13:32:19Z",
+    "description": "KVDB resource used by helper function tests."
+  },
+  "content": {
+    "0x0": "KDC_ERR_NONE",
+    "0x1": "KDC_ERR_NAME_EXP",
+    "0x2": "KDC_ERR_SERVICE_EXP",
+    "0x3": "KDC_ERR_BAD_PVNO",
+    "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+    "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+    "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+    "bitmask_test_values": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      16,
+      17,
+      18,
+      19,
+      20,
+      24,
+      28,
+      29,
+      30,
+      31
+    ],
+    "access_mask": {
+      "0": "Create Child",
+      "1": "Delete Child",
+      "2": "List Contents",
+      "3": "SELF",
+      "4": "Read Property",
+      "5": "Write Property",
+      "6": "Delete Tree",
+      "7": "List Object",
+      "8": "Control Access",
+      "16": "DELETE",
+      "17": "READ_CONTROL",
+      "18": "WRITE_DAC",
+      "19": "WRITE_OWNER",
+      "20": "SYNCHRONIZE",
+      "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+      "31": "ADS_RIGHT_GENERIC_READ",
+      "30": "ADS_RIGHT_GENERIC_WRITE",
+      "29": "ADS_RIGHT_GENERIC_EXECUTE",
+      "28": "ADS_RIGHT_GENERIC_ALL"
+    }
+  },
+  "enabled": true
+}
+```
 
 ---
 # merge

--- a/src/engine/source/base/include/base/utils/metaHelpers.hpp
+++ b/src/engine/source/base/include/base/utils/metaHelpers.hpp
@@ -60,17 +60,9 @@ decltype(auto) executeWithRetry(Func&& operation,
         }
         catch (const std::exception& e)
         {
-            if (attempt < maxAttempts)
-            {
-                LOG_INFO_L(componentOperationName.c_str(),
-                           "[{}] {} - Attempt {}/{}: {}",
-                           componentOperationName,
-                           message,
-                           attempt,
-                           maxAttempts,
-                           e.what());
-            }
-            else
+            const bool isLastAttempt = attempt == maxAttempts;
+
+            if (isLastAttempt)
             {
                 LOG_WARNING_L(componentOperationName.c_str(),
                               "[{}] {} - Attempt {}/{}: {}",
@@ -79,24 +71,27 @@ decltype(auto) executeWithRetry(Func&& operation,
                               attempt,
                               maxAttempts,
                               e.what());
-            }
-            if (attempt < maxAttempts)
-            {
-                // Split sleep into 1-second chunks for responsive abort
-                for (std::size_t s = 0; s < waitSeconds; ++s)
-                {
-                    if (shutdownRequested.load(std::memory_order_relaxed))
-                    {
-                        throw std::runtime_error(fmt::format(
-                            "{}::{} aborted during retry wait (attempt {})", message, componentOperationName, attempt));
-                    }
-                    std::this_thread::sleep_for(std::chrono::seconds(1));
-                }
-            }
-            else
-            {
                 throw std::runtime_error(fmt::format(
                     "{}::{} failed after {} attempts: {}", message, componentOperationName, maxAttempts, e.what()));
+            }
+
+            LOG_INFO_L(componentOperationName.c_str(),
+                       "[{}] {} - Attempt {}/{}: {}",
+                       componentOperationName,
+                       message,
+                       attempt,
+                       maxAttempts,
+                       e.what());
+
+            // Split sleep into 1-second chunks for responsive abort
+            for (std::size_t s = 0; s < waitSeconds; ++s)
+            {
+                if (shutdownRequested.load(std::memory_order_relaxed))
+                {
+                    throw std::runtime_error(fmt::format(
+                        "{}::{} aborted during retry wait (attempt {})", message, componentOperationName, attempt));
+                }
+                std::this_thread::sleep_for(std::chrono::seconds(1));
             }
         }
     }

--- a/src/engine/source/base/include/base/utils/metaHelpers.hpp
+++ b/src/engine/source/base/include/base/utils/metaHelpers.hpp
@@ -60,13 +60,26 @@ decltype(auto) executeWithRetry(Func&& operation,
         }
         catch (const std::exception& e)
         {
-            LOG_WARNING_L(componentOperationName.c_str(),
-                          "[{}] {} - Attempt {}/{}: {}",
-                          componentOperationName,
-                          message,
-                          attempt,
-                          maxAttempts,
-                          e.what());
+            if (attempt < maxAttempts)
+            {
+                LOG_INFO_L(componentOperationName.c_str(),
+                           "[{}] {} - Attempt {}/{}: {}",
+                           componentOperationName,
+                           message,
+                           attempt,
+                           maxAttempts,
+                           e.what());
+            }
+            else
+            {
+                LOG_WARNING_L(componentOperationName.c_str(),
+                              "[{}] {} - Attempt {}/{}: {}",
+                              componentOperationName,
+                              message,
+                              attempt,
+                              maxAttempts,
+                              e.what());
+            }
             if (attempt < maxAttempts)
             {
                 // Split sleep into 1-second chunks for responsive abort
@@ -74,10 +87,8 @@ decltype(auto) executeWithRetry(Func&& operation,
                 {
                     if (shutdownRequested.load(std::memory_order_relaxed))
                     {
-                        throw std::runtime_error(fmt::format("{}::{} aborted during retry wait (attempt {})",
-                                                             message,
-                                                             componentOperationName,
-                                                             attempt));
+                        throw std::runtime_error(fmt::format(
+                            "{}::{} aborted during retry wait (attempt {})", message, componentOperationName, attempt));
                     }
                     std::this_thread::sleep_for(std::chrono::seconds(1));
                 }

--- a/src/engine/source/confremote/src/confremotemanager.cpp
+++ b/src/engine/source/confremote/src/confremotemanager.cpp
@@ -59,8 +59,7 @@ void ConfRemoteManager::synchronize()
             return;
         }
 
-        LOG_WARNING("Failed to synchronize remote settings. Keeping current state.");
-        LOG_DEBUG("Synchronize failure detail: {}.", e.what());
+        LOG_WARNING("[ConfRemote] Failed to synchronize remote settings: {}. Keeping current state.", e.what());
         return;
     }
 

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/mark_down_generator.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/documentation_generator/mark_down_generator.py
@@ -1,5 +1,6 @@
 from helper_test.documentation_generator.types import Documentation, Example
 from helper_test.documentation_generator.exporter import *
+from helper_test.runner import get_helper_test_kvdb_resource
 from collections import defaultdict
 from pathlib import Path
 from typing import List
@@ -215,6 +216,20 @@ class MarkdownGenerator(IExporter):
 
         self.content.append("\n")
 
+    def uses_test_kvdb(self, doc: Documentation) -> bool:
+        """
+        Return whether the helper documentation should include the helper test KVDB resource.
+        """
+        return doc.name.startswith("kvdb_") or "kvdb" in doc.keywords
+
+    def create_test_kvdb_section(self):
+        """
+        Add the KVDB resource used by KVDB helper examples.
+        """
+        self.content.append("## Test KVDB\n")
+        self.content.append("The examples for this helper use the following KVDB resource during tests:\n")
+        self.content.append("```json\n" + json.dumps(get_helper_test_kvdb_resource(), indent=2) + "\n```\n")
+
     def create_document(self, doc: Documentation):
         """
         Creates a Markdown document for a given helper function's documentation.
@@ -262,6 +277,9 @@ class MarkdownGenerator(IExporter):
 
         if doc.examples:
             self.create_tests_table(doc)
+
+        if self.uses_test_kvdb(doc):
+            self.create_test_kvdb_section()
 
         self.all_contents[doc.helper_type][doc.name] = {
             "keywords": doc.keywords,

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/runner.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/runner.py
@@ -43,6 +43,65 @@ HELPERS_INTEG_UUID   = "e9d1a9c3-8f2b-4a6a-9f4b-2c6d5e7f2b10"
 
 # KVDB resource UUID in CM
 KVDB_RESOURCE_UUID = "3c7d9b5e-2f4a-4b6a-9c1d-8e7a2b4c5d10"
+HELPER_TEST_ASSET_AUTHOR = "Wazuh Inc."
+HELPER_TEST_ASSET_DATE = "2025-10-06T13:32:19Z"
+
+
+def get_helper_test_asset_metadata(title: str, description: str) -> dict:
+    """
+    Return asset metadata following the ruleset asset format.
+    """
+    return {
+        "title": title,
+        "author": HELPER_TEST_ASSET_AUTHOR,
+        "date": HELPER_TEST_ASSET_DATE,
+        "description": description,
+    }
+
+
+def get_helper_test_kvdb_resource() -> dict:
+    """
+    Return the KVDB resource used by helper function tests.
+    """
+    return {
+        "id": KVDB_RESOURCE_UUID,
+        "metadata": get_helper_test_asset_metadata(
+            "windows_kerberos_status_code_to_code_name",
+            "KVDB resource used by helper function tests.",
+        ),
+        "content": {
+            "0x0": "KDC_ERR_NONE",
+            "0x1": "KDC_ERR_NAME_EXP",
+            "0x2": "KDC_ERR_SERVICE_EXP",
+            "0x3": "KDC_ERR_BAD_PVNO",
+            "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
+            "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
+            "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
+            "bitmask_test_values": [0, 1, 2, 3, 4, 16, 17, 18, 19, 20, 24, 28, 29, 30, 31],
+            "access_mask": {
+                "0": "Create Child",
+                "1": "Delete Child",
+                "2": "List Contents",
+                "3": "SELF",
+                "4": "Read Property",
+                "5": "Write Property",
+                "6": "Delete Tree",
+                "7": "List Object",
+                "8": "Control Access",
+                "16": "DELETE",
+                "17": "READ_CONTROL",
+                "18": "WRITE_DAC",
+                "19": "WRITE_OWNER",
+                "20": "SYNCHRONIZE",
+                "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
+                "31": "ADS_RIGHT_GENERIC_READ",
+                "30": "ADS_RIGHT_GENERIC_WRITE",
+                "29": "ADS_RIGHT_GENERIC_EXECUTE",
+                "28": "ADS_RIGHT_GENERIC_ALL",
+            },
+        },
+        "enabled": True,
+    }
 
 
 # ===================================================================
@@ -477,7 +536,10 @@ def create_helpers_integration(api_client: APIClient):
     integration_json = json.dumps(
         {
             "id": HELPERS_INTEG_UUID,
-            "metadata": {"title": "helpers-test"},
+            "metadata": get_helper_test_asset_metadata(
+                "helpers-test",
+                "Integration used by helper function tests.",
+            ),
             "enabled": True,
             "category": "other",
             "default_parent": HELPERS_DECODER_UUID,
@@ -505,7 +567,10 @@ def create_policy(api_client: APIClient):
         {
             "type": "policy",
             "enabled": True,
-            "metadata": {"title": "Helpers Testing Policy"},
+            "metadata": get_helper_test_asset_metadata(
+                "Helpers Testing Policy",
+                "Policy used by helper function tests.",
+            ),
             "hash": "helpers-test-hash",
             "enrichments": [],
             "filters": [],
@@ -558,49 +623,7 @@ def create_kvdb_resource(api_client: APIClient):
     Create or update a KVDB resource in POLICY_NS using valid JSON content.
     """
 
-    kvdb_json = {
-        "id": KVDB_RESOURCE_UUID,
-        "date": "2025-10-06T13:32:19Z",
-        "metadata": {"title": "windows_kerberos_status_code_to_code_name"},
-        "author": "Wazuh Inc.",
-        "content": {
-
-            "0x0": "KDC_ERR_NONE",
-            "0x1": "KDC_ERR_NAME_EXP",
-            "0x2": "KDC_ERR_SERVICE_EXP",
-            "0x3": "KDC_ERR_BAD_PVNO",
-            "0x4": "KDC_ERR_C_OLD_MAST_KVNO",
-            "0x5": "KDC_ERR_S_OLD_MAST_KVNO",
-            "0x6": "KDC_ERR_C_PRINCIPAL_UNKNOWN",
-
-
-            "bitmask_test_values": [0, 1, 2, 3, 4, 16, 17, 18, 19, 20, 24, 28, 29, 30, 31],
-
-
-            "access_mask": {
-                "0": "Create Child",
-                "1": "Delete Child",
-                "2": "List Contents",
-                "3": "SELF",
-                "4": "Read Property",
-                "5": "Write Property",
-                "6": "Delete Tree",
-                "7": "List Object",
-                "8": "Control Access",
-                "16": "DELETE",
-                "17": "READ_CONTROL",
-                "18": "WRITE_DAC",
-                "19": "WRITE_OWNER",
-                "20": "SYNCHRONIZE",
-                "24": "ADS_RIGHT_ACCESS_SYSTEM_SECURITY",
-                "31": "ADS_RIGHT_GENERIC_READ",
-                "30": "ADS_RIGHT_GENERIC_WRITE",
-                "29": "ADS_RIGHT_GENERIC_EXECUTE",
-                "28": "ADS_RIGHT_GENERIC_ALL"
-            },
-        },
-        "enabled": True,
-    }
+    kvdb_json = get_helper_test_kvdb_resource()
 
     req = api_crud.resourcePost_Request()
     req.space = POLICY_NS

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -670,7 +670,7 @@ private:
             {
                 std::lock_guard<std::mutex> lock(errorsMutex);
                 errors.push_back("Slice " + std::to_string(sliceId) + ": " + e.what());
-                logError(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
+                logDebug1(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
             }
         };
 

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -670,7 +670,7 @@ private:
             {
                 std::lock_guard<std::mutex> lock(errorsMutex);
                 errors.push_back("Slice " + std::to_string(sliceId) + ": " + e.what());
-                logDebug1(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
+                logError(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
             }
         };
 

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -50,6 +50,8 @@ class TMonitoring final
     std::atomic<bool> m_stop {false};
     uint32_t m_interval {INTERVAL};
     THttpRequest* m_httpRequest;
+    std::map<std::string, std::string, std::less<>> m_unavailableReasonByServer;
+    std::map<std::string, bool, std::less<>> m_previousServerAvailability;
 
     /**
      * @brief Checks the health of a server.
@@ -65,6 +67,10 @@ class TMonitoring final
     void healthCheck(const std::string& serverAddress, const SecureCommunication& authentication)
     {
         auto& serverStatus = m_servers[serverAddress];
+        const auto previousAvailability = m_previousServerAvailability.find(serverAddress);
+        const bool wasAvailable =
+            previousAvailability == m_previousServerAvailability.end() || previousAvailability->second;
+        std::string unavailableReason;
 
         // Set the server status to unavailable by default
         serverStatus = false;
@@ -105,8 +111,8 @@ class TMonitoring final
         };
 
         // On error callback
-        const auto onError =
-            [&serverAddress](const std::string& error, const long statusCode, const std::string& errorBody)
+        const auto onError = [&serverAddress, &unavailableReason](
+                                 const std::string& error, const long statusCode, const std::string& errorBody)
         {
             // LCOV_EXCL_START
             //  Try to extract error details from JSON
@@ -137,51 +143,36 @@ class TMonitoring final
             {
                 if (!errorType.empty() && !errorReason.empty())
                 {
-                    logDebug2(MONITOR_NAME,
-                              "Health check failed for '%s' - type: '%s', reason: '%s' - Check indexer credentials",
-                              serverAddress.c_str(),
-                              errorType.c_str(),
-                              errorReason.c_str());
+                    unavailableReason =
+                        "Unauthorized (" + errorType + ": " + errorReason + ") - Check indexer credentials";
                 }
                 else
                 {
-                    logDebug2(MONITOR_NAME,
-                              "Health check failed for '%s' - Unauthorized - Check indexer credentials",
-                              serverAddress.c_str());
+                    unavailableReason = "Unauthorized - Check indexer credentials";
                 }
             }
             else if (statusCode == 403)
             {
                 if (!errorType.empty() && !errorReason.empty())
                 {
-                    logDebug2(MONITOR_NAME,
-                              "Health check failed for '%s' - type: '%s', reason: '%s' - Check user permissions",
-                              serverAddress.c_str(),
-                              errorType.c_str(),
-                              errorReason.c_str());
+                    unavailableReason = "Forbidden (" + errorType + ": " + errorReason + ") - Check user permissions";
                 }
                 else
                 {
-                    logDebug2(MONITOR_NAME,
-                              "Health check failed for '%s' - Forbidden - Check user permissions",
-                              serverAddress.c_str());
+                    unavailableReason = "Forbidden - Check user permissions";
                 }
             }
             else if (statusCode >= 500)
             {
-                logDebug2(MONITOR_NAME,
-                          "Health check failed for '%s' - Server error (%ld)",
-                          serverAddress.c_str(),
-                          statusCode);
+                unavailableReason = "Server error (HTTP " + std::to_string(statusCode) + ")";
             }
             else
             {
-                logDebug2(MONITOR_NAME,
-                          "Health check failed for '%s' - status: %ld, error: %s",
-                          serverAddress.c_str(),
-                          statusCode,
-                          error.c_str());
+                unavailableReason = error.empty() ? "status: " + std::to_string(statusCode) : error;
             }
+
+            logDebug2(
+                MONITOR_NAME, "Health check failed for '%s' - %s", serverAddress.c_str(), unavailableReason.c_str());
         };
         // LCOV_EXCL_STOP
 
@@ -192,6 +183,34 @@ class TMonitoring final
         m_httpRequest->get(RequestParameters {.url = HttpURL(url), .secureCommunication = authentication},
                            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                            ConfigurationParameters {.timeout = HEALTH_CHECK_TIMEOUT_MS});
+
+        if (!serverStatus && unavailableReason.empty())
+        {
+            unavailableReason = "Cluster reported unhealthy status";
+        }
+
+        if (!serverStatus)
+        {
+            m_unavailableReasonByServer[serverAddress] = unavailableReason;
+        }
+        else
+        {
+            m_unavailableReasonByServer.erase(serverAddress);
+        }
+
+        if (wasAvailable && !serverStatus)
+        {
+            logInfo(MONITOR_NAME,
+                    "Indexer node '%s' is no longer available. Reason: %s",
+                    serverAddress.c_str(),
+                    unavailableReason.c_str());
+        }
+        else if (!wasAvailable && serverStatus)
+        {
+            logInfo(MONITOR_NAME, "Indexer node '%s' is available again.", serverAddress.c_str());
+        }
+
+        m_previousServerAvailability[serverAddress] = serverStatus;
     }
 
     /**
@@ -287,6 +306,30 @@ public:
             throw std::out_of_range("Server not found in monitoring");
         }
         return it->second;
+    }
+
+    std::string getUnavailableServersDetails()
+    {
+        std::scoped_lock lock(m_mutex);
+        std::string result;
+        for (const auto& [serverAddress, available] : m_servers)
+        {
+            if (available)
+            {
+                continue;
+            }
+
+            const auto unavailableReason = m_unavailableReasonByServer.find(serverAddress);
+            if (!result.empty())
+            {
+                result += "; ";
+            }
+            result += serverAddress + ": " +
+                      (unavailableReason == m_unavailableReasonByServer.end() ? std::string {"unknown"}
+                                                                              : unavailableReason->second);
+        }
+
+        return result.empty() ? "no error details available" : result;
     }
 };
 

--- a/src/shared_modules/indexer_connector/src/serverSelector.hpp
+++ b/src/shared_modules/indexer_connector/src/serverSelector.hpp
@@ -63,7 +63,8 @@ public:
             retValue = RoundRobinSelector<std::string>::getNext();
             if (retValue.compare(initialValue) == 0)
             {
-                throw std::runtime_error("No available server");
+                throw std::runtime_error("No available server. Unavailable nodes: " +
+                                         m_monitoring->getUnavailableServersDetails());
             }
         }
         return retValue;


### PR DESCRIPTION
# Description

This PR reduces noisy and duplicated warning/error messages emitted when the manager cannot connect to the indexer during CMSync, ConfRemote, IndexerDownloader, and Indexer Connector operations.

The previous behavior logged repeated warnings for intermediate retry attempts and later surfaced a generic `No available server` message. That made it hard to distinguish between different indexer connection problems, such as an indexer being down, bad credentials, certificate/TLS issues, or other connection failures.

Closes #36772 


# Proposed Changes

- Reduce retry log noise by logging intermediate retry attempts as `INFO` and keeping `WARNING` only for the final failed attempt.
- Preserve the real indexer connection failure reason per node during health checks, so callers no longer receive only a generic `No available server` error.
- Expand `No available server` with the unavailable node list and its concrete reason, for example connection refused, TLS/certificate validation failure, or invalid credentials.
- Log indexer node availability transitions when a node becomes unavailable or available again, instead of relying only on repeated health-check debug messages.
- Make ConfRemote warnings easier to trace by including the module context in the final synchronization warning.
- Move IndexerDownloader per-slice failures to debug-level logs to avoid duplicated warnings when the higher-level operation already reports the retry/failure.

## Additional requested changes (unrelated to #36772)

The following changes are not related to the indexer connection logging issue, but were included in this PR by request:

- Document the test KVDB resource at the end of every generated helper-function section that uses KVDB helpers.
- Align the metadata generated for helper-test KVDB, integration, and policy assets with the asset metadata structure used by `wazuh-decoders`, keeping `title`, `author`, `date`, and `description` inside `metadata`.

# Evidence

## Build and Install

```bash

General settings:
    TARGET:             manager
    V:                  
    DEBUG:              yes
    INSTALLDIR:         
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29734
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh-manager
    WAZUH_USER:         wazuh-manager
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                cc
    MAKE              /usr/bin/make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building manager

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/36772-reduce-indexer-connection-log-noise› 
╰─# service wazuh-manager status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/36772-reduce-indexer-connection-log-noise› 
╰─# engine-private ns list                                                                                                                           1 ↵
engine-router list

- cmsync_standard_67c3

- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_67c3
  priority: 1
  uptime: 65

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh/src/build ‹bug/36772-reduce-indexer-connection-log-noise› 
╰─# ctest --test-dir /workspaces/Wazuh_5x/wazuh/src/build/engine  --output-on-failure -j4


100% tests passed, 0 tests failed out of 9740

Total Test time (real) = 216.97 sec

```
```console

2026/06/19 04:58:45 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/06/19 04:58:45 wazuh-manager-analysisd: INFO: Dumper Events initialized.
2026/06/19 04:58:45 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/06/19 04:58:45 wazuh-manager-analysisd: INFO: Engine started.
2026/06/19 04:58:45 wazuh-manager-analysisd: INFO: Scheduler started.

2026/06/19 04:58:56 wazuh-manager-monitord: INFO: wazuh: Manager started.
```

## Testing

### Scenario : one unavailable indexer node, at least one healthy node

Expected behavior: the unavailable node is reported, but indexing succeeds because another configured indexer node is available.

Config:

```json
{
  "name": "three-hosts-one-bad-regenerated",
  "hosts": [
    "https://127.0.0.1:9200",
    "https://127.0.0.1:19200",
    "https://127.0.0.1:9200"
  ],
  "username": "admin",
  "password": "admin",
  "ssl": {
    "certificate_authorities": [
      "/workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e/certs/root-ca.pem"
    ]
  },
  "index": "wazuh-test-indexer-connector"
}
```

Event :

```json
[
  {
    "id": "test-001",
    "operation": "INSERT",
    "data": {
      "message": "test with indexer connector failure scenarios",
      "source": "indexer_connector_tool"
    }
  }
]
```

Command:

```bash

./build/bin/indexer_connector_tool push-events \
  -c /tmp/indexer-3hosts-one-bad.json \
  -e /tmp/indexer-event.json \
  -L 5 \
  -D 2 \
  -l /tmp/indexer-tool-one-bad.log
```

Before:

```console
monitoring:monitoring.hpp:179 operator() : Health check failed for 'https://127.0.0.1:19200' - status: -1, error: Could not connect to server
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:1318 bulkIndex : No version specified for document doc-0, using default versioning
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:430 processBulk : Sending bulk data to: https://127.0.0.1:9200/_bulk
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:431 processBulk : Bulk data: {"index":{"_index":"wazuh-test-indexer-connector","_id":"doc-0"}}
{"data":{"message":"test with indexer connector failure scenarios","source":"indexer_connector_tool"},"id":"test-001","operation":"INSERT"}

testtool (indexer-connector):indexerConnectorSyncImpl.hpp:354 operator() : Response: {"took":214,"errors":false,"items":[{"index":{"_index":"wazuh-test-indexer-connector","_id":"doc-0","_version":2,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":1,"_primary_term":2,"status":200}}]}
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:140 validateBulkResponse : Bulk operation completed with no errors
```

After:

```console
monitoring:monitoring.hpp:172 operator() : Health check failed for 'https://127.0.0.1:19200' - Could not connect to server
monitoring:monitoring.hpp:201 healthCheck : Indexer node 'https://127.0.0.1:19200' is no longer available. Reason: Could not connect to server
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:1318 bulkIndex : No version specified for document doc-0, using default versioning
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:430 processBulk : Sending bulk data to: https://127.0.0.1:9200/_bulk
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:431 processBulk : Bulk data: {"index":{"_index":"wazuh-test-indexer-connector","_id":"doc-0"}}
{"data":{"message":"test with indexer connector failure scenarios","source":"indexer_connector_tool"},"id":"test-001","operation":"INSERT"}

testtool (indexer-connector):indexerConnectorSyncImpl.hpp:354 operator() : Response: {"took":172,"errors":false,"items":[{"index":{"_index":"wazuh-test-indexer-connector","_id":"doc-0","_version":3,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":2,"_primary_term":2,"status":200}}]}
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:140 validateBulkResponse : Bulk operation completed with no errors
```

### Scenario : all indexer nodes unavailable

Expected behavior: indexing fails, and the final error includes the reason for each unavailable node.

Config:

```json
{
  "name": "all-hosts-bad",
  "hosts": [
    "https://127.0.0.1:19200",
    "https://127.0.0.1:19201"
  ],
  "username": "admin",
  "password": "admin",
  "ssl": {
    "certificate_authorities": [
      "/workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e/certs/root-ca.pem"
    ]
  },
  "index": "wazuh-test-indexer-connector"
}
```

Event:

```json
[
  {
    "id": "test-001",
    "operation": "INSERT",
    "data": {
      "message": "test with indexer connector failure scenarios",
      "source": "indexer_connector_tool"
    }
  }
]
```

Command:

```bash

./build/bin/indexer_connector_tool push-events \
  -c /tmp/indexer-all-bad.json \
  -e /tmp/indexer-event.json \
  -L 1 \
  -D 1 \
  -l /tmp/indexer-tool-all-bad.log
```

Before:

```console
monitoring:monitoring.hpp:179 operator() : Health check failed for 'https://127.0.0.1:19200' - status: -1, error: Could not connect to server
monitoring:monitoring.hpp:179 operator() : Health check failed for 'https://127.0.0.1:19201' - status: -1, error: Could not connect to server
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:1318 bulkIndex : No version specified for document doc-0, using default versioning
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:724 operator() : Cannot process bulk: No available server
```

After:

```console
monitoring:monitoring.hpp:172 operator() : Health check failed for 'https://127.0.0.1:19200' - Could not connect to server
monitoring:monitoring.hpp:201 healthCheck : Indexer node 'https://127.0.0.1:19200' is no longer available. Reason: Could not connect to server
monitoring:monitoring.hpp:172 operator() : Health check failed for 'https://127.0.0.1:19201' - Could not connect to server
monitoring:monitoring.hpp:201 healthCheck : Indexer node 'https://127.0.0.1:19201' is no longer available. Reason: Could not connect to server
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:1318 bulkIndex : No version specified for document doc-0, using default versioning
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:724 operator() : Cannot process bulk: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server; https://127.0.0.1:19201: Could not connect to server
```

### Scenario : bad indexer credentials

Expected behavior: indexing fails, and the final error identifies the authentication problem instead of only reporting a generic unavailable server.

Config:

```json
{
  "name": "bad-credentials",
  "hosts": [
    "https://127.0.0.1:9200"
  ],
  "username": "admin",
  "password": "wrong-password",
  "ssl": {
    "certificate_authorities": [
      "/workspaces/Wazuh_5x/wazuh/src/engine/tools/devContainer/e2e/certs/root-ca.pem"
    ]
  },
  "index": "wazuh-test-indexer-connector"
}
```

Event:

```json
[
  {
    "id": "test-001",
    "operation": "INSERT",
    "data": {
      "message": "test with indexer connector failure scenarios",
      "source": "indexer_connector_tool"
    }
  }
]
```

Command:

```bash

cd /workspaces/Wazuh_5x/wazuh/src

./build/bin/indexer_connector_tool push-events \
  -c /tmp/indexer-bad-credentials.json \
  -e /tmp/indexer-event.json \
  -L 1 \
  -D 1 \
  -l /tmp/indexer-tool-bad-credentials.log

```


Before:

```console
monitoring:monitoring.hpp:148 operator() : Health check failed for 'https://127.0.0.1:9200' - Unauthorized - Check indexer credentials
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:1318 bulkIndex : No version specified for document doc-0, using default versioning
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:724 operator() : Cannot process bulk: No available server
```

After:

```console
monitoring:monitoring.hpp:172 operator() : Health check failed for 'https://127.0.0.1:9200' - Unauthorized - Check indexer credentials
monitoring:monitoring.hpp:201 healthCheck : Indexer node 'https://127.0.0.1:9200' is no longer available. Reason: Unauthorized - Check indexer credentials
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:1318 bulkIndex : No version specified for document doc-0, using default versioning
testtool (indexer-connector):indexerConnectorSyncImpl.hpp:724 operator() : Cannot process bulk: No available server. Unavailable nodes: https://127.0.0.1:9200: Unauthorized - Check indexer credentials
```

### Manager scenario: unavailable indexer host

Expected behavior: manager components report the unavailable indexer with the concrete connection reason, intermediate retry attempts are logged as `INFO`, and only the final retry attempt is logged as `WARNING`.

```bash

# Config: indexer host temporarily changed from https://127.0.0.1:9200
# to https://127.0.0.1:19200 in /var/wazuh-manager/etc/wazuh-manager.conf.

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/36772-reduce-indexer-connection-log-noise› 
╰─# : > /var/wazuh-manager/logs/wazuh-manager.log
service wazuh-manager start
sleep 120


```


Before:

```console
2026/06/19 04:00:21 monitoring[252322] monitoring.hpp:179 at operator()(): DEBUG: Health check failed for 'https://127.0.0.1:19200' - status: -1, error: Could not connect to server

2026/06/19 04:00:28 wazuh-manager-analysisd[252322] metaHelpers.hpp:63 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 1/3: No available server
2026/06/19 04:00:33 wazuh-manager-analysisd[252322] metaHelpers.hpp:63 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 2/3: No available server
2026/06/19 04:00:38 wazuh-manager-analysisd[252322] metaHelpers.hpp:63 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 3/3: No available server

2026/06/19 04:00:22 wazuh-manager-analysisd[252322] metaHelpers.hpp:63 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 1/3: No available server
2026/06/19 04:00:27 wazuh-manager-analysisd[252322] metaHelpers.hpp:63 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 2/3: No available server
2026/06/19 04:00:32 wazuh-manager-analysisd[252322] metaHelpers.hpp:63 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 3/3: No available server
2026/06/19 04:00:32 wazuh-manager-analysisd[252322] cmsync.cpp:684 at synchronize(): WARNING: [CMSync] Failed to synchronize namespace for space 'standard': Check 'standard' space in wazuh-indexer::CMSync failed after 3 attempts: No available server

2026/06/19 04:00:29 wazuh-manager-modulesd:content-updater[252825] IndexerDownloader.hpp:276 at waitUntilConsumerIdle(): WARNING: IndexerDownloader: Failed to query consumer 'cti:catalog:consumer:vulnerabilities' in '.wazuh-cti-consumers' (No available server). Waiting 60 s before retrying.
```

After:

```console
2026/06/18 20:49:16 monitoring[98766] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://127.0.0.1:19200' is no longer available. Reason: Could not connect to server

2026/06/18 20:49:20 wazuh-manager-analysisd[98766] metaHelpers.hpp:65 at ConfRemote(): INFO: [ConfRemote] Checking remote settings from indexer - Attempt 1/3: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server
2026/06/18 20:49:25 wazuh-manager-analysisd[98766] metaHelpers.hpp:65 at ConfRemote(): INFO: [ConfRemote] Checking remote settings from indexer - Attempt 2/3: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server
2026/06/18 20:49:30 wazuh-manager-analysisd[98766] metaHelpers.hpp:75 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 3/3: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server
2026/06/18 20:49:30 wazuh-manager-analysisd[98766] confremotemanager.cpp:62 at synchronize(): WARNING: [ConfRemote] Failed to synchronize remote settings: Checking remote settings from indexer::ConfRemote failed after 3 attempts: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server. Keeping current state.

2026/06/18 20:50:29 wazuh-manager-analysisd[98766] metaHelpers.hpp:65 at CMSync(): INFO: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 1/3: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server
2026/06/18 20:50:34 wazuh-manager-analysisd[98766] metaHelpers.hpp:65 at CMSync(): INFO: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 2/3: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server
2026/06/18 20:50:39 wazuh-manager-analysisd[98766] metaHelpers.hpp:75 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 3/3: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server
2026/06/18 20:50:39 wazuh-manager-analysisd[98766] cmsync.cpp:684 at synchronize(): WARNING: [CMSync] Failed to synchronize namespace for space 'standard': Check 'standard' space in wazuh-indexer::CMSync failed after 3 attempts: No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server

2026/06/18 20:49:23 wazuh-manager-modulesd:content-updater[99125] IndexerDownloader.hpp:276 at waitUntilConsumerIdle(): WARNING: IndexerDownloader: Failed to query consumer 'cti:catalog:consumer:vulnerabilities' in '.wazuh-cti-consumers' (No available server. Unavailable nodes: https://127.0.0.1:19200: Could not connect to server). Waiting 60 s before retrying.
```

### Manager scenario: invalid indexer CA

Expected behavior: manager components report the unavailable indexer with the concrete TLS/certificate reason, intermediate retry attempts are logged as `INFO`, and only the final retry attempt is logged as `WARNING`.


```bash

# Config: indexer CA temporarily changed from etc/certs/root-ca.pem
# to etc/certs/manager.pem in /var/wazuh-manager/etc/wazuh-manager.conf.

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/36772-reduce-indexer-connection-log-noise› 
╰─# : > /var/wazuh-manager/logs/wazuh-manager.log
service wazuh-manager start
sleep 120

```

Before:

```console
2026/06/19 04:10:10 monitoring[257087] monitoring.hpp:179 at operator()(): DEBUG: Health check failed for 'https://127.0.0.1:9200' - status: -1, error: SSL peer certificate or SSH remote key was not OK

2026/06/19 04:10:11 wazuh-manager-analysisd[257087] metaHelpers.hpp:63 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 1/3: No available server
2026/06/19 04:10:16 wazuh-manager-analysisd[257087] metaHelpers.hpp:63 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 2/3: No available server
2026/06/19 04:10:21 wazuh-manager-analysisd[257087] metaHelpers.hpp:63 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 3/3: No available server

2026/06/19 04:10:11 wazuh-manager-analysisd[257087] metaHelpers.hpp:63 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 1/3: No available server
2026/06/19 04:10:16 wazuh-manager-analysisd[257087] metaHelpers.hpp:63 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 2/3: No available server
2026/06/19 04:10:21 wazuh-manager-analysisd[257087] metaHelpers.hpp:63 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 3/3: No available server
2026/06/19 04:10:21 wazuh-manager-analysisd[257087] cmsync.cpp:684 at synchronize(): WARNING: [CMSync] Failed to synchronize namespace for space 'standard': Check 'standard' space in wazuh-indexer::CMSync failed after 3 attempts: No available server

2026/06/19 04:10:14 wazuh-manager-modulesd:content-updater[257456] IndexerDownloader.hpp:276 at waitUntilConsumerIdle(): WARNING: IndexerDownloader: Failed to query consumer 'cti:catalog:consumer:vulnerabilities' in '.wazuh-cti-consumers' (No available server). Waiting 60 s before retrying.
```

After:

```console
2026/06/18 21:16:50 monitoring[109934] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://127.0.0.1:9200' is no longer available. Reason: SSL peer certificate or SSH remote key was not OK

2026/06/18 21:16:54 wazuh-manager-analysisd[109934] metaHelpers.hpp:65 at ConfRemote(): INFO: [ConfRemote] Checking remote settings from indexer - Attempt 1/3: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK
2026/06/18 21:16:59 wazuh-manager-analysisd[109934] metaHelpers.hpp:65 at ConfRemote(): INFO: [ConfRemote] Checking remote settings from indexer - Attempt 2/3: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK
2026/06/18 21:17:04 wazuh-manager-analysisd[109934] metaHelpers.hpp:75 at ConfRemote(): WARNING: [ConfRemote] Checking remote settings from indexer - Attempt 3/3: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK
2026/06/18 21:17:04 wazuh-manager-analysisd[109934] confremotemanager.cpp:62 at synchronize(): WARNING: [ConfRemote] Failed to synchronize remote settings: Checking remote settings from indexer::ConfRemote failed after 3 attempts: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK. Keeping current state.

2026/06/18 21:18:03 wazuh-manager-analysisd[109934] metaHelpers.hpp:65 at CMSync(): INFO: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 1/3: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK
2026/06/18 21:18:08 wazuh-manager-analysisd[109934] metaHelpers.hpp:65 at CMSync(): INFO: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 2/3: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK
2026/06/18 21:18:13 wazuh-manager-analysisd[109934] metaHelpers.hpp:75 at CMSync(): WARNING: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 3/3: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK
2026/06/18 21:18:13 wazuh-manager-analysisd[109934] cmsync.cpp:684 at synchronize(): WARNING: [CMSync] Failed to synchronize namespace for space 'standard': Check 'standard' space in wazuh-indexer::CMSync failed after 3 attempts: No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK

2026/06/18 21:16:57 wazuh-manager-modulesd:content-updater[110324] IndexerDownloader.hpp:276 at waitUntilConsumerIdle(): WARNING: IndexerDownloader: Failed to query consumer 'cti:catalog:consumer:vulnerabilities' in '.wazuh-cti-consumers' (No available server. Unavailable nodes: https://127.0.0.1:9200: SSL peer certificate or SSH remote key was not OK). Waiting 60 s before retrying.
```


### Updated metada and added database on documentation

<img width="642" height="800" alt="Captura desde 2026-06-18 19-59-53" src="https://github.com/user-attachments/assets/59e53055-1758-4d33-a8c3-0b6bf5e5eaf7" />
