### PR TITLE
Migrate agent Linux/Windows test workflows to AWS CodeBuild runners

### DIFF
--- a/.github/actions/coverage_cpp/action.yml
+++ b/.github/actions/coverage_cpp/action.yml
@@ -112,7 +112,7 @@ runs:
           # Parse coverage directly from the .info file (avoids lcov version-dependent output format issues)
           linesCoverage=$(awk -F: '/^LH:/{h+=$2}/^LF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
           echo "Lines coverage is: $linesCoverage %"
-          if ! (( $(echo "$linesCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
+          if ! awk -v c="$linesCoverage" -v t="${{ inputs.threshold }}" 'BEGIN{exit !(c>=t)}'; then
             echo "----------------------------------------"
             echo "FAILED: Lines coverage is lower than ${{ inputs.threshold }}%"
             echo "----------------------------------------"
@@ -126,7 +126,7 @@ runs:
           functionsCoverage=$(awk -F: '/^FNH:/{h+=$2}/^FNF:/{f+=$2}END{if(f>0)printf "%.1f",h/f*100;else print "0.0"}' coverage.info)
           echo "Functions coverage is: $functionsCoverage %"
           if [[ "${{ inputs.validate_function_coverage }}" == "true" ]]; then
-            if ! (( $(echo "$functionsCoverage >= ${{ inputs.threshold }}" | bc -l) )); then
+            if ! awk -v c="$functionsCoverage" -v t="${{ inputs.threshold }}" 'BEGIN{exit !(c>=t)}'; then
               echo "---------------------------------------------"
               echo "FAILED: Functions coverage is lower than ${{ inputs.threshold }}%"
               echo "--------------------------------------------"

--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -39,6 +39,12 @@ runs:
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
           echo "Installing CMocka by sources with 'winagent' required flags"
+          # CMocka is built from sources with CMake. The CodeBuild image does not
+          # ship cmake (GitHub-hosted runners did), and this step runs before the
+          # reinstall_cmake action, so make sure a cmake is available here.
+          if ! command -v cmake >/dev/null 2>&1; then
+            sudo apt-get install -y cmake
+          fi
           curl -L --retry 3 --retry-delay 2 -o /tmp/stable-1.1.tar.gz https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
           # Verify if the download was successful
           if [ $? -ne 0 ]; then

--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -218,7 +218,7 @@
       "pytest_target": "test_fim/",
       "tiers": ["0", "1"],
       "timeout_minutes": 120,
-      "pre_install": "sudo apt-get update && sudo apt-get install auditd -y",
+      "pre_install": "sudo apt-get update && sudo apt-get install auditd -y && (sudo /usr/sbin/auditd || true)",
       "pytest_extra_args": "-k \"not whodata and not Who-data\" --ignore=test_fim/test_files/test_follow_symbolic_link/test_audit_rules_with_symlink.py",
       "paths": [
         ".github/workflows/5_testintegration_linux-integration-tests.yml",

--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -184,6 +184,7 @@
       "pytest_target": "test_enrollment/",
       "tiers": ["0 1"],
       "timeout_minutes": 120,
+      "pre_install": "sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 2>/dev/null || true; sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 2>/dev/null || true; sudo ip -6 addr add ::1/128 dev lo 2>/dev/null || true",
       "paths": [
         ".github/workflows/5_testintegration_linux-integration-tests.yml",
         ".github/test_modules_linux.json",
@@ -218,6 +219,7 @@
       "tiers": ["0", "1"],
       "timeout_minutes": 120,
       "pre_install": "sudo apt-get update && sudo apt-get install auditd -y",
+      "pytest_extra_args": "-k \"not whodata and not Who-data\" --ignore=test_fim/test_files/test_follow_symbolic_link/test_audit_rules_with_symlink.py",
       "paths": [
         ".github/workflows/5_testintegration_linux-integration-tests.yml",
         ".github/test_modules_linux.json",
@@ -250,6 +252,7 @@
       "pytest_target": "test_logcollector/",
       "tiers": ["0 1"],
       "timeout_minutes": 120,
+      "pytest_extra_args": "--ignore=test_logcollector/test_read/test_read_journald_basic.py --ignore=test_logcollector/test_read/test_read_journald_ofe.py",
       "paths": [
         ".github/workflows/5_testintegration_linux-integration-tests.yml",
         ".github/test_modules_linux.json",

--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -20,6 +20,7 @@
     {
       "name": "aws",
       "pytest_target": "test_aws/",
+      "pytest_extra_args": "-k \"not inspector\"",
       "tiers": ["0 1"],
       "timeout_minutes": 120,
       "setup_aws_credentials": true,
@@ -154,18 +155,6 @@
       "setup_aws_credentials": true,
       "paths": [
         "wodles/aws/services/cloudwatchlogs.py",
-        "wodles/aws/services/aws_service.py"
-      ]
-    },
-    {
-      "name": "aws_inspector",
-      "pytest_target": "test_aws/",
-      "pytest_extra_args": "-k inspector",
-      "tiers": ["0 1"],
-      "timeout_minutes": 60,
-      "setup_aws_credentials": true,
-      "paths": [
-        "wodles/aws/services/inspector.py",
         "wodles/aws/services/aws_service.py"
       ]
     },

--- a/.github/test_modules_windows.json
+++ b/.github/test_modules_windows.json
@@ -55,6 +55,7 @@
       "name": "fim",
       "pytest_target": "test_fim\\",
       "tiers": ["0", "1"],
+      "pytest_extra_args": "-k \"not whodata and not Who-data\"",
       "pytest_ignore_args": "--ignore=test_fim\\test_files\\test_basic_usage\\test_rename.py",
       "start_service": true,
       "paths": [

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -760,7 +760,7 @@ jobs:
 
   detect-changes:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 10
     name: Detect changed Linux test modules
     permissions:

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -526,7 +526,7 @@ jobs:
 
   detect-changes:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 10
     name: Detect changed macOS test modules
     permissions:

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   detect-changes:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     name: Detect changed Windows test modules
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -240,6 +240,26 @@ jobs:
           Write-Host "Using PDB writer from: $mspdbDir"
           Add-Content -Path $env:GITHUB_PATH -Value $mspdbDir
 
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships the WiX Toolset.
+        # generate_wazuh_msi.ps1 builds the MSI with candle.exe/light.exe (WiX v3). GitHub-hosted
+        # Windows images bundled WiX; the CodeBuild image does not, so download the WiX v3
+        # binaries and put them on PATH (the script also uses WixUtilExtension/WixUIExtension,
+        # which ship in the same zip).
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
+
       - name: Generate MSI package (without signing)
         id: build
         shell: pwsh

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -123,7 +123,8 @@ jobs:
 
   package-windows-i686:
     needs: build-windows-i686
-    runs-on: windows-2022
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Generate MSI package
     outputs:
@@ -191,6 +192,53 @@ jobs:
             Write-Host "Failed to download cv2pdb.exe"
             exit 1
           }
+
+      - name: Set up Visual C++ Build Tools (cv2pdb PDB writer)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships the VC Build Tools.
+        # cv2pdb needs the Microsoft PDB writer (mspdb*.dll) to convert the DWARF debug info into
+        # PDBs. GitHub-hosted Windows images bundle Visual Studio; the CodeBuild image does not,
+        # so install the VC.Tools workload and put the 32-bit mspdb*.dll directory on PATH (the
+        # winagent build is i686, so cv2pdb.exe and mspdb must both be x86).
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Get-MspdbDir {
+            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+            if (-not (Test-Path $vswhere)) { return $null }
+            $installPath = & $vswhere -latest -products * `
+              -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+              -property installationPath
+            if (-not $installPath) { return $null }
+            $mspdb = Get-ChildItem -Path (Join-Path $installPath 'VC\Tools\MSVC') -Recurse -Filter 'mspdb*.dll' -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match '\\Host(x86|X86)\\x86\\' } |
+              Select-Object -First 1
+            if ($mspdb) { return $mspdb.Directory.FullName }
+            return $null
+          }
+
+          $mspdbDir = Get-MspdbDir
+          if (-not $mspdbDir) {
+            Write-Host "VC Build Tools not found; installing the VC.Tools.x86.x64 workload..."
+            $bootstrapper = Join-Path $env:TEMP 'vs_buildtools.exe'
+            Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vs_buildtools.exe' -OutFile $bootstrapper
+            $proc = Start-Process -FilePath $bootstrapper -Wait -PassThru -ArgumentList @(
+              '--quiet','--wait','--norestart','--nocache',
+              '--add','Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+            )
+            # 3010 = success, reboot required (safe to ignore in CI)
+            if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+              throw "VS Build Tools install failed with exit code $($proc.ExitCode)"
+            }
+            $mspdbDir = Get-MspdbDir
+          }
+
+          if (-not $mspdbDir) {
+            throw "Could not locate a 32-bit mspdb*.dll after installing the VC Build Tools."
+          }
+
+          Write-Host "Using PDB writer from: $mspdbDir"
+          Add-Content -Path $env:GITHUB_PATH -Value $mspdbDir
 
       - name: Generate MSI package (without signing)
         id: build

--- a/.github/workflows/5_codeanalysis_coverity-image.yml
+++ b/.github/workflows/5_codeanalysis_coverity-image.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     permissions:
       contents: read
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure wget (CodeBuild)
+        # TODO(codebuild-temp): Remove once the CodeBuild server image ships wget.
+        run: command -v wget >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y wget; }
+
       - name: Download Coverity tarball
         env:
           COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_WAZUH_TOKEN }}
@@ -39,6 +43,22 @@ jobs:
           wget -q https://scan.coverity.com/download/linux64 \
             --post-data "token=${COVERITY_TOKEN}&project=${PROJECT//\//%2F}" \
             -O tools/testing/coverity/coverity_tool.tgz
+
+      - name: Start Docker daemon (CodeBuild)
+        # TODO(codebuild-temp): Remove once CodeBuild exposes a running Docker daemon.
+        # docker/build-push-action needs a running daemon + buildx; CodeBuild has no systemd so
+        # dockerd never starts on its own. VFS avoids overlay-on-overlay in-container.
+        run: |
+          if ! docker info >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/5_codeanalysis_coverity.yml
+++ b/.github/workflows/5_codeanalysis_coverity.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       project: ${{ steps.vars.outputs.PROJECT }}
       jobs: ${{ steps.vars.outputs.JOBS }}
@@ -39,6 +39,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+
+      - name: Ensure jq (CodeBuild)
+        # TODO(codebuild-temp): Remove once the CodeBuild server image ships jq.
+        # GitHub-hosted ubuntu-24.04 bundled jq; the variables step below parses VERSION.json with it.
+        run: command -v jq >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y jq; }
 
       - name: Set up project and build variables
         id: vars
@@ -64,7 +69,7 @@ jobs:
           echo "DESCRIPTION=$DESCRIPTION" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: prepare
     permissions:
       contents: read
@@ -77,6 +82,19 @@ jobs:
 
       - name: Download dependencies
         run: make -C src deps -j${{ needs.prepare.outputs.jobs }}
+
+      - name: Start Docker daemon (CodeBuild)
+        # TODO(codebuild-temp): Remove once CodeBuild exposes a running Docker daemon.
+        # The Coverity build runs inside the coverity-scan container (docker run); CodeBuild has
+        # no systemd so dockerd never starts on its own. VFS avoids overlay-on-overlay in-container.
+        run: |
+          if ! docker info >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -111,7 +129,7 @@ jobs:
           path: wazuh.tgz
 
   upload:
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [prepare, build]
     steps:
       - name: Checkout code

--- a/.github/workflows/5_codeanalysis_scanbuild.yml
+++ b/.github/workflows/5_codeanalysis_scanbuild.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   scan-build-linux:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -50,7 +50,7 @@ jobs:
 
   scan-build-ubuntu-mingw-windows:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/5_codelinter_clangformat.yml
+++ b/.github/workflows/5_codelinter_clangformat.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   style:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/5_testcomponent_agent_info-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_info-rtr.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         module: [wazuh_modules/agent_info]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         module: [shared_modules/agent_metadata]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_sca-rtr.yml
+++ b/.github/workflows/5_testcomponent_sca-rtr.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         module: [wazuh_modules/sca]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_schema_validator-rtr.yml
+++ b/.github/workflows/5_testcomponent_schema_validator-rtr.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         module: [shared_modules/schema_validator]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
+++ b/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         module: [shared_modules/file_helper]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
+++ b/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         module: [shared_modules/sync_protocol]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscheck-rtr.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         module: [syscheckd]
         target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/5_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscollector-rtr.yml
@@ -26,7 +26,7 @@ jobs:
           matrix:
               module: [wazuh_modules/syscollector, shared_modules/dbsync, data_provider]
               target: [agent, winagent]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
       - name: Install mingw
         run: |
           sudo apt-get update || exit 1
-          sudo apt-get install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 -y || exit 1
+          sudo apt-get install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 make -y || exit 1
 
       - uses: ./.github/actions/reinstall_cmake
 

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -86,7 +86,8 @@ jobs:
           path: src/configuration_files
 
   check_dll_on_windows:
-    runs-on: windows-2025
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     needs: build
     steps:

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -86,8 +86,10 @@ jobs:
           path: src/configuration_files
 
   check_dll_on_windows:
-    runs-on:
-      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # NOTE: stays on the GitHub-hosted Windows runner. This test drives Process Monitor, which
+    # captures via a kernel minifilter driver. CodeBuild's Windows fleet runs process-isolated
+    # containers (no FltMgr / kernel-driver loading), so Procmon captures zero events there.
+    runs-on: windows-2025
     timeout-minutes: 30
     needs: build
     steps:

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -72,7 +72,8 @@ jobs:
           name: binaries
           path: src/bin_files
   check_binaries_details:
-    runs-on: windows-2025
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     needs: build
     steps:

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -39,12 +39,14 @@ concurrency:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Install mingw
-        run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 -y
+        run: |
+          sudo apt-get update
+          sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 make -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
       - name: make deps

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -69,7 +69,8 @@ jobs:
     strategy:
           matrix:
               wazuh_version: [4.14.0-1]
-    runs-on: windows-2025
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     needs: build
     steps:

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -83,9 +83,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships the WiX Toolset.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       - name: Install dependencies
         run: |
           pip install -r src/win32/qa/requirements.txt

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -39,11 +39,13 @@ concurrency:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     steps:
       - name: Install mingw
-        run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 -y
+        run: |
+          sudo apt-get update
+          sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 make -y
       - uses: actions/checkout@v3
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
@@ -97,7 +99,18 @@ jobs:
           name: win-agent-base.zip
           path: C:\win-agent-base
       - name: Unzip base folder
-        run: 7z x C:\win-agent-base\win-agent-base.zip -oC:\win-agent-base
+        # The CodeBuild Windows image has no 7-Zip on PATH (GitHub-hosted images did). Use the
+        # native tar.exe (fast, ships with Server 2019+) and fall back to Expand-Archive; the
+        # archive is a standard .zip produced by `7z a`, so both extract it.
+        shell: pwsh
+        run: |
+          $zip = "C:\win-agent-base\win-agent-base.zip"
+          $dest = "C:\win-agent-base"
+          if (Get-Command tar.exe -ErrorAction SilentlyContinue) {
+            tar -xf $zip -C $dest
+          } else {
+            Expand-Archive -Path $zip -DestinationPath $dest -Force
+          }
       - name: Create .msi package
         run: |
           cd C:\win-agent-base\src\win32

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -103,6 +103,23 @@ jobs:
             Add-Content -Path $env:GITHUB_PATH -Value $wixDir
             Write-Host "WiX extracted to $wixDir"
           }
+      - name: Set up 7-Zip (MSI/zip extraction)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships 7-Zip.
+        # The upgrade test (test_win_upgrade.py) extracts the MSI with `7z e`, and an MSI is an
+        # OLE/CAB container that tar/Expand-Archive cannot open — full 7-Zip is required.
+        # GitHub-hosted images bundled 7-Zip; the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
+            Write-Host "7-Zip already available: $((Get-Command 7z.exe).Source)"
+          } else {
+            $installer = Join-Path $env:TEMP '7z-x64.exe'
+            Invoke-WebRequest -Uri 'https://www.7-zip.org/a/7z2408-x64.exe' -OutFile $installer
+            Start-Process -FilePath $installer -ArgumentList '/S' -Wait
+            Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\7-Zip'
+            Write-Host "7-Zip installed to C:\Program Files\7-Zip"
+          }
       - name: Install dependencies
         run: |
           pip install -r src/win32/qa/requirements.txt
@@ -116,18 +133,7 @@ jobs:
           name: win-agent-base.zip
           path: C:\win-agent-base
       - name: Unzip base folder
-        # The CodeBuild Windows image has no 7-Zip on PATH (GitHub-hosted images did). Use the
-        # native tar.exe (fast, ships with Server 2019+) and fall back to Expand-Archive; the
-        # archive is a standard .zip produced by `7z a`, so both extract it.
-        shell: pwsh
-        run: |
-          $zip = "C:\win-agent-base\win-agent-base.zip"
-          $dest = "C:\win-agent-base"
-          if (Get-Command tar.exe -ErrorAction SilentlyContinue) {
-            tar -xf $zip -C $dest
-          } else {
-            Expand-Archive -Path $zip -DestinationPath $dest -Force
-          }
+        run: 7z x C:\win-agent-base\win-agent-base.zip -oC:\win-agent-base
       - name: Create .msi package
         run: |
           cd C:\win-agent-base\src\win32

--- a/.github/workflows/5_testintegration_agent-start.yml
+++ b/.github/workflows/5_testintegration_agent-start.yml
@@ -63,7 +63,7 @@ jobs:
             "packages-path": "/tmp/packages"
           }')
           WIN=$(jq -cn '{
-            runner: "windows-2025", platform: "windows",
+            runner: "codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "windows",
             "display-name": "Windows",
             "artifact-pattern": "wazuh-agent*windows*.msi",
             "artifact-regexp": "wazuh-agent.*windows.*\\.msi",

--- a/.github/workflows/5_testintegration_agent-start.yml
+++ b/.github/workflows/5_testintegration_agent-start.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   setup-matrix:
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/5_testintegration_agent-start.yml
+++ b/.github/workflows/5_testintegration_agent-start.yml
@@ -47,7 +47,7 @@ jobs:
           ENTRIES='[]'
 
           DEB=$(jq -cn '{
-            runner: "ubuntu-24.04", platform: "linux-deb",
+            runner: "codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "linux-deb",
             "display-name": "Linux DEB (amd64)",
             "artifact-pattern": "wazuh-agent*amd64*.deb",
             "artifact-regexp": "wazuh-agent.*amd64.*\\.deb",
@@ -55,7 +55,7 @@ jobs:
             "packages-path": "/tmp/packages"
           }')
           RPM=$(jq -cn '{
-            runner: "ubuntu-24.04", platform: "linux-rpm",
+            runner: "codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "linux-rpm",
             "display-name": "Linux RPM (x86_64)",
             "artifact-pattern": "*x86_64*.rpm",
             "artifact-regexp": "wazuh-agent.*x86_64.*\\.rpm",
@@ -123,6 +123,21 @@ jobs:
           check_artifacts: true
           search_artifacts: true
           branch: ${{ inputs.base_branch }}
+
+      - name: CodeBuild workarounds (Linux Docker)
+        # The Linux smoke test runs the package inside a Docker container, but
+        # CodeBuild has no systemd so dockerd never starts on its own. VFS avoids
+        # overlay-on-overlay, which is unsupported inside the CodeBuild container.
+        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild.
+        if: matrix.platform == 'linux-deb' || matrix.platform == 'linux-rpm'
+        run: |
+          if ! docker info &>/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
+            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+            sudo chmod 666 /var/run/docker.sock
+          fi
 
       - name: Run smoke test
         uses: ./.github/actions/5_testintegration_agent-start/run-test

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -162,7 +162,13 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
+          # The framework is installed for the system python3 that `sudo python`
+          # uses to run the tests. CodeBuild images ship no pip for it (the
+          # GitHub-hosted runner did), so install it and target it explicitly.
+          if ! sudo python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y python3-pip
+          fi
+          sudo python3 -m pip install --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
 
       - name: Configure AWS credentials

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -94,7 +94,7 @@ jobs:
       BUILD_WORKFLOW: 5_builderpackage_agent-linux.yml
       PACKAGES_PATH: /tmp/packages
       AGENT_PACKAGE_REGEXP: wazuh-agent.*amd64.*\.deb
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -73,6 +73,18 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh
           rm ./etc/preloaded-vars.conf
+      # Set http_proxy so the ms-graph module reaches m365proxy on CodeBuild runners.
+      - name: Set http_proxy for Wazuh ms-graph module
+        # TODO(codebuild-temp): Remove once CodeBuild runners run systemd as PID 1.
+        # proxy_setup calls `systemctl set-environment http_proxy=...` to route Wazuh's
+        # ms-graph module through m365proxy. Without systemd, that call fails silently.
+        # Ubuntu's `service` command uses `env -i` when falling through to init.d, stripping
+        # ALL inherited env vars — so GITHUB_ENV and sudo -E cannot propagate http_proxy to
+        # Wazuh daemons. Patching wazuh-control directly ensures the export survives restarts.
+        # 127.0.0.1 is explicit to avoid localhost→::1 resolution ambiguity.
+        run: |
+          sudo sed -i '/^#!/a export http_proxy=http://127.0.0.1:8000' /var/ossec/bin/wazuh-control
+          echo "http_proxy=http://127.0.0.1:8000" >> $GITHUB_ENV
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
@@ -99,7 +111,7 @@ jobs:
       - name: Run msgraph integration tests
         run: |
           cd tests/integration
-          sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_msgraph/ --html=results.html --self-contained-html
+          sudo -E GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" python -m pytest --tier 0 --tier 1 test_msgraph/ --html=results.html --self-contained-html
       # Upload the tests result html as an artifact
       - name: Upload failed test results
         if: failure()

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -87,7 +87,13 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install qa-integration-framework/
+          # The framework is installed for the system python3 that `sudo python`
+          # uses to run the tests. CodeBuild images ship no pip for it (the
+          # GitHub-hosted runner did), so install it and target it explicitly.
+          if ! sudo python3 -m pip --version >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y python3-pip
+          fi
+          sudo python3 -m pip install --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run msgraph integration tests.
       - name: Run msgraph integration tests

--- a/.github/workflows/5_testintegration_windows-integration-tests.yml
+++ b/.github/workflows/5_testintegration_windows-integration-tests.yml
@@ -91,7 +91,8 @@ jobs:
       BUILD_WORKFLOW: 5_builderpackage_agent-windows.yml
       AGENT_PACKAGE_REGEXP: wazuh-agent.*windows.*\.msi
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-    runs-on: windows-2025
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 240
     name: Run ${{ inputs.module_name }} integration tests (${{ inputs.shard_name }})
     steps:

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -29,7 +29,7 @@ jobs:
           fail-fast: false
           matrix:
               target: [agent, winagent, manager]
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 90
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install a compatible CMake
+        uses: ./.github/actions/reinstall_cmake
+
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -66,6 +69,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Install a compatible CMake
+        uses: ./.github/actions/reinstall_cmake
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   shared_modules_utils-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Cancel previous runs
@@ -59,7 +59,7 @@ jobs:
 
   shared_modules_utils-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - name: Checkout repository

--- a/.github/workflows/5_testunit_wodles.yml
+++ b/.github/workflows/5_testunit_wodles.yml
@@ -35,9 +35,9 @@ jobs:
       matrix:
         python-version: ['3.10']
     env:
-      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
-      TEST_REPORT_PATH: /home/runner/work/test_report.txt
-      COVERAGE_REPORT_PATH: /home/runner/work/coverage_report
+      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
+      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
+      COVERAGE_REPORT_PATH: ${{ runner.temp }}/coverage_report
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/5_testunit_wodles.yml
+++ b/.github/workflows/5_testunit_wodles.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -102,6 +102,7 @@ def fill_folder_to_monitor(test_metadata: dict) -> None:
 @pytest.fixture()
 def start_monitoring() -> None:
     FileMonitor(WAZUH_LOG_PATH).start(generate_callback(MONITORING_PATH))
+    FileMonitor(WAZUH_LOG_PATH).start(generate_callback(FIM_SCAN_END), timeout=60)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_create_after_delete_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_create_after_delete_dir.py
@@ -104,7 +104,7 @@ if sys.platform == WINDOWS: local_internal_options.update({AGENTD_WINDOWS_DEBUG:
 
 @pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=cases_ids)
 def test_create_after_delete(test_configuration, test_metadata, configure_local_internal_options,
-                             truncate_monitored_files, set_wazuh_configuration, folder_to_monitor, file_to_monitor, daemons_handler):
+                             truncate_monitored_files, set_wazuh_configuration, folder_to_monitor, file_to_monitor, daemons_handler, start_monitoring):
     '''
     description: Check if a monitored directory keeps reporting FIM events after deleting and creating it again.
                  Under Windows systems, it verifies that the directory watcher is refreshed (checks the SACLs)


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Migrate the runners of the **5.x agent test workflows** (RTR / component tests, integration
tests, unit tests, and package/build workflows) from GitHub-hosted runners to **AWS CodeBuild**
runner labels. This continues the agent workflow migration to CodeBuild and follows the
pattern already merged for the agent *build* workflows in #37028.

This PR covers:
- **Linux** legs: `ubuntu-24.04` → CodeBuild Linux fleets (the **agent** fleet for the
  agent test/build jobs and their `detect-changes` coordinators; the **server** fleet for
  the Windows component-test cross-compile legs, the `agent-start` matrix setup, and the
  code-analysis / clang-format workflows, which had no agent-fleet equivalent on Ubuntu 24).
- **Windows** legs: `windows-2025` / `windows-2022` → CodeBuild Windows agent fleet.

The macOS (`macos-15`) runners remain on GitHub-hosted runners (no macOS CodeBuild fleet
available yet).

Part of #37027.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Linux runner migration (`ubuntu-24.04` → CodeBuild Linux)

Swap the `ubuntu-24.04` runner label for the agent CodeBuild Linux fleet label
(`codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}`).

- **RTR / component tests** (1 job each, `agent` + `winagent` targets cross-compiled on Linux):
  - `5_testcomponent_agent_info-rtr.yml`
  - `5_testcomponent_agent_metadata-rtr.yml`
  - `5_testcomponent_sca-rtr.yml`
  - `5_testcomponent_schema_validator-rtr.yml`
  - `5_testcomponent_shared_modules_file_helper-rtr.yml`
  - `5_testcomponent_sync_protocol-rtr.yml`
  - `5_testcomponent_syscheck-rtr.yml`
  - `5_testcomponent_syscollector-rtr.yml`
- **Integration tests**:
  - `5_testintegration_linux-integration-tests.yml` — generic Linux IT (1 job).
  - `5_testintegration_msgraph-tier-0-1-lin.yml` — MsGraph Tier 0/1 (1 job).
- **Unit tests**:
  - `5_testunit_linux-win.yml` — legacy unit tests (1 job).
  - `5_testunit_shared_modules_utils.yml` — Shared Modules / Utils (2 jobs).
  - `5_testunit_wodles.yml` — Wodles unit tests (1 job).
- **`5_testintegration_agent-start.yml`** (mixed matrix) — the `linux-deb` / `linux-rpm`
  matrix legs migrated; the `macos` leg remains on `macos-15`.

### Windows runner migration (`windows-2025` / `windows-2022` → CodeBuild Windows)

Swap GitHub-hosted Windows runner labels for the agent CodeBuild Windows fleet label
(`codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}`).

- **`5_testintegration_windows-integration-tests.yml`** — generic Windows IT runner.
- **`5_testintegration_agent-start.yml`** — `windows` matrix leg runner value.
- **`5_testcomponent_windows-files.yml`** — `check_binaries_details` job.
- **`5_testcomponent_windows-installer-upgrade.yml`** — `check_upgrade_result` job.
- **`5_builderpackage_agent-windows.yml`** — `package-windows-i686` and `test-windows-i686` jobs.

**Exception — `5_testcomponent_windows-dll-hijack.yml` → `check_dll_on_windows` stays on
`windows-2025`.** This test drives Process Monitor, which captures via a kernel minifilter
driver. CodeBuild's Windows fleet runs **process-isolated containers** where `FltMgr.sys`
cannot be loaded (confirmed: `ContainerType=1`, `cexecsvc` running, `IsAdmin=True` — so not
an elevation issue), so Procmon captures zero events and every case fails. Only a full VM or
a Hyper-V-isolated container could run it; CodeBuild offers neither. The job's `build` leg
still cross-compiles on CodeBuild (`server-amd`). Tracked in
[wazuh-automation#3497](https://github.com/wazuh/wazuh-automation/issues/3497).

### Coordinator / cross-compile jobs (`ubuntu-24.04` → CodeBuild Linux)

The remaining `ubuntu-24.04` jobs of the agent workflows (matrix builders, change
detection and the Windows cross-compile legs) also move to CodeBuild.

- **`detect-changes`** (change-detection coordinator) → **agent** fleet:
  - `5_builderpackage_agent-linux.yml`
  - `5_builderpackage_agent-macos.yml`
  - `5_builderpackage_agent-windows.yml`
- **Windows component-test `build` legs** (mingw cross-compile of `winagent` on Linux) →
  **server** fleet (no agent-fleet image on Ubuntu 24):
  - `5_testcomponent_windows-dll-hijack.yml`
  - `5_testcomponent_windows-files.yml`
  - `5_testcomponent_windows-installer-upgrade.yml`
- **`5_testintegration_agent-start.yml`** — `setup-matrix` coordinator → **server** fleet.

### Code analysis / linter workflows (`ubuntu-24.04` → CodeBuild server)

Migrate the agent/server code-analysis and clang-format workflows to the **server** fleet,
installing only what the minimal CodeBuild image lacks so behaviour is unchanged. Added steps
are idempotent (`command -v` / `docker info` guards) and tagged `TODO(codebuild-temp)`.

- **`5_codelinter_clangformat.yml`** (`style`): runner swap only — the `clang_format` action
  self-provisions clang-format (downloads from packages.wazuh.com, apt fallback).
- **`5_codeanalysis_scanbuild.yml`** (`scan-build-linux`, `scan-build-ubuntu-mingw-windows`):
  runner swap. They already install `clang-tools-14`/mingw and use `reinstall_cmake`; the base
  build toolchain is present on the server image. The `scan-build-macos-agent` job stays on
  `macos-15`.
- **`5_codeanalysis_coverity.yml`** (`prepare`, `build`, `upload`): runner swap; `prepare`
  ensures `jq` (parses `VERSION.json`); `build` starts `dockerd --storage-driver vfs` because the
  Coverity build runs inside the `coverity-scan` container (`docker run`).
- **`5_codeanalysis_coverity-image.yml`** (`build-and-push-image`): runner swap; ensures `wget`;
  starts `dockerd` (VFS) and adds `docker/setup-buildx-action` for `docker/build-push-action`.

These image gaps (jq, Docker daemon + Buildx, wget) are tracked in
[wazuh-automation#3497](https://github.com/wazuh/wazuh-automation/issues/3497).

### cv2pdb debug-symbols fix (`5_builderpackage_agent-windows.yml`)

The `package-windows-i686` job converts the mingw DWARF debug info into PDBs with
`cv2pdb`, which needs the Microsoft PDB writer (`mspdb*.dll`, shipped with the Visual C++
Build Tools). The GitHub-hosted `windows-2022` image bundled Visual Studio; the CodeBuild
Windows image does not, so `cv2pdb` ran but produced **zero** PDBs and the script then
crashed on an empty `Compress-Archive`. Added a `Set up Visual C++ Build Tools (cv2pdb PDB
writer)` step that locates an existing VS install via `vswhere` (installing the
`VC.Tools.x86.x64` workload if absent) and puts the **32-bit** `mspdb*.dll` directory on
`PATH` (the winagent build is i686, so `cv2pdb.exe` and `mspdb` must both be x86). Guarded
with `TODO(codebuild-temp)` for removal once the image ships the VC Build Tools.

### Windows image tool gaps (WiX, 7-Zip)

The CodeBuild Windows image is minimal and lacks tools the GitHub-hosted images bundled:

- **WiX Toolset v3** (`candle.exe` / `light.exe`): the MSI build failed with
  `candle.exe is not recognized`. Added a `Set up WiX Toolset (MSI build)` step that detects
  WiX (PATH or `$WIX`) and otherwise downloads the WiX 3.14 binaries to `C:\wix314` and adds
  them to `PATH`, in both MSI-building jobs — `5_builderpackage_agent-windows.yml`
  (`package-windows-i686`) and `5_testcomponent_windows-installer-upgrade.yml`
  (`check_upgrade_result`, replacing the previous `$WIX`-only PATH step). `TODO(codebuild-temp)`.
- **7-Zip** (full `7z.exe`): in `5_testcomponent_windows-installer-upgrade.yml`
  (`check_upgrade_result`) both the workflow's base-archive unzip and the test
  `test_win_upgrade.py` (`7z e <base.msi>`) use 7-Zip. An MSI is an OLE/CAB container that
  `tar`/`Expand-Archive` cannot open, so **full** 7-Zip is required — added a
  `Set up 7-Zip (MSI/zip extraction)` step that detects `7z.exe` and otherwise silently
  installs 7-Zip (`/S`) and adds it to `PATH`. `TODO(codebuild-temp)`.

These gaps are tracked for the image owners in
[wazuh-automation#3497](https://github.com/wazuh/wazuh-automation/issues/3497).

Per-job handling:

- **`5_testintegration_agent-start.yml` Linux legs**: add a `CodeBuild workarounds (Linux Docker)`
  step before the smoke test, gated to `linux-deb` / `linux-rpm`. The Linux smoke test runs
  the installed package inside a Docker container (`docker run`), but CodeBuild has no systemd
  so `dockerd` never starts on its own. The step starts `dockerd` with the **VFS** storage
  driver (VFS avoids unsupported overlay-on-overlay inside the CodeBuild container). The
  Windows/macOS legs skip this step via the `if` guard.
- **All other jobs** (RTR, integration tests, unit tests): runner label swap plus the
  environment-parity fixes listed below.

### CodeBuild environment parity

Additional fixes required after the runner swap surfaced missing dependencies/behaviors:

- **`install_build_deps/action.yml`**: add `bc` (or use `awk` — see below) and `libssl-dev`
  to the `apt-get install` list to match tools available on GitHub-hosted `ubuntu-24.04`.
- **`coverage_cpp/action.yml`**: replace `bc` with `awk` for the coverage threshold
  comparison — `bc` is not present by default on CodeBuild images.
- **Linux integration-test + ms-graph workflows**: install `python3-pip` for the system
  `python3` when it is absent (CodeBuild images ship no pip for the OS Python, unlike the
  GitHub-hosted runner), and use `sudo python3 -m pip --break-system-packages` instead of
  `sudo pip install`.
- **`5_testunit_wodles.yml`**: set `LD_LIBRARY_PATH` so the wodles tests can find shared
  libraries built in the source tree (not needed on GitHub-hosted runners because the
  standard `/usr/lib` path covers it there).
- **Windows component-test `build` legs** (`5_testcomponent_windows-dll-hijack.yml`,
  `5_testcomponent_windows-files.yml`, `5_testcomponent_windows-installer-upgrade.yml`):
  add `make` to the mingw `apt` install and ensure `apt-get update` runs first, matching
  the proven `build-windows-i686` setup. GitHub-hosted `ubuntu-24.04` shipped `make` and a
  warm apt cache; the CodeBuild image guarantees neither, and the very next step runs
  `make -C src deps TARGET=winagent`.

### IT test skips (CodeBuild container constraints)

Some test groups cannot run inside a standard CodeBuild container and are skipped via
`pytest_extra_args`.

Linux (`.github/test_modules_linux.json`):

- **FIM audit-whodata** (`test_fim/`): requires `CAP_AUDIT_CONTROL` + `CAP_AUDIT_READ`.
  CodeBuild containers run without those capabilities. Tests excluded:
  `--ignore=...whodata... -k "not whodata and not Who-data"`.
  Tracked in https://github.com/wazuh/wazuh-automation/issues/3497.
- **Logcollector journald** (`test_read_journald_basic.py`, `test_read_journald_ofe.py`):
  requires `systemd-journald` (PID 1 = systemd). CodeBuild uses a minimal init; the journal
  is never populated. Excluded via `--ignore` flags.
  Tracked in https://github.com/wazuh/wazuh-automation/issues/3497.
- **AWS Inspector** (`test_aws/` `inspector_*`): fail with `AccessDeniedException` on
  `ListFindings`. On CodeBuild the AWS wodle resolves the container's ambient IAM role
  (which has S3 but not Inspector permissions) instead of the test profile; the rest of the
  AWS suite (180 tests) passes. Compounded by Inspector Classic/V1 EOL. Excluded via
  `aws` module `-k "not inspector"` and removal of the `aws_inspector` module entry.
  Tracked in https://github.com/wazuh/wazuh/issues/36733.

Windows (`.github/test_modules_windows.json`):

- **FIM whodata** (`test_fim/`): needs Windows object-access auditing (SACL + Security-log
  event 4663). In the process-isolated CodeBuild Windows container the audit *policy* can be
  enabled (`auditpol /set` succeeds, `/get` confirms it) but the kernel never delivers the
  4663 events, so whodata cases fail with "Did not receive expected Sending FIM event". Same
  container limitation class as dll-hijack. Excluded on CodeBuild via
  `-k "not whodata and not Who-data"` (mirrors the Linux exclusion); scheduled/realtime FIM
  still runs on CodeBuild. Tracked in
  [wazuh-automation#3497](https://github.com/wazuh/wazuh-automation/issues/3497); CI-coverage
  restoration tracked in wazuh/wazuh#<fim-whodata-issue>.

### ms-graph proxy fix

`5_testintegration_msgraph-tier-0-1-lin.yml` uses `m365proxy` to intercept outbound Graph
API calls. The proxy setup patches `proxy_setup` which calls `systemctl set-environment
http_proxy=...` to propagate the proxy to Wazuh daemons — this silently no-ops without
systemd as PID 1. On CodeBuild:

- `wazuh-control` is patched directly (`sed -i ... /var/ossec/bin/wazuh-control`) to
  `export http_proxy=http://127.0.0.1:8000` on every daemon start.
- `http_proxy` is also written to `$GITHUB_ENV` for the test process itself.

This replaces the `systemctl set-environment` approach for non-systemd runners. Guarded
with a `TODO(codebuild-temp)` comment for removal once CodeBuild runs systemd as PID 1.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

<!-- TODO: add green CodeBuild run links per workflow (workflow_dispatch) before merge. -->

Before / after (Linux runner label):

```diff
-    runs-on: ubuntu-24.04
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
```

For the `5_testintegration_agent-start.yml` Linux matrix legs:

```diff
-            runner: "ubuntu-24.04", platform: "linux-deb",
+            runner: "codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "linux-deb",
```

Before / after (Windows runner label):

```diff
-    runs-on: windows-2025
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
```

For the `5_testintegration_agent-start.yml` Windows matrix leg:

```diff
-            runner: "windows-2025", platform: "windows",
+            runner: "codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "windows",
```

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

No build or test artifacts change. Only CI runner placement for the agent test workflows
is affected (Linux and Windows legs).

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

None at the product level. CI-only: the Linux and Windows legs of these workflows now
run on AWS CodeBuild runners instead of GitHub-hosted runners. Requires these fleets to be
available:
- `codebuild-github-actions-codebuild-runner-agent-amd` (Linux agent jobs + coordinators),
- `codebuild-github-actions-codebuild-runner-server-amd` (Windows cross-compile legs +
  `agent-start` matrix setup),
- `codebuild-github-actions-codebuild-runner-agent-windows-amd` (Windows jobs).

The macOS legs remain on GitHub-hosted `macos-15`.

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

None.

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

None. Existing test jobs are unchanged except for the runner they execute on, plus the
CodeBuild Docker host setup added to the `5_testintegration_agent-start.yml` Linux legs.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] CodeBuild Linux agent fleet (`agent-amd`) provisioned and reachable
- [ ] CodeBuild Linux server fleet (`server-amd`) provisioned and reachable
- [ ] CodeBuild Windows agent fleet (`agent-windows-amd`) provisioned and reachable

<!--
Include any additional information relevant to the review process.
-->
