### PR TITLE
Patch cluster authentication

### DIFF
--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -11,13 +11,14 @@ from wazuh.core.cluster.control import get_health, get_nodes, get_node_ruleset_i
 from wazuh.core.cluster.utils import get_cluster_status, read_cluster_config, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
-from wazuh.rbac.decorators import expose_resources, async_list_handler
+from wazuh.rbac.decorators import expose_resources, async_list_handler, mask_sensitive_config
 
 cluster_enabled = not read_cluster_config(from_import=True)['disabled']
 node_id = get_node().get('node') if cluster_enabled else None
 node_type = get_node().get('type') if cluster_enabled else 'master'
 
 
+@mask_sensitive_config()
 @expose_resources(actions=['cluster:read'], resources=[f'node:id:{node_id}'])
 def read_config_wrapper() -> AffectedItemsWazuhResult:
     """Wrapper for read_config.
@@ -31,7 +32,7 @@ def read_config_wrapper() -> AffectedItemsWazuhResult:
                                       none_msg='No information was returned'
                                       )
     try:
-        result.affected_items.append(read_config())
+        result.affected_items.append(dict(read_config()))
     except WazuhError as e:
         result.add_failed_item(id_=node_id, error=e)
     result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -27,11 +27,14 @@ default_config = {'disabled': True, 'node_type': 'master', 'name': 'wazuh', 'nod
                   'key': '', 'port': 1516, 'bind_addr': '0.0.0.0', 'nodes': ['NODE_IP'], 'hidden': 'no'}
 
 
-@patch('wazuh.cluster.read_config', return_value=default_config)
-def test_read_config_wrapper(mock_read_config):
+@patch('wazuh.rbac.decorators._has_update_permissions', return_value=True)
+def test_read_config_wrapper(mock_perms):
     """Verify that the read_config_wrapper returns the default configuration."""
-    result = cluster.read_config_wrapper()
-    assert result.affected_items == [default_config]
+    fresh_config = dict(default_config)
+    with patch('wazuh.cluster.read_config', return_value=fresh_config):
+        result = cluster.read_config_wrapper()
+    # Admin (has update perms) is not masked: the full config must be returned unchanged.
+    assert result.affected_items[0] == default_config
 
 
 @patch('wazuh.cluster.read_config', side_effect=WazuhError(1001))
@@ -39,6 +42,61 @@ def test_read_config_wrapper_exception(mock_read_config):
     """Verify the exceptions raised in read_config_wrapper."""
     result = cluster.read_config_wrapper()
     assert list(result.failed_items.keys())[0] == WazuhError(1001)
+
+
+def _cluster_config_with_key():
+    """Return a fresh cluster config dict carrying a real key.
+
+    A new dict is built on every call so tests stay isolated even if a future
+    change masks the affected item in place instead of a copy.
+    """
+    return {'disabled': False, 'node_type': 'master', 'name': 'wazuh', 'node_name': 'master-node',
+            'key': 'REAL_CLUSTER_SECRET', 'port': 1516, 'bind_addr': '0.0.0.0',
+            'nodes': ['wazuh-master'], 'hidden': 'no'}
+
+
+@pytest.mark.parametrize('has_perms,expected_key', [
+    (False, '*****'),
+    (True, 'REAL_CLUSTER_SECRET'),
+])
+def test_read_config_wrapper_key_visibility(has_perms, expected_key):
+    """Key is masked for readonly users and exposed for admins."""
+    with patch('wazuh.rbac.decorators._has_update_permissions', return_value=has_perms):
+        with patch('wazuh.cluster.read_config', return_value=_cluster_config_with_key()):
+            result = cluster.read_config_wrapper()
+    assert result.affected_items[0]['key'] == expected_key
+
+
+@patch('wazuh.rbac.decorators._has_update_permissions', return_value=False)
+def test_read_config_wrapper_masking_preserves_other_fields(mock_perms):
+    """Masking only touches the key field, not other config fields."""
+    with patch('wazuh.cluster.read_config', return_value=_cluster_config_with_key()):
+        result = cluster.read_config_wrapper()
+    item = result.affected_items[0]
+    assert item['key'] == '*****'
+    assert item['name'] == 'wazuh'
+    assert item['node_name'] == 'master-node'
+    assert item['port'] == 1516
+    assert item['nodes'] == ['wazuh-master']
+
+
+def test_read_config_wrapper_no_cache_poisoning():
+    """Masking must not mutate the shared read_config() source dict (in-place-mutation regression guard)."""
+    shared_config = _cluster_config_with_key()
+
+    with patch('wazuh.cluster.read_config', return_value=shared_config):
+        # Readonly: the response is masked, but the shared (cached) dict must stay intact
+        with patch('wazuh.rbac.decorators._has_update_permissions', return_value=False):
+            ro_result = cluster.read_config_wrapper()
+
+        assert ro_result.affected_items[0]['key'] == '*****'
+        assert shared_config['key'] == 'REAL_CLUSTER_SECRET'
+
+        # A subsequent admin read still sees the real key (cache was not poisoned).
+        with patch('wazuh.rbac.decorators._has_update_permissions', return_value=True):
+            result = cluster.read_config_wrapper()
+
+        assert result.affected_items[0]['key'] == 'REAL_CLUSTER_SECRET'
 
 
 @patch('wazuh.cluster.read_config', return_value=default_config)


### PR DESCRIPTION

## Description

The `@mask_sensitive_config()` decorator masks some configuration fields in configuration-read responses for users without `manager:update_config` / `cluster:update_config`. It was already applied to `GET /manager/configuration` (`wazuh.manager.read_ossec_conf`) but not to `GET /cluster/local/config` (`wazuh.cluster.read_config_wrapper`), so the two configuration-read endpoints behaved inconsistently.

This change applies the same decorator to `read_config_wrapper` so both endpoints mask sensitive fields the same way. 

## Proposed Changes

- `framework/wazuh/cluster.py`: import `mask_sensitive_config` from `wazuh.rbac.decorators` and decorate `read_config_wrapper` with `@mask_sensitive_config()` (above the existing `@expose_resources`), matching the sibling `wazuh.manager.read_ossec_conf`. The wrapper appends a copy of the configuration (`dict(read_config())`) so the in-place masking operates on a per-response copy and does not mutate the cached dict returned by `read_config()`.
- `framework/wazuh/tests/test_cluster.py`: unit tests covering the masking behaviour and the no-cache-mutation guarantee.


## Configuration options

N/A — no new configuration parameters; RBAC defaults are unchanged.

## Results and Evidence

Framework unit suites under Python 3.12 (`PYTHONPATH=api:framework`):

- `framework/wazuh/tests/test_cluster.py` → 14 passed (4 new cases for the masking behaviour and the no-cache-mutation guarantee).
- `framework/wazuh/rbac/tests/test_decorators.py` + `framework/wazuh/tests/test_manager.py` → 164 passed.
- Full framework suite → 2694 passed.

Manual check on a single-node cluster with a key configured performed.

### Tests Introduced

- `test_read_config_wrapper_key_visibility` (parametrized) — cluster key masked (`*****`) for users without update-config and returned in clear for update-config holders.
- `test_read_config_wrapper_masking_preserves_other_fields` — masking only touches the `key` field, leaving the other config fields intact.
- `test_read_config_wrapper_no_cache_poisoning` — masking operates on a per-response copy, so the dict returned by `read_config()` is not mutated.
- `test_read_config_wrapper` pinned to the update-config path so it keeps asserting the unmasked behaviour.

## Credits

Thanks to @evilgensec and @geo-chen for raising this issue to our attention.

## Tests

- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Added unit tests (for new features)
- [x] Retrocompatibility with older Wazuh versions (update-config users see the values exactly as before)
- [ ] Working on cluster environments


