### PR TITLE
Remove merged.mg hash cache to fix stale syscollector flush

### DIFF
--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -215,9 +215,6 @@ bool reloadAgent(void);
 // Verify remote configuration. Return 0 on success or -1 on error.
 int verifyRemoteConf();
 
-// Clear merged.mg hash cache value.
-void clear_merged_hash_cache();
-
 // Initialize startup gate state for module workload blocking.
 void startup_gate_initialize(void);
 

--- a/src/client-agent/src/notify.c
+++ b/src/client-agent/src/notify.c
@@ -17,8 +17,6 @@
 #include "metadata_provider.h"
 #include "cJSON.h"
 
-/* Keeps hash in memory until a change is identified */
-static char *g_shared_mg_file_hash = NULL;
 /* Keeps the timestamp of the last notification. */
 static time_t g_saved_time = 0;
 
@@ -72,11 +70,6 @@ char *get_agent_ip()
     }
 
     return strdup(agent_ip);
-}
-
-/* Clear merged hash cache, to be updated in the next iteration.*/
-void clear_merged_hash_cache() {
-    os_free(g_shared_mg_file_hash);
 }
 
 /* Build JSON keepalive message from metadata_provider and additional fields */
@@ -237,16 +230,15 @@ void run_notify()
         merror(MEM_ERROR, errno, strerror(errno));
     }
 
-    /* Get shared files */
-    struct stat stat_fd;
-    if (!g_shared_mg_file_hash) {
-        g_shared_mg_file_hash = getsharedfiles();
-        if (!g_shared_mg_file_hash) {
-            merror(MEM_ERROR, errno, strerror(errno));
-            return;
-        }
-    } else if(w_stat(SHAREDCFG_FILE, &stat_fd) == -1 && ENOENT == errno) {
-        clear_merged_hash_cache();
+    /* Get shared files: compute the merged.mg hash fresh on every keepalive so
+     * the manager always sees the current state. A cached value would hide
+     * in-place edits/corruption of merged.mg from the server. getsharedfiles()
+     * returns "x" when the file is missing, which still forces a re-push. 
+     * */
+    char *merged_hash = getsharedfiles();
+    if (!merged_hash) {
+        merror(MEM_ERROR, errno, strerror(errno));
+        return;
     }
 
     time_t now = time(NULL);
@@ -267,8 +259,9 @@ void run_notify()
     /* Create JSON keepalive message */
     char *json_keepalive = build_json_keepalive(
         agent_ip[0] ? agent_ip : NULL,
-        g_shared_mg_file_hash
+        merged_hash
     );
+    os_free(merged_hash);   // build_json_keepalive already copied it into the JSON
     if (!json_keepalive) {
         merror("Failed to build JSON keepalive");
         return;

--- a/src/client-agent/src/receiver.c
+++ b/src/client-agent/src/receiver.c
@@ -250,7 +250,6 @@ int receive_msg()
                                     if (cldir_ex_ignore(SHAREDCFG_DIR, (const char **)ignore_list)) {
                                         mwarn("Could not clean up shared directory.");
                                     }
-                                    clear_merged_hash_cache();
                                     if (agt->flags.remote_conf && !verifyRemoteConf()) {
                                         const bool gate_was_blocked = !startup_gate_is_ready();
                                         const bool gate_would_release = gate_was_blocked && startup_gate_check_hash_match();


### PR DESCRIPTION


## Description
Replace the cached g_shared_mg_file_hash with a fresh getsharedfiles()
call on every keepalive so the manager always receives the current
merged.mg state. The cache was causing syscollector flush to fail
repeatedly after a newly created group was assigned to an agent, because
the stale hash prevented the manager from detecting the updated shared
config.

## Proposed Changes
The hash cache of merged.mg was removed to recalculate each activity maintenance message. This way, if the group file becomes outdated or truncated, the administrator detects the file inconsistency and triggers a binding protocol.
<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

```bash
2026/06/22 16:35:27 wazuh-agentd[987] notify.c:274 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"001","name":"agt2","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"LAPTOP-J631ENT0","architecture":"x86_64","ip":"127.0.0.1","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}
2026/06/22 16:35:47 wazuh-agentd[987] notify.c:274 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"001","name":"agt2","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"LAPTOP-J631ENT0","architecture":"x86_64","ip":"127.0.0.1","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}
[!NOTE] hash number changed
2026/06/22 16:36:07 wazuh-agentd[987] notify.c:274 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"001","name":"agt2","version":"v5.0.0","merged_sum":"d41d8cd98f00b204e9800998ecf8427e","groups":["default"]},"host":{"hostname":"LAPTOP-J631ENT0","architecture":"x86_64","ip":"127.0.0.1","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}
2026/06/22 16:36:27 wazuh-agentd[987] notify.c:274 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"001","name":"agt2","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"LAPTOP-J631ENT0","architecture":"x86_64","ip":"127.0.0.1","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}}
2026/06/22 16:36:47 wazuh-agentd[987] notify.c:274 at run_notify(): DEBUG: Sending keep alive: #!-{"version":"1.0","agent":{"id":"001","name":"agt2","version":"v5.0.0","merged_sum":"ca35f9148a3273413eccb79f149f4757","groups":["default"]},"host":{"hostname":"LAPTOP-J631ENT0","architecture":"x86_64","ip":"127.0.0.1","os":{"name":"Ubuntu","version":"24.04.4 LTS (Noble Numbat)","platform":"ubuntu","type":"linux"}},"cluster":{"name":"wazuh","node":"node01"}
```

Why you won't see "Agent groups cleared (no groups found)"

Timing: the keepalive wins the race

With the new change, the full sequence is:

t=0      truncate -s 0 /var/ossec/etc/shared/merged.mg
          merged.mg is now empty → MD5 changes

t≤20s    run_notify() calls getsharedfiles() FRESH
          → computes MD5 of the empty file (d41d8cd98f00b204e...)
          → sends keepalive to the manager with the new hash

t~20s    Manager detects hash mismatch
          → re-pushes the correct merged.mg to the agent

t=60s    populateAgentMetadata() runs
          → reads merged.mg → already restored
          → groups != empty → "Agent groups populated successfully"

The keepalive fires every 20 s (NOTIFY_TIME = 20 in src/shared/include/defs.h:48), and populateAgentMetadata runs every 60 s by default (interval = 60 in src/wazuh_modules/src/wm_agent_info.c:468). The manager restores the file before the agent_info module ever reads it as empty.

With the old behavior (cached hash), the manager never saw the change → the file stayed empty → populateAgentMetadata would read no groups and log that message. That is precisely the bug this fix addresses.

Interval summary
|What| Interval|Source |
|------|--------|--------|
| run_notify() → keepalive |  20 s  | defs.h → NOTIFY_TIME  |
| populateAgentMetadata() | 60 s (configurable) | wm_agent_info.c:468 → interval|
| First populateAgentMetadata run| 5 s after startup| agent_info_impl.cpp:181 → wait_for(5s)|

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes
N-A

### Tests Introduced
N-A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
