### PR TITLE
Improve API authentication stability and resource limits

### DIFF
--- a/api/api/api_exception.py
+++ b/api/api/api_exception.py
@@ -87,3 +87,11 @@ class ExpectFailedException(ProblemException):
     def __init__(self, *, status=417, title=None, detail=None):
         ext = {"code": 417}
         super().__init__(status=status, title=title, detail=detail, ext=ext)
+
+
+class PayloadTooLargeException(ProblemException):
+    """Exception for request bodies that exceed the maximum allowed size (status code 413)."""
+
+    def __init__(self, *, title=None, detail=None):
+        ext = {"code": 413}
+        super().__init__(status=413, title=title, detail=detail, ext=ext)

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -7,6 +7,7 @@ from functools import cache
 import hashlib
 import json
 import jwt
+import threading
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
@@ -32,8 +33,9 @@ from wazuh.core.decorators import dapi_allower
 
 INVALID_TOKEN = "Invalid token"
 EXPIRED_TOKEN = "Token expired"
-pool = ThreadPoolExecutor(max_workers=1)
-
+login_pool = ThreadPoolExecutor(max_workers=4)
+token_pool = ThreadPoolExecutor(max_workers=2)
+rbac_pool = ThreadPoolExecutor(max_workers=4)
 
 @dapi_allower()
 def check_user_master(user: str, password: str) -> dict:
@@ -84,7 +86,7 @@ def check_user(user: str, password: str, required_scopes=None) -> Union[dict, No
                           wait_for_complete=False,
                           logger=logging.getLogger('wazuh-api')
                           )
-    data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
+    data = raise_if_exc(login_pool.submit(asyncio.run, dapi.distribute_function()).result())
 
     if data['result']:
         return {'sub': user, 'active': True }
@@ -95,6 +97,7 @@ JWT_ISSUER = 'wazuh'
 JWT_ALGORITHM = 'ES512'
 _private_key_path = os.path.join(SECURITY_PATH, 'private_key.pem')
 _public_key_path = os.path.join(SECURITY_PATH, 'public_key.pem')
+_keypair_lock = threading.Lock()
 
 @cache
 def generate_keypair():
@@ -105,23 +108,24 @@ def generate_keypair():
     WazuhInternalError(6003)
         If there was an error trying to load the JWT secret.
     """
-    try:
-        if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
-            private_key, public_key = change_keypair()
-            try:
-                os.chown(_private_key_path, wazuh_uid(), wazuh_gid())
-                os.chown(_public_key_path, wazuh_uid(), wazuh_gid())
-            except PermissionError:
-                pass
-            os.chmod(_private_key_path, 0o640)
-            os.chmod(_public_key_path, 0o640)
-        else:
-            with open(_private_key_path, mode='r') as key_file:
-                private_key = key_file.read()
-            with open(_public_key_path, mode='r') as key_file:
-                public_key = key_file.read()
-    except IOError:
-        raise WazuhInternalError(6003)
+    with _keypair_lock:
+        try:
+            if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
+                private_key, public_key = change_keypair()
+                try:
+                    os.chown(_private_key_path, wazuh_uid(), wazuh_gid())
+                    os.chown(_public_key_path, wazuh_uid(), wazuh_gid())
+                except PermissionError:
+                    pass
+                os.chmod(_private_key_path, 0o640)
+                os.chmod(_public_key_path, 0o640)
+            else:
+                with open(_private_key_path, mode='r') as key_file:
+                    private_key = key_file.read()
+                with open(_public_key_path, mode='r') as key_file:
+                    public_key = key_file.read()
+        except IOError:
+            raise WazuhInternalError(6003)
 
     return private_key, public_key
 
@@ -183,6 +187,7 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
                           wait_for_complete=False,
                           logger=logging.getLogger('wazuh-api')
                           )
+    pool = rbac_pool if auth_context is not None else token_pool
     result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
     timestamp = int(core_utils.get_utc_now().timestamp())
 
@@ -278,7 +283,7 @@ def decode_token(token: str) -> dict:
                               wait_for_complete=False,
                               logger=logging.getLogger('wazuh-api')
                               )
-        data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).to_dict()
+        data = raise_if_exc(token_pool.submit(asyncio.run, dapi.distribute_function()).result()).to_dict()
 
         if not data['result']['valid']:
             raise Unauthorized(INVALID_TOKEN)
@@ -292,7 +297,7 @@ def decode_token(token: str) -> dict:
                               wait_for_complete=False,
                               logger=logging.getLogger('wazuh-api')
                               )
-        result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
+        result = raise_if_exc(token_pool.submit(asyncio.run, dapi.distribute_function()).result())
 
         current_rbac_mode = result['rbac_mode']
         current_expiration_time = result['auth_token_exp_timeout']

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -3,7 +3,6 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
-from functools import cache
 import hashlib
 import json
 import jwt
@@ -98,17 +97,36 @@ JWT_ALGORITHM = 'ES512'
 _private_key_path = os.path.join(SECURITY_PATH, 'private_key.pem')
 _public_key_path = os.path.join(SECURITY_PATH, 'public_key.pem')
 _keypair_lock = threading.Lock()
+_keypair: tuple = None
 
-@cache
+
+def clear_keypair():
+    """Clears the key pair to leave it empty for a next key generation"""
+    global _keypair
+    with _keypair_lock:
+        _keypair = None
+
+
 def generate_keypair():
     """Generate key files to keep safe or load existing public and private keys.
+
+    Returns the same keypair on every call after the first successful load;
+    the result is cached in the module-level ``_keypair`` variable under
+    ``_keypair_lock`` so concurrent first-callers do not race on the files.
 
     Raises
     ------
     WazuhInternalError(6003)
         If there was an error trying to load the JWT secret.
     """
+    global _keypair
+
+    keypair = _keypair
+    if keypair is not None:
+        return keypair
     with _keypair_lock:
+        if _keypair is not None:
+            return _keypair
         try:
             if not os.path.exists(_private_key_path) or not os.path.exists(_public_key_path):
                 private_key, public_key = change_keypair()
@@ -126,8 +144,8 @@ def generate_keypair():
                     public_key = key_file.read()
         except IOError:
             raise WazuhInternalError(6003)
-
-    return private_key, public_key
+        _keypair = (private_key, public_key)
+    return _keypair
 
 
 def change_keypair():

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -15,7 +15,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
-from connexion.exceptions import OAuthProblem
+from connexion.exceptions import OAuthProblem, ProblemException
 from connexion.lifecycle import ConnexionRequest
 from connexion.security import AbstractSecurityHandler
 
@@ -41,6 +41,9 @@ LOGIN_ENDPOINT = '/security/user/authenticate'
 
 # Authentication context hash key
 HASH_AUTH_CONTEXT_KEY = 'hash_auth_context'
+
+# Allowed upper bound for auth_context payload
+AUTH_CONTEXT_MAX_PAYLOAD_SIZE = 8 * 1024
 
 # API secure headers
 server = Server().set("Wazuh")
@@ -227,6 +230,22 @@ class CheckRateLimitsMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
 
+class CheckAuthContextSizeMiddleware(BaseHTTPMiddleware):
+    """Reject run_as requests whose body exceeds AUTH_CONTEXT_MAX_PAYLOAD_SIZE."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path == RUN_AS_LOGIN_ENDPOINT and request.method == "POST":
+            body = await request.body()
+            if len(body) > AUTH_CONTEXT_MAX_PAYLOAD_SIZE:
+                raise ProblemException(
+                    status=413,
+                    title="Request Entity Too Large",
+                    detail=f"Auth context payload exceeds the maximum allowed size of "
+                           f"{AUTH_CONTEXT_MAX_PAYLOAD_SIZE} bytes.",
+                )
+        return await call_next(request)
+
+
 class CheckBlockedIP(BaseHTTPMiddleware):
     """Rate Limits Middleware."""
 
@@ -259,9 +278,10 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
         prev_time = time.time()
 
         body = await request.body()
-        if body:
+
+        if body and not(request.url.path == RUN_AS_LOGIN_ENDPOINT and len(body) > AUTH_CONTEXT_MAX_PAYLOAD_SIZE):
             try:
-                # Load the request body to the _json field before calling the controller so it's cached before the stream 
+                # Load the request body to the _json field before calling the controller so it's cached before the stream
                 # is consumed. If there's a json error we skip it so it's handled later.
                 # Related to https://github.com/wazuh/wazuh/issues/24060.
                 _ = await request.json()
@@ -304,28 +324,28 @@ class CheckExpectHeaderMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: ConnexionRequest, call_next: RequestResponseEndpoint) -> Response:
         """Check for specific request headers and generate error 417 if conditions are not met.
-                
+
         Parameters
         ----------
             request : Request
             HTTP Request received.
         call_next :  RequestResponseEndpoint
             Endpoint callable to be executed.
-        
+
         Returns
         -------
             Returned response.
         """
-        
+
         if 'Expect' not in request.headers:
             response = await call_next(request)
             return response
         else:
             expect_value = request.headers["Expect"].lower()
-            
+
             if expect_value != '100-continue':
                 raise ExpectFailedException(status=417, title="Expectation failed", detail="Unknown Expect")
-            
+
             if 'Content-Length' in request.headers:
                 content_length = int(request.headers["Content-Length"])
                 max_upload_size = configuration.api_conf["max_upload_size"]
@@ -333,6 +353,6 @@ class CheckExpectHeaderMiddleware(BaseHTTPMiddleware):
                     raise ExpectFailedException(status=417, title="Expectation failed",
                                                 detail=f"Maximum content size limit ({max_upload_size}) exceeded "
                                                        f"({content_length} bytes read)")
-                
+
         response = await call_next(request)
         return response

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -15,7 +15,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
-from connexion.exceptions import OAuthProblem, ProblemException
+from connexion.exceptions import OAuthProblem
 from connexion.lifecycle import ConnexionRequest
 from connexion.security import AbstractSecurityHandler
 
@@ -26,7 +26,7 @@ from wazuh.core.utils import get_utc_now
 from api import configuration
 from api.alogging import custom_logging
 from api.authentication import generate_keypair, JWT_ALGORITHM
-from api.api_exception import BlockedIPException, MaxRequestsException, ExpectFailedException
+from api.api_exception import BlockedIPException, ExpectFailedException, MaxRequestsException, PayloadTooLargeException
 from api.controllers.util import build_recursion_error_response
 
 # Default of the max event requests allowed per minute
@@ -237,8 +237,7 @@ class CheckAuthContextSizeMiddleware(BaseHTTPMiddleware):
         if request.url.path == RUN_AS_LOGIN_ENDPOINT and request.method == "POST":
             body = await request.body()
             if len(body) > AUTH_CONTEXT_MAX_PAYLOAD_SIZE:
-                raise ProblemException(
-                    status=413,
+                raise PayloadTooLargeException(
                     title="Request Entity Too Large",
                     detail=f"Auth context payload exceeds the maximum allowed size of "
                            f"{AUTH_CONTEXT_MAX_PAYLOAD_SIZE} bytes.",
@@ -279,7 +278,9 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
 
         body = await request.body()
 
-        if body and not(request.url.path == RUN_AS_LOGIN_ENDPOINT and len(body) > AUTH_CONTEXT_MAX_PAYLOAD_SIZE):
+        # Don't allow heavy bodies when trying to authenticate. Necessary because this middleware is executed before
+        # CheckAuthContextSizeMiddleware can be executed
+        if body and (request.url.path != RUN_AS_LOGIN_ENDPOINT or len(body) <= AUTH_CONTEXT_MAX_PAYLOAD_SIZE):
             try:
                 # Load the request body to the _json field before calling the controller so it's cached before the stream
                 # is consumed. If there's a json error we skip it so it's handled later.

--- a/api/api/signals.py
+++ b/api/api/signals.py
@@ -23,7 +23,7 @@ from api.constants import (
     UPDATE_INFORMATION_KEY,
     SECURITY_PATH
 )
-from api.authentication import generate_keypair, _private_key_path, _public_key_path
+from api.authentication import _private_key_path, _public_key_path, clear_keypair
 
 ONE_DAY_SLEEP = 60*60*24
 
@@ -64,7 +64,7 @@ async def load_installation_uid() -> None:
         logger.info("Getting installation UID...")
     else:
         logger.info("Populating installation UID...")
-    
+
     cti_context[INSTALLATION_UID_KEY] = get_installation_uid()
 
 
@@ -89,7 +89,7 @@ async def clean_auth_keys_cache():
         inotify.add_watch(SECURITY_PATH, Mask.MODIFY | Mask.CREATE )
         async for event in inotify:
             if event.path and event.path.as_posix() in FILES:
-                generate_keypair.cache_clear()
+                clear_keypair()
 
 
 @contextlib.asynccontextmanager

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -55,7 +55,7 @@ original_payload = {
 
 @pytest.fixture(autouse=True)
 def clear_generate_keypair_cache():
-    authentication.generate_keypair.cache_clear()
+    authentication.clear_keypair()
 
 def test_check_user_master():
     result = authentication.check_user_master('test_user', 'test_pass')
@@ -95,7 +95,7 @@ def test_generate_keypair(mock_open, mock_chown, mock_chmod, mock_change_keypair
              call(authentication._public_key_path, 0o640)]
     mock_chmod.assert_has_calls(calls)
 
-    authentication.generate_keypair.cache_clear()
+    authentication.clear_keypair()
 
     with patch('os.path.exists', return_value=True):
         authentication.generate_keypair()
@@ -213,7 +213,7 @@ def test_check_token(mock_tokenmanager):
 @patch('api.authentication.raise_if_exc', side_effect=None)
 async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_dapi, mock_generate_keypair,
                       mock_decode):
-    
+
     mock_decode.return_value = deepcopy(original_payload)
     mock_raise_if_exc.side_effect = [WazuhResult({'valid': True, 'policies': {'value': 'test'}}),
                                      WazuhResult(security_conf)]

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -17,8 +17,9 @@ from connexion.exceptions import ProblemException, OAuthProblem
 from freezegun import freeze_time
 
 from api.middlewares import check_rate_limit, check_blocked_ip, MAX_REQUESTS_EVENTS_DEFAULT, UNKNOWN_USER_STRING, \
-    LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, CheckRateLimitsMiddleware, WazuhAccessLoggerMiddleware, CheckBlockedIP, \
-    SecureHeadersMiddleware, CheckExpectHeaderMiddleware, secure_headers, access_log
+    LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, CheckAuthContextSizeMiddleware, CheckRateLimitsMiddleware, \
+    WazuhAccessLoggerMiddleware, CheckBlockedIP, \
+    SecureHeadersMiddleware, CheckExpectHeaderMiddleware, secure_headers, access_log, AUTH_CONTEXT_MAX_PAYLOAD_SIZE
 from api.api_exception import ExpectFailedException
 
 @pytest.fixture
@@ -37,6 +38,7 @@ def mock_req(request, request_info):
     req.json = AsyncMock(side_effect=lambda: {'ctx': ''} )
     req.context = MagicMock()
     req.context.get = MagicMock(return_value={})
+    req.body = AsyncMock(return_value=b'x' * (AUTH_CONTEXT_MAX_PAYLOAD_SIZE + 1))
 
     return req
 
@@ -613,3 +615,21 @@ async def test_access_log_no_warning_for_normal_username(mock_req):
         await access_log(request=mock_req, response=response, prev_time=expected_time)
 
         mock_warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_as_login_oversized_payload():
+    """CheckAuthContextSizeMiddleware must reject run_as payloads larger than AUTH_CONTEXT_MAX_PAYLOAD_SIZE with 413."""
+    mock_req = AsyncMock()
+    mock_req.body = AsyncMock(return_value=b'x' * (AUTH_CONTEXT_MAX_PAYLOAD_SIZE + 1))
+    mock_req.url.path = RUN_AS_LOGIN_ENDPOINT
+    mock_req.method = "POST"
+
+    dispatch_mock = AsyncMock()
+    middleware = CheckAuthContextSizeMiddleware(AsyncApp(__name__), dispatch=dispatch_mock)
+
+    with pytest.raises(ProblemException) as exc_info:
+        await middleware.dispatch(request=mock_req, call_next=dispatch_mock)
+
+    assert exc_info.value.status == 413
+    dispatch_mock.assert_not_called()

--- a/api/api/test/test_signals.py
+++ b/api/api/test/test_signals.py
@@ -188,7 +188,7 @@ async def test_register_background_tasks(
 @pytest.mark.asyncio
 @patch('api.signals._private_key_path', new='/path/to/private.key')
 @patch('api.signals._public_key_path', new='/path/to/public.key')
-@patch('api.signals.generate_keypair.cache_clear')
+@patch('api.signals.clear_keypair')
 @pytest.mark.parametrize(
     'filename',
     ['/path/to/private.key', '/path/to/public.key', 'other_file.txt']

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -182,6 +182,7 @@ def start(params: dict):
         app.add_middleware(CheckRateLimitsMiddleware, MiddlewarePosition.BEFORE_SECURITY)
     app.add_middleware(CheckExpectHeaderMiddleware)
     app.add_middleware(CheckBlockedIP, MiddlewarePosition.BEFORE_SECURITY)
+    app.add_middleware(CheckAuthContextSizeMiddleware, MiddlewarePosition.BEFORE_SECURITY)
     app.add_middleware(WazuhAccessLoggerMiddleware, MiddlewarePosition.BEFORE_EXCEPTION)
     app.add_middleware(SecureHeadersMiddleware, MiddlewarePosition.BEFORE_EXCEPTION)
     if api_conf['max_upload_size']:
@@ -337,6 +338,7 @@ if __name__ == '__main__':
     from api.configuration import api_conf, generate_private_key, generate_self_signed_certificate, security_conf
     from api.constants import API_LOG_PATH
     from api.middlewares import (
+        CheckAuthContextSizeMiddleware,
         CheckBlockedIP,
         CheckRateLimitsMiddleware,
         SecureHeadersMiddleware,

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -15,7 +15,7 @@ click==8.1.3
 clickclick==20.10.2
 connexion==3.1.0
 content-size-limit-asgi==0.1.5
-cryptography==46.0.7
+cryptography==48.0.1
 Cython==0.29.36
 defusedxml==0.6.0
 docker==7.1.0
@@ -38,7 +38,7 @@ grpcio-status==1.33.2
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.26.0
-idna==3.7
+idna==3.15
 inflection==0.5.1
 isodate==0.6.1
 Jinja2==3.1.6
@@ -66,11 +66,11 @@ pyarrow==14.0.1
 pyasn1==0.6.3
 pyasn1-modules==0.4.2
 pycparser==2.21
-PyJWT==2.12.1
+PyJWT==2.13.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 python-json-logger==2.0.2
-python-multipart==0.0.27
+python-multipart==0.0.31
 pytz==2020.1
 PyYAML==6.0.3
 referencing==0.31.1
@@ -85,7 +85,7 @@ setuptools==80.10.2
 six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==2.0.23
-starlette==0.49.1
+starlette==1.3.1
 tabulate==0.8.9
 typing-extensions==4.15.0
 typing-inspect==0.7.1

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -74,6 +74,7 @@ python-multipart==0.0.27
 pytz==2020.1
 PyYAML==6.0.3
 referencing==0.31.1
+regex==2026.5.9
 requests==2.33.1
 rfc3339-validator==0.1.4
 rpds-py==0.15.2

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -12,6 +12,15 @@ from wazuh.rbac import orm
 # Sets the find_item recursive max depth
 MAX_FIND_ITEM_DEPTH = 8
 
+
+class AuthContextDepthExceeded(Exception):
+    """Raised when find_item exceeds MAX_FIND_ITEM_DEPTH levels of recursion.
+
+    This is a business-logic depth limit, distinct from CPython's built-in
+    RecursionError (stack overflow).  Callers that want to suppress both must
+    catch each type explicitly.
+    """
+
 logger = logging.getLogger('wazuh')
 
 class RBAChecker:
@@ -313,7 +322,7 @@ class RBAChecker:
 
         if depth >= MAX_FIND_ITEM_DEPTH:
             logger.warning("auth_context depth limit reached for role_id=%s", role_id)
-            raise RecursionError
+            raise AuthContextDepthExceeded
 
         mode = self.set_mode(mode, role_id)
 
@@ -367,7 +376,7 @@ class RBAChecker:
                     if self.match_item(role_chunk=rule[rule_key], mode=rule_key):
                         return 1
                 elif rule_key == self._functions[2] or rule_key == self._functions[3]:  # FIND, FIND$
-                    if self.find_item(role_chunk=rule[rule_key], mode=rule_key, role_id=role_id):
+                    if self.find_item(role_chunk=rule[rule_key], mode=rule_key, role_id=role_id, depth=0):
                         return 1
 
         return False
@@ -388,7 +397,13 @@ class RBAChecker:
                     if (rule['id'] > orm.MAX_ID_RESERVED or self.user_id == 2) and self.check_rule(rule['rule']):
                         list_roles.append(role['id'])
                         break
+                except AuthContextDepthExceeded:
+                    # Auth context was nested beyond MAX_FIND_ITEM_DEPTH; skip this role.
+                    logger.warning("auth_context depth limit reached for role_id=%s", role['id'])
+                    break
                 except RecursionError:
+                    # CPython call-stack overflow; skip this role.
+                    logger.warning("RecursionError evaluating role_id=%s", role['id'])
                     break
         return list_roles
 

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -3,7 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
-import re
+import regex
 import logging
 from collections import defaultdict
 from typing import Union
@@ -12,6 +12,8 @@ from wazuh.rbac import orm
 # Sets the find_item recursive max depth
 MAX_FIND_ITEM_DEPTH = 8
 
+# Sets time limit for user-reachable regex
+REGEX_TIME_LIMIT = 0.1
 
 class AuthContextDepthExceeded(Exception):
     """Raised when find_item exceeds MAX_FIND_ITEM_DEPTH levels of recursion.
@@ -149,10 +151,13 @@ class RBAChecker:
         counter = 0
         for index, value in enumerate(auth_context):
             for v in role_chunk:
-                regex = self.check_regex(v)
-                if regex:
-                    if regex.match(value):
-                        counter += 1
+                pattern = self.check_regex(v)
+                if pattern:
+                    try:
+                        if pattern.match(value, timeout=REGEX_TIME_LIMIT):
+                            counter += 1
+                    except regex.TimeoutError:
+                        continue
                 else:
                     if value == v:
                         counter += 1
@@ -217,7 +222,7 @@ class RBAChecker:
 
         return None
 
-    def check_regex(self, expression: str) -> Union[re.Pattern, bool]:
+    def check_regex(self, expression: str) -> Union[regex.Pattern, bool]:
         """Check if a certain string is a regular expression.
 
         Parameters
@@ -227,16 +232,16 @@ class RBAChecker:
 
         Returns
         -------
-        re.Pattern or bool
+        regex.Pattern or bool
             Compiled regex if a valid regex is provided else return False.
         """
         if isinstance(expression, str):
             if not expression.startswith(self._regex_prefix):
                 return False
             try:
-                regex = ''.join(expression[self._initial_index_for_regex:-2])
-                regex = re.compile(regex)
-                return regex
+                pattern = ''.join(expression[self._initial_index_for_regex:-2])
+                pattern = regex.compile(pattern)
+                return pattern
             except:
                 return False
         return False
@@ -266,23 +271,29 @@ class RBAChecker:
         # We're not in the deep end yet.
         if isinstance(role_chunk, dict) and isinstance(auth_context, dict):
             for key_rule, value_rule in role_chunk.items():
-                regex = self.check_regex(key_rule)
-                if regex:
+                pattern = self.check_regex(key_rule)
+                if pattern:
                     for key_auth in auth_context.keys():
-                        if regex.match(key_auth):
-                            validator_counter += self.match_item(role_chunk[key_rule], auth_context[key_auth], mode)
+                        try:
+                            if pattern.match(key_auth, timeout=REGEX_TIME_LIMIT):
+                                validator_counter += self.match_item(role_chunk[key_rule], auth_context[key_auth], mode)
+                        except regex.TimeoutError:
+                            continue
                 if key_rule in auth_context.keys():
                     validator_counter += self.match_item(role_chunk[key_rule], auth_context[key_rule], mode)
         # It's a possible end
         else:
             role_chunk, auth_context = self.preprocess_to_list(role_chunk, auth_context)
-            regex = self.check_regex(role_chunk)
-            if regex:
+            pattern = self.check_regex(role_chunk)
+            if pattern:
                 if not isinstance(auth_context, list):
                     auth_context = [auth_context]
                 for context in auth_context:
-                    if regex.match(context):
-                        return 1
+                    try:
+                        if pattern.match(context, timeout=REGEX_TIME_LIMIT):
+                            return 1
+                    except regex.TimeoutError:
+                        continue
             if role_chunk == auth_context:
                 return 1
             if isinstance(role_chunk, str):

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -4,11 +4,15 @@
 
 import json
 import re
+import logging
 from collections import defaultdict
 from typing import Union
-
 from wazuh.rbac import orm
 
+# Sets the find_item recursive max depth
+MAX_FIND_ITEM_DEPTH = 8
+
+logger = logging.getLogger('wazuh')
 
 class RBAChecker:
     """
@@ -228,6 +232,7 @@ class RBAChecker:
                 return False
         return False
 
+
     def match_item(self, role_chunk: Union[list, dict], auth_context: Union[list, dict] = None,
                    mode: str = 'MATCH') -> Union[int, bool]:
         """This function will go through all authorization contexts and system roles recursively until it finds the
@@ -282,7 +287,7 @@ class RBAChecker:
         return False
 
     def find_item(self, role_chunk: Union[list, dict], auth_context: dict = None, mode: str = 'FIND',
-                  role_id: int = None) -> bool:
+                  role_id: int = None, depth: int = 0) -> bool:
         """This function will use the match function and will launch it recursively on all the authorization context
         tree, on all the levels.
 
@@ -296,6 +301,8 @@ class RBAChecker:
             FIND -> MATCH | FIND$ -> MATCH$.
         role_id : int
             ID of the current role.
+        depth : int
+            Current depth level reached in recursive calls.
 
         Returns
         -------
@@ -303,6 +310,11 @@ class RBAChecker:
             True if the item was found, false otherwise.
         """
         auth_context = self.authorization_context if auth_context is None else auth_context
+
+        if depth >= MAX_FIND_ITEM_DEPTH:
+            logger.warning("auth_context depth limit reached for role_id=%s", role_id)
+            raise RecursionError
+
         mode = self.set_mode(mode, role_id)
 
         validator_counter = self.match_item(role_chunk, auth_context, mode)
@@ -313,12 +325,12 @@ class RBAChecker:
             if self.match_item(role_chunk, value, mode):
                 return True
             elif isinstance(value, dict):
-                if self.find_item(role_chunk, value, mode=mode):
+                if self.find_item(role_chunk, value, mode=mode, role_id=role_id, depth=depth + 1):
                     return True
             elif isinstance(value, list):
                 for v in value:
                     if isinstance(v, dict):
-                        if self.find_item(role_chunk, v, mode=mode):
+                        if self.find_item(role_chunk, v, mode=mode, role_id=role_id, depth=depth + 1):
                             return True
 
         return False
@@ -372,10 +384,12 @@ class RBAChecker:
         for role in self.roles_list:
             for rule in role['rules']:
                 # wazuh-wui has id 2
-                if (rule['id'] > orm.MAX_ID_RESERVED or self.user_id == 2) and self.check_rule(rule['rule']):
-                    list_roles.append(role['id'])
+                try:
+                    if (rule['id'] > orm.MAX_ID_RESERVED or self.user_id == 2) and self.check_rule(rule['rule']):
+                        list_roles.append(role['id'])
+                        break
+                except RecursionError:
                     break
-
         return list_roles
 
     def run_auth_context(self) -> defaultdict:

--- a/framework/wazuh/rbac/auth_context.py
+++ b/framework/wazuh/rbac/auth_context.py
@@ -156,7 +156,7 @@ class RBAChecker:
                     try:
                         if pattern.match(value, timeout=REGEX_TIME_LIMIT):
                             counter += 1
-                    except regex.TimeoutError:
+                    except TimeoutError:
                         continue
                 else:
                     if value == v:
@@ -277,7 +277,7 @@ class RBAChecker:
                         try:
                             if pattern.match(key_auth, timeout=REGEX_TIME_LIMIT):
                                 validator_counter += self.match_item(role_chunk[key_rule], auth_context[key_auth], mode)
-                        except regex.TimeoutError:
+                        except TimeoutError:
                             continue
                 if key_rule in auth_context.keys():
                     validator_counter += self.match_item(role_chunk[key_rule], auth_context[key_rule], mode)
@@ -292,7 +292,7 @@ class RBAChecker:
                     try:
                         if pattern.match(context, timeout=REGEX_TIME_LIMIT):
                             return 1
-                    except regex.TimeoutError:
+                    except TimeoutError:
                         continue
             if role_chunk == auth_context:
                 return 1

--- a/framework/wazuh/rbac/tests/test_auth_context.py
+++ b/framework/wazuh/rbac/tests/test_auth_context.py
@@ -4,7 +4,8 @@
 
 import json
 import os
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from wazuh.rbac.auth_context import RBAChecker, MAX_FIND_ITEM_DEPTH
 
 import pytest
 from sqlalchemy import create_engine
@@ -104,3 +105,40 @@ def test_auth_roles(db_setup):
                     else:
                         assert len(test.get_user_roles()) == 0
         roles = values()[1]
+
+
+def _make_checker(auth_context=None):
+    """Return an RBAChecker with no DB interaction."""
+    with patch('wazuh.rbac.auth_context.orm.RolesManager') as mock_rm, \
+         patch('wazuh.rbac.auth_context.orm.RulesManager'):
+        mock_rm.return_value.__enter__.return_value.get_roles.return_value = []
+        return RBAChecker(auth_context=auth_context or {})
+
+
+def test_find_item_depth_limit_raises():
+    """find_item must raise RecursionError when nesting exceeds MAX_FIND_ITEM_DEPTH."""
+    checker = _make_checker()
+    # Build a dict nested one level deeper than the allowed maximum
+    deep = {"leaf": "value"}
+    for _ in range(MAX_FIND_ITEM_DEPTH + 1):
+        deep = {"level": deep}
+
+    with pytest.raises(RecursionError):
+        checker.find_item({"leaf": "value"}, auth_context=deep, mode='FIND')
+
+
+def test_get_user_roles_denies_when_depth_exceeded():
+    """get_user_roles must not grant a role when find_item hits the depth limit.
+
+    A NOT+FIND rule would incorrectly grant access if the truncated search returned
+    False (no match found), because NOT(False) evaluates to True. Raising RecursionError
+    instead causes get_user_roles to skip the role entirely.
+    """
+    deep = {"leaf": "value"}
+    for _ in range(MAX_FIND_ITEM_DEPTH + 1):
+        deep = {"level": deep}
+    checker = _make_checker(auth_context=deep)
+    checker.user_id = 2
+    checker.roles_list = [{"id": 1, "rules": [{"id": 1, "rule": {"NOT": [{"FIND": {"leaf": "value"}}]}}]}]
+
+    assert checker.get_user_roles() == []

--- a/framework/wazuh/rbac/tests/test_auth_context.py
+++ b/framework/wazuh/rbac/tests/test_auth_context.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import regex
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -147,3 +148,29 @@ def test_get_user_roles_denies_when_depth_exceeded():
     checker.roles_list = [{"id": 1, "rules": [{"id": 1, "rule": {"NOT": [{"FIND": {"leaf": "value"}}]}}]}]
 
     assert checker.get_user_roles() == []
+
+
+def test_process_lists_handles_regex_timeout():
+    """process_lists must not propagate a regex timeout; it should skip and continue."""
+    checker = _make_checker()
+    fake_pattern = MagicMock()
+    fake_pattern.match.side_effect = TimeoutError('regex timed out')
+    with patch.object(checker, 'check_regex', return_value=fake_pattern):
+        result = checker.process_lists(["ignored"], ["anything"], 'MATCH')
+    assert result == 0
+
+
+def test_match_item_survives_catastrophic_backtracking():
+    """match_item must not hang or raise when a role regex causes catastrophic backtracking.
+
+    (a|a)+$ against a string of 'a's with no terminating match is a classic ReDoS pattern;
+    without the timeout it would hang for minutes. check_regex is patched to bypass the
+    'r\\'...\\'' marker parsing so this test exercises the timeout handling directly, not the
+    marker string slicing.
+    """
+    checker = _make_checker()
+    evil_pattern = regex.compile(r'(a|a)+$')
+    evil_input = "a" * 30 + "!"  # never matches; triggers exponential backtracking
+    with patch.object(checker, 'check_regex', return_value=evil_pattern):
+        result = checker.match_item("irrelevant", [evil_input], 'MATCH')
+    assert result in (0, False)

--- a/framework/wazuh/rbac/tests/test_auth_context.py
+++ b/framework/wazuh/rbac/tests/test_auth_context.py
@@ -5,7 +5,6 @@
 import json
 import os
 from unittest.mock import patch, MagicMock
-from wazuh.rbac.auth_context import RBAChecker, MAX_FIND_ITEM_DEPTH
 
 import pytest
 from sqlalchemy import create_engine
@@ -109,6 +108,10 @@ def test_auth_roles(db_setup):
 
 def _make_checker(auth_context=None):
     """Return an RBAChecker with no DB interaction."""
+    # Imported lazily (not at module scope) so collecting this file does not import
+    # wazuh.rbac.orm before sibling tests that reload it under patched engines; a
+    # module-level import leaves a stale orm reference and breaks test_auth_roles.
+    from wazuh.rbac.auth_context import RBAChecker
     with patch('wazuh.rbac.auth_context.orm.RolesManager') as mock_rm, \
          patch('wazuh.rbac.auth_context.orm.RulesManager'):
         mock_rm.return_value.__enter__.return_value.get_roles.return_value = []
@@ -116,14 +119,15 @@ def _make_checker(auth_context=None):
 
 
 def test_find_item_depth_limit_raises():
-    """find_item must raise RecursionError when nesting exceeds MAX_FIND_ITEM_DEPTH."""
+    """find_item must raise AuthContextDepthExceeded when nesting exceeds MAX_FIND_ITEM_DEPTH."""
+    from wazuh.rbac.auth_context import AuthContextDepthExceeded, MAX_FIND_ITEM_DEPTH
     checker = _make_checker()
     # Build a dict nested one level deeper than the allowed maximum
     deep = {"leaf": "value"}
     for _ in range(MAX_FIND_ITEM_DEPTH + 1):
         deep = {"level": deep}
 
-    with pytest.raises(RecursionError):
+    with pytest.raises(AuthContextDepthExceeded):
         checker.find_item({"leaf": "value"}, auth_context=deep, mode='FIND')
 
 
@@ -131,9 +135,10 @@ def test_get_user_roles_denies_when_depth_exceeded():
     """get_user_roles must not grant a role when find_item hits the depth limit.
 
     A NOT+FIND rule would incorrectly grant access if the truncated search returned
-    False (no match found), because NOT(False) evaluates to True. Raising RecursionError
-    instead causes get_user_roles to skip the role entirely.
+    False (no match found), because NOT(False) evaluates to True. Raising
+    AuthContextDepthExceeded instead causes get_user_roles to skip the role entirely.
     """
+    from wazuh.rbac.auth_context import MAX_FIND_ITEM_DEPTH
     deep = {"leaf": "value"}
     for _ in range(MAX_FIND_ITEM_DEPTH + 1):
         deep = {"level": deep}

--- a/framework/wazuh/rbac/tests/test_orm.py
+++ b/framework/wazuh/rbac/tests/test_orm.py
@@ -982,7 +982,7 @@ def test_databasemanager_get_table(fresh_in_memory_db):
     current_columns = set(re.findall(column_regex, str(fresh_in_memory_db.db_manager.get_table(
         session, fresh_in_memory_db.User))))
     with patch("wazuh.rbac.orm._new_columns", new={"new_column"}):
-        updated_columns = set(re.findall(column_regex, str(fresh_in_memory_db.db_manager.get_table(session, 
+        updated_columns = set(re.findall(column_regex, str(fresh_in_memory_db.db_manager.get_table(session,
                                                                                                    EnhancedUser))))
 
     assert current_columns == updated_columns
@@ -1084,7 +1084,7 @@ def test_check_database_integrity_exceptions(remove_mock, close_sessions_mock, e
 ])
 def test_migrate_data(db_setup, from_id, to_id, users):
     """Test `migrate_data` function briefly.
-    
+
     NOTE: To correctly test this procedure, use the RBAC database migration integration tests."""
     # This test case updates the default user passwords and omits the rest of the migration
     if to_id == WAZUH_WUI_USER_ID:

--- a/src/Makefile
+++ b/src/Makefile
@@ -2400,7 +2400,7 @@ ifeq (,${INSTALLDIR})
 endif
 
 ifeq (,$(wildcard ${EXTERNAL_CPYTHON}/python))
-	export WPATH_LIB="'\$$\$$ORIGIN/../../../lib'" && export SOURCE_PATH=${ROUTE_PATH} && export WAZUH_FFI_PATH=${EXTERNAL_LIBFFI} && export LD_LIBRARY_PATH=${ROUTE_PATH} && export ac_cv_header_crypt_h=no && export ac_cv_lib_crypt_crypt=no && cd ${EXTERNAL_CPYTHON} && ./configure --prefix="${WPYTHON_DIR}" --libdir="${WPYTHON_DIR}/lib" --enable-shared --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="${ARCH_FLAGS} -L${ROUTE_PATH} -L${ROUTE_PATH}/${EXTERNAL_SQLITE} -L${ROUTE_PATH}/${EXTERNAL_LIBFFI}${TARGET}/.libs -Wl,-rpath,'\$$\$$ORIGIN/../../../lib',--disable-new-dtags" CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include -I${ROUTE_PATH}/${EXTERNAL_SQLITE} -I${ROUTE_PATH}/${EXTERNAL_LIBFFI}include" LIBS="-lwazuhext" $(CPYTHON_FLAGS) && ${MAKE}
+	export WPATH_LIB="'\$$\$$ORIGIN/../../../lib'" && export SOURCE_PATH=${ROUTE_PATH} && export WAZUH_FFI_PATH=${EXTERNAL_LIBFFI} && export LD_LIBRARY_PATH=${ROUTE_PATH} && export ac_cv_header_crypt_h=no && export ac_cv_search_crypt=no && export ac_cv_search_crypt_r=no && cd ${EXTERNAL_CPYTHON} && ./configure --prefix="${WPYTHON_DIR}" --libdir="${WPYTHON_DIR}/lib" --enable-shared --with-openssl="${ROUTE_PATH}/${EXTERNAL_OPENSSL}" LDFLAGS="${ARCH_FLAGS} -L${ROUTE_PATH} -L${ROUTE_PATH}/${EXTERNAL_SQLITE} -L${ROUTE_PATH}/${EXTERNAL_LIBFFI}${TARGET}/.libs -Wl,-rpath,'\$$\$$ORIGIN/../../../lib',--disable-new-dtags" CPPFLAGS="-I${ROUTE_PATH}/${EXTERNAL_OPENSSL}include -I${ROUTE_PATH}/${EXTERNAL_SQLITE} -I${ROUTE_PATH}/${EXTERNAL_LIBFFI}include" LIBS="-lwazuhext" $(CPYTHON_FLAGS) && ${MAKE}
 endif
 
 build_python: $(WAZUHEXT_LIB)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

This PR improves the stability and resource management of the API authentication flow by introducing bounded thread pools, regex execution timeouts, recursion depth limits, and payload size enforcement.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- Split `api/api/authentication.py` thread pooling in `login`, `rbac` and `token` pools with four, four and two threads, respectively, to avoid starving, and submitted each pool to the methods that make use of each of them.
- Added a constant `MAX_FIND_ITEM_DEPTH` to avoid `find_item` function go too deep in the recursion.
- Added a constant `AUTH_CONTEXT_MAX_PAYLOAD_SIZE` and a new middleware in `api/api/middlewares.py` to reject heavy bodies using said middleware.

### Results and Evidence
https://github.com/wazuh/internal-devel-requests/issues/5119#issuecomment-4791247260

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Issues Ref.** | **Status** |
|--|--|--|--|--|--|--|--|
| api/api/controllers/test/test_active_response_controller.py | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_agent_controller.py | 45 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_cdb_list_controller.py | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_ciscat_controller.py | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_cluster_controller.py | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_controller_util.py | 3 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_decoder_controller.py | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_default_controller.py | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_event_controller.py | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_experimental_controller.py | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_manager_controller.py | 22 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_mitre_controller.py | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_overview_controller.py | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_rootcheck_controller.py | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_rule_controller.py | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_sca_controller.py | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_security_controller.py | 51 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_syscheck_controller.py | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_syscollector_controller.py | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/controllers/test/test_task_controller.py | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/models/test/test_model.py | 30 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_alogging.py | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_authentication.py | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_configuration.py | 51 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_encoder.py | 3 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_error_handler.py | 33 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_middlewares.py | 51 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_signals.py | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_uri_parser.py | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_util.py | 41 | 0 | 0 | 0 | 0 |  | :green_circle: |
| api/api/test/test_validator.py | 176 | 0 | 0 | 0 | 0 |  | :green_circle: |

<details>
<summary>Manager logs</summary>

```
root@wazuh-master:/home/vagrant# cat /var/ossec/logs/ossec.log 
2026/07/07 10:39:27 wazuh-modulesd:router: INFO: Loaded router module.
2026/07/07 10:39:27 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2026/07/07 10:39:27 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
2026/07/07 10:39:28 wazuh-csyslogd: INFO: Remote syslog server not configured. Clean exit.
2026/07/07 10:39:28 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
2026/07/07 10:39:28 wazuh-agentlessd: INFO: Not configured. Exiting.
2026/07/07 10:39:28 wazuh-authd: INFO: Started (pid: 52541).
2026/07/07 10:39:28 wazuh-authd: INFO: Accepting connections on port 1515. No password required.
2026/07/07 10:39:28 wazuh-authd: INFO: Setting network timeout to 1.000000 sec.
2026/07/07 10:39:28 wazuh-db: INFO: Started (pid: 52553).
2026/07/07 10:39:28 :router: INFO: Registering GET endpoint: /v1/agents/ids
2026/07/07 10:39:28 :router: INFO: Registering GET endpoint: /v1/agents/ids/groups/:name
2026/07/07 10:39:28 :router: INFO: Registering GET endpoint: /v1/agents/ids/groups
2026/07/07 10:39:28 :router: INFO: Registering GET endpoint: /v1/agents/:agent_id/groups
2026/07/07 10:39:28 :router: INFO: Registering POST endpoint: /v1/agents/summary
2026/07/07 10:39:28 :router: INFO: Registering GET endpoint: /v1/agents/sync
2026/07/07 10:39:28 :router: INFO: Registering POST endpoint: /v1/agents/sync
2026/07/07 10:39:28 :router: INFO: Registering POST endpoint: /v1/agents/restartinfo
2026/07/07 10:39:28 :router: INFO: API started successfully
2026/07/07 10:39:29 wazuh-db: INFO: Created Global database backup "backup/db/global.db-backup-2026-07-07-10:39:29.gz"
2026/07/07 10:39:29 wazuh-execd: INFO: Started (pid: 52598).
2026/07/07 10:39:29 wazuh-syscheckd: INFO: Started (pid: 52618).
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/07/07 10:39:29 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/07/07 10:39:29 rootcheck: INFO: Starting rootcheck scan.
2026/07/07 10:39:30 wazuh-remoted: INFO: Started (pid: 52633). Listening on port 1514/TCP (secure).
2026/07/07 10:39:30 wazuh-remoted: INFO: (1410): Reading authentication keys file.
2026/07/07 10:39:30 wazuh-analysisd: INFO: Total rules enabled: '8451'
2026/07/07 10:39:30 wazuh-analysisd: INFO: Started (pid: 52609).
2026/07/07 10:39:30 wazuh-analysisd: INFO: (7200): Logtest started
2026/07/07 10:39:30 wazuh-analysisd: INFO: EPS limit disabled
2026/07/07 10:39:31 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2026/07/07 10:39:31 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2026/07/07 10:39:31 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2026/07/07 10:39:31 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2026/07/07 10:39:31 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2026/07/07 10:39:31 wazuh-logcollector: INFO: Started (pid: 52716).
2026/07/07 10:39:31 wazuh-monitord: INFO: Started (pid: 52732).
2026/07/07 10:39:31 wazuh-modulesd:router: INFO: Loaded router module.
2026/07/07 10:39:31 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2026/07/07 10:39:31 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
2026/07/07 10:39:31 wazuh-modulesd: INFO: Started (pid: 52741).
2026/07/07 10:39:31 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/07/07 10:39:31 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2026/07/07 10:39:31 sca: INFO: Module started.
2026/07/07 10:39:31 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2026/07/07 10:39:31 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2026/07/07 10:39:31 wazuh-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/07/07 10:39:31 wazuh-modulesd:router: INFO: Starting router module.
2026/07/07 10:39:31 wazuh-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2026/07/07 10:39:31 sca: INFO: Starting Security Configuration Assessment scan.
2026/07/07 10:39:31 wazuh-modulesd:content_manager: INFO: Starting content_manager module.
2026/07/07 10:39:31 wazuh-modulesd:download: INFO: Module started.
2026/07/07 10:39:31 wazuh-modulesd:database: INFO: Module started.
2026/07/07 10:39:31 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/07 10:39:31 wazuh-modulesd:inventory-harvester: INFO: Starting inventory_harvester module.
2026/07/07 10:39:31 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2026/07/07 10:39:31 wazuh-modulesd:syscollector: INFO: Module started.
2026/07/07 10:39:31 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/07 10:39:31 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/07/07 10:39:31 wazuh-syscheckd: INFO: FIM sync module started.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-packages-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-vulnerabilities-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 wazuh-modulesd:vulnerability-scanner: INFO: Starting database file decompression.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-system-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-processes-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-ports-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-hotfixes-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-hardware-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-protocols-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:31 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-interfaces-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:32 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-networks-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:32 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-users-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:32 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-groups-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:32 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/07/07 10:39:32 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-browser-extensions-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:32 logger-helper: INFO: InventoryHarvesterFacade module started.
2026/07/07 10:39:32 indexer-connector: WARNING: IndexerConnector initialization failed for index 'wazuh-states-inventory-services-wazuh-master', retrying until the connection is successful.
2026/07/07 10:39:33 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2026/07/07 10:39:35 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2026/07/07 10:39:35 sca: INFO: Security Configuration Assessment scan finished. Duration: 4 seconds.
2026/07/07 10:39:42 wazuh-syscheckd: INFO: netstat not available. Skipping port check.
2026/07/07 10:39:47 rootcheck: INFO: Ending rootcheck scan.
2026/07/07 10:40:07 wazuh-modulesd:vulnerability-scanner: INFO: Database decompression finished.
2026/07/07 10:40:07 wazuh-modulesd:vulnerability-scanner: INFO: Vulnerability scanner module started.
2026/07/07 10:40:16 wazuh-modulesd:vulnerability-scanner: INFO: Initiating update feed process.
2026/07/07 10:41:03 wazuh-modulesd:vulnerability-scanner: INFO: Triggered a re-scan after content update.
2026/07/07 10:41:03 wazuh-modulesd:vulnerability-scanner: INFO: Feed update process completed.
2026/07/07 10:44:36 wazuh-monitord: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:36 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:36 wazuh-remoted: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:36 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/07/07 10:44:36 wazuh-analysisd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:36 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/07/07 10:44:36 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:36 wazuh-db: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:36 wazuh-authd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:37 wazuh-authd: INFO: Exiting...
2026/07/07 10:44:37 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/07 10:44:37 :router: INFO: Stopping server thread
2026/07/07 10:44:37 wazuh-db: INFO: Graceful process shutdown.
2026/07/07 10:44:37 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2026/07/07 10:44:37 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/07/07 10:44:37 wazuh-modulesd:syscollector: INFO: Module finished.
2026/07/07 10:44:37 wazuh-modulesd:vulnerability-scanner: INFO: Stopping vulnerability_scanner module.
2026/07/07 10:44:38 wazuh-modulesd:router: INFO: Stopping router module.
2026/07/07 10:44:38 wazuh-modulesd:content_manager: INFO: Stopping content_manager module.
2026/07/07 10:44:38 wazuh-modulesd:inventory-harvester: INFO: Stopping inventory_harvester module.
2026/07/07 10:44:38 logger-helper: INFO: Inventory harvester module stopped.
2026/07/07 10:44:39 wazuh-modulesd:router: INFO: Loaded router module.
2026/07/07 10:44:39 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2026/07/07 10:44:39 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
2026/07/07 10:44:41 wazuh-csyslogd: INFO: Remote syslog server not configured. Clean exit.
2026/07/07 10:44:41 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
2026/07/07 10:44:41 wazuh-agentlessd: INFO: Not configured. Exiting.
2026/07/07 10:44:41 wazuh-authd: INFO: Started (pid: 55043).
2026/07/07 10:44:41 wazuh-authd: INFO: Accepting connections on port 1515. No password required.
2026/07/07 10:44:41 wazuh-authd: INFO: Setting network timeout to 1.000000 sec.
2026/07/07 10:44:41 wazuh-db: INFO: Started (pid: 55055).
2026/07/07 10:44:41 :router: INFO: Registering GET endpoint: /v1/agents/ids
2026/07/07 10:44:41 :router: INFO: Registering GET endpoint: /v1/agents/ids/groups/:name
2026/07/07 10:44:41 :router: INFO: Registering GET endpoint: /v1/agents/ids/groups
2026/07/07 10:44:41 :router: INFO: Registering GET endpoint: /v1/agents/:agent_id/groups
2026/07/07 10:44:41 :router: INFO: Registering POST endpoint: /v1/agents/summary
2026/07/07 10:44:41 :router: INFO: Registering GET endpoint: /v1/agents/sync
2026/07/07 10:44:41 :router: INFO: Registering POST endpoint: /v1/agents/sync
2026/07/07 10:44:41 :router: INFO: Registering POST endpoint: /v1/agents/restartinfo
2026/07/07 10:44:41 :router: INFO: API started successfully
2026/07/07 10:44:42 wazuh-execd: INFO: Started (pid: 55090).
2026/07/07 10:44:42 wazuh-syscheckd: INFO: Started (pid: 55110).
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/07/07 10:44:42 rootcheck: INFO: Starting rootcheck scan.
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/07/07 10:44:42 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/07/07 10:44:42 wazuh-analysisd: INFO: Total rules enabled: '8451'
2026/07/07 10:44:42 wazuh-analysisd: INFO: Started (pid: 55101).
2026/07/07 10:44:42 wazuh-analysisd: INFO: (7200): Logtest started
2026/07/07 10:44:42 wazuh-analysisd: INFO: EPS limit disabled
2026/07/07 10:44:43 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/07/07 10:44:43 wazuh-syscheckd: INFO: FIM sync module started.
2026/07/07 10:44:43 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2026/07/07 10:44:43 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2026/07/07 10:44:43 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2026/07/07 10:44:43 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2026/07/07 10:44:43 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2026/07/07 10:44:43 wazuh-logcollector: INFO: Started (pid: 55192).
2026/07/07 10:44:43 wazuh-remoted: INFO: Started (pid: 55180). Listening on port 1514/TCP (secure).
2026/07/07 10:44:43 wazuh-remoted: INFO: (1410): Reading authentication keys file.
2026/07/07 10:44:44 wazuh-monitord: INFO: Started (pid: 55269).
2026/07/07 10:44:45 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2026/07/07 10:44:45 wazuh-modulesd:router: INFO: Loaded router module.
2026/07/07 10:44:45 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2026/07/07 10:44:45 wazuh-modulesd:inventory-harvester: INFO: Loaded Inventory harvester module.
2026/07/07 10:44:45 wazuh-modulesd: INFO: Started (pid: 55327).
2026/07/07 10:44:45 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2026/07/07 10:44:45 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2026/07/07 10:44:45 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2026/07/07 10:44:45 wazuh-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2026/07/07 10:44:45 sca: INFO: Module started.
2026/07/07 10:44:45 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2026/07/07 10:44:45 wazuh-modulesd:vulnerability-scanner: INFO: Starting vulnerability_scanner module.
2026/07/07 10:44:45 sca: INFO: Starting Security Configuration Assessment scan.
2026/07/07 10:44:45 wazuh-modulesd:router: INFO: Starting router module.
2026/07/07 10:44:45 wazuh-modulesd:database: INFO: Module started.
2026/07/07 10:44:45 wazuh-modulesd:content_manager: INFO: Starting content_manager module.
2026/07/07 10:44:45 wazuh-modulesd:download: INFO: Module started.
2026/07/07 10:44:45 wazuh-modulesd:syscollector: INFO: Module started.
2026/07/07 10:44:45 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/07 10:44:45 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/07 10:44:45 wazuh-modulesd:inventory-harvester: INFO: Starting inventory_harvester module.
2026/07/07 10:44:45 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2026/07/07 10:44:45 wazuh-modulesd:vulnerability-scanner: INFO: Vulnerability scanner module started.
2026/07/07 10:44:46 logger-helper: INFO: InventoryHarvesterFacade module started.
2026/07/07 10:44:46 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/07/07 10:44:46 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-vulnerabilities-wazuh-master.
2026/07/07 10:44:46 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-system-wazuh-master.
2026/07/07 10:44:46 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-packages-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-hardware-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-processes-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-hotfixes-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-ports-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-users-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-networks-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-interfaces-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-protocols-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-groups-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-browser-extensions-wazuh-master.
2026/07/07 10:44:47 indexer-connector: INFO: IndexerConnector initialized successfully for index: wazuh-states-inventory-services-wazuh-master.
2026/07/07 10:44:50 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu24-04.yml'
2026/07/07 10:44:50 sca: INFO: Security Configuration Assessment scan finished. Duration: 5 seconds.
2026/07/07 10:44:53 wazuh-syscheckd: INFO: netstat not available. Skipping port check.
2026/07/07 10:44:59 rootcheck: INFO: Ending rootcheck scan.
```

</details>

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
- [ ] Log syntax and correct language review

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

- `api/api/test/test_middlewares.py::test_run_as_login_oversized_payload`: Sends a payload bigger than the allowed size (`AUTH_CONTEXT_MAX_PAYLOAD_SIZE`).
- `framework/wazuh/rbac/tests/test_auth_context.py::test_find_item_depth_limit_returns_false`: Forces `find_item` to exceed `MAX_FIND_ITEM_DEPTH`.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
