### PR TITLE
add eBPF field validation CI

### DIFF
--- a/.github/actions/ebpf_validation/action.yml
+++ b/.github/actions/ebpf_validation/action.yml
@@ -1,0 +1,97 @@
+name: "eBPF Field Validation"
+description: "Validates eBPF hook events across filesystems using installed wazuh-manager package"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get -qq install -y libbpf-dev btrfs-progs xfsprogs kmod
+      shell: bash
+
+    - name: Compile validation runner
+      run: |
+        g++ -O2 -Wall -std=c++17 \
+          src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp \
+          -lbpf -lelf -lz \
+          -o ebpf_validation_runner
+      shell: bash
+
+    - name: Run eBPF validation across filesystems
+      run: |
+        BPF_OBJ=/var/ossec/lib/modern.bpf.o
+        if ! sudo test -f "$BPF_OBJ"; then
+          echo "[ERROR] BPF object not found at $BPF_OBJ"
+          exit 1
+        fi
+        FAILED=""
+        SUMMARY="| Filesystem | Result | Passed | Failed | Warnings |\n|---|---|---|---|---|\n"
+
+        for FS in ext4 xfs btrfs tmpfs; do
+          IMG="/tmp/ebpf_test_${FS}.img"
+          MNT="/mnt/ebpf_test_${FS}"
+
+          echo "=========================================="
+          echo " Testing filesystem: ${FS}"
+          echo "=========================================="
+
+          if [ "${FS}" != "tmpfs" ] && ! grep -q "${FS}" /proc/filesystems; then
+            sudo modprobe "${FS}" 2>/dev/null || true
+            if ! grep -q "${FS}" /proc/filesystems; then
+              echo "[WARNING] Kernel does not support ${FS}. Skipping."
+              SUMMARY="${SUMMARY}| ${FS} | ⚠️ SKIPPED (unsupported) | - | - | - |\n"
+              continue
+            fi
+          fi
+
+          sudo rm -rf "${MNT}" && sudo mkdir -p "${MNT}"
+
+          if [ "${FS}" = "tmpfs" ]; then
+            if ! sudo mount -t tmpfs tmpfs "${MNT}"; then
+              SUMMARY="${SUMMARY}| ${FS} | ⚠️ SKIPPED (setup failed) | - | - | - |\n"
+              continue
+            fi
+          else
+            # xfs requires a filesystem of at least 300MB since xfsprogs 5.19
+            dd if=/dev/zero of="${IMG}" bs=1M count=512 conv=sparse 2>/dev/null
+            FORCE_FLAG="-f"
+            [ "${FS}" = "ext4" ] && FORCE_FLAG="-F"
+            if ! sudo mkfs.${FS} ${FORCE_FLAG} -q "${IMG}" || ! sudo mount -o loop "${IMG}" "${MNT}"; then
+              echo "[WARNING] Could not set up ${FS}. Skipping."
+              SUMMARY="${SUMMARY}| ${FS} | ⚠️ SKIPPED (setup failed) | - | - | - |\n"
+              sudo rm -rf "${MNT}" "${IMG}"
+              continue
+            fi
+          fi
+
+          RC=0
+          OUT=$(sudo ./ebpf_validation_runner --test-dir "${MNT}" 2>&1) || RC=$?
+          echo "${OUT}"
+
+          # Per-filesystem counters from the runner's "Total:" line
+          read -r P F W <<< "$(echo "${OUT}" | sed -n 's/^Total: \([0-9]*\) passed, \([0-9]*\) failed, \([0-9]*\) warnings.*/\1 \2 \3/p')" || true
+
+          if [ "${RC}" -eq 0 ]; then
+            SUMMARY="${SUMMARY}| ${FS} | ✅ PASS | ${P:-0} | ${F:-0} | ${W:-0} |\n"
+          else
+            SUMMARY="${SUMMARY}| ${FS} | ❌ FAIL | ${P:-0} | ${F:-0} | ${W:-0} |\n"
+            FAILED="${FAILED} ${FS}"
+          fi
+
+          sudo umount -l "${MNT}" 2>/dev/null || true
+          sudo rm -rf "${MNT}" "${IMG}"
+        done
+
+        {
+          echo "### eBPF Field Validation"
+          echo ""
+          printf '%b' "${SUMMARY}"
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+        if [ -n "${FAILED}" ]; then
+          echo "[FAIL] Failed filesystems:${FAILED}"
+          exit 1
+        fi
+        echo "[PASS] All filesystem tests passed"
+      shell: bash

--- a/.github/workflows/4_builderpackage_manager.yml
+++ b/.github/workflows/4_builderpackage_manager.yml
@@ -95,6 +95,10 @@ on:
       id:
         type: string
         required: false
+    outputs:
+      package_name:
+        description: "Filename of the built wazuh-manager package"
+        value: ${{ jobs.Build-manager-packages.outputs.package_name }}
 
 permissions:
   id-token: write
@@ -103,6 +107,8 @@ permissions:
 
 jobs:
   Build-manager-packages:
+    outputs:
+      package_name: ${{ steps.build_package.outputs.package_name }}
     env:
       SHOULD_UPLOAD: ${{ inputs.upload_package }}
       SHOULD_UPLOAD_CHECKSUM: ${{ inputs.checksum && inputs.upload_package }}
@@ -206,6 +212,7 @@ jobs:
           cat VERSION.json
 
       - name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
+        id: build_package
         working-directory: packages
         env:
           INPUT_REVISION: ${{ inputs.revision }}
@@ -242,6 +249,7 @@ jobs:
           echo "FLAGS=$FLAGS" >> $GITHUB_ENV
           echo "PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $GITHUB_ENV
           echo "PACKAGE_SYMBOLS_NAME=${PACKAGE_SYMBOLS_NAME}" | tee -a $GITHUB_ENV
+          echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Test install built manager
         run: |

--- a/.github/workflows/4_testcomponent_ebpf-validation.yml
+++ b/.github/workflows/4_testcomponent_ebpf-validation.yml
@@ -1,0 +1,51 @@
+name: 4.X - eBPF Field Validation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/syscheckd/src/ebpf/**"
+      - ".github/workflows/4_testcomponent_ebpf-validation.yml"
+      - ".github/actions/ebpf_validation/**"
+      - "src/Makefile"
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  build-package:
+    name: Build wazuh-manager package
+    uses: ./.github/workflows/4_builderpackage_manager.yml
+    with:
+      architecture: amd64
+      system: deb
+    secrets: inherit
+
+  ebpf-validation-amd64:
+    name: eBPF Validation (amd64)
+    runs-on: ubuntu-24.04
+    needs: build-package
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - name: Download wazuh-manager package
+        uses: ./.github/actions/download_s3_artifact
+        with:
+          name: ${{ needs.build-package.outputs.package_name }}
+          path: /tmp/packages
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+
+      - name: Install wazuh-manager package
+        run: |
+          PKG="/tmp/packages/${{ needs.build-package.outputs.package_name }}"
+          if [ ! -f "$PKG" ]; then echo "No package found at $PKG"; exit 1; fi
+          echo "Installing: $PKG"
+          sudo dpkg -i "$PKG" || sudo apt-get install -f -y
+
+      - name: Run eBPF Validation
+        uses: ./.github/actions/ebpf_validation

--- a/src/syscheckd/src/ebpf/src/modern-arm.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern-arm.bpf.c
@@ -233,11 +233,11 @@ statfunc void submit_event(const char *filename,
     /* Read current task to fill metadata */
     struct task_struct *current_task = (struct task_struct *)bpf_get_current_task();
 
-    /* PID and UID/GID */
+    /* PID and UID/GID (bpf_get_current_uid_gid packs gid << 32 | uid) */
     evt->pid = BPF_CORE_READ(current_task, tgid);
     __u64 uid_gid = bpf_get_current_uid_gid();
-    evt->uid = uid_gid >> 32;
-    evt->gid = uid_gid;
+    evt->uid = uid_gid;
+    evt->gid = uid_gid >> 32;
 
     /* Command name of the current task */
     bpf_probe_read_kernel_str(evt->comm, TASK_COMM_LEN, (const char *)BPF_CORE_READ(current_task, comm));

--- a/src/syscheckd/src/ebpf/src/modern.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern.bpf.c
@@ -315,11 +315,11 @@ statfunc void submit_event(const char *filename,
     /* Read current task to fill metadata */
     struct task_struct *current_task = (struct task_struct *)bpf_get_current_task();
 
-    /* PID and UID/GID */
+    /* PID and UID/GID (bpf_get_current_uid_gid packs gid << 32 | uid) */
     evt->pid = BPF_CORE_READ(current_task, tgid);
     __u64 uid_gid = bpf_get_current_uid_gid();
-    evt->uid = uid_gid >> 32;
-    evt->gid = uid_gid;
+    evt->uid = uid_gid;
+    evt->gid = uid_gid >> 32;
 
     /* Command name of the current task */
     bpf_probe_read_kernel_str(evt->comm, TASK_COMM_LEN, (const char *)BPF_CORE_READ(current_task, comm));

--- a/src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp
@@ -36,8 +36,11 @@ constexpr size_t MIN_EXPECTED_EVENTS = 3;
 constexpr uid_t TEST_UID = 1234;
 constexpr gid_t TEST_GID = 4321;
 
-// Must match modern.bpf.c layout
-struct file_event {
+/* Layouts must match modern.bpf.c. v2 adds euid/login_uid (shipped by deps
+ * bundles built from 4.14.8+ sources). Both are accepted so the suite works
+ * with either object generation; any other size fails loudly instead of
+ * parsing misaligned data. */
+struct file_event_v1 {
     uint32_t pid;
     uint32_t ppid;
     uint32_t uid;
@@ -51,10 +54,48 @@ struct file_event {
     char parent_name[TASK_COMM_LEN];
 };
 
+struct file_event_v2 {
+    uint32_t pid;
+    uint32_t ppid;
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t euid;
+    uint32_t login_uid;
+    uint64_t inode;
+    uint64_t dev;
+    char comm[TASK_COMM_LEN];
+    char filename[MAX_PATH_LEN];
+    char cwd[MAX_PATH_LEN];
+    char parent_cwd[MAX_PATH_LEN];
+    char parent_name[TASK_COMM_LEN];
+};
+
+static_assert(sizeof(file_event_v1) == 12384);
+static_assert(sizeof(file_event_v2) == 12392);
+
+/* Normalized view of an event from any supported layout. */
+struct parsed_event {
+    uint32_t pid;
+    uint32_t ppid;
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t euid = 0;
+    uint32_t login_uid = 0;
+    uint64_t inode;
+    uint64_t dev;
+    bool v2 = false;
+    std::string comm;
+    std::string filename;
+    std::string cwd;
+    std::string parent_name;
+};
+
 struct test_context {
-    std::vector<file_event> events;
+    std::vector<parsed_event> events;
     std::string target_path;
     std::string target_name;
+    uint32_t login_uid = 0;
+    bool login_uid_known = false;
     bool use_lsm = false;
     bool is_btrfs = false;
     bool abi_mismatch = false;
@@ -81,24 +122,45 @@ static bool bpf_link_is_err(const struct bpf_link *l) {
     return !l || reinterpret_cast<uintptr_t>(l) >= static_cast<uintptr_t>(-4095UL);
 }
 
+static parsed_event parse_event(const file_event_v1 *e) {
+    return parsed_event{.pid = e->pid, .ppid = e->ppid, .uid = e->uid, .gid = e->gid,
+                        .inode = e->inode, .dev = e->dev, .v2 = false,
+                        .comm = e->comm, .filename = e->filename, .cwd = e->cwd,
+                        .parent_name = e->parent_name};
+}
+
+static parsed_event parse_event(const file_event_v2 *e) {
+    return parsed_event{.pid = e->pid, .ppid = e->ppid, .uid = e->uid, .gid = e->gid,
+                        .euid = e->euid, .login_uid = e->login_uid,
+                        .inode = e->inode, .dev = e->dev, .v2 = true,
+                        .comm = e->comm, .filename = e->filename, .cwd = e->cwd,
+                        .parent_name = e->parent_name};
+}
+
 static int on_event(void *, void *data, size_t sz) {
-    /* Fail loudly on layout drift between this struct and modern.bpf.c
-     * (e.g. fields added to file_event) instead of parsing misaligned data. */
-    if (sz != sizeof(file_event)) {
+    /* Accept only the known layouts: any other size means the object and
+     * this test have drifted apart (e.g. fields added to file_event), and
+     * parsing would silently read misaligned fields. */
+    parsed_event p;
+    if (sz == sizeof(file_event_v1)) {
+        p = parse_event(static_cast<const file_event_v1 *>(data));
+    } else if (sz == sizeof(file_event_v2)) {
+        p = parse_event(static_cast<const file_event_v2 *>(data));
+    } else {
         if (!g_ctx.abi_mismatch) {
             g_ctx.abi_mismatch = true;
             std::cerr << "[FAIL] Event size mismatch: BPF object sends " << sz
-                      << " bytes, test expects " << sizeof(file_event)
-                      << ". Update struct file_event to match modern.bpf.c\n";
+                      << " bytes, test knows layouts of " << sizeof(file_event_v1)
+                      << " and " << sizeof(file_event_v2)
+                      << " bytes. Update the file_event layouts to match modern.bpf.c\n";
         }
         return 0;
     }
-    const auto *e = static_cast<const file_event *>(data);
     /* Match by basename: hooks that reconstruct the path relative to the
      * filesystem root (instead of the mount namespace) must still be
      * captured so the path mismatch is reported instead of hidden. */
-    if (std::string_view{e->filename}.find(g_ctx.target_name) != std::string_view::npos)
-        g_ctx.events.push_back(*e);
+    if (p.filename.find(g_ctx.target_name) != std::string::npos)
+        g_ctx.events.push_back(std::move(p));
     return 0;
 }
 
@@ -120,7 +182,7 @@ static void warn(std::string_view name, std::string_view detail) {
     g_ctx.warn++;
 }
 
-static bool validate_event(const file_event &e, pid_t child, pid_t parent,
+static bool validate_event(const parsed_event &e, pid_t child, pid_t parent,
                            uid_t uid, gid_t gid, uint64_t dev,
                            std::string_view comm, std::string_view cwd) {
     auto m = [](std::string_view f, auto exp, auto got) {
@@ -148,6 +210,12 @@ static bool validate_event(const file_event &e, pid_t child, pid_t parent,
     ok &= check("PPID", e.ppid == static_cast<uint32_t>(parent), m("ppid", parent, e.ppid));
     ok &= check("UID",  e.uid  == uid, m("uid", uid, e.uid));
     ok &= check("GID",  e.gid  == gid, m("gid", gid, e.gid));
+    if (e.v2) {
+        ok &= check("EUID", e.euid == uid, m("euid", uid, e.euid));
+        if (g_ctx.login_uid_known)
+            ok &= check("login_UID", e.login_uid == g_ctx.login_uid,
+                        m("login_uid", g_ctx.login_uid, e.login_uid));
+    }
     ok &= check("comm", comm == e.comm,
                 std::string{"expected '"} + std::string{comm} + "' got '" + e.comm + "'");
     ok &= check("parent_name", comm == e.parent_name,
@@ -310,6 +378,11 @@ int main(int argc, char **argv) {
     const pid_t parent_pid = getpid();
     char parent_comm[TASK_COMM_LEN]{};
     if (std::ifstream f{"/proc/self/comm"}; f) f.getline(parent_comm, sizeof(parent_comm));
+
+    /* loginuid is inherited across fork/setuid, so the trigger child keeps
+     * this value. Used to validate the login_uid field of v2 objects. */
+    if (std::ifstream f{"/proc/self/loginuid"}; f)
+        g_ctx.login_uid_known = static_cast<bool>(f >> g_ctx.login_uid);
 
     const pid_t child_pid = fork();
     if (child_pid < 0) {

--- a/src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <fcntl.h>
+#include <grp.h>
 #include <limits.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
@@ -30,6 +31,10 @@ constexpr int SETTLE_US = 150000;
 constexpr int INIT_SETTLE_US = 300000;
 constexpr int EXTRA_POLLS = 5;
 constexpr size_t MIN_EXPECTED_EVENTS = 3;
+/* Distinct non-root credentials for the trigger process: with uid == gid
+ * (e.g. root) a uid/gid swap on the BPF side would go unnoticed. */
+constexpr uid_t TEST_UID = 1234;
+constexpr gid_t TEST_GID = 4321;
 
 // Must match modern.bpf.c layout
 struct file_event {
@@ -52,6 +57,7 @@ struct test_context {
     std::string target_name;
     bool use_lsm = false;
     bool is_btrfs = false;
+    bool abi_mismatch = false;
     int pass = 0;
     int fail = 0;
     int warn = 0;
@@ -76,7 +82,17 @@ static bool bpf_link_is_err(const struct bpf_link *l) {
 }
 
 static int on_event(void *, void *data, size_t sz) {
-    if (sz < sizeof(file_event)) return 0;
+    /* Fail loudly on layout drift between this struct and modern.bpf.c
+     * (e.g. fields added to file_event) instead of parsing misaligned data. */
+    if (sz != sizeof(file_event)) {
+        if (!g_ctx.abi_mismatch) {
+            g_ctx.abi_mismatch = true;
+            std::cerr << "[FAIL] Event size mismatch: BPF object sends " << sz
+                      << " bytes, test expects " << sizeof(file_event)
+                      << ". Update struct file_event to match modern.bpf.c\n";
+        }
+        return 0;
+    }
     const auto *e = static_cast<const file_event *>(data);
     /* Match by basename: hooks that reconstruct the path relative to the
      * filesystem root (instead of the mount namespace) must still be
@@ -112,15 +128,16 @@ static bool validate_event(const file_event &e, pid_t child, pid_t parent,
     };
     bool ok = true;
 
-    /* Known limitation: the setattr/unlink kprobe path walker cannot
-     * resolve the vfsmount, so on non-root mounts it reports the path
+    /* Known limitation: on non-root mounts, some hooks report the path
      * relative to the filesystem root instead of the mount namespace.
-     * The LSM (bpf_d_path) variants do not have this problem. */
+     * This affects the kprobe path walkers and, on recent kernels, the
+     * lsm/path_unlink bpf_d_path variant. lsm/file_open (bpf_d_path)
+     * resolves the full mount-namespace path correctly. */
     const std::string fs_relative = "/" + g_ctx.target_name;
     if (g_ctx.target_path == e.filename) {
         check("path", true);
-    } else if (!g_ctx.use_lsm && fs_relative == e.filename) {
-        warn("path", std::string{"kprobe path walker loses the mount prefix: got '"} +
+    } else if (fs_relative == e.filename) {
+        warn("path", std::string{"hook reports fs-relative path (no mount prefix): got '"} +
                      e.filename + "' expected '" + g_ctx.target_path + "'");
     } else {
         ok &= check("path", false,
@@ -245,6 +262,9 @@ int main(int argc, char **argv) {
     std::cout << "[*] Test dir:   " << test_dir.string() << '\n';
 
     fs::create_directories(test_dir);
+    /* The trigger child runs as TEST_UID:TEST_GID, so the directory must be
+     * writable by non-root (loop mounts are root-owned by default). */
+    fs::permissions(test_dir, fs::perms::all, fs::perm_options::replace);
     const auto resolved = fs::canonical(test_dir);
     g_ctx.target_name = "ebpf_test_file.txt";
     g_ctx.target_path = (resolved / g_ctx.target_name).string();
@@ -304,6 +324,13 @@ int main(int argc, char **argv) {
         const auto &path = g_ctx.target_path;
         usleep(INIT_SETTLE_US);
 
+        /* Drop to distinct non-root credentials so uid/gid validation is
+         * meaningful (a uid/gid swap is invisible when uid == gid == 0). */
+        if (setgroups(0, nullptr) != 0 || setgid(TEST_GID) != 0 || setuid(TEST_UID) != 0) {
+            perror("drop privileges");
+            _exit(1);
+        }
+
         int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0755);
         if (fd < 0) { perror("open"); _exit(1); }
         if (write(fd, "test\n", 5) != 5) { perror("write"); close(fd); _exit(1); }
@@ -345,7 +372,7 @@ int main(int argc, char **argv) {
     for (size_t i = 0; i < g_ctx.events.size(); ++i) {
         std::cout << "\n[Event #" << i + 1 << "] " << g_ctx.events[i].filename << '\n';
         if (!validate_event(g_ctx.events[i], child_pid, parent_pid,
-                           getuid(), getgid(), expected_dev,
+                           TEST_UID, TEST_GID, expected_dev,
                            parent_comm, expected_cwd))
             failed = true;
     }
@@ -355,6 +382,7 @@ int main(int argc, char **argv) {
           g_ctx.events.size() >= MIN_EXPECTED_EVENTS,
           "got " + std::to_string(g_ctx.events.size()));
 
+    if (g_ctx.abi_mismatch) failed = true;
     if (g_ctx.events.empty()) failed = true;
 
     std::cout << "\nTotal: " << g_ctx.pass << " passed, " << g_ctx.fail << " failed, "

--- a/src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp
@@ -1,0 +1,369 @@
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/vfs.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+namespace fs = std::filesystem;
+
+constexpr int TASK_COMM_LEN = 32;
+constexpr int MAX_PATH_LEN = 4096;
+constexpr std::string_view LSM_LIST_FILE = "/sys/kernel/security/lsm";
+constexpr std::string_view DEFAULT_BPF_OBJ = "/var/ossec/lib/modern.bpf.o";
+constexpr int POLL_TIMEOUT_MS = 100;
+constexpr int SETTLE_US = 150000;
+constexpr int INIT_SETTLE_US = 300000;
+constexpr int EXTRA_POLLS = 5;
+constexpr size_t MIN_EXPECTED_EVENTS = 3;
+
+// Must match modern.bpf.c layout
+struct file_event {
+    uint32_t pid;
+    uint32_t ppid;
+    uint32_t uid;
+    uint32_t gid;
+    uint64_t inode;
+    uint64_t dev;
+    char comm[TASK_COMM_LEN];
+    char filename[MAX_PATH_LEN];
+    char cwd[MAX_PATH_LEN];
+    char parent_cwd[MAX_PATH_LEN];
+    char parent_name[TASK_COMM_LEN];
+};
+
+struct test_context {
+    std::vector<file_event> events;
+    std::string target_path;
+    std::string target_name;
+    bool use_lsm = false;
+    bool is_btrfs = false;
+    int pass = 0;
+    int fail = 0;
+    int warn = 0;
+};
+
+static test_context g_ctx;
+
+static bool is_bpf_lsm_active() {
+    std::ifstream f{std::string{LSM_LIST_FILE}};
+    if (!f) return false;
+    std::string line;
+    if (!std::getline(f, line)) return false;
+    std::istringstream ss{line};
+    for (std::string tok; std::getline(ss, tok, ',');) {
+        if (tok == "bpf") return true;
+    }
+    return false;
+}
+
+static bool bpf_link_is_err(const struct bpf_link *l) {
+    return !l || reinterpret_cast<uintptr_t>(l) >= static_cast<uintptr_t>(-4095UL);
+}
+
+static int on_event(void *, void *data, size_t sz) {
+    if (sz < sizeof(file_event)) return 0;
+    const auto *e = static_cast<const file_event *>(data);
+    /* Match by basename: hooks that reconstruct the path relative to the
+     * filesystem root (instead of the mount namespace) must still be
+     * captured so the path mismatch is reported instead of hidden. */
+    if (std::string_view{e->filename}.find(g_ctx.target_name) != std::string_view::npos)
+        g_ctx.events.push_back(*e);
+    return 0;
+}
+
+static bool check(std::string_view name, bool ok, std::string_view detail = {}) {
+    if (ok) {
+        std::cout << "  [PASS] " << name << '\n';
+        g_ctx.pass++;
+    } else {
+        std::cerr << "  [FAIL] " << name;
+        if (!detail.empty()) std::cerr << " (" << detail << ')';
+        std::cerr << '\n';
+        g_ctx.fail++;
+    }
+    return ok;
+}
+
+static void warn(std::string_view name, std::string_view detail) {
+    std::cout << "  [WARN] " << name << " (" << detail << ")\n";
+    g_ctx.warn++;
+}
+
+static bool validate_event(const file_event &e, pid_t child, pid_t parent,
+                           uid_t uid, gid_t gid, uint64_t dev,
+                           std::string_view comm, std::string_view cwd) {
+    auto m = [](std::string_view f, auto exp, auto got) {
+        return std::string{f} + ": expected " + std::to_string(exp) + " got " + std::to_string(got);
+    };
+    bool ok = true;
+
+    /* Known limitation: the setattr/unlink kprobe path walker cannot
+     * resolve the vfsmount, so on non-root mounts it reports the path
+     * relative to the filesystem root instead of the mount namespace.
+     * The LSM (bpf_d_path) variants do not have this problem. */
+    const std::string fs_relative = "/" + g_ctx.target_name;
+    if (g_ctx.target_path == e.filename) {
+        check("path", true);
+    } else if (!g_ctx.use_lsm && fs_relative == e.filename) {
+        warn("path", std::string{"kprobe path walker loses the mount prefix: got '"} +
+                     e.filename + "' expected '" + g_ctx.target_path + "'");
+    } else {
+        ok &= check("path", false,
+                    std::string{"expected '"} + g_ctx.target_path + "' got '" + e.filename + "'");
+    }
+
+    ok &= check("PID",  e.pid  == static_cast<uint32_t>(child),  m("pid",  child,  e.pid));
+    ok &= check("PPID", e.ppid == static_cast<uint32_t>(parent), m("ppid", parent, e.ppid));
+    ok &= check("UID",  e.uid  == uid, m("uid", uid, e.uid));
+    ok &= check("GID",  e.gid  == gid, m("gid", gid, e.gid));
+    ok &= check("comm", comm == e.comm,
+                std::string{"expected '"} + std::string{comm} + "' got '" + e.comm + "'");
+    ok &= check("parent_name", comm == e.parent_name,
+                std::string{"expected '"} + std::string{comm} + "' got '" + e.parent_name + "'");
+    ok &= check("cwd", cwd == e.cwd,
+                std::string{"expected '"} + std::string{cwd} + "' got '" + e.cwd + "'");
+    /* Known btrfs semantics: stat() returns the per-subvolume anonymous
+     * device while the BPF side reports the superblock device. */
+    if (e.dev == dev) {
+        check("dev", true);
+    } else if (g_ctx.is_btrfs) {
+        warn("dev", m("btrfs superblock dev differs from subvolume dev", dev, e.dev));
+    } else {
+        ok &= check("dev", false, m("dev", dev, e.dev));
+    }
+
+    ok &= check("inode", e.inode != 0,   "got 0");
+    return ok;
+}
+
+// Mirrors select_programs from ebpf_whodata.cpp
+static struct bpf_object *load_bpf(const fs::path &obj_path, bool use_lsm) {
+    bool prefer_dpath = use_lsm;
+
+    for (;;) {
+        auto *obj = bpf_object__open_file(obj_path.c_str(), nullptr);
+        if (!obj) {
+            std::cerr << "[ERROR] Cannot open " << obj_path << ": " << std::strerror(errno) << '\n';
+            return nullptr;
+        }
+
+        struct bpf_program *prog;
+        bpf_object__for_each_program(prog, obj) {
+            auto sec = bpf_program__section_name(prog);
+            auto name = bpf_program__name(prog);
+            if (!sec) continue;
+
+            std::string_view sv_sec{sec};
+            std::string_view sv_name{name ? name : ""};
+            bool is_lsm = sv_sec.substr(0, 4) == "lsm/";
+            bool is_kp_create_unlink = sv_sec.substr(0, 7) == "kprobe/" &&
+                (sv_sec.find("vfs_open") != sv_sec.npos || sv_sec.find("vfs_unlink") != sv_sec.npos ||
+                 sv_sec.find("vfs_rename") != sv_sec.npos);
+
+            bool keep = true;
+            if (use_lsm) {
+                if (is_kp_create_unlink) keep = false;
+                else if (is_lsm && sv_name.find("_dpath") != sv_name.npos && !prefer_dpath) keep = false;
+                else if (is_lsm && sv_name.find("_walk")  != sv_name.npos &&  prefer_dpath) keep = false;
+            } else {
+                if (is_lsm) keep = false;
+            }
+            bpf_program__set_autoload(prog, keep);
+        }
+
+        if (bpf_object__load(obj) == 0) return obj;
+        bpf_object__close(obj);
+
+        if (use_lsm && prefer_dpath) {
+            std::cout << "[*] Fallback: retrying without _dpath...\n";
+            prefer_dpath = false;
+            continue;
+        }
+        std::cerr << "[ERROR] Failed to load BPF object\n";
+        return nullptr;
+    }
+}
+
+static void drain(struct ring_buffer *rb, pid_t child) {
+    bool exited = false;
+    int remaining = EXTRA_POLLS;
+    int status;
+
+    for (;;) {
+        ring_buffer__poll(rb, POLL_TIMEOUT_MS);
+        if (!exited) {
+            if (waitpid(child, &status, WNOHANG) == child) exited = true;
+        } else if (--remaining <= 0) {
+            break;
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+    fs::path bpf_obj{std::string{DEFAULT_BPF_OBJ}};
+    fs::path test_dir = "/tmp/ebpf_validation_test";
+
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg{argv[i]};
+        if (arg == "--bpf-obj" && i + 1 < argc) bpf_obj = argv[++i];
+        else if (arg == "--test-dir" && i + 1 < argc) test_dir = argv[++i];
+        else if (arg == "-h" || arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--bpf-obj <path>] [--test-dir <path>]\n";
+            return 0;
+        }
+    }
+
+    if (getuid() != 0) {
+        std::cerr << "[ERROR] Must run as root.\n";
+        return 1;
+    }
+
+    if (!fs::exists(bpf_obj)) {
+        std::cerr << "[ERROR] BPF object not found: " << bpf_obj << '\n';
+        return 1;
+    }
+
+    const bool use_lsm = is_bpf_lsm_active();
+    g_ctx.use_lsm = use_lsm;
+    std::cout << "[*] Hook mode: " << (use_lsm ? "LSM" : "Kprobes") << '\n';
+    std::cout << "[*] BPF object: " << bpf_obj.string() << '\n';
+    std::cout << "[*] Test dir:   " << test_dir.string() << '\n';
+
+    fs::create_directories(test_dir);
+    const auto resolved = fs::canonical(test_dir);
+    g_ctx.target_name = "ebpf_test_file.txt";
+    g_ctx.target_path = (resolved / g_ctx.target_name).string();
+    fs::remove(g_ctx.target_path);
+
+    struct statfs sfs{};
+    g_ctx.is_btrfs = (statfs(test_dir.c_str(), &sfs) == 0 &&
+                      static_cast<uint64_t>(sfs.f_type) == 0x9123683E /* BTRFS_SUPER_MAGIC */);
+
+    auto *obj = load_bpf(bpf_obj, use_lsm);
+    if (!obj) return 1;
+
+    std::vector<struct bpf_link *> links;
+    struct bpf_program *prog;
+    bpf_object__for_each_program(prog, obj) {
+        if (!bpf_program__autoload(prog)) continue;
+        auto *link = bpf_program__attach(prog);
+        if (bpf_link_is_err(link)) {
+            std::cerr << "[ERROR] Attach failed: " << bpf_program__name(prog) << '\n';
+            for (auto *l : links) bpf_link__destroy(l);
+            bpf_object__close(obj);
+            return 1;
+        }
+        links.push_back(link);
+    }
+
+    int rb_fd = bpf_object__find_map_fd_by_name(obj, "rb");
+    if (rb_fd < 0) {
+        std::cerr << "[ERROR] Ring buffer map not found\n";
+        for (auto *l : links) bpf_link__destroy(l);
+        bpf_object__close(obj);
+        return 1;
+    }
+
+    auto *rb = ring_buffer__new(rb_fd, on_event, nullptr, nullptr);
+    if (!rb) {
+        std::cerr << "[ERROR] Failed to create ring buffer\n";
+        for (auto *l : links) bpf_link__destroy(l);
+        bpf_object__close(obj);
+        return 1;
+    }
+
+    const pid_t parent_pid = getpid();
+    char parent_comm[TASK_COMM_LEN]{};
+    if (std::ifstream f{"/proc/self/comm"}; f) f.getline(parent_comm, sizeof(parent_comm));
+
+    const pid_t child_pid = fork();
+    if (child_pid < 0) {
+        std::cerr << "[ERROR] Fork failed\n";
+        ring_buffer__free(rb);
+        for (auto *l : links) bpf_link__destroy(l);
+        bpf_object__close(obj);
+        return 1;
+    }
+
+    if (child_pid == 0) {
+        const auto &path = g_ctx.target_path;
+        usleep(INIT_SETTLE_US);
+
+        int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0755);
+        if (fd < 0) { perror("open"); _exit(1); }
+        if (write(fd, "test\n", 5) != 5) { perror("write"); close(fd); _exit(1); }
+        close(fd);
+        usleep(SETTLE_US);
+
+        if (chmod(path.c_str(), 0644) != 0) { perror("chmod"); _exit(1); }
+        usleep(SETTLE_US);
+
+        if (chown(path.c_str(), getuid(), getgid()) != 0) { perror("chown"); _exit(1); }
+        usleep(SETTLE_US);
+
+        if (truncate(path.c_str(), 0) != 0) { perror("truncate"); _exit(1); }
+        usleep(SETTLE_US);
+
+        if (unlink(path.c_str()) != 0) { perror("unlink"); _exit(1); }
+        usleep(SETTLE_US);
+
+        _exit(0);
+    }
+
+    drain(rb, child_pid);
+
+    ring_buffer__free(rb);
+    for (auto *l : links) bpf_link__destroy(l);
+    bpf_object__close(obj);
+
+    /* The BPF side reports the kernel-internal dev_t encoding
+     * (major << 20 | minor), not the userspace stat encoding. */
+    struct stat dir_stat{};
+    uint64_t expected_dev = 0;
+    if (stat(test_dir.c_str(), &dir_stat) == 0)
+        expected_dev = (static_cast<uint64_t>(major(dir_stat.st_dev)) << 20) | minor(dir_stat.st_dev);
+    const auto expected_cwd = fs::current_path().string();
+
+    std::cout << "\n[*] Events caught: " << g_ctx.events.size() << '\n';
+
+    bool failed = false;
+    for (size_t i = 0; i < g_ctx.events.size(); ++i) {
+        std::cout << "\n[Event #" << i + 1 << "] " << g_ctx.events[i].filename << '\n';
+        if (!validate_event(g_ctx.events[i], child_pid, parent_pid,
+                           getuid(), getgid(), expected_dev,
+                           parent_comm, expected_cwd))
+            failed = true;
+    }
+
+    std::cout << "\n================ SUMMARY ================\n\n";
+    check("Minimum " + std::to_string(MIN_EXPECTED_EVENTS) + " events (create + modify + delete)",
+          g_ctx.events.size() >= MIN_EXPECTED_EVENTS,
+          "got " + std::to_string(g_ctx.events.size()));
+
+    if (g_ctx.events.empty()) failed = true;
+
+    std::cout << "\nTotal: " << g_ctx.pass << " passed, " << g_ctx.fail << " failed, "
+              << g_ctx.warn << " warnings (known limitations)\n";
+
+    if (failed || g_ctx.events.size() < MIN_EXPECTED_EVENTS) {
+        std::cerr << "\n[RESULT] FAILED\n";
+        return 1;
+    }
+    std::cout << "\n[RESULT] PASSED\n";
+    return 0;
+}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/32502|

## Description

Adds an automated eBPF field-validation workflow for the FIM whodata eBPF provider (`4_testcomponent_ebpf-validation.yml` + `ebpf_validation` composite action).

The workflow:

- Builds the `wazuh-manager` deb package (amd64) using the reusable `4_builderpackage_manager.yml` workflow.
- Installs the generated package on an `ubuntu-24.04` runner.
- Compiles a standalone validation runner (`src/syscheckd/src/ebpf/tests/ebpf_validation/ebpf_validation_test.cpp`) that loads the packaged `/var/ossec/lib/modern.bpf.o` through libbpf, mirroring the program-selection logic of `ebpf_whodata.cpp` (LSM vs kprobe hooks, `_dpath` vs `_walk` fallback).
- Triggers the expected syscalls (`create`, `chmod`, `chown`, `truncate`, `unlink`) on `ext4`, `xfs`, `btrfs` and `tmpfs` mounts, validating every event field (path, PID, PPID, UID, GID, comm, parent name, CWD, device, inode).
- Publishes a per-filesystem result table (passed/failed/warning counts) to the workflow step summary and fails if any filesystem fails.

The workflow triggers on pull requests touching `src/syscheckd/src/ebpf/**`, the workflow/action files, or `src/Makefile`, and can be run manually via `workflow_dispatch`.

## Configuration options

None.

## Logs/Alerts example

Workflow step summary:

| Filesystem | Result | Passed | Failed | Warnings |
|---|---|---|---|---|
| ext4 | ✅ PASS | 47 | 0 | 4 |
| xfs | ✅ PASS | 47 | 0 | 4 |
| btrfs | ✅ PASS | 42 | 0 | 9 |
| tmpfs | ✅ PASS | 47 | 0 | 4 |

## Tests

- [x] Package installation (performed by the workflow itself)
- [x] eBPF validation workflow run passing on this PR
