### PR TITLE
fix(packages): use wazuh-manager-control in manager init.d scripts

### DIFF
--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -57,8 +57,8 @@ override_dh_install:
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
-	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-debian.init
-	cp src/init/templates/wazuh-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
+	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-manager-debian.init
+	cp src/init/templates/wazuh-manager-debian.init ${TARGET_DIR}/etc/init.d/wazuh-manager
 
 	# Copying systemd file
 	mkdir -p ${TARGET_DIR}/usr/lib/systemd/system/

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -84,8 +84,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}
 
 # Copy the installed files into RPM_BUILD_ROOT directory
 cp -pr %{_localstatedir}/* ${RPM_BUILD_ROOT}%{_localstatedir}/
-sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-rh.init
-install -m 0755 src/init/templates/wazuh-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-manager-rh.init
+install -m 0755 src/init/templates/wazuh-manager-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-manager
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
 sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-manager.service
 install -m 0644 src/init/templates/wazuh-manager.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system/
@@ -102,8 +102,8 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/sles
 
 # Add SUSE initscript
-sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-suse.init
-cp -rp src/init/templates/wazuh-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
+sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-manager-suse.init
+cp -rp src/init/templates/wazuh-manager-suse.init ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/init/
 
 # Copy scap templates
 cp -rp  etc/templates/config/generic/* ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/generic

--- a/src/init/templates/wazuh-manager-debian.init
+++ b/src/init/templates/wazuh-manager-debian.init
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Copyright (C) 2015, Wazuh Inc.
+# Wazuh         Controls Wazuh Manager
+# Author:       Daniel B. Cid <dcid@ossec.net>
+# Modified for Debian by Michael Starks (patch by Costas Drogos)
+
+### BEGIN INIT INFO
+# Provides:          wazuh-manager
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Should-Start:      $network
+# Should-Stop:       $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start and stop Wazuh Manager
+# Description:       Controls Wazuh Manager daemons
+#
+### END INIT INFO
+
+WAZUH_HOME=WAZUH_HOME_TMP
+WAZUH_CONTROL="$WAZUH_HOME/bin/wazuh-manager-control"
+
+start() {
+    ${WAZUH_CONTROL} start
+}
+
+stop() {
+    ${WAZUH_CONTROL} stop
+}
+
+status() {
+    ${WAZUH_CONTROL} status
+}
+
+case "$1" in
+start)
+    start
+    ;;
+stop)
+    stop
+    ;;
+restart)
+    stop
+    start
+    ;;
+status)
+    status
+    ;;
+*)
+    echo "*** Usage: $0 {start|stop|restart|status}"
+    exit 1
+esac

--- a/src/init/templates/wazuh-manager-rh.init
+++ b/src/init/templates/wazuh-manager-rh.init
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Copyright (C) 2015, Wazuh Inc.
+# Wazuh         Controls Wazuh Manager on Redhat-based systems
+# Author:       Kayvan A. Sylvan <kayvan@sylvan.com>
+# Author:       Daniel B. Cid <dcid@ossec.net>
+#
+# chkconfig: 2345 99 15
+# description: Starts and stops Wazuh Manager (Host Intrusion Detection System)
+#
+# This will work on Redhat systems (maybe others too)
+
+# Source function library.
+export LANG=C
+
+. /etc/init.d/functions
+
+WAZUH_HOME=WAZUH_HOME_TMP
+WAZUH_CONTROL="$WAZUH_HOME/bin/wazuh-manager-control"
+
+start() {
+    echo -n "Starting Wazuh: "
+    ${WAZUH_CONTROL} start > /dev/null
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ]; then
+        success
+    else
+        failure
+    fi
+    echo
+    return $RETVAL
+}
+
+stop() {
+    echo -n "Stopping Wazuh: "
+    ${WAZUH_CONTROL} stop > /dev/null
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ]; then
+        success
+    else
+        failure
+    fi
+    echo
+    return $RETVAL
+}
+
+status() {
+    ${WAZUH_CONTROL} status
+    RETVAL=$?
+    return $RETVAL
+}
+
+case "$1" in
+start)
+    start
+    ;;
+stop)
+    stop
+    ;;
+restart)
+    stop
+    start
+    ;;
+status)
+    status
+    ;;
+*)
+    echo "*** Usage: wazuh {start|stop|restart|status}"
+    exit 1
+esac
+
+exit $?

--- a/src/init/templates/wazuh-manager-suse.init
+++ b/src/init/templates/wazuh-manager-suse.init
@@ -1,0 +1,86 @@
+#!/bin/sh
+#
+# Copyright (C) 2015, Wazuh Inc.
+# Author: Scott Knauss scott@knauss.com
+#
+# /etc/init.d/wazuh
+#
+#
+### BEGIN INIT INFO
+# Provides:       wazuh-manager
+# Required-Start: $syslog
+# Required-Stop:  $null
+# Default-Start:  2 3 5
+# Default-Stop:   0 1 6
+# Description:    Start the Wazuh Manager daemon
+### END INIT INFO
+
+# Shell functions sourced from /etc/rc.status:
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     ditto but be verbose in local rc status
+#      rc_status -v -r  ditto and clear the local rc status
+#      rc_failed        set local and overall rc status to failed
+#      rc_failed <num>  set local and overall rc status to <num>
+#      rc_reset         clear local rc status (overall remains)
+#      rc_exit          exit appropriate to overall rc status
+. /etc/rc.status
+
+# First reset status of this service
+rc_reset
+
+# Return values acc. to LSB for all commands but status:
+# 0 - success
+# 1 - generic or unspecified error
+# 2 - invalid or excess argument(s)
+# 3 - unimplemented feature (e.g. "reload")
+# 4 - insufficient privilege
+# 5 - program is not installed
+# 6 - program is not configured
+# 7 - program is not running
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signalling is not supported) are
+# considered a success.
+
+# Just to make sure wazuh is installed ...
+WAZUH_HOME=WAZUH_HOME_TMP
+WAZUH_CONTROL="$WAZUH_HOME/bin/wazuh-manager-control"
+
+test -x $WAZUH_CONTROL || { echo "$WAZUH_CONTROL not installed";
+    if [ "$1" = "stop" ]; then exit 0;
+    else exit 5; fi; }
+
+start() {
+    ${WAZUH_CONTROL} start
+}
+
+stop() {
+    ${WAZUH_CONTROL} stop
+}
+
+status() {
+    ${WAZUH_CONTROL} status
+}
+
+case "$1" in
+start)
+    start
+    ;;
+stop)
+    stop
+    ;;
+restart)
+    stop
+    start
+    ;;
+status)
+    status
+    ;;
+*)
+    echo "*** Usage: $0 {start|stop|restart|status}"
+    exit 1
+esac
+
+exit 0


### PR DESCRIPTION
Fixes #37058

The manager and agent packages built their init.d scripts from the same templates (`wazuh-debian.init` for deb; `wazuh-rh.init` and `wazuh-suse.init` for rpm). The manager binary was renamed to `wazuh-manager-control` and the systemd units were updated, but the shared init.d templates still referenced `wazuh-control`, which no longer exists under the manager installation.

Editing the shared templates would break the agent (which still uses `wazuh-control`), so this adds manager-specific init.d templates and points the manager package specs at them.

## Changes

- `src/init/templates/wazuh-manager-debian.init`: new deb init.d template using `wazuh-manager-control`
- `src/init/templates/wazuh-manager-rh.init`: new RedHat init.d template using `wazuh-manager-control`
- `src/init/templates/wazuh-manager-suse.init`: new SUSE init.d template using `wazuh-manager-control`
- `packages/debs/SPECS/wazuh-manager/debian/rules`: use `wazuh-manager-debian.init`
- `packages/rpms/SPECS/wazuh-manager.spec`: use `wazuh-manager-rh.init` and `wazuh-manager-suse.init`



## Evidences
## Dockers without systemd
- deb, manager:
```
root@17e0231274fb:/# service wazuh-manager restart
wazuh-manager-clusterd not running...
wazuh-manager-modulesd not running...
wazuh-manager-monitord not running...
wazuh-manager-remoted not running...
wazuh-manager-analysisd not running...
wazuh-manager-db not running...
wazuh-manager-authd not running...
wazuh-manager-apid not running...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
```
- deb, agent:
```
root@17e0231274fb:/# service wazuh-agent restart
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Killing wazuh-modulesd...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
```

- rpm, manager:
```
[root@2cc4f5c90be6 /]# service wazuh-agent restart
Stopping Wazuh:
                                                           [  OK  ]
Starting Wazuh:                                            [  OK  ]
```

- rpm, agent:
```
[root@2cc4f5c90be6 /]# service wazuh-manager restart
Stopping Wazuh:                                            [  OK  ]
Starting Wazuh:                                            [  OK  ]
```


## Using VMs with systemd
- deb, manager:
```
root@ubuntu24:/vagrant/packages# service wazuh-manager restart
root@ubuntu24:/vagrant/packages# journalctl -u wazuh-manager -f
Jun 23 12:41:51 ubuntu24 systemd[1]: Stopping wazuh-manager.service - Wazuh manager...
Jun 23 12:41:51 ubuntu24 env[29694]: Killing wazuh-manager-clusterd...
Jun 23 12:41:51 ubuntu24 env[29694]: Killing wazuh-manager-modulesd...
Jun 23 12:41:52 ubuntu24 env[29694]: Killing wazuh-manager-monitord...
Jun 23 12:41:52 ubuntu24 env[29694]: Killing wazuh-manager-remoted...
Jun 23 12:41:52 ubuntu24 env[29694]: Killing wazuh-manager-analysisd...
Jun 23 12:41:52 ubuntu24 env[29694]: Killing wazuh-manager-db...
Jun 23 12:41:52 ubuntu24 env[29694]: Killing wazuh-manager-authd...
Jun 23 12:41:52 ubuntu24 env[29694]: Killing wazuh-manager-apid...
Jun 23 12:41:54 ubuntu24 env[29694]: Wazuh v5.0.0 Stopped
Jun 23 12:41:54 ubuntu24 systemd[1]: wazuh-manager.service: Deactivated successfully.
Jun 23 12:41:54 ubuntu24 systemd[1]: Stopped wazuh-manager.service - Wazuh manager.
Jun 23 12:41:54 ubuntu24 systemd[1]: Starting wazuh-manager.service - Wazuh manager...
Jun 23 12:41:54 ubuntu24 env[29763]: Starting Wazuh v5.0.0...
Jun 23 12:41:55 ubuntu24 env[29763]: Started wazuh-manager-apid...
Jun 23 12:41:55 ubuntu24 env[29763]: Started wazuh-manager-authd...
Jun 23 12:41:55 ubuntu24 env[29763]: Started wazuh-manager-db...
Jun 23 12:41:56 ubuntu24 env[29763]: Started wazuh-manager-analysisd...
Jun 23 12:41:56 ubuntu24 env[29763]: Started wazuh-manager-remoted...
Jun 23 12:41:56 ubuntu24 env[29763]: Started wazuh-manager-monitord...
Jun 23 12:41:56 ubuntu24 env[29763]: Started wazuh-manager-modulesd...
Jun 23 12:41:56 ubuntu24 env[29763]: Started wazuh-manager-clusterd...
Jun 23 12:41:58 ubuntu24 env[29763]: Completed.
Jun 23 12:41:58 ubuntu24 systemd[1]: Started wazuh-manager.service - Wazuh manager.
```

- deb, agent:
```
root@ubuntu24:/vagrant/packages# service wazuh-agent restart
root@ubuntu24:/vagrant/packages# journalctl -u wazuh-agent -f
Jun 23 12:45:25 ubuntu24 systemd[1]: Stopping wazuh-agent.service - Wazuh agent...
Jun 23 12:45:25 ubuntu24 env[33419]: Killing wazuh-modulesd...
Jun 23 12:45:25 ubuntu24 env[33419]: Killing wazuh-logcollector...
Jun 23 12:45:25 ubuntu24 env[33419]: Killing wazuh-syscheckd...
Jun 23 12:45:25 ubuntu24 env[33419]: Killing wazuh-agentd...
Jun 23 12:45:25 ubuntu24 env[33419]: Killing wazuh-execd...
Jun 23 12:45:27 ubuntu24 env[33419]: Wazuh v5.0.0 Stopped
Jun 23 12:45:27 ubuntu24 systemd[1]: wazuh-agent.service: Deactivated successfully.
Jun 23 12:45:27 ubuntu24 systemd[1]: Stopped wazuh-agent.service - Wazuh agent.
Jun 23 12:45:27 ubuntu24 systemd[1]: wazuh-agent.service: Consumed 10.797s CPU time.
Jun 23 12:45:27 ubuntu24 systemd[1]: Starting wazuh-agent.service - Wazuh agent...
Jun 23 12:45:27 ubuntu24 env[33479]: Starting Wazuh v5.0.0...
Jun 23 12:45:27 ubuntu24 env[33479]: Started wazuh-execd...
Jun 23 12:45:28 ubuntu24 env[33479]: Started wazuh-agentd...
Jun 23 12:45:28 ubuntu24 env[33479]: Started wazuh-syscheckd...
Jun 23 12:45:28 ubuntu24 env[33479]: Started wazuh-logcollector...
Jun 23 12:45:28 ubuntu24 env[33479]: Started wazuh-modulesd...
Jun 23 12:45:30 ubuntu24 env[33479]: Completed.
Jun 23 12:45:30 ubuntu24 systemd[1]: Started wazuh-agent.service - Wazuh agent.
```

- rpm, manager:
```
[root@fedora40 vagrant]# service wazuh-manager restart
Redirecting to /bin/systemctl restart wazuh-manager.service
[root@fedora40 vagrant]# journalctl -u wazuh-manager -f
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-apid...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-authd...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-db...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-analysisd...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-remoted...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-monitord...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-modulesd...
Jun 23 13:28:06 fedora40 env[25465]: Started wazuh-manager-clusterd...
Jun 23 13:28:08 fedora40 env[25465]: Completed.
Jun 23 13:28:08 fedora40 systemd[1]: Started wazuh-manager.service - Wazuh manager.
```

- rpm, agent:
```
[root@fedora40 vagrant]# service wazuh-agent restart
Redirecting to /bin/systemctl restart wazuh-agent.service
[root@fedora40 vagrant]# journalctl -u wazuh-agent -f
Jun 23 13:32:30 fedora40 env[27162]: Killing wazuh-execd...
Jun 23 13:32:31 fedora40 env[27162]: Wazuh v5.0.0 Stopped
Jun 23 13:32:32 fedora40 env[27162]: Starting Wazuh v5.0.0...
Jun 23 13:32:32 fedora40 env[27162]: Started wazuh-execd...
Jun 23 13:32:32 fedora40 env[27162]: wazuh-agentd already running...
Jun 23 13:32:32 fedora40 env[27162]: Started wazuh-syscheckd...
Jun 23 13:32:32 fedora40 env[27162]: Started wazuh-logcollector...
Jun 23 13:32:33 fedora40 env[27162]: Started wazuh-modulesd...
Jun 23 13:32:35 fedora40 env[27162]: Completed.
Jun 23 13:32:35 fedora40 systemd[1]: Reloaded wazuh-agent.service - Wazuh agent.
```
