### PR TITLE
fix: correct blob URL refs for release branch

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -44,7 +44,7 @@ info:
   title: 'Wazuh API REST'
   license:
     name: 'GPL 2.0'
-    url: 'https://github.com/wazuh/wazuh/blob/v5.0.0-beta3/LICENSE'
+    url: 'https://github.com/wazuh/wazuh/blob/5.0.0/LICENSE'
 
 servers:
   - url: '{protocol}://{host}:{port}'
@@ -4007,7 +4007,7 @@ paths:
                 api_version: "v4.5.0"
                 revision: 'beta3'
                 license_name: "GPL 2.0"
-                license_url: "https://github.com/wazuh/wazuh/blob/v5.0.0-beta3/LICENSE"
+                license_url: "https://github.com/wazuh/wazuh/blob/5.0.0/LICENSE"
                 hostname: "wazuh"
                 timestamp: "2019-04-02T08:08:11Z"
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -353,16 +353,21 @@ update_file_api() {
         local version_short
         version_short=$(echo "$new_version" | awk -F. '{print $1 "." $2}')
         if [[ -z "$skip_urls" ]]; then
-            # Build the target Git ref for blob/ URLs. Pre-release stages tag as
-            # vMAJOR.MINOR.PATCH-STAGE (e.g. v5.0.0-beta2), so without the stage
-            # suffix the URL would point to a tag that does not exist yet.
-            local tag_ref="v${new_version}"
-            [[ -n "$new_stage" ]] && tag_ref="${tag_ref}-${new_stage}"
+            # Build the target ref for blob/ URLs.
+            # - Pre-release (stage non-empty): tag format vMAJOR.MINOR.PATCH-STAGE (e.g. v5.0.0-beta3)
+            # - Release branch (stage empty): branch name format MAJOR.MINOR.PATCH (e.g. 5.0.0, no v)
+            local url_ref
+            if [[ -n "$new_stage" ]]; then
+                url_ref="v${new_version}-${new_stage}"
+            else
+                url_ref="${new_version}"
+            fi
 
-            # blob/ paths: match main, vMAJOR.MINOR.PATCH, and vMAJOR.MINOR.PATCH-STAGE
-            # so subsequent stage bumps can replace an existing tagged ref.
+            # blob/ paths: match main, vMAJOR.MINOR.PATCH, vMAJOR.MINOR.PATCH-STAGE,
+            # and MAJOR.MINOR.PATCH (branch name without v) so any existing ref format
+            # can be replaced on subsequent bumps.
             sed -i -E \
-                "s~(blob/)(v?main|v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?)(/)~\1${tag_ref}\4~g" \
+                "s~(blob/)(v?main|v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+)(/)~\1${url_ref}\4~g" \
                 "$spec_file"
             # documentation URLs use 2-part version without v prefix (e.g. wazuh.com/5.0/)
             sed -i -E \


### PR DESCRIPTION
The bump applied `blob/v5.0.0-beta3/` references in `spec.yaml` instead of the branch name `5.0.0`. Two issues in `repository_bumper.sh` caused this:

1. The URL ref was built as `v{version}-{stage}` unconditionally, even when the target is a release branch (where the correct ref is the branch name without `v` prefix and without stage suffix).
2. The regex did not match the branch-name format (`MAJOR.MINOR.PATCH` without `v`), preventing future bumps from correcting it.

**Changes:**
- `api/api/spec/spec.yaml`: replace `blob/v5.0.0-beta3/` with `blob/5.0.0/`
- `tools/repository_bumper.sh`: when `--stage` is not passed, use branch-name format (`{version}`) for blob URLs; when `--stage` is passed, use tag format (`v{version}-{stage}`). Extend the regex to also match the branch-name format.

Relates to #37040.