### PR TITLE
Migrate agent build workflows to AWS CodeBuild runners

### DIFF
--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -59,7 +59,7 @@ jobs:
   # ===================== DEB JOBS =====================
   build-deb-arm64:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'deb'
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Build DEB package
     outputs:
@@ -85,6 +85,37 @@ jobs:
           echo "TAG=$VERSION" >> $GITHUB_ENV
           echo "CONTAINER_NAME=pkg_deb_agent_builder_${ARCH}" >> $GITHUB_ENV
           echo "SYSTEM=deb" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for package building
         run: |
@@ -147,7 +178,7 @@ jobs:
 
   test-deb-arm64:
     needs: build-deb-arm64
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test DEB package
 
@@ -169,6 +200,37 @@ jobs:
           echo "TAG=${{ needs.build-deb-arm64.outputs.tag }}" >> $GITHUB_ENV
           echo "ARCH=arm64" >> $GITHUB_ENV
           echo "SYSTEM=deb" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for testing
         run: |
@@ -231,7 +293,7 @@ jobs:
   upload-deb-arm64-to-s3:
     needs: [build-deb-arm64, test-deb-arm64]
     if: success()
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload DEB to S3
 
@@ -311,7 +373,7 @@ jobs:
   # ===================== RPM JOBS =====================
   build-rpm-arm64:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'rpm'
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Build RPM package
     outputs:
@@ -337,6 +399,37 @@ jobs:
           echo "TAG=$VERSION" >> $GITHUB_ENV
           echo "CONTAINER_NAME=pkg_rpm_agent_builder_${ARCH}" >> $GITHUB_ENV
           echo "SYSTEM=rpm" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for package building
         run: |
@@ -399,7 +492,7 @@ jobs:
 
   test-rpm-arm64:
     needs: build-rpm-arm64
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test RPM package
 
@@ -421,6 +514,37 @@ jobs:
           echo "TAG=${{ needs.build-rpm-arm64.outputs.tag }}" >> $GITHUB_ENV
           echo "ARCH=arm64" >> $GITHUB_ENV
           echo "SYSTEM=rpm" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for testing
         run: |
@@ -483,7 +607,7 @@ jobs:
   upload-rpm-arm64-to-s3:
     needs: [build-rpm-arm64, test-rpm-arm64]
     if: success()
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload RPM to S3
 

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -65,7 +65,7 @@ jobs:
   # ===================== DEB JOBS =====================
   build-deb:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'deb'
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Build DEB ${{ matrix.arch }} package
     strategy:
@@ -91,6 +91,37 @@ jobs:
           echo "TAG=$VERSION" >> $GITHUB_ENV
           echo "CONTAINER_NAME=pkg_deb_agent_builder_${ARCH}" >> $GITHUB_ENV
           echo "SYSTEM=deb" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for package building
         run: |
@@ -153,7 +184,7 @@ jobs:
 
   test-deb:
     needs: build-deb
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test DEB ${{ matrix.arch }} package
     strategy:
@@ -192,6 +223,37 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "CONTAINER_NAME=pkg_deb_agent_builder_${{ matrix.arch }}" >> $GITHUB_ENV
           echo "TAG=$VERSION" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for testing
         run: |
@@ -274,7 +336,7 @@ jobs:
   upload-deb-to-s3:
     needs: [build-deb, test-deb]
     if: success()
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload DEB ${{ matrix.arch }} to S3
     strategy:
@@ -337,7 +399,7 @@ jobs:
   # ===================== RPM JOBS =====================
   build-rpm:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.draft) || inputs.system == 'rpm'
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Build RPM ${{ matrix.arch }} package
     strategy:
@@ -370,6 +432,37 @@ jobs:
           echo "TAG=$VERSION" >> $GITHUB_ENV
           echo "CONTAINER_NAME=pkg_rpm_agent_builder_${ARCH}" >> $GITHUB_ENV
           echo "SYSTEM=rpm" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for package building
         run: |
@@ -432,7 +525,7 @@ jobs:
 
   test-rpm:
     needs: build-rpm
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test RPM ${{ matrix.arch }} package
     strategy:
@@ -479,6 +572,37 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "CONTAINER_NAME=pkg_rpm_agent_builder_${{ matrix.arch }}" >> $GITHUB_ENV
           echo "TAG=$VERSION" >> $GITHUB_ENV
+
+      - name: CodeBuild workarounds
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+        run: |
+          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
+          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          #    which the older git inside builder Docker images cannot read.
+          git config core.repositoryformatversion 0
+          # Install uuidgen
+          if ! command -v uuidgen >/dev/null 2>&1; then
+            sudo apt-get install -y uuid-runtime
+          fi
+          # 3. pip: the get-last-stable-version / get-upgrade-test-package-url actions
+          #    install requests/packaging via pip, which the CodeBuild image lacks.
+          if ! python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get install -y python3-pip
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
+          password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for testing
         run: |
@@ -561,7 +685,7 @@ jobs:
   upload-rpm-to-s3:
     needs: [build-rpm, test-rpm]
     if: success()
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload RPM ${{ matrix.arch }} to S3
     strategy:

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -207,7 +207,7 @@ jobs:
   upload-macos-intel64-to-s3:
     needs: [build-macos-intel64, test-macos-intel64]
     if: success()
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload PKG to S3 (intel64)
 
@@ -438,7 +438,7 @@ jobs:
   upload-macos-arm64-to-s3:
     needs: [build-macos-arm64, test-macos-arm64]
     if: success()
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload PKG to S3 (arm64)
 

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -69,7 +69,7 @@ jobs:
 
   build-windows-i686:
     needs: detect-changes
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     name: Build Windows agent binaries
     outputs:
@@ -83,6 +83,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64 make
+
+      - name: Install a compatible CMake
+        # TODO(codebuild-temp): Remove when CodeBuild base images ship cmake.
+        # The winagent deps build (make -C src deps) builds cmocka with cmake internally.
+        uses: ./.github/actions/reinstall_cmake
 
       - name: Set VERSION
         id: set-version
@@ -327,7 +332,7 @@ jobs:
   upload-windows-i686-to-s3:
     needs: [package-windows-i686, test-windows-i686]
     if: success()
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     name: Upload MSI to S3
 

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -290,6 +290,13 @@ jobs:
           & checkfiles_env\Scripts\Activate.ps1
           python -m pip install --upgrade pip
           python -m pip install -r .github/actions/check_files/requirements.txt
+          # pywin32 is Windows-only, so it is NOT in the shared check_files
+          # requirements.txt (that file is also installed on Linux/macOS runners).
+          # check_files.py imports win32file on Windows; install it here and run the
+          # post-install so the win32 DLLs load inside the isolated venv (otherwise
+          # it fails with "No module named 'win32file'" / "DLL load failed").
+          python -m pip install pywin32==308
+          python checkfiles_env\Scripts\pywin32_postinstall.py -install
 
       - name: Check installed files
         shell: pwsh


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Migrate the runners of the **5.x agent package build workflows** from the self-hosted
`wz-linux-amd64` / `wz-linux-arm64` labels to **AWS CodeBuild** runner labels. This is
the first step of the agent workflow migration to CodeBuild and follows the pattern
already merged for the server/manager workflows in #37012.

Scope of this PR is limited to the **agent build (`5_builderpackage_agent-*`) workflows**.
Test workflows (RTR / integration) and the Windows/macOS *native* runners
(`windows-2022`, `macos-1x`) are out of scope and stay on their current runners.

Part of #37027.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

Swap the self-hosted runner labels for the agent CodeBuild fleet labels
(`codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}`
and the `-agent-arm-` variant) and add the host setup required by the CodeBuild base image.

Runner migration (`wz-*` → CodeBuild):

- **`5_builderpackage_agent-linux.yml`** — 6 jobs `wz-linux-amd64` → `runner-agent-amd`.
- **`5_builderpackage_agent-linux-arm64.yml`** — 6 jobs `wz-linux-arm64` → `runner-agent-arm`.
- **`5_builderpackage_agent-windows.yml`** — 2 Linux jobs `wz-linux-amd64` → `runner-agent-amd`
  (the Linux cross-compile + the S3 upload; the `windows-2022` packaging/test jobs are untouched).
- **`5_builderpackage_agent-macos.yml`** — 2 Linux jobs `wz-linux-amd64` → `runner-agent-amd`
  (S3 upload jobs; the `macos-1x` build/test jobs are untouched).

Per-job handling:

- **Docker-based build/test jobs** (DEB/RPM build and test): add a `CodeBuild workarounds`
  step before any Docker usage, which:
  1. Starts `dockerd` with the **VFS** storage driver (CodeBuild has no systemd, so the
     daemon never starts on its own; VFS avoids unsupported overlay-on-overlay).
  2. Sets `git config core.repositoryformatversion 0` so the older git inside the builder
     Docker images can read the repo checked out by `actions/checkout`.
  3. Installs `uuidgen` (`uuid-runtime`).
  4. Installs `python3-pip` — the `get-last-stable-version` / `get-upgrade-test-package-url`
     actions install `requests`/`packaging` via pip, which the CodeBuild image lacks.

  These jobs also add a **Docker Hub login** step to avoid anonymous pull rate limits.
- **Windows cross-compile build** (`build-windows-i686`): adds `reinstall_cmake` (the
  winagent deps build compiles cmocka with cmake internally).
- **S3 upload jobs**: label swap only (no Docker, no checkout).

The shared actions touched by #37012 (`check_files` dropping `sudo`, `reinstall_cmake`
adding `hash -r`) are already on `main`, so no action changes are needed here.

#### Windows MSI test fix (pywin32)

While validating, the `Test MSI package` job (still on `windows-2022`) failed with
`No module named 'win32file'`. `check_files.py` imports `win32file` (pywin32) on Windows,
but the job runs it inside an isolated `checkfiles_env` venv whose `requirements.txt`
only pinned `pandas`. It used to work only because the `windows-2022` image shipped
pywin32 in the global Python; a recent runner-image update removed it, exposing the gap.
(The test normally appeared green because `detect-changes` skipped it; this PR exercises it.)

Fix: install `pywin32` **only in the Windows job's venv** (`pip install pywin32==308` +
`pywin32_postinstall.py -install`). It is intentionally **not** added to the shared
`check_files/requirements.txt`, since that file is also installed on Linux/macOS runners
where pywin32 has no wheels.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

All migrated agent build workflows are green on CodeBuild, including the Windows MSI
build + test:
  https://github.com/wazuh/wazuh/actions/runs/27841042273
  https://github.com/wazuh/wazuh/actions/runs/27841042275
  https://github.com/wazuh/wazuh/actions/runs/27841042259
  https://github.com/wazuh/wazuh/actions/runs/27841042522


Before / after (runner label):

```diff
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
```

```diff
-    runs-on: wz-linux-arm64
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
```

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

No build artifacts change. Only CI runner placement for the agent package build
workflows is affected:
- DEB / RPM agent packages (amd64, arm64)
- Windows agent MSI (Linux cross-compile stage)
- macOS agent PKG (S3 upload stage)

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

None at the product level. CI-only: jobs now run on AWS CodeBuild runners instead of the
self-hosted `wz-*` runners. Requires the `codebuild-github-actions-codebuild-runner-agent-amd`
and `-agent-arm` fleets and the `CI_WAZUHCI_DOCKERHUB_USER` / `CI_WAZUHCI_DOCKERHUB_TOKEN`
secrets to be available.

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

None.

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

None. Existing build/test jobs are unchanged except for the runner they execute on, the
CodeBuild host setup steps, and the Windows pywin32 install.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] CodeBuild agent fleets (amd/arm) provisioned and reachable

<!--
Include any additional information relevant to the review process.
-->
